### PR TITLE
Add address verification checks to routes (and Error refactor)

### DIFF
--- a/server/routes/acceptInvite.ts
+++ b/server/routes/acceptInvite.ts
@@ -39,7 +39,7 @@ const acceptInvite = async (models, req: Request, res: Response, next: NextFunct
 
   const userAddresses = await req.user.getAddresses();
   const isUser = userAddresses
-    .filter((addr) => addr.verified)
+    .filter((addr) => !!addr.verified)
     .filter((add) => add.address === addressObj.address);
 
   if (isUser.length === 0) {

--- a/server/routes/addChainNode.ts
+++ b/server/routes/addChainNode.ts
@@ -5,15 +5,23 @@ import { factory, formatFilename } from '../../shared/logging';
 const Op = Sequelize.Op;
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  MustBeAdmin: 'Must be admin',
+  MissingParams: 'Must provide chain id, name, symbol, network, and node url',
+  NodeExists: 'Node already exists',
+  MustSpecifyContract: 'This is a contract, you must specify a contract address',
+};
+
 const addChainNode = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.user.isAdmin) {
-    return next(new Error('Must be admin'));
+    return next(new Error(Errors.MustBeAdmin));
   }
   if (!req.body.id || !req.body.name || !req.body.symbol || !req.body.network || !req.body.node_url) {
-    return next(new Error('Must provide chain id, name, symbol, network, and node url'));
+    return next(new Error(Errors.MissingParams));
   }
 
   let chain = await models.Chain.findOne({ where: {
@@ -29,7 +37,7 @@ const addChainNode = async (models, req: Request, res: Response, next: NextFunct
       url: req.body.node_url,
     } });
     if (existingNode) {
-      return next(new Error('Node already exists'));
+      return next(new Error(Errors.NodeExists));
     }
   } else {
     chain = await models.Chain.create({
@@ -43,7 +51,7 @@ const addChainNode = async (models, req: Request, res: Response, next: NextFunct
   }
 
   if (chain.type === 'dao' && !req.body.address) {
-    return next(new Error('This is a contract, you must specify a contract address'));
+    return next(new Error(Errors.MustSpecifyContract));
   }
 
   const node = await models.ChainNode.create({

--- a/server/routes/bulkComments.ts
+++ b/server/routes/bulkComments.ts
@@ -4,12 +4,16 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  MutuallyExclusive: 'Cannot select mutually exclusive offchain threads and proposals only options',
+};
+
 const bulkComments = async (models, req: Request, res: Response, next: NextFunction) => {
   const { Op } = models.sequelize;
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
 
   if (req.query.offchain_threads_only && req.query.proposals_only) {
-    return next(new Error('cannot select mutually exclusive offchain threads and proposals only options'));
+    return next(new Error(Errors.MutuallyExclusive));
   }
   const whereOptions: any = {};
   if (community) {

--- a/server/routes/bulkEntities.ts
+++ b/server/routes/bulkEntities.ts
@@ -1,15 +1,20 @@
 import { Response, NextFunction, Request } from 'express';
 
+export const Errors = {
+  NeedChain: 'Must specify entity chain',
+  InvalidChain: 'Invalid chain',
+};
+
 const bulkEntities = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.query.chain) {
-    return next(new Error('must specify entity chain'));
+    return next(new Error(Errors.NeedChain));
   }
 
   const chain = await models.Chain.findOne({
     where: { id: req.query.chain }
   });
   if (!chain) {
-    return next(new Error('Invalid chain'));
+    return next(new Error(Errors.InvalidChain));
   }
 
   const entityFindOptions: any = {

--- a/server/routes/bulkTags.ts
+++ b/server/routes/bulkTags.ts
@@ -4,10 +4,14 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NeedChainOrCommunity: 'Tags must be called for a chain or community',
+};
+
 const bulkTags = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
 
-  if (!chain && !community) return next(new Error('Tags must be called for a chain or community'));
+  if (!chain && !community) return next(new Error(Errors.NeedChainOrCommunity));
   const tags = await models.OffchainTag.findAll({
     where: community
       ? { community_id: community.id }

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -33,7 +33,7 @@ const bulkThreads = async (models, req: Request, res: Response, next: NextFuncti
   });
 
   const userAddresses = await req.user.getAddresses();
-  const userAddressIds = Array.from(userAddresses.map((address) => address.id));
+  const userAddressIds = Array.from(userAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id));
   const rolesQuery = (community)
     ? { address_id: { [Op.in]: userAddressIds }, offchain_community_id: community.id, }
     : { address_id: { [Op.in]: userAddressIds }, chain_id: chain.id };

--- a/server/routes/createAddress.ts
+++ b/server/routes/createAddress.ts
@@ -3,21 +3,27 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NeedAddress: 'Must provide address',
+  NeedChain: 'Must provide chain',
+  InvalidChain: 'Invalid chain',
+};
+
 const createAddress = async (models, req: Request, res: Response, next: NextFunction) => {
   // start the process of creating a new address. this may be called
   // when logged in to link a new address for an existing user, or
   // when logged out to create a new user by showing proof of an address.
   if (!req.body.address) {
-    return next(new Error('Must provide address'));
+    return next(new Error(Errors.NeedAddress));
   }
   if (!req.body.chain) {
-    return next(new Error('Must provide chain'));
+    return next(new Error(Errors.NeedChain));
   }
   const chain = await models.Chain.findOne({
     where: { id: req.body.chain }
   });
   if (!chain) {
-    return next(new Error('Invalid chain'));
+    return next(new Error(Errors.InvalidChain));
   }
 
   const existingAddress = await models.Address.findOne({

--- a/server/routes/createHedgehogAuthentication.ts
+++ b/server/routes/createHedgehogAuthentication.ts
@@ -3,6 +3,10 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  SignUpError: 'Error signing up a user',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   const body = req.body;
   if (body && body.iv && body.cipherText && body.lookupKey) {
@@ -15,7 +19,7 @@ export default async (models, req: Request, res: Response, next: NextFunction) =
       return res.json({ status: 'Success', result: authObj.toJSON() });
     } catch (err) {
       log.error('Error signing up a user', err);
-      return next(new Error('Error signing up a user'));
+      return next(new Error(Errors.SignUpError));
     }
   } else return next(new Error('Missing one of the required fields: iv, cipherText, lookupKey'));
 };

--- a/server/routes/createHedgehogUser.ts
+++ b/server/routes/createHedgehogUser.ts
@@ -5,6 +5,12 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  AccountExists: 'Account already exists for user, try logging in',
+  SignUpError: 'Error signing up a user',
+  MissingField: 'Missing one of the required fields: username, walletAddress',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   const body = req.body;
 
@@ -12,24 +18,24 @@ export default async (models, req: Request, res: Response, next: NextFunction) =
     const username = body.username.toLowerCase();
     const existingUser = await models.HedgehogUser.findOne({
       where: {
-        username: username
+        username,
       }
     });
 
     if (existingUser) {
-      return next(new Error('Account already exists for user, try logging in'));
+      return next(new Error(Errors.AccountExists));
     }
 
     try {
       const hedgehogObj = await models.HedgehogUser.create({
-        username: username,
+        username,
         walletAddress: body.walletAddress
       });
 
       return res.json({ status: 'Success', result: hedgehogObj.toJSON() });
     } catch (err) {
-      log.error('Error signing up a user', err);
-      return next(new Error('Error signing up a user'));
+      log.error(Errors.SignUpError, err);
+      return next(new Error(Errors.SignUpError));
     }
-  } else return next(new Error('Missing one of the required fields: username, walletAddress'));
+  } else return next(new Error(Errors.MissingField));
 };

--- a/server/routes/createMembership.ts
+++ b/server/routes/createMembership.ts
@@ -6,14 +6,20 @@ import { factory, formatFilename } from '../../shared/logging';
 const Op = Sequelize.Op;
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  InvalidChain: 'Invalid chain or community',
+  NotLoggedIn: 'Not logged in',
+  MemberAlreadyExists: 'Membership already exists',
+};
+
 const createMembership = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
-  if (!chain && !community) return next(new Error('Invalid chain or community'));
-  if (chain && community) return next(new Error('Invalid chain or community'));
-  if (!req.user) return next(new Error('Not logged in'));
+  if (!chain && !community) return next(new Error(Errors.InvalidChain));
+  if (chain && community) return next(new Error(Errors.InvalidChain));
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
 
   // Privacy check: Cannot join a private community, but we shouldn't reveal the existence of private communities here
-  if (community && community.privacyEnabled) return next(new Error('Invalid chain or community'));
+  if (community && community.privacyEnabled) return next(new Error(Errors.InvalidChain));
 
   const existingMembership = await models.Membership.findOne({ where: chain ? {
     user_id: req.user.id,
@@ -22,7 +28,7 @@ const createMembership = async (models, req: Request, res: Response, next: NextF
     user_id: req.user.id,
     community: community.id,
   } });
-  if (existingMembership) return next(new Error('Membership already exists'));
+  if (existingMembership) return next(new Error(Errors.MemberAlreadyExists));
 
   // We should require an address to be created when joining a community.
   // For now, we can just let people join without one, and prompt them to create one afterwards.

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -10,11 +10,11 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-enum CreateReactionErrors {
-  NoPostId = 'Must provide a comment or thread id',
-  NoReaction = 'Must provide a reaction string',
-  NoProposalMatch = 'No matching proposal found.'
-}
+export const Errors = {
+  NoPostId: 'Must provide a comment or thread id',
+  NoReaction: 'Must provide a reaction string',
+  NoProposalMatch: 'No matching proposal found.'
+};
 
 const createReaction = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
@@ -22,10 +22,10 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   const { reaction, comment_id, thread_id } = req.body;
 
   if (!thread_id && !comment_id) {
-    return next(new Error(CreateReactionErrors.NoPostId));
+    return next(new Error(Errors.NoPostId));
   }
   if (!reaction) {
-    return next(new Error(CreateReactionErrors.NoReaction));
+    return next(new Error(Errors.NoReaction));
   }
 
   const options = {
@@ -78,7 +78,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
       root_type = 'discussion';
     }
   } catch (err) {
-    return next(new Error(CreateReactionErrors.NoProposalMatch));
+    return next(new Error(Errors.NoProposalMatch));
   }
 
   // dispatch notifications

--- a/server/routes/createTag.ts
+++ b/server/routes/createTag.ts
@@ -1,13 +1,20 @@
 import { Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 
+export const Errors = {
+  InvalidChainOrCommuntiy: 'Invalid chain or community',
+  NotLoggedIn: 'Not logged in',
+  TagRequired: 'Tag name required',
+  MustBeAdmin: 'Must be an admin',
+};
+
 const createTag = async (models, req, res: Response, next: NextFunction) => {
   const { Op } = models.sequelize;
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
-  if (!chain && !community) return next(new Error('Invalid chain or community'));
-  if (chain && community) return next(new Error('Invalid chain or community'));
-  if (!req.user) return next(new Error('Not logged in'));
-  if (!req.body.name) return next(new Error('Tag name required'));
+  if (!chain && !community) return next(new Error(Errors.InvalidChainOrCommuntiy));
+  if (chain && community) return next(new Error(Errors.InvalidChainOrCommuntiy));
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
+  if (!req.body.name) return next(new Error(Errors.TagRequired));
 
   const chainOrCommObj = community ? { offchain_community_id: community.id } : { chain_id: chain.id };
   const userAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
@@ -18,7 +25,7 @@ const createTag = async (models, req, res: Response, next: NextFunction) => {
     },
   });
   if (userMembership.permission !== 'admin') {
-    return next(new Error('Must be an admin'));
+    return next(new Error(Errors.MustBeAdmin));
   }
 
   const chainOrCommObj2 = community ? { community_id: community.id } : { chain_id: chain.id };

--- a/server/routes/createTag.ts
+++ b/server/routes/createTag.ts
@@ -10,7 +10,7 @@ const createTag = async (models, req, res: Response, next: NextFunction) => {
   if (!req.body.name) return next(new Error('Tag name required'));
 
   const chainOrCommObj = community ? { offchain_community_id: community.id } : { chain_id: chain.id };
-  const userAddressIds = await req.user.getAddresses().map((address) => address.id);
+  const userAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
   const userMembership = await models.Role.findOne({
     where: {
       address_id: { [Op.in]: userAddressIds },

--- a/server/routes/deleteAddress.ts
+++ b/server/routes/deleteAddress.ts
@@ -3,29 +3,37 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NeedAddress: 'Must provide address',
+  NeedChain: 'Must provide chain',
+  AddressNotFound: 'Address not found',
+  LastAddress: 'Cannot delete last address',
+};
+
 const deleteAddress = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.address) {
-    return next(new Error('Must provide address'));
+    return next(new Error(Errors.NeedAddress));
   }
   if (!req.body.chain) {
-    return next(new Error('Must provide chain'));
+    return next(new Error(Errors.NeedChain));
   }
 
   const addressObj = await models.Address.findOne({
     where: { chain: req.body.chain, address: req.body.address }
   });
   if (!addressObj || addressObj.user_id !== req.user.id) {
-    return next(new Error('Not found'));
+    return next(new Error(Errors.AddressNotFound));
   }
 
   if (req.body.chain) {
     const existingMemberships = await models.Membership.findAll({
       where: { chain: req.body.chain, user_id: req.user.id, active: true }
     });
-    if (existingMemberships.length > 0) return next(new Error('Cannot delete last address'));
+    if (existingMemberships.length > 0) return next(new Error(Errors.LastAddress));
   }
 
   try {

--- a/server/routes/deleteChainNode.ts
+++ b/server/routes/deleteChainNode.ts
@@ -3,29 +3,37 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NotAdmin: 'Must be admin',
+  NeedParams: 'Must provide chain id and url',
+  ChainNotFound: 'Chain not found',
+  NodeNotFound: 'Node not found',
+};
+
 const deleteChainNode = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.user.isAdmin) {
-    return next(new Error('Must be admin'));
+    return next(new Error(Errors.NotAdmin));
   }
   if (!req.body.id || !req.body.node_url) {
-    return next(new Error('Must provide chain id and url'));
+    return next(new Error(Errors.NeedParams));
   }
 
   const chain = await models.Chain.findOne({ where: {
     id: req.body.id
   } });
   if (!chain) {
-    return next(new Error('Chain not found'));
+    return next(new Error(Errors.ChainNotFound));
   }
   const node = await models.ChainNode.findOne({
     chain: chain.id,
     url: req.body.node_url,
   });
   if (!node) {
-    return next(new Error('Node not found'));
+    return next(new Error(Errors.NodeNotFound));
   }
 
   await node.destroy();

--- a/server/routes/deleteChainObjectQuery.ts
+++ b/server/routes/deleteChainObjectQuery.ts
@@ -3,15 +3,21 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NotAdmin: 'Must be admin',
+  NoQueryId: 'Must provide query_id',
+};
+
 const deleteChainObjectQuery = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.user.isAdmin) {
-    return next(new Error('Must be admin'));
+    return next(new Error(Errors.NotAdmin));
   }
   if (!req.body.query_id) {
-    return next(new Error('Must provide query_id'));
+    return next(new Error(Errors.NoQueryId));
   }
 
   try {

--- a/server/routes/deleteComment.ts
+++ b/server/routes/deleteComment.ts
@@ -17,7 +17,7 @@ const deleteComment = async (models, req: Request, res: Response, next: NextFunc
       where: { id: req.body.comment_id, },
       include: [ models.Address ],
     });
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     // actually delete

