### PR TITLE
Add pagination for validator list 

### DIFF
--- a/client/scripts/views/components/widgets/tabs.ts
+++ b/client/scripts/views/components/widgets/tabs.ts
@@ -24,7 +24,13 @@ const Tabs = {
             class: (vnode.state.selectedIndex === index ? 'active' : '')
               + (vnode.children[index].disabled ? ' disabled' : ''),
             href: '#',
-            onclick: ((i, e) => { e.preventDefault(); vnode.state.selectedIndex = i; }).bind(this, index)
+            onclick: ((i, e) => {
+              e.preventDefault();
+              vnode.state.selectedIndex = i;
+              if (typeof vnode.children[vnode.state.selectedIndex].callback === 'function') {
+                vnode.children[vnode.state.selectedIndex].callback(i);
+              }
+            }).bind(this, index)
           }, name);
         }),
         m('.clear'),

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -60,6 +60,7 @@ const PresentationComponent = (state, chain: Substrate) => {
 
   return m('div',
     m(Tabs, [{
+      callback: model.reset,
       name: 'Current Validators',
       content: m('table.validators-table', [
         m('tr.validators-heading', [

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -9,7 +9,7 @@ import ValidatorRow from './validator_row';
 import RecentBlock from './recent_block';
 
 const model = {
-  perPage: 10,
+  perPage: 20,
   currentPage: 1,
   currentTab: 'current',
   show: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add pagination for validator list

## Motivation and Context
Currently for some chains, especially some of the newer ones like Acala, there are a tremendous number of nodes and validators (potentially in the thousands).

## How has this been tested?
Tested for edgeware and kusama

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no