### PR TITLE
Permit signaling proposal vote fetch even if completed.

### DIFF
--- a/client/scripts/controllers/chain/edgeware/signaling_proposal.ts
+++ b/client/scripts/controllers/chain/edgeware/signaling_proposal.ts
@@ -223,7 +223,9 @@ export class EdgewareSignalingProposal
   private _subscribeVoters(): Unsubscribable {
     return this._Chain.api.pipe(
       switchMap((api: ApiRx) => api.query.voting.voteRecords<Option<VoteRecord>>(this.data.voteIndex)),
-      takeWhile<Option<VoteRecord>>((v) => v.isSome && this.initialized && !this.completed),
+      takeWhile<Option<VoteRecord>>((v) => v.isSome && this.initialized),
+      // permit one vote query even if completed
+      takeWhile<Option<VoteRecord>>((v) => !this.completed, true),
 
       // grab latest voter balances as well, to avoid subscribing to each on vote-creation
       flatMap((v) => combineLatest(


### PR DESCRIPTION
## Description
Fixes #320. Previously, signaling votes were not fetched at all if the proposal was marked completed. This fix permits one vote query if the proposal is completed, to populate the final tally, and then closes the subscription.

## Motivation and Context
Solves the bug where completed signaling proposals have no vote count.

## How has this been tested?
Ran against edgeware mainnet, it fetched votes correctly.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no