### PR TITLE
Add tooltip to User component in discussion row

### DIFF
--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -112,7 +112,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
           // comments
           m('.discussion-commenters', app.comments.nComments(proposal) > 0 ? [
             m('.commenters-avatars', app.comments.uniqueCommenters(proposal).map(([chain, address]) => {
-              return m(User, { user: [address, chain], avatarOnly: true, avatarSize: 20 });
+              return m(User, { user: [address, chain], avatarOnly: true, tooltip: true, avatarSize: 20 });
             })),
             link(
               'a.commenters-label',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Issue #341 was about deduplicating the circular user icon below each thread (see issue for example) and enabling the tooltip for more user info. Upon inspection, the user icon was not being duplicated as it appeared, rather a user with multiple addresses (with same offchain profile picture) commented in the thread, creating an appearance of duplication; a bug that solved itself. 
Otherwise this pr just turns on the tooltip for the discussion row.

Closes #341 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug and more info for user.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Hover over user icon, tooltip will appear.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no