### PR TITLE
Link + Unlink Github Account from Settings Page

### DIFF
--- a/client/scripts/views/components/settings/github_well.ts
+++ b/client/scripts/views/components/settings/github_well.ts
@@ -1,0 +1,42 @@
+import 'components/settings/settings_well.scss';
+
+import { default as m } from 'mithril';
+import app from 'state';
+
+import { DropdownFormField, RadioSelectorFormField } from 'views/components/forms';
+import { notifySuccess } from 'controllers/app/notifications';
+import SettingsController from 'controllers/app/settings';
+import { selectNode } from 'app';
+import { NodeInfo } from 'models';
+
+interface IState {
+  initialized: boolean;
+  showMoreSettings: boolean;
+}
+
+const GithubWell: m.Component<{}, IState> = {
+  view: (vnode) => {
+    const nodes = (app.chain && app.chain.meta ? [] : [{
+      name: 'node',
+      label: 'Select a node',
+      value: undefined,
+      selected: true,
+    }]).concat(app.config.nodes.getAll().map((n) => ({
+      name: 'node',
+      label: `${n.chain.id} - ${n.url}`,
+      value: n.id,
+      selected: app.chain && app.chain.meta && n.url === app.chain.meta.url && n.chain === app.chain.meta.chain,
+    })));
+
+    return m('.GithubWell', [
+      m('form', [
+        m('h4', 'Email'),
+        m('input[type="email"]', {
+          value: app.login.socialAccounts || 'None'
+        }),
+      ]),
+    ]);
+  }
+};
+
+export default GithubWell;

--- a/client/scripts/views/components/settings/github_well.ts
+++ b/client/scripts/views/components/settings/github_well.ts
@@ -1,4 +1,4 @@
-import 'components/settings/settings_well.scss';
+import 'components/settings/github_well.scss';
 
 import m from 'mithril';
 import $ from 'jquery';
@@ -8,7 +8,7 @@ import { DropdownFormField, RadioSelectorFormField } from 'views/components/form
 import { notifySuccess } from 'controllers/app/notifications';
 import SettingsController from 'controllers/app/settings';
 import { SocialAccount } from 'models';
