### PR TITLE
Featured Tags in Sidebar Update with Pin/Unpin

### DIFF
--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -51,6 +51,16 @@ class ChainInfo {
     this.description = updatedChain.description;
   }
 
+  public addFeaturedTag(tag: string) {
+    this.featuredTags.push(tag);
+  }
+
+  public removeFeaturedTag(tag: string) {
+    if (this.featuredTags.includes(tag)) {
+      this.featuredTags.splice(this.featuredTags.indexOf(tag), 1);
+    }
+  }
+
   public async updateFeaturedTags(tags: string[]) {
     try {
       await $.post(`${app.serverUrl()}/updateChain`, {

--- a/client/scripts/models/CommunityInfo.ts
+++ b/client/scripts/models/CommunityInfo.ts
@@ -64,11 +64,7 @@ class CommunityInfo {
 
   public removeFeaturedTag(tag: string) {
     if (this.featuredTags.includes(tag)) {
-      console.dir(`before: ${this.featuredTags.length}`);
-      console.dir(this.featuredTags);
       this.featuredTags.splice(this.featuredTags.indexOf(tag), 1);
-      console.dir(`after: ${this.featuredTags.length}`);
-      console.dir(this.featuredTags);
     }
   }
 

--- a/client/scripts/models/CommunityInfo.ts
+++ b/client/scripts/models/CommunityInfo.ts
@@ -58,6 +58,20 @@ class CommunityInfo {
     this.invitesEnabled = updatedCommunity.invitesEnabled;
   }
 
+  public addFeaturedTag(tag: string) {
+    this.featuredTags.push(tag);
+  }
+
+  public removeFeaturedTag(tag: string) {
+    if (this.featuredTags.includes(tag)) {
+      console.dir(`before: ${this.featuredTags.length}`);
+      console.dir(this.featuredTags);
+      this.featuredTags.splice(this.featuredTags.indexOf(tag), 1);
+      console.dir(`after: ${this.featuredTags.length}`);
+      console.dir(this.featuredTags);
+    }
+  }
+
   public async updateFeaturedTags(tags: string[]) {
     try {
       await $.post(`${app.serverUrl()}/updateCommunity`, {

--- a/client/scripts/views/components/sidebar/tag_selector.ts
+++ b/client/scripts/views/components/sidebar/tag_selector.ts
@@ -256,16 +256,22 @@ const TagSelector: m.Component<{
     const activeEntity = app.community ? app.community : app.chain;
     if (!activeEntity) return;
 
-    if (!vnode.state.featuredTagIds) {
-      vnode.state.featuredTagIds = app.community?.meta?.featuredTags || app.chain?.meta?.chain?.featuredTags;
-    }
+    vnode.state.featuredTagIds = app.community?.meta?.featuredTags || app.chain?.meta?.chain?.featuredTags;
     const featuredTagIds = vnode.state.featuredTagIds || [];
     const addFeaturedTag = (tagId: string) => {
-      vnode.state.featuredTagIds.push(tagId);
+      if (app.community) {
+        app.community.meta.addFeaturedTag(tagId);
+      } else if (app.chain) {
+        app.chain.meta.chain.addFeaturedTag(tagId);
+      }
       m.redraw();
     };
     const removeFeaturedTag = (tagId: string) => {
-      vnode.state.featuredTagIds = vnode.state.featuredTagIds.filter((t) => Number(t) !== Number(tagId));
+      if (app.community) {
+        app.community.meta.removeFeaturedTag(tagId);
+      } else if (app.chain) {
+        app.chain.meta.chain.removeFeaturedTag(tagId);
+      }
       m.redraw();
     };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The sidebar featured tags were not updating when an admin adjusts them in the tags page. This was an issue with the fact that we're rendering the same component in two different instances, on the page and in the sidebar and we were only updating the state in the page. I changed the logic to so the state gets updated from the app each time, not just at initialization, and that when you update a tag to be featured, it updates in the app and trickles down into the components. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug.

<img width="737" alt="Screen Shot 2020-06-02 at 2 58 56 PM" src="https://user-images.githubusercontent.com/16248081/83558892-af11d600-a4e1-11ea-8788-587bdaa423ef.png">


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Clicked around and seems to work now.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no