### PR TITLE
Fix readonly toggle button silent failure

### DIFF
--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -261,7 +261,7 @@ export const ProposalHeaderPrivacyButtons: m.Component<{ proposal: AnyProposal |
         class: 'read-only-toggle',
         onclick: (e) => {
           e.preventDefault();
-          app.threads.edit(proposal, null, null, true).then(() => m.redraw());
+          app.threads.edit(proposal, null, null, !proposal.readOnly).then(() => m.redraw());
         },
         label: proposal.readOnly ? 'Make Commentable?' : 'Make Read-Only?'
       }),

--- a/server/router.ts
+++ b/server/router.ts
@@ -140,7 +140,7 @@ function setupRouter(app, models, fetcher, viewCountCache: ViewCountCache) {
   // TODO: Change to POST /thread
   router.post('/createThread', passport.authenticate('jwt', { session: false }), createThread.bind(this, models));
   // TODO: Change to PUT /thread
-  router.post('/editThread', passport.authenticate('jwt', { session: false }), editThread.bind(this, models));
+  router.put('/editThread', passport.authenticate('jwt', { session: false }), editThread.bind(this, models));
   // TODO: Change to DELETE /thread
   router.post('/deleteThread', passport.authenticate('jwt', { session: false }), deleteThread.bind(this, models));
   // TODO: Change to GET /threads

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -438,7 +438,7 @@ describe('Thread Tests', () => {
       const readOnly = true;
       const privacy = false;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -462,7 +462,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -484,7 +484,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = false;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -509,7 +509,7 @@ describe('Thread Tests', () => {
       let readOnly = false;
       const privacy = false;
       let res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -529,7 +529,7 @@ describe('Thread Tests', () => {
       // turning on read_only
       readOnly = true;
       res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -554,7 +554,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       let privacy = false;
       let res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -574,7 +574,7 @@ describe('Thread Tests', () => {
       // failing to turn on privacy, thread.private stays false.
       privacy = true;
       res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread.id,
@@ -600,7 +600,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread_id,
@@ -623,7 +623,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': null,
@@ -648,7 +648,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread_id,
@@ -673,7 +673,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': null,
@@ -699,7 +699,7 @@ describe('Thread Tests', () => {
       const readOnly = false;
       const privacy = true;
       const res = await chai.request(app)
-        .post('/api/editThread')
+        .put('/api/editThread')
         .set('Accept', 'application/json')
         .send({
           'thread_id': thread_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
'Make Readonly' / 'Make Commentable' toggle button was failing to make a thread commentable after readonly being turned on. I fixed the logic in the controller that was creating the error and also refactored the route call to be a PUT as a code comment requested. All related route tests were updated as well.

Closes #339 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix and the move toward more RESTful code.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
You can click on the button and it toggles as expected, no silent failure. Moreover, running `yarn test-api` will continue to work with all affected tests. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: 85%