### PR TITLE
Remove Default Imports

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -4,8 +4,8 @@ import 'lib/flexboxgrid.css';
 import 'lity/dist/lity.min.css';
 import 'construct.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { FocusManager } from 'construct-ui';
 
 import app, { ApiStatus, LoginState } from 'state';
@@ -14,8 +14,8 @@ import { Layout, LoadingLayout } from 'views/layout';
 import { ChainInfo, CommunityInfo, NodeInfo,
   OffchainTag, ChainClass, ChainNetwork, NotificationCategory, Notification } from 'models';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import { default as moment } from 'moment-twitter';
-import { default as mixpanel } from 'mixpanel-browser';
+import moment from 'moment-twitter';
+import mixpanel from 'mixpanel-browser';
 
 import { WebsocketMessageType, IWebsocketsPayload } from 'types';
 import { clearActiveAddresses, updateActiveAddresses, updateActiveUser } from 'controllers/app/login';

--- a/client/scripts/controllers/app/login.ts
+++ b/client/scripts/controllers/app/login.ts
@@ -1,8 +1,8 @@
 /**
  * @file Manages logged-in user accounts and local storage.
  */
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import app from 'state';
 
 import { getRoleInCommunity, getAllRolesInCommunity, getDefaultAddressInCommunity } from 'helpers';

--- a/client/scripts/controllers/chain/cosmos/account.ts
+++ b/client/scripts/controllers/chain/cosmos/account.ts
@@ -1,4 +1,4 @@
-import { default as _ } from 'lodash';
+import _ from 'lodash';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 

--- a/client/scripts/controllers/chain/cosmos/proposal.ts
+++ b/client/scripts/controllers/chain/cosmos/proposal.ts
@@ -15,7 +15,7 @@ import { CosmosApi } from 'adapters/chain/cosmos/api';
 import { Unsubscribable, BehaviorSubject } from 'rxjs';
 import { filter, takeWhile } from 'rxjs/operators';
 import { ProposalStore } from 'stores';
-import { default as moment } from 'moment-twitter';
+import moment from 'moment-twitter';
 import { CosmosAccount, CosmosAccounts } from './account';
 import CosmosChain from './chain';
 import CosmosGovernance, { marshalTally } from './governance';

--- a/client/scripts/controllers/chain/edgeware/shared.ts
+++ b/client/scripts/controllers/chain/edgeware/shared.ts
@@ -1,4 +1,4 @@
-import { default as SubstrateChain } from 'controllers/chain/substrate/shared';
+import SubstrateChain from 'controllers/chain/substrate/shared';
 
 class EdgewareChain extends SubstrateChain {
 

--- a/client/scripts/controllers/chain/edgeware/signaling.ts
+++ b/client/scripts/controllers/chain/edgeware/signaling.ts
@@ -4,7 +4,7 @@ import { BlockNumber, BalanceOf, Balance } from '@polkadot/types/interfaces';
 
 import { IEdgewareSignalingProposal } from 'adapters/chain/edgeware/types';
 import { ProposalModule, ChainEntity, } from 'models';
-import { default as SubstrateChain } from 'controllers/chain/substrate/shared';
+import SubstrateChain from 'controllers/chain/substrate/shared';
 import SubstrateAccounts, { SubstrateAccount } from 'controllers/chain/substrate/account';
 import { SubstrateCoin } from 'adapters/chain/substrate/types';
 import { SubstrateEntityKind } from 'events/edgeware/types';

--- a/client/scripts/controllers/chain/edgeware/signaling_proposal.ts
+++ b/client/scripts/controllers/chain/edgeware/signaling_proposal.ts
@@ -10,7 +10,7 @@ import {
   Account, Proposal, ProposalStatus, ProposalEndTime, IVote, VotingType,
   VotingUnit, ChainClass, ChainEntity, ChainEvent
 } from 'models';
-import { default as SubstrateChain } from 'controllers/chain/substrate/shared';
+import SubstrateChain from 'controllers/chain/substrate/shared';
 import SubstrateAccounts, { SubstrateAccount } from 'controllers/chain/substrate/account';
 import { BehaviorSubject, Unsubscribable, combineLatest, of } from 'rxjs';
 import { SubstrateCoin } from 'adapters/chain/substrate/types';

--- a/client/scripts/controllers/chain/ethereum/main.ts
+++ b/client/scripts/controllers/chain/ethereum/main.ts
@@ -1,4 +1,4 @@
-import { default as EthereumChain } from 'controllers/chain/ethereum/chain';
+import EthereumChain from 'controllers/chain/ethereum/chain';
 import { default as EthereumAccounts, EthereumAccount } from 'controllers/chain/ethereum/account';
 import { EthereumCoin } from 'adapters/chain/ethereum/types';
 import { IChainAdapter, ChainBase, ChainClass } from 'models';

--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -6,7 +6,7 @@ import { SubstrateEntityKind } from 'events/edgeware/types';
 import { ProposalModule, ChainEntity } from 'models';
 import { Unsubscribable } from 'rxjs';
 import { Vec } from '@polkadot/types';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateCollectiveProposal } from './collective_proposal';
 

