### PR TITLE
Add @types/sequelize and split models into Attributes/Instance/Model interfaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/mocha": "^5.2.6",
     "@types/moment": "^2.13.0",
     "@types/react": "^16.9.2",
+    "@types/sequelize": "^4.28.8",
     "@types/toastr": "^2.1.35",
     "@types/underscore": "^1.9.4",
     "@types/websocket": "^1.0.0",

--- a/server/database.ts
+++ b/server/database.ts
@@ -15,14 +15,18 @@ const sequelize = new Sequelize(DATABASE_URI, {
     requestTimeout: 10000
   },
 });
-const db = { sequelize, Sequelize };
+const db = {
+  sequelize,
+  Sequelize,
+};
 
-// import all files in models folder
-fs.readdirSync(__dirname + '/models')
+fs.readdirSync(`${__dirname}/models`)
   .filter((file) => file.indexOf('.') !== 0 && file !== 'index.js')
   .forEach((file) => {
     const model = sequelize.import(path.join(__dirname, 'models', file));
-    db[model.name] = model;
+    if (!db[model.name]) {
+      db[model.name] = model;
+    }
   });
 
 // setup associations

--- a/server/database.ts
+++ b/server/database.ts
@@ -15,6 +15,8 @@ const sequelize = new Sequelize(DATABASE_URI, {
     requestTimeout: 10000
   },
 });
