### PR TITLE
Make entityConstructor non-abstract but take constructorFn.

### DIFF
--- a/client/scripts/controllers/chain/cosmos/governance.ts
+++ b/client/scripts/controllers/chain/cosmos/governance.ts
@@ -50,10 +50,6 @@ class CosmosGovernance extends ProposalModule<
 
   private _proposalSubscription: Unsubscribable;
 
-  protected _entityConstructor(entity): CosmosProposal {
-    throw new Error('not implemented');
-  }
-
   public async init(ChainInfo: CosmosChain, Accounts: CosmosAccounts): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;

--- a/client/scripts/controllers/chain/edgeware/signaling.ts
+++ b/client/scripts/controllers/chain/edgeware/signaling.ts
@@ -31,10 +31,6 @@ class EdgewareSignaling extends ProposalModule<
   private _Chain: SubstrateChain;
   private _Accounts: SubstrateAccounts;
 
-  protected _entityConstructor(entity: ChainEntity): EdgewareSignalingProposal {
-    return new EdgewareSignalingProposal(this._Chain, this._Accounts, this, entity);
-  }
-
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
@@ -51,7 +47,8 @@ class EdgewareSignaling extends ProposalModule<
         this._proposalBond = this._Chain.coins(proposalcreationbond as Balance);
 
         const entities = this.app.chainEntities.store.getByType(SubstrateEntityKind.SignalingProposal);
-        const proposals = entities.map((e) => this._entityConstructor(e));
+        const constructorFunc = (e) => new EdgewareSignalingProposal(this._Chain, this._Accounts, this, e);
+        const proposals = entities.map((e) => this._entityConstructor(constructorFunc, e));
         this._initialized = true;
         resolve();
       },

--- a/client/scripts/controllers/chain/ethereum/moloch/governance.ts
+++ b/client/scripts/controllers/chain/ethereum/moloch/governance.ts
@@ -52,10 +52,6 @@ export default class MolochGovernance extends ProposalModule<
   public get fetcher() { return this._fetcher; }
 
   // INIT / DEINIT