--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -10,7 +10,7 @@ import {
   VotingUnit, ChainEntity, ChainEvent
 } from 'models';
 import { ISubstrateCollectiveProposed, SubstrateEventKind } from 'events/edgeware/types';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import SubstrateCollective from './collective';
 

--- a/client/scripts/controllers/chain/substrate/democracy.ts
+++ b/client/scripts/controllers/chain/substrate/democracy.ts
@@ -4,7 +4,7 @@ import { Vote as SrmlVote, BlockNumber } from '@polkadot/types/interfaces';
 import { ISubstrateDemocracyReferendum, SubstrateCoin } from 'adapters/chain/substrate/types';
 import { ITXModalData, ProposalModule, ChainEntity } from 'models';
 import { SubstrateEntityKind } from 'events/edgeware/types';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateDemocracyReferendum } from './democracy_referendum';
 

--- a/client/scripts/controllers/chain/substrate/democracy_referendum.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_referendum.ts
@@ -15,7 +15,7 @@ import {
 import { SubstrateEventKind, ISubstrateDemocracyStarted } from 'events/edgeware/types';
 import { BehaviorSubject, Unsubscribable, of } from 'rxjs';
 import { Coin } from 'adapters/currency';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import SubstrateDemocracy from './democracy';
 

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -9,7 +9,7 @@ import {
 } from 'adapters/chain/substrate/types';
 import { ProposalModule, ChainEntity } from 'models';
 import { SubstrateEntityKind } from 'events/edgeware/types';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateTreasuryProposal } from './treasury_proposal';
 

--- a/client/scripts/controllers/chain/substrate/treasury_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/treasury_proposal.ts
@@ -9,7 +9,7 @@ import {
   VotingType, VotingUnit, ChainEntity, ChainEvent
 } from 'models';
 import { ISubstrateTreasuryProposed, SubstrateEventKind } from 'events/edgeware/types';
-import { default as SubstrateChain } from './shared';
+import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import SubstrateTreasury from './treasury';
 

--- a/client/scripts/controllers/server/chain_entities.ts
+++ b/client/scripts/controllers/server/chain_entities.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
-import { default as $ } from 'jquery';
-import { default as _ } from 'lodash';
+import $ from 'jquery';
+import _ from 'lodash';
 
 import { ChainEntityStore } from 'stores';
 import { ChainEntity, ChainEvent } from 'models';

--- a/client/scripts/controllers/server/chain_objects.ts
+++ b/client/scripts/controllers/server/chain_objects.ts
@@ -1,4 +1,4 @@
-import { default as $ } from 'jquery';
+import $ from 'jquery';
 import app from 'state';
 import { ChainObject } from 'models';
 

--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -1,6 +1,6 @@
-import { default as $ } from 'jquery';
-import { default as _ } from 'lodash';
-import { default as moment } from 'moment-twitter';
+import $ from 'jquery';
+import _ from 'lodash';
+import moment from 'moment-twitter';
 
 import app from 'state';
 import { uniqueIdToProposal } from 'identifiers';

--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
-import { default as $ } from 'jquery';
-import { default as _ } from 'lodash';
+import $ from 'jquery';
+import _ from 'lodash';
 
 import { NotificationStore } from 'stores';
 import { NotificationSubscription, Notification } from 'models';

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -1,8 +1,8 @@
 /* eslint-disable dot-notation */
 /* eslint-disable no-restricted-syntax */
-import { default as $ } from 'jquery';
-import { default as _ } from 'lodash';
-import { default as moment } from 'moment-twitter';
+import $ from 'jquery';
+import _ from 'lodash';
+import moment from 'moment-twitter';
 
 import app from 'state';
 import { uniqueIdToProposal } from 'identifiers';

--- a/client/scripts/controllers/server/socket/chat.ts
+++ b/client/scripts/controllers/server/socket/chat.ts
@@ -1,5 +1,5 @@
 /*
-import { default as moment } from 'moment-twitter';
+import moment from 'moment-twitter';
 import { Account } from 'models';
 import app from 'state';
 import WebsocketController, { IWebsocketsPayload } from '.';

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-restricted-syntax */
-import { default as _ } from 'lodash';
-import { default as moment } from 'moment-twitter';
-import { ProposalStore, TagsStore } from 'stores';
+import _ from 'lodash';
+import moment from 'moment-twitter';
+import { ProposalStore } from 'stores';
 import { OffchainThread, OffchainAttachment, OffchainTag, CommunityInfo } from 'models';
 
