### PR TITLE
Refactor identity calls to use module with cache.

### DIFF
--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -11,7 +11,7 @@ import { ChainClass, IChainAdapter, ChainBase, ChainEntity, ChainEvent } from 'm
 import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import EdgewareSignaling from './signaling';
 import WebWalletController from '../../app/web_wallet';
-import SubstrateIdentities from '../substrate/identity';
+import SubstrateIdentities from '../substrate/identities';
 import { handleSubstrateEntityUpdate } from '../substrate/shared';
 
 

--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -21,9 +21,7 @@ import { AccountsStore } from 'stores';
 import { Codec } from '@polkadot/types/types';
 import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import BN from 'bn.js';
-import { constants } from 'ethers';
 import SubstrateChain from './shared';
-import { SubstrateIdentity } from './identity';
 
 function addressFromSeed(seed: string, chain: SubstrateChain): string {
   return `${(chain.keyring()).addFromUri(`\/\/${seed}`).address}`;
@@ -308,18 +306,6 @@ export class SubstrateAccount extends Account<SubstrateCoin> {
         .map(([ stash ]) => this._Accounts.get(stash))
       ),
     );
-  }
-
-  public get identity(): Observable<Registration> {
-    if (!this._Chain?.apiInitialized) return;
-    return this._Chain.query((api: ApiRx) => api.query.identity.identityOf(this.address))
-      .pipe(map((id) => {
-        if (id.isSome) {
-          return id.unwrap();
-        } else {
-          return null;
-        }
-      }));
   }
 
   private _Chain: SubstrateChain;

--- a/client/scripts/controllers/chain/substrate/identities.ts
+++ b/client/scripts/controllers/chain/substrate/identities.ts
@@ -1,0 +1,274 @@
+import { IApp } from 'state';
+import { StorageModule } from 'models';
+import { ProposalStore } from 'stores';
+import { SubstrateCoin } from 'adapters/chain/substrate/types';
+import {
+  Call,
+  Registration,
+  AccountId,
+  RegistrarInfo,
+  IdentityJudgement,
+  IdentityFields
+} from '@polkadot/types/interfaces';
+import { Codec } from '@polkadot/types/types';
+import { Vec, Option, Data } from '@polkadot/types';
+import { Unsubscribable, Observable, of } from 'rxjs';
+import { first, takeWhile, map } from 'rxjs/operators';
+import { ApiRx } from '@polkadot/api';
+import BN from 'bn.js';
+import SubstrateChain from './shared';
+import SubstrateAccounts, { SubstrateAccount } from './account';
+import SubstrateIdentity from './identity';
+
+class SubstrateIdentityStore extends ProposalStore<SubstrateIdentity> { }
+
+export type SuperCodec = [ AccountId, Data ] & Codec;
+export type IdentityInfoProps = {
+  display?: any;
+  legal?: any;
+  web?: any;
+  riot?: any;
+  email?: any;
+  pgpFingerprint?: any;
+  twitter?: any;
+  image?: any;
+  additional: any[];
+};
+
+class SubstrateIdentities implements StorageModule {
+  private _initialized: boolean = false;
+  public get initialized() { return this._initialized; }
+
+  private _store: SubstrateIdentityStore = new SubstrateIdentityStore();
+  public get store() { return this._store; }
+
+  private _Chain: SubstrateChain;
+  private _Accounts: SubstrateAccounts;
+
+  private _registrarSubscription: Unsubscribable;
+  private _registrars: Array<RegistrarInfo | null>; // with gaps
+  public get registrars() { return this._registrars; }
+
+  private _fieldDeposit: SubstrateCoin;
+  private _basicDeposit: SubstrateCoin;
+  private _subAcctDeposit: SubstrateCoin;
+  private _maxSubAccts: number;
+  private _maxAddlFields: number;
+  public get fieldDeposit() { return this._fieldDeposit; }
+  public get basicDeposit() { return this._basicDeposit; }
+  public get subAcctDeposit() { return this._subAcctDeposit; }
+  public get maxSubAccts() { return this._maxSubAccts; }
+  public get maxAddlFields() { return this._maxAddlFields; }
+
+  private _app: IApp;
+  public get app() { return this._app; }
+
+  constructor(app: IApp) {
+    this._app = app;
+  }
+
+  public deinit() {
+    if (this._registrarSubscription) {
+      this._registrarSubscription.unsubscribe();
+    }
+    this._initialized = false;
+    this.store.clear();
+  }
+
+  // given an account, fetch the corresponding identity (works on sub-accounts)
+  public get(who: SubstrateAccount): Observable<SubstrateIdentity> {
+    // check immediately if we have the id
+    const existingIdentity = this.store.getByIdentifier(who.address);
+    if (existingIdentity) {
+      return of(existingIdentity);
+    }
+
+    // NOTE: the block of code below is commented out, because we do not necessarily want to
+    //   resolve sub-addresses to their super-identities -- this is a decision requiring discussion.
+    // check for a super-identity (maybe they passed in a sub address)
+    let acctToFetch = who;
+    // const superId = await this._Chain.query(
+    //   (api: ApiRx) => api.query.identity.superOf<Option<SuperCodec>>(who.address).pipe(first())
+    // ).toPromise();
+    // if (superId.isSome) {
+    //   const superAcct = this._Accounts.get(superId.unwrap()[0].toString());
+    //   const existingSuperId = this.store.getByIdentifier(superAcct.address);
+    //   if (existingSuperId) {
+    //     return of(existingSuperId);
+    //   }
+    //   acctToFetch = superAcct;
+    // }
+
+    // check on chain for registration we haven't seen yet & wait for it to appear
+    // if we have a super address to fetch, grab that instead
+    return this._Chain.query(
+      (api: ApiRx) => api.query.identity.identityOf<Option<Registration>>(acctToFetch.address)
+    ).pipe(
+      takeWhile((id) => !id.isSome, true),
+      map((id) => id.isSome
+        ? new SubstrateIdentity(this._Chain, this._Accounts, this, acctToFetch, id.unwrap())
+        : null),
+    );
+  }
+
+  public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._Chain = ChainInfo;
+    this._Accounts = Accounts;
+    return new Promise((resolve) => {
+      this._Chain.api.pipe(first()).subscribe((api: ApiRx) => {
+        // init consts
+        // XXX: for now, these aren't exposed in the Rust code. Which means the module isn't
+        //   ready for use. Since the module isn't ready, the module is disabled on Substrate
+        //   and Edgeware.
+        //
+        // pub const BasicDeposit: Balance = 10 * DOLLARS;       // 258 bytes on-chain
+        // pub const FieldDeposit: Balance = 250 * CENTS;        // 66 bytes on-chain
+        // pub const SubAccountDeposit: Balance = 2 * DOLLARS;   // 53 bytes on-chain
+        // pub const MaxSubAccounts: u32 = 100;
+        // pub const MaxAdditionalFields: u32 = 100;
+
+        // this._basicDeposit = this._Chain.coins(api.consts.identity.basicDeposit as BalanceOf);
+        // this._fieldDeposit = this._Chain.coins(api.consts.identity.fieldDeposit as BalanceOf);
+        // this._subAcctDeposit = this._Chain.coins(api.consts.identity.subAccountDeposit as BalanceOf);
+        // this._maxSubAccts = +api.consts.identity.maxSubAccounts;
+        // this._maxAddlFields = +api.consts.identity.maxAdditionalFields;
+        if (!this._basicDeposit) this._basicDeposit = this._Chain.coins(10, true);
+        if (!this._fieldDeposit) this._fieldDeposit = this._Chain.coins(2.5, true);
+        if (!this._subAcctDeposit) this._subAcctDeposit = this._Chain.coins(2, true);
+        if (!this._maxSubAccts) this._maxSubAccts = 100;
+        if (!this._maxAddlFields) this._maxAddlFields = 100;
+
+        // kick off long-running subscription to registrars
+        this._registrarSubscription = this._Chain.query(
+          (apiRx: ApiRx) => apiRx.query.identity.registrars()
+        ).subscribe((rs: Vec<Option<RegistrarInfo>>) => {
+          this._registrars = rs.map((r) => r.unwrapOr(null));
+          if (!this._initialized) {
+            this._initialized = true;
+            resolve();
+          }
+        });
+      });
+    });
+  }
+
+  // TRANSACTIONS
+  // TODO: add helper for mashalling substrate Data fields
+  public async setIdentityTx(who: SubstrateAccount, data: IdentityInfoProps) {
+    const info = this._Chain.createType('IdentityInfo', data);
+    if (info.additional.length > this.maxAddlFields) {
+      throw new Error('too many additional fields');
+    }
+
+    // compute the basic required balance for the registration
+    let requiredBalance = this.basicDeposit.add(this.fieldDeposit.muln(info.additional.length));
+
+    // compare with preexisting deposit from old registration, if exists
+    const oldId = this.store.getByIdentifier(who.address);
+    if (oldId && oldId.deposit.lt(requiredBalance)) {
+      requiredBalance = requiredBalance.sub(oldId.deposit);
+    } else if (oldId && oldId.deposit.gte(requiredBalance)) {
+      requiredBalance = new BN(0);
+    }
+
+    // verify the account has sufficient funds based on above computation
+    const txFunc = (api: ApiRx) => api.tx.identity.setIdentity(info);
+    if (!(await this._Chain.canPayFee(who, txFunc, this._Chain.coins(requiredBalance)))) {
+      throw new Error('insufficient funds');
+    }
+    return this._Chain.createTXModalData(
+      who,
+      txFunc,
+      'setIdentity',
+      `${who.address} registers identity ${info.display.toString()}`
+    );
+  }
+
+  public setRegistrarFeeTx(who: SubstrateAccount, regIdx: number, fee: SubstrateCoin) {
+    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
+      throw new Error('invalid registrar');
+    }
+    if (this.registrars[regIdx].account.toString() !== who.address) {
+      throw new Error('invalid account');
+    }
+    return this._Chain.createTXModalData(
+      who,
+      (api: ApiRx) => api.tx.identity.setFee(regIdx, fee),
+      'setFee',
+      `registrar ${regIdx} updates fee to ${fee.format(true)}`,
+    );
+  }
+
+  public setRegistrarAccountTx(who: SubstrateAccount, regIdx: number, newAcct: SubstrateAccount) {
+    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
+      throw new Error('invalid registrar');
+    }
+    if (this.registrars[regIdx].account.toString() !== who.address) {
+      throw new Error('invalid account');
+    }
+    return this._Chain.createTXModalData(
+      who,
+      (api: ApiRx) => api.tx.identity.setAccountId(regIdx, newAcct.address),
+      'setAccountId',
+      `registrar ${regIdx} updates account to ${newAcct.address}`,
+    );
+  }
+
+  public setRegistrarFieldsTx(who: SubstrateAccount, regIdx: number, fields: IdentityFields) {
+    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
+      throw new Error('invalid registrar');
+    }
+    if (this.registrars[regIdx].account.toString() !== who.address) {
+      throw new Error('invalid account');
+    }
+    return this._Chain.createTXModalData(
+      who,
+      (api: ApiRx) => api.tx.identity.setFields(regIdx, fields),
+      'setFee',
+      `registrar ${regIdx} updates fields`,
+    );
+  }
+
+  public providejudgementTx(
+    who: SubstrateAccount,
+    regIdx: number,
+    target: SubstrateIdentity,
+    judgement: IdentityJudgement
+  ) {
+    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
+      throw new Error('invalid registrar');
+    }
+    if (this.registrars[regIdx].account.toString() !== who.address) {
+      throw new Error('invalid account');
+    }
+    if (!target.exists) {
+      throw new Error('target identity does not exist');
+    }
+    if (judgement.isFeePaid) {
+      throw new Error('invalid judgement');
+    }
+    return this._Chain.createTXModalData(
+      who,
+      (api: ApiRx) => api.tx.identity.provideJudgement(regIdx, target.account.address, judgement),
+      'providejudgement',
+      `registrar ${regIdx} provides judgement for identity ${target.username}`,
+    );
+  }
+
+  // requires RegistrarOrigin or Root!
+  public addRegistrarMethod(account: SubstrateAccount): Call {
+    const func = this._Chain.getTxMethod('identity', 'addRegistrar');
+    return func(account.address).method;
+  }
+
+  // requires ForceOrigin or Root!
+  public killIdentityMethod(target: SubstrateIdentity): Call {
+    if (!target.exists) {
+      throw new Error('target identity does not exist');
+    }
+    const func = this._Chain.getTxMethod('identity', 'killIdentity');
+    return func(target.account.address).method;
+  }
+}
+
+export default SubstrateIdentities;

--- a/client/scripts/controllers/chain/substrate/identity.ts
+++ b/client/scripts/controllers/chain/substrate/identity.ts
@@ -1,273 +1,20 @@
-import { IApp } from 'state';
-import { StorageModule, Identity } from 'models';
-import { ProposalStore } from 'stores';
+import { Identity } from 'models';
 import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import {
-  Call,
   Registration,
   RegistrationJudgement,
   BalanceOf,
   AccountId,
   IdentityInfo,
-  RegistrarInfo,
-  IdentityJudgement,
-  IdentityFields
 } from '@polkadot/types/interfaces';
 import { Codec } from '@polkadot/types/types';
-import { Vec, Option, Data } from '@polkadot/types';
+import { Vec, Option } from '@polkadot/types';
 import { Observable, Unsubscribable } from 'rxjs';
 import { map, takeWhile, first } from 'rxjs/operators';
 import { ApiRx } from '@polkadot/api';
-import BN from 'bn.js';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
-
-export class SubstrateIdentityStore extends ProposalStore<SubstrateIdentity> { }
-
-export type SuperCodec = [ AccountId, Data ] & Codec;
-export type IdentityInfoProps = {
-  display?: any;
-  legal?: any;
-  web?: any;
-  riot?: any;
-  email?: any;
-  pgpFingerprint?: any;
-  twitter?: any;
-  image?: any;
-  additional: any[];
-};
-
-class SubstrateIdentities implements StorageModule {
-  private _initialized: boolean = false;
-  public get initialized() { return this._initialized; }
-
-  private _store: SubstrateIdentityStore = new SubstrateIdentityStore();
-  public get store() { return this._store; }
-
-  private _Chain: SubstrateChain;
-  private _Accounts: SubstrateAccounts;
-
-  private _registrarSubscription: Unsubscribable;
-  private _registrars: Array<RegistrarInfo | null>; // with gaps
-  public get registrars() { return this._registrars; }
-
-  private _fieldDeposit: SubstrateCoin;
-  private _basicDeposit: SubstrateCoin;
-  private _subAcctDeposit: SubstrateCoin;
-  private _maxSubAccts: number;
-  private _maxAddlFields: number;
-  public get fieldDeposit() { return this._fieldDeposit; }
-  public get basicDeposit() { return this._basicDeposit; }
-  public get subAcctDeposit() { return this._subAcctDeposit; }
-  public get maxSubAccts() { return this._maxSubAccts; }
-  public get maxAddlFields() { return this._maxAddlFields; }
-
-  private _app: IApp;
-  public get app() { return this._app; }
-
-  constructor(app: IApp) {
-    this._app = app;
-  }
-
-  public deinit() {
-    if (this._registrarSubscription) {
-      this._registrarSubscription.unsubscribe();
-    }
-    this._initialized = false;
-    this.store.clear();
-  }
-
-  // given an account, fetch the corresponding identity (works on sub-accounts)
-  public async get(who: SubstrateAccount): Promise<SubstrateIdentity | null> {
-    // check immediately if we have the id
-    const existingIdentity = this.store.getByIdentifier(who.address);
-    if (existingIdentity) {
-      return existingIdentity;
-    }
-
-    // check for a super-identity (maybe they passed in a sub address)
-    let acctToFetch = who;
-    const superId = await this._Chain.query(
-      (api: ApiRx) => api.query.identity.superOf<Option<SuperCodec>>(who.address).pipe(first())
-    ).toPromise();
-    if (superId.isSome) {
-      const superAcct = this._Accounts.get(superId.unwrap()[0].toString());
-      const existingSuperId = this.store.getByIdentifier(superAcct.address);
-      if (existingSuperId) {
-        return existingSuperId;
-      }
-      acctToFetch = superAcct;
-    }
-
-    // check on chain for registration we haven't seen yet
-    // if we have a super address to fetch, grab that instead
-    const idData: Option<Registration> = await this._Chain.query(
-      (api: ApiRx) => api.query.identity.identityOf<Option<Registration>>(acctToFetch.address).pipe(first())
-    ).toPromise();
-    if (idData.isSome) {
-      return new SubstrateIdentity(this._Chain, this._Accounts, this, acctToFetch, idData.unwrap());
-    } else {
-      // we tried hard, but it's not found!
-      return null;
-    }
-  }
-
-  public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
-    this._Chain = ChainInfo;
-    this._Accounts = Accounts;
-    return new Promise((resolve) => {
-      this._Chain.api.pipe(first()).subscribe((api: ApiRx) => {
-        // init consts
-        // XXX: for now, these aren't exposed in the Rust code. Which means the module isn't
-        //   ready for use. Since the module isn't ready, the module is disabled on Substrate
-        //   and Edgeware.
-        //
-        // pub const BasicDeposit: Balance = 10 * DOLLARS;       // 258 bytes on-chain
-        // pub const FieldDeposit: Balance = 250 * CENTS;        // 66 bytes on-chain
-        // pub const SubAccountDeposit: Balance = 2 * DOLLARS;   // 53 bytes on-chain
-        // pub const MaxSubAccounts: u32 = 100;
-        // pub const MaxAdditionalFields: u32 = 100;
-
-        // this._basicDeposit = this._Chain.coins(api.consts.identity.basicDeposit as BalanceOf);
-        // this._fieldDeposit = this._Chain.coins(api.consts.identity.fieldDeposit as BalanceOf);
-        // this._subAcctDeposit = this._Chain.coins(api.consts.identity.subAccountDeposit as BalanceOf);
-        // this._maxSubAccts = +api.consts.identity.maxSubAccounts;
-        // this._maxAddlFields = +api.consts.identity.maxAdditionalFields;
-        if (!this._basicDeposit) this._basicDeposit = this._Chain.coins(10, true);
-        if (!this._fieldDeposit) this._fieldDeposit = this._Chain.coins(2.5, true);
-        if (!this._subAcctDeposit) this._subAcctDeposit = this._Chain.coins(2, true);
-        if (!this._maxSubAccts) this._maxSubAccts = 100;
-        if (!this._maxAddlFields) this._maxAddlFields = 100;
-
-        // kick off long-running subscription to registrars
-        this._registrarSubscription = this._Chain.query(
-          (apiRx: ApiRx) => apiRx.query.identity.registrars()
-        ).subscribe((rs: Vec<Option<RegistrarInfo>>) => {
-          this._registrars = rs.map((r) => r.unwrapOr(null));
-          if (!this._initialized) {
-            this._initialized = true;
-            resolve();
-          }
-        });
-      });
-    });
-  }
-
-  // TRANSACTIONS
-  // TODO: add helper for mashalling substrate Data fields
-  public async setIdentityTx(who: SubstrateAccount, data: IdentityInfoProps) {
-    const info = this._Chain.createType('IdentityInfo', data);
-    if (info.additional.length > this.maxAddlFields) {
-      throw new Error('too many additional fields');
-    }
-
-    // compute the basic required balance for the registration
-    let requiredBalance = this.basicDeposit.add(this.fieldDeposit.muln(info.additional.length));
-
-    // compare with preexisting deposit from old registration, if exists
-    const oldId = this.store.getByIdentifier(who.address);
-    if (oldId && oldId.deposit.lt(requiredBalance)) {
-      requiredBalance = requiredBalance.sub(oldId.deposit);
-    } else if (oldId && oldId.deposit.gte(requiredBalance)) {
-      requiredBalance = new BN(0);
-    }
-
-    // verify the account has sufficient funds based on above computation
-    const txFunc = (api: ApiRx) => api.tx.identity.setIdentity(info);
-    if (!(await this._Chain.canPayFee(who, txFunc, this._Chain.coins(requiredBalance)))) {
-      throw new Error('insufficient funds');
-    }
-    return this._Chain.createTXModalData(
-      who,
-      txFunc,
-      'setIdentity',
-      `${who.address} registers identity ${info.display.toString()}`
-    );
-  }
-
-  public setRegistrarFeeTx(who: SubstrateAccount, regIdx: number, fee: SubstrateCoin) {
-    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
-      throw new Error('invalid registrar');
-    }
-    if (this.registrars[regIdx].account.toString() !== who.address) {
-      throw new Error('invalid account');
-    }
-    return this._Chain.createTXModalData(
-      who,
-      (api: ApiRx) => api.tx.identity.setFee(regIdx, fee),
-      'setFee',
-      `registrar ${regIdx} updates fee to ${fee.format(true)}`,
-    );
-  }
-
-  public setRegistrarAccountTx(who: SubstrateAccount, regIdx: number, newAcct: SubstrateAccount) {
-    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
-      throw new Error('invalid registrar');
-    }
-    if (this.registrars[regIdx].account.toString() !== who.address) {
-      throw new Error('invalid account');
-    }
-    return this._Chain.createTXModalData(
-      who,
-      (api: ApiRx) => api.tx.identity.setAccountId(regIdx, newAcct.address),
-      'setAccountId',
-      `registrar ${regIdx} updates account to ${newAcct.address}`,
-    );
-  }
-
-  public setRegistrarFieldsTx(who: SubstrateAccount, regIdx: number, fields: IdentityFields) {
-    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
-      throw new Error('invalid registrar');
-    }
-    if (this.registrars[regIdx].account.toString() !== who.address) {
-      throw new Error('invalid account');
-    }
-    return this._Chain.createTXModalData(
-      who,
-      (api: ApiRx) => api.tx.identity.setFields(regIdx, fields),
-      'setFee',
-      `registrar ${regIdx} updates fields`,
-    );
-  }
-
-  public providejudgementTx(who: SubstrateAccount, regIdx: number, target: SubstrateIdentity, judgement: IdentityJudgement) {
-    if (!this.registrars[regIdx] || !this.registrars[regIdx].account) {
-      throw new Error('invalid registrar');
-    }
-    if (this.registrars[regIdx].account.toString() !== who.address) {
-      throw new Error('invalid account');
-    }
-    if (!target.exists) {
-      throw new Error('target identity does not exist');
-    }
-    if (judgement.isFeePaid) {
-      throw new Error('invalid judgement');
-    }
-    return this._Chain.createTXModalData(
-      who,
-      (api: ApiRx) => api.tx.identity.provideJudgement(regIdx, target.account.address, judgement),
-      'providejudgement',
-      `registrar ${regIdx} provides judgement for identity ${target.username}`,
-    );
-  }
-
-  // requires RegistrarOrigin or Root!
-  public addRegistrarMethod(account: SubstrateAccount): Call {
-    const func = this._Chain.getTxMethod('identity', 'addRegistrar');
-    return func(account.address).method;
-  }
-
-  // requires ForceOrigin or Root!
-  public killIdentityMethod(target: SubstrateIdentity): Call {
-    if (!target.exists) {
-      throw new Error('target identity does not exist');
-    }
-    const func = this._Chain.getTxMethod('identity', 'killIdentity');
-    return func(target.account.address).method;
-  }
-}
-
-export default SubstrateIdentities;
+import SubstrateIdentities, { SuperCodec } from './identities';
 
 export interface IIdentitySubs {
   subs: SubstrateAccount[];
@@ -276,7 +23,7 @@ export interface IIdentitySubs {
 
 type SubsCodec = [ BalanceOf, Vec<AccountId> ] & Codec;
 
-export class SubstrateIdentity extends Identity<SubstrateCoin> {
+export default class SubstrateIdentity extends Identity<SubstrateCoin> {
   // override identity prop
   public readonly account: SubstrateAccount;
 
@@ -297,14 +44,13 @@ export class SubstrateIdentity extends Identity<SubstrateCoin> {
   // all sub-accounts have names, but we don't currently fetch them, because
   // that requires a backward lookup for each. instead we expose a getter.
   public subs(): Observable<IIdentitySubs> {
-    return this._Chain.query((api: ApiRx) =>
-      api.query.identity.subsOf(this.account.address).pipe(
+    return this._Chain.query((api: ApiRx) => api.query.identity.subsOf(this.account.address)
+      .pipe(
         map((subResult: SubsCodec) => ({
           deposit: this._Chain.coins(subResult[0]),
           subs: subResult[1].map((v) => this._Accounts.get(v.toString())),
         }))
-      )
-    );
+      ));
   }
 
   private _subscription: Unsubscribable;
@@ -315,22 +61,22 @@ export class SubstrateIdentity extends Identity<SubstrateCoin> {
 
   // keeps track of changing registration info
   private _subscribe() {
-    this._subscription = this._Chain.query((api: ApiRx) =>
-      api.query.identity.identityOf(this.account.address).pipe(
+    this._subscription = this._Chain.query((api: ApiRx) => api.query.identity.identityOf(this.account.address)
+      .pipe(
         takeWhile((rOpt: Option<Registration>) => rOpt.isSome, true),
-      )
-    ).subscribe((rOpt: Option<Registration>) => {
-      if (rOpt.isSome) {
-        const { judgements, deposit, info } = rOpt.unwrap();
-        this._judgements = judgements;
-        this._deposit = this._Chain.coins(deposit);
-        this._info = info;
-      } else {
-        this._exists = false;
-        this._judgements = [];
-        this._deposit = this._Chain.coins(0);
-      }
-    });
+      ))
+      .subscribe((rOpt: Option<Registration>) => {
+        if (rOpt.isSome) {
+          const { judgements, deposit, info } = rOpt.unwrap();
+          this._judgements = judgements;
+          this._deposit = this._Chain.coins(deposit);
+          this._info = info;
+        } else {
+          this._exists = false;
+          this._judgements = [];
+          this._deposit = this._Chain.coins(0);
+        }
+      });
   }
 
   // unused -- subscription auto-terminated if account is killed
@@ -367,20 +113,19 @@ export class SubstrateIdentity extends Identity<SubstrateCoin> {
   }
 
   public subName(sub: SubstrateAccount): Observable<string> {
-    return this._Chain.query((api: ApiRx) =>
-      api.query.identity.superOf(sub.address).pipe(
+    return this._Chain.query((api: ApiRx) => api.query.identity.superOf(sub.address)
+      .pipe(
         map((dataOpt: Option<SuperCodec>) => {
           if (!dataOpt.isSome) {
-            throw { msg: 'provided account is not a sub' };
+            throw new Error('provided account is not a sub');
           }
           const [ superAcct, name ] = dataOpt.unwrap();
           if (superAcct.toString() !== this.account.address) {
-            throw { msg: 'provided account is not your sub' };
+            throw new Error('provided account is not your sub');
           }
           return name.toString();
         })
-      )
-    );
+      ));
   }
 
   // TRANSACTIONS

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -9,7 +9,7 @@ import { IChainAdapter, ChainBase, ChainClass, ChainEntity, ChainEvent } from 'm
 import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import WebWalletController from '../../app/web_wallet';
 import SubstratePhragmenElections from './phragmen_elections';
-import SubstrateIdentities from './identity';
+import SubstrateIdentities from './identities';
 
 class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   public chain: SubstrateChain;

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -14,6 +14,9 @@ import { SubstrateAccount } from 'controllers/chain/substrate/account';
 import { Registration } from '@polkadot/types/interfaces';
 import { Data } from '@polkadot/types/primitive';
 import { u8aToString } from '@polkadot/util';
+import Substrate from 'client/scripts/controllers/chain/substrate/main';
+import { from } from 'rxjs';
+import SubstrateIdentity from 'client/scripts/controllers/chain/substrate/identity';
 
 interface IAttrs {
   user: Account<any> | [string, string];
@@ -33,21 +36,23 @@ export interface ISubstrateIdentityAttrs {
 
 export interface ISubstrateIdentityState {
   dynamic: {
-    identity: Registration | null;
+    identity: SubstrateIdentity | null;
   },
 }
 
-const SubstrateIdentity = makeDynamicComponent<ISubstrateIdentityAttrs, ISubstrateIdentityState>({
+const SubstrateIdentityWidget = makeDynamicComponent<ISubstrateIdentityAttrs, ISubstrateIdentityState>({
   getObservables: (attrs) => ({
     groupKey: attrs.account.address,
-    identity: (attrs.account instanceof SubstrateAccount) ? attrs.account.identity : null,
+    identity: (attrs.account instanceof SubstrateAccount)
+      ? (app.chain as Substrate).identities.get(attrs.account)
+      : null,
   }),
   view: (vnode) => {
     const { profile, linkify, account } = vnode.attrs;
 
     // return polkadot identity if possible
     const displayNameHex = vnode.state.dynamic.identity?.info?.display;
-    const judgements = vnode.state.dynamic.identity?.judgements?.toArray() || [];
+    const judgements = vnode.state.dynamic.identity?.judgements || [];
     if (displayNameHex && judgements) {
       // Polkadot identity judgements. See:
       // https://github.com/polkadot-js/apps/blob/master/packages/react-components/src/AccountName.tsx#L126
@@ -120,9 +125,9 @@ const User : m.Component<IAttrs> = {
         showAvatar && m('.user-avatar', {
           style: `width: ${avatarSize}px; height: ${avatarSize}px;`,
         }, profile && profile.getAvatar(avatarSize)),
-        (account instanceof SubstrateAccount && account.identity)
+        (account instanceof SubstrateAccount && app.chain.loaded)
           // substrate name
-          ? m(SubstrateIdentity, { account, linkify, profile }) : [
+          ? m(SubstrateIdentityWidget, { account, linkify, profile }) : [
             // non-substrate name
             linkify
               ? link(`a.user-display-name${
@@ -145,8 +150,8 @@ const User : m.Component<IAttrs> = {
             : profile.getAvatar(32)
       ]),
       m('.user-name', [
-        (account instanceof SubstrateAccount && account.identity)
-          ? m(SubstrateIdentity, { account, linkify: true, profile })
+        (account instanceof SubstrateAccount && app.chain.loaded)
+          ? m(SubstrateIdentityWidget, { account, linkify: true, profile })
           : link(`a.user-display-name${
             (profile && profile.displayName !== 'Anonymous') ? '.username' : '.anonymous'}`,
           profile ? `/${profile.chain}/account/${profile.address}` : 'javascript:',

--- a/client/scripts/views/modals/edit_identity_modal.ts
+++ b/client/scripts/views/modals/edit_identity_modal.ts
@@ -4,18 +4,16 @@ import m from 'mithril';
 import $ from 'jquery';
 import app from 'state';
 
-import { createType } from '@polkadot/types/create';
 import { IdentityInfo } from '@polkadot/types/interfaces';
 import { Data } from '@polkadot/types/primitive';
 import { u8aToString } from '@polkadot/util';
 
 import CharacterLimitedTextInput from '../components/widgets/character_limited_text_input';
 import { createTXModal } from './tx_signing_modal';
-import { Account } from 'models';
 import { SubstrateAccount } from '../../controllers/chain/substrate/account';
 import AvatarUpload from '../components/avatar_upload';
 import Substrate from '../../controllers/chain/substrate/main';
-import { IdentityInfoProps } from '../../controllers/chain/substrate/identity';
+import { IdentityInfoProps } from '../../controllers/chain/substrate/identities';
 
 interface IAttrs {
   currentIdentity?: IdentityInfo;

--- a/client/scripts/views/pages/profile/profile_header.ts
+++ b/client/scripts/views/pages/profile/profile_header.ts
@@ -5,6 +5,9 @@ import app from 'state';
 import * as clipboard from 'clipboard-polyfill';
 import { Registration, IdentityInfo } from '@polkadot/types/interfaces';
 import { Account, ChainBase } from 'models';
+import { of } from 'rxjs';
+import Substrate from 'controllers/chain/substrate/main';
+import SubstrateIdentity from 'controllers/chain/substrate/identity';
 import { formatAddressShort, link } from '../../../helpers';
 import EditProfileModal from '../../modals/edit_profile_modal';
 import { SubstrateAccount } from '../../../controllers/chain/substrate/account';
@@ -34,7 +37,7 @@ export interface IProfileHeaderAttrs {
 
 export interface IProfileHeaderState {
   dynamic: {
-    identity: Registration | null;
+    identity: SubstrateIdentity | null;
   },
   copied: boolean;
 }
@@ -44,7 +47,9 @@ const ProfileHeader = makeDynamicComponent<IProfileHeaderAttrs, IProfileHeaderSt
     // if attrs.account loads later than the component, we need our group key to force an update
     // to the observed values
     groupKey: attrs.account.address,
-    identity: (attrs.account instanceof SubstrateAccount) ? attrs.account.identity : null,
+    identity: (attrs.account instanceof SubstrateAccount)
+      ? (app.chain as Substrate).identities.get(attrs.account)
+      : null,
   }),
   view: (vnode) => {
     const account: Account<any> = vnode.attrs.account;


### PR DESCRIPTION
## Description
Replaces the account.identity call with calls from the SubstrateIdentities module. Refactors that module by moving the SubstrateIdentity instance class to a new file, and by converting the get() function into an observable, so that we can have immediate (non-page-refresh) updates on new identity registrations.

## How has this been tested?
Ran through all identity flows on local chain, tested identity viewing on edgeware mainnet and kusama.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no