### PR TITLE
Convert polkadot extension validation to signRaw.

### DIFF
--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -351,8 +351,11 @@ export class SubstrateAccount extends Account<SubstrateCoin> {
   }
 
   public async isValidSignature(message: string, signature: string): Promise<boolean> {
+    const signatureU8a = signature.slice(0, 2) === '0x'
+      ? hexToU8a(signature)
+      : hexToU8a(`0x${signature}`);
     const keyring = this._Chain.keyring(this.isEd25519).addFromAddress(this.address);
-    return keyring.verify(stringToU8a(message), hexToU8a(`0x${signature}`));
+    return keyring.verify(stringToU8a(message), signatureU8a);
   }
 
   // keys

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@lunie/cosmos-keys": "^0.0.11",
     "@openzeppelin/contracts": "^2.4.0",
     "@polkadot/api": "1.18.1",
-    "@polkadot/extension-dapp": "^0.21.1",
+    "@polkadot/extension-dapp": "^0.30.1",
     "@polkadot/keyring": "^2.13",
     "@polkadot/ui-identicon": "^0.41.1",
     "@polkadot/util": "^2.13",

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -180,8 +180,13 @@ export default (
         const signedPayload = new ExtrinsicPayload(new TypeRegistry(), params).toU8a(true);
         isValid = signerKeyring.verify(signedPayload, hexToU8a(signatureString));
       } else {
-        const signedMessage = stringToU8a(`${addressModel.verification_token}\n`);
-        isValid = signerKeyring.verify(signedMessage, hexToU8a(`0x${signatureString}`));
+        const signedMessageNewline = stringToU8a(`${addressModel.verification_token}\n`);
+        const signedMessageNoNewline = stringToU8a(addressModel.verification_token);
+        const signatureU8a = signatureString.slice(0, 2) === '0x'
+          ? hexToU8a(signatureString)
+          : hexToU8a(`0x${signatureString}`);
+        isValid = signerKeyring.verify(signedMessageNewline, signatureU8a)
+          || signerKeyring.verify(signedMessageNoNewline, signatureU8a);
       }
     } else if (chain.network === 'cosmos') {
       const signatureData = JSON.parse(signatureString);

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,7 +737,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.4.5", "@babel/runtime@^7.5.4", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
@@ -889,20 +889,22 @@
     eventemitter3 "^4.0.4"
     rxjs "^6.5.5"
 
-"@polkadot/extension-dapp@^0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.21.1.tgz#8746a43fef8e7f818bf801e0415445cd554f5db3"
-  integrity sha512-qky1AURWqWaeuzVTkdcvEUf1eWQJp06wFZg3D2MzA0f8+ARfT73ccdo+xE71IkC/SLWYYoT14/UqF+7K6Adphg==
+"@polkadot/extension-dapp@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.30.1.tgz#9e65d83d5fddde08e0cdc468398a4fa0c136ce39"
+  integrity sha512-P3f1ozqmQvrBuYURmpon8Lz8Hdh1IwtBLA3+ihjy1xPUPTz587BqdgvIjUfuyztcmx6gQ7lKoooHwn0cILJpPw==
   dependencies:
-    "@babel/runtime" "^7.8.3"
-    "@polkadot/extension-inject" "^0.21.1"
+    "@babel/runtime" "^7.10.2"
+    "@polkadot/extension-inject" "0.30.1"
+    "@polkadot/util" "^2.13.0-beta.3"
+    "@polkadot/util-crypto" "^2.13.0-beta.3"
 
-"@polkadot/extension-inject@^0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/extension-inject/-/extension-inject-0.21.1.tgz#fc6595ae25f0ae37c2c416fd8a81fbef43dc7752"
-  integrity sha512-2KgDp2ZEghgcc8E72bWKStwMDWs/4Scbwcig5PaQwfLObSqwEgqHYNkbeTf4gSC9AMw9VVBF4NP/WoR6Amu25Q==
+"@polkadot/extension-inject@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/extension-inject/-/extension-inject-0.30.1.tgz#d5b0abafbb14ed81ff2cf50530a94408d4cfa03c"
+  integrity sha512-npFGKq6zDcY+JxIjaeo9E6zzk+2EC100mCmuY9Brs1UMTzWi2fmMbGc3KT+i7IVJHGMina7thFHx/UWfzgWF5w==
   dependencies:
-    "@babel/runtime" "^7.8.3"
+    "@babel/runtime" "^7.10.2"
 
 "@polkadot/keyring@^2.13", "@polkadot/keyring@^2.13.1":
   version "2.13.1"
@@ -1000,7 +1002,7 @@
     "@types/store" "^2.0.2"
     store "^2.0.12"
 
-"@polkadot/util-crypto@2.13.1", "@polkadot/util-crypto@^2.13", "@polkadot/util-crypto@^2.13.1":
+"@polkadot/util-crypto@2.13.1", "@polkadot/util-crypto@^2.13", "@polkadot/util-crypto@^2.13.0-beta.3", "@polkadot/util-crypto@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.13.1.tgz#02ae12f02d5a636bb8ff5c8804d4696a1308624b"
   integrity sha512-AZZCwzW6EOql/KTKfDNgUUKpaGkKEk04cxMWdUzU52gmCLcGS8NXdl/YEs+R8JmQsF41q11gcSD/WzTFuv4ehQ==
@@ -1019,7 +1021,7 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@2.13.1", "@polkadot/util@^2.13", "@polkadot/util@^2.13.1":
+"@polkadot/util@2.13.1", "@polkadot/util@^2.13", "@polkadot/util@^2.13.0-beta.3", "@polkadot/util@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.13.1.tgz#59cbe50822026a9849589a10c5ee15a5754dce62"
   integrity sha512-k1GrS3W5c57sLJJyKYF2bq7H5d8vn6jzTaK8rDM7hRp9Ai2Crl4SjyY+5Tdr0LWG+UTybfc8rIieJklB3amA3w==


### PR DESCRIPTION
## Description
Upgrades polkadot extension library and converts our signature-checking code to use signRaw rather than a signed "fake" payload.

## Motivation and Context
Should fix the white screen issue when linking an address via polkadot API.

## How has this been tested?
Tested linking both with extension and cmd line, tested tx signing with extension.

You might need to reset your polkadot extension in the browser if there are broken transactions pending (small red number in corner).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run tests