--- a/server/routes/deleteComment.ts
+++ b/server/routes/deleteComment.ts
@@ -3,12 +3,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoCommentId: 'Must provide comment_id',
+  AddressNotOwned: 'Not owned by this user',
+};
+
 const deleteComment = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.comment_id) {
-    return next(new Error('Must provide comment_id'));
+    return next(new Error(Errors.NoCommentId));
   }
 
   try {
@@ -18,7 +24,7 @@ const deleteComment = async (models, req: Request, res: Response, next: NextFunc
       include: [ models.Address ],
     });
     if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
-      return next(new Error('Not owned by this user'));
+      return next(new Error(Errors.AddressNotOwned));
     }
     // actually delete
     await comment.destroy();

--- a/server/routes/deleteCommunity.ts
+++ b/server/routes/deleteCommunity.ts
@@ -16,7 +16,7 @@ const deleteCommunity = async (models, req: Request, res: Response, next: NextFu
     const community = await models.OffchainCommunity.findOne({
       where: { id: req.body.community_id },
     });
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(community.creator_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(community.creator_id) === -1) {
       return next(new Error('Only the original creator can delete this community'));
     }
     const communityTags = await community.getTags();

--- a/server/routes/deleteCommunity.ts
+++ b/server/routes/deleteCommunity.ts
@@ -3,12 +3,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NeedCommunityId: 'Must provide community_id',
+  NotCreate: 'Only the original creator can delete this community',
+};
+
 const deleteCommunity = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.community_id) {
-    return next(new Error('Must provide community_id'));
+    return next(new Error(Errors.NeedCommunityId));
   }
 
   try {
@@ -17,7 +23,7 @@ const deleteCommunity = async (models, req: Request, res: Response, next: NextFu
       where: { id: req.body.community_id },
     });
     if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(community.creator_id) === -1) {
-      return next(new Error('Only the original creator can delete this community'));
+      return next(new Error(Errors.NotCreate));
     }
     const communityTags = await community.getTags();
     community.removeTags(communityTags);

