### PR TITLE
Discussion Row Carat overflow bugfix

### DIFF
--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -106,7 +106,7 @@ const ThreadCaratMenu: m.Component<IThreadCaratMenuAttrs, { isOpen: boolean }> =
       m(PopoverMenu, {
         transitionDuration: 0,
         closeOnOutsideClick: true,
-        menuAttrs: { size: 'sm' },
+        menuAttrs: {},
         content: [
           canEditThread && m(TagEditorButton, {
             popoverMenu: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Discussion row carat menu was overflowing with ellipses. See #342.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Descriptive content was being hidden. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Clicked on the carat and now it doesn't overflow. Doesn't ensure future overflow of even longer texted rows, but something to mindful of.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no