-import { default as $ } from 'jquery';
+import $ from 'jquery';
 import app from 'state';
 import { notifyError } from 'controllers/app/notifications';
 

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import _ from 'lodash';
 import moment from 'moment-twitter';
-import { ProposalStore } from 'stores';
+import { ProposalStore, TagsStore } from 'stores';
 import { OffchainThread, OffchainAttachment, OffchainTag, CommunityInfo } from 'models';
 
 import $ from 'jquery';

--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as moment } from 'moment-twitter';
+import m from 'mithril';
+import moment from 'moment-twitter';
 
 import app from 'state';
 import { Account } from 'models';

--- a/client/scripts/views/components/autocomplete_tag_form.ts
+++ b/client/scripts/views/components/autocomplete_tag_form.ts
@@ -1,6 +1,8 @@
 import 'components/autocomplete_tag_form.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
+import { SelectList, ListItem, Colors, Button, Icons, List } from 'construct-ui';
+import { OffchainTag } from 'client/scripts/models';
 import { symbols } from '../../helpers';
 import { AutoCompleteForm } from './autocomplete_input';
 

--- a/client/scripts/views/components/autocomplete_tag_form.ts
+++ b/client/scripts/views/components/autocomplete_tag_form.ts
@@ -1,8 +1,6 @@
 import 'components/autocomplete_tag_form.scss';
 
 import m from 'mithril';
-import { SelectList, ListItem, Colors, Button, Icons, List } from 'construct-ui';
-import { OffchainTag } from 'client/scripts/models';
 import { symbols } from '../../helpers';
 import { AutoCompleteForm } from './autocomplete_input';
 

--- a/client/scripts/views/components/avatar_upload.ts
+++ b/client/scripts/views/components/avatar_upload.ts
@@ -1,8 +1,8 @@
 import 'components/avatar_upload.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
-import { default as Dropzone } from 'dropzone';
+import $ from 'jquery';
+import m from 'mithril';
+import Dropzone from 'dropzone';
 import { featherIcon } from 'helpers';
 import app from 'state';
 

