### PR TITLE
Add descriptions on-hover and load spinner while first paginated validator data loads

### DIFF
--- a/client/scripts/views/pages/validators/substrate/im_online.ts
+++ b/client/scripts/views/pages/validators/substrate/im_online.ts
@@ -1,5 +1,5 @@
 import m from 'mithril';
-import { Icons, Icon } from 'construct-ui';
+import { Icons, Icon, Tooltip } from 'construct-ui';
 import { u32 } from '@polkadot/types';
 
 interface ImOnlineAttrs {
@@ -11,17 +11,28 @@ interface ImOnlineAttrs {
 
 const ImOnline: m.Component<ImOnlineAttrs, {}> = {
   view: (vnode) => {
-    return m('td.val-im-online',
-      m('span.im-online-icons', [
-        vnode.attrs.toBeElected
-    && m(Icon, { name: Icons.ARROW_LEFT_CIRCLE, size: 'sm' }),
-        vnode.attrs.isOnline
-    && m(Icon, { name: Icons.WIFI, size: 'sm' }),
-        vnode.attrs.hasMessage
-    && m(Icon, { name: Icons.MESSAGE_SQUARE, size: 'sm' }),
-        vnode.attrs.blockCount
-    && m('label.block-count', vnode.attrs.blockCount)
-      ]));
+    return m(
+      "td.val-im-online",
+      m("span.im-online-icons", [
+        vnode.attrs.toBeElected &&
+        m(Tooltip, {
+          trigger: m(Icon, { name: Icons.ARROW_LEFT_CIRCLE, size: "sm" }),
+          content: m("div", "Validator is to be Elected"),
+        }),
+        vnode.attrs.isOnline &&
+          m(Tooltip, {
+            trigger: m(Icon, { name: Icons.WIFI, size: "sm" }),
+            content: m("div", "Validator is Online!"),
+          }),
+        vnode.attrs.hasMessage &&
+          m(Tooltip, {
+            trigger: m(Icon, { name: Icons.MESSAGE_SQUARE, size: "sm" }),
+            content: m("div", "New Message!"),
+          }),
+        vnode.attrs.blockCount &&
+          m("label.block-count", vnode.attrs.blockCount),
+      ])
+    );
   },
 };
 

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -8,6 +8,8 @@ import Tabs from '../../../components/widgets/tabs';
 import ValidatorRow from './validator_row';
 import ValidatorRowWaiting from './validator_row_waiting';
 import RecentBlock from './recent_block';
+import PageLoading from "views/pages/loading";
+
 
 const model = {
   perPage: 20,
@@ -37,7 +39,8 @@ const model = {
 
 const PresentationComponent = (state, chain: Substrate) => {
   const validators = state.dynamic.validators;
-  if (!validators) return;
+  if (!validators) return m(PageLoading, {message:"Loading Validators..."});
+  
 
   const lastHeaders = (app.chain.base === ChainBase.Substrate)
     ? (app.chain as Substrate).staking.lastHeaders


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add descriptions on-hover over icons in validator list.
Add load spinner while first paginated validator data loads

## Motivation and Context
We are now showing icons for ImOnline, toBeElected, and potentially other messages. It would be worthwhile to be able to hover over these icons and see a description of their purpose.
We should ensure that until the validators have been loaded, we show a spinner on the validator pages.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no