+
+// TODO: separate Sequelize and SequelizeStatic into new object & type this as Sequelize.Models
 const db = {
   sequelize,
   Sequelize,

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -17,6 +17,10 @@ import { KeyringOptions } from '@polkadot/keyring/types';
 import { keyToSignMsg } from '../../shared/adapters/chain/cosmos/keys';
 import { NotificationCategories } from '../../shared/types';
 import { ADDRESS_TOKEN_EXPIRES_IN } from '../config';
+import { ChainAttributes } from './chain';
+import { UserAttributes } from './user';
+import { OffchainProfileAttributes } from './offchain_profile';
+import { RoleAttributes } from './role';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -36,6 +40,12 @@ export interface AddressAttributes {
   created_at?: Date;
   updated_at?: Date;
   user_id?: number;
+
+  // associations
+  Chain?: ChainAttributes;
+  User?: UserAttributes;
+  OffchainProfile?: OffchainProfileAttributes;
+  Roles?: RoleAttributes[];
 }
 
 export interface AddressInstance extends Sequelize.Instance<AddressAttributes>, AddressAttributes {

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -1,7 +1,7 @@
 (global as any).window = {};
 
+import * as Sequelize from 'sequelize';
 import crypto from 'crypto';
-import { ADDRESS_TOKEN_EXPIRES_IN } from '../config';
 
 import Keyring, { decodeAddress } from '@polkadot/keyring';
 import { stringToU8a, hexToU8a, u8aToString } from '@polkadot/util';
@@ -16,22 +16,56 @@ import nacl from 'tweetnacl';
 import { KeyringOptions } from '@polkadot/keyring/types';
 import { keyToSignMsg } from '../../shared/adapters/chain/cosmos/keys';
 import { NotificationCategories } from '../../shared/types';
+import { ADDRESS_TOKEN_EXPIRES_IN } from '../config';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 // tslint:disable-next-line
 const ethUtil = require('ethereumjs-util');
 
-module.exports = (sequelize, DataTypes) => {
-  const Address = sequelize.define('Address', {
-    address:                    { type: DataTypes.STRING, allowNull: false },
-    chain:                      { type: DataTypes.STRING, allowNull: false },
-    selected:                   { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-    verification_token:         { type: DataTypes.STRING, allowNull: false },
-    verification_token_expires: { type: DataTypes.DATE, allowNull: true },
-    verified:                   { type: DataTypes.DATE, allowNull: true },
-    keytype:                    { type: DataTypes.STRING, allowNull: true },
-    name:                       { type: DataTypes.STRING, allowNull: true }
+export interface AddressAttributes {
+  id?: number;
+  address: string;
+  chain: string;
+  selected?: boolean;
+  verification_token: string;
+  verification_token_expires?: Date;
+  verified?: Date;
+  keytype?: string;
+  name?: string;
+  created_at?: Date;
+  updated_at?: Date;
+  user_id?: number;
+}
+
+export interface AddressInstance extends Sequelize.Instance<AddressAttributes>, AddressAttributes {
+  // no mixins used yet
+}
+
+export interface AddressModel extends Sequelize.Model<AddressInstance, AddressAttributes> {
+  // TODO: type these
+  createWithToken: any;
+  updateWithToken: any;
+  verifySignature: any;
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): Sequelize.Model<AddressInstance, AddressAttributes> => {
+  const Address = sequelize.define<AddressInstance, AddressAttributes>('Address', {
+    id:                         { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    address:                    { type: dataTypes.STRING, allowNull: false },
+    chain:                      { type: dataTypes.STRING, allowNull: false },
+    selected:                   { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    verification_token:         { type: dataTypes.STRING, allowNull: false },
+    verification_token_expires: { type: dataTypes.DATE, allowNull: true },
+    verified:                   { type: dataTypes.DATE, allowNull: true },
+    keytype:                    { type: dataTypes.STRING, allowNull: true },
+    name:                       { type: dataTypes.STRING, allowNull: true },
+    created_at:                 { type: dataTypes.DATE, allowNull: false },
+    updated_at:                 { type: dataTypes.DATE, allowNull: false },
+    user_id:                    { type: dataTypes.INTEGER, allowNull: true },
   }, {
     underscored: true,
     indexes: [
@@ -39,160 +73,161 @@ module.exports = (sequelize, DataTypes) => {
       { fields: ['user_id'] },
       { fields: ['name'] }
     ],
+    classMethods: {
+      // Create an unverified 'stub' address, with a verification token
+      // tslint:disable:variable-name
+      createWithToken: (user_id, chain, address, keytype?) => {
+        const verification_token = crypto.randomBytes(18).toString('hex');
+        const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
+        return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
+      },
+
+      // Update an existing address' verification token
+      updateWithToken: (address, user_id?, keytype?) => {
+        const verification_token = crypto.randomBytes(18).toString('hex');
+        const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
+        if (user_id) {
+          address.user_id = user_id;
+        }
+        address.keytype = keytype;
+        address.verification_token = verification_token;
+        address.verification_token_expires = verification_token_expires;
+        return address.save();
+      },
+
+      // Verify an address' verification token. Requires some data to be
+      // passed from the frontend to show exactly what was signed.
+      // Supports Substrate, Ethereum, Cosmos, and NEAR.
+      verifySignature: async (
+        models,
+        chain,
+        addressModel,
+        user_id,
+        signatureString: string,
+        signatureParams: string,
+      ) => {
+        if (!chain) {
+          console.error('no chain provided to verifySignature');
+          return false;
+        }
+
+        let isValid;
+        if (chain.network === 'edgeware' || chain.network === 'kusama') {
+          const address = decodeAddress(addressModel.address);
+          const keyringOptions: KeyringOptions = { type: 'sr25519' };
+          if (addressModel.keytype) {
+            if (addressModel.keytype !== 'sr25519' && addressModel.keytype !== 'ed25519') {
+              console.error('invalid keytype');
+              return false;
+            }
+            keyringOptions.type = addressModel.keytype;
+          }
+          if (chain.network === 'kusama') {
+            keyringOptions.ss58Format = 2;
+          } else if (chain.network === 'edgeware') {
+            keyringOptions.ss58Format = 7; // edgeware chain id
+          } else {
+            keyringOptions.ss58Format = 42; // default chain id
+          }
+          const signerKeyring = new Keyring(keyringOptions).addFromAddress(address);
+          if (signatureParams) {
+            let params;
+            try {
+              params = JSON.parse(signatureParams);
+              const verificationToken = u8aToString(hexToU8a(params.method));
+              const verificationTokenValid = verificationToken.indexOf(addressModel.verification_token) !== -1;
+              if (!verificationTokenValid) return false;
+            } catch (e) {
+              console.error('Invalid signatureParams');
+              return false;
+            }
+            const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
+            isValid = signerKeyring.verify(signedPayload, hexToU8a(signatureString));
+          } else {
+            const signedMessage = stringToU8a(`${addressModel.verification_token}\n`);
+            isValid = signerKeyring.verify(signedMessage, hexToU8a(`0x${signatureString}`));
+          }
+        } else if (chain.network === 'cosmos') {
+          const signatureData = JSON.parse(signatureString);
+          // this saved "address" is actually just the address
+          const msg = keyToSignMsg(addressModel.address, addressModel.verification_token);
+          const signature = Buffer.from(signatureData.signature, 'base64');
+          const pk = Buffer.from(signatureData.pub_key.value, 'base64');
+
+          // we generate an address from the actual public key and verify that it matches,
+          // this prevents people from using a different key to sign the message than
+          // the account they registered with
+          const generatedAddress = getCosmosAddress(pk);
+          if (generatedAddress === addressModel.address) {
+            const signHash = Buffer.from(CryptoJS.SHA256(msg).toString(), 'hex');
+            isValid = secp256k1.verify(signHash, signature, pk);
+          } else {
+            isValid = false;
+          }
+        } else if (chain.network === 'ethereum'
+          || chain.network === 'moloch'
+          || chain.network === 'metacart'
+        ) {
+          const msgBuffer = Buffer.from(addressModel.verification_token.trim());
+          // toBuffer() doesn't work if there is a newline
+          const msgHash = ethUtil.hashPersonalMessage(msgBuffer);
+          const ethSignatureBuffer = ethUtil.toBuffer(signatureString.trim());
+          const ethSignatureParams = ethUtil.fromRpcSig(ethSignatureBuffer);
+          const publicKey = ethUtil.ecrecover(
+            msgHash,
+            ethSignatureParams.v,
+            ethSignatureParams.r,
+            ethSignatureParams.s
+          );
+          const addressBuffer = ethUtil.publicToAddress(publicKey);
+          const address = ethUtil.bufferToHex(addressBuffer);
+          isValid = (addressModel.address.toLowerCase() === address.toLowerCase());
+        } else if (chain.network === 'near') {
+          // both in base64 encoding
+          const { signature: sigObj, publicKey } = JSON.parse(signatureString);
+          isValid = nacl.sign.detached.verify(
+            Buffer.from(`${addressModel.verification_token}\n`),
+            Buffer.from(sigObj, 'base64'),
+            Buffer.from(publicKey, 'base64'),
+          );
+        } else {
+          // invalid network
+          console.error(`invalid network: ${chain.network}`);
+          isValid = false;
+        }
+
+        if (isValid && user_id === null) {
+          // mark the address as verified, and if it doesn't have an associated user, create a new user
+          addressModel.verification_token_expires = null;
+          addressModel.verified = new Date();
+          if (!addressModel.user_id) {
+            const user = await models.User.create({ email: null });
+            await models.Subscription.create({
+              subscriber_id: user.id,
+              category_id: NotificationCategories.NewMention,
+              object_id: `user-${user.id}`,
+              is_active: true,
+            });
+            addressModel.user_id = user.id;
+          }
+          await addressModel.save();
+        } else if (isValid) {
+          // mark the address as verified
+          addressModel.verification_token_expires = null;
+          addressModel.verified = new Date();
+          addressModel.user_id = user_id;
+          await addressModel.save();
+        }
+        return isValid;
+      },
+    }
   });
 
   Address.associate = (models) => {
     models.Address.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
     models.Address.belongsTo(models.User, { foreignKey: 'user_id', targetKey: 'id' });
     models.Address.hasOne(models.OffchainProfile);
-    models.Address.hasMany(models.Role, { foreignKey: 'address_id', targetKey: 'id' });
-  };
-
-  // Create an unverified 'stub' address, with a verification token
-  // tslint:disable:variable-name
-  Address.createWithToken = (user_id, chain, address, keytype?) => {
-    const verification_token = crypto.randomBytes(18).toString('hex');
-    const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
-    return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
-  };
-
-  // Update an existing address' verification token
-  Address.updateWithToken = (address, user_id?, keytype?) => {
-    const verification_token = crypto.randomBytes(18).toString('hex');
-    const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
-    if (user_id) {
-      address.user_id = user_id;
-    }
-    address.keytype = keytype;
-    address.verification_token = verification_token;
-    address.verification_token_expires = verification_token_expires;
-    return address.save();
-  };
-
-  // Verify an address' verification token. Requires some data to be
-  // passed from the frontend to show exactly what was signed.
-  // Supports Substrate, Ethereum, Cosmos, and NEAR.
-  Address.verifySignature = async (
-    models,
-    chain,
-    addressModel,
-    user_id,
-    signatureString: string,
-    signatureParams: string,
-  ) => {
-    if (!chain) {
-      log.error('no chain provided to verifySignature');
-      return false;
-    }
-
-    let isValid;
-    if (chain.network === 'edgeware' || chain.network === 'kusama') {
-      const address = decodeAddress(addressModel.address);
-      const keyringOptions: KeyringOptions = { type: 'sr25519' };
-      if (addressModel.keytype) {
-        if (addressModel.keytype !== 'sr25519' && addressModel.keytype !== 'ed25519') {
-          log.error('invalid keytype');
-          return false;
-        }
-        keyringOptions.type = addressModel.keytype;
-      }
-      if (chain.network === 'kusama') {
-        keyringOptions.ss58Format = 2;
-      } else if (chain.network === 'edgeware') {
-        keyringOptions.ss58Format = 7; // edgeware chain id
-      } else {
-        keyringOptions.ss58Format = 42; // default chain id
-      }
-      const signerKeyring = new Keyring(keyringOptions).addFromAddress(address);
-      if (signatureParams) {
-        let params;
-        try {
-          params = JSON.parse(signatureParams);
-          const verificationToken = u8aToString(hexToU8a(params.method));
-          const verificationTokenValid = verificationToken.indexOf(addressModel.verification_token) !== -1;
-          if (!verificationTokenValid) return false;
-        } catch (e) {
-          log.error('Invalid signatureParams');
-          return false;
-        }
-        const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
-        isValid = signerKeyring.verify(signedPayload, hexToU8a(signatureString));
-      } else {
-        const signedMessage = stringToU8a(addressModel.verification_token + '\n');
-        isValid = signerKeyring.verify(signedMessage, hexToU8a('0x' + signatureString));
-      }
-    } else if (chain.network === 'cosmos') {
-      const signatureData = JSON.parse(signatureString);
-      // this saved "address" is actually just the address
-      const msg = keyToSignMsg(addressModel.address, addressModel.verification_token);
-      const signature = Buffer.from(signatureData.signature, 'base64');
-      const pk = Buffer.from(signatureData.pub_key.value, 'base64');
-
-      // we generate an address from the actual public key and verify that it matches,
-      // this prevents people from using a different key to sign the message than
-      // the account they registered with
-      const generatedAddress = getCosmosAddress(pk);
-      if (generatedAddress === addressModel.address) {
-        const signHash = Buffer.from(CryptoJS.SHA256(msg).toString(), `hex`);
-        isValid = secp256k1.verify(signHash, signature, pk);
-      } else {
-        isValid = false;
-      }
-    } else if (chain.network === 'ethereum'
-      || chain.network === 'moloch'
-      || chain.network === 'metacart'
-    ) {
-      const msgBuffer = Buffer.from(addressModel.verification_token.trim());
-      // toBuffer() doesn't work if there is a newline
-      const msgHash = ethUtil.hashPersonalMessage(msgBuffer);
-      const ethSignatureBuffer = ethUtil.toBuffer(signatureString.trim());
-      const ethSignatureParams = ethUtil.fromRpcSig(ethSignatureBuffer);
-      const publicKey = ethUtil.ecrecover(
-        msgHash,
-        ethSignatureParams.v,
-        ethSignatureParams.r,
-        ethSignatureParams.s
-      );
-      const addressBuffer = ethUtil.publicToAddress(publicKey);
-      const address = ethUtil.bufferToHex(addressBuffer);
-      isValid = (addressModel.address.toLowerCase() === address.toLowerCase()) ? true : false ;
-    } else if (chain.network === 'near') {
-      // both in base64 encoding
-      const { signature: sigObj, publicKey } = JSON.parse(signatureString);
-      isValid = nacl.sign.detached.verify(
-        Buffer.from(addressModel.verification_token + '\n'),
-        Buffer.from(sigObj, 'base64'),
-        Buffer.from(publicKey, 'base64'),
-      );
-    } else {
-      // invalid network
-      log.error('invalid network: ' + chain.network);
-      isValid = false;
-    }
-
-    if (isValid && user_id === null) {
-      // mark the address as verified, and if it doesn't have an associated user, create a new user
-      addressModel.verification_token_expires = null;
-      addressModel.verified = new Date();
-      if (!addressModel.user_id) {
-        const user = await models.User.create({ email: null });
-        await models.Subscription.create({
-          subscriber_id: user.id,
-          category_id: NotificationCategories.NewMention,
-          object_id: `user-${user.id}`,
-          is_active: true,
-        });
-        addressModel.user_id = user.id;
-      }
-      await addressModel.save();
-    } else if (isValid) {
-      // mark the address as verified
-      addressModel.verification_token_expires = null;
-      addressModel.verified = new Date();
-      addressModel.user_id = user_id;
-      await addressModel.save();
-    }
-    return isValid;
+    models.Address.hasMany(models.Role, { foreignKey: 'address_id' });
   };
 
   return Address;

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -143,7 +143,7 @@ export default (
     signatureParams: string,
   ): Promise<boolean> => {
     if (!chain) {
-      console.error('no chain provided to verifySignature');
+      log.error('no chain provided to verifySignature');
       return false;
     }
 
@@ -153,7 +153,7 @@ export default (
       const keyringOptions: KeyringOptions = { type: 'sr25519' };
       if (addressModel.keytype) {
         if (addressModel.keytype !== 'sr25519' && addressModel.keytype !== 'ed25519') {
-          console.error('invalid keytype');
+          log.error('invalid keytype');
           return false;
         }
         keyringOptions.type = addressModel.keytype;
@@ -174,7 +174,7 @@ export default (
           const verificationTokenValid = verificationToken.indexOf(addressModel.verification_token) !== -1;
           if (!verificationTokenValid) return false;
         } catch (e) {
-          console.error('Invalid signatureParams');
+          log.error('Invalid signatureParams');
           return false;
         }
         const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
@@ -228,7 +228,7 @@ export default (
       );
     } else {
       // invalid network
-      console.error(`invalid network: ${chain.network}`);
+      log.error(`invalid network: ${chain.network}`);
       isValid = false;
     }
 

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -17,7 +17,7 @@ import { KeyringOptions } from '@polkadot/keyring/types';
 import { keyToSignMsg } from '../../shared/adapters/chain/cosmos/keys';
 import { NotificationCategories } from '../../shared/types';
 import { ADDRESS_TOKEN_EXPIRES_IN } from '../config';
-import { ChainAttributes } from './chain';
+import { ChainAttributes, ChainInstance } from './chain';
 import { UserAttributes } from './user';
 import { OffchainProfileAttributes } from './offchain_profile';
 import { RoleAttributes } from './role';
@@ -53,10 +53,31 @@ export interface AddressInstance extends Sequelize.Instance<AddressAttributes>, 
 }
 
 export interface AddressModel extends Sequelize.Model<AddressInstance, AddressAttributes> {
-  // TODO: type these
-  createWithToken: any;
-  updateWithToken: any;
-  verifySignature: any;
+  // static methods
+  createWithToken: (
+    user_id: number,
+    chain: string,
+    address: string,
+    keytype?: string
+  ) => Promise<AddressInstance>;
+
+  updateWithToken: (
+    models,
+    chain: ChainInstance,
+    addressModel: AddressInstance,
+    user_id: number,
+    signatureString: string,
+    signatureParams: string,
+  ) => Promise<boolean>;
+
+  verifySignature: (
+    models: Sequelize.Models,
+    chain: ChainInstance,
+    addressModel: AddressInstance,
+    user_id: number,
+    signatureString: string,
+    signatureParams: string,
+  ) => Promise<boolean>;
 }
 
 export default (
@@ -86,14 +107,19 @@ export default (
     classMethods: {
       // Create an unverified 'stub' address, with a verification token
       // tslint:disable:variable-name
-      createWithToken: (user_id, chain, address, keytype?) => {
+      createWithToken: (
+        user_id: number,
+        chain: string,
+        address: string,
+        keytype?: string
+      ): Promise<AddressInstance> => {
         const verification_token = crypto.randomBytes(18).toString('hex');
         const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
         return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
       },
 
       // Update an existing address' verification token
-      updateWithToken: (address, user_id?, keytype?) => {
+      updateWithToken: (address: AddressInstance, user_id?: number, keytype?: string): Promise<AddressInstance> => {
         const verification_token = crypto.randomBytes(18).toString('hex');
         const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
         if (user_id) {
@@ -109,13 +135,13 @@ export default (
       // passed from the frontend to show exactly what was signed.
       // Supports Substrate, Ethereum, Cosmos, and NEAR.
       verifySignature: async (
-        models,
-        chain,
-        addressModel,
-        user_id,
+        models: Sequelize.Models,
+        chain: ChainInstance,
+        addressModel: AddressInstance,
+        user_id: number,
         signatureString: string,
         signatureParams: string,
-      ) => {
+      ): Promise<boolean> => {
         if (!chain) {
           console.error('no chain provided to verifySignature');
           return false;

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -54,23 +54,20 @@ export interface AddressInstance extends Sequelize.Instance<AddressAttributes>, 
 
 export interface AddressModel extends Sequelize.Model<AddressInstance, AddressAttributes> {
   // static methods
-  createWithToken: (
+  createWithToken?: (
     user_id: number,
     chain: string,
     address: string,
     keytype?: string
   ) => Promise<AddressInstance>;
 
-  updateWithToken: (
-    models,
-    chain: ChainInstance,
-    addressModel: AddressInstance,
-    user_id: number,
-    signatureString: string,
-    signatureParams: string,
-  ) => Promise<boolean>;
+  updateWithToken?: (
+    address: AddressInstance,
+    user_id?: number,
+    keytype?: string
+  ) => Promise<AddressInstance>;
 
-  verifySignature: (
+  verifySignature?: (
     models: Sequelize.Models,
     chain: ChainInstance,
     addressModel: AddressInstance,
@@ -83,8 +80,8 @@ export interface AddressModel extends Sequelize.Model<AddressInstance, AddressAt
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes,
-): Sequelize.Model<AddressInstance, AddressAttributes> => {
-  const Address = sequelize.define<AddressInstance, AddressAttributes>('Address', {
+): AddressModel => {
+  const Address: AddressModel = sequelize.define<AddressInstance, AddressAttributes>('Address', {
     id:                         { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     address:                    { type: dataTypes.STRING, allowNull: false },
     chain:                      { type: dataTypes.STRING, allowNull: false },
@@ -103,161 +100,162 @@ export default (
       { fields: ['address', 'chain'], unique: true },
       { fields: ['user_id'] },
       { fields: ['name'] }
-    ],
-    classMethods: {
-      // Create an unverified 'stub' address, with a verification token
-      // tslint:disable:variable-name
-      createWithToken: (
-        user_id: number,
-        chain: string,
-        address: string,
-        keytype?: string
-      ): Promise<AddressInstance> => {
-        const verification_token = crypto.randomBytes(18).toString('hex');
-        const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
-        return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
-      },
+    ]
+  });
 
-      // Update an existing address' verification token
-      updateWithToken: (address: AddressInstance, user_id?: number, keytype?: string): Promise<AddressInstance> => {
-        const verification_token = crypto.randomBytes(18).toString('hex');
-        const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
-        if (user_id) {
-          address.user_id = user_id;
-        }
-        address.keytype = keytype;
-        address.verification_token = verification_token;
-        address.verification_token_expires = verification_token_expires;
-        return address.save();
-      },
+  Address.createWithToken = (
+    user_id: number,
+    chain: string,
+    address: string,
+    keytype?: string
+  ): Promise<AddressInstance> => {
+    const verification_token = crypto.randomBytes(18).toString('hex');
+    const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
+    return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
+  };
 
-      // Verify an address' verification token. Requires some data to be
-      // passed from the frontend to show exactly what was signed.
-      // Supports Substrate, Ethereum, Cosmos, and NEAR.
-      verifySignature: async (
-        models: Sequelize.Models,
-        chain: ChainInstance,
-        addressModel: AddressInstance,
-        user_id: number,
-        signatureString: string,
-        signatureParams: string,
-      ): Promise<boolean> => {
-        if (!chain) {
-          console.error('no chain provided to verifySignature');
+  // Update an existing address' verification token
+  Address.updateWithToken = (
+    address: AddressInstance,
+    user_id?: number,
+    keytype?: string,
+  ): Promise<AddressInstance> => {
+    const verification_token = crypto.randomBytes(18).toString('hex');
+    const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
+    if (user_id) {
+      address.user_id = user_id;
+    }
+    address.keytype = keytype;
+    address.verification_token = verification_token;
+    address.verification_token_expires = verification_token_expires;
+    return address.save();
+  };
+
+  // Verify an address' verification token. Requires some data to be
+  // passed from the frontend to show exactly what was signed.
+  // Supports Substrate, Ethereum, Cosmos, and NEAR.
+  Address.verifySignature = async (
+    models: Sequelize.Models,
+    chain: ChainInstance,
+    addressModel: AddressInstance,
+    user_id: number,
+    signatureString: string,
+    signatureParams: string,
+  ): Promise<boolean> => {
+    if (!chain) {
+      console.error('no chain provided to verifySignature');
+      return false;
+    }
+
+    let isValid;
+    if (chain.network === 'edgeware' || chain.network === 'kusama') {
+      const address = decodeAddress(addressModel.address);
+      const keyringOptions: KeyringOptions = { type: 'sr25519' };
+      if (addressModel.keytype) {
+        if (addressModel.keytype !== 'sr25519' && addressModel.keytype !== 'ed25519') {
+          console.error('invalid keytype');
           return false;
         }
-
-        let isValid;
-        if (chain.network === 'edgeware' || chain.network === 'kusama') {
-          const address = decodeAddress(addressModel.address);
-          const keyringOptions: KeyringOptions = { type: 'sr25519' };
-          if (addressModel.keytype) {
-            if (addressModel.keytype !== 'sr25519' && addressModel.keytype !== 'ed25519') {
-              console.error('invalid keytype');
-              return false;
-            }
-            keyringOptions.type = addressModel.keytype;
-          }
-          if (chain.network === 'kusama') {
-            keyringOptions.ss58Format = 2;
-          } else if (chain.network === 'edgeware') {
-            keyringOptions.ss58Format = 7; // edgeware chain id
-          } else {
-            keyringOptions.ss58Format = 42; // default chain id
-          }
-          const signerKeyring = new Keyring(keyringOptions).addFromAddress(address);
-          if (signatureParams) {
-            let params;
-            try {
-              params = JSON.parse(signatureParams);
-              const verificationToken = u8aToString(hexToU8a(params.method));
-              const verificationTokenValid = verificationToken.indexOf(addressModel.verification_token) !== -1;
-              if (!verificationTokenValid) return false;
-            } catch (e) {
-              console.error('Invalid signatureParams');
-              return false;
-            }
-            const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
-            isValid = signerKeyring.verify(signedPayload, hexToU8a(signatureString));
-          } else {
-            const signedMessage = stringToU8a(`${addressModel.verification_token}\n`);
-            isValid = signerKeyring.verify(signedMessage, hexToU8a(`0x${signatureString}`));
-          }
-        } else if (chain.network === 'cosmos') {
-          const signatureData = JSON.parse(signatureString);
-          // this saved "address" is actually just the address
-          const msg = keyToSignMsg(addressModel.address, addressModel.verification_token);
-          const signature = Buffer.from(signatureData.signature, 'base64');
-          const pk = Buffer.from(signatureData.pub_key.value, 'base64');
-
-          // we generate an address from the actual public key and verify that it matches,
-          // this prevents people from using a different key to sign the message than
-          // the account they registered with
-          const generatedAddress = getCosmosAddress(pk);
-          if (generatedAddress === addressModel.address) {
-            const signHash = Buffer.from(CryptoJS.SHA256(msg).toString(), 'hex');
-            isValid = secp256k1.verify(signHash, signature, pk);
-          } else {
-            isValid = false;
-          }
-        } else if (chain.network === 'ethereum'
-          || chain.network === 'moloch'
-          || chain.network === 'metacart'
-        ) {
-          const msgBuffer = Buffer.from(addressModel.verification_token.trim());
-          // toBuffer() doesn't work if there is a newline
-          const msgHash = ethUtil.hashPersonalMessage(msgBuffer);
-          const ethSignatureBuffer = ethUtil.toBuffer(signatureString.trim());
-          const ethSignatureParams = ethUtil.fromRpcSig(ethSignatureBuffer);
-          const publicKey = ethUtil.ecrecover(
-            msgHash,
-            ethSignatureParams.v,
-            ethSignatureParams.r,
-            ethSignatureParams.s
-          );
-          const addressBuffer = ethUtil.publicToAddress(publicKey);
-          const address = ethUtil.bufferToHex(addressBuffer);
-          isValid = (addressModel.address.toLowerCase() === address.toLowerCase());
-        } else if (chain.network === 'near') {
-          // both in base64 encoding
-          const { signature: sigObj, publicKey } = JSON.parse(signatureString);
-          isValid = nacl.sign.detached.verify(
-            Buffer.from(`${addressModel.verification_token}\n`),
-            Buffer.from(sigObj, 'base64'),
-            Buffer.from(publicKey, 'base64'),
-          );
-        } else {
-          // invalid network
-          console.error(`invalid network: ${chain.network}`);
-          isValid = false;
+        keyringOptions.type = addressModel.keytype;
+      }
+      if (chain.network === 'kusama') {
+        keyringOptions.ss58Format = 2;
+      } else if (chain.network === 'edgeware') {
+        keyringOptions.ss58Format = 7; // edgeware chain id
+      } else {
+        keyringOptions.ss58Format = 42; // default chain id
+      }
+      const signerKeyring = new Keyring(keyringOptions).addFromAddress(address);
+      if (signatureParams) {
+        let params;
+        try {
+          params = JSON.parse(signatureParams);
+          const verificationToken = u8aToString(hexToU8a(params.method));
+          const verificationTokenValid = verificationToken.indexOf(addressModel.verification_token) !== -1;
+          if (!verificationTokenValid) return false;
+        } catch (e) {
+          console.error('Invalid signatureParams');
+          return false;
         }
+        const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
+        isValid = signerKeyring.verify(signedPayload, hexToU8a(signatureString));
+      } else {
+        const signedMessage = stringToU8a(`${addressModel.verification_token}\n`);
+        isValid = signerKeyring.verify(signedMessage, hexToU8a(`0x${signatureString}`));
+      }
+    } else if (chain.network === 'cosmos') {
+      const signatureData = JSON.parse(signatureString);
+      // this saved "address" is actually just the address
+      const msg = keyToSignMsg(addressModel.address, addressModel.verification_token);
+      const signature = Buffer.from(signatureData.signature, 'base64');
+      const pk = Buffer.from(signatureData.pub_key.value, 'base64');
 
-        if (isValid && user_id === null) {
-          // mark the address as verified, and if it doesn't have an associated user, create a new user
-          addressModel.verification_token_expires = null;
-          addressModel.verified = new Date();
-          if (!addressModel.user_id) {
-            const user = await models.User.create({ email: null });
-            await models.Subscription.create({
-              subscriber_id: user.id,
-              category_id: NotificationCategories.NewMention,
-              object_id: `user-${user.id}`,
-              is_active: true,
-            });
-            addressModel.user_id = user.id;
-          }
-          await addressModel.save();
-        } else if (isValid) {
-          // mark the address as verified
-          addressModel.verification_token_expires = null;
-          addressModel.verified = new Date();
-          addressModel.user_id = user_id;
-          await addressModel.save();
-        }
-        return isValid;
-      },
+      // we generate an address from the actual public key and verify that it matches,
+      // this prevents people from using a different key to sign the message than
+      // the account they registered with
+      const generatedAddress = getCosmosAddress(pk);
+      if (generatedAddress === addressModel.address) {
+        const signHash = Buffer.from(CryptoJS.SHA256(msg).toString(), 'hex');
+        isValid = secp256k1.verify(signHash, signature, pk);
+      } else {
+        isValid = false;
+      }
+    } else if (chain.network === 'ethereum'
+      || chain.network === 'moloch'
+      || chain.network === 'metacart'
+    ) {
+      const msgBuffer = Buffer.from(addressModel.verification_token.trim());
+      // toBuffer() doesn't work if there is a newline
+      const msgHash = ethUtil.hashPersonalMessage(msgBuffer);
+      const ethSignatureBuffer = ethUtil.toBuffer(signatureString.trim());
+      const ethSignatureParams = ethUtil.fromRpcSig(ethSignatureBuffer);
+      const publicKey = ethUtil.ecrecover(
+        msgHash,
+        ethSignatureParams.v,
+        ethSignatureParams.r,
+        ethSignatureParams.s
+      );
+      const addressBuffer = ethUtil.publicToAddress(publicKey);
+      const address = ethUtil.bufferToHex(addressBuffer);
+      isValid = (addressModel.address.toLowerCase() === address.toLowerCase());
+    } else if (chain.network === 'near') {
+      // both in base64 encoding
+      const { signature: sigObj, publicKey } = JSON.parse(signatureString);
+      isValid = nacl.sign.detached.verify(
+        Buffer.from(`${addressModel.verification_token}\n`),
+        Buffer.from(sigObj, 'base64'),
+        Buffer.from(publicKey, 'base64'),
+      );
+    } else {
+      // invalid network
+      console.error(`invalid network: ${chain.network}`);
+      isValid = false;
     }
-  });
+
+    if (isValid && user_id === null) {
+      // mark the address as verified, and if it doesn't have an associated user, create a new user
+      addressModel.verification_token_expires = null;
+      addressModel.verified = new Date();
+      if (!addressModel.user_id) {
+        const user = await models.User.create({ email: null });
+        await models.Subscription.create({
+          subscriber_id: user.id,
+          category_id: NotificationCategories.NewMention,
+          object_id: `user-${user.id}`,
+          is_active: true,
+        });
+        addressModel.user_id = user.id;
+      }
+      await addressModel.save();
+    } else if (isValid) {
+      // mark the address as verified
+      addressModel.verification_token_expires = null;
+      addressModel.verified = new Date();
+      addressModel.user_id = user_id;
+      await addressModel.save();
+    }
+    return isValid;
+  };
 
   Address.associate = (models) => {
     models.Address.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -35,7 +35,9 @@ export interface ChainInstance extends Sequelize.Instance<ChainAttributes>, Chai
   getChainNodes: Sequelize.HasManyGetAssociationsMixin<ChainNodeInstance>;
 }
 
-export type ChainModel = Sequelize.Model<ChainInstance, ChainAttributes>;
+export interface ChainModel extends Sequelize.Model<ChainInstance, ChainAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -1,26 +1,49 @@
-module.exports = (sequelize, DataTypes) => {
-  const Chain = sequelize.define('Chain', {
-    id: { type: DataTypes.STRING, primaryKey: true },
-    name: { type: DataTypes.STRING, allowNull: false },
-    description: { type: DataTypes.STRING, allowNull: true },
-    featured_tags: { type: DataTypes.ARRAY(DataTypes.STRING), allowNull: false, defaultValue: [] },
-    symbol: { type: DataTypes.STRING, allowNull: false },
-    network: { type: DataTypes.STRING, allowNull: false },
-    icon_url: { type: DataTypes.STRING },
-    active: { type: DataTypes.BOOLEAN },
-    type: { type: DataTypes.STRING, allowNull: false },
+import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
+import { ChainNodeInstance } from './chain_node';
+
+export interface ChainAttributes {
+  id: string;
+  name: string;
+  description?: string;
+  featured_tags: string[];
+  symbol: string;
+  network: string;
+  icon_url: string;
+  active: boolean;
+  type: string;
+}
+
+export interface ChainInstance extends Sequelize.Instance<ChainAttributes>, ChainAttributes {
+  // TODO: add mixins as needed
+  getChainNodes: Sequelize.HasManyGetAssociationsMixin<ChainNodeInstance>;
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): Sequelize.Model<ChainInstance, ChainAttributes> => {
+  const Chain = sequelize.define<ChainInstance, ChainAttributes>('Chain', {
+    id: { type: dataTypes.STRING, primaryKey: true },
+    name: { type: dataTypes.STRING, allowNull: false },
+    description: { type: dataTypes.STRING, allowNull: true },
+    featured_tags: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
+    symbol: { type: dataTypes.STRING, allowNull: false },
+    network: { type: dataTypes.STRING, allowNull: false },
+    icon_url: { type: dataTypes.STRING },
+    active: { type: dataTypes.BOOLEAN },
+    type: { type: dataTypes.STRING, allowNull: false },
   }, {
     timestamps: false,
     underscored: true,
   });
 
   Chain.associate = (models) => {
-    models.Chain.hasMany(models.ChainNode, { foreignKey: 'chain', targetKey: 'id' });
-    models.Chain.hasMany(models.Address, { foreignKey: 'chain', targetKey: 'id' });
-    models.Chain.hasMany(models.Membership, { foreignKey: 'chain', targetKey: 'id' });
-    models.Chain.hasMany(models.OffchainTag, { as: 'tags', foreignKey: 'chain_id', targetKey: 'id', });
-    models.Chain.hasMany(models.OffchainThread, { foreignKey: 'chain', targetKey: 'id' });
-    models.Chain.hasMany(models.OffchainComment, { foreignKey: 'chain', targetKey: 'id' });
+    models.Chain.hasMany(models.ChainNode, { foreignKey: 'chain' });
+    models.Chain.hasMany(models.Address, { foreignKey: 'chain' });
+    models.Chain.hasMany(models.Membership, { foreignKey: 'chain' });
+    models.Chain.hasMany(models.OffchainTag, { as: 'tags', foreignKey: 'chain_id' });
+    models.Chain.hasMany(models.OffchainThread, { foreignKey: 'chain' });
+    models.Chain.hasMany(models.OffchainComment, { foreignKey: 'chain' });
     models.Chain.belongsToMany(models.User, { through: models.WaitlistRegistration });
 
     // currently we have a 1-to-1 mapping from chain <--> chain_object_version

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -1,5 +1,12 @@
 import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
-import { ChainNodeInstance } from './chain_node';
+
+import { AddressAttributes } from './address';
+import { ChainNodeInstance, ChainNodeAttributes } from './chain_node';
+import { MembershipAttributes } from './membership';
+import { OffchainTagAttributes } from './offchain_tag';
+import { OffchainThreadAttributes } from './offchain_thread';
+import { OffchainCommentAttributes } from './offchain_comment';
+import { UserAttributes } from './user';
 
 export interface ChainAttributes {
   id?: string;
@@ -11,10 +18,20 @@ export interface ChainAttributes {
   icon_url: string;
   active: boolean;
   type: string;
+
+  // associations
+  ChainNodes?: ChainNodeAttributes[] | ChainNodeAttributes['id'][];
+  Addresses?: AddressAttributes[] | AddressAttributes['id'][];
+  Memberships?: MembershipAttributes[] | MembershipAttributes['id'][];
+  tags?: OffchainTagAttributes[] | OffchainTagAttributes['id'][];
+  OffchainThreads?: OffchainThreadAttributes[] | OffchainThreadAttributes['id'][];
+  OffchainComments?: OffchainCommentAttributes[] | OffchainCommentAttributes['id'][];
+  Users?: UserAttributes[] | UserAttributes['id'][];
+  ChainObjectVersion?; // TODO
 }
 
 export interface ChainInstance extends Sequelize.Instance<ChainAttributes>, ChainAttributes {
-  // TODO: add mixins as needed
+  // add mixins as needed
   getChainNodes: Sequelize.HasManyGetAssociationsMixin<ChainNodeInstance>;
 }
 

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -2,7 +2,7 @@ import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
 import { ChainNodeInstance } from './chain_node';
 
 export interface ChainAttributes {
-  id: string;
+  id?: string;
   name: string;
   description?: string;
   featured_tags: string[];
@@ -18,10 +18,12 @@ export interface ChainInstance extends Sequelize.Instance<ChainAttributes>, Chai
   getChainNodes: Sequelize.HasManyGetAssociationsMixin<ChainNodeInstance>;
 }
 
+export type ChainModel = Sequelize.Model<ChainInstance, ChainAttributes>;
+
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes,
-): Sequelize.Model<ChainInstance, ChainAttributes> => {
+): ChainModel => {
   const Chain = sequelize.define<ChainInstance, ChainAttributes>('Chain', {
     id: { type: dataTypes.STRING, primaryKey: true },
     name: { type: dataTypes.STRING, allowNull: false },

--- a/server/models/chain_entity.ts
+++ b/server/models/chain_entity.ts
@@ -1,14 +1,46 @@
-module.exports = (sequelize, DataTypes) => {
-  const ChainEntity = sequelize.define('ChainEntity', {
-    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    chain: { type: DataTypes.STRING, allowNull: false },
-    type: { type: DataTypes.STRING, allowNull: false },
-    type_id: { type: DataTypes.STRING, allowNull: false },
-    thread_id: { type: DataTypes.INTEGER, allowNull: true },
-    completed: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+import * as Sequelize from 'sequelize';
 
-    created_at: { type: DataTypes.DATE, allowNull: false },
-    updated_at: { type: DataTypes.DATE, allowNull: false },
+import { ChainAttributes } from './chain';
+import { OffchainThreadAttributes } from './offchain_thread';
+import { ChainEventAttributes } from './chain_event';
+
+export interface ChainEntityAttributes {
+  id?: number;
+  chain: string;
+  type: string;
+  type_id: string;
+  thread_id?: number;
+  completed?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+
+  Chain?: ChainAttributes;
+  OffchainThread?: OffchainThreadAttributes;
+  ChainEvents?: ChainEventAttributes[];
+}
+
+export interface ChainEntityInstance
+extends Sequelize.Instance<ChainEntityAttributes>, ChainEntityAttributes {
+
+}
+
+export interface ChainEntityModel extends Sequelize.Model<ChainEntityInstance, ChainEntityAttributes> {
+
+}
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ChainEntityModel => {
+  const ChainEntity = sequelize.define<ChainEntityInstance, ChainEntityAttributes>('ChainEntity', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    chain: { type: dataTypes.STRING, allowNull: false },
+    type: { type: dataTypes.STRING, allowNull: false },
+    type_id: { type: dataTypes.STRING, allowNull: false },
+    thread_id: { type: dataTypes.INTEGER, allowNull: true },
+    completed: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     timestamps: true,
     underscored: true,

--- a/server/models/chain_event.ts
+++ b/server/models/chain_event.ts
@@ -1,12 +1,42 @@
-module.exports = (sequelize, DataTypes) => {
-  const ChainEvent = sequelize.define('ChainEvent', {
-    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    chain_event_type_id: { type: DataTypes.STRING, allowNull: false },
-    block_number: { type: DataTypes.INTEGER, allowNull: false },
-    entity_id: { type: DataTypes.INTEGER, allowNull: true },
-    event_data: { type: DataTypes.JSONB, allowNull: false },
-    created_at: { type: DataTypes.DATE, allowNull: false },
-    updated_at: { type: DataTypes.DATE, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+import { ChainEventTypeAttributes } from './chain_event_type';
+import { ChainEntityAttributes } from './chain_entity';
+
+export interface ChainEventAttributes {
+  id?: number;
+  chain_event_type_id: string;
+  block_number: number;
+  entity_id?: number;
+  event_data: object;
+  created_at?: Date;
+  updated_at?: Date;
+
+  ChainEventType?: ChainEventTypeAttributes;
+  ChainEntity?: ChainEntityAttributes;
+}
+
+export interface ChainEventInstance
+extends Sequelize.Instance<ChainEventAttributes>, ChainEventAttributes {
+
+}
+
+export interface ChainEventModel extends Sequelize.Model<ChainEventInstance, ChainEventAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ChainEventModel => {
+  const ChainEvent = sequelize.define<ChainEventInstance, ChainEventAttributes>('ChainEvent', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    chain_event_type_id: { type: dataTypes.STRING, allowNull: false },
+    block_number: { type: dataTypes.INTEGER, allowNull: false },
+    entity_id: { type: dataTypes.INTEGER, allowNull: true },
+    event_data: { type: dataTypes.JSONB, allowNull: false },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     timestamps: true,
     underscored: true,

--- a/server/models/chain_event_type.ts
+++ b/server/models/chain_event_type.ts
@@ -1,9 +1,35 @@
-module.exports = (sequelize, DataTypes) => {
-  const ChainEventType = sequelize.define('ChainEventType', {
+import * as Sequelize from 'sequelize';
+
+import { ChainEventAttributes } from './chain_event';
+import { ChainAttributes } from './chain';
+
+export interface ChainEventTypeAttributes {
+  id: string;
+  chain: string;
+  event_name: string;
+
+  ChainEvents?: ChainEventAttributes[];
+  Chain?: ChainAttributes;
+}
+
+export interface ChainEventTypeInstance
+extends Sequelize.Instance<ChainEventTypeAttributes>, ChainEventTypeAttributes {
+
+}
+
+export interface ChainEventTypeModel extends Sequelize.Model<ChainEventTypeInstance, ChainEventTypeAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ChainEventTypeModel => {
+  const ChainEventType = sequelize.define<ChainEventTypeInstance, ChainEventTypeAttributes>('ChainEventType', {
     // id = chain-event_name (event_name is value of string enum)
-    id: { type: DataTypes.STRING, primaryKey: true },
-    chain: { type: DataTypes.STRING, allowNull: false },
-    event_name: { type: DataTypes.STRING, allowNull: false },
+    id: { type: dataTypes.STRING, primaryKey: true },
+    chain: { type: dataTypes.STRING, allowNull: false },
+    event_name: { type: dataTypes.STRING, allowNull: false },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -1,8 +1,30 @@
-module.exports = (sequelize, DataTypes) => {
-  const ChainNode = sequelize.define('ChainNode', {
-    chain: { type: DataTypes.STRING, allowNull: false },
-    url: { type: DataTypes.STRING, allowNull: false },
-    address: { type: DataTypes.STRING, allowNull: true },
+type ChainAttributes = {};
+type ChainInstance = {};
+
+import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
+
+export interface ChainNodeAttributes {
+  id: number;
+  chain: string;
+  url: string;
+  address: string;
+}
+
+export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttributes>, ChainNodeAttributes {
+  getChain: Sequelize.BelongsToGetAssociationMixin<ChainInstance>;
+  setChain: Sequelize.BelongsToSetAssociationMixin<ChainInstance, string>;
+  createChain: Sequelize.BelongsToCreateAssociationMixin<ChainAttributes, ChainInstance>;
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes
+): Sequelize.Model<ChainNodeInstance, ChainNodeAttributes> => {
+  const ChainNode = sequelize.define<ChainNodeInstance, ChainNodeAttributes>('ChainNode', {
+    id: { type: dataTypes.INTEGER, primaryKey: true },
+    chain: { type: dataTypes.STRING, allowNull: false },
+    url: { type: dataTypes.STRING, allowNull: false },
+    address: { type: dataTypes.STRING, allowNull: true },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -1,11 +1,14 @@
 import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
-import { ChainInstance } from './chain';
+import { ChainInstance, ChainAttributes } from './chain';
 
 export interface ChainNodeAttributes {
   id?: number;
   chain: string;
   url: string;
   address: string;
+
+  // associations
+  Chain: ChainAttributes;
 }
 
 export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttributes>, ChainNodeAttributes {

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -8,7 +8,7 @@ export interface ChainNodeAttributes {
   address: string;
 
   // associations
-  Chain: ChainAttributes;
+  Chain?: ChainAttributes;
 }
 
 export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttributes>, ChainNodeAttributes {

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -16,7 +16,9 @@ export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttribute
   getChain: Sequelize.BelongsToGetAssociationMixin<ChainInstance>;
 }
 
-export type ChainNodeModel = Sequelize.Model<ChainNodeInstance, ChainNodeAttributes>;
+export interface ChainNodeModel extends Sequelize.Model<ChainNodeInstance, ChainNodeAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -2,7 +2,7 @@ import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
 import { ChainInstance } from './chain';
 
 export interface ChainNodeAttributes {
-  id: number;
+  id?: number;
   chain: string;
   url: string;
   address: string;
@@ -13,12 +13,14 @@ export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttribute
   getChain: Sequelize.BelongsToGetAssociationMixin<ChainInstance>;
 }
 
+export type ChainNodeModel = Sequelize.Model<ChainNodeInstance, ChainNodeAttributes>;
+
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes
-): Sequelize.Model<ChainNodeInstance, ChainNodeAttributes> => {
+): ChainNodeModel => {
   const ChainNode = sequelize.define<ChainNodeInstance, ChainNodeAttributes>('ChainNode', {
-    id: { type: dataTypes.INTEGER, primaryKey: true },
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     chain: { type: dataTypes.STRING, allowNull: false },
     url: { type: dataTypes.STRING, allowNull: false },
     address: { type: dataTypes.STRING, allowNull: true },

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -1,7 +1,5 @@
-type ChainAttributes = {};
-type ChainInstance = {};
-
 import * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
+import { ChainInstance } from './chain';
 
 export interface ChainNodeAttributes {
   id: number;
@@ -11,9 +9,8 @@ export interface ChainNodeAttributes {
 }
 
 export interface ChainNodeInstance extends Sequelize.Instance<ChainNodeAttributes>, ChainNodeAttributes {
+  // TODO: add mixins as needed
   getChain: Sequelize.BelongsToGetAssociationMixin<ChainInstance>;
-  setChain: Sequelize.BelongsToSetAssociationMixin<ChainInstance, string>;
-  createChain: Sequelize.BelongsToCreateAssociationMixin<ChainAttributes, ChainInstance>;
 }
 
 export default (

--- a/server/models/chat_message.ts
+++ b/server/models/chat_message.ts
@@ -1,9 +1,35 @@
-module.exports = (sequelize, DataTypes) => {
-  const ChatMessage = sequelize.define('ChatMessage', {
-    chain: { type: DataTypes.STRING, allowNull: false },
-    address: { type: DataTypes.STRING, allowNull: false },
-    text: { type: DataTypes.TEXT, allowNull: false },
-    room: { type: DataTypes.STRING, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface ChatMessageAttributes {
+  id?: number;
+  chain: string;
+  address: string;
+  text: string;
+  room: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface ChatMessageInstance
+extends Sequelize.Instance<ChatMessageAttributes>, ChatMessageAttributes {
+
+}
+
+export interface ChatMessageModel
+extends Sequelize.Model<ChatMessageInstance, ChatMessageAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ChatMessageModel => {
+  const ChatMessage = sequelize.define<ChatMessageInstance, ChatMessageAttributes>('ChatMessage', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    chain: { type: dataTypes.STRING, allowNull: false },
+    address: { type: dataTypes.STRING, allowNull: false },
+    text: { type: dataTypes.TEXT, allowNull: false },
+    room: { type: dataTypes.STRING, allowNull: false },
   }, {
     underscored: true,
     timestamps: true,

--- a/server/models/contract_category.ts
+++ b/server/models/contract_category.ts
@@ -1,9 +1,32 @@
-module.exports = (sequelize, DataTypes) => {
-  const ContractCategory = sequelize.define('ContractCategory', {
-    id:          { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true, allowNull: false },
-    name:        { type: DataTypes.STRING, allowNull: false },
-    description: { type: DataTypes.TEXT, allowNull: false },
-    color:       { type: DataTypes.STRING, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface ContractCategoryAttributes {
+  id?: number;
+  name: string;
+  description: string;
+  color: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface ContractCategoryInstance
+extends Sequelize.Instance<ContractCategoryAttributes>, ContractCategoryAttributes {
+
+}
+
+export interface ContractCategoryModel extends Sequelize.Model<ContractCategoryInstance, ContractCategoryAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ContractCategoryModel => {
+  const ContractCategory = sequelize.define<ContractCategoryInstance, ContractCategoryAttributes>('ContractCategory', {
+    id:          { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    name:        { type: dataTypes.STRING, allowNull: false },
+    description: { type: dataTypes.TEXT, allowNull: false },
+    color:       { type: dataTypes.STRING, allowNull: false },
   }, {
     underscored: true,
   });

--- a/server/models/contract_item.ts
+++ b/server/models/contract_item.ts
@@ -1,11 +1,42 @@
-module.exports = (sequelize, DataTypes) => {
-  const ContractItem = sequelize.define('ContractItem', {
-    id:          { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true, allowNull: false },
-    chain:       { type: DataTypes.STRING, allowNull: false },
-    name:        { type: DataTypes.STRING, allowNull: false },
-    description: { type: DataTypes.TEXT, allowNull: false },
-    color:       { type: DataTypes.STRING, allowNull: false },
-    category_id: { type: DataTypes.INTEGER, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+import { ChainAttributes } from './chain';
+import { ContractCategoryAttributes } from './contract_category';
+
+export interface ContractItemAttributes {
+  id?: number;
+  chain: string;
+  name: string;
+  description: string;
+  color: string;
+  category_id: number;
+  created_at?: Date;
+  updated_at?: Date;
+  Chain?: ChainAttributes;
+  ContractCategory?: ContractCategoryAttributes;
+}
+
+export interface ContractItemInstance
+extends Sequelize.Instance<ContractItemAttributes>, ContractItemAttributes {
+
+}
+
+export interface ContractItemModel
+extends Sequelize.Model<ContractItemInstance, ContractItemAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): ContractItemModel => {
+  const ContractItem = sequelize.define<ContractItemInstance, ContractItemAttributes>('ContractItem', {
+    id:          { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true, allowNull: false },
+    chain:       { type: dataTypes.STRING, allowNull: false },
+    name:        { type: dataTypes.STRING, allowNull: false },
+    description: { type: dataTypes.TEXT, allowNull: false },
+    color:       { type: dataTypes.STRING, allowNull: false },
+    category_id: { type: dataTypes.INTEGER, allowNull: false },
   }, {
     underscored: true,
   });

--- a/server/models/edgeware_lockdrop_balance.ts
+++ b/server/models/edgeware_lockdrop_balance.ts
@@ -1,8 +1,34 @@
-module.exports = (sequelize, DataTypes) => {
-  const EdgewareLockdropBalance = sequelize.define('EdgewareLockdropBalance', {
-    address: { type: DataTypes.STRING, allowNull: false },
-    balance: { type: DataTypes.STRING, allowNull: false },
-    blocknum: { type: DataTypes.INTEGER, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface EdgewareLockdropBalanceAttributes {
+  id?: number;
+  address: string;
+  balance: string;
+  blocknum: number;
+}
+
+export interface EdgewareLockdropBalanceInstance
+extends Sequelize.Instance<EdgewareLockdropBalanceAttributes>, EdgewareLockdropBalanceAttributes {
+
+}
+
+export interface EdgewareLockdropBalanceModel extends Sequelize.Model<
+  EdgewareLockdropBalanceInstance, EdgewareLockdropBalanceAttributes
+> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): EdgewareLockdropBalanceModel => {
+  const EdgewareLockdropBalance = sequelize.define<
+    EdgewareLockdropBalanceInstance, EdgewareLockdropBalanceAttributes
+  >('EdgewareLockdropBalance', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    address: { type: dataTypes.STRING, allowNull: false },
+    balance: { type: dataTypes.STRING, allowNull: false },
+    blocknum: { type: dataTypes.INTEGER, allowNull: false },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/edgeware_lockdrop_event.ts
+++ b/server/models/edgeware_lockdrop_event.ts
@@ -1,11 +1,38 @@
-module.exports = (sequelize, DataTypes) => {
-  const EdgewareLockdropEvent = sequelize.define('EdgewareLockdropEvent', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    origin: { type: DataTypes.STRING, allowNull: false },
-    blocknum: { type: DataTypes.INTEGER, allowNull: false },
-    timestamp: { type: DataTypes.STRING, allowNull: true },
-    name: { type: DataTypes.STRING, allowNull: false },
-    data: { type: DataTypes.TEXT, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+export interface EdgewareLockdropEventAttributes {
+  id?: number;
+  origin: string;
+  blocknum: number;
+  timestamp?: string;
+  name: string;
+  data?: string;
+}
+
+export interface EdgewareLockdropEventInstance
+extends Sequelize.Instance<EdgewareLockdropEventAttributes>, EdgewareLockdropEventAttributes {
+
+}
+
+export interface EdgewareLockdropEventModel extends Sequelize.Model<
+  EdgewareLockdropEventInstance, EdgewareLockdropEventAttributes
+> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): EdgewareLockdropEventModel => {
+  const EdgewareLockdropEvent = sequelize.define<
+    EdgewareLockdropEventInstance, EdgewareLockdropEventAttributes
+  >('EdgewareLockdropEvent', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    origin: { type: dataTypes.STRING, allowNull: false },
+    blocknum: { type: dataTypes.INTEGER, allowNull: false },
+    timestamp: { type: dataTypes.STRING, allowNull: true },
+    name: { type: dataTypes.STRING, allowNull: false },
+    data: { type: dataTypes.TEXT, allowNull: true },
   }, {
     underscored: true,
     timestamps: false,

--- a/server/models/edgeware_lockdrop_everything.ts
+++ b/server/models/edgeware_lockdrop_everything.ts
@@ -1,8 +1,33 @@
-module.exports = (sequelize, DataTypes) => {
-  const EdgewareLockdropEverything = sequelize.define('EdgewareLockdropEverything', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    createdAt: { type: DataTypes.DATE, allowNull: false },
-    data: { type: DataTypes.TEXT, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+export interface EdgewareLockdropEverythingAttributes {
+  id?: number;
+  createdAt: Date;
+  data?: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface EdgewareLockdropEverythingInstance
+extends Sequelize.Instance<EdgewareLockdropEverythingAttributes>, EdgewareLockdropEverythingAttributes {
+
+}
+
+export interface EdgewareLockdropEverythingModel
+extends Sequelize.Model<EdgewareLockdropEverythingInstance, EdgewareLockdropEverythingAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): EdgewareLockdropEverythingModel => {
+  const EdgewareLockdropEverything = sequelize.define<
+    EdgewareLockdropEverythingInstance, EdgewareLockdropEverythingAttributes
+  >('EdgewareLockdropEverything', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    createdAt: { type: dataTypes.DATE, allowNull: false },
+    data: { type: dataTypes.TEXT, allowNull: true },
   }, {
     underscored: true,
     timestamps: true,

--- a/server/models/hedgehog_authentication.ts
+++ b/server/models/hedgehog_authentication.ts
@@ -1,8 +1,34 @@
-module.exports = (sequelize, DataTypes) => {
-  const HedgehogAuthentication = sequelize.define('HedgehogAuthentication', {
-    iv:         { type: DataTypes.STRING, allowNull: false },
-    cipherText: { type: DataTypes.STRING, allowNull: false },
-    lookupKey:  { type: DataTypes.STRING, allowNull: false, unique: true, primaryKey: true },
+import * as Sequelize from 'sequelize';
+
+export interface HedgehogAuthenticationAttributes {
+  iv: string;
+  cipherText: string;
+  lookupKey: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface HedgehogAuthenticationInstance
+extends Sequelize.Instance<HedgehogAuthenticationAttributes>, HedgehogAuthenticationAttributes {
+
+}
+
+export interface HedgehogAuthenticationModel extends Sequelize.Model<
+  HedgehogAuthenticationInstance, HedgehogAuthenticationAttributes
+> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): HedgehogAuthenticationModel => {
+  const HedgehogAuthentication = sequelize.define<
+    HedgehogAuthenticationInstance, HedgehogAuthenticationAttributes
+  >('HedgehogAuthentication', {
+    iv:         { type: dataTypes.STRING, allowNull: false },
+    cipherText: { type: dataTypes.STRING, allowNull: false },
+    lookupKey:  { type: dataTypes.STRING, allowNull: false, unique: true, primaryKey: true },
   }, {
     underscored: true
   });

--- a/server/models/hedgehog_user.ts
+++ b/server/models/hedgehog_user.ts
@@ -1,8 +1,29 @@
-module.exports = (sequelize, DataTypes) => {
-  const HedgehogUser = sequelize.define('HedgehogUser', {
-    id:            { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true, allowNull: false },
-    username:      { type: DataTypes.STRING, allowNull: false, unique: true },
-    walletAddress: { type: DataTypes.STRING, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+export interface HedgehogUserAttributes {
+  id?: number;
+  username: string;
+  walletAddress: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface HedgehogUserInstance extends Sequelize.Instance<HedgehogUserAttributes>, HedgehogUserAttributes {
+
+}
+
+export interface HedgehogUserModel extends Sequelize.Model<HedgehogUserInstance, HedgehogUserAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): HedgehogUserModel => {
+  const HedgehogUser = sequelize.define<HedgehogUserInstance, HedgehogUserAttributes>('HedgehogUser', {
+    id:            { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true, allowNull: false },
+    username:      { type: dataTypes.STRING, allowNull: false, unique: true },
+    walletAddress: { type: dataTypes.STRING, allowNull: true },
   }, {
     underscored: true,
   });

--- a/server/models/invite_code.ts
+++ b/server/models/invite_code.ts
@@ -1,11 +1,40 @@
-module.exports = (sequelize, DataTypes) => {
-  const InviteCode = sequelize.define('InviteCode', {
-    id: { type: DataTypes.STRING, primaryKey: true },
-    community_id: { type: DataTypes.STRING, allowNull: false },
-    community_name: { type: DataTypes.STRING, allowNull: true },
-    creator_id: { type: DataTypes.INTEGER, allowNull: false },
-    invited_email: { type: DataTypes.STRING, allowNull: true, defaultValue: null },
-    used: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+import * as Sequelize from 'sequelize';
+
+import { OffchainCommunityAttributes } from './offchain_community';
+
+export interface InviteCodeAttributes {
+  id?: number;
+  community_id: string;
+  community_name?: string;
+  creator_id: number;
+  invited_email?: string;
+  used?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+  OffchainCommunity?: OffchainCommunityAttributes;
+}
+
+export interface InviteCodeInstance
+extends Sequelize.Instance<InviteCodeAttributes>, InviteCodeAttributes {
+
+}
+
+export interface InviteCodeModel
+extends Sequelize.Model<InviteCodeInstance, InviteCodeAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): InviteCodeModel => {
+  const InviteCode = sequelize.define<InviteCodeInstance, InviteCodeAttributes>('InviteCode', {
+    id: { type: dataTypes.STRING, primaryKey: true, autoIncrement: true },
+    community_id: { type: dataTypes.STRING, allowNull: false },
+    community_name: { type: dataTypes.STRING, allowNull: true },
+    creator_id: { type: dataTypes.INTEGER, allowNull: false },
+    invited_email: { type: dataTypes.STRING, allowNull: true, defaultValue: null },
+    used: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   }, {
     underscored: true,
     paranoid: true,

--- a/server/models/invite_code.ts
+++ b/server/models/invite_code.ts
@@ -3,7 +3,7 @@ import * as Sequelize from 'sequelize';
 import { OffchainCommunityAttributes } from './offchain_community';
 
 export interface InviteCodeAttributes {
-  id?: number;
+  id?: string;
   community_id: string;
   community_name?: string;
   creator_id: number;
@@ -29,7 +29,7 @@ export default (
   dataTypes: Sequelize.DataTypes,
 ): InviteCodeModel => {
   const InviteCode = sequelize.define<InviteCodeInstance, InviteCodeAttributes>('InviteCode', {
-    id: { type: dataTypes.STRING, primaryKey: true, autoIncrement: true },
+    id: { type: dataTypes.STRING, primaryKey: true },
     community_id: { type: dataTypes.STRING, allowNull: false },
     community_name: { type: dataTypes.STRING, allowNull: true },
     creator_id: { type: dataTypes.INTEGER, allowNull: false },

--- a/server/models/invite_link.ts
+++ b/server/models/invite_link.ts
@@ -1,14 +1,52 @@
-module.exports = (sequelize, DataTypes) => {
-  const InviteLink = sequelize.define('InviteLink', {
-    id: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
-    community_id: { type: DataTypes.STRING, allowNull: false },
-    creator_id: { type: DataTypes.INTEGER, allowNull: false },
-    active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
-    multi_use: { type: DataTypes.INTEGER, allowNull: true, defaultValue: null },
-    used: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+import * as Sequelize from 'sequelize';
+
+import { OffchainCommunityAttributes } from './offchain_community';
+
+export enum InviteLinkTimeLimit {
+  '24h' = '24h',
+  '48h' = '48h',
+  '1w' = '1w',
+  '30d' = '30d',
+  'none' = 'none',
+}
+
+export interface InviteLinkAttributes {
+  id?: number;
+  community_id: string;
+  creator_id: number;
+  active?: boolean;
+  multi_use?: number;
+  used?: number;
+  time_limit?: InviteLinkTimeLimit;
+  created_at?: Date;
+  updated_at?: Date;
+  OffchainCommunity?: OffchainCommunityAttributes;
+}
+
+export interface InviteLinkInstance
+extends Sequelize.Instance<InviteLinkAttributes>, InviteLinkAttributes {
+
+}
+
+export interface InviteLinkModel
+extends Sequelize.Model<InviteLinkInstance, InviteLinkAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): InviteLinkModel => {
+  const InviteLink = sequelize.define<InviteLinkInstance, InviteLinkAttributes>('InviteLink', {
+    id: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
+    community_id: { type: dataTypes.STRING, allowNull: false },
+    creator_id: { type: dataTypes.INTEGER, allowNull: false },
+    active: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    multi_use: { type: dataTypes.INTEGER, allowNull: true, defaultValue: null },
+    used: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
     time_limit: {
-      type: DataTypes.ENUM,
-      values: ['24h', '48h', '1w', '30d', 'none'],
+      type: dataTypes.ENUM,
+      values: Object.keys(InviteLinkTimeLimit),
       defaultValue: 'none',
       allowNull: false,
     },

--- a/server/models/login_token.ts
+++ b/server/models/login_token.ts
@@ -24,13 +24,14 @@ export interface LoginTokenInstance extends Sequelize.Instance<LoginTokenAttribu
 }
 
 export interface LoginTokenModel extends Sequelize.Model<LoginTokenInstance, LoginTokenAttributes> {
-  createForEmail: (email: string, path?: string) => Promise<LoginTokenInstance>;
+  createForEmail?: (email: string, path?: string) => Promise<LoginTokenInstance>;
 }
+
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes,
-): Sequelize.Model<LoginTokenInstance, LoginTokenAttributes> => {
-  const LoginToken = sequelize.define<LoginTokenInstance, LoginTokenAttributes>('LoginToken', {
+): LoginTokenModel => {
+  const LoginToken: LoginTokenModel = sequelize.define<LoginTokenInstance, LoginTokenAttributes>('LoginToken', {
     id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     token: { type: dataTypes.STRING, allowNull: false },
     email: { type: dataTypes.STRING, allowNull: true },
@@ -44,15 +45,14 @@ export default (
     indexes: [
       { fields: ['token', 'email'] },
     ],
-    classMethods: {
-      createForEmail: async (email: string, path?: string): Promise<LoginTokenInstance> => {
-        const token = crypto.randomBytes(24).toString('hex');
-        const expires = new Date(+(new Date()) + LOGIN_TOKEN_EXPIRES_IN * 60 * 1000);
-        const result = await LoginToken.create({ email, expires, token, redirect_path: path });
-        return result;
-      }
-    }
   });
+
+  LoginToken.createForEmail = async (email: string, path?: string): Promise<LoginTokenInstance> => {
+    const token = crypto.randomBytes(24).toString('hex');
+    const expires = new Date(+(new Date()) + LOGIN_TOKEN_EXPIRES_IN * 60 * 1000);
+    const result = await LoginToken.create({ email, expires, token, redirect_path: path });
+    return result;
+  };
 
   LoginToken.associate = (models) => {
     models.LoginToken.hasMany(models.SocialAccount);

--- a/server/models/login_token.ts
+++ b/server/models/login_token.ts
@@ -1,26 +1,58 @@
+import * as Sequelize from 'sequelize';
+
 import crypto from 'crypto';
 import { LOGIN_TOKEN_EXPIRES_IN } from '../config';
+import { SocialAccountAttributes } from './social_account';
 
-module.exports = (sequelize, DataTypes) => {
-  const LoginToken = sequelize.define('LoginToken', {
-    token: { type: DataTypes.STRING, allowNull: false },
-    email: { type: DataTypes.STRING, allowNull: true },
-    expires: { type: DataTypes.DATE, allowNull: false },
-    redirect_path: { type: DataTypes.STRING, allowNull: true },
-    used: { type: DataTypes.DATE },
+export interface LoginTokenAttributes {
+  id?: number;
+  token: string;
+  email?: string;
+  expires: Date;
+  redirect_path?: string;
+  used?: Date;
+
+  created_at?: Date;
+  updated_at?: Date;
+
+  // associations
+  SocialAccounts?: SocialAccountAttributes[];
+}
+
+export interface LoginTokenInstance extends Sequelize.Instance<LoginTokenAttributes>, LoginTokenAttributes {
+  // no mixins used yet
+}
+
+export interface LoginTokenModel extends Sequelize.Model<LoginTokenInstance, LoginTokenAttributes> {
+  createForEmail: (email: string, path?: string) => Promise<LoginTokenInstance>;
+}
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): Sequelize.Model<LoginTokenInstance, LoginTokenAttributes> => {
+  const LoginToken = sequelize.define<LoginTokenInstance, LoginTokenAttributes>('LoginToken', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    token: { type: dataTypes.STRING, allowNull: false },
+    email: { type: dataTypes.STRING, allowNull: true },
+    expires: { type: dataTypes.DATE, allowNull: false },
+    redirect_path: { type: dataTypes.STRING, allowNull: true },
+    used: { type: dataTypes.DATE, allowNull: true },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     underscored: true,
     indexes: [
       { fields: ['token', 'email'] },
     ],
+    classMethods: {
+      createForEmail: async (email: string, path?: string): Promise<LoginTokenInstance> => {
+        const token = crypto.randomBytes(24).toString('hex');
+        const expires = new Date(+(new Date()) + LOGIN_TOKEN_EXPIRES_IN * 60 * 1000);
+        const result = await LoginToken.create({ email, expires, token, redirect_path: path });
+        return result;
+      }
+    }
   });
-
-  LoginToken.createForEmail = async (email, path?) => {
-    const token = crypto.randomBytes(24).toString('hex');
-    const expires = new Date(+(new Date()) + LOGIN_TOKEN_EXPIRES_IN * 60 * 1000);
-    const result = await LoginToken.create({ email, expires, token, redirect_path: path });
-    return result;
-  };
 
   LoginToken.associate = (models) => {
     models.LoginToken.hasMany(models.SocialAccount);

--- a/server/models/membership.ts
+++ b/server/models/membership.ts
@@ -1,5 +1,9 @@
 import * as Sequelize from 'sequelize';
 
+import { UserAttributes } from './user';
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+
 export interface MembershipAttributes {
   id?: number;
   user_id: number;
@@ -8,6 +12,11 @@ export interface MembershipAttributes {
   active?: boolean;
   created_at?: Date;
   updated_at?: Date;
+
+  // associations
+  User?: UserAttributes | UserAttributes['id'];
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
 }
 
 export interface MembershipInstance extends Sequelize.Instance<MembershipAttributes>, MembershipAttributes {

--- a/server/models/membership.ts
+++ b/server/models/membership.ts
@@ -1,11 +1,33 @@
-module.exports = (sequelize, DataTypes) => {
-  const Membership = sequelize.define('Membership', {
-    user_id: { type: DataTypes.INTEGER, allowNull: false },
-    chain: { type: DataTypes.STRING, allowNull: true },
-    community: { type: DataTypes.STRING, allowNull: true },
-    active: { type: DataTypes.BOOLEAN, defaultValue: true },
-    created_at: { type: DataTypes.DATE, allowNull: false },
-    updated_at: { type: DataTypes.DATE, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface MembershipAttributes {
+  id?: number;
+  user_id: number;
+  chain?: string;
+  community?: string;
+  active?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface MembershipInstance extends Sequelize.Instance<MembershipAttributes>, MembershipAttributes {
+  // no mixins used
+}
+
+export type MembershipModel = Sequelize.Model<MembershipInstance, MembershipAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): MembershipModel => {
+  const Membership = sequelize.define<MembershipInstance, MembershipAttributes>('Membership', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    user_id: { type: dataTypes.INTEGER, allowNull: false },
+    chain: { type: dataTypes.STRING, allowNull: true },
+    community: { type: dataTypes.STRING, allowNull: true },
+    active: { type: dataTypes.BOOLEAN, defaultValue: true },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/membership.ts
+++ b/server/models/membership.ts
@@ -23,7 +23,9 @@ export interface MembershipInstance extends Sequelize.Instance<MembershipAttribu
   // no mixins used
 }
 
-export type MembershipModel = Sequelize.Model<MembershipInstance, MembershipAttributes>;
+export interface MembershipModel extends Sequelize.Model<MembershipInstance, MembershipAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/notification.ts
+++ b/server/models/notification.ts
@@ -1,9 +1,37 @@
-module.exports = (sequelize, DataTypes) => {
-  const Notification = sequelize.define('Notification', {
-    subscription_id: { type: DataTypes.INTEGER, allowNull: false },
-    notification_data: { type: DataTypes.TEXT, allowNull: false },
-    is_read: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false },
-    chain_event_id: { type: DataTypes.INTEGER, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+import { SubscriptionAttributes } from './subscription';
+
+export interface NotificationAttributes {
+  id?: number;
+  subscription_id: number;
+  notification_data: string;
+  is_read?: boolean;
+  chain_event_id?: number;
+  created_at?: Date;
+  updated_at?: Date;
+  Subscription?: SubscriptionAttributes;
+}
+
+export interface NotificationInstance
+extends Sequelize.Instance<NotificationAttributes>, NotificationAttributes {
+
+}
+
+export interface NotificationModel extends Sequelize.Model<NotificationInstance, NotificationAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): NotificationModel => {
+  const Notification = sequelize.define<NotificationInstance, NotificationAttributes>('Notification', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    subscription_id: { type: dataTypes.INTEGER, allowNull: false },
+    notification_data: { type: dataTypes.TEXT, allowNull: false },
+    is_read: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
+    chain_event_id: { type: dataTypes.INTEGER, allowNull: true },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/notification_category.ts
+++ b/server/models/notification_category.ts
@@ -1,7 +1,31 @@
-module.exports = (sequelize, DataTypes) => {
-  const NotificationCategory = sequelize.define('NotificationCategory', {
-    name: { type: DataTypes.STRING, primaryKey: true },
-    description: { type: DataTypes.TEXT, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface NotificationCategoryAttributes {
+  name: string;
+  description: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface NotificationCategoryInstance
+extends Sequelize.Instance<NotificationCategoryAttributes>, NotificationCategoryAttributes {
+
+}
+
+export interface NotificationCategoryModel
+extends Sequelize.Model<NotificationCategoryInstance, NotificationCategoryAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): NotificationCategoryModel => {
+  const NotificationCategory = sequelize.define<
+    NotificationCategoryInstance, NotificationCategoryAttributes
+  >('NotificationCategory', {
+    name: { type: dataTypes.STRING, primaryKey: true },
+    description: { type: dataTypes.TEXT, allowNull: false },
   }, {
     underscored: true,
   });

--- a/server/models/offchain_attachment.ts
+++ b/server/models/offchain_attachment.ts
@@ -1,16 +1,49 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainAttachment = sequelize.define('OffchainAttachment', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    attachable: { type: DataTypes.STRING, allowNull: false },
-    attachment_id: { type: DataTypes.INTEGER, allowNull: false },
-    url: { type: DataTypes.TEXT, allowNull: false },
-    description: { type: DataTypes.TEXT, allowNull: false },
-  }, {
-    underscored: true,
-    indexes: [
-      { fields: ['attachable', 'attachment_id'] },
-    ],
-  });
+import * as Sequelize from 'sequelize';
+
+import { OffchainCommentAttributes } from './offchain_comment';
+import { OffchainThreadAttributes } from './offchain_thread';
+
+export interface OffchainAttachmentAttributes {
+  id?: number;
+  attachable: string;
+  attachment_id: number;
+  url: string;
+  description: string;
+  created_at?: Date;
+  updated_at?: Date;
+
+  // associations
+  comment?: OffchainCommentAttributes | OffchainCommentAttributes['id'];
+  thread?: OffchainThreadAttributes | OffchainThreadAttributes['id'];
+}
+
+export interface OffchainAttachmentInstance
+extends Sequelize.Instance<OffchainAttachmentAttributes>, OffchainAttachmentAttributes {
+
+}
+
+export type OffchainAttachmentModel = Sequelize.Model<OffchainAttachmentInstance, OffchainAttachmentAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainAttachmentModel => {
+  const OffchainAttachment = sequelize.define<OffchainAttachmentInstance, OffchainAttachmentAttributes>(
+    'OffchainAttachment', {
+      id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+      attachable: { type: dataTypes.STRING, allowNull: false },
+      attachment_id: { type: dataTypes.INTEGER, allowNull: false },
+      url: { type: dataTypes.TEXT, allowNull: false },
+      description: { type: dataTypes.TEXT, allowNull: false },
+      created_at: { type: dataTypes.DATE, allowNull: false },
+      updated_at: { type: dataTypes.DATE, allowNull: false },
+    }, {
+      underscored: true,
+      indexes: [
+        { fields: ['attachable', 'attachment_id'] },
+      ],
+    }
+  );
 
   OffchainAttachment.associate = (models) => {
     models.OffchainAttachment.belongsTo(models.OffchainComment, {

--- a/server/models/offchain_attachment.ts
+++ b/server/models/offchain_attachment.ts
@@ -22,7 +22,11 @@ extends Sequelize.Instance<OffchainAttachmentAttributes>, OffchainAttachmentAttr
 
 }
 
-export type OffchainAttachmentModel = Sequelize.Model<OffchainAttachmentInstance, OffchainAttachmentAttributes>;
+export interface OffchainAttachmentModel extends Sequelize.Model<
+  OffchainAttachmentInstance, OffchainAttachmentAttributes
+> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_comment.ts
+++ b/server/models/offchain_comment.ts
@@ -1,14 +1,44 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainComment = sequelize.define('OffchainComment', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    chain: { type: DataTypes.STRING, allowNull: true },
-    root_id: { type: DataTypes.STRING, allowNull: false },
-    parent_id: { type: DataTypes.STRING, allowNull: true },
-    child_comments: { type: DataTypes.ARRAY(DataTypes.INTEGER), allowNull: false, defaultValue: [] },
-    address_id: { type: DataTypes.INTEGER, allowNull: false },
-    text: { type: DataTypes.TEXT, allowNull: false },
-    community: { type: DataTypes.STRING, allowNull: true },
-    version_history: { type: DataTypes.ARRAY(DataTypes.TEXT), defaultValue: [], allowNull: false }
+import * as Sequelize from 'sequelize';
+
+export interface OffchainCommentAttributes {
+  id?: number;
+  chain?: string;
+  root_id: string;
+  parent_id?: string;
+  child_comments?: number[];
+  address_id: number;
+  text: string;
+  community?: string;
+  version_history?: string[];
+  created_at?: Date;
+  updated_at?: Date;
+  deleted_at?: Date;
+}
+
+export interface OffchainCommentInstance
+extends Sequelize.Instance<OffchainCommentAttributes>, OffchainCommentAttributes {
+  // no mixins used
+}
+
+export type OffchainCommentModel = Sequelize.Model<OffchainCommentInstance, OffchainCommentAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainCommentModel => {
+  const OffchainComment = sequelize.define<OffchainCommentInstance, OffchainCommentAttributes>('OffchainComment', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    chain: { type: dataTypes.STRING, allowNull: true },
+    root_id: { type: dataTypes.STRING, allowNull: false },
+    parent_id: { type: dataTypes.STRING, allowNull: true },
+    child_comments: { type: dataTypes.ARRAY(dataTypes.INTEGER), allowNull: false, defaultValue: [] },
+    address_id: { type: dataTypes.INTEGER, allowNull: false },
+    text: { type: dataTypes.TEXT, allowNull: false },
+    community: { type: dataTypes.STRING, allowNull: true },
+    version_history: { type: dataTypes.ARRAY(dataTypes.TEXT), defaultValue: [], allowNull: false },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
+    deleted_at: { type: dataTypes.DATE, allowNull: true },
   }, {
     underscored: true,
     paranoid: true,

--- a/server/models/offchain_comment.ts
+++ b/server/models/offchain_comment.ts
@@ -31,7 +31,9 @@ extends Sequelize.Instance<OffchainCommentAttributes>, OffchainCommentAttributes
   // no mixins used
 }
 
-export type OffchainCommentModel = Sequelize.Model<OffchainCommentInstance, OffchainCommentAttributes>;
+export interface OffchainCommentModel extends Sequelize.Model<OffchainCommentInstance, OffchainCommentAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_comment.ts
+++ b/server/models/offchain_comment.ts
@@ -1,5 +1,10 @@
 import * as Sequelize from 'sequelize';
 
+import { AddressAttributes } from './address';
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { OffchainAttachmentAttributes } from './offchain_attachment';
+
 export interface OffchainCommentAttributes {
   id?: number;
   chain?: string;
@@ -13,6 +18,12 @@ export interface OffchainCommentAttributes {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+
+  // associations
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+  Address?: AddressAttributes;
+  OffchainAttachments?: OffchainAttachmentAttributes[] | OffchainAttachmentAttributes['id'][];
 }
 
 export interface OffchainCommentInstance

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -32,7 +32,9 @@ extends Sequelize.Instance<OffchainCommunityAttributes>, OffchainCommunityAttrib
 
 }
 
-export type OffchainCommunityModel = Sequelize.Model<OffchainComunityInstance, OffchainCommunityAttributes>;
+export interface OffchainCommunityModel extends Sequelize.Model<OffchainComunityInstance, OffchainCommunityAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -1,5 +1,11 @@
 import * as Sequelize from 'sequelize';
 
+import { AddressAttributes } from './address';
+import { ChainAttributes } from './chain';
+import { MembershipAttributes } from './membership';
+import { OffchainTagAttributes } from './offchain_tag';
+import { OffchainThreadAttributes } from './offchain_thread';
+
 export interface OffchainCommunityAttributes {
   id: string;
   name: string;
@@ -12,6 +18,13 @@ export interface OffchainCommunityAttributes {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+
+  // associations
+  Chain?: ChainAttributes;
+  Address?: AddressAttributes;
+  tags?: OffchainTagAttributes[] | OffchainTagAttributes['id'][];
+  OffchainThreads?: OffchainThreadAttributes[] | OffchainThreadAttributes['id'][];
+  Memberships?: MembershipAttributes[] | MembershipAttributes['id'][];
 }
 
 export interface OffchainComunityInstance

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -1,31 +1,61 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainCommunity = sequelize.define('OffchainCommunity', {
-    id: { type: DataTypes.STRING, primaryKey: true },
-    name: { type: DataTypes.STRING, allowNull: false },
-    creator_id: { type: DataTypes.INTEGER, allowNull: false },
-    default_chain: { type: DataTypes.STRING, allowNull: false },
-    description: { type: DataTypes.TEXT, allowNull: true },
-    featured_tags: { type: DataTypes.ARRAY(DataTypes.STRING), allowNull: false, defaultValue: [] },
-    // auth_forum: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-    // auth_condition: { type: DataTypes.STRING, allowNull: true, defaultValue: null }, // For Auth Forum Checking
-    // ^^^ other names: community_config, OffchainCommunityConfiguration, CommunityConditions
-    privacyEnabled: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-    invitesEnabled: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-  }, {
-    underscored: true,
-    paranoid: true,
-    indexes: [
-      { fields: ['id'], unique: true },
-      { fields: ['creator_id'] },
-    ],
-  });
+import * as Sequelize from 'sequelize';
+
+export interface OffchainCommunityAttributes {
+  id: string;
+  name: string;
+  creator_id: number;
+  default_chain: string;
+  description?: string;
+  featured_tags?: string[];
+  privacyEnabled?: boolean;
+  invitesEnabled?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+  deleted_at?: Date;
+}
+
+export interface OffchainComunityInstance
+extends Sequelize.Instance<OffchainCommunityAttributes>, OffchainCommunityAttributes {
+
+}
+
+export type OffchainCommunityModel = Sequelize.Model<OffchainComunityInstance, OffchainCommunityAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainCommunityModel => {
+  const OffchainCommunity = sequelize.define<OffchainComunityInstance, OffchainCommunityAttributes>(
+    'OffchainCommunity', {
+      id: { type: dataTypes.STRING, primaryKey: true },
+      name: { type: dataTypes.STRING, allowNull: false },
+      creator_id: { type: dataTypes.INTEGER, allowNull: false },
+      default_chain: { type: dataTypes.STRING, allowNull: false },
+      description: { type: dataTypes.TEXT, allowNull: true },
+      featured_tags: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
+      // auth_forum: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+      // auth_condition: { type: DataTypes.STRING, allowNull: true, defaultValue: null }, // For Auth Forum Checking
+      // ^^^ other names: community_config, OffchainCommunityConfiguration, CommunityConditions
+
+      // XXX: mixing camelCase and underscore_case is bad practice
+      privacyEnabled: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+      invitesEnabled: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    }, {
+      underscored: true,
+      paranoid: true,
+      indexes: [
+        { fields: ['id'], unique: true },
+        { fields: ['creator_id'] },
+      ],
+    }
+  );
 
   OffchainCommunity.associate = (models) => {
     models.OffchainCommunity.belongsTo(models.Chain, { foreignKey: 'default_chain', targetKey: 'id', });
     models.OffchainCommunity.belongsTo(models.Address, { foreignKey: 'creator_id', targetKey: 'id', });
-    models.OffchainCommunity.hasMany(models.OffchainTag, { as: 'tags', foreignKey: 'community_id', targetKey: 'id', });
-    models.OffchainCommunity.hasMany(models.OffchainThread, { foreignKey: 'community', targetKey: 'id' });
-    models.OffchainCommunity.hasMany(models.Membership, { foreignKey: 'chain', targetKey: 'id' });
+    models.OffchainCommunity.hasMany(models.OffchainTag, { as: 'tags', foreignKey: 'community_id' });
+    models.OffchainCommunity.hasMany(models.OffchainThread, { foreignKey: 'community' });
+    models.OffchainCommunity.hasMany(models.Membership, { foreignKey: 'chain' });
   };
 
   return OffchainCommunity;

--- a/server/models/offchain_profile.ts
+++ b/server/models/offchain_profile.ts
@@ -1,8 +1,12 @@
 import * as Sequelize from 'sequelize';
+import { AddressAttributes } from './address';
 
 export interface OffchainProfileAttributes {
   address_id: number;
   data?: string;
+
+  // associations
+  Address: AddressAttributes;
 }
 
 export interface OffchainProfileInstance

--- a/server/models/offchain_profile.ts
+++ b/server/models/offchain_profile.ts
@@ -1,14 +1,33 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainProfile = sequelize.define('OffchainProfile', {
-    address_id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true },
-    data: { type: DataTypes.TEXT, allowNull: true },
-  }, {
-    underscored: true,
-    timestamps: false,
-    indexes: [
-      { fields: ['address_id'] },
-    ],
-  });
+import * as Sequelize from 'sequelize';
+
+export interface OffchainProfileAttributes {
+  address_id: number;
+  data?: string;
+}
+
+export interface OffchainProfileInstance
+extends Sequelize.Instance<OffchainProfileAttributes>, OffchainProfileAttributes {
+
+}
+
+export type OffchainProfileModel = Sequelize.Model<OffchainProfileInstance, OffchainProfileAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainProfileModel => {
+  const OffchainProfile = sequelize.define<OffchainProfileInstance, OffchainProfileAttributes>(
+    'OffchainProfile', {
+      address_id: { type: dataTypes.INTEGER, allowNull: false, primaryKey: true },
+      data: { type: dataTypes.TEXT, allowNull: true },
+    }, {
+      underscored: true,
+      timestamps: false,
+      indexes: [
+        { fields: ['address_id'] },
+      ],
+    }
+  );
 
   OffchainProfile.associate = (models) => {
     models.OffchainProfile.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });

--- a/server/models/offchain_profile.ts
+++ b/server/models/offchain_profile.ts
@@ -6,7 +6,7 @@ export interface OffchainProfileAttributes {
   data?: string;
 
   // associations
-  Address: AddressAttributes;
+  Address?: AddressAttributes;
 }
 
 export interface OffchainProfileInstance
@@ -14,7 +14,9 @@ extends Sequelize.Instance<OffchainProfileAttributes>, OffchainProfileAttributes
 
 }
 
-export type OffchainProfileModel = Sequelize.Model<OffchainProfileInstance, OffchainProfileAttributes>;
+export interface OffchainProfileModel extends Sequelize.Model<OffchainProfileInstance, OffchainProfileAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -1,12 +1,45 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainReaction = sequelize.define('OffchainReaction', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    chain: { type: DataTypes.STRING, allowNull: true },
-    thread_id: { type: DataTypes.INTEGER, allowNull: true },
-    comment_id: { type: DataTypes.INTEGER, allowNull: true },
-    address_id: { type: DataTypes.INTEGER, allowNull: false },
-    reaction: { type: DataTypes.STRING, allowNull: false },
-    community: { type: DataTypes.STRING, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { AddressAttributes } from './address';
+
+export interface OffchainReactionAttributes {
+  id?: number;
+  chain?: string;
+  thread_id?: number;
+  comment_id?: number;
+  address_id: number;
+  reaction: string;
+  community?: string;
+  created_at?: Date;
+  updated_at?: Date;
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+  Address?: AddressAttributes;
+}
+
+export interface OffchainReactionInstance
+extends Sequelize.Instance<OffchainReactionAttributes>, OffchainReactionAttributes {
+
+}
+
+export interface OffchainReactionModel extends Sequelize.Model<OffchainReactionInstance, OffchainReactionAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainReactionModel => {
+  const OffchainReaction = sequelize.define<OffchainReactionInstance, OffchainReactionAttributes>('OffchainReaction', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    chain: { type: dataTypes.STRING, allowNull: true },
+    thread_id: { type: dataTypes.INTEGER, allowNull: true },
+    comment_id: { type: dataTypes.INTEGER, allowNull: true },
+    address_id: { type: dataTypes.INTEGER, allowNull: false },
+    reaction: { type: dataTypes.STRING, allowNull: false },
+    community: { type: dataTypes.STRING, allowNull: true },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/offchain_tag.ts
+++ b/server/models/offchain_tag.ts
@@ -25,7 +25,9 @@ export interface OffchainTagInstance extends Sequelize.Instance<OffchainTagAttri
   // TODO: do we need to implement the "as" stuff here?
 }
 
-export type OffchainTagModel = Sequelize.Model<OffchainTagInstance, OffchainTagAttributes>;
+export interface OffchainTagModel extends Sequelize.Model<OffchainTagInstance, OffchainTagAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_tag.ts
+++ b/server/models/offchain_tag.ts
@@ -1,5 +1,9 @@
 import * as Sequelize from 'sequelize';
 
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { OffchainThreadAttributes } from './offchain_thread';
+
 export interface OffchainTagAttributes {
   id?: number;
   name: string;
@@ -9,6 +13,11 @@ export interface OffchainTagAttributes {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+
+  // associations
+  community?: OffchainCommunityAttributes;
+  chain?: ChainAttributes;
+  threads?: OffchainThreadAttributes[] | OffchainTagAttributes['id'][];
 }
 
 export interface OffchainTagInstance extends Sequelize.Instance<OffchainTagAttributes>, OffchainTagAttributes {

--- a/server/models/offchain_tag.ts
+++ b/server/models/offchain_tag.ts
@@ -1,9 +1,36 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainTag = sequelize.define('OffchainTag', {
-    name: { type: DataTypes.STRING, allowNull: false },
-    description: { type: DataTypes.TEXT, allowNull: false, defaultValue: '' },
-    community_id: { type: DataTypes.STRING, allowNull: true },
-    chain_id: { type: DataTypes.STRING, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+export interface OffchainTagAttributes {
+  id?: number;
+  name: string;
+  description?: string;
+  community_id: string;
+  chain_id: string;
+  created_at?: Date;
+  updated_at?: Date;
+  deleted_at?: Date;
+}
+
+export interface OffchainTagInstance extends Sequelize.Instance<OffchainTagAttributes>, OffchainTagAttributes {
+  // no mixins used
+  // TODO: do we need to implement the "as" stuff here?
+}
+
+export type OffchainTagModel = Sequelize.Model<OffchainTagInstance, OffchainTagAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainTagModel => {
+  const OffchainTag = sequelize.define<OffchainTagInstance, OffchainTagAttributes>('OffchainTag', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    name: { type: dataTypes.STRING, allowNull: false },
+    description: { type: dataTypes.TEXT, allowNull: false, defaultValue: '' },
+    community_id: { type: dataTypes.STRING, allowNull: true },
+    chain_id: { type: dataTypes.STRING, allowNull: true },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
+    deleted_at: { type: dataTypes.DATE, allowNull: true },
   }, {
     underscored: true,
     paranoid: true,

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -35,7 +35,9 @@ export interface OffchainThreadInstance extends Sequelize.Instance<OffchainThrea
   // no mixins used
 }
 
-export type OffchainThreadModel = Sequelize.Model<OffchainThreadInstance, OffchainThreadAttributes>;
+export interface OffchainThreadModel extends Sequelize.Model<OffchainThreadInstance, OffchainThreadAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -1,17 +1,49 @@
-module.exports = (sequelize, DataTypes) => {
+import * as Sequelize from 'sequelize';
 
-  const OffchainThread = sequelize.define('OffchainThread', {
-    author_id: { type: DataTypes.INTEGER, allowNull: false },
-    title: { type: DataTypes.TEXT, allowNull: false },
-    body: { type: DataTypes.TEXT, allowNull: true },
-    kind: { type: DataTypes.TEXT, allowNull: false },
-    url: { type: DataTypes.TEXT, allowNull: true },
-    pinned: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false },
-    chain: { type: DataTypes.STRING, allowNull: true },
-    community: { type: DataTypes.STRING, allowNull: true },
-    private: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-    read_only: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-    version_history: { type: DataTypes.ARRAY(DataTypes.TEXT), defaultValue: [], allowNull: false }
+export interface OffchainThreadAttributes {
+  id?: number;
+  author_id: number;
+  title: string;
+  body?: string;
+  kind: string;
+  url?: string;
+  pinned?: boolean;
+  chain?: string;
+  community?: string;
+  private?: boolean;
+  read_only?: boolean;
+  version_history?: string[];
+  created_at?: Date;
+  updated_at?: Date;
+  deleted_at?: Date;
+}
+
+export interface OffchainThreadInstance extends Sequelize.Instance<OffchainThreadAttributes>, OffchainThreadAttributes {
+  // no mixins used
+}
+
+export type OffchainThreadModel = Sequelize.Model<OffchainThreadInstance, OffchainThreadAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainThreadModel => {
+  const OffchainThread = sequelize.define<OffchainThreadInstance, OffchainThreadAttributes>('OffchainThread', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    author_id: { type: dataTypes.INTEGER, allowNull: false },
+    title: { type: dataTypes.TEXT, allowNull: false },
+    body: { type: dataTypes.TEXT, allowNull: true },
+    kind: { type: dataTypes.TEXT, allowNull: false },
+    url: { type: dataTypes.TEXT, allowNull: true },
+    pinned: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
+    chain: { type: dataTypes.STRING, allowNull: true },
+    community: { type: dataTypes.STRING, allowNull: true },
+    private: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    read_only: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    version_history: { type: dataTypes.ARRAY(dataTypes.TEXT), defaultValue: [], allowNull: false },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
+    deleted_at: { type: dataTypes.DATE, allowNull: true },
   }, {
     underscored: true,
     paranoid: true,

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -1,5 +1,11 @@
 import * as Sequelize from 'sequelize';
 
+import { AddressAttributes } from './address';
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { OffchainTagAttributes } from './offchain_tag';
+import { OffchainAttachmentAttributes } from './offchain_attachment';
+
 export interface OffchainThreadAttributes {
   id?: number;
   author_id: number;
@@ -16,6 +22,13 @@ export interface OffchainThreadAttributes {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+
+  // associations
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+  Address?: AddressAttributes;
+  OffchainAttachments?: OffchainAttachmentAttributes[] | OffchainAttachmentAttributes['id'][];
+  tags?: OffchainTagAttributes[] | OffchainTagAttributes['id'][];
 }
 
 export interface OffchainThreadInstance extends Sequelize.Instance<OffchainThreadAttributes>, OffchainThreadAttributes {

--- a/server/models/offchain_viewcount.ts
+++ b/server/models/offchain_viewcount.ts
@@ -1,19 +1,51 @@
-module.exports = (sequelize, DataTypes) => {
-  const OffchainViewCount = sequelize.define('OffchainViewCount', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true},
-    chain: { type: DataTypes.STRING },
-    community: { type: DataTypes.STRING },
-    object_id: { type: DataTypes.INTEGER, allowNull: false },
-    view_count: { type: DataTypes.INTEGER, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { OffchainThreadAttributes } from './offchain_thread';
+
+export interface OffchainViewCountAttributes {
+  id?: number;
+  chain?: string;
+  community?: string;
+  object_id: number;
+  view_count: number;
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+  OffchainThread?: OffchainThreadAttributes;
+}
+
+export interface OffchainViewCountInstance
+extends Sequelize.Instance<OffchainViewCountAttributes>, OffchainViewCountAttributes {
+
+}
+
+export interface OffchainViewCountModel
+extends Sequelize.Model<OffchainViewCountInstance, OffchainViewCountAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): OffchainViewCountModel => {
+  const OffchainViewCount = sequelize.define<
+    OffchainViewCountInstance, OffchainViewCountAttributes
+  >('OffchainViewCount', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    chain: { type: dataTypes.STRING },
+    community: { type: dataTypes.STRING },
+    object_id: { type: dataTypes.INTEGER, allowNull: false },
+    view_count: { type: dataTypes.INTEGER, allowNull: false },
   }, {
     underscored: true,
     timestamps: false,
     indexes: [
-      {fields: ['id']},
-      {fields: ['chain', 'object_id']},
-      {fields: ['community', 'object_id']},
-      {fields: ['chain', 'community', 'object_id']},
-      {fields: ['view_count']},
+      { fields: ['id'] },
+      { fields: ['chain', 'object_id'] },
+      { fields: ['community', 'object_id'] },
+      { fields: ['chain', 'community', 'object_id'] },
+      { fields: ['view_count'] },
     ],
   });
 

--- a/server/models/role.ts
+++ b/server/models/role.ts
@@ -24,13 +24,15 @@ export interface RoleInstance extends Sequelize.Instance<RoleAttributes>, RoleAt
 
 }
 
-export type RoleModel = Sequelize.Model<RoleInstance, RoleAttributes>;
+export interface RoleModel extends Sequelize.Model<RoleInstance, RoleAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes,
 ): RoleModel => {
-  const Role = sequelize.define('Role', {
+  const Role = sequelize.define<RoleInstance, RoleAttributes>('Role', {
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     offchain_community_id: { type: dataTypes.STRING, allowNull: true },

--- a/server/models/role.ts
+++ b/server/models/role.ts
@@ -1,15 +1,48 @@
-module.exports = (sequelize, DataTypes) => {
+import * as Sequelize from 'sequelize';
+import { AddressAttributes } from './address';
+import { OffchainCommunityAttributes } from './offchain_community';
+import { ChainAttributes } from './chain';
+
+export type Permission = 'admin' | 'moderator' | 'member';
+
+export interface RoleAttributes {
+  id?: number;
+  address_id: number;
+  offchain_community_id?: string;
+  chain_id?: string;
+  permission: Permission;
+  created_at?: Date;
+  updated_at?: Date;
+
+  // associations
+  Address?: AddressAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+  Chain?: ChainAttributes;
+}
+
+export interface RoleInstance extends Sequelize.Instance<RoleAttributes>, RoleAttributes {
+
+}
+
+export type RoleModel = Sequelize.Model<RoleInstance, RoleAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): RoleModel => {
   const Role = sequelize.define('Role', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    address_id: { type: DataTypes.INTEGER, allowNull: false },
-    offchain_community_id: { type: DataTypes.STRING, allowNull: true },
-    chain_id: { type: DataTypes.STRING, allowNull: true },
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    address_id: { type: dataTypes.INTEGER, allowNull: false },
+    offchain_community_id: { type: dataTypes.STRING, allowNull: true },
+    chain_id: { type: dataTypes.STRING, allowNull: true },
     permission: {
-      type: DataTypes.ENUM,
+      type: dataTypes.ENUM,
       values: ['admin', 'moderator', 'member'],
       defaultValue: 'member',
       allowNull: false,
     },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/social_account.ts
+++ b/server/models/social_account.ts
@@ -1,10 +1,37 @@
-module.exports = (sequelize, DataTypes) => {
-  const SocialAccount = sequelize.define('SocialAccount', {
-    provider: { type: DataTypes.STRING },
-    provider_username: { type: DataTypes.STRING },
-    provider_userid: { type: DataTypes.STRING },
-    access_token: { type: DataTypes.STRING },
-    refresh_token: { type: DataTypes.STRING },
+import * as Sequelize from 'sequelize';
+import { UserInstance } from './user';
+
+export interface SocialAccountAttributes {
+  id?: number;
+  provider: string;
+  provider_username: string;
+  provider_userid: string;
+  access_token: string;
+  refresh_token: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface SocialAccountInstance extends Sequelize.Instance<SocialAccountAttributes>, SocialAccountAttributes {
+  getUser: Sequelize.BelongsToGetAssociationMixin<UserInstance>;
+  setUser: Sequelize.BelongsToSetAssociationMixin<UserInstance, UserInstance['id']>;
+}
+
+export type SocialAccountModel = Sequelize.Model<SocialAccountInstance, SocialAccountAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): SocialAccountModel => {
+  const SocialAccount = sequelize.define<SocialAccountInstance, SocialAccountAttributes>('SocialAccount', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    provider: { type: dataTypes.STRING },
+    provider_username: { type: dataTypes.STRING },
+    provider_userid: { type: dataTypes.STRING },
+    access_token: { type: dataTypes.STRING },
+    refresh_token: { type: dataTypes.STRING },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/social_account.ts
+++ b/server/models/social_account.ts
@@ -20,7 +20,9 @@ export interface SocialAccountInstance extends Sequelize.Instance<SocialAccountA
   setUser: Sequelize.BelongsToSetAssociationMixin<UserInstance, UserInstance['id']>;
 }
 
-export type SocialAccountModel = Sequelize.Model<SocialAccountInstance, SocialAccountAttributes>;
+export interface SocialAccountModel extends Sequelize.Model<SocialAccountInstance, SocialAccountAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/social_account.ts
+++ b/server/models/social_account.ts
@@ -1,5 +1,5 @@
 import * as Sequelize from 'sequelize';
-import { UserInstance } from './user';
+import { UserInstance, UserAttributes } from './user';
 
 export interface SocialAccountAttributes {
   id?: number;
@@ -10,6 +10,9 @@ export interface SocialAccountAttributes {
   refresh_token: string;
   created_at?: Date;
   updated_at?: Date;
+
+  // associations
+  User?: UserAttributes | UserAttributes['id'];
 }
 
 export interface SocialAccountInstance extends Sequelize.Instance<SocialAccountAttributes>, SocialAccountAttributes {

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -34,138 +34,139 @@ extends Sequelize.Instance<SubscriptionAttributes>, SubscriptionAttributes {
 
 export interface SubscriptionModel
 extends Sequelize.Model<SubscriptionInstance, SubscriptionAttributes> {
-
+  emitNotifications?: any;
 }
 
 export default (
   sequelize: Sequelize.Sequelize,
   dataTypes: Sequelize.DataTypes,
-): Sequelize.Model<SubscriptionInstance, SubscriptionAttributes> => {
-  const Subscription = sequelize.define<SubscriptionInstance, SubscriptionAttributes>('Subscription', {
-    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    subscriber_id: { type: dataTypes.INTEGER, allowNull: false },
-    category_id: { type: dataTypes.STRING, allowNull: false },
-    object_id: { type: dataTypes.STRING, allowNull: false },
-    is_active: { type: dataTypes.BOOLEAN, defaultValue: true, allowNull: false },
-  }, {
-    underscored: true,
-    paranoid: true,
-    indexes: [
-      { fields: ['subscriber_id'] },
-      { fields: ['category_id', 'object_id', 'is_active'] },
-    ],
-    classMethods: {
-      emitNotifications: async (
-        models,
-        category_id: string,
-        object_id: string,
-        notification_data: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData,
-        webhook_data?: WebhookContent,
-        wss?: WebSocket.Server,
-        excludeAddresses?: string[],
-        includeAddresses?: string[],
-      ) => {
-        // get subscribers to send notifications to
-        const findOptions: any = {
-          [Op.and]: [
-            { category_id },
-            { object_id },
-            { is_active: true },
-          ],
-        };
+): SubscriptionModel => {
+  const Subscription: SubscriptionModel = sequelize.define<SubscriptionInstance, SubscriptionAttributes>(
+    'Subscription', {
+      id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+      subscriber_id: { type: dataTypes.INTEGER, allowNull: false },
+      category_id: { type: dataTypes.STRING, allowNull: false },
+      object_id: { type: dataTypes.STRING, allowNull: false },
+      is_active: { type: dataTypes.BOOLEAN, defaultValue: true, allowNull: false },
+    }, {
+      underscored: true,
+      paranoid: true,
+      indexes: [
+        { fields: ['subscriber_id'] },
+        { fields: ['category_id', 'object_id', 'is_active'] },
+      ],
+    }
+  );
 
-        // typeguard function to differentiate between chain event notifications as needed
-        const isChainEventData = (
-          n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData
-        ): n is IChainEventNotificationData => {
-          return (n as IChainEventNotificationData).chainEvent !== undefined;
-        };
+  Subscription.emitNotifications = async (
+    models,
+    category_id: string,
+    object_id: string,
+    notification_data: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData,
+    webhook_data?: WebhookContent,
+    wss?: WebSocket.Server,
+    excludeAddresses?: string[],
+    includeAddresses?: string[],
+  ) => {
+    // get subscribers to send notifications to
+    const findOptions: any = {
+      [Op.and]: [
+        { category_id },
+        { object_id },
+        { is_active: true },
+      ],
+    };
 
-        const fetchUsersFromAddresses = async (addresses: string[]): Promise<number[]> => {
-          // fetch user ids from address models
-          const addressModels = await models.Address.findAll({
-            where: {
-              address: {
-                [Op.in]: addresses,
-              },
-            },
-          });
-          if (addressModels && addressModels.length > 0) {
-            const userIds = addressModels.map((a) => a.user_id);
+    // typeguard function to differentiate between chain event notifications as needed
+    const isChainEventData = (
+      n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData
+    ): n is IChainEventNotificationData => {
+      return (n as IChainEventNotificationData).chainEvent !== undefined;
+    };
 
-            // remove duplicates
-            const userIdsDedup = userIds.filter((a, b) => userIds.indexOf(a) === b);
-            return userIdsDedup;
-          } else {
-            return [];
-          }
-        };
+    const fetchUsersFromAddresses = async (addresses: string[]): Promise<number[]> => {
+      // fetch user ids from address models
+      const addressModels = await models.Address.findAll({
+        where: {
+          address: {
+            [Op.in]: addresses,
+          },
+        },
+      });
+      if (addressModels && addressModels.length > 0) {
+        const userIds = addressModels.map((a) => a.user_id);
 
-        // currently excludes override includes, but we may want to provide the option for both
-        if (excludeAddresses && excludeAddresses.length > 0) {
-          const ids = await fetchUsersFromAddresses(excludeAddresses);
-          if (ids && ids.length > 0) {
-            findOptions[Op.and].push({ subscriber_id: { [Op.notIn]: ids } });
-          }
-        } else if (includeAddresses && includeAddresses.length > 0) {
-          const ids = await fetchUsersFromAddresses(includeAddresses);
-          if (ids && ids.length > 0) {
-            findOptions[Op.and].push({ subscriber_id: { [Op.in]: ids } });
-          }
-        }
+        // remove duplicates
+        const userIdsDedup = userIds.filter((a, b) => userIds.indexOf(a) === b);
+        return userIdsDedup;
+      } else {
+        return [];
+      }
+    };
 
-        const subscribers = await models.Subscription.findAll({ where: findOptions });
-
-        // create notifications (data should always exist, but we check anyway)
-        if (!notification_data) return [];
-        const notifications: any[] = await Promise.all(subscribers.map(async (subscription) => {
-          const notificationObj: any = {
-            subscription_id: subscription.id,
-          };
-          if (isChainEventData(notification_data)) {
-            notificationObj.notification_data = '';
-            notificationObj.chain_event_id = notification_data.chainEvent.id;
-          } else {
-            notificationObj.notification_data = JSON.stringify(notification_data);
-          }
-          const notification = await models.Notification.create(notificationObj);
-          return notification;
-        }));
-
-        // send data to relevant webhooks
-        if (webhook_data) {
-          await send(models, {
-            notificationCategory: category_id,
-            ...webhook_data
-          });
-        }
-
-        // send websocket state updates
-        const created_at = new Date();
-        if (wss) {
-          const payload: IWebsocketsPayload<any> = {
-            event: WebsocketMessageType.Notification,
-            data: {
-              topic: category_id,
-              object_id,
-              created_at,
-            }
-          };
-          if (isChainEventData(notification_data)) {
-            payload.data.notification_data = {};
-            payload.data.ChainEvent = notification_data.chainEvent.toJSON();
-            payload.data.ChainEvent.ChainEventType = notification_data.chainEventType.toJSON();
-          } else {
-            payload.data.notification_data = notification_data;
-          }
-          const subscriberIds: number[] = subscribers.map((s) => s.subscriber_id);
-          const userNotificationMap = _.object(subscriberIds, notifications);
-          wss.emit(WebsocketMessageType.Notification, payload, userNotificationMap);
-        }
-        return notifications;
+    // currently excludes override includes, but we may want to provide the option for both
+    if (excludeAddresses && excludeAddresses.length > 0) {
+      const ids = await fetchUsersFromAddresses(excludeAddresses);
+      if (ids && ids.length > 0) {
+        findOptions[Op.and].push({ subscriber_id: { [Op.notIn]: ids } });
+      }
+    } else if (includeAddresses && includeAddresses.length > 0) {
+      const ids = await fetchUsersFromAddresses(includeAddresses);
+      if (ids && ids.length > 0) {
+        findOptions[Op.and].push({ subscriber_id: { [Op.in]: ids } });
       }
     }
-  });
+
+    const subscribers = await models.Subscription.findAll({ where: findOptions });
+
+    // create notifications (data should always exist, but we check anyway)
+    if (!notification_data) return [];
+    const notifications: any[] = await Promise.all(subscribers.map(async (subscription) => {
+      const notificationObj: any = {
+        subscription_id: subscription.id,
+      };
+      if (isChainEventData(notification_data)) {
+        notificationObj.notification_data = '';
+        notificationObj.chain_event_id = notification_data.chainEvent.id;
+      } else {
+        notificationObj.notification_data = JSON.stringify(notification_data);
+      }
+      const notification = await models.Notification.create(notificationObj);
+      return notification;
+    }));
+
+    // send data to relevant webhooks
+    if (webhook_data) {
+      await send(models, {
+        notificationCategory: category_id,
+        ...webhook_data
+      });
+    }
+
+    // send websocket state updates
+    const created_at = new Date();
+    if (wss) {
+      const payload: IWebsocketsPayload<any> = {
+        event: WebsocketMessageType.Notification,
+        data: {
+          topic: category_id,
+          object_id,
+          created_at,
+        }
+      };
+      if (isChainEventData(notification_data)) {
+        payload.data.notification_data = {};
+        payload.data.ChainEvent = notification_data.chainEvent.toJSON();
+        payload.data.ChainEvent.ChainEventType = notification_data.chainEventType.toJSON();
+      } else {
+        payload.data.notification_data = notification_data;
+      }
+      const subscriberIds: number[] = subscribers.map((s) => s.subscriber_id);
+      const userNotificationMap = _.object(subscriberIds, notifications);
+      wss.emit(WebsocketMessageType.Notification, payload, userNotificationMap);
+    }
+    return notifications;
+  };
 
   Subscription.associate = (models) => {
     models.Subscription.belongsTo(models.User, { foreignKey: 'subscriber_id', targetKey: 'id' });

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -1,7 +1,10 @@
+import * as Sequelize from 'sequelize';
 import _ from 'underscore';
 import WebSocket from 'ws';
-import Sequelize from 'sequelize';
 import send, { WebhookContent } from '../webhookNotifier';
+import { UserAttributes } from './user';
+import { NotificationCategoryAttributes } from './notification_category';
+import { NotificationAttributes } from './notification';
 import {
   WebsocketMessageType, IWebsocketsPayload,
   IPostNotificationData, ICommunityNotificationData, IChainEventNotificationData
@@ -11,12 +14,39 @@ const { Op } = Sequelize;
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
-module.exports = (sequelize, DataTypes) => {
-  const Subscription = sequelize.define('Subscription', {
-    subscriber_id: { type: DataTypes.INTEGER, allowNull: false },
-    category_id: { type: DataTypes.STRING, allowNull: false },
-    object_id: { type: DataTypes.STRING, allowNull: false },
-    is_active: { type: DataTypes.BOOLEAN, defaultValue: true, allowNull: false },
+export interface SubscriptionAttributes {
+  id?: number;
+  subscriber_id: number;
+  category_id: string;
+  object_id: string;
+  is_active?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+  User?: UserAttributes;
+  NotificationCategory?: NotificationCategoryAttributes;
+  Notifications?: NotificationAttributes[];
+}
+
+export interface SubscriptionInstance
+extends Sequelize.Instance<SubscriptionAttributes>, SubscriptionAttributes {
+
+}
+
+export interface SubscriptionModel
+extends Sequelize.Model<SubscriptionInstance, SubscriptionAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): Sequelize.Model<SubscriptionInstance, SubscriptionAttributes> => {
+  const Subscription = sequelize.define<SubscriptionInstance, SubscriptionAttributes>('Subscription', {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    subscriber_id: { type: dataTypes.INTEGER, allowNull: false },
+    category_id: { type: dataTypes.STRING, allowNull: false },
+    object_id: { type: dataTypes.STRING, allowNull: false },
+    is_active: { type: dataTypes.BOOLEAN, defaultValue: true, allowNull: false },
   }, {
     underscored: true,
     paranoid: true,
@@ -24,122 +54,123 @@ module.exports = (sequelize, DataTypes) => {
       { fields: ['subscriber_id'] },
       { fields: ['category_id', 'object_id', 'is_active'] },
     ],
+    classMethods: {
+      emitNotifications: async (
+        models,
+        category_id: string,
+        object_id: string,
+        notification_data: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData,
+        webhook_data?: WebhookContent,
+        wss?: WebSocket.Server,
+        excludeAddresses?: string[],
+        includeAddresses?: string[],
+      ) => {
+        // get subscribers to send notifications to
+        const findOptions: any = {
+          [Op.and]: [
+            { category_id },
+            { object_id },
+            { is_active: true },
+          ],
+        };
+
+        // typeguard function to differentiate between chain event notifications as needed
+        const isChainEventData = (
+          n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData
+        ): n is IChainEventNotificationData => {
+          return (n as IChainEventNotificationData).chainEvent !== undefined;
+        };
+
+        const fetchUsersFromAddresses = async (addresses: string[]): Promise<number[]> => {
+          // fetch user ids from address models
+          const addressModels = await models.Address.findAll({
+            where: {
+              address: {
+                [Op.in]: addresses,
+              },
+            },
+          });
+          if (addressModels && addressModels.length > 0) {
+            const userIds = addressModels.map((a) => a.user_id);
+
+            // remove duplicates
+            const userIdsDedup = userIds.filter((a, b) => userIds.indexOf(a) === b);
+            return userIdsDedup;
+          } else {
+            return [];
+          }
+        };
+
+        // currently excludes override includes, but we may want to provide the option for both
+        if (excludeAddresses && excludeAddresses.length > 0) {
+          const ids = await fetchUsersFromAddresses(excludeAddresses);
+          if (ids && ids.length > 0) {
+            findOptions[Op.and].push({ subscriber_id: { [Op.notIn]: ids } });
+          }
+        } else if (includeAddresses && includeAddresses.length > 0) {
+          const ids = await fetchUsersFromAddresses(includeAddresses);
+          if (ids && ids.length > 0) {
+            findOptions[Op.and].push({ subscriber_id: { [Op.in]: ids } });
+          }
+        }
+
+        const subscribers = await models.Subscription.findAll({ where: findOptions });
+
+        // create notifications (data should always exist, but we check anyway)
+        if (!notification_data) return [];
+        const notifications: any[] = await Promise.all(subscribers.map(async (subscription) => {
+          const notificationObj: any = {
+            subscription_id: subscription.id,
+          };
+          if (isChainEventData(notification_data)) {
+            notificationObj.notification_data = '';
+            notificationObj.chain_event_id = notification_data.chainEvent.id;
+          } else {
+            notificationObj.notification_data = JSON.stringify(notification_data);
+          }
+          const notification = await models.Notification.create(notificationObj);
+          return notification;
+        }));
+
+        // send data to relevant webhooks
+        if (webhook_data) {
+          await send(models, {
+            notificationCategory: category_id,
+            ...webhook_data
+          });
+        }
+
+        // send websocket state updates
+        const created_at = new Date();
+        if (wss) {
+          const payload: IWebsocketsPayload<any> = {
+            event: WebsocketMessageType.Notification,
+            data: {
+              topic: category_id,
+              object_id,
+              created_at,
+            }
+          };
+          if (isChainEventData(notification_data)) {
+            payload.data.notification_data = {};
+            payload.data.ChainEvent = notification_data.chainEvent.toJSON();
+            payload.data.ChainEvent.ChainEventType = notification_data.chainEventType.toJSON();
+          } else {
+            payload.data.notification_data = notification_data;
+          }
+          const subscriberIds: number[] = subscribers.map((s) => s.subscriber_id);
+          const userNotificationMap = _.object(subscriberIds, notifications);
+          wss.emit(WebsocketMessageType.Notification, payload, userNotificationMap);
+        }
+        return notifications;
+      }
+    }
   });
 
   Subscription.associate = (models) => {
     models.Subscription.belongsTo(models.User, { foreignKey: 'subscriber_id', targetKey: 'id' });
     models.Subscription.belongsTo(models.NotificationCategory, { foreignKey: 'category_id', targetKey: 'name' });
     models.Subscription.hasMany(models.Notification);
-  };
-
-  Subscription.emitNotifications = async (
-    models,
-    category_id: string,
-    object_id: string,
-    notification_data: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData,
-    webhook_data?: WebhookContent,
-    wss?: WebSocket.Server,
-    excludeAddresses?: string[],
-    includeAddresses?: string[],
-  ) => {
-    // get subscribers to send notifications to
-    const findOptions: any = {
-      [Op.and]: [
-        { category_id },
-        { object_id },
-        { is_active: true },
-      ],
-    };
-
-    // typeguard function to differentiate between chain event notifications as needed
-    const isChainEventData = (
-      n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData
-    ): n is IChainEventNotificationData => {
-      return (n as IChainEventNotificationData).chainEvent !== undefined;
-    };
-
-    const fetchUsersFromAddresses = async (addresses: string[]): Promise<number[]> => {
-      // fetch user ids from address models
-      const addressModels = await models.Address.findAll({
-        where: {
-          address: {
-            [Op.in]: addresses,
-          },
-        },
-      });
-      if (addressModels && addressModels.length > 0) {
-        const userIds = addressModels.map((a) => a.user_id);
-
-        // remove duplicates
-        const userIdsDedup = userIds.filter((a, b) => userIds.indexOf(a) === b);
-        return userIdsDedup;
-      } else {
-        return [];
-      }
-    };
-
-    // currently excludes override includes, but we may want to provide the option for both
-    if (excludeAddresses && excludeAddresses.length > 0) {
-      const ids = await fetchUsersFromAddresses(excludeAddresses);
-      if (ids && ids.length > 0) {
-        findOptions[Op.and].push({ subscriber_id: { [Op.notIn]: ids } });
-      }
-    } else if (includeAddresses && includeAddresses.length > 0) {
-      const ids = await fetchUsersFromAddresses(includeAddresses);
-      if (ids && ids.length > 0) {
-        findOptions[Op.and].push({ subscriber_id: { [Op.in]: ids } });
-      }
-    }
-
-    const subscribers = await models.Subscription.findAll({ where: findOptions });
-
-    // create notifications (data should always exist, but we check anyway)
-    if (!notification_data) return [];
-    const notifications: any[] = await Promise.all(subscribers.map(async (subscription) => {
-      const notificationObj: any = {
-        subscription_id: subscription.id,
-      };
-      if (isChainEventData(notification_data)) {
-        notificationObj.notification_data = '';
-        notificationObj.chain_event_id = notification_data.chainEvent.id;
-      } else {
-        notificationObj.notification_data = JSON.stringify(notification_data);
-      }
-      const notification = await models.Notification.create(notificationObj);
-      return notification;
-    }));
-
-    // send data to relevant webhooks
-    if (webhook_data) {
-      await send(models, {
-        notificationCategory: category_id,
-        ...webhook_data
-      });
-    }
-
-    // send websocket state updates
-    const created_at = new Date();
-    if (wss) {
-      const payload: IWebsocketsPayload<any> = {
-        event: WebsocketMessageType.Notification,
-        data: {
-          topic: category_id,
-          object_id,
-          created_at,
-        }
-      };
-      if (isChainEventData(notification_data)) {
-        payload.data.notification_data = {};
-        payload.data.ChainEvent = notification_data.chainEvent.toJSON();
-        payload.data.ChainEvent.ChainEventType = notification_data.chainEventType.toJSON();
-      } else {
-        payload.data.notification_data = notification_data;
-      }
-      const subscriberIds: number[] = subscribers.map((s) => s.subscriber_id);
-      const userNotificationMap = _.object(subscriberIds, notifications);
-      wss.emit(WebsocketMessageType.Notification, payload, userNotificationMap);
-    }
-    return notifications;
   };
 
   return Subscription;

--- a/server/models/tagged_threads.ts
+++ b/server/models/tagged_threads.ts
@@ -1,7 +1,28 @@
-module.exports = (sequelize, DataTypes) => {
-  const TaggedThread = sequelize.define('TaggedThread', {
-    tag_id: { type: DataTypes.STRING, allowNull: false },
-    thread_id: { type: DataTypes.INTEGER, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+export interface TaggedThreadAttributes {
+  tag_id: string;
+  thread_id: number;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface TaggedThreadInstance
+extends Sequelize.Instance<TaggedThreadAttributes>, TaggedThreadAttributes {
+
+}
+
+export interface TaggedThreadModel extends Sequelize.Model<TaggedThreadInstance, TaggedThreadAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): TaggedThreadModel => {
+  const TaggedThread = sequelize.define<TaggedThreadInstance, TaggedThreadAttributes>('TaggedThread', {
+    tag_id: { type: dataTypes.STRING, allowNull: false },
+    thread_id: { type: dataTypes.INTEGER, allowNull: false },
   }, {
     timestamps: true,
     underscored: true,

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -38,7 +38,9 @@ export interface UserInstance extends Sequelize.Instance<UserAttributes>, UserAt
   getMemberships: Sequelize.HasManyGetAssociationsMixin<MembershipInstance>;
 }
 
-export type UserModel = Sequelize.Model<UserInstance, UserAttributes>;
+export interface UserModel extends Sequelize.Model<UserInstance, UserAttributes> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -16,8 +16,7 @@ export interface UserAttributes {
   created_at?: Date;
   updated_at?: Date;
 
-  // associations
-  // XXX: do everywhere, see https://vivacitylabs.com/setup-typescript-sequelize/
+  // associations (see https://vivacitylabs.com/setup-typescript-sequelize/)
   selectedNode?: ChainNodeAttributes | ChainNodeAttributes['id'];
   Addresses?: AddressAttributes[] | AddressAttributes['id'][];
   SocialAccounts?: SocialAccountAttributes[] | SocialAccountAttributes['id'][];

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -1,10 +1,59 @@
-module.exports = (sequelize, DataTypes) => {
-  const User = sequelize.define('User', {
-    email: { type: DataTypes.STRING },
-    emailVerified: { type: DataTypes.DATE, allowNull: true },
-    isAdmin: { type: DataTypes.BOOLEAN, defaultValue: false },
-    lastVisited: { type: DataTypes.TEXT, allowNull: false, defaultValue: '{}' },
-    disableRichText: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false },
+import * as Sequelize from 'sequelize';
+
+import { AddressInstance, AddressAttributes } from './address';
+import { ChainAttributes } from './chain';
+import { ChainNodeInstance, ChainNodeAttributes } from './chain_node';
+import { SocialAccountInstance, SocialAccountAttributes } from './social_account';
+import { MembershipInstance, MembershipAttributes } from './membership';
+
+export interface UserAttributes {
+  id?: number;
+  email: string;
+  emailVerified?: Date;
+  isAdmin?: boolean;
+  lastVisited?: string;
+  disableRichText?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+
+  // associations
+  // XXX: do everywhere, see https://vivacitylabs.com/setup-typescript-sequelize/
+  selectedNode?: ChainNodeAttributes | ChainNodeAttributes['id'];
+  Addresses?: AddressAttributes[] | AddressAttributes['id'][];
+  SocialAccounts?: SocialAccountAttributes[] | SocialAccountAttributes['id'][];
+  Memberships?: MembershipAttributes[] | MembershipAttributes['id'][];
+  Chains?: ChainAttributes[] | ChainAttributes['id'][];
+}
+
+export interface UserInstance extends Sequelize.Instance<UserAttributes>, UserAttributes {
+  getSelectedNode: Sequelize.BelongsToGetAssociationMixin<ChainNodeInstance>;
+  setSelectedNode: Sequelize.BelongsToSetAssociationMixin<ChainNodeInstance, ChainNodeInstance['id']>;
+
+  hasAddresses: Sequelize.HasManyHasAssociationsMixin<AddressInstance, AddressInstance['id']>;
+  getAddresses: Sequelize.HasManyGetAssociationsMixin<AddressInstance>;
+  setAddresses: Sequelize.HasManySetAssociationsMixin<AddressInstance, AddressInstance['id']>;
+
+  getSocialAccounts: Sequelize.HasManyGetAssociationsMixin<SocialAccountInstance>;
+  setSocialAccounts: Sequelize.HasManySetAssociationsMixin<SocialAccountInstance, SocialAccountInstance['id']>;
+
+  getMemberships: Sequelize.HasManyGetAssociationsMixin<MembershipInstance>;
+}
+
+export type UserModel = Sequelize.Model<UserInstance, UserAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): UserModel => {
+  const User = sequelize.define<UserInstance, UserAttributes>('User', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    email: { type: dataTypes.STRING },
+    emailVerified: { type: dataTypes.DATE, allowNull: true },
+    isAdmin: { type: dataTypes.BOOLEAN, defaultValue: false },
+    lastVisited: { type: dataTypes.TEXT, allowNull: false, defaultValue: '{}' },
+    disableRichText: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
+    created_at: { type: dataTypes.DATE, allowNull: false },
+    updated_at: { type: dataTypes.DATE, allowNull: false },
   }, {
     underscored: true,
     indexes: [

--- a/server/models/waitlist_registration.ts
+++ b/server/models/waitlist_registration.ts
@@ -13,7 +13,11 @@ extends Sequelize.Instance<WaitlistRegistrationAttributes>, WaitlistRegistration
 
 }
 
-export type WaitlistRegistrationModel = Sequelize.Model<WaitlistRegistrationInstance, WaitlistRegistrationAttributes>;
+export interface WaitlistRegistrationModel extends Sequelize.Model<
+  WaitlistRegistrationInstance, WaitlistRegistrationAttributes
+> {
+
+}
 
 export default (
   sequelize: Sequelize.Sequelize,

--- a/server/models/waitlist_registration.ts
+++ b/server/models/waitlist_registration.ts
@@ -1,11 +1,35 @@
-module.exports = (sequelize, DataTypes) => {
-  const WaitlistRegistration = sequelize.define('WaitlistRegistration', {
-    user_id: { type: DataTypes.INTEGER, allowNull: false },
-    chain_id: { type: DataTypes.STRING, allowNull: false },
-    address: { type: DataTypes.STRING, allowNull: true },
-  }, {
-    timestamps: true,
-    underscored: true,
-  });
+import * as Sequelize from 'sequelize';
+
+export interface WaitlistRegistrationAttributes {
+  user_id: number;
+  chain_id: string;
+  address?: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface WaitlistRegistrationInstance
+extends Sequelize.Instance<WaitlistRegistrationAttributes>, WaitlistRegistrationAttributes {
+
+}
+
+export type WaitlistRegistrationModel = Sequelize.Model<WaitlistRegistrationInstance, WaitlistRegistrationAttributes>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): WaitlistRegistrationModel => {
+  const WaitlistRegistration = sequelize.define<WaitlistRegistrationInstance, WaitlistRegistrationAttributes>(
+    'WaitlistRegistration', {
+      user_id: { type: dataTypes.INTEGER, allowNull: false },
+      chain_id: { type: dataTypes.STRING, allowNull: false },
+      address: { type: dataTypes.STRING, allowNull: true },
+      created_at: { type: dataTypes.DATE, allowNull: false },
+      updated_at: { type: dataTypes.DATE, allowNull: false },
+    }, {
+      timestamps: true,
+      underscored: true,
+    }
+  );
   return WaitlistRegistration;
 };

--- a/server/models/webhook.ts
+++ b/server/models/webhook.ts
@@ -1,9 +1,36 @@
-module.exports = (sequelize, DataTypes) => {
-  const Webhook = sequelize.define('Webhook', {
-    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    url: { type: DataTypes.STRING, allowNull: false },
-    chain_id: { type: DataTypes.STRING, allowNull: true },
-    offchain_community_id: { type: DataTypes.STRING, allowNull: true },
+import * as Sequelize from 'sequelize';
+
+import { ChainAttributes } from './chain';
+import { OffchainCommunityAttributes } from './offchain_community';
+
+export interface WebhookAttributes {
+  id?: number;
+  url: string;
+  chain_id?: string;
+  offchain_community_id?: string;
+  created_at?: Date;
+  updated_at?: Date;
+  Chain?: ChainAttributes;
+  OffchainCommunity?: OffchainCommunityAttributes;
+}
+
+export interface WebhookInstance extends Sequelize.Instance<WebhookAttributes>, WebhookAttributes {
+
+}
+
+export interface WebhookModel extends Sequelize.Model<WebhookInstance, WebhookAttributes> {
+
+}
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: Sequelize.DataTypes,
+): WebhookModel => {
+  const Webhook = sequelize.define<WebhookInstance, WebhookAttributes>('Webhook', {
+    id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    url: { type: dataTypes.STRING, allowNull: false },
+    chain_id: { type: dataTypes.STRING, allowNull: true },
+    offchain_community_id: { type: dataTypes.STRING, allowNull: true },
   }, {
     underscored: true,
     indexes: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,6 +1087,11 @@
   resolved "https://registry.yarnpkg.com/@tendermint/amino-js/-/amino-js-0.5.1.tgz#018fb5c8bc162c6d7be0547222964be8e52c1cea"
   integrity sha512-BUb6gNE/mVYuuQ8/Nst/5S6z532wgoZJGwYYhTlIfAMJDXeVFxsOPltd2VYzTZl01OkUUOgNCoewx0zFss+nOA==
 
+"@types/bluebird@*":
+  version "3.5.30"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.30.tgz#ee034a0eeea8b84ed868b1aa60d690b08a6cfbc5"
+  integrity sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw==
+
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.4", "@types/bn.js@^4.11.5", "@types/bn.js@^4.11.6":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -1135,6 +1140,13 @@
   version "3.4.33"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/continuation-local-storage@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/continuation-local-storage/-/continuation-local-storage-3.2.2.tgz#7cbf177a6206ece87bc4b808784772ad2aa5f6db"
+  integrity sha512-aItm+aYPJ4rT1cHmAxO+OdWjSviQ9iB5UKb5f0Uvgln0N4hS2mcDodHtPiqicYBXViUYhqyBjhA5uyOcT+S34Q==
   dependencies:
     "@types/node" "*"
 
@@ -1233,7 +1245,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.123":
+"@types/lodash@*", "@types/lodash@^4.14.123":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
@@ -1371,6 +1383,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/sequelize@^4.28.8":
+  version "4.28.8"
+  resolved "https://registry.yarnpkg.com/@types/sequelize/-/sequelize-4.28.8.tgz#e97b5745d25c12881b348533c1d9e750adf8278b"
+  integrity sha512-3n/iSpOtO5NynSBgEJ+738DK/ctxkqnVMvdPLZxrbZrf/rQgNm8wgDPDSarS1rmluvOe5ZMRDF8DXhts5MIbag==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/continuation-local-storage" "*"
+    "@types/lodash" "*"
+    "@types/validator" "*"
+
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
@@ -1418,6 +1440,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/validator@*":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
 
 "@types/vfile-message@*":
   version "2.0.0"


### PR DESCRIPTION
## Description
This PR changes no server functionality, but splits every server model into three interfaces:
* Attributes defines the set of properties or columns on the model, such as what you might get via calling `.toJSON()` on a Sequelize row. These are intended for use on both client and server.
* Instance extends Attributes to include additional model fetching functions such as `.getChain()`. An instance is what's returned from a call like `models.User.getUser(id)`.
* Model represents the "InstanceFactory" that contains class methods such as `models.Subscription.emitNotification` as well as the standard Sequelize `create`, `find`, etc. calls. These models are load from their respective files and initialized into singletons by `database.ts`, then placed into the `models` object used across the server.

## Motivation and Context
This change leads to way to moving these Attributes classes into a shared folder, which can be combined with our client-side models. We should also figure out a way to include explicit types on Models and Instances used in routes, to improve our type safety there as well.

## How has this been tested?
Server resets and all tests pass.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested (same coverage as before)