--- a/client/scripts/views/components/cancel_proposal_button.ts
+++ b/client/scripts/views/components/cancel_proposal_button.ts
@@ -1,6 +1,6 @@
 import 'components/cancel_proposal_button.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app, { ApiStatus } from 'state';
 
 interface IAttrs {

--- a/client/scripts/views/components/chain_icon.ts
+++ b/client/scripts/views/components/chain_icon.ts
@@ -1,6 +1,6 @@
 import 'components/chain_icon.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import { ChainInfo, CommunityInfo } from 'models';
 
 export const ChainIcon: m.Component<{ chain: ChainInfo }> = {

--- a/client/scripts/views/components/chain_status_indicator.ts
+++ b/client/scripts/views/components/chain_status_indicator.ts
@@ -1,6 +1,6 @@
 import 'components/chain_status_indicator.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app, { ApiStatus } from 'state';
 
 interface IAttrs {

--- a/client/scripts/views/components/countdown.ts
+++ b/client/scripts/views/components/countdown.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as moment } from 'moment-twitter';
+import m from 'mithril';
+import moment from 'moment-twitter';
 
 import { formatDuration, blocknumToTime } from 'helpers';
 

--- a/client/scripts/views/components/dropzone_textarea.ts
+++ b/client/scripts/views/components/dropzone_textarea.ts
@@ -1,8 +1,8 @@
 import 'components/dropzone_textarea.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
-import { default as Dropzone } from 'dropzone';
+import $ from 'jquery';
+import m from 'mithril';
+import Dropzone from 'dropzone';
 import { featherIcon } from 'helpers';
 import app from 'state';
 import ResizableTextarea from 'views/components/widgets/resizable_textarea';

--- a/client/scripts/views/components/forms.ts
+++ b/client/scripts/views/components/forms.ts
@@ -1,7 +1,7 @@
 import 'components/forms.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import ResizableTextarea from 'views/components/widgets/resizable_textarea';
 
 interface ITextFormFieldAttrs {

--- a/client/scripts/views/components/hedgehog_login_form.ts
+++ b/client/scripts/views/components/hedgehog_login_form.ts
@@ -1,9 +1,9 @@
 import 'components/hedgehog_login_form.scss';
 
 import axios from 'axios';
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
-import { default as app } from 'state';
+import $ from 'jquery';
+import m from 'mithril';
+import app from 'state';
 import { createUserWithAddress } from 'controllers/app/login';
 import { EthereumAccount } from 'client/scripts/controllers/chain/ethereum/account';
 

--- a/client/scripts/views/components/inline_thread_composer.ts
+++ b/client/scripts/views/components/inline_thread_composer.ts
@@ -1,8 +1,8 @@
 import 'components/inline_thread_composer.scss';
 
-import { default as m } from 'mithril';
-import { default as _ } from 'lodash';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import _ from 'lodash';
+import $ from 'jquery';
 import { Button, Input, RadioGroup, Radio } from 'construct-ui';
 
 import app from 'state';

--- a/client/scripts/views/components/markdown_formatted_text.ts
+++ b/client/scripts/views/components/markdown_formatted_text.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-useless-escape */
 import 'components/markdown_formatted_text.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
+import $ from 'jquery';
+import m from 'mithril';
 
 // Three-pass Markdown formatter.
 //

--- a/client/scripts/views/components/membership_button.ts
+++ b/client/scripts/views/components/membership_button.ts
@@ -1,7 +1,7 @@
 import 'components/membership_button.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { Button, Icon, Icons, MenuItem, MenuDivider, PopoverMenu } from 'construct-ui';
 
 import app from 'state';

--- a/client/scripts/views/components/proposals/convictions_table.ts
+++ b/client/scripts/views/components/proposals/convictions_table.ts
@@ -1,6 +1,6 @@
 import 'components/proposals/convictions_table.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import { formatDuration, blockperiodToDuration } from 'helpers';
 import { convictionToWeight, convictionToLocktime, convictions } from 'controllers/chain/substrate/democracy_referendum';
 import Substrate from 'controllers/chain/substrate/main';

--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -1,6 +1,6 @@
 import 'components/proposals/voting_results.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import { VoteOutcome } from 'edgeware-node-types/dist';
 import { u8aToString } from '@polkadot/util';
 

--- a/client/scripts/views/components/proposals_loading_row.ts
+++ b/client/scripts/views/components/proposals_loading_row.ts
@@ -1,6 +1,6 @@
 import 'components/proposals_loading_row.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 const ProposalsLoadingRow: m.Component = {
   view: (vnode: m.VnodeDOM) => {

--- a/client/scripts/views/components/quill_formatted_text.ts
+++ b/client/scripts/views/components/quill_formatted_text.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-syntax */
 import 'components/quill_formatted_text.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
+import $ from 'jquery';
+import m from 'mithril';
 import { stringUpperFirst } from '@polkadot/util';
 import { loadScript } from '../../helpers';
 

--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -1,7 +1,7 @@
 import 'components/reaction_button.scss';
 
-import { default as m, VnodeDOM } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import { Tooltip } from 'construct-ui';
 
 import app from 'state';

--- a/client/scripts/views/components/sending_from.ts
+++ b/client/scripts/views/components/sending_from.ts
@@ -1,6 +1,6 @@
 import 'components/sending_from.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import User from 'views/components/widgets/user';
 import { Coin } from 'adapters/currency';
 import { makeDynamicComponent } from 'models/mithril';

--- a/client/scripts/views/components/settings/send_edg_well.ts
+++ b/client/scripts/views/components/settings/send_edg_well.ts
@@ -1,6 +1,6 @@
 import 'components/settings/send_edg_well.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app from 'state';
 
 import { SubstrateAccount } from 'controllers/chain/substrate/account';

--- a/client/scripts/views/components/settings/settings_well.ts
+++ b/client/scripts/views/components/settings/settings_well.ts
@@ -1,6 +1,6 @@
 import 'components/settings/settings_well.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app from 'state';
 
 import { DropdownFormField, RadioSelectorFormField } from 'views/components/forms';

--- a/client/scripts/views/components/subkey_instructions.ts
+++ b/client/scripts/views/components/subkey_instructions.ts
@@ -1,4 +1,4 @@
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app from 'state';
 import SubkeyInstructionsModal from 'views/modals/subkey_instructions_modal';
 

--- a/client/scripts/views/components/widgets/account_balance.ts
+++ b/client/scripts/views/components/widgets/account_balance.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/account_balance.scss';
 
 import { BalanceLock, BalanceLockTo212 } from '@polkadot/types/interfaces';
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 import { Coin, formatCoin } from 'adapters/currency';
 import { SubstrateCoin } from 'adapters/chain/substrate/types';

--- a/client/scripts/views/components/widgets/character_limited_text_input.ts
+++ b/client/scripts/views/components/widgets/character_limited_text_input.ts
@@ -1,8 +1,8 @@
 import 'components/widgets/character_limited_text_input.scss';
 
-import { default as m } from 'mithril';
-import { default as _ } from 'lodash';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import _ from 'lodash';
+import $ from 'jquery';
 
 const debouncedRedraw = _.debounce(() => { m.redraw(); }, 100, { leading: true, trailing: true });
 

--- a/client/scripts/views/components/widgets/code_block.ts
+++ b/client/scripts/views/components/widgets/code_block.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/code_block.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 
 interface IAttrs {
   clickToSelect: boolean;

--- a/client/scripts/views/components/widgets/dropdown_button.ts
+++ b/client/scripts/views/components/widgets/dropdown_button.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/dropdown_button.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 
 import { featherIcon } from 'helpers';
 

--- a/client/scripts/views/components/widgets/horizontal_tabs.ts
+++ b/client/scripts/views/components/widgets/horizontal_tabs.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/horizontal_tabs.scss';
 
-import { default as _ } from 'lodash';
-import { default as m } from 'mithril';
+import _ from 'lodash';
+import m from 'mithril';
 
 const HorizontalTabs = {
   view: (vnode) => {

--- a/client/scripts/views/components/widgets/popopen_truncated_text.ts
+++ b/client/scripts/views/components/widgets/popopen_truncated_text.ts
@@ -1,5 +1,5 @@
 import 'components/widgets/popopen_truncated_text.scss';
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 interface IAttrs {
   text: string;

--- a/client/scripts/views/components/widgets/profile_block.ts
+++ b/client/scripts/views/components/widgets/profile_block.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/profile_block.scss';
 
-import { default as m } from 'mithril';
-import { default as app } from 'state';
+import m from 'mithril';
+import app from 'state';
 import User from 'views/components/widgets/user';
 import { Account, ChainBase } from 'models';
 import { formatCoin, Coin } from 'adapters/currency';

--- a/client/scripts/views/components/widgets/tabs.ts
+++ b/client/scripts/views/components/widgets/tabs.ts
@@ -1,7 +1,7 @@
 import 'components/widgets/tabs.scss';
 
-import { default as _ } from 'lodash';
-import { default as m } from 'mithril';
+import _ from 'lodash';
+import m from 'mithril';
 
 const Tabs = {
   view: (vnode) => {

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-script-url */
 import 'components/widgets/user.scss';
 
-import { default as m } from 'mithril';
-import { default as _ } from 'lodash';
+import m from 'mithril';
+import _ from 'lodash';
 import { formatAddressShort, link } from 'helpers';
 import { Tooltip } from 'construct-ui';
 

--- a/client/scripts/views/modal.ts
+++ b/client/scripts/views/modal.ts
@@ -36,8 +36,8 @@
 
 import 'modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 
 import app from 'state';
 import { featherIcon, symbols } from 'helpers';

--- a/client/scripts/views/modals/confirm_modal.ts
+++ b/client/scripts/views/modals/confirm_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/confirm_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import app from 'state';
 import { Button } from 'construct-ui';
 

--- a/client/scripts/views/modals/council_voting_modal.ts
+++ b/client/scripts/views/modals/council_voting_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/council_voting_modal.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
+import $ from 'jquery';
+import m from 'mithril';
 
 import app from 'state';
 

--- a/client/scripts/views/modals/create_community_modal.ts
+++ b/client/scripts/views/modals/create_community_modal.ts
@@ -1,11 +1,11 @@
 import 'modals/create_community_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as _ } from 'lodash';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import $ from 'jquery';
+import _ from 'lodash';
+import mixpanel from 'mixpanel-browser';
 
-import { default as app } from 'state';
+import app from 'state';
 import { inputModalWithText } from 'views/modals/input_modal';
 
 // import User from 'views/components/widgets/user';

--- a/client/scripts/views/modals/edit_profile_modal.ts
+++ b/client/scripts/views/modals/edit_profile_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/edit_profile_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import app from 'state';
 import {
   PROFILE_BIO_MAX_CHARS,

--- a/client/scripts/views/modals/edit_tag_modal.ts
+++ b/client/scripts/views/modals/edit_tag_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/edit_tag_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as app } from 'state';
+import m from 'mithril';
+import app from 'state';
 import $ from 'jquery';
 import { Button } from 'construct-ui';
 

--- a/client/scripts/views/modals/feedback_modal.ts
+++ b/client/scripts/views/modals/feedback_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/feedback_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { Button, Form, FormGroup, TextArea } from 'construct-ui';
 import app from 'state';
 

--- a/client/scripts/views/modals/input_modal.ts
+++ b/client/scripts/views/modals/input_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/input_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import app from 'state';
 import { Button } from 'construct-ui';
 

--- a/client/scripts/views/modals/message_signing_modal.ts
+++ b/client/scripts/views/modals/message_signing_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/message_signing_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import app from 'state';
 
 import CodeBlock from 'views/components/widgets/code_block';

--- a/client/scripts/views/modals/preview_modal.ts
+++ b/client/scripts/views/modals/preview_modal.ts
@@ -1,6 +1,6 @@
 import 'modals/preview_modal.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import QuillFormattedText from 'views/components/quill_formatted_text';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
 import { CompactModalExitButton } from 'views/modal';

--- a/client/scripts/views/modals/ragequit_modal.ts
+++ b/client/scripts/views/modals/ragequit_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/ragequit_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { TextInputFormField } from 'views/components/forms';
 import { MolochShares } from 'adapters/chain/ethereum/types';
 import MolochMember from 'controllers/chain/ethereum/moloch/member';

--- a/client/scripts/views/modals/subkey_instructions_modal.ts
+++ b/client/scripts/views/modals/subkey_instructions_modal.ts
@@ -1,6 +1,6 @@
 import 'modals/subkey_instructions_modal.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import CodeBlock from 'views/components/widgets/code_block';
 
 const SubkeyInstructionsModal: m.Component<{}> = {

--- a/client/scripts/views/modals/token_approval_modal.ts
+++ b/client/scripts/views/modals/token_approval_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/token_approval_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { TextInputFormField } from 'views/components/forms';
 import MolochMember from 'controllers/chain/ethereum/moloch/member';
 import { notifyError } from 'controllers/app/notifications';

--- a/client/scripts/views/modals/update_delegate_modal.ts
+++ b/client/scripts/views/modals/update_delegate_modal.ts
@@ -1,7 +1,7 @@
 import 'modals/update_delegate_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import { TextInputFormField } from 'views/components/forms';
 import MolochMember from 'controllers/chain/ethereum/moloch/member';
 import { notifyError } from 'controllers/app/notifications';

--- a/client/scripts/views/modals/version_history_modal.ts
+++ b/client/scripts/views/modals/version_history_modal.ts
@@ -4,7 +4,7 @@ import m from 'mithril';
 import $ from 'jquery';
 import app from 'state';
 import Quill from 'quill';
-import moment from 'moment-twitter';
+import moment from 'moment';
 import { OffchainThread, OffchainComment } from 'models';
 import { CompactModalExitButton } from '../modal';
 import QuillFormattedText from '../components/quill_formatted_text';

--- a/client/scripts/views/modals/version_history_modal.ts
+++ b/client/scripts/views/modals/version_history_modal.ts
@@ -1,10 +1,10 @@
 import 'modals/version_history_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as app } from 'state';
-import { default as Quill } from 'quill';
-import { default as moment } from 'moment';
+import m from 'mithril';
+import $ from 'jquery';
+import app from 'state';
+import Quill from 'quill';
+import moment from 'moment-twitter';
 import { OffchainThread, OffchainComment } from 'models';
 import { CompactModalExitButton } from '../modal';
 import QuillFormattedText from '../components/quill_formatted_text';

--- a/client/scripts/views/modals/waiting_list_modal.ts
+++ b/client/scripts/views/modals/waiting_list_modal.ts
@@ -1,8 +1,8 @@
 import 'modals/waiting_list_modal.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import $ from 'jquery';
+import mixpanel from 'mixpanel-browser';
 import app from 'state';
 
 const sampleAddresses = {

--- a/client/scripts/views/pages/404.ts
+++ b/client/scripts/views/pages/404.ts
@@ -1,7 +1,7 @@
 import 'pages/404.scss';
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import { EmptyState, Icon, Icons } from 'construct-ui';
 import Sublayout from 'views/sublayout';
 

--- a/client/scripts/views/pages/admin.ts
+++ b/client/scripts/views/pages/admin.ts
@@ -1,8 +1,8 @@
 import 'pages/admin.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import $ from 'jquery';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import { SubmittableResult, ApiRx } from '@polkadot/api';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { switchMap } from 'rxjs/operators';

--- a/client/scripts/views/pages/council.ts
+++ b/client/scripts/views/pages/council.ts
@@ -1,8 +1,8 @@
 import 'pages/council.scss';
 
-import { default as _ } from 'lodash';
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import _ from 'lodash';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 
 import app, { ApiStatus } from 'state';
 import { ProposalType } from 'identifiers';

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -1,8 +1,8 @@
 import 'pages/discussions/discussion_row.scss';
 
-import { default as m } from 'mithril';
-import { default as _ } from 'lodash';
-import { default as moment } from 'moment-twitter';
+import m from 'mithril';
+import _ from 'lodash';
+import moment from 'moment-twitter';
 import { Icon, Icons, Tag } from 'construct-ui';
 
 import app from 'state';

--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -1,4 +1,4 @@
-import { default as m } from 'mithril';
+import m from 'mithril';
 import app from 'state';
 
 import { isRoleOfCommunity } from 'helpers/roles';

--- a/client/scripts/views/pages/finish_near_login.ts
+++ b/client/scripts/views/pages/finish_near_login.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 
 import app from 'state';
 import { initAppState } from 'app';

--- a/client/scripts/views/pages/home/community_cards.ts
+++ b/client/scripts/views/pages/home/community_cards.ts
@@ -1,6 +1,6 @@
 import 'pages/home/community_cards.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import { link } from 'helpers';
 import { ChainIcon, CommunityIcon } from 'views/components/chain_icon';
 import MembershipButton, { isMember } from 'views/components/membership_button';

--- a/client/scripts/views/pages/home/index.ts
+++ b/client/scripts/views/pages/home/index.ts
@@ -1,6 +1,6 @@
 import 'pages/home/index.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import MarketingModules from './marketing_modules';
 import CommunityCards from './community_cards';
 import Header from './header';

--- a/client/scripts/views/pages/landing/about.ts
+++ b/client/scripts/views/pages/landing/about.ts
@@ -1,7 +1,7 @@
 import 'pages/landing/about.scss';
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import LandingPage from 'views/pages/landing/landing';
 import { renderMultilineText } from 'helpers';
 

--- a/client/scripts/views/pages/landing/landing.ts
+++ b/client/scripts/views/pages/landing/landing.ts
@@ -1,6 +1,6 @@
 import 'pages/landing/landing.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 import app from 'state';
 import { symbols } from 'helpers';

--- a/client/scripts/views/pages/landing/privacy.ts
+++ b/client/scripts/views/pages/landing/privacy.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import { renderMultilineText } from 'helpers';
 
 const PrivacyPolicy = `

--- a/client/scripts/views/pages/landing/terms.ts
+++ b/client/scripts/views/pages/landing/terms.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import { renderMultilineText } from 'helpers';
 
 const TermsOfService = `

--- a/client/scripts/views/pages/login.ts
+++ b/client/scripts/views/pages/login.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import app from 'state';
 import Login from 'views/components/login';
 import Sublayout from 'views/sublayout';

--- a/client/scripts/views/pages/new_signaling.ts
+++ b/client/scripts/views/pages/new_signaling.ts
@@ -1,8 +1,8 @@
 import 'pages/new_signaling.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import $ from 'jquery';
+import mixpanel from 'mixpanel-browser';
 import {
   Grid, Col, Classes, ButtonGroup, Callout, Form, FormGroup,
   FormLabel, Button, Icon, Icons, Radio, RadioGroup, Tag, Input, TextArea

--- a/client/scripts/views/pages/notification_list.ts
+++ b/client/scripts/views/pages/notification_list.ts
@@ -1,6 +1,6 @@
 import 'pages/notifications.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 import app from 'state';
 import { NotificationSubscription, Notification, OffchainComment } from 'models';

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -1,7 +1,7 @@
 import 'pages/proposals.scss';
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 
 import app from 'state';
 import { formatCoin } from 'adapters/currency';

--- a/client/scripts/views/pages/settings.ts
+++ b/client/scripts/views/pages/settings.ts
@@ -1,7 +1,7 @@
 import 'pages/settings.scss';
 
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 import app from 'state';
 
 import { SubstrateAccount } from 'controllers/chain/substrate/account';

--- a/client/scripts/views/pages/supernova/atom_instructions.ts
+++ b/client/scripts/views/pages/supernova/atom_instructions.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import CodeBlock from '../../components/widgets/code_block';
 import SocialShare from './social_share';
 

--- a/client/scripts/views/pages/supernova/btc_instructions.ts
+++ b/client/scripts/views/pages/supernova/btc_instructions.ts
@@ -1,5 +1,5 @@
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
+import m from 'mithril';
+import $ from 'jquery';
 import CodeBlock from '../../components/widgets/code_block';
 import SocialShare from './social_share';
 

--- a/client/scripts/views/pages/supernova/eth_instructions.ts
+++ b/client/scripts/views/pages/supernova/eth_instructions.ts
@@ -1,5 +1,5 @@
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
+import $ from 'jquery';
+import m from 'mithril';
 
 import CodeBlock from '../../components/widgets/code_block';
 import SocialShare from './social_share';

--- a/client/scripts/views/pages/supernova/key_gen.ts
+++ b/client/scripts/views/pages/supernova/key_gen.ts
@@ -1,6 +1,6 @@
 import 'pages/supernova/key_gen.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 import CodeBlock from '../../components/widgets/code_block';
 import SupernovaPreheader from './supernova_preheader';

--- a/client/scripts/views/pages/supernova/landing.ts
+++ b/client/scripts/views/pages/supernova/landing.ts
@@ -1,9 +1,9 @@
 import 'pages/supernova/landing.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as mixpanel } from 'mixpanel-browser';
-import { default as moment } from 'moment-twitter';
+import m from 'mithril';
+import $ from 'jquery';
+import mixpanel from 'mixpanel-browser';
+import moment from 'moment-twitter';
 import Countdown from 'views/components/countdown';
 
 import app from 'state';

--- a/client/scripts/views/pages/supernova/lock_atom.ts
+++ b/client/scripts/views/pages/supernova/lock_atom.ts
@@ -1,8 +1,8 @@
 import 'pages/supernova/lock_atom.scss';
 
 import app from 'state';
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 
 import { CosmosAccount } from 'controllers/chain/cosmos/account';
 import { createTXModal } from 'views/modals/tx_signing_modal';

--- a/client/scripts/views/pages/supernova/lock_btc.ts
+++ b/client/scripts/views/pages/supernova/lock_btc.ts
@@ -1,8 +1,8 @@
 import 'pages/supernova/lock_btc.scss';
 
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
-import { default as mixpanel } from 'mixpanel-browser';
+import $ from 'jquery';
+import m from 'mithril';
+import mixpanel from 'mixpanel-browser';
 
 import { TextInputFormField } from '../../components/forms';
 import CodeBlock from '../../components/widgets/code_block';

--- a/client/scripts/views/pages/supernova/lock_eth.ts
+++ b/client/scripts/views/pages/supernova/lock_eth.ts
@@ -1,8 +1,8 @@
 import 'pages/supernova/lock_eth.scss';
 
-import { default as m } from 'mithril';
-import { default as $ } from 'jquery';
-import { default as mixpanel } from 'mixpanel-browser';
+import m from 'mithril';
+import $ from 'jquery';
+import mixpanel from 'mixpanel-browser';
 
 import { formatAsTitleCase } from 'helpers';
 import app from 'state';

--- a/client/scripts/views/pages/supernova/lock_notes.ts
+++ b/client/scripts/views/pages/supernova/lock_notes.ts
@@ -1,6 +1,6 @@
 import 'pages/supernova/lock_notes.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 import CodeBlock from '../../components/widgets/code_block';
 import SupernovaPreheader from './supernova_preheader';
 

--- a/client/scripts/views/pages/supernova/lookup.ts
+++ b/client/scripts/views/pages/supernova/lookup.ts
@@ -1,8 +1,8 @@
 import 'pages/supernova/lookup.scss';
 
 import app from 'state';
-import { default as $ } from 'jquery';
-import { default as m } from 'mithril';
+import $ from 'jquery';
+import m from 'mithril';
 
 import { pluralize } from 'helpers';
 import { isHex, formatNumber } from 'views/stats/stats_helpers';

--- a/client/scripts/views/pages/supernova/social_share.ts
+++ b/client/scripts/views/pages/supernova/social_share.ts
@@ -1,6 +1,6 @@
 import 'pages/supernova/social_share.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 const SocialShare: m.Component = {
   view: (vnode) => {

--- a/client/scripts/views/pages/supernova/supernova_preheader.ts
+++ b/client/scripts/views/pages/supernova/supernova_preheader.ts
@@ -1,6 +1,6 @@
 import 'pages/supernova/supernova_preheader.scss';
 
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 const SupernovaPreheader = {
   view: (vnode) => {

--- a/client/scripts/views/pages/validators/cosmos.ts
+++ b/client/scripts/views/pages/validators/cosmos.ts
@@ -1,4 +1,4 @@
-import { default as m } from 'mithril';
+import m from 'mithril';
 
 import app from 'state';
 import { formatCoin } from 'adapters/currency';

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -1,5 +1,5 @@
-import { default as crypto } from 'crypto';
-import { default as sgMail } from '@sendgrid/mail';
+import crypto from 'crypto';
+import sgMail from '@sendgrid/mail';
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { SERVER_URL, SENDGRID_API_KEY } from '../config';

--- a/shared/adapters/chain/cosmos/api.ts
+++ b/shared/adapters/chain/cosmos/api.ts
@@ -1,6 +1,6 @@
 import { Observable, Subject } from 'rxjs';
 import * as $ from 'jquery';
-import { default as _ } from 'lodash';
+import _ from 'lodash';
 import { takeWhile } from 'rxjs/operators';
 
 export interface ITxEvent {


### PR DESCRIPTION
It was requested that I remove [an old default import](https://github.com/hicommonwealth/commonwealth/pull/312#discussion_r434879941) from lodash in my code. Seemed silly to just fix one case so I did a quick search and replace.

## How has this been tested?
Made sure server compiled without errors.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no