### PR TITLE
Remove next up and combine into "Waiting Validators"

### DIFF
--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -44,7 +44,7 @@ export interface IValidatorValue {
   exposure: Exposure,
   controller: string,
   isElected: boolean,
-  isWaiting?: boolean,
+  toBeElected?: boolean,
   commissionPer?: number,
   eraPoints?: string
 }

--- a/client/scripts/controllers/chain/substrate/staking.ts
+++ b/client/scripts/controllers/chain/substrate/staking.ts
@@ -96,7 +96,7 @@ class SubstrateStaking implements StorageModule {
             exposure: exposures[i],
             controller: controllers[i].toString(),
             isElected: true,
-            isWaiting: false,
+            toBeElected: false,
             eraPoints: eraPoints[key]
           };
         }
@@ -107,7 +107,7 @@ class SubstrateStaking implements StorageModule {
             exposure: nextUpExposures[i],
             controller: nextUpControllers[i].toString(),
             isElected: false,
-            isWaiting: false,
+            toBeElected: true,
             eraPoints: eraPoints[key]
           };
         }
@@ -118,7 +118,7 @@ class SubstrateStaking implements StorageModule {
             exposure: null,
             controller: null,
             isElected: false,
-            isWaiting: true,
+            toBeElected: false,
             eraPoints: eraPoints[key]
           };
         }

--- a/client/scripts/views/pages/validators/index.ts
+++ b/client/scripts/views/pages/validators/index.ts
@@ -32,7 +32,8 @@ export interface IValidatorAttrs {
   commissionPer?: number;
   onChangeHandler?: any;
   waiting?: boolean;
-  eraPoints?: string
+  eraPoints?: string;
+  toBeElected?: boolean;
 }
 
 export interface IValidatorPageState {

--- a/client/scripts/views/pages/validators/substrate/preheader.ts
+++ b/client/scripts/views/pages/validators/substrate/preheader.ts
@@ -57,7 +57,7 @@ export const SubstratePreHeader = makeDynamicComponent<IPreHeaderAttrs, IPreHead
         });
     }
 
-    Object.entries(validators).forEach(([_stash, { exposure, isWaiting }]) => {
+    Object.entries(validators).forEach(([_stash, { exposure, isElected }]) => {
       const valStake = (app.chain as Substrate).chain.coins(exposure?.total.toBn())
       || (app.chain as Substrate).chain.coins(0);
       totalStaked = (app.chain as Substrate).chain.coins(totalStaked.asBN.add(valStake.asBN));
@@ -71,10 +71,10 @@ export const SubstratePreHeader = makeDynamicComponent<IPreHeaderAttrs, IPreHead
         }
       });
       // count elected and waiting validators
-      if (isWaiting) {
-        waiting++;
-      } else {
+      if (isElected) {
         elected++;
+      } else {
+        waiting++;
       }
     });
     const totalbalance = (app.chain as Substrate).chain.totalbalance;

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -22,7 +22,7 @@ const PresentationComponent = (state, chain: Substrate) => {
         m('th.val-action', ''),
       ]),
       Object.keys(validators).filter((validator) => (
-        validators[validator].isElected === true && validators[validator].isWaiting === false
+        validators[validator].isElected === true
       )).sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
         .map((validator) => {
           // total stake
@@ -66,46 +66,6 @@ const PresentationComponent = (state, chain: Substrate) => {
         }),
     ])
   }, {
-    name: 'Next Up',
-    content: m('table.validators-table', [
-      m('tr.validators-heading', [
-        m('th.val-controller', 'Controller'),
-        m('th.val-stash', 'Stash'),
-        m('th.val-total', 'Total Stake'),
-        m('th.val-total', 'Own Stake'),
-        m('th.val-total', 'Other Stake'),
-        m('th.val-commission', 'Commission'),
-        m('th.val-points', 'Points'),
-        // m('th.val-age', 'Validator Age'),
-        m('th.val-action', ''),
-      ]),
-      Object.keys(validators).filter((validator) => (
-        validators[validator].isElected === false && validators[validator].isWaiting === false
-      )).sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
-        .map((validator) => {
-          const total = chain.chain.coins(validators[validator].exposure.total);
-          const bonded = chain.chain.coins(validators[validator].exposure.own);
-          const nominated = chain.chain.coins(total.asBN.sub(bonded.asBN));
-          const commissionPer = validators[validator].commissionPer;
-          const nominators = validators[validator].exposure.others.map(({ who, value }) => ({
-            stash: who.toString(),
-            balance: chain.chain.coins(value),
-          }));
-          const controller = validators[validator].controller;
-          const eraPoints = validators[validator].eraPoints;
-          return m(ValidatorRow, {
-            stash: validator,
-            controller,
-            total,
-            bonded,
-            nominated,
-            nominators,
-            commissionPer,
-            eraPoints
-          });
-        }),
-    ])
-  }, {
     name: 'Waiting Validators',
     content: m('table.validators-table', [
       m('tr.validators-heading', [
@@ -116,7 +76,7 @@ const PresentationComponent = (state, chain: Substrate) => {
         m('th.val-action', ''),
       ]),
       Object.keys(validators).filter((validator) => (
-        validators[validator].isElected === false && validators[validator].isWaiting === true
+        validators[validator].isElected === false
       )).sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
         .map((validator) => {
           const total = chain.chain.coins(0);
@@ -126,6 +86,7 @@ const PresentationComponent = (state, chain: Substrate) => {
           const nominators = [];
           const controller = validators[validator].controller;
           const eraPoints = validators[validator].eraPoints;
+          const toBeElected = validators[validator].toBeElected;
           return m(ValidatorRow, {
             stash: validator,
             controller,
@@ -135,7 +96,8 @@ const PresentationComponent = (state, chain: Substrate) => {
             nominators,
             commissionPer,
             waiting: true,
-            eraPoints
+            eraPoints,
+            toBeElected
           });
         }),
     ])

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -125,6 +125,11 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
       (!vnode.attrs.waiting
         && m('td.val-points', vnode.attrs.eraPoints || '-')
       ),
+      (vnode.attrs.waiting
+        && m('td.val-points', vnode.attrs.toBeElected
+          ? 'PolkadotJS'
+          : '')
+      ),
       // m('td.val-action', [
       //   m('button.view-validator.formular-button-primary', {
       //     onclick: (e) => {


### PR DESCRIPTION

## Description
Individual "next up" validators on the waiting list can then be highlighted as they are on the PolkadotJS Apps in the waiting validators tab. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested for kusama and edgeware. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no

[Ticket # 299](https://github.com/hicommonwealth/commonwealth/issues/299)