### PR TITLE
Add client fetching of chain entities and support entity archival.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -458,7 +458,6 @@ $(() => {
           WebsocketMessageType.Notification,
           (payload: IWebsocketsPayload<any>) => {
             if (payload.data && payload.data.subscription_id) {
-              console.log(payload.data.subscription_id, app.login.notifications.subscriptions);
               const subscription = app.login.notifications.subscriptions.find(
                 (sub) => sub.id === payload.data.subscription_id
               );

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -39,6 +39,9 @@ class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   }
 
   public async init(onServerLoaded?) {
+    // if set to true, loads chain entity data from the node directly on the client
+    // if set to false, chain entity data is loaded from the server
+    // in both cases, archived proposals (no longer on chain) are loaded from the server
     const useClientChainEntities = true;
     console.log(`Starting ${this.meta.chain.id} on node: ${this.meta.url}`);
     this.chain = new EdgewareChain(this.app); // edgeware chain this.appid

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -12,7 +12,12 @@ import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import EdgewareSignaling from './signaling';
 import WebWalletController from '../../app/web_wallet';
 import SubstrateIdentities from '../substrate/identity';
-import { handleSubstrateEntityUpdate } from '../substrate/shared';
+import {
+  handleSubstrateEntityUpdate,
+  initApiPromise,
+  initChainEntities,
+  initChainEntitySubscription
+} from '../substrate/shared';
 
 
 class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
@@ -84,6 +89,9 @@ class Edgeware extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
       this.signaling.init(this.chain, this.accounts),
     ]);
     await this._postModuleLoad();
+    const apiPromise = await initApiPromise(this.meta.chain.id, this.meta.url);
+    await initChainEntities(this.app, apiPromise, this.meta.chain.id);
+    await initChainEntitySubscription(this.app, apiPromise, this.meta.chain.id);
     await this.chain.initEventLoop();
 
     this._loaded = true;

--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -94,10 +94,17 @@ export class SubstrateCollectiveProposal
     }
     switch (e.data.kind) {
       case SubstrateEventKind.CollectiveProposed: {
+        // proposer always submits an implicit yes vote
+        const voter = this._Accounts.fromAddress(e.data.proposer);
+        this.addOrUpdateVote(new SubstrateCollectiveVote(this, voter, true));
+        break;
+      }
+      case SubstrateEventKind.CollectiveVoted: {
+        const voter = this._Accounts.fromAddress(e.data.voter);
+        this.addOrUpdateVote(new SubstrateCollectiveVote(this, voter, e.data.vote));
         break;
       }
       case SubstrateEventKind.CollectiveDisapproved: {
-        console.log('disapproved', e);
         this._approved.next(false);
         this.complete();
         break;

--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -95,8 +95,10 @@ export class SubstrateCollectiveProposal
     switch (e.data.kind) {
       case SubstrateEventKind.CollectiveProposed: {
         // proposer always submits an implicit yes vote
-        const voter = this._Accounts.fromAddress(e.data.proposer);
-        this.addOrUpdateVote(new SubstrateCollectiveVote(this, voter, true));
+        if (e.data.proposer) {
+          const voter = this._Accounts.fromAddress(e.data.proposer);
+          this.addOrUpdateVote(new SubstrateCollectiveVote(this, voter, true));
+        }
         break;
       }
       case SubstrateEventKind.CollectiveVoted: {

--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -99,19 +99,11 @@ export class SubstrateCollectiveProposal
       case SubstrateEventKind.CollectiveDisapproved: {
         console.log('disapproved', e);
         this._approved.next(false);
-        this._updateVotes(
-          e.data.ayes.map((who) => this._Accounts.fromAddress(who)),
-          e.data.nays.map((who) => this._Accounts.fromAddress(who)),
-        );
         this.complete();
         break;
       }
       case SubstrateEventKind.CollectiveApproved: {
         this._approved.next(true);
-        this._updateVotes(
-          e.data.ayes.map((who) => this._Accounts.fromAddress(who)),
-          e.data.nays.map((who) => this._Accounts.fromAddress(who)),
-        );
         break;
       }
       case SubstrateEventKind.CollectiveExecuted: {

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -1,4 +1,3 @@
-import SubstrateChain, { handleSubstrateEntityUpdate } from 'controllers/chain/substrate/shared';
 import SubstrateAccounts, { SubstrateAccount } from 'controllers/chain/substrate/account';
 import SubstrateDemocracy from 'controllers/chain/substrate/democracy';
 import SubstrateDemocracyProposals from 'controllers/chain/substrate/democracy_proposals';
@@ -10,6 +9,12 @@ import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import WebWalletController from '../../app/web_wallet';
 import SubstratePhragmenElections from './phragmen_elections';
 import SubstrateIdentities from './identity';
+import SubstrateChain, {
+  handleSubstrateEntityUpdate,
+  initApiPromise,
+  initChainEntities,
+  initChainEntitySubscription
+} from './shared';
 
 class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   public chain: SubstrateChain;
@@ -51,6 +56,7 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
       await this.chain.initMetadata();
     }, onServerLoaded);
     await this.accounts.init(this.chain);
+
     await Promise.all([
       this.phragmenElections.init(this.chain, this.accounts),
       this.council.init(this.chain, this.accounts),
@@ -61,6 +67,9 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
       this.identities.init(this.chain, this.accounts),
     ]);
     await this._postModuleLoad();
+    const apiPromise = await initApiPromise(this.meta.chain.id, this.meta.url);
+    await initChainEntities(this.app, apiPromise, this.meta.chain.id);
+    await initChainEntitySubscription(this.app, apiPromise, this.meta.chain.id);
     await this.chain.initEventLoop();
 
     this._loaded = true;

--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -45,7 +45,7 @@ import {
 } from 'models';
 
 import { CWEvent } from 'events/interfaces';
-import loadSubstrateEvents from 'events/edgeware/migration';
+import fetchSubstrateEvents from 'events/edgeware/storageFetcher';
 import EdgewareEventSubscriber from 'events/edgeware/subscriber';
 import EdgewareEventProcessor from 'events/edgeware/processor';
 import {
@@ -315,7 +315,7 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
   // load existing events and subscribe to future via client node connection
   public async initChainEntities(chain: string) {
     // get existing events
-    const existingEvents = await loadSubstrateEvents(this._apiPromise);
+    const existingEvents = await fetchSubstrateEvents(this._apiPromise);
     // eslint-disable-next-line no-restricted-syntax
     for (const cwEvent of existingEvents) {
       this._handleCWEvent(chain, cwEvent);

--- a/client/scripts/controllers/server/chain_entities.ts
+++ b/client/scripts/controllers/server/chain_entities.ts
@@ -37,7 +37,7 @@ class ChainEntityController {
   }
 
   public update(entity: ChainEntity, event: ChainEvent) {
-    const existingEntity = this.store.getById(entity.id);
+    const existingEntity = this.store.get(entity);
     if (!existingEntity) {
       this._store.add(entity);
     } else {
@@ -46,7 +46,10 @@ class ChainEntityController {
     entity.addEvent(event);
   }
 
-  public refresh(chain) {
+  public refresh(chain: string, completed: boolean = false) {
+    // TODO: add a way on route to only get completed entities if set to true
+    //  for now, it duplicates the data from chain, but shouldn't affect the results.
+    if (completed) return Promise.resolve();
     return get('/bulkEntities', { chain }, (result) => {
       for (const entityJSON of result) {
         const entity = ChainEntity.fromJSON(entityJSON);

--- a/client/scripts/controllers/server/chain_entities.ts
+++ b/client/scripts/controllers/server/chain_entities.ts
@@ -46,10 +46,10 @@ class ChainEntityController {
     entity.addEvent(event);
   }
 
-  public refresh(chain: string, completed: boolean = false) {
+  public refresh(chain: string, loadIncompleteEntities: boolean = false) {
     // TODO: add a way on route to only get completed entities if set to true
     //  for now, it duplicates the data from chain, but shouldn't affect the results.
-    if (completed) return Promise.resolve();
+    if (!loadIncompleteEntities) return Promise.resolve();
     return get('/bulkEntities', { chain }, (result) => {
       for (const entityJSON of result) {
         const entity = ChainEntity.fromJSON(entityJSON);

--- a/client/scripts/controllers/server/chain_entities.ts
+++ b/client/scripts/controllers/server/chain_entities.ts
@@ -47,10 +47,11 @@ class ChainEntityController {
   }
 
   public refresh(chain: string, loadIncompleteEntities: boolean = false) {
-    // TODO: add a way on route to only get completed entities if set to true
-    //  for now, it duplicates the data from chain, but shouldn't affect the results.
-    if (!loadIncompleteEntities) return Promise.resolve();
-    return get('/bulkEntities', { chain }, (result) => {
+    const options: any = { chain };
+    if (!loadIncompleteEntities) {
+      options.completed = true;
+    }
+    return get('/bulkEntities', options, (result) => {
       for (const entityJSON of result) {
         const entity = ChainEntity.fromJSON(entityJSON);
         this._store.add(entity);

--- a/client/scripts/models/ChainEntity.ts
+++ b/client/scripts/models/ChainEntity.ts
@@ -35,10 +35,13 @@ class ChainEntity {
     this.createdAt = moment(createdAt);
     this._updatedAt = moment(updatedAt);
 
-    // TODO: move this into a chain event controller to avoid duplication
-    this._chainEvents = (chainEvents || [])
-      .map((c) => ChainEvent.fromJSON(c))
-      .sort(({ blockNumber: bn1 }, { blockNumber: bn2 }) => bn1 - bn2); // sort ascending
+    if (chainEvents && chainEvents.length > 0) {
+      this._chainEvents = chainEvents
+        .map((c) => ChainEvent.fromJSON(c))
+        .sort(({ blockNumber: bn1 }, { blockNumber: bn2 }) => bn1 - bn2); // sort ascending
+    } else {
+      this._chainEvents = [];
+    }
   }
 
   public static fromJSON(json) {
@@ -46,9 +49,9 @@ class ChainEntity {
       json.chain,
       json.type,
       json.type_id,
+      json.ChainEvents,
       json.created_at,
       json.updated_at,
-      json.ChainEvents,
       json.id,
       json.thread_id,
     );

--- a/client/scripts/models/ChainEntity.ts
+++ b/client/scripts/models/ChainEntity.ts
@@ -4,21 +4,29 @@ import { IChainEntityKind } from 'events/interfaces';
 import ChainEvent from './ChainEvent';
 
 class ChainEntity {
-  public readonly id: number;
+  public readonly id?: number;
   public readonly chain: string;
   public readonly type: IChainEntityKind;
   public readonly typeId: string;
 
   public readonly threadId?: number;
-  public readonly createdAt: moment.Moment;
+  public readonly createdAt?: moment.Moment;
 
-  private _updatedAt: moment.Moment;
+  private _updatedAt?: moment.Moment;
   public get updatedAt() { return this._updatedAt; }
 
   private _chainEvents: ChainEvent[];
   public get chainEvents() { return this._chainEvents; }
 
-  constructor(id, chain, type, typeId, createdAt, updatedAt, chainEvents, threadId?) {
+  public get stringId(): string {
+    return `${this.chain}-${this.type}-${this.typeId}`;
+  }
+
+  public eq(e: ChainEntity) {
+    return e.chain === this.chain && e.type === this.type && e.typeId === this.typeId;
+  }
+
+  constructor(chain, type, typeId, chainEvents, createdAt?, updatedAt?, id?, threadId?) {
     this.id = id;
     this.chain = chain;
     this.type = type;
@@ -30,24 +38,24 @@ class ChainEntity {
     // TODO: move this into a chain event controller to avoid duplication
     this._chainEvents = (chainEvents || [])
       .map((c) => ChainEvent.fromJSON(c))
-      .sort(({ id: id1 }, { id: id2 }) => id1 - id2); // sort ascending
+      .sort(({ blockNumber: bn1 }, { blockNumber: bn2 }) => bn1 - bn2); // sort ascending
   }
 
   public static fromJSON(json) {
     return new ChainEntity(
-      json.id,
       json.chain,
       json.type,
       json.type_id,
       json.created_at,
       json.updated_at,
       json.ChainEvents,
+      json.id,
       json.thread_id,
     );
   }
 
   public addEvent(chainEvent: ChainEvent, updatedAt?: moment.Moment) {
-    if (!this._chainEvents.find((e) => e.id === chainEvent.id)) {
+    if (!this._chainEvents.find((e) => e.eq(chainEvent))) {
       this._chainEvents.push(chainEvent);
       if (updatedAt) {
         this._updatedAt = updatedAt;

--- a/client/scripts/models/ChainEvent.ts
+++ b/client/scripts/models/ChainEvent.ts
@@ -1,13 +1,18 @@
+import _ from 'underscore';
 import { IChainEventData } from 'events/interfaces';
 import ChainEventType from './ChainEventType';
 
 class ChainEvent {
-  public readonly id: number;
+  public readonly id?: number;
   public readonly blockNumber: number;
   public readonly data: IChainEventData;
   public readonly type: ChainEventType;
 
-  constructor(id, blockNumber, data, type) {
+  public eq(e: ChainEvent) {
+    return e.data.kind === this.data.kind && _.isEqual(this.data, e.data);
+  }
+
+  constructor(blockNumber, data, type, id?) {
     this.id = id;
     this.blockNumber = blockNumber;
     this.data = data;
@@ -16,10 +21,10 @@ class ChainEvent {
 
   public static fromJSON(json) {
     return new ChainEvent(
-      json.id,
       json.block_number,
       json.event_data,
       ChainEventType.fromJSON(json.ChainEventType),
+      json.id,
     );
   }
 }

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -52,14 +52,14 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
   public async init(
     onServerLoaded? : () => void,
     initChainModuleFn?: () => Promise<void>,
-    loadEntities = false,
+    loadIncompleteEntities = false,
   ): Promise<void> {
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true, true);
     await this.app.reactions.refreshAll(this.id, null, true);
 
     // if we're loading entities from chain, only pull completed (for now, does nothing)
-    await this.app.chainEntities.refresh(this.meta.chain.id, !loadEntities);
+    await this.app.chainEntities.refresh(this.meta.chain.id, loadIncompleteEntities);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
     await initChainModuleFn();

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -18,40 +18,48 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
   protected _serverLoaded: boolean;
   get serverLoaded() { return this._serverLoaded; }
 
-  protected async _postModuleLoad(): Promise<void> {
+  protected async _postModuleLoad(listenEvents = false): Promise<void> {
     await this.app.comments.refreshAll(this.id, null, true, false, true);
     // await this.app.reactions.refreshAll(this.id, null, false);
 
     // attach listener for entity update events
-    this.app.socket.addListener(
-      WebsocketMessageType.ChainEntity,
-      (payload: IWebsocketsPayload<any>) => {
-        if (payload
-          && payload.data
-          && payload.data.chainEntity.chain === this.meta.chain.id
-        ) {
-          const { chainEntity, chainEvent, chainEventType } = payload.data;
+    if (listenEvents) {
+      this.app.socket.addListener(
+        WebsocketMessageType.ChainEntity,
+        (payload: IWebsocketsPayload<any>) => {
+          if (payload
+            && payload.data
+            && payload.data.chainEntity.chain === this.meta.chain.id
+          ) {
+            const { chainEntity, chainEvent, chainEventType } = payload.data;
 
-          // add fake "include" for construction purposes
-          chainEvent.ChainEventType = chainEventType;
-          const eventModel = ChainEvent.fromJSON(chainEvent);
+            // add fake "include" for construction purposes
+            chainEvent.ChainEventType = chainEventType;
+            const eventModel = ChainEvent.fromJSON(chainEvent);
 
-          let existingEntity = this.app.chainEntities.store.getById(chainEntity.id);
-          if (!existingEntity) {
-            existingEntity = ChainEntity.fromJSON(chainEntity);
+            let existingEntity = this.app.chainEntities.store.get(chainEntity);
+            if (!existingEntity) {
+              existingEntity = ChainEntity.fromJSON(chainEntity);
+            }
+            this.app.chainEntities.update(existingEntity, eventModel);
+            this.handleEntityUpdate(existingEntity, eventModel);
           }
-          this.app.chainEntities.update(existingEntity, eventModel);
-          this.handleEntityUpdate(existingEntity, eventModel);
         }
-      }
-    );
+      );
+    }
   }
 
-  public async init(onServerLoaded? : () => void, initChainModuleFn?: () => Promise<void>): Promise<void> {
+  public async init(
+    onServerLoaded? : () => void,
+    initChainModuleFn?: () => Promise<void>,
+    loadEntities = false,
+  ): Promise<void> {
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true, true);
     await this.app.reactions.refreshAll(this.id, null, true);
-    await this.app.chainEntities.refresh(this.meta.chain.id);
+
+    // if we're loading entities from chain, only pull completed (for now, does nothing)
+    await this.app.chainEntities.refresh(this.meta.chain.id, !loadEntities);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();
     await initChainModuleFn();

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -58,7 +58,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     await this.app.comments.refreshAll(this.id, null, true, true);
     await this.app.reactions.refreshAll(this.id, null, true);
 
-    // if we're loading entities from chain, only pull completed (for now, does nothing)
+    // if we're loading entities from chain, only pull completed
     await this.app.chainEntities.refresh(this.meta.chain.id, loadIncompleteEntities);
     this._serverLoaded = true;
     if (onServerLoaded) await onServerLoaded();

--- a/client/scripts/stores/ChainEntityStore.ts
+++ b/client/scripts/stores/ChainEntityStore.ts
@@ -1,14 +1,19 @@
 import { IChainEntityKind } from 'events/interfaces';
 
-import IdStore from './IdStore';
 import { ChainEntity } from '../models';
+import Store from './Store';
 
-class ChainEntityStore extends IdStore<ChainEntity> {
-  private _storeType: { [type: string]: { [id: number]: ChainEntity } } = { };
+class ChainEntityStore extends Store<ChainEntity> {
+  private _storeType: { [type: string]: { [stringId: string]: ChainEntity } } = { };
+
+  public get(entity: ChainEntity) {
+    return this._store.find((e) => e.eq(entity));
+  }
 
   public add(entity: ChainEntity) {
     // override duplicates manually
-    if (this.getById(entity.id)) {
+    const existingEntity = this.get(entity);
+    if (existingEntity) {
       this.remove(entity);
     }
 
@@ -17,14 +22,14 @@ class ChainEntityStore extends IdStore<ChainEntity> {
     if (!this._storeType[entity.type]) {
       this._storeType[entity.type] = {};
     }
-    this._storeType[entity.type][entity.id] = entity;
+    this._storeType[entity.type][entity.stringId] = entity;
     return this;
   }
 
   public remove(entity: ChainEntity) {
     super.remove(entity);
-    if (this._storeType[entity.type] && this._storeType[entity.type][entity.id]) {
-      delete this._storeType[entity.type][entity.id];
+    if (this._storeType[entity.type] && this._storeType[entity.type][entity.stringId]) {
+      delete this._storeType[entity.type][entity.stringId];
     }
     return this;
   }

--- a/server.ts
+++ b/server.ts
@@ -17,7 +17,7 @@ import logger from 'morgan';
 import prerenderNode from 'prerender-node';
 import devWebpackConfig from './webpack/webpack.config.dev.js';
 import prodWebpackConfig from './webpack/webpack.config.prod.js';
-import { factory, formatFilename } from './server/util/logging';
+import { factory, formatFilename } from './shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 import ViewCountCache from './server/util/viewCountCache';

--- a/server/database.ts
+++ b/server/database.ts
@@ -4,7 +4,7 @@ import Sequelize from 'sequelize';
 
 import { DATABASE_URI } from './config';
 
-import { factory, formatFilename } from './util/logging';
+import { factory, formatFilename } from '../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const sequelize = new Sequelize(DATABASE_URI, {

--- a/server/eventHandlers/edgeware/entityArchival.ts
+++ b/server/eventHandlers/edgeware/entityArchival.ts
@@ -161,6 +161,7 @@ export default class extends IEventHandler {
         const { proposalHash } = event.data;
         return createEntityFn(SubstrateEntityKind.CollectiveProposal, proposalHash);
       }
+      case SubstrateEventKind.CollectiveVoted:
       case SubstrateEventKind.CollectiveApproved: {
         const { proposalHash } = event.data;
         return updateEntityFn(SubstrateEntityKind.CollectiveProposal, proposalHash);

--- a/server/eventHandlers/edgeware/entityArchival.ts
+++ b/server/eventHandlers/edgeware/entityArchival.ts
@@ -6,7 +6,7 @@ import { IEventHandler, CWEvent } from '../../../shared/events/interfaces';
 import { SubstrateEventKind, SubstrateEntityKind } from '../../../shared/events/edgeware/types';
 import { NotificationCategories, WebsocketMessageType, IWebsocketsPayload } from '../../../shared/types';
 
-import { factory, formatFilename } from '../../util/logging';
+import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IEventHandler {

--- a/server/eventHandlers/edgeware/migration.ts
+++ b/server/eventHandlers/edgeware/migration.ts
@@ -10,9 +10,10 @@ import {
   ISubstrateTreasuryProposalEvents,
   ISubstrateCollectiveProposalEvents,
   ISubstrateSignalingProposalEvents,
+  entityToFieldName,
 } from '../../../shared/events/edgeware/types';
 
-import { factory, formatFilename } from '../../util/logging';
+import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IEventHandler {
@@ -62,34 +63,9 @@ export default class extends IEventHandler {
 
     const entityKind = eventToEntity(event.data.kind);
     if (entityKind === null) return null;
-    switch (entityKind) {
-      case SubstrateEntityKind.DemocracyProposal: {
-        const proposalIndex = (event.data as ISubstrateDemocracyProposalEvents).proposalIndex;
-        return createOrUpdateModel('proposalIndex', proposalIndex);
-      }
-      case SubstrateEntityKind.DemocracyReferendum: {
-        const referendumIndex = (event.data as ISubstrateDemocracyReferendumEvents).referendumIndex;
-        return createOrUpdateModel('referendumIndex', referendumIndex);
-      }
-      case SubstrateEntityKind.DemocracyPreimage: {
-        const proposalHash = (event.data as ISubstrateDemocracyPreimageEvents).proposalHash;
-        return createOrUpdateModel('proposalHash', proposalHash);
-      }
-      case SubstrateEntityKind.TreasuryProposal: {
-        const proposalIndex = (event.data as ISubstrateTreasuryProposalEvents).proposalIndex;
-        return createOrUpdateModel('proposalIndex', proposalIndex);
-      }
-      case SubstrateEntityKind.CollectiveProposal: {
-        const proposalHash = (event.data as ISubstrateCollectiveProposalEvents).proposalHash;
-        return createOrUpdateModel('proposalHash', proposalHash);
-      }
-      case SubstrateEntityKind.SignalingProposal: {
-        const proposalHash = (event.data as ISubstrateSignalingProposalEvents).proposalHash;
-        return createOrUpdateModel('proposalHash', proposalHash);
-      }
-      default: {
-        return null;
-      }
-    }
+    const fieldName = entityToFieldName(entityKind);
+    if (!fieldName) return null;
+    const fieldValue = event.data[fieldName];
+    return createOrUpdateModel(fieldName, fieldValue);
   }
 }

--- a/server/eventHandlers/edgeware/migration.ts
+++ b/server/eventHandlers/edgeware/migration.ts
@@ -2,16 +2,7 @@
  * Processes events during migration, upgrading from simple notifications to entities.
  */
 import { IEventHandler, CWEvent } from '../../../shared/events/interfaces';
-import {
-  eventToEntity, SubstrateEntityKind,
-  ISubstrateDemocracyProposalEvents,
-  ISubstrateDemocracyReferendumEvents,
-  ISubstrateDemocracyPreimageEvents,
-  ISubstrateTreasuryProposalEvents,
-  ISubstrateCollectiveProposalEvents,
-  ISubstrateSignalingProposalEvents,
-  entityToFieldName,
-} from '../../../shared/events/edgeware/types';
+import { eventToEntity, entityToFieldName } from '../../../shared/events/edgeware/types';
 
 import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));

--- a/server/eventHandlers/notifications.ts
+++ b/server/eventHandlers/notifications.ts
@@ -5,7 +5,7 @@ import WebSocket from 'ws';
 import { IEventHandler, CWEvent } from '../../shared/events/interfaces';
 import { NotificationCategories } from '../../shared/types';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IEventHandler {

--- a/server/eventHandlers/storage.ts
+++ b/server/eventHandlers/storage.ts
@@ -3,7 +3,7 @@
  */
 import { IEventHandler, CWEvent } from '../../shared/events/interfaces';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IEventHandler {

--- a/server/migrations/20200415152936-add-chain-events.js
+++ b/server/migrations/20200415152936-add-chain-events.js
@@ -37,6 +37,7 @@ const SubstrateEventKinds = {
   ElectionMemberRenounced: 'election-member-renounced',
 
   CollectiveProposed: 'collective-proposed',
+  CollectiveVoted: 'collective-voted',
   CollectiveApproved: 'collective-approved',
   CollectiveDisapproved: 'collective-disapproved',
   CollectiveExecuted: 'collective-executed',

--- a/server/migrations/20200428174007-add-chain-entities.js
+++ b/server/migrations/20200428174007-add-chain-entities.js
@@ -17,6 +17,11 @@ module.exports = {
           allowNull: true,
           references: { model: 'OffchainThreads', key: 'id' },
         },
+        completed: {
+          type: Sequelize.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+        },
         created_at: { type: Sequelize.DATE, allowNull: false },
         updated_at: { type: Sequelize.DATE, allowNull: false },
       }, {

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -16,7 +16,7 @@ import nacl from 'tweetnacl';
 import { KeyringOptions } from '@polkadot/keyring/types';
 import { keyToSignMsg } from '../../shared/adapters/chain/cosmos/keys';
 import { NotificationCategories } from '../../shared/types';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 // tslint:disable-next-line

--- a/server/models/chain_entity.ts
+++ b/server/models/chain_entity.ts
@@ -5,6 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     type: { type: DataTypes.STRING, allowNull: false },
     type_id: { type: DataTypes.STRING, allowNull: false },
     thread_id: { type: DataTypes.INTEGER, allowNull: true },
+    completed: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 
     created_at: { type: DataTypes.DATE, allowNull: false },
     updated_at: { type: DataTypes.DATE, allowNull: false },

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -8,7 +8,7 @@ import {
 } from '../../shared/types';
 
 const { Op } = Sequelize;
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 module.exports = (sequelize, DataTypes) => {

--- a/server/routes/acceptInvite.ts
+++ b/server/routes/acceptInvite.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const Errors = {

--- a/server/routes/acceptInviteLink.ts
+++ b/server/routes/acceptInviteLink.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import crypto from 'crypto';
 import { SERVER_URL } from '../config';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const redirectWithError = (res, message: string) => {

--- a/server/routes/addChainNode.ts
+++ b/server/routes/addChainNode.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const addChainNode = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/addChainObjectQuery.ts
+++ b/server/routes/addChainObjectQuery.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const addChainObjectQuery = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/addMember.ts
+++ b/server/routes/addMember.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const addMember = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkAddresses.ts
+++ b/server/routes/bulkAddresses.ts
@@ -2,7 +2,7 @@
 import Sequelize from 'sequelize';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 const { Op } = Sequelize;
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 // the bulkAddress route takes a chain/community (mandatory) and a limit & order (both optional)
 // If a chain is supplied, queried addresses are limited to being on said chain.

--- a/server/routes/bulkComments.ts
+++ b/server/routes/bulkComments.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkComments = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkEntities.ts
+++ b/server/routes/bulkEntities.ts
@@ -34,6 +34,9 @@ const bulkEntities = async (models, req: Request, res: Response, next: NextFunct
   if (req.query.type_id) {
     entityFindOptions.where.type_id = req.query.type_id;
   }
+  if (req.query.completed) {
+    entityFindOptions.where.completed = true;
+  }
   const entities = await models.ChainEntity.findAll(entityFindOptions);
   return res.json({ status: 'Success', result: entities.map((e) => e.toJSON()) });
 };

--- a/server/routes/bulkMembers.ts
+++ b/server/routes/bulkMembers.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkMembers = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkProfiles.ts
+++ b/server/routes/bulkProfiles.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkProfiles = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkReactions.ts
+++ b/server/routes/bulkReactions.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkReactions = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkTags.ts
+++ b/server/routes/bulkTags.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkTags = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkThreads = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/clearReadNotifications.ts
+++ b/server/routes/clearReadNotifications.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createAddress.ts
+++ b/server/routes/createAddress.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createAddress = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -6,7 +6,7 @@ import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
 import { getProposalUrl } from '../../shared/utils';
 import proposalIdToEntity from '../util/proposalIdToEntity';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const Errors = {

--- a/server/routes/createCommunity.ts
+++ b/server/routes/createCommunity.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { NotificationCategories } from '../../shared/types';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const Errors = {

--- a/server/routes/createHedgehogAuthentication.ts
+++ b/server/routes/createHedgehogAuthentication.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createHedgehogUser.ts
+++ b/server/routes/createHedgehogUser.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { successResponse } from '../util/apiHelpers';
 import { redirectWithLoginError, redirectWithLoginSuccess } from './finishEmailLogin';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -15,7 +15,7 @@ export const Errors = {
 };
 
 sgMail.setApiKey(SENDGRID_API_KEY);
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createInvite = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createInviteLink.ts
+++ b/server/routes/createInviteLink.ts
@@ -1,6 +1,6 @@
 
 import crypto from 'crypto';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createInviteLink = async (models, req, res, next) => {

--- a/server/routes/createMembership.ts
+++ b/server/routes/createMembership.ts
@@ -2,7 +2,7 @@ import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createMembership = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -7,7 +7,7 @@ import { NotificationCategories } from '../../shared/types';
 import { getProposalUrl } from '../../shared/utils';
 import proposalIdToEntity from '../util/proposalIdToEntity';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createReaction = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createSubscription.ts
+++ b/server/routes/createSubscription.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -4,7 +4,7 @@ import { NotificationCategories, ProposalType } from '../../shared/types';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
 import { getProposalUrl } from '../../shared/utils';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const Errors = {

--- a/server/routes/deleteAddress.ts
+++ b/server/routes/deleteAddress.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteAddress = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteChain.ts
+++ b/server/routes/deleteChain.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import deleteCommunity from "./deleteCommunity";
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteChain = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteChainNode.ts
+++ b/server/routes/deleteChainNode.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteChainNode = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteChainObjectQuery.ts
+++ b/server/routes/deleteChainObjectQuery.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteChainObjectQuery = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteComment.ts
+++ b/server/routes/deleteComment.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteComment = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteCommunity.ts
+++ b/server/routes/deleteCommunity.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteCommunity = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteMembership.ts
+++ b/server/routes/deleteMembership.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteMembership = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteReaction.ts
+++ b/server/routes/deleteReaction.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteReaction = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteSubscription.ts
+++ b/server/routes/deleteSubscription.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/deleteThread.ts
+++ b/server/routes/deleteThread.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteThread = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/disableSubscriptions.ts
+++ b/server/routes/disableSubscriptions.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/edgeware_lockdrop_balances.ts
+++ b/server/routes/edgeware_lockdrop_balances.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const edgewareLockdropBalances = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/edgeware_lockdrop_events.ts
+++ b/server/routes/edgeware_lockdrop_events.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const edgewareLockdropEvents = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -5,7 +5,7 @@ import { NotificationCategories } from '../../shared/types';
 import { getProposalUrl } from '../../shared/utils';
 import proposalIdToEntity from '../util/proposalIdToEntity';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const editComment = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/editTag.ts
+++ b/server/routes/editTag.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const editTag = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
 import { NotificationCategories, ProposalType } from '../../shared/types';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const Errors = {

--- a/server/routes/enableSubscriptions.ts
+++ b/server/routes/enableSubscriptions.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/finishEmailLogin.ts
+++ b/server/routes/finishEmailLogin.ts
@@ -1,6 +1,6 @@
 import { SERVER_URL } from '../config';
 import { NotificationCategories } from '../../shared/types';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export const redirectWithLoginSuccess = (res, email, path?, newAcct = false) => {

--- a/server/routes/getEdgewareLockdropLookup.ts
+++ b/server/routes/getEdgewareLockdropLookup.ts
@@ -3,7 +3,7 @@ import Web3 from 'web3';
 import _ from 'lodash';
 import { Request, Response, NextFunction } from 'express';
 import { INFURA_API_KEY } from '../config';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const MAINNET_LOCKDROP_ORIG = '0x1b75B90e60070d37CfA9d87AFfD124bB345bf70a';

--- a/server/routes/getEdgewareLockdropStats.ts
+++ b/server/routes/getEdgewareLockdropStats.ts
@@ -11,7 +11,7 @@ import {
   getSignalsForAddress
 } from './getEdgewareLockdropLookup';
 const { toBN } = Web3.utils;
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const MAINNET_LOCKDROP_ORIG = '0x1b75B90e60070d37CfA9d87AFfD124bB345bf70a';

--- a/server/routes/getHedgehogAuthentication.ts
+++ b/server/routes/getHedgehogAuthentication.ts
@@ -1,6 +1,6 @@
 import { successResponse } from '../util/apiHelpers';
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/getInviteLinks.ts
+++ b/server/routes/getInviteLinks.ts
@@ -1,4 +1,4 @@
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const getInviteLinks = async (models, req, res, next) => {

--- a/server/routes/getInvites.ts
+++ b/server/routes/getInvites.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const getInvites = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/getUploadSignature.ts
+++ b/server/routes/getUploadSignature.ts
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk';
 import uuidv4 from 'uuid/v4';
 
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 AWS.config.update({

--- a/server/routes/logout.ts
+++ b/server/routes/logout.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const logout = async (models, req: Request, res: Response) => {

--- a/server/routes/markNotificationsRead.ts
+++ b/server/routes/markNotificationsRead.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/refreshChainObjects.ts
+++ b/server/routes/refreshChainObjects.ts
@@ -1,4 +1,4 @@
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, fetcher, req, res, next) => {

--- a/server/routes/registerWaitingList.ts
+++ b/server/routes/registerWaitingList.ts
@@ -4,7 +4,7 @@ import { Request, Response, NextFunction } from 'express';
 import { SERVER_URL, SENDGRID_API_KEY, LOGIN_RATE_LIMIT_MINS, LOGIN_RATE_LIMIT_TRIES } from '../config';
 
 sgMail.setApiKey(SENDGRID_API_KEY);
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const registerWaitingList = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/selectAddress.ts
+++ b/server/routes/selectAddress.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const selectAddress = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/selectNode.ts
+++ b/server/routes/selectNode.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const selectNode = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/sendFeedback.ts
+++ b/server/routes/sendFeedback.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import request from 'superagent';
 import { SLACK_FEEDBACK_WEBHOOK } from '../config';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const sendFeedback = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/startEmailLogin.ts
+++ b/server/routes/startEmailLogin.ts
@@ -4,7 +4,7 @@ import { Request, Response, NextFunction } from 'express';
 import { SERVER_URL, SENDGRID_API_KEY, LOGIN_RATE_LIMIT_MINS, LOGIN_RATE_LIMIT_TRIES } from '../config';
 
 sgMail.setApiKey(SENDGRID_API_KEY);
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const startEmailLogin = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/status.ts
+++ b/server/routes/status.ts
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 import _ from 'lodash';
 import { Request, Response, NextFunction } from 'express';
 import { JWT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } from '../config';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 import '../types';
 const log = factory.getLogger(formatFilename(__filename));
 

--- a/server/routes/supernova_lockdrop_atom_locks.ts
+++ b/server/routes/supernova_lockdrop_atom_locks.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const supernovaLockdropATOMLocks = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/supernova_lockdrop_btc_locks.ts
+++ b/server/routes/supernova_lockdrop_btc_locks.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const supernovaLockdropBTCLocks = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/supernova_lockdrop_eth_locks.ts
+++ b/server/routes/supernova_lockdrop_eth_locks.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const supernovaLockdropETHLocks = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/updateChain.ts
+++ b/server/routes/updateChain.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const updateChain = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/updateCommunity.ts
+++ b/server/routes/updateCommunity.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const updateCommunity = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/updateProfile.ts
+++ b/server/routes/updateProfile.ts
@@ -5,7 +5,7 @@ import {
   PROFILE_NAME_MAX_CHARS,
   PROFILE_NAME_MIN_CHARS
 } from '../../shared/types';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const updateProfile = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/upgradeMember.ts
+++ b/server/routes/upgradeMember.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const upgradeMember = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/verifyAddress.ts
+++ b/server/routes/verifyAddress.ts
@@ -1,6 +1,6 @@
 import sgMail from '@sendgrid/mail';
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const verifyAddress = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewChainObjectQueries.ts
+++ b/server/routes/viewChainObjectQueries.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const viewChainObjectQueries = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewChainObjects.ts
+++ b/server/routes/viewChainObjects.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const viewChainObjects = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewComments.ts
+++ b/server/routes/viewComments.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const viewComments = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewCount.ts
+++ b/server/routes/viewCount.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import ViewCountCache from '../util/viewCountCache';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const viewCount = async (models, cache: ViewCountCache, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewNotifications.ts
+++ b/server/routes/viewNotifications.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 const Op = Sequelize.Op;
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewReactions.ts
+++ b/server/routes/viewReactions.ts
@@ -1,7 +1,7 @@
 /* eslint-disable dot-notation */
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const viewReactions = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/viewSubscriptions.ts
+++ b/server/routes/viewSubscriptions.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/webhooks/createWebhook.ts
+++ b/server/routes/webhooks/createWebhook.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../../util/lookupCommunityIsVisibleToUser';
 import Errors from './errors';
-import { factory, formatFilename } from '../../util/logging';
+import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const createWebhook = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/webhooks/deleteWebhook.ts
+++ b/server/routes/webhooks/deleteWebhook.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../../util/lookupCommunityIsVisibleToUser';
 import Errors from './errors';
-import { factory, formatFilename } from '../../util/logging';
+import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const deleteWebhook = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/webhooks/getWebhooks.ts
+++ b/server/routes/webhooks/getWebhooks.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../../util/lookupCommunityIsVisibleToUser';
 import Errors from './errors';
-import { factory, formatFilename } from '../../util/logging';
+import { factory, formatFilename } from '../../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const getWebhooks = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/writeUserSetting.ts
+++ b/server/routes/writeUserSetting.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const writeUserSetting = async (models, req: Request, res: Response, next: NextFunction) => {

--- a/server/scripts/resetServer.ts
+++ b/server/scripts/resetServer.ts
@@ -5,7 +5,7 @@ import addChainObjectQueries from './addChainObjectQueries';
 import app from '../../server';
 import { SubstrateEventKinds } from '../../shared/events/edgeware/types';
 import { EventSupportingChains } from '../../shared/events/interfaces';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const nodes = [

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -32,11 +32,6 @@ const discoverReconnectRange = async (models, chain: string): Promise<IDisconnec
 };
 
 const setupChainEventListeners = async (models, wss: WebSocket.Server, skipCatchup = false, migrate = false) => {
-  // XXX: remove this once no longer testing client-side entity fetching
-  log.error('skipping chain event listening');
-  return;
-
-  /* eslint-disable no-unreachable */
   log.info('Fetching node urls...');
   const nodes = await models.ChainNode.findAll();
   log.info('Setting up event listeners...');

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -6,7 +6,7 @@ import EdgewareEntityArchivalHandler from '../eventHandlers/edgeware/entityArchi
 import subscribeEdgewareEvents from '../../shared/events/edgeware/index';
 import { IDisconnectedRange, EventSupportingChains, IEventHandler } from '../../shared/events/interfaces';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const discoverReconnectRange = async (models, chain: string): Promise<IDisconnectedRange> => {
@@ -32,6 +32,11 @@ const discoverReconnectRange = async (models, chain: string): Promise<IDisconnec
 };
 
 const setupChainEventListeners = async (models, wss: WebSocket.Server, skipCatchup = false, migrate = false) => {
+  // XXX: remove this once no longer testing client-side entity fetching
+  log.error('skipping chain event listening');
+  return;
+
+  /* eslint-disable no-unreachable */
   log.info('Fetching node urls...');
   const nodes = await models.ChainNode.findAll();
   log.info('Setting up event listeners...');

--- a/server/scripts/setupErrorHandlers.ts
+++ b/server/scripts/setupErrorHandlers.ts
@@ -1,4 +1,4 @@
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const setupErrorHandlers = (app, rollbar) => {

--- a/server/scripts/setupServer.ts
+++ b/server/scripts/setupServer.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import { Express } from 'express-serve-static-core';
 import { DEFAULT_PORT } from '../config';
 import setupWebsocketServer from '../socket';
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const setupServer = (app: Express, wss: WebSocket.Server, sessionParser: express.RequestHandler) => {

--- a/server/socket/index.ts
+++ b/server/socket/index.ts
@@ -6,7 +6,7 @@ import * as net from 'net';
 import { WebsocketEventType, WebsocketMessageType, IWebsocketsPayload } from '../../shared/types';
 import { JWT_SECRET } from '../config';
 
-import { factory, formatFilename } from '../util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 const ALIVE_TIMEOUT = 30 * 1000; // heartbeats are 15 seconds

--- a/shared/events/edgeware/filters/enricher.ts
+++ b/shared/events/edgeware/filters/enricher.ts
@@ -377,21 +377,12 @@ export default async function (
       case SubstrateEventKind.CollectiveApproved:
       case SubstrateEventKind.CollectiveDisapproved: {
         const [ hash ] = event.data as unknown as [ Hash ] & Codec;
-        const infoOpt = await api.query[event.section].voting<Option<Votes>>(hash);
-        if (!infoOpt.isSome) {
-          throw new Error('could not fetch info for collective proposal');
-        }
-        const { index, threshold, ayes, nays } = infoOpt.unwrap();
         return {
           data: {
             kind,
             collectiveName: event.section === 'council' || event.section === 'technicalCommittee'
               ? event.section : undefined,
             proposalHash: hash.toString(),
-            proposalIndex: +index,
-            threshold: +threshold,
-            ayes: ayes.map((v) => v.toString()),
-            nays: nays.map((v) => v.toString()),
           }
         };
       }

--- a/shared/events/edgeware/filters/enricher.ts
+++ b/shared/events/edgeware/filters/enricher.ts
@@ -374,6 +374,20 @@ export default async function (
           }
         };
       }
+      case SubstrateEventKind.CollectiveVoted: {
+        const [ voter, hash, vote ] = event.data as unknown as [ AccountId, Hash, bool ] & Codec;
+        return {
+          excludeAddresses: [ voter.toString() ],
+          data: {
+            kind,
+            collectiveName: event.section === 'council' || event.section === 'technicalCommittee'
+              ? event.section : undefined,
+            proposalHash: hash.toString(),
+            voter: voter.toString(),
+            vote: vote.isTrue,
+          }
+        };
+      }
       case SubstrateEventKind.CollectiveApproved:
       case SubstrateEventKind.CollectiveDisapproved: {
         const [ hash ] = event.data as unknown as [ Hash ] & Codec;

--- a/shared/events/edgeware/filters/labeler.ts
+++ b/shared/events/edgeware/filters/labeler.ts
@@ -304,6 +304,16 @@ const labelEdgewareEvent: LabelerFilter = (
         linkUrl: chainId ? `/${chainId}/proposal/councilmotion/${proposalHash}` : null,
       };
     }
+    case SubstrateEventKind.CollectiveVoted: {
+      const { vote, proposalHash, collectiveName } = data;
+      const collective = collectiveName && collectiveName === 'technicalCommittee'
+        ? 'Technical Committee' : 'Council';
+      return {
+        heading: `Member Voted on ${collective} Proposal`,
+        label: `A council member has voted ${vote ? 'Yes' : 'No'} on a collective proposal.`,
+        linkUrl: chainId ? `/${chainId}/proposal/councilmotion/${proposalHash}` : null,
+      };
+    }
     case SubstrateEventKind.CollectiveApproved: {
       const { proposalHash, collectiveName } = data;
       const collective = collectiveName && collectiveName === 'technicalCommittee'

--- a/shared/events/edgeware/filters/labeler.ts
+++ b/shared/events/edgeware/filters/labeler.ts
@@ -305,22 +305,22 @@ const labelEdgewareEvent: LabelerFilter = (
       };
     }
     case SubstrateEventKind.CollectiveApproved: {
-      const { proposalHash, proposalIndex, ayes, nays, collectiveName } = data;
+      const { proposalHash, collectiveName } = data;
       const collective = collectiveName && collectiveName === 'technicalCommittee'
         ? 'Technical Committee' : 'Council';
       return {
         heading: `${collective} Proposal Approved`,
-        label: `${collective} proposal ${proposalIndex} was approved by vote ${ayes.length}-${nays.length}.`,
+        label: `A ${collective} proposal was approved.`,
         linkUrl: chainId ? `/${chainId}/proposal/councilmotion/${proposalHash}` : null,
       };
     }
     case SubstrateEventKind.CollectiveDisapproved: {
-      const { proposalIndex, ayes, nays, collectiveName, proposalHash } = data;
+      const { collectiveName, proposalHash } = data;
       const collective = collectiveName && collectiveName === 'technicalCommittee'
         ? 'Technical Committee' : 'Council';
       return {
         heading: `${collective} Proposal Disapproved`,
-        label: `${collective} proposal ${proposalIndex} was disapproved by vote ${ayes.length}-${nays.length}.`,
+        label: `A ${collective} proposal was disapproved.`,
         linkUrl: chainId ? `/${chainId}/proposal/councilmotion/${proposalHash}` : null,
       };
     }

--- a/shared/events/edgeware/filters/titler.ts
+++ b/shared/events/edgeware/filters/titler.ts
@@ -187,6 +187,12 @@ const titlerFunc: TitlerFilter = (kind: SubstrateEventKind): IEventTitle => {
         description: 'A new collective proposal is introduced.',
       };
     }
+    case SubstrateEventKind.CollectiveVoted: {
+      return {
+        title: 'Collective Proposal Vote',
+        description: 'A collective proposal receives a vote.',
+      };
+    }
     case SubstrateEventKind.CollectiveApproved: {
       return {
         title: 'Collective Proposal Approved',

--- a/shared/events/edgeware/filters/type_parser.ts
+++ b/shared/events/edgeware/filters/type_parser.ts
@@ -1,4 +1,3 @@
-import { Event, Extrinsic } from '@polkadot/types/interfaces';
 import { SubstrateEventKind } from '../types';
 
 /**
@@ -62,6 +61,7 @@ export default function (
     case 'technicalCollective':
       switch (method) {
         case 'Proposed': return SubstrateEventKind.CollectiveProposed;
+        case 'Voted': return SubstrateEventKind.CollectiveVoted;
         case 'Approved': return SubstrateEventKind.CollectiveApproved;
         case 'Disapproved': return SubstrateEventKind.CollectiveDisapproved;
         case 'Executed': return SubstrateEventKind.CollectiveExecuted;

--- a/shared/events/edgeware/index.ts
+++ b/shared/events/edgeware/index.ts
@@ -10,7 +10,7 @@ import { SubstrateBlock } from './types';
 import { IEventHandler, IBlockSubscriber, IDisconnectedRange, CWEvent } from '../interfaces';
 import migrate from './migration';
 
-import { factory, formatFilename } from '../../../server/util/logging';
+import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 /**

--- a/shared/events/edgeware/index.ts
+++ b/shared/events/edgeware/index.ts
@@ -65,9 +65,11 @@ export default async function (
   performMigration?: boolean,
 ): Promise<IBlockSubscriber<any, SubstrateBlock>> {
   const provider = new WsProvider(url);
+  let unsubscribe: () => void;
   await new Promise((resolve) => {
-    provider.on('connected', () => resolve());
+    unsubscribe = provider.on('connected', () => resolve());
   });
+  if (unsubscribe) unsubscribe();
 
   const api = await createApi(provider, chain.startsWith('edgeware')).isReady;
 

--- a/shared/events/edgeware/index.ts
+++ b/shared/events/edgeware/index.ts
@@ -8,7 +8,7 @@ import Poller from './poller';
 import Processor from './processor';
 import { SubstrateBlock } from './types';
 import { IEventHandler, IBlockSubscriber, IDisconnectedRange, CWEvent } from '../interfaces';
-import migrate from './migration';
+import fetchFromStorage from './storageFetcher';
 
 import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
@@ -105,7 +105,7 @@ export default async function (
   if (performMigration) {
     const version = await api.rpc.state.getRuntimeVersion();
     log.info(`Starting event migration for ${version.specName}:${version.specVersion} at ${url}.`);
-    const events = await migrate(api);
+    const events = await fetchFromStorage(api);
     await Promise.all(events.map((event) => handleEventFn(event)));
     return;
   }

--- a/shared/events/edgeware/migration.ts
+++ b/shared/events/edgeware/migration.ts
@@ -27,7 +27,7 @@ import {
   ISubstrateSignalingVotingCompleted,
 } from './types';
 
-import { factory, formatFilename } from '../../../server/util/logging';
+import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 async function fetchDemocracyProposals(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {

--- a/shared/events/edgeware/poller.ts
+++ b/shared/events/edgeware/poller.ts
@@ -7,7 +7,7 @@ import { Hash } from '@polkadot/types/interfaces';
 import { IBlockPoller, IDisconnectedRange } from '../interfaces';
 import { SubstrateBlock } from './types';
 
-import { factory, formatFilename } from '../../../server/util/logging';
+import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IBlockPoller<ApiPromise, SubstrateBlock> {

--- a/shared/events/edgeware/processor.ts
+++ b/shared/events/edgeware/processor.ts
@@ -10,7 +10,7 @@ import { SubstrateBlock, isEvent } from './types';
 import parseEventType from './filters/type_parser';
 import enrichEvent from './filters/enricher';
 
-import { factory, formatFilename } from '../../../server/util/logging';
+import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IBlockProcessor<ApiPromise, SubstrateBlock> {

--- a/shared/events/edgeware/storageFetcher.ts
+++ b/shared/events/edgeware/storageFetcher.ts
@@ -31,7 +31,7 @@ import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 async function fetchDemocracyProposals(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {
-  log.info('Migrating democracy proposals...');
+  log.info('Fetching democracy proposals...');
   const publicProps = await api.query.democracy.publicProps();
   const deposits: Array<Option<[BalanceOf, Vec<AccountId>] & Codec>> = await api.queryMulti(
     publicProps.map(([ idx ]) => [ api.query.democracy.depositOf, idx ])
@@ -54,7 +54,7 @@ async function fetchDemocracyProposals(api: ApiPromise, blockNumber: number): Pr
 }
 
 async function fetchDemocracyReferenda(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {
-  log.info('Migrating democracy referenda...');
+  log.info('Fetching democracy referenda...');
   const activeReferenda = await api.derive.democracy.referendumsActive();
   const startEvents = activeReferenda.map((r) => {
     return {
@@ -92,7 +92,7 @@ async function fetchDemocracyReferenda(api: ApiPromise, blockNumber: number): Pr
 
 // must pass proposal hashes found in prior events
 async function fetchDemocracyPreimages(api: ApiPromise, hashes: string[]): Promise<CWEvent[]> {
-  log.info('Migrating preimages...');
+  log.info('Fetching preimages...');
   const hashCodecs = hashes.map((hash) => api.createType('Hash', hash));
   const preimages = await api.derive.democracy.preimages(hashCodecs);
   const notedEvents: Array<[ number, ISubstratePreimageNoted ]> = _.zip(hashes, preimages)
@@ -117,7 +117,7 @@ async function fetchDemocracyPreimages(api: ApiPromise, hashes: string[]): Promi
 }
 
 async function fetchTreasuryProposals(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {
-  log.info('Migrating treasury proposals...');
+  log.info('Fetching treasury proposals...');
   const proposals = await api.derive.treasury.proposals();
   const proposedEvents = proposals.proposals.map((p) => {
     return {
@@ -134,7 +134,7 @@ async function fetchTreasuryProposals(api: ApiPromise, blockNumber: number): Pro
 }
 
 async function fetchCollectiveProposals(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {
-  log.info('Migrating collective proposals...');
+  log.info('Fetching collective proposals...');
   const councilProposals = await api.derive.council.proposals();
   let technicalCommitteeProposals = [];
   if (api.query.technicalCommittee) {
@@ -168,7 +168,7 @@ async function fetchCollectiveProposals(api: ApiPromise, blockNumber: number): P
 }
 
 async function fetchSignalingProposals(api: ApiPromise, blockNumber: number): Promise<CWEvent[]> {
-  log.info('Migrating signaling proposals...');
+  log.info('Fetching signaling proposals...');
   if (!api.query.voting || !api.query.signaling) {
     log.info('Found no signaling proposals (wrong chain)!');
     return [];
@@ -280,7 +280,7 @@ export default async function (
   /** signaling proposals */
   const signalingProposalEvents = await fetchSignalingProposals(api, blockNumber);
 
-  log.info('Migration complete.');
+  log.info('Fetch complete.');
   return [
     ...democracyProposalEvents,
     ...democracyReferendaEvents,

--- a/shared/events/edgeware/subscriber.ts
+++ b/shared/events/edgeware/subscriber.ts
@@ -7,7 +7,7 @@ import { Header, RuntimeVersion, Extrinsic } from '@polkadot/types/interfaces';
 import { IBlockSubscriber } from '../interfaces';
 import { SubstrateBlock } from './types';
 
-import { factory, formatFilename } from '../../../server/util/logging';
+import { factory, formatFilename } from '../../logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 export default class extends IBlockSubscriber<ApiPromise, SubstrateBlock> {

--- a/shared/events/edgeware/types.ts
+++ b/shared/events/edgeware/types.ts
@@ -74,6 +74,7 @@ export enum SubstrateEventKind {
   ElectionMemberRenounced = 'election-member-renounced',
 
   CollectiveProposed = 'collective-proposed',
+  CollectiveVoted = 'collective-voted',
   CollectiveApproved = 'collective-approved',
   CollectiveDisapproved = 'collective-disapproved',
   CollectiveExecuted = 'collective-executed',
@@ -289,6 +290,14 @@ export interface ISubstrateCollectiveProposed extends ISubstrateEvent {
   };
 }
 
+export interface ISubstrateCollectiveVoted extends ISubstrateEvent {
+  kind: SubstrateEventKind.CollectiveVoted;
+  collectiveName?: 'council' | 'technicalCommittee';
+  proposalHash: string;
+  voter: SubstrateAccountId;
+  vote: boolean;
+}
+
 export interface ISubstrateCollectiveApproved extends ISubstrateEvent {
   kind: SubstrateEventKind.CollectiveApproved;
   collectiveName?: 'council' | 'technicalCommittee';
@@ -392,6 +401,7 @@ export type ISubstrateEventData =
   | ISubstrateElectionMemberKicked
   | ISubstrateElectionMemberRenounced
   | ISubstrateCollectiveProposed
+  | ISubstrateCollectiveVoted
   | ISubstrateCollectiveApproved
   | ISubstrateCollectiveDisapproved
   | ISubstrateCollectiveExecuted
@@ -422,7 +432,7 @@ export type ISubstrateDemocracyPreimageEvents =
 export type ISubstrateTreasuryProposalEvents =
   ISubstrateTreasuryProposed | ISubstrateTreasuryRejected | ISubstrateTreasuryAwarded;
 export type ISubstrateCollectiveProposalEvents =
-  ISubstrateCollectiveProposed | ISubstrateCollectiveApproved
+  ISubstrateCollectiveProposed | ISubstrateCollectiveVoted | ISubstrateCollectiveApproved
   | ISubstrateCollectiveDisapproved | ISubstrateCollectiveExecuted;
 export type ISubstrateSignalingProposalEvents =
   ISubstrateSignalingNewProposal | ISubstrateSignalingCommitStarted
@@ -485,6 +495,7 @@ export function eventToEntity(event: SubstrateEventKind): SubstrateEntityKind {
     }
 
     case SubstrateEventKind.CollectiveProposed:
+    case SubstrateEventKind.CollectiveVoted:
     case SubstrateEventKind.CollectiveApproved:
     case SubstrateEventKind.CollectiveDisapproved:
     case SubstrateEventKind.CollectiveExecuted: {

--- a/shared/events/edgeware/types.ts
+++ b/shared/events/edgeware/types.ts
@@ -293,20 +293,12 @@ export interface ISubstrateCollectiveApproved extends ISubstrateEvent {
   kind: SubstrateEventKind.CollectiveApproved;
   collectiveName?: 'council' | 'technicalCommittee';
   proposalHash: string;
-  proposalIndex: number;
-  threshold: number;
-  ayes: SubstrateAccountId[];
-  nays: SubstrateAccountId[];
 }
 
 export interface ISubstrateCollectiveDisapproved extends ISubstrateEvent {
   kind: SubstrateEventKind.CollectiveDisapproved;
   collectiveName?: 'council' | 'technicalCommittee';
   proposalHash: string;
-  proposalIndex: number;
-  threshold: number;
-  ayes: SubstrateAccountId[];
-  nays: SubstrateAccountId[];
 }
 
 export interface ISubstrateCollectiveExecuted extends ISubstrateEvent {

--- a/shared/events/edgeware/types.ts
+++ b/shared/events/edgeware/types.ts
@@ -436,6 +436,33 @@ export type ISubstrateSignalingProposalEvents =
   ISubstrateSignalingNewProposal | ISubstrateSignalingCommitStarted
   | ISubstrateSignalingVotingStarted | ISubstrateSignalingVotingCompleted;
 
+
+export function entityToFieldName(entity: SubstrateEntityKind): string | null {
+  switch (entity) {
+    case SubstrateEntityKind.DemocracyProposal: {
+      return 'proposalIndex';
+    }
+    case SubstrateEntityKind.DemocracyReferendum: {
+      return 'referendumIndex';
+    }
+    case SubstrateEntityKind.DemocracyPreimage: {
+      return 'proposalHash';
+    }
+    case SubstrateEntityKind.TreasuryProposal: {
+      return 'proposalIndex';
+    }
+    case SubstrateEntityKind.CollectiveProposal: {
+      return 'proposalHash';
+    }
+    case SubstrateEntityKind.SignalingProposal: {
+      return 'proposalHash';
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
 export function eventToEntity(event: SubstrateEventKind): SubstrateEntityKind {
   switch (event) {
     case SubstrateEventKind.DemocracyProposed:

--- a/shared/logging.ts
+++ b/shared/logging.ts
@@ -27,5 +27,5 @@ const factoryControl = control.getLoggerFactoryControl(0);
 
 // Change the loglevel for all LogGroups for this factory to Debug
 // (so all existing/new loggers from this factory will log to Debug)
-const DEV = process.env.NODE_ENV !== 'production';
-factoryControl.change({ group: 'all', logLevel: DEV ? 'Debug' : 'Info' } as LogGroupControlSettings);
+const logLevel = process.env.NODE_ENV !== 'production' ? 'Debug' : 'Info';
+factoryControl.change({ group: 'all', logLevel } as LogGroupControlSettings);

--- a/test/unit/events/edgeware/enricher.spec.ts
+++ b/test/unit/events/edgeware/enricher.spec.ts
@@ -552,10 +552,6 @@ describe('Edgeware Event Enricher Filter Tests', () => {
         kind,
         collectiveName: 'council',
         proposalHash: 'hash',
-        proposalIndex: 1,
-        threshold: 3,
-        ayes: [ 'alice', 'bob' ],
-        nays: [ 'charlie', 'dave' ],
       }
     });
   });
@@ -569,10 +565,6 @@ describe('Edgeware Event Enricher Filter Tests', () => {
         kind,
         collectiveName: 'council',
         proposalHash: 'hash',
-        proposalIndex: 1,
-        threshold: 3,
-        ayes: [ 'alice', 'bob' ],
-        nays: [ 'charlie', 'dave' ],
       }
     });
   });

--- a/test/unit/events/edgeware/enricher.spec.ts
+++ b/test/unit/events/edgeware/enricher.spec.ts
@@ -542,6 +542,22 @@ describe('Edgeware Event Enricher Filter Tests', () => {
       }
     });
   });
+  it('should enrich collective-voted event', async () => {
+    const kind = SubstrateEventKind.CollectiveVoted;
+    const event = constructEvent([ 'alice', 'hash', constructBool(true), '1', '0' ], 'council');
+    const result = await EdgewareEnricherFunc(api, blockNumber, kind, event);
+    assert.deepEqual(result, {
+      blockNumber,
+      excludeAddresses: [ 'alice' ],
+      data: {
+        kind,
+        collectiveName: 'council',
+        proposalHash: 'hash',
+        voter: 'alice',
+        vote: true,
+      }
+    });
+  });
   it('should enrich collective-approved event', async () => {
     const kind = SubstrateEventKind.CollectiveApproved;
     const event = constructEvent([ 'hash' ], 'council');

--- a/test/unit/events/edgeware/storageFetcher.spec.ts
+++ b/test/unit/events/edgeware/storageFetcher.spec.ts
@@ -18,7 +18,8 @@ import {
   ISubstrateCollectiveProposed,
   ISubstrateSignalingNewProposal,
   ISubstrateSignalingVotingStarted,
-  ISubstrateSignalingVotingCompleted
+  ISubstrateSignalingVotingCompleted,
+  ISubstrateCollectiveVoted
 } from '../../../../shared/events/edgeware/types';
 import fetch from '../../../../shared/events/edgeware/storageFetcher';
 
@@ -92,6 +93,8 @@ const api = constructFakeApi({
     votes: {
       index: '15',
       threshold: '4',
+      ayes: ['Alice'],
+      nays: ['Bob'],
     },
     hash: 'council-hash',
     proposal: {
@@ -266,6 +269,24 @@ describe('Edgeware Event Migration Tests', () => {
             args: [ 'proposal-arg-1', 'proposal-arg-2' ],
           }
         } as ISubstrateCollectiveProposed
+      },
+      { blockNumber,
+        data: {
+          kind: SubstrateEventKind.CollectiveVoted,
+          collectiveName: 'council',
+          proposalHash: 'council-hash',
+          voter: 'Alice',
+          vote: true,
+        } as ISubstrateCollectiveVoted
+      },
+      { blockNumber,
+        data: {
+          kind: SubstrateEventKind.CollectiveVoted,
+          collectiveName: 'council',
+          proposalHash: 'council-hash',
+          voter: 'Bob',
+          vote: false,
+        } as ISubstrateCollectiveVoted
       },
       { blockNumber,
         data: {

--- a/test/unit/events/edgeware/storageFetcher.spec.ts
+++ b/test/unit/events/edgeware/storageFetcher.spec.ts
@@ -20,7 +20,7 @@ import {
   ISubstrateSignalingVotingStarted,
   ISubstrateSignalingVotingCompleted
 } from '../../../../shared/events/edgeware/types';
-import migrate from '../../../../shared/events/edgeware/migration';
+import fetch from '../../../../shared/events/edgeware/storageFetcher';
 
 const { assert } = chai;
 
@@ -182,7 +182,7 @@ const api = constructFakeApi({
 describe('Edgeware Event Migration Tests', () => {
   /** staking events */
   it('should generate all events', async () => {
-    const events = await migrate(api);
+    const events = await fetch(api);
     assert.sameDeepMembers(events, [
       { blockNumber,
         data: {

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -4,7 +4,7 @@ import 'chai/register-should';
 import moment from 'moment';
 import wallet from 'ethereumjs-wallet';
 import { NotificationCategory } from 'models';
-import { factory, formatFilename } from '../../server/util/logging';
+import { factory, formatFilename } from '../../shared/logging';
 import app from '../../server-test';
 import models from '../../server/database';
 const ethUtil = require('ethereumjs-util');


### PR DESCRIPTION
## Description
This PR repurposes the `migration.ts` file, designed to populate the backend with extant proposals, to fetch the current set of ChainEntities on the client directly from the node.

It adds a set of client-facing code to handle the shared `CWEvents` that get emitted as a result, and also modifies the ChainEntity model on the client to support creation and querying without the database-only features, such as `id` and `created_at` and `updated_at`.

Note that majority of the file changes, mostly to server routes, are because I had to move the logger initialization into a shared folder in order to get it to run on the client.

## Motivation and Context
We decided we wanted the client to fetch more data through their connection to the node, vs from the server, so this PR lets them fetch their data from the node, but also supports archiving via server.

## How has this been tested?
Ran test cases, and tried out examples on an edgeware-local chain, but needs more thorough QA.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run tests