-  protected _entityConstructor(entity): MolochProposal {
-    throw new Error('not implemented');
-  }
-
   public async init(
     api: MolochAPI,
     MolochMembers: MolochMembers,

--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -28,10 +28,6 @@ class SubstrateCollective extends ProposalModule<
   private _Chain: SubstrateChain;
   private _Accounts: SubstrateAccounts;
 
-  protected _entityConstructor(entity: ChainEntity): SubstrateCollectiveProposal {
-    return new SubstrateCollectiveProposal(this._Chain, this._Accounts, this, entity);
-  }
-
   // TODO: we may want to track membership here as well as in elections
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts, moduleName: string): Promise<void> {
     this._Chain = ChainInfo;
@@ -39,7 +35,8 @@ class SubstrateCollective extends ProposalModule<
     this._moduleName = moduleName;
     return new Promise((resolve, reject) => {
       const entities = this.app.chainEntities.store.getByType(SubstrateEntityKind.CollectiveProposal);
-      const proposals = entities.map((e) => this._entityConstructor(e));
+      const constructorFunc = (e) => new SubstrateCollectiveProposal(this._Chain, this._Accounts, this, e);
+      const proposals = entities.map((e) => this._entityConstructor(constructorFunc, e));
 
       this._Chain.api.pipe(first()).subscribe((api: ApiRx) => {
         const memberP = new Promise((memberResolve) => {

--- a/client/scripts/controllers/chain/substrate/democracy.ts
+++ b/client/scripts/controllers/chain/substrate/democracy.ts
@@ -33,9 +33,6 @@ class SubstrateDemocracy extends ProposalModule<
     return this.store.getAll().find((referendum) => referendum.hash === hash);
   }
 
-  protected _entityConstructor(entity: ChainEntity): SubstrateDemocracyReferendum {
-    return new SubstrateDemocracyReferendum(this._Chain, this._Accounts, this, entity);
-  }
   // Loads all proposals and referendums currently present in the democracy module
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts, useRedesignLogic: boolean): Promise<void> {
     this._Chain = ChainInfo;
@@ -43,7 +40,8 @@ class SubstrateDemocracy extends ProposalModule<
     this._useRedesignLogic = useRedesignLogic;
     return new Promise((resolve, reject) => {
       const entities = this.app.chainEntities.store.getByType(SubstrateEntityKind.DemocracyReferendum);
-      const proposals = entities.map((e) => this._entityConstructor(e));
+      const constructorFunc = (e) => new SubstrateDemocracyReferendum(this._Chain, this._Accounts, this, e);
+      const proposals = entities.map((e) => this._entityConstructor(constructorFunc, e));
 
       this._Chain.api.pipe(first()).subscribe((api: ApiRx) => {
         // save parameters

--- a/client/scripts/controllers/chain/substrate/democracy_proposals.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposals.ts
@@ -56,16 +56,14 @@ class SubstrateDemocracyProposals extends ProposalModule<
     return this.store.getAll().find((proposal) => proposal.hash === hash);
   }
 
-  protected _entityConstructor(entity: ChainEntity): SubstrateDemocracyProposal {
-    return new SubstrateDemocracyProposal(this._Chain, this._Accounts, this, entity);
-  }
   // Loads all proposals and referendums currently present in the democracy module
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
     return new Promise((resolve, reject) => {
       const entities = this.app.chainEntities.store.getByType(SubstrateEntityKind.DemocracyProposal);
-      const proposals = entities.map((e) => this._entityConstructor(e));
+      const constructorFunc = (e) => new SubstrateDemocracyProposal(this._Chain, this._Accounts, this, e);
+      const proposals = entities.map((e) => this._entityConstructor(constructorFunc, e));
 
       this._Chain.api.pipe(first()).subscribe((api: ApiRx) => {
         // save parameters

--- a/client/scripts/controllers/chain/substrate/phragmen_elections.ts
+++ b/client/scripts/controllers/chain/substrate/phragmen_elections.ts
@@ -60,9 +60,6 @@ class SubstratePhragmenElections extends ProposalModule<
     super.deinit();
   }
 
-  protected _entityConstructor(entity: ChainEntity): SubstratePhragmenElection {
-    throw new Error('not implemented');
-  }
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts, moduleName?: string): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;

--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -59,6 +59,11 @@ import { InterfaceTypes, CallFunction } from '@polkadot/types/types';
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
 import { u128, TypeRegistry } from '@polkadot/types';
 import { SubstrateAccount } from './account';
+import SubstrateDemocracyProposal from './democracy_proposal';
+import { SubstrateDemocracyReferendum } from './democracy_referendum';
+import { SubstrateTreasuryProposal } from './treasury_proposal';
+import { SubstrateCollectiveProposal } from './collective_proposal';
+import { EdgewareSignalingProposal } from '../edgeware/signaling_proposal';
 
 export type HandlerId = number;
 
@@ -86,10 +91,16 @@ async function createApiProvider(node: NodeInfo): Promise<WsProvider> {
 export function handleSubstrateEntityUpdate(chain, entity: ChainEntity, event: ChainEvent): void {
   switch (entity.type) {
     case SubstrateEntityKind.DemocracyProposal: {
-      return chain.democracyProposals.updateProposal(entity, event);
+      const constructorFunc = (e) => new SubstrateDemocracyProposal(
+        chain.chain, chain.accounts, chain.democracyProposals, e
+      );
+      return chain.democracyProposals.updateProposal(constructorFunc, entity, event);
     }
     case SubstrateEntityKind.DemocracyReferendum: {
-      return chain.democracy.updateProposal(entity, event);
+      const constructorFunc = (e) => new SubstrateDemocracyReferendum(
+        chain.chain, chain.accounts, chain.democracy, e
+      );
+      return chain.democracy.updateProposal(constructorFunc, entity, event);
     }
     case SubstrateEntityKind.DemocracyPreimage: {
       if (event.data.kind === SubstrateEventKind.PreimageNoted) {
@@ -106,19 +117,31 @@ export function handleSubstrateEntityUpdate(chain, entity: ChainEntity, event: C
       break;
     }
     case SubstrateEntityKind.TreasuryProposal: {
-      return chain.treasury.updateProposal(entity, event);
+      const constructorFunc = (e) => new SubstrateTreasuryProposal(
+        chain.chain, chain.accounts, chain.treasury, e
+      );
+      return chain.treasury.updateProposal(constructorFunc, entity, event);
     }
     case SubstrateEntityKind.CollectiveProposal: {
       const collectiveName = (event.data as ISubstrateCollectiveProposalEvents).collectiveName;
       if (collectiveName && collectiveName === 'technicalCommittee' && chain.class === ChainClass.Kusama) {
-        return chain.technicalCommittee.updateProposal(entity, event);
+        const constructorFunc = (e) => new SubstrateCollectiveProposal(
+          chain.chain, chain.accounts, chain.technicalCommittee, e
+        );
+        return chain.technicalCommittee.updateProposal(constructorFunc, entity, event);
       } else {
-        return chain.council.updateProposal(entity, event);
+        const constructorFunc = (e) => new SubstrateCollectiveProposal(
+          chain.chain, chain.accounts, chain.council, e
+        );
+        return chain.council.updateProposal(constructorFunc, entity, event);
       }
     }
     case SubstrateEntityKind.SignalingProposal: {
       if (chain.class === ChainClass.Edgeware) {
-        return chain.signaling.updateProposal(entity, event);
+        const constructorFunc = (e) => new EdgewareSignalingProposal(
+          chain.chain, chain.accounts, chain.signaling, e
+        );
+        return chain.signaling.updateProposal(constructorFunc, entity, event);
       } else {
         console.error('Received signaling update on non-edgeware chain!');
         break;

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -58,10 +58,6 @@ class SubstrateTreasury extends ProposalModule<
   private _Chain: SubstrateChain;
   private _Accounts: SubstrateAccounts;
 
-  protected _entityConstructor(entity: ChainEntity) {
-    return new SubstrateTreasuryProposal(this._Chain, this._Accounts, this, entity);
-  }
-
   public init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
@@ -81,7 +77,8 @@ class SubstrateTreasury extends ProposalModule<
         });
         */
         const entities = this.app.chainEntities.store.getByType(SubstrateEntityKind.TreasuryProposal);
-        const proposals = entities.map((e) => this._entityConstructor(e));
+        const constructorFunc = (e) => new SubstrateTreasuryProposal(this._Chain, this._Accounts, this, e);
+        const proposals = entities.map((e) => this._entityConstructor(constructorFunc, e));
 
         this._initialized = true;
         resolve();

--- a/client/scripts/models/ProposalModule.ts
+++ b/client/scripts/models/ProposalModule.ts
@@ -22,11 +22,18 @@ export abstract class ProposalModule<
   private _app: IApp;
   public get app() { return this._app; }
 
-  protected abstract _entityConstructor(entity: ChainEntity): ProposalT;
-  public updateProposal(entity: ChainEntity, event: ChainEvent): void {
+  protected _entityConstructor(constructorFunc: (e: ChainEntity) => ProposalT, entity: ChainEntity): ProposalT {
+    try {
+      return constructorFunc(entity);
+    } catch (e) {
+      console.error('failed to construct proposal from entity: ', entity);
+    }
+  }
+
+  public updateProposal(constructorFunc: (e: ChainEntity) => ProposalT, entity: ChainEntity, event: ChainEvent): void {
     const proposal = this.store.getByIdentifier(entity.typeId);
     if (!proposal) {
-      this._entityConstructor(entity);
+      this._entityConstructor(constructorFunc, entity);
     } else {
       proposal.update(event);
     }


### PR DESCRIPTION
## Description
Before this PR, the `ProposalModule` class had a required abstract method called "_entityConstructor", which was supposed to be overriden with a function that constructed a "Proposal" (i.e. SignalingProposal) from an "Entity", as fetched from the chain or from the server.

However, using an abstract method here means that making global changes requires me to change every function. I wanted to add a try/catch error handling statement to avoid throwing errors on invalid ChainEntities, so instead of modifying every class's implementation, I simplified the logic by making it a concrete method that takes a constructor function. This also allowed me to remove the implementations on `ProposalModule`s that do not utilize ChainEntities.

## Motivation and Context
Might avoid future bugs if server goes out of sync with client. Mostly for cleanup purposes.

## How has this been tested?
Built and ran to confirm it worked as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no