--- a/server/routes/deleteGithubAccount.ts
+++ b/server/routes/deleteGithubAccount.ts
@@ -2,10 +2,6 @@ import { Request, Response, NextFunction } from 'express';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
-export const Errors = {
-  NotLoggedIn: 'Not logged in',
-};
-
 const deleteGithubAccount = async (models, req: Request, res: Response, next: NextFunction) => {
   const socialAccounts = await req.user.getSocialAccounts();
   const githubAccount = socialAccounts.find((sa) => sa.provider === 'github');

--- a/server/routes/deleteMembership.ts
+++ b/server/routes/deleteMembership.ts
@@ -4,12 +4,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  InvalidChainOrCommunity: 'Invalid chain or community',
+  NoMembership: 'Membership does not exist',
+};
+
 const deleteMembership = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
-  if (!req.user) return next(new Error('Not logged in'));
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
 
   // Privacy check: Cannot join a private community, but we shouldn't reveal the existence of private communities here
-  if (community && community.privacyEnabled) return next(new Error('Invalid chain or community'));
+  if (community && community.privacyEnabled) return next(new Error(Errors.InvalidChainOrCommunity));
 
   const existingMembership = await models.Membership.findOne({ where: chain ? {
     user_id: req.user.id,
@@ -18,7 +24,7 @@ const deleteMembership = async (models, req: Request, res: Response, next: NextF
     user_id: req.user.id,
     community: community.id,
   } });
-  if (!existingMembership) return next(new Error('Membership does not exist'));
+  if (!existingMembership) return next(new Error(Errors.NoMembership));
 
   await existingMembership.destroy();
   return res.json({ status: 'Success' });

--- a/server/routes/deleteReaction.ts
+++ b/server/routes/deleteReaction.ts
@@ -17,7 +17,7 @@ const deleteReaction = async (models, req: Request, res: Response, next: NextFun
       where: { id: req.body.reaction_id, },
       include: [ models.Address ],
     });
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(reaction.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(reaction.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     // actually delete

--- a/server/routes/deleteReaction.ts
+++ b/server/routes/deleteReaction.ts
@@ -3,12 +3,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoReactionId: 'Must provide reaction_id',
+  AddressNotOwned: 'Not owned by this user',
+};
+
 const deleteReaction = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.reaction_id) {
-    return next(new Error('Must provide reaction_id'));
+    return next(new Error(Errors.NoReactionId));
   }
 
   try {
@@ -18,7 +24,7 @@ const deleteReaction = async (models, req: Request, res: Response, next: NextFun
       include: [ models.Address ],
     });
     if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(reaction.address_id) === -1) {
-      return next(new Error('Not owned by this user'));
+      return next(new Error(Errors.AddressNotOwned));
     }
     // actually delete
     await reaction.destroy();

--- a/server/routes/deleteTag.ts
+++ b/server/routes/deleteTag.ts
@@ -2,26 +2,34 @@
 import { Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoTagId: 'Must supply tag ID',
+  NotAdmin: 'Only admins can delete tags',
+  TagNotFound: 'Tag not found',
+  DeleteFail: 'Could not delete tag',
+};
+
 const deleteTag = async (models, req, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.id) {
-    return next(new Error('Must supply tag ID'));
+    return next(new Error(Errors.NoTagId));
   }
   if (req.body.featured_order && !req.user.isAdmin) {
-    return next(new Error('Only admins can delete tags'));
+    return next(new Error(Errors.NotAdmin));
   }
 
   const { id } = req.body;
   const tag = await models.OffchainTag.findOne({ where: { id } });