-import { Button } from 'construct-ui';
+import { Button, Input, Icons, Icon } from 'construct-ui';
 
 interface IState {
   githubAccount: SocialAccount;
@@ -23,16 +23,20 @@ const GithubWell: m.Component<{}, IState> = {
     return m('.GithubWell', [
       m('form', [
         m('h4', 'Github'),
-        m('input[type="text"]', {
-          value: githubAccount.username || 'None',
+        githubAccount && m(Input, {
+          value: githubAccount?.username || '',
+          contentLeft: m(Icon, { name: Icons.GITHUB }),
+          disabled: true,
         }),
         m(Button, {
           label: githubAccount ? 'Unlink Account' : 'Link Account',
-          href: githubAccount ? '#' : `${app.serverUrl()}/auth/github`,
+          href: githubAccount ? '' : `${app.serverUrl()}/auth/github`,
+          intent: githubAccount ? 'negative' : 'none',
           onclick: () => {
             if (githubAccount) {
-              $.post(`${app.serverUrl()}/deleteGithubAccount`, { jwt: app.login.jwt }).then((response) => {
-                if (response.status === 'Success') vnode.state.githubAccount = null;
+              $.post(`${app.serverUrl()}/deleteGithubAccount`, { jwt: app.login.jwt }).then((res) => {
+                if (res.status === 'Success') vnode.state.githubAccount = null;
+                m.redraw();
               }).catch((err: any) => {
                 console.dir(err);
                 m.redraw();
@@ -42,6 +46,7 @@ const GithubWell: m.Component<{}, IState> = {
                 timestamp: (+new Date()).toString(),
                 path: m.route.get()
               }));
+              m.redraw();
             }
           },
         })

--- a/client/scripts/views/pages/settings.ts
+++ b/client/scripts/views/pages/settings.ts
@@ -10,6 +10,7 @@ import Sublayout from 'views/sublayout';
 import AccountsWell from 'views/components/settings/accounts_well';
 import SettingsWell from 'views/components/settings/settings_well';
 import SendEDGWell from 'views/components/settings/send_edg_well';
+import GithubWell from 'views/components/settings/github_well';
 
 const SettingsPage: m.Component<{}> = {
   oncreate: (vnode) => {
@@ -28,6 +29,7 @@ const SettingsPage: m.Component<{}> = {
         : m('.forum-container', [
           m('h2.page-title', 'Settings'),
           m(SettingsWell),
+          m(GithubWell),
           m(AccountsWell),
           !app.community && app.vm.activeAccount && app.vm.activeAccount instanceof SubstrateAccount
             && m(SendEDGWell, { sender: app.vm.activeAccount }),

--- a/client/styles/components/settings/github_well.scss
+++ b/client/styles/components/settings/github_well.scss
@@ -1,0 +1,11 @@
+@import 'client/styles/shared';
+
+.GithubWell {
+    @include well;
+    h4 {
+        margin-top: 20px;
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+}

--- a/client/styles/components/settings/github_well.scss
+++ b/client/styles/components/settings/github_well.scss
@@ -2,10 +2,7 @@
 
 .GithubWell {
     @include well;
-    h4 {
-        margin-top: 20px;
-        &:first-child {
-            margin-top: 0;
-        }
+    input { 
+        margin-right: 12px;
     }
 }

--- a/server/router.ts
+++ b/server/router.ts
@@ -58,6 +58,7 @@ import upgradeMember from './routes/upgradeMember';
 import createInviteLink from './routes/createInviteLink';
 import acceptInviteLink from './routes/acceptInviteLink';
 import getInviteLinks from './routes/getInviteLinks';
+import deleteGithubAccount from './routes/deleteGithubAccount';
 
 import createRole from './routes/createRole';
 import deleteRole from './routes/deleteRole';
@@ -182,6 +183,10 @@ function setupRouter(app, models, fetcher, viewCountCache: ViewCountCache) {
   // offchain profiles
   router.post('/updateProfile', passport.authenticate('jwt', { session: false }), updateProfile.bind(this, models));
   router.post('/bulkProfiles', bulkProfiles.bind(this, models));
+
+  // social accounts
+  router.post('/deleteGithubAccount', passport.authenticate('jwt', { session: false }), deleteGithubAccount.bind(this, models));
+
 
   // offchain viewCount
   router.post('/viewCount', viewCount.bind(this, models, viewCountCache));

--- a/server/routes/deleteGithubAccount.ts
+++ b/server/routes/deleteGithubAccount.ts
@@ -7,14 +7,11 @@ export const Errors = {
 };
 
 const deleteGithubAccount = async (models, req: Request, res: Response, next: NextFunction) => {
-  const { Op } = models.sequelize;
   if (!req.user) return next(new Error(Errors.NotLoggedIn));
-
   const socialAccounts = await req.user.getSocialAccounts();
   const githubAccount = socialAccounts.find((sa) => sa.provider === 'github');
   await githubAccount.destroy();
-
-  return res.json({ status: 'Success', });
+  return res.json({ status: 'Success' });
 };
 
 export default deleteGithubAccount;

--- a/server/routes/deleteGithubAccount.ts
+++ b/server/routes/deleteGithubAccount.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+};
+
+const deleteGithubAccount = async (models, req: Request, res: Response, next: NextFunction) => {
+  const { Op } = models.sequelize;
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
+
+  const socialAccounts = await req.user.getSocialAccounts();
+  const githubAccount = socialAccounts.find((sa) => sa.provider === 'github');
+  await githubAccount.destroy();
+
+  return res.json({ status: 'Success', });
+};
+
+export default deleteGithubAccount;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Created a Github Well in the Settings Page which populates with the User's Github account if they have their account linked. If not linked, button to link triggers github auth redirect back to settings page and updates UI accordingly.
- New route `/deleteGithubAccount` to access the User's Social Accounts, filter by Github, and the `.destroy()`. To unlink account.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User's cannot, at this time, unlink a github account.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
When linked, UI reflects accordingly. After pressing button "unlink", route passes successfully and refreshed UI. Check DB `SELECT * FROM 'SocialAccounts'` and see the account was destroyed. 
When unlinked, UI reflects accordingly. After pressing button "link", it triggers the github auth sequences and reroutes back to settings page. UI reflects new `/status` call with github social account present as expected.  

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are not tested: The route is 5 lines, and they all get run to function properly. Moreover, we don't really have an infrastructure to test social accounts (no other routes currently) and we can't spin up a model to delete directly yet in tests. 