### PR TITLE
Add PersistentStore type to store SubstrateIdentities in localStorage.

### DIFF
--- a/client/scripts/controllers/chain/cosmos/proposal.ts
+++ b/client/scripts/controllers/chain/cosmos/proposal.ts
@@ -341,8 +341,6 @@ export class CosmosProposal extends Proposal<
     this._totalDeposit = state.totalDeposit;
     if (state.completed) {
       super.complete(store);
-    } else {
-      store.update(this);
     }
   }
 }

--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -95,7 +95,9 @@ class NotificationsController {
   }
 
   public update(n: Notification) {
-    this._store.add(n);
+    if (!this._store.getById(n.id)) {
+      this._store.add(n);
+    }
   }
 
   public refresh() {

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -2,7 +2,7 @@ import moment from 'moment-twitter';
 import { ApiStatus, IApp } from 'state';
 import { Coin } from 'adapters/currency';
 import { WebsocketMessageType, IWebsocketsPayload } from 'types';
-
+import { clearLocalStorage } from 'stores/PersistentStore';
 import { IChainModule, IAccountsModule, IBlockInfo } from './interfaces';
 import { ChainBase, ChainClass } from './types';
 import { Account, NodeInfo, ChainEntity, ChainEvent } from '.';
@@ -54,6 +54,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     initChainModuleFn?: () => Promise<void>,
     loadIncompleteEntities = false,
   ): Promise<void> {
+    clearLocalStorage();
     await this.app.threads.refreshAll(this.id, null, true);
     await this.app.comments.refreshAll(this.id, null, true, true);
     await this.app.reactions.refreshAll(this.id, null, true);

--- a/client/scripts/models/Identity.ts
+++ b/client/scripts/models/Identity.ts
@@ -1,14 +1,14 @@
 import { Coin } from 'adapters/currency';
-import { IIdentifiable } from 'adapters/shared';
 import Account from './Account';
+import { IHasId } from '../stores';
 
-abstract class Identity<C extends Coin> implements IIdentifiable {
+abstract class Identity<C extends Coin> implements IHasId {
   public readonly account: Account<C>;
-  public readonly identifier: string;
-  public readonly username: string;
-  constructor(account: Account<C>, identifier: string, username: string) {
+  public readonly id: string;
+  public username: string;
+  constructor(account: Account<C>, identifier: string, username?: string) {
     this.account = account;
-    this.identifier = identifier;
+    this.id = identifier;
     this.username = username;
   }
 }

--- a/client/scripts/models/Proposal.ts
+++ b/client/scripts/models/Proposal.ts
@@ -68,7 +68,6 @@ abstract class Proposal<
       throw new Error('cannot update state once marked completed');
     }
     this._completed.next(true);
-    store.update(this);
     this._initialized.complete();
   }
 

--- a/client/scripts/models/mithril.ts
+++ b/client/scripts/models/mithril.ts
@@ -24,9 +24,9 @@ export interface IDynamicComponent<
 export const makeDynamicComponent = <
   Attrs = {}, State extends IDynamicVnodeStateLifecycle<Attrs, State> = { dynamic: {} }
 >(
-  component: IDynamicComponent<Attrs, State>,
-  debounceTime: number = 100,
-): IDynamicComponent<Attrs, State> => {
+    component: IDynamicComponent<Attrs, State>,
+    debounceTime: number = 100,
+  ): IDynamicComponent<Attrs, State> => {
   const oninit = component.oninit;
   const onremove = component.onremove;
   const onbeforeupdate = component.onbeforeupdate;
@@ -52,13 +52,14 @@ export const makeDynamicComponent = <
       ).pipe(
         // this throttle prevents the subscription from being hit too rapidly if several observables
         // update in quick succession
-        //throttle(() => interval(debounceTime)),
+        // throttle(() => interval(debounceTime)),
         takeUntil(vnode.state['_complete']),
       ).subscribe(([properties, results]) => {
         // swap out each dynamic value with new value from subscription
         for (let i = 0; i < properties.length; ++i) {
-          //console.log(`got update to ${properties[i]}: old = ${vnode.state.dynamic[name]}, new = ${results[i]}`);
-          vnode.state.dynamic[properties[i]] = results[i];
+          const name = properties[i];
+          // console.log(`got update to ${name}: old = ${vnode.state.dynamic[name]}, new = ${results[i]}`);
+          vnode.state.dynamic[name] = results[i];
         }
         // in theory, we could diff the old/new and only redraw if something changed, but
         // redraws are cheap enough that it's not a big deal

--- a/client/scripts/stores/IdStore.ts
+++ b/client/scripts/stores/IdStore.ts
@@ -16,6 +16,12 @@ class IdStore<T extends IHasId> extends Store<T> {
     return this;
   }
 
+  public update(n: T) {
+    super.update(n);
+    this._storeId[n.id.toString()] = n;
+    return this;
+  }
+
   public clear() {
     super.clear();
     this._storeId = {};

--- a/client/scripts/stores/PersistentStore.ts
+++ b/client/scripts/stores/PersistentStore.ts
@@ -1,0 +1,100 @@
+import IdStore from './IdStore';
+import { IHasId, ISerializable } from './interfaces';
+
+function getLocalStorageKey(prefix: string, chain: string, name: string, id: string) {
+  return `${prefix}_${chain}_${name}_${id}`;
+}
+
+interface IStorageItem<T> {
+  data: T;
+  timestamp: number;
+}
+
+// defaults will clear all items in every PersistentStore older than 10 minutes
+// this will NOT clear items from the internal stores of active PersistentStores, it ONLY
+//   removes items from localStorage -- for safety, only run this function before stores are queried.
+export function clearLocalStorage(prefix: string = 'cwstore', maxAge: number = 10 * 60 * 1000) {
+  if (!localStorage) {
+    throw new Error('cannot clear localStorage, not found!');
+  }
+
+  console.log(`Clearing localStorage of items with prefix "${prefix}", older than ${maxAge / (60 * 1000)} minutes...`);
+  const now = Date.now();
+  let nCleared = 0;
+  const nItems = localStorage.length;
+  for (let i = 0; i < nItems; ++i) {
+    const key = localStorage.key(i);
+    if (key.startsWith(prefix)) {
+      const storageItem: IStorageItem<any> = JSON.parse(localStorage.getItem(key));
+      if (now - storageItem.timestamp > maxAge) {
+        localStorage.removeItem(key);
+        nCleared++;
+      }
+    }
+  }
+  console.log(`Viewed ${nItems} items in localStorage and cleared ${nItems}.`);
+}
+
+// T is the object we are keeping in the store, SerializedT is a JSON.parse-able object
+// that can be used to reconstruct T via the constructorFunc.
+class PersistentStore<SerializedT, T extends IHasId & ISerializable<SerializedT>> extends IdStore<T> {
+  constructor(
+    public readonly chain: string,
+    public readonly name: string,
+    private readonly _constructorFunc: (s: SerializedT) => T,
+  ) {
+    super();
+    if (!localStorage) {
+      throw new Error('cannot create PersistentStore, localStorage not found.');
+    }
+  }
+
+  private _getKey(id: string): string {
+    return getLocalStorageKey('cwstore', this.chain, this.name, id);
+  }
+
+  public add(n: T) {
+    super.add(n);
+    const storageItem: IStorageItem<SerializedT> = { data: n.serialize(), timestamp: Date.now() };
+    localStorage.setItem(this._getKey(n.id.toString()), JSON.stringify(storageItem));
+    return this;
+  }
+
+  public remove(n: T) {
+    super.remove(n);
+    localStorage.removeItem(this._getKey(n.id.toString()));
+    return this;
+  }
+
+  // NOTE: does not clear localStorage entries
+  public clear() {
+    super.clear();
+    // if we wanted to clear localStorage entries too, we could run the following:
+    //   clearLocalStorage(`cwstore_${this.chain}_${this.name}`);
+    // but we should evaluate the efficiency of doing so
+  }
+
+  // NOTE: will fetch from localStorage if not found in memory!
+  public getById(id: number | string): T {
+    const item = super.getById(id);
+    if (item) return item;
+
+    // attempt to find and revive item from localStorage, if it exists
+    const localStorageItem = localStorage.getItem(this._getKey(id.toString()));
+    if (localStorageItem) {
+      const { data, timestamp }: IStorageItem<SerializedT> = JSON.parse(localStorageItem);
+      const revivedItem: T = this._constructorFunc(data);
+      this.add(revivedItem);
+      return revivedItem;
+    } else {
+      return null;
+    }
+  }
+
+  // NOTE: this will not return localStorage entries which we have not yet seen
+  public getAll(): T[] {
+    return this._store;
+  }
+}
+
+export default PersistentStore;

--- a/client/scripts/stores/Store.ts
+++ b/client/scripts/stores/Store.ts
@@ -1,17 +1,8 @@
-// TODO: we can make this even better if we have T implement a StoreKey mixin,
-import { BehaviorSubject, Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
-import { IStoreUpdate, UpdateType } from './interfaces';
-
-// then we can look up items by key, prevent duplicates from being inserted, etc
 abstract class Store<T> {
   protected _store: T[] = [];
 
-  private _subject: BehaviorSubject<IStoreUpdate<T> | null> = new BehaviorSubject(null);
-
   public add(item: T): Store<T> {
     this._store.push(item);
-    this._subject.next({ item, updateType: UpdateType.Add });
     return this;
   }
 
@@ -22,26 +13,15 @@ abstract class Store<T> {
       return this;
     }
     this._store.splice(index, 1);
-    this._subject.next({ item, updateType: UpdateType.Remove });
-    return this;
-  }
-
-  public update(item: T): Store<T> {
-    this._subject.next({ item, updateType: UpdateType.Update });
     return this;
   }
 
   public clear() {
     this._store = [];
-    this._subject = new BehaviorSubject(null);
   }
 
   public getAll(): T[] {
     return this._store;
-  }
-
-  public getObservable(): Observable<IStoreUpdate<T>> {
-    return this._subject.asObservable().pipe(filter((s) => s !== null));
   }
 }
 

--- a/client/scripts/stores/Store.ts
+++ b/client/scripts/stores/Store.ts
@@ -16,6 +16,16 @@ abstract class Store<T> {
     return this;
   }
 
+  public update(item: T): Store<T> {
+    const index = this._store.indexOf(item);
+    if (index === -1) {
+      console.error('Attempting to update an object that was not found in the store');
+      return this;
+    }
+    this._store[index] = item;
+    return this;
+  }
+
   public clear() {
     this._store = [];
   }

--- a/client/scripts/stores/index.ts
+++ b/client/scripts/stores/index.ts
@@ -11,5 +11,6 @@ export { default as ReactionsStore } from './ReactionsStore';
 export { default as Store } from './Store';
 export { default as TagsStore } from './TagsStore';
 export { default as ChainEntityStore } from './ChainEntityStore';
+export { default as PersistentStore } from './PersistentStore';
 
-export { UpdateType, IStoreUpdate, IHasId, IHasAddress } from './interfaces';
+export { UpdateType, IHasId, ISerializable, IHasAddress } from './interfaces';

--- a/client/scripts/stores/interfaces.ts
+++ b/client/scripts/stores/interfaces.ts
@@ -6,6 +6,7 @@ export enum UpdateType {
 
 export interface ISerializable<T> {
   serialize: () => T;
+  deserialize: (data: T) => void;
 }
 
 export interface IHasId {

--- a/client/scripts/stores/interfaces.ts
+++ b/client/scripts/stores/interfaces.ts
@@ -4,9 +4,8 @@ export enum UpdateType {
   Update,
 }
 
-export interface IStoreUpdate<T> {
-  item: T;
-  updateType: UpdateType;
+export interface ISerializable<T> {
+  serialize: () => T;
 }
 
 export interface IHasId {

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -45,10 +45,10 @@ const SubstrateIdentityWidget = makeDynamicComponent<ISubstrateIdentityAttrs, IS
   }),
   view: (vnode) => {
     const { profile, linkify, account } = vnode.attrs;
-
     // return polkadot identity if possible
-    const displayName = vnode.state.dynamic.identity?.username;
-    const quality = vnode.state.dynamic.identity?.quality;
+    const identity = vnode.state.dynamic.identity;
+    const displayName = identity?.exists ? identity.username : undefined;
+    const quality = identity?.exists ? identity.quality : undefined;
     if (displayName && quality) {
       const name = [ m(`span.identity-icon${
         quality === IdentityQuality.Good ? '.icon-ok-circled' : '.icon-minus-circled'

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -11,12 +11,8 @@ import Tooltip from 'views/components/tooltip';
 
 import { makeDynamicComponent } from 'models/mithril';
 import { SubstrateAccount } from 'controllers/chain/substrate/account';
-import { Registration } from '@polkadot/types/interfaces';
-import { Data } from '@polkadot/types/primitive';
-import { u8aToString } from '@polkadot/util';
-import Substrate from 'client/scripts/controllers/chain/substrate/main';
-import { from } from 'rxjs';
-import SubstrateIdentity from 'client/scripts/controllers/chain/substrate/identity';
+import Substrate from 'controllers/chain/substrate/main';
+import SubstrateIdentity, { IdentityQuality } from 'controllers/chain/substrate/identity';
 
 interface IAttrs {
   user: Account<any> | [string, string];
@@ -51,18 +47,14 @@ const SubstrateIdentityWidget = makeDynamicComponent<ISubstrateIdentityAttrs, IS
     const { profile, linkify, account } = vnode.attrs;
 
     // return polkadot identity if possible
-    const displayNameHex = vnode.state.dynamic.identity?.info?.display;
-    const judgements = vnode.state.dynamic.identity?.judgements || [];
-    if (displayNameHex && judgements) {
-      // Polkadot identity judgements. See:
-      // https://github.com/polkadot-js/apps/blob/master/packages/react-components/src/AccountName.tsx#L126
-      // https://github.com/polkadot-js/apps/blob/master/packages/react-components/src/AccountName.tsx#L182
-      const isGood = _.some(judgements, (j) => j[1].toString() === 'KnownGood' || j[1].toString() === 'Reasonable');
-      const isBad = _.some(judgements, (j) => j[1].toString() === 'Erroneous' || j[1].toString() === 'LowQuality');
-      const d2s = (d: Data) => u8aToString(d.toU8a()).replace(/[^\x20-\x7E]/g, '');
+    const displayName = vnode.state.dynamic.identity?.username;
+    const quality = vnode.state.dynamic.identity?.quality;
+    if (displayName && quality) {
       const name = [ m(`span.identity-icon${
-        isGood ? '.icon-ok-circled' : '.icon-minus-circled'
-      }${isGood ? '.green' : isBad ? '.red' : '.gray'}`), d2s(displayNameHex) ];
+        quality === IdentityQuality.Good ? '.icon-ok-circled' : '.icon-minus-circled'
+      }${quality === IdentityQuality.Good
+        ? '.green' : quality === IdentityQuality.Bad
+          ? '.red' : '.gray'}`), displayName ];
 
       return linkify
         ? link(

--- a/client/scripts/views/modals/edit_identity_modal.ts
+++ b/client/scripts/views/modals/edit_identity_modal.ts
@@ -14,9 +14,10 @@ import { SubstrateAccount } from '../../controllers/chain/substrate/account';
 import AvatarUpload from '../components/avatar_upload';
 import Substrate from '../../controllers/chain/substrate/main';
 import { IdentityInfoProps } from '../../controllers/chain/substrate/identities';
+import SubstrateIdentity from '../../controllers/chain/substrate/identity';
 
 interface IAttrs {
-  currentIdentity?: IdentityInfo;
+  currentIdentity?: SubstrateIdentity;
   account: SubstrateAccount;
 }
 
@@ -27,7 +28,7 @@ interface IState {
 
 const EditIdentityModal: m.Component<IAttrs, IState> = {
   oncreate: (vnode: m.VnodeDOM<IAttrs, IState>) => {
-    if (vnode.attrs.currentIdentity) {
+    if (vnode.attrs.currentIdentity?.info) {
       const {
         additional,
         display,
@@ -38,7 +39,7 @@ const EditIdentityModal: m.Component<IAttrs, IState> = {
         // pgpFingerprint,
         image,
         twitter
-      } = vnode.attrs.currentIdentity;
+      } = vnode.attrs.currentIdentity.info;
 
       // do not display SHA values, only raw strings
       const d2s = (d: Data) => u8aToString(d.toU8a()).replace(/[^\x20-\x7E]/g, '');
@@ -107,7 +108,7 @@ const EditIdentityModal: m.Component<IAttrs, IState> = {
           name: inputName,
           id: inputName,
           placeholder: description,
-          limit: limit,
+          limit,
         }),
       ]);
     };

--- a/client/scripts/views/pages/profile/profile_header.ts
+++ b/client/scripts/views/pages/profile/profile_header.ts
@@ -19,9 +19,11 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-const editIdentityAction = (account: Account<any>, currentIdentity?: IdentityInfo) => {
+const editIdentityAction = (account: Account<any>, currentIdentity: SubstrateIdentity | undefined) => {
   const chainName = capitalizeFirstLetter(app.chain.class);
   return (app.chain.base === ChainBase.Substrate) && m('button.formular-button-primary', {
+    // wait for info to load before making it clickable, if identity exists
+    class: !currentIdentity || currentIdentity.info ? '' : 'disabled',
     onclick: async () => {
       app.modals.create({
         modal: EditIdentityModal,
@@ -90,7 +92,7 @@ const ProfileHeader = makeDynamicComponent<IProfileHeaderAttrs, IProfileHeaderSt
         // Add in identity actions here
         m('.bio-actions', [
           (app.vm.activeAccount && account.address === app.vm.activeAccount.address) ? [
-            editIdentityAction(account, vnode.state.dynamic.identity?.info),
+            editIdentityAction(account, vnode.state.dynamic.identity),
             m('button.formular-button-primary', {
               onclick: () => {
                 app.modals.create({

--- a/client/scripts/views/pages/profile/profile_header.ts
+++ b/client/scripts/views/pages/profile/profile_header.ts
@@ -19,18 +19,18 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-const editIdentityAction = (account: Account<any>, currentIdentity: SubstrateIdentity | undefined) => {
+const editIdentityAction = (account: Account<any>, currentIdentity: SubstrateIdentity | null) => {
   const chainName = capitalizeFirstLetter(app.chain.class);
   return (app.chain.base === ChainBase.Substrate) && m('button.formular-button-primary', {
     // wait for info to load before making it clickable, if identity exists
-    class: !currentIdentity || currentIdentity.info ? '' : 'disabled',
+    class: !currentIdentity || !currentIdentity.exists || currentIdentity.info ? '' : 'disabled',
     onclick: async () => {
       app.modals.create({
         modal: EditIdentityModal,
         data: { account: account as SubstrateAccount, currentIdentity },
       });
     },
-  }, currentIdentity ? `Edit ${chainName} identity` : `Set ${chainName} identity`);
+  }, currentIdentity?.exists ? `Edit ${chainName} identity` : `Set ${chainName} identity`);
 };
 
 export interface IProfileHeaderAttrs {


### PR DESCRIPTION
## Description
Fixes #239. Adds a new type of store that writes to localStorage in addition to keeping a local list available. Also adds a clearing function run at page load, which checks timestamps and removes entries older than 10 minutes.

PR also converts the SubstrateIdentity controllers to utilize this cache, and ensures the changes are reflected in the view logic.

## Motivation and Context
Should speed up identity loading times from the chain, and remove flicker.

## How has this been tested?
Ran on Kusama and Edgeware and guaranteed identities load from chain and are stored correctly in PersistentStore. Set cleanup time to 10 seconds and ensured identities are removed and re-fetched. Ran on Edgeware Local and created and edited a new identity to ensure that feature worked as well.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no