-  if (!tag) return next(new Error('Tag not found'));
+  if (!tag) return next(new Error(Errors.TagNotFound));
 
   tag.destroy().then(() => {
     res.json({ status: 'Success' });
   }).catch((e) => {
-    next(new Error('Could not delete tag'));
+    next(new Error(Errors.DeleteFail));
   });
 };
 

--- a/server/routes/deleteThread.ts
+++ b/server/routes/deleteThread.ts
@@ -24,7 +24,7 @@ const deleteThread = async (models, req: Request, res: Response, next: NextFunct
       where: { id: req.body.thread_id, },
       include: [ models.Chain, models.OffchainCommunity ]
     });
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
       return next(new Error(DeleteThreadErrors.NoPermission));
     }
 

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -40,7 +40,7 @@ const editComment = async (models, req: Request, res: Response, next: NextFuncti
       where: { id: req.body.id },
     });
 
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
       return next(new Error('Not owned by this user'));
     }
     const arr = comment.version_history;

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -8,12 +8,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoId: 'Must provide id',
+  NotAddrOwner: 'Address not owned by this user',
+  NoProposal: 'No matching proposal found',
+};
+
 const editComment = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   const author = await lookupAddressIsOwnedByUser(models, req, next);
 
   if (!req.body.id) {
-    return next(new Error('Must provide id'));
+    return next(new Error(Errors.NoId));
   }
 
   const attachFiles = async () => {
@@ -41,7 +47,7 @@ const editComment = async (models, req: Request, res: Response, next: NextFuncti
     });
 
     if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(comment.address_id) === -1) {
-      return next(new Error('Not owned by this user'));
+      return next(new Error(Errors.NotAddrOwner));
     }
     const arr = comment.version_history;
     arr.unshift(req.body.version_history);
@@ -68,7 +74,7 @@ const editComment = async (models, req: Request, res: Response, next: NextFuncti
       log.error(`No matching proposal of thread for root_id ${comment.root_id}`);
     }
     if (!proposal) {
-      throw new Error('No matching proposal found.');
+      throw new Error(Errors.NoProposal);
     }
 
     const cwUrl = getProposalUrl(prefix, proposal, comment);

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -48,7 +48,7 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
       where: { id: thread_id },
     });
     if (!thread) return next(new Error('No thread with that id found'));
-    if (userOwnedAddresses.filter((addr) => addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
+    if (userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id).indexOf(thread.author_id) === -1) {
       return next(new Error(Errors.IncorrectOwner));
     }
     const arr = thread.version_history;

--- a/server/routes/getEdgewareLockdropStats.ts
+++ b/server/routes/getEdgewareLockdropStats.ts
@@ -27,6 +27,10 @@ const generalizedLocks = {
   ],
 };
 
+export const Errors = {
+  NoLockingEvent: 'No locking events returned from the API',
+};
+
 export const isHex = (inputString) => {
   const re = /^(0x)?[0-9A-Fa-f]+$/g;
   const result = re.test(inputString);
@@ -367,7 +371,7 @@ export const getCountsByBlock = async (web3, contracts) => {
   allEvents.sort((a, b) => a.blockNumber - b.blockNumber);
 
   if (allEvents.length === 0) {
-    throw new Error('No locking events returned from the API');
+    throw new Error(Error.NoLockingEvent);
   }
 
   // set number of blocks to quantize our x-axis to

--- a/server/routes/getHedgehogAuthentication.ts
+++ b/server/routes/getHedgehogAuthentication.ts
@@ -4,6 +4,11 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  IncorrectLogin: 'Username or password is incorrect',
+  NoKey: 'Missing field: lookupKey',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   if (req.query && req.query.lookupKey) {
     const existingAuth = await models.HedgehogAuthentication.findOne({
@@ -17,6 +22,6 @@ export default async (models, req: Request, res: Response, next: NextFunction) =
       res.status(r.statusCode).send(r.object);
     }
 
-    return next(new Error('Username or password is incorrect'));
-  } else return next(new Error('Missing field: lookupKey'));
+    return next(new Error(Errors.IncorrectLogin));
+  } else return next(new Error(Errors.NoKey));
 };

--- a/server/routes/getInviteLinks.ts
+++ b/server/routes/getInviteLinks.ts
@@ -2,10 +2,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoCommunity: 'Must include community_id',
+  NotAdminOrMod: 'Must be an admin/mod to create Invite Link',
+  InvalidCommunity: 'Invalid community',
+  ErrorFetchingLinks: 'Error fetching links',
+};
+
 const getInviteLinks = async (models, req, res, next) => {
-  if (!req.user) return next(new Error('Not logged in'));
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
   const { community_id } = req.query;
-  if (!community_id) return next(new Error('Error finding comunity'));
+  if (!community_id) return next(new Error(Errors.NoCommunity));
 
   const address = await models.Address.findOne({
     where: {
@@ -20,21 +28,21 @@ const getInviteLinks = async (models, req, res, next) => {
       permission: ['admin', 'moderator'],
     },
   });
-  if (!requesterIsAdminOrMod) return next(new Error('Must be an admin/mod to create Invite Link'));
+  if (!requesterIsAdminOrMod) return next(new Error(Errors.NotAdminOrMod));
 
   const community = await models.OffchainCommunity.findOne({
     where: {
       id: community_id,
     },
   });
-  if (!community) return next(new Error('Invalid community'));
+  if (!community) return next(new Error(Errors.InvalidCommunity));
 
   const inviteLinks = await models.InviteLink.findAll({
     where: {
       community_id: community.id,
     },
   });
-  if (!inviteLinks) return next(new Error('Error Fetching Links'));
+  if (!inviteLinks) return next(new Error(Errors.ErrorFetchingLinks));
 
   return res.json({ status: 'Success', data: inviteLinks });
 };

--- a/server/routes/getInvites.ts
+++ b/server/routes/getInvites.ts
@@ -3,12 +3,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoUser: 'Cannot find associated User',
+  NoEmail: 'No email included for User, cannot query invites',
+};
+
 const getInvites = async (models, req: Request, res: Response, next: NextFunction) => {
-  if (!req.user) return next(new Error('Not Logged In'));
+  if (!req.user) return next(new Error(Errors.NotLoggedIn));
   const { user } = req;
 
-  if (!user) return next(new Error('Cannot find associated User'));
-  if (!user.email) return next(new Error('No email included for User, cannot query Invites'));
+  if (!user) return next(new Error(Errors.NoUser));
+  if (!user.email) return next(new Error(Errors.NoEmail));
 
   const invites = await models.InviteCode.findAll({
     where: {

--- a/server/routes/getUploadSignature.ts
+++ b/server/routes/getUploadSignature.ts
@@ -10,18 +10,24 @@ AWS.config.update({
   signatureVersion: 'v4'
 });
 
+export const Errors = {
+  NotLoggedIn: 'Must be logged in',
+  MissingParams: 'Must specify name and mimetype',
+  ImageType: 'Can only upload JPG, PNG, GIF, and WEBP images',
+};
+
 const getUploadSignature = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Must be logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.name || !req.body.mimetype) {
-    return next(new Error('Must specify name and mimetype'));
+    return next(new Error(Errors.MissingParams));
   }
   const extension = req.body.name.split('.').pop();
   const filename = uuidv4() + '.' + extension;
   const contentType = req.body.mimetype;
   if (['image/gif', 'image/png', 'image/jpeg', 'image/webp'].indexOf(contentType) === -1) {
-    return next(new Error('Can only upload JPG, PNG, GIF, and WEBP images'));
+    return next(new Error(Errors.ImageType));
   }
 
   const s3 = new AWS.S3();

--- a/server/routes/markNotificationsRead.ts
+++ b/server/routes/markNotificationsRead.ts
@@ -8,7 +8,7 @@ const log = factory.getLogger(formatFilename(__filename));
 export const Errors = {
   NotLoggedIn: 'Not lgoged in',
   NoNotificationIds: 'Must specify notification ids',
-  NotifWrongOwner: 'Notification not woned by user',
+  WrongOwner: 'Notification not woned by user',
 };
 
 export default async (models, req: Request, res: Response, next: NextFunction) => {
@@ -32,7 +32,7 @@ export default async (models, req: Request, res: Response, next: NextFunction) =
   });
 
   if (notifications.find((n) => n.Subscription.subscriber_id !== req.user.id)) {
-    return next(new Error(Errors.NotifWrongOwner));
+    return next(new Error(Errors.WrongOwner));
   }
 
   // TODO: transactionalize this

--- a/server/routes/markNotificationsRead.ts
+++ b/server/routes/markNotificationsRead.ts
@@ -5,12 +5,18 @@ import { factory, formatFilename } from '../../shared/logging';
 const Op = Sequelize.Op;
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not lgoged in',
+  NoNotificationIds: 'Must specify notification ids',
+  NotifWrongOwner: 'Notification not woned by user',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body['notification_ids[]']) {
-    return next(new Error('must specifiy notification ids'));
+    return next(new Error(Errors.NoNotificationIds));
   }
 
   let idOptions;
@@ -26,7 +32,7 @@ export default async (models, req: Request, res: Response, next: NextFunction) =
   });
 
   if (notifications.find((n) => n.Subscription.subscriber_id !== req.user.id)) {
-    return next(new Error('notification not owned by user'));
+    return next(new Error(Errors.NotifWrongOwner));
   }
 
   // TODO: transactionalize this

--- a/server/routes/refreshChainObjects.ts
+++ b/server/routes/refreshChainObjects.ts
@@ -2,9 +2,16 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoChainId: 'Must provide chain object id',
+  NoQuery: 'No fetch queries found',
+  NoFetchType: 'Must provide fetch type',
+  InvalidType: 'Invalid fetch type, must be ADD, UPDATE, or INIT', 
+};
+
 export default async (models, fetcher, req, res, next) => {
   if (!req.query.chain_object_id) {
-    return next(new Error('Must provide chain object id'));
+    return next(new Error(Errors.NoChainId));
   }
   const fetchQuery = await models.ChainObjectQuery.findOne({
     where: {
@@ -12,17 +19,17 @@ export default async (models, fetcher, req, res, next) => {
     }
   });
   if (!fetchQuery) {
-    return next(new Error('No fetch queries found'));
+    return next(new Error(Errors.NoQuery));
   }
 
   // TODO: should we permit fetching all types?
   if (!req.query.fetch_type) {
-    return next(new Error('Must provide fetch type'));
+    return next(new Error(Errors.NoFetchType));
   }
   const fetchType = req.query.fetch_type;
   // TODO: enumify this
   if (fetchType !== 'ADD' && fetchType !== 'UPDATE' && fetchType !== 'INIT') {
-    return next(new Error('invalid fetch type, must be ADD, UPDATE, or INIT'));
+    return next(new Error(Errors.InvalidType));
   }
 
   // force refresh of chain objects and return all new rows

--- a/server/routes/registerWaitingList.ts
+++ b/server/routes/registerWaitingList.ts
@@ -7,18 +7,25 @@ sgMail.setApiKey(SENDGRID_API_KEY);
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoEmail: 'Must provide email',
+  InvalidChain: 'Invalid chain',
+  AlreadyRegisterd: 'Already registered',
+  InvalidEmail: 'Invalid email',
+};
+
 const registerWaitingList = async (models, req: Request, res: Response, next: NextFunction) => {
   const email = req.body.email;
   const address = req.body.address;
   const chain = await models.Chain.findOne({ where: { id: req.body.chain }});
-  const existingUser = await models.User.findOne({ where: { email: email }});
+  const existingUser = await models.User.findOne({ where: { email } });
   // TODO: Check if the address already exists
   // TODO: Check if it conforms to the public key format for he chain
   if (!req.body.email) {
-    return next(new Error('Must provide email'));
+    return next(new Error(Errors.NoEmail));
   }
   if (!chain) {
-    return next(new Error('Invalid chain'));
+    return next(new Error(Errors.InvalidChain));
   }
 
   if (existingUser) {
@@ -28,7 +35,7 @@ const registerWaitingList = async (models, req: Request, res: Response, next: Ne
     }});
     if (existingRegistration) {
       // existing user, already on waitlist
-      return next(new Error('Already registered'));
+      return next(new Error(Errors.AlreadyRegisterd));
     } else {
       // existing user, add to waitlist
       const newRegistration = await models.WaitlistRegistration.create({
@@ -47,7 +54,7 @@ const registerWaitingList = async (models, req: Request, res: Response, next: Ne
 
     const recentTokens = await models.LoginToken.findAndCountAll({
       where: {
-        email: email,
+        email,
         created_at: {
           $gte: moment().subtract(LOGIN_RATE_LIMIT_MINS, 'minutes').toDate()
         }
@@ -64,9 +71,9 @@ const registerWaitingList = async (models, req: Request, res: Response, next: Ne
 
     const validEmailRegex = /\S+@\S+\.\S+/;
     if (!email) {
-      return next(new Error('Missing email'));
+      return next(new Error(Errors.NoEmail));
     } else if (!validEmailRegex.test(email)) {
-      return next(new Error('Invalid email'));
+      return next(new Error(Errors.InvalidEmail));
     }
     const tokenObj = await models.LoginToken.createForEmail(email);
     const registrationLink = SERVER_URL + `/api/finishLogin?token=${tokenObj.token}&email=${email}`;

--- a/server/routes/selectAddress.ts
+++ b/server/routes/selectAddress.ts
@@ -11,7 +11,7 @@ const selectAddress = async (models, req: Request, res: Response, next: NextFunc
   // get user's addresses
   const addresses = await req.user.getAddresses();
   const newSelectedAddress = addresses.filter((addr) => {
-    return addr.chain === req.body.chain && addr.address === req.body.address && !!addr.verified
+    return addr.chain === req.body.chain && addr.address === req.body.address && !!addr.verified;
   });
   if (newSelectedAddress.length === 0) {
     return next(new Error('Invalid address'));
@@ -19,7 +19,7 @@ const selectAddress = async (models, req: Request, res: Response, next: NextFunc
 
   // set other addresses to unselected
   const prevSelectedAddresses = addresses.filter((addr) => {
-    return addr.selected && (addr.chain !== req.body.chain || addr.address !== req.body.address)
+    return addr.selected && (addr.chain !== req.body.chain || addr.address !== req.body.address);
   });
   for (const prevSelectedAddress of prevSelectedAddresses) {
     prevSelectedAddress.selected = false;

--- a/server/routes/selectNode.ts
+++ b/server/routes/selectNode.ts
@@ -3,20 +3,27 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoUrl: 'Must provide url',
+  NoChain: 'Must provide chain',
+  NodeNF: 'Node not found',
+};
+
 const selectNode = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.body.url) {
-    return next(new Error('Must provide url'));
+    return next(new Error(Errors.NoUrl));
   }
   if (!req.body.chain) {
-    return next(new Error('Must provide chain'));
+    return next(new Error(Errors.NoChain));
   }
 
   const node = await models.ChainNode.findOne({ where: { chain: req.body.chain, url: req.body.url } });
   if (!node) {
-    return next(new Error('Node not found'));
+    return next(new Error(Errors.NodeNF));
   }
   req.user.setSelectedNode(node);
   await req.user.save();

--- a/server/routes/sendFeedback.ts
+++ b/server/routes/sendFeedback.ts
@@ -5,15 +5,18 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotSent: 'Nothing sent!'
+};
+
 const sendFeedback = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.body.text) {
-    return next(new Error('Nothing sent!'));
+    return next(new Error(Errors.NotSent));
   }
 
-  const userText =
-    !req.user ? '<Anonymous>' :
-    req.user.email ? req.user.email :
-    `<User ${req.user.id}>`;
+  const userText = !req.user ? '<Anonymous>'
+    : req.user.email ? req.user.email
+      : `<User ${req.user.id}>`;
 
   const urlText = req.body.url || '<Unknown URL>';
 

--- a/server/routes/starCommunity.ts
+++ b/server/routes/starCommunity.ts
@@ -1,6 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 
+export const Errors = {
+  NoStarValue: 'Must specify true or false to set starred status',
+};
+
 const starCommunity = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
 
@@ -24,7 +28,7 @@ const starCommunity = async (models, req: Request, res: Response, next: NextFunc
     }
     return res.json({ status: 'Success' });
   } else {
-    return next(new Error('Must specify true or false to set starred status'));
+    return next(new Error(Errors.NoStarValue));
   }
 };
 

--- a/server/routes/updateChain.ts
+++ b/server/routes/updateChain.ts
@@ -20,7 +20,7 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
   const chain = await models.Chain.findOne({ where: { id: req.body.id } });
   if (!chain) return next(new Error(Errors.NoChainFound));
   else {
-    const userAddressIds = await req.user.getAddresses().map((address) => address.id);
+    const userAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
     const userMembership = await models.Role.findOne({
       where: {
         address_id: { [Op.in]: userAddressIds },

--- a/server/routes/updateCommunity.ts
+++ b/server/routes/updateCommunity.ts
@@ -21,7 +21,7 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
   });
   if (!community) return next(new Error(Errors.CommunityNotFound));
   else {
-    const userAddressIds = await req.user.getAddresses().map((address) => address.id);
+    const userAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
     const userRole = await models.Role.findOne({
       where: {
         address_id: userAddressIds,

--- a/server/routes/updateTags.ts
+++ b/server/routes/updateTags.ts
@@ -17,7 +17,7 @@ const updateTags = async (models, req, res: Response, next: NextFunction) => {
   if (!req.body.tag_name) return next(new Error(UpdateTagsErrors.NoTag));
 
   const userAddresses = await req.user.getAddresses();
-  const userAddress = userAddresses.find((a) => a.verified && a.address === req.body.address);
+  const userAddress = userAddresses.find((a) => !!a.verified && a.address === req.body.address);
   if (!userAddress) return next(new Error(UpdateTagsErrors.InvalidAddr));
 
   const thread = await models.OffchainThread.findOne({

--- a/server/routes/upgradeMember.ts
+++ b/server/routes/upgradeMember.ts
@@ -25,7 +25,7 @@ const upgradeMember = async (models, req: Request, res: Response, next: NextFunc
   // if chain is present we know we are dealing with a chain first community
   const chainOrCommObj = (chain) ? { chain_id: chain.id } : { offchain_community_id: community.id };
   const requesterAddresses = await req.user.getAddresses();
-  const requesterAddressIds = requesterAddresses.map((a) => a.id);
+  const requesterAddressIds = requesterAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id);
   const requesterIsAdmin = await models.Role.findAll({
     where: {
       ...chainOrCommObj,

--- a/server/routes/verifyAddress.ts
+++ b/server/routes/verifyAddress.ts
@@ -35,7 +35,7 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
       return next(new Error('Token has expired, please re-register'));
     }
     // check for validity
-    const isAddressTransfer = existingAddress.verified && req.user && existingAddress.user_id !== req.user.id;
+    const isAddressTransfer = !!existingAddress.verified && req.user && existingAddress.user_id !== req.user.id;
     const oldId = existingAddress.user_id;
     try {
       const valid = req.body.signature

--- a/server/routes/verifyAddress.ts
+++ b/server/routes/verifyAddress.ts
@@ -3,6 +3,16 @@ import { factory, formatFilename } from '../../shared/logging';
 const sgMail = require('@sendgrid/mail');
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoAddress: 'Must provide address',
+  NoChain: 'Must provide chain',
+  NoSignature: 'Must provide signature',
+  AddressNF: 'Address not found',
+  ExpiredToken: 'Token has expired, please re-register',
+  InvalidSignature: 'Invalid signature, please re-register',
+  NoEmail: 'No email to alert',
+};
+
 const verifyAddress = async (models, req: Request, res: Response, next: NextFunction) => {
   // Verify that a linked address is actually owned by its supposed user.
   //
@@ -11,13 +21,13 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
   // bytes but can sign a no-op tx like Substrate's system.remark().
 
   if (!req.body.address) {
-    return next(new Error('Must provide address'));
+    return next(new Error(Errors.NoAddress));
   }
   if (!req.body.chain) {
-    return next(new Error('Must provide chain'));
+    return next(new Error(Errors.NoChain));
   }
   if (!req.body.signature && !(req.body.txSignature && req.body.txParams)) {
-    return next(new Error('Must provide signature'));
+    return next(new Error(Errors.NoSignature));
   }
   const chain = await models.Chain.findOne({
     where: { id: req.body.chain }
@@ -27,12 +37,12 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
     where: { chain: req.body.chain, address: req.body.address }
   });
   if (!existingAddress) {
-    return next(new Error('Address not found'));
+    return next(new Error(Errors.AddressNF));
   } else {
     // first, check whether the token has expired
     const expiration = existingAddress.verification_token_expires;
     if (expiration && +expiration <= +(new Date())) {
-      return next(new Error('Token has expired, please re-register'));
+      return next(new Error(Errors.ExpiredToken));
     }
     // check for validity
     const isAddressTransfer = !!existingAddress.verified && req.user && existingAddress.user_id !== req.user.id;
@@ -46,7 +56,7 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
           models, chain, existingAddress, (req.user ? req.user.id : null), req.body.txSignature, req.body.txParams
         );
       if (!valid) {
-        return next(new Error('Invalid signature, please re-register'));
+        return next(new Error(Errors.InvalidSignature));
       }
     } catch (e) {
       return next(e);
@@ -57,7 +67,7 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
     if (isAddressTransfer) {
       try {
         const user = await models.User.findOne({ where: { id: oldId } });
-        if (!user.email) throw new Error('No email to alert'); // users who register thru github don't have emails!
+        if (!user.email) throw new Error(Errors.NoEmail); // users who register thru github don't have emails by default!
         const msg = {
           to: user.email,
           from: 'Commonwealth <no-reply@commonwealth.im>',

--- a/server/routes/viewChainObjectQueries.ts
+++ b/server/routes/viewChainObjectQueries.ts
@@ -3,12 +3,17 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NotSiteAdmin: 'Not site admin',
+};
+
 const viewChainObjectQueries = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
   if (!req.user.isAdmin) {
-    return next(new Error('Must be admin'));
+    return next(new Error(Errors.NotSiteAdmin));
   }
   const versions = await models.ChainObjectVersion.findAll({
     include: [{

--- a/server/routes/viewChainObjects.ts
+++ b/server/routes/viewChainObjects.ts
@@ -3,9 +3,13 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoObjectType: 'Must provide object_type',
+};
+
 const viewChainObjects = async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.query.object_type) {
-    return next(new Error('Must provide object_type'));
+    return next(new Error(Errors.NoObjectType));
   }
   const options: any = {
     where: { object_type: req.query.object_type },

--- a/server/routes/viewComments.ts
+++ b/server/routes/viewComments.ts
@@ -4,11 +4,15 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoRootId: 'Must provide root_id',
+};
+
 const viewComments = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
 
   if (!req.query.root_id) {
-    return next(new Error('Must provide root_id'));
+    return next(new Error(Errors.NoRootId));
   }
 
   const comments = await models.OffchainComment.findAll({

--- a/server/routes/viewCount.ts
+++ b/server/routes/viewCount.ts
@@ -4,12 +4,19 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoObjectId: 'Must provide object_id',
+  NoChainOrComm: 'Must provide chain or community',
+  InvalidChainOrComm: 'Invalid chain or community',
+  InvalidThread: 'Invalid offchain thread',
+};
+
 const viewCount = async (models, cache: ViewCountCache, req: Request, res: Response, next: NextFunction) => {
   if (!req.body.object_id) {
-    return next(new Error('Must provide object_id'));
+    return next(new Error(Errors.NoObjectId));
   }
   if (!req.body.chain && !req.body.community) {
-    return next(new Error('Must provide chain or community'));
+    return next(new Error(Errors.NoChainOrComm));
   }
   const chain = await models.Chain.findOne({
     where: { id: req.body.chain }
@@ -19,7 +26,7 @@ const viewCount = async (models, cache: ViewCountCache, req: Request, res: Respo
   });
 
   if (!chain && !community) {
-    return next(new Error('Invalid community or chain'));
+    return next(new Error(Errors.InvalidChainOrComm));
   }
 
   // verify thread exists before querying
@@ -33,7 +40,7 @@ const viewCount = async (models, cache: ViewCountCache, req: Request, res: Respo
     }
   });
   if (!obj) {
-    return next(new Error('Invalid offchain thread'));
+    return next(new Error(Errors.InvalidThread));
   }
 
   // query view counts, creating as needed

--- a/server/routes/viewNotifications.ts
+++ b/server/routes/viewNotifications.ts
@@ -5,9 +5,13 @@ import { factory, formatFilename } from '../../shared/logging';
 const Op = Sequelize.Op;
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
 
   // locate active subscriptions, filter by category if specified

--- a/server/routes/viewReactions.ts
+++ b/server/routes/viewReactions.ts
@@ -5,11 +5,15 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NoCommentOrThreadId: 'Must provide a comment or thread id',
+};
+
 const viewReactions = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
 
   if (!req.query.thread_id && !req.query.comment_id) {
-    return next(new Error('Must provide a comment or thread id'));
+    return next(new Error(Errors.NoCommentOrThreadId));
   }
 
   const options = {};

--- a/server/routes/viewSubscriptions.ts
+++ b/server/routes/viewSubscriptions.ts
@@ -3,9 +3,13 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+};
+
 export default async (models, req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
-    return next(new Error('Not logged in'));
+    return next(new Error(Errors.NotLoggedIn));
   }
 
   const subscriptions = await models.Subscription.findAll({

--- a/server/routes/webhooks/createWebhook.ts
+++ b/server/routes/webhooks/createWebhook.ts
@@ -16,7 +16,7 @@ const createWebhook = async (models, req: Request, res: Response, next: NextFunc
   const adminRoles = await models.Role.findAll({
     where: {
       ...chainOrCommObj,
-      address_id: addresses.map((addr) => addr.id),
+      address_id: addresses.filter((addr) => !!addr.verified).map((addr) => addr.id),
       permission: ['admin']
     },
   });

--- a/server/routes/webhooks/deleteWebhook.ts
+++ b/server/routes/webhooks/deleteWebhook.ts
@@ -16,7 +16,7 @@ const deleteWebhook = async (models, req: Request, res: Response, next: NextFunc
   const adminRoles = await models.Role.findAll({
     where: {
       ...chainOrCommObj,
-      address_id: addresses.map((addr) => addr.id),
+      address_id: addresses.filter((addr) => !!addr.verified).map((addr) => addr.id),
       permission: ['admin']
     },
   });

--- a/server/routes/webhooks/getWebhooks.ts
+++ b/server/routes/webhooks/getWebhooks.ts
@@ -16,7 +16,7 @@ const getWebhooks = async (models, req: Request, res: Response, next: NextFuncti
   const adminRoles = await models.Role.findAll({
     where: {
       ...chainOrCommObj,
-      address_id: addresses.map((addr) => addr.id),
+      address_id: addresses.filter((addr) => !!addr.verified).map((addr) => addr.id),
       permission: ['admin']
     },
   });

--- a/server/routes/writeUserSetting.ts
+++ b/server/routes/writeUserSetting.ts
@@ -3,14 +3,20 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+export const Errors = {
+  InvalidUser: 'InvalidUser',
+  NoKeyValue: 'Must provide key and value',
+  InvalidSetting: 'Invalid setting',
+};
+
 const writeUserSetting = async (models, req: Request, res: Response, next: NextFunction) => {
   const { key, value } = req.body;
 
   if (!req.user) {
-    return next(new Error('Invalid user'));
+    return next(new Error(Errors.InvalidUser));
   }
   if (!key || !value) {
-    return next(new Error('Key and value must be supplied'));
+    return next(new Error(Errors.NoKeyValue));
   }
 
   if (key === 'lastVisited') {
@@ -28,7 +34,7 @@ const writeUserSetting = async (models, req: Request, res: Response, next: NextF
     req.user.disableRichText = false;
     await req.user.save();
   } else {
-    return next(new Error('Invalid setting'));
+    return next(new Error(Errors.InvalidSetting));
   }
 
   return res.json({ status: 'Success', result: { key, value } });

--- a/server/util/lookupCommunityIsVisibleToUser.ts
+++ b/server/util/lookupCommunityIsVisibleToUser.ts
@@ -45,7 +45,7 @@ const lookupCommunityIsVisibleToUser = async (models, params, user, next: NextFu
 
   if (community && community.privacyEnabled) {
     if (!user) return next(new Error('Invalid community or chain'));
-    const userAddressIds = await user.getAddresses().map((address) => address.id);
+    const userAddressIds = await user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
     const userMembership = await models.Role.findOne({
       where: {
         address_id: userAddressIds,

--- a/test/unit/api/subscriptions.spec.ts
+++ b/test/unit/api/subscriptions.spec.ts
@@ -10,6 +10,7 @@ import app, { resetDatabase } from '../../../server-test';
 import { JWT_SECRET } from '../../../server/config';
 import * as modelUtils from '../../util/modelUtils';
 import Errors from '../../../server/routes/subscription/errors';
+import { Errors as MarkNotifErrors } from '../../../server/routes/markNotificationsRead';
 
 chai.use(chaiHttp);
 const { expect } = chai;
@@ -165,12 +166,14 @@ describe('Subscriptions Tests', () => {
         .send({ jwt: newJWT, 'subscription_ids[]': [subscription.id] });
       expect(res.body).to.not.be.null;
       expect(res.body.error).to.not.be.null;
+      expect(res.body.error).to.be.equal(Errors.NotUsersSubscription);
       res = await chai.request(app)
         .post('/api/disableSubscriptions')
         .set('Accept', 'application/json')
         .send({ jwt: newJWT, 'subscription_ids[]': [subscription.id] });
       expect(res.body).to.not.be.null;
       expect(res.body.error).to.not.be.null;
+      expect(res.body.error).to.be.equal(Errors.NotUsersSubscription);
     });
 
     it('should fail to enable and disable subscription when no subscriptions are passed to route', async () => {
@@ -180,12 +183,14 @@ describe('Subscriptions Tests', () => {
         .send({ jwt: jwtToken });
       expect(res.body).to.not.be.null;
       expect(res.body.error).to.not.be.null;
+      expect(res.body.error).to.be.equal(Errors.NoSubscriptionId);
       res = await chai.request(app)
         .post('/api/disableSubscriptions')
         .set('Accept', 'application/json')
         .send({ jwt: jwtToken });
       expect(res.body).to.not.be.null;
       expect(res.body.error).to.not.be.null;
+      expect(res.body.error).to.be.equal(Errors.NoSubscriptionId);
     });
   });
 
@@ -296,6 +301,7 @@ describe('Subscriptions Tests', () => {
         .set('Accept', 'application/json')
         .send({ jwt: jwtToken });
       expect(res.body.error).to.not.be.null;
+      expect(res.body.error).to.be.equal(Errors.NoSubscriptionId);
     });
 
     it('should fail to find a bad subscription id', async () => {
@@ -405,6 +411,7 @@ describe('Subscriptions Tests', () => {
           .send({ jwt: jwtToken });
         expect(res.body).to.not.be.null;
         expect(res.body.error).to.not.be.null;
+        expect(res.body.error).to.be.equal(MarkNotifErrors.NoNotificationIds);
       });
       it('should fail when not the owner of the notification', async () => {
         expect(notifications).to.not.be.null;
@@ -417,6 +424,7 @@ describe('Subscriptions Tests', () => {
           .send({ jwt: newJwt, 'notification_ids[]': notification_ids });
         expect(res.body).to.not.be.null;
         expect(res.body.error).to.not.be.null;
+        expect(res.body.error).to.be.equal(MarkNotifErrors.WrongOwner);
       });
     });
 

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { Errors as ThreadErrors } from 'server/routes/createThread';
 import { Errors as EditThreadErrors } from 'server/routes/editThread';
 import { Errors as CreateCommentErrors } from 'server/routes/createComment';
+import { Errors as ViewCountErrors } from 'server/routes/viewCount';
 import app, { resetDatabase } from '../../../server-test';
 import { JWT_SECRET } from '../../../server/config';
 import * as modelUtils from '../../util/modelUtils';
@@ -843,7 +844,7 @@ describe('Thread Tests', () => {
         .send({ chain });
       expect(res.status).to.equal(500);
       expect(res.body).to.not.be.null;
-      expect(res.body.error).to.equal('Must provide object_id');
+      expect(res.body.error).to.equal(ViewCountErrors.NoObjectId);
     });
 
     it('should not track views without chain or community', async () => {
@@ -853,7 +854,7 @@ describe('Thread Tests', () => {
         .send({ object_id: '9999' });
       expect(res.status).to.equal(500);
       expect(res.body).to.not.be.null;
-      expect(res.body.error).to.equal('Must provide chain or community');
+      expect(res.body.error).to.equal(ViewCountErrors.NoChainOrComm);
     });
 
     it('should not track views with invalid chain or community', async () => {
@@ -863,7 +864,7 @@ describe('Thread Tests', () => {
         .send({ chain: 'adkgjkjgda', object_id: '9999' });
       expect(res.status).to.equal(500);
       expect(res.body).to.not.be.null;
-      expect(res.body.error).to.equal('Invalid community or chain');
+      expect(res.body.error).to.equal(ViewCountErrors.InvalidChainOrComm);
     });
 
     it('should not track views with invalid object_id', async () => {
@@ -873,7 +874,7 @@ describe('Thread Tests', () => {
         .send({ chain, object_id: '9999' });
       expect(res.status).to.equal(500);
       expect(res.body).to.not.be.null;
-      expect(res.body.error).to.equal('Invalid offchain thread');
+      expect(res.body.error).to.equal(ViewCountErrors.InvalidThread);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In routes, we frequently call `User.getAddresses()` however we hadn't previously checked to see if they're all verified. I added a verification filter `.filter((addr) => !!addr.verified)` to all these calls or in-chain with `.map()` contextually. All previous filters with the usage `.filter((addr) => addr.verified)` without the `!!` have been modified to include the `!!` as it forces the value to be a boolean. 

### Addendum:
Per @drewstone's request, I also factored out all error messages into objects at the top of each route and modified all previously written error tests to test the error type as well. No new tests were written in this PR.

Closing #162 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Security reasons for our users. Gotta make sure they're verified!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`yarn test-api` still passes after dozens of files were modified.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: all pass like before, no change in coverage. 