### PR TITLE
Auto-Subscribe user to New Threads when joining community

### DIFF
--- a/client/scripts/views/pages/discussions/thread_carat_menu.ts
+++ b/client/scripts/views/pages/discussions/thread_carat_menu.ts
@@ -16,8 +16,12 @@ export const ThreadSubscriptionButton: m.Component<{ proposal: OffchainThread }>
     return m(MenuItem, {
       onclick: (e) => {
         e.preventDefault();
-        if (notificationSubscription) {
-          app.user.notifications.deleteSubscription(notificationSubscription).then(() => {
+        if (notificationSubscription && notificationSubscription.isActive) {
+          app.user.notifications.disableSubscriptions([notificationSubscription]).then(() => {
+            m.redraw();
+          });
+        } else if (notificationSubscription) { // subscription, but not active
+          app.user.notifications.enableSubscriptions([notificationSubscription]).then(() => {
             m.redraw();
           });
         } else {
@@ -26,8 +30,8 @@ export const ThreadSubscriptionButton: m.Component<{ proposal: OffchainThread }>
           });
         }
       },
-      label: notificationSubscription ? 'Turn off notifications' : 'Turn on notifications',
-      iconLeft: notificationSubscription ? Icons.VOLUME_X : Icons.VOLUME_2,
+      label: notificationSubscription?.isActive ? 'Turn off notifications' : 'Turn on notifications',
+      iconLeft: notificationSubscription?.isActive ? Icons.VOLUME_X : Icons.VOLUME_2,
     });
   },
 };

--- a/server/routes/acceptInvite.ts
+++ b/server/routes/acceptInvite.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { factory, formatFilename } from '../../shared/logging';
+import { NotificationCategories } from '../../shared/types';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -65,7 +66,14 @@ const acceptInvite = async (models, req: Request, res: Response, next: NextFunct
   });
   if (!updatedCode) return next(new Error(Errors.CodeUpdateFailure));
 
-  return res.json({ status: 'Success', result: { updatedCode, role } });
+  const subscription = await models.Subscription.create({
+    subscriber_id: req.user.id,
+    category_id: NotificationCategories.NewThread,
+    object_id: community.id,
+    is_active: true,
+  });
+
+  return res.json({ status: 'Success', result: { updatedCode, role, subscription } });
 };
 
 export default acceptInvite;

--- a/server/routes/createRole.ts
+++ b/server/routes/createRole.ts
@@ -55,7 +55,7 @@ const createRole = async (models, req, res: Response, next: NextFunction) => {
     is_active: true,
   });
 
-  return res.json({ status: 'Success', result: newRole.toJSON() });
+  return res.json({ status: 'Success', result: { newRole, subscription } });
 };
 
 export default createRole;

--- a/server/routes/createRole.ts
+++ b/server/routes/createRole.ts
@@ -1,6 +1,7 @@
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import Sequelize from 'sequelize';
 import { Response, NextFunction } from 'express';
+import { NotificationCategories } from '../../shared/types';
 
 export const Errors = {
   InvalidChainComm: 'Invalid chain or community',
@@ -45,6 +46,13 @@ const createRole = async (models, req, res: Response, next: NextFunction) => {
     address_id: req.body.address_id,
     offchain_community_id: community.id,
     permission: 'member',
+  });
+
+  const subscription = await models.Subscription.create({
+    subscriber_id: req.user.id,
+    category_id: NotificationCategories.NewThread,
+    object_id: (chain) ? chain.id : community.id,
+    is_active: true,
   });
 
   return res.json({ status: 'Success', result: newRole.toJSON() });

--- a/test/unit/api/invites.spec.ts
+++ b/test/unit/api/invites.spec.ts
@@ -11,6 +11,7 @@ import { Errors as CreateInviteLinkErrors } from 'server/routes/createInviteLink
 import { JWT_SECRET } from 'server/config';
 import * as modelUtils from '../../util/modelUtils';
 import app, { resetDatabase } from '../../../server-test';
+import { NotificationCategories } from '../../../shared/types';
 
 chai.use(chaiHttp);
 const { expect } = chai;
@@ -355,6 +356,9 @@ describe('Invite Tests', () => {
       expect(res.body.result.updatedCode.community_id).to.be.equal(community);
       expect(res.body.result.updatedCode.invited_email).to.be.equal(userEmail);
       expect(res.body.result.updatedCode.used).to.be.true;
+      expect(res.body.result.subscription).to.not.be.null;
+      expect(res.body.result.subscription.object_id).to.be.equal(community);
+      expect(res.body.result.subscription.category_id).to.be.equal(NotificationCategories.NewThread);
     });
 
     it('should fail to accept an invite created by an admin as a user who does not own the address', async () => {

--- a/test/unit/api/invites.spec.ts
+++ b/test/unit/api/invites.spec.ts
@@ -356,6 +356,8 @@ describe('Invite Tests', () => {
       expect(res.body.result.updatedCode.community_id).to.be.equal(community);
       expect(res.body.result.updatedCode.invited_email).to.be.equal(userEmail);
       expect(res.body.result.updatedCode.used).to.be.true;
+      expect(res.body.result.role).to.not.be.null;
+      expect(res.body.result.role.offchain_community_id).to.be.equal(community);
       expect(res.body.result.subscription).to.not.be.null;
       expect(res.body.result.subscription.object_id).to.be.equal(community);
       expect(res.body.result.subscription.category_id).to.be.equal(NotificationCategories.NewThread);

--- a/test/unit/api/roles.spec.ts
+++ b/test/unit/api/roles.spec.ts
@@ -52,8 +52,8 @@ describe('Roles Test', () => {
           address_id: user.address_id,
         });
       expect(res.body.status).to.be.equal('Success');
-      expect(res.body.result.address_id).to.be.equal(user.address_id);
-      expect(res.body.result.offchain_community_id).to.be.equal(community);
+      expect(res.body.result.newRole.address_id).to.be.equal(user.address_id);
+      expect(res.body.result.newRole.offchain_community_id).to.be.equal(community);
     });
 
     it('should fail to create duplicate role for a public community a user is a member of', async () => {

--- a/test/unit/api/roles.spec.ts
+++ b/test/unit/api/roles.spec.ts
@@ -54,6 +54,9 @@ describe('Roles Test', () => {
       expect(res.body.status).to.be.equal('Success');
       expect(res.body.result.newRole.address_id).to.be.equal(user.address_id);
       expect(res.body.result.newRole.offchain_community_id).to.be.equal(community);
+      expect(res.body.result.subscription).to.not.be.null;
+      expect(res.body.result.subscription.object_id).to.be.equal(community);
+      expect(res.body.result.subscription.category_id).to.be.equal(NotificationCategories.NewThread);
     });
 
     it('should fail to create duplicate role for a public community a user is a member of', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds auto-generates a NewThread Subscription for the user when they either join a public community (using the ~currently inactive~ `/createRole` but works in unit-tests) or accept an invite. _(edit: `/createRole` is now called to issue a member role when you select an address for a public community of which you are not a member of yet)_

Closes #432 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Toward a general notifications goal of not needing to generate a subscription in the client via the `/notification-settings` page, but rather just enable/disable notifications.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`yarn test-api`, and you can click on the `thread-carat-menu` a few times on different threads and watch the server log.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested