### PR TITLE
Fix app.comments.refreshAll

### DIFF
--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -1,6 +1,7 @@
 import { CommunityInfo, ICommunityAdapter } from 'models';
 
 import { Coin } from 'adapters/currency';
+import { CommentRefreshOption } from 'controllers/server/comments';
 import OffchainAccounts, { OffchainAccount } from './account';
 
 class Community extends ICommunityAdapter<Coin, OffchainAccount> {
@@ -16,7 +17,7 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
     console.log(`Starting ${this.meta.name}`);
     this.accounts = new OffchainAccounts(this.app);
     await this.app.threads.refreshAll(null, this.id, true);
-    await this.app.comments.refreshAll(null, this.id, true);
+    await this.app.comments.refreshAll(null, this.id, CommentRefreshOption.ResetAndLoadOffchainComments);
     await this.app.reactions.refreshAll(null, this.id, true);
     this._serverLoaded = true;
     this._loaded = true;

--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -186,10 +186,10 @@ class CommentsController {
         chain: chainId,
         community: communityId,
       };
-      if (CommentRefreshOption.ResetAndLoadOffchainComments) {
+      if (reset === CommentRefreshOption.ResetAndLoadOffchainComments) {
         args.offchain_threads_only = 1;
       }
-      if (CommentRefreshOption.LoadProposalComments) {
+      if (reset === CommentRefreshOption.LoadProposalComments) {
         args.proposals_only = 1;
       }
       const response = await $.get(`${app.serverUrl()}/bulkComments`, args);

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -3,6 +3,7 @@ import { ApiStatus, IApp } from 'state';
 import { Coin } from 'adapters/currency';
 import { WebsocketMessageType, IWebsocketsPayload } from 'types';
 
+import { CommentRefreshOption } from 'controllers/server/comments';
 import { IChainModule, IAccountsModule, IBlockInfo } from './interfaces';
 import { ChainBase, ChainClass } from './types';
 import { Account, NodeInfo, ChainEntity, ChainEvent } from '.';
@@ -19,7 +20,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
   get serverLoaded() { return this._serverLoaded; }
 
   protected async _postModuleLoad(listenEvents = false): Promise<void> {
-    await this.app.comments.refreshAll(this.id, null, true, false, true);
+    await this.app.comments.refreshAll(this.id, null, CommentRefreshOption.LoadProposalComments);
     // await this.app.reactions.refreshAll(this.id, null, false);
 
     // attach listener for entity update events
@@ -55,7 +56,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     loadIncompleteEntities = false,
   ): Promise<void> {
     await this.app.threads.refreshAll(this.id, null, true);
-    await this.app.comments.refreshAll(this.id, null, true, true);
+    await this.app.comments.refreshAll(this.id, null, CommentRefreshOption.ResetAndLoadOffchainComments);
     await this.app.reactions.refreshAll(this.id, null, true);
 
     // if we're loading entities from chain, only pull completed


### PR DESCRIPTION
## Description

When any chain's postLoad function was called, we were clearing the comment store and wiping all offchain comments.

This PR fixes that and introduces an enum to specify how the comment controller's refreshAll function is called, replacing the current argument system which has potential ambiguities/edge cases.

## Motivation and Context

Resolving critical bug.

## How has this been tested?

- Load Edgeware with a node that connects, and observe that correct comments are present on proposals and offchain threads
- Load a community, and observe that correct comments are present on proposals and offchain threads

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [X] no