### PR TITLE
Implement design for Twitter like on-chain identity tooltip 

### DIFF
--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -47,6 +47,7 @@ export interface IValidatorValue {
   blockCount?: u32,
   hasMessage?: boolean,
   isOnline?: boolean,
+  otherTotal?: BN,
 }
 export interface IValidators {
   [address: string]: IValidatorValue;

--- a/client/scripts/controllers/chain/substrate/staking.ts
+++ b/client/scripts/controllers/chain/substrate/staking.ts
@@ -34,6 +34,7 @@ export interface IAccountInfo extends DeriveAccountRegistration{
   isLowQuality: boolean;
   isReasonable: boolean;
   waitCount: number;
+  stash: string;
 }
 
 function extractNominators(nominations: [StorageKey, Option<Nominations>][]): Record<string, iInfo[]> {
@@ -110,6 +111,7 @@ class SubstrateStaking implements StorageModule {
         const isLowQuality = judgements.some(([, judgement]) => judgement.isLowQuality);
         info = {
           name,
+          stash: address,
           ...identity,
           isBad: isErroneous || isLowQuality,
           isErroneous,
@@ -122,6 +124,7 @@ class SubstrateStaking implements StorageModule {
         };
       }
       info.name = name || '';
+      info.stash = address || '';
       return info;
     }));
   }

--- a/client/scripts/controllers/chain/substrate/staking.ts
+++ b/client/scripts/controllers/chain/substrate/staking.ts
@@ -34,7 +34,6 @@ export interface IAccountInfo extends DeriveAccountRegistration{
   isLowQuality: boolean;
   isReasonable: boolean;
   waitCount: number;
-  stash: string;
 }
 
 function extractNominators(nominations: [StorageKey, Option<Nominations>][]): Record<string, iInfo[]> {
@@ -111,7 +110,6 @@ class SubstrateStaking implements StorageModule {
         const isLowQuality = judgements.some(([, judgement]) => judgement.isLowQuality);
         info = {
           name,
-          stash: address,
           ...identity,
           isBad: isErroneous || isLowQuality,
           isErroneous,
@@ -124,7 +122,6 @@ class SubstrateStaking implements StorageModule {
         };
       }
       info.name = name || '';
-      info.stash = address || '';
       return info;
     }));
   }

--- a/client/scripts/controllers/chain/substrate/staking.ts
+++ b/client/scripts/controllers/chain/substrate/staking.ts
@@ -181,6 +181,7 @@ class SubstrateStaking implements StorageModule {
           const key = currentSet[i].toString();
           result[key] = {
             exposure: exposures[i],
+            otherTotal: exposures[i]?.total.unwrap().sub(exposures[i]?.own.unwrap()),
             controller: controllers[i].toString(),
             isElected: true,
             toBeElected: false,
@@ -195,6 +196,7 @@ class SubstrateStaking implements StorageModule {
           const key = toBeElected[i].toString();
           result[key] = {
             exposure: nextUpExposures[i],
+            otherTotal: exposures[i]?.total.unwrap().sub(exposures[i]?.own.unwrap()),
             controller: nextUpControllers[i].toString(),
             isElected: false,
             toBeElected: true,

--- a/client/scripts/views/pages/validators/index.ts
+++ b/client/scripts/views/pages/validators/index.ts
@@ -42,6 +42,7 @@ export interface IValidatorAttrs {
   blockCount?: u32;
   hasMessage?: boolean;
   isOnline?: boolean;
+  commission?: number;
 }
 
 export interface IValidatorPageState {

--- a/client/scripts/views/pages/validators/index.ts
+++ b/client/scripts/views/pages/validators/index.ts
@@ -26,6 +26,7 @@ import { SubstratePreHeader, SubstratePresentationComponent } from './substrate'
 export interface IValidatorAttrs {
   stash: string;
   total?: Coin;
+  otherTotal?: Coin;
   nominators?: any;
   error?: any;
   sending?: boolean;

--- a/client/scripts/views/pages/validators/substrate/identity.ts
+++ b/client/scripts/views/pages/validators/substrate/identity.ts
@@ -1,42 +1,76 @@
 import m from 'mithril';
 import app from 'state';
 import User from 'views/components/widgets/user';
+import { ChainBase } from 'models';
+import Substrate from 'controllers/chain/substrate/main';
+import { makeDynamicComponent } from 'models/mithril';
 import { Icons, Icon } from 'construct-ui';
 import { IAccountInfo } from 'controllers/chain/substrate/staking';
 
-const Identity: m.Component<IAccountInfo, {}> = {
+export interface IValidatorState {
+  dynamic: {
+    info: IAccountInfo;
+  },
+  isNominating: boolean;
+}
+
+export interface IdentityAttrs {
+  stash: string;
+}
+
+const Identity = makeDynamicComponent<IdentityAttrs, IValidatorState>({
+  getObservables: (attrs) => ({
+    // we need a group key to satisfy the dynamic object constraints, so here we use the chain class
+    groupKey: app.chain.class.toString(),
+    info: (app.chain.base === ChainBase.Substrate)
+      ? (app.chain as Substrate).staking.info(attrs.stash)
+      : null
+  }),
   view: (vnode) => {
-    const clsName = vnode.attrs.isGood ? '.icon-ok-circled.green' : vnode.attrs.isBad ? '.icon-cancel-circle.red' : '.icon-minus-circled.gray';
-    const clsText = vnode.attrs?.judgements.length
-      ? (vnode.attrs.isGood
-        ? (vnode.attrs.isKnownGood ? 'Known good' : 'Reasonable')
-        : (vnode.attrs.isErroneous ? 'Erroneous' : 'Low quality')
-      )
+    const { info } = vnode.state.dynamic;
+    if (!info)
+      return m('span', [
+        m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }),
+        m('hr'),
+        m('p', 'Loading ...'),
+      ]);
+
+    const clsName = info.isGood
+      ? '.icon-ok-circled.green'
+      : info.isBad
+        ? '.icon-cancel-circle.red'
+        : '.icon-minus-circled.gray';
+
+    const clsText = info?.judgements.length
+      ? (info.isGood
+        ? (info.isKnownGood ? 'Known good' : 'Reasonable')
+        : (info.isErroneous ? 'Erroneous' : 'Low quality'))
       : 'No judgments';
+
     return m('div.identity',
       m('span', [
         m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }),
         m('hr'),
-        m('p', vnode.attrs.legal),
-        vnode.attrs.email
+        m('p', info.legal),
+        info.email
           && m('p', [
             m(Icon, { name: Icons.AT_SIGN, size: 'sm' }),
-            m('label', `  ${vnode.attrs.email}`)
+            m('label', `  ${info.email}`)
           ]),
-        vnode.attrs.web
+        info.web
           && m('p', [
             m(Icon, { name: Icons.GLOBE, size: 'sm' }),
-            m('label', `  ${vnode.attrs.web}`)
+            m('label', `  ${info.web}`)
           ]),
-        vnode.attrs.twitter
+        info.twitter
           && m('p', [
             m(Icon, { name: Icons.TWITTER, size: 'sm' }),
-            m('label', `  ${vnode.attrs.twitter}`)
+            m('label', `  ${info.twitter}`)
           ]),
-        vnode.attrs.riot
+        info.riot
           && m('p', [
             m(Icon, { name: Icons.FIGMA, size: 'sm' }),
-            m('label', `  ${vnode.attrs.riot}`)
+            m('label', `  ${info.riot}`)
           ]),
         m('p.User', [
           m(`span.identity-icon${clsName}`, ''),
@@ -44,6 +78,6 @@ const Identity: m.Component<IAccountInfo, {}> = {
         ])
       ]));
   }
-};
+});
 
 export default Identity;

--- a/client/scripts/views/pages/validators/substrate/identity.ts
+++ b/client/scripts/views/pages/validators/substrate/identity.ts
@@ -2,6 +2,7 @@ import m from 'mithril';
 import app from 'state';
 import User from 'views/components/widgets/user';
 import { ChainBase } from 'models';
+import {truncate} from 'lodash';
 import Substrate from 'controllers/chain/substrate/main';
 import { makeDynamicComponent } from 'models/mithril';
 import { Icons, Icon } from 'construct-ui';
@@ -65,7 +66,7 @@ const Identity = makeDynamicComponent<IdentityAttrs, IValidatorState>({
         info.twitter
           && m('p', [
             m(Icon, { name: Icons.TWITTER, size: 'sm' }),
-            m('label', `  ${info.twitter}`)
+            m('label', `  ${truncate(info.twitter)}`)
           ]),
         info.riot
           && m('p', [

--- a/client/scripts/views/pages/validators/substrate/identity.ts
+++ b/client/scripts/views/pages/validators/substrate/identity.ts
@@ -1,10 +1,12 @@
 import m from 'mithril';
+import app from 'state';
+import User from 'views/components/widgets/user';
+import { Icons, Icon } from 'construct-ui';
 import { IAccountInfo } from 'controllers/chain/substrate/staking';
 
 const Identity: m.Component<IAccountInfo, {}> = {
   view: (vnode) => {
-
-    const clsName = vnode.attrs.isGood ? 'green' : vnode.attrs.isBad ? 'red' : 'yellow';
+    const clsName = vnode.attrs.isGood ? '.icon-ok-circled.green' : vnode.attrs.isBad ? '.icon-cancel-circle.red' : '.icon-minus-circled.gray';
     const clsText = vnode.attrs?.judgements.length
       ? (vnode.attrs.isGood
         ? (vnode.attrs.isKnownGood ? 'Known good' : 'Reasonable')
@@ -13,17 +15,33 @@ const Identity: m.Component<IAccountInfo, {}> = {
       : 'No judgments';
     return m('div.identity',
       m('span', [
-        m('p', vnode.attrs.name),
+        m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }),
+        m('hr'),
         m('p', vnode.attrs.legal),
         vnode.attrs.email
-          && m('p', `email: ${vnode.attrs.email}`),
+          && m('p', [
+            m(Icon, { name: Icons.AT_SIGN, size: 'sm' }),
+            m('label', `  ${vnode.attrs.email}`)
+          ]),
         vnode.attrs.web
-          && m('p', `website: ${vnode.attrs.web}`),
+          && m('p', [
+            m(Icon, { name: Icons.GLOBE, size: 'sm' }),
+            m('label', `  ${vnode.attrs.web}`)
+          ]),
         vnode.attrs.twitter
-          && m('p', `twitter: ${vnode.attrs.twitter}`),
+          && m('p', [
+            m(Icon, { name: Icons.TWITTER, size: 'sm' }),
+            m('label', `  ${vnode.attrs.twitter}`)
+          ]),
         vnode.attrs.riot
-          && m('p', `riot: ${vnode.attrs.riot}`),
-        m(`p.${clsName}`, clsText)
+          && m('p', [
+            m(Icon, { name: Icons.FIGMA, size: 'sm' }),
+            m('label', `  ${vnode.attrs.riot}`)
+          ]),
+        m('p.User', [
+          m(`span.identity-icon${clsName}`, ''),
+          m('label', `  ${clsText}`)
+        ])
       ]));
   }
 };

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -75,13 +75,17 @@ const PresentationComponent = (state, chain: Substrate) => {
           m('th.val-stash', 'Stash'),
           m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.total') }, 'Total Stake'),
           m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.own') }, 'Own Stake'),
-          m('th.val-total', 'Other Stake'),
+          m('th.val-total.pointer', { onclick: () => model.changeSort('otherTotal') }, 'Other Stake'),
           m('th.val-commission', 'Commission'),
           m('th.val-points.pointer', { onclick: () => model.changeSort('eraPoints') }, 'Points'),
           m('th.val-last-hash', 'last #'),
           m('th.val-action', ''),
         ]),
         currentValidators.map((validator) => {
+          // total stake
+          const total = chain.chain.coins(validators[validator].exposure.total);
+          // own stake
+          const bonded = chain.chain.coins(validators[validator].exposure.own);
           const nominators = validators[validator].exposure.others.map(({ who, value }) => ({
             stash: who.toString(),
             balance: chain.chain.coins(value),
@@ -91,15 +95,12 @@ const PresentationComponent = (state, chain: Substrate) => {
           const blockCount = validators[validator].blockCount;
           const hasMessage = validators[validator]?.hasMessage;
           const isOnline = validators[validator]?.isOnline;
-          // const hasNominated: boolean = app.user.activeAccount && nominators
-          //   && !!nominators.find(({ stash }) => stash === app.user.activeAccount.address);
-          // // add validator to collection if hasNominated already
-          // if (hasNominated) {
-          //   state.nominations.push(validator);
-          //   state.originalNominations.push(validator);
-          // }
+          const otherTotal = validators[validator]?.otherTotal;
           return m(ValidatorRow, {
             stash: validator,
+            total,
+            bonded,
+            otherTotal,
             controller,
             nominators,
             eraPoints,

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -4,12 +4,11 @@ import Substrate from 'controllers/chain/substrate/main';
 import { ChainBase } from 'models';
 import { formatNumber } from '@polkadot/util';
 import { Icon, Icons } from 'construct-ui';
+import PageLoading from 'views/pages/loading';
 import Tabs from '../../../components/widgets/tabs';
 import ValidatorRow from './validator_row';
 import ValidatorRowWaiting from './validator_row_waiting';
 import RecentBlock from './recent_block';
-import PageLoading from "views/pages/loading";
-
 
 const model = {
   perPage: 20,
@@ -26,21 +25,23 @@ const model = {
       model.currentTab = 'waiting';
     if (index > 1)
       model.show = false;
+    m.redraw();
   },
   previous() {
     if (model.currentPage > 1)
       model.currentPage--;
+    m.redraw();
   },
   next() {
     if (model.currentPage < Math.ceil(model.total[model.currentTab] / model.perPage))
       model.currentPage++;
+    m.redraw();
   }
 };
 
 const PresentationComponent = (state, chain: Substrate) => {
   const validators = state.dynamic.validators;
-  if (!validators) return m(PageLoading, {message:"Loading Validators..."});
-  
+  if (!validators) return m(PageLoading, { message:'Loading Validators...' });
 
   const lastHeaders = (app.chain.base === ChainBase.Substrate)
     ? (app.chain as Substrate).staking.lastHeaders

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -67,7 +67,7 @@ const PresentationComponent = (state, chain: Substrate) => {
     .slice(model.perPage * (model.currentPage - 1), model.perPage * model.currentPage);
 
   const waitingValidators = Object.keys(validators).filter((validator) => (validators[validator].isElected === false))
-    .sort((val1, val2) => validators[val2].eraPoints - validators[val1].eraPoints)
+    .sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
     .slice(model.perPage * (model.currentPage - 1), model.perPage * model.currentPage);
 
   return m('div',

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -17,10 +17,13 @@ const model = {
   currentTab: 'current',
   show: true,
   total: { waiting: 0, current: 0 },
-  sortKey: 'exposure.total',
+  sortKey: 'exposure',
+  sortAsc: true,
   sortIcon(key: string) {
     return model.sortKey === key
-      ? Icons.ARROW_UP
+      ? model.sortAsc
+        ? Icons.ARROW_UP
+        : Icons.ARROW_DOWN
       : Icons.MINUS;
   },
   reset(index) {
@@ -42,6 +45,8 @@ const model = {
       model.currentPage++;
   },
   changeSort(key: string) {
+    if (key === model.sortKey)
+      model.sortAsc = !model.sortAsc;
     model.sortKey = key;
   }
 };
@@ -63,7 +68,11 @@ const PresentationComponent = (state, chain: Substrate) => {
   ).length;
 
   const currentValidators = Object.keys(validators).filter((validator) => (validators[validator].isElected === true))
-    .sort((val1, val2) => get(validators[val2], model.sortKey, 0) - get(validators[val1], model.sortKey, 0))
+    .sort((val1, val2) => {
+      if (model.sortAsc)
+        return get(validators[val2], model.sortKey, 0) - get(validators[val1], model.sortKey, 0);
+      return get(validators[val1], model.sortKey, 0) - get(validators[val2], model.sortKey, 0);
+    })
     .slice(model.perPage * (model.currentPage - 1), model.perPage * model.currentPage);
 
   const waitingValidators = Object.keys(validators).filter((validator) => (validators[validator].isElected === false))
@@ -76,7 +85,6 @@ const PresentationComponent = (state, chain: Substrate) => {
       name: 'Current Validators',
       content: m('table.validators-table', [
         m('tr.validators-heading', [
-          m('th.val-controller', 'Controller'),
           m('th.val-stash', 'Stash'),
           m('th.val-total', 'Total Stake',
             m(Icon, { name: model.sortIcon('exposure.total'),

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -25,17 +25,14 @@ const model = {
       model.currentTab = 'waiting';
     if (index > 1)
       model.show = false;
-    m.redraw();
   },
   previous() {
     if (model.currentPage > 1)
       model.currentPage--;
-    m.redraw();
   },
   next() {
     if (model.currentPage < Math.ceil(model.total[model.currentTab] / model.perPage))
       model.currentPage++;
-    m.redraw();
   }
 };
 

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -1,5 +1,6 @@
 import m from 'mithril';
 import app from 'state';
+import { get } from 'lodash';
 import Substrate from 'controllers/chain/substrate/main';
 import { ChainBase } from 'models';
 import { formatNumber } from '@polkadot/util';
@@ -16,6 +17,7 @@ const model = {
   currentTab: 'current',
   show: true,
   total: { waiting: 0, current: 0 },
+  sortKey: 'eraPoints',
   reset(index) {
     model.currentPage = 1;
     model.show = true;
@@ -33,6 +35,9 @@ const model = {
   next() {
     if (model.currentPage < Math.ceil(model.total[model.currentTab] / model.perPage))
       model.currentPage++;
+  },
+  changeSort(key: string) {
+    model.sortKey = key;
   }
 };
 
@@ -53,11 +58,11 @@ const PresentationComponent = (state, chain: Substrate) => {
   ).length;
 
   const currentValidators = Object.keys(validators).filter((validator) => (validators[validator].isElected === true))
-    .sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
+    .sort((val1, val2) => get(validators[val2], model.sortKey, 0) - get(validators[val1], model.sortKey, 0))
     .slice(model.perPage * (model.currentPage - 1), model.perPage * model.currentPage);
 
   const waitingValidators = Object.keys(validators).filter((validator) => (validators[validator].isElected === false))
-    .sort((val1, val2) => validators[val2].exposure - validators[val1].exposure)
+    .sort((val1, val2) => validators[val2].eraPoints - validators[val1].eraPoints)
     .slice(model.perPage * (model.currentPage - 1), model.perPage * model.currentPage);
 
   return m('div',
@@ -68,11 +73,11 @@ const PresentationComponent = (state, chain: Substrate) => {
         m('tr.validators-heading', [
           m('th.val-controller', 'Controller'),
           m('th.val-stash', 'Stash'),
-          m('th.val-total', 'Total Stake'),
-          m('th.val-total', 'Own Stake'),
+          m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.total') }, 'Total Stake'),
+          m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.own') }, 'Own Stake'),
           m('th.val-total', 'Other Stake'),
           m('th.val-commission', 'Commission'),
-          m('th.val-points', 'Points'),
+          m('th.val-points.pointer', { onclick: () => model.changeSort('eraPoints') }, 'Points'),
           m('th.val-last-hash', 'last #'),
           m('th.val-action', ''),
         ]),

--- a/client/scripts/views/pages/validators/substrate/presentation_component.ts
+++ b/client/scripts/views/pages/validators/substrate/presentation_component.ts
@@ -17,7 +17,12 @@ const model = {
   currentTab: 'current',
   show: true,
   total: { waiting: 0, current: 0 },
-  sortKey: 'eraPoints',
+  sortKey: 'exposure.total',
+  sortIcon(key: string) {
+    return model.sortKey === key
+      ? Icons.ARROW_UP
+      : Icons.MINUS;
+  },
   reset(index) {
     model.currentPage = 1;
     model.show = true;
@@ -73,11 +78,26 @@ const PresentationComponent = (state, chain: Substrate) => {
         m('tr.validators-heading', [
           m('th.val-controller', 'Controller'),
           m('th.val-stash', 'Stash'),
-          m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.total') }, 'Total Stake'),
-          m('th.val-total.pointer', { onclick: () => model.changeSort('exposure.own') }, 'Own Stake'),
-          m('th.val-total.pointer', { onclick: () => model.changeSort('otherTotal') }, 'Other Stake'),
-          m('th.val-commission', 'Commission'),
-          m('th.val-points.pointer', { onclick: () => model.changeSort('eraPoints') }, 'Points'),
+          m('th.val-total', 'Total Stake',
+            m(Icon, { name: model.sortIcon('exposure.total'),
+              size: 'lg',
+              onclick: () => model.changeSort('exposure.total') })),
+          m('th.val-total', 'Own Stake',
+            m(Icon, { name: model.sortIcon('exposure.own'),
+              size: 'lg',
+              onclick: () => model.changeSort('exposure.own') })),
+          m('th.val-total', 'Other Stake',
+            m(Icon, { name: model.sortIcon('otherTotal'),
+              size: 'lg',
+              onclick: () => model.changeSort('otherTotal') })),
+          m('th.val-commission', 'Commission',
+            m(Icon, { name: model.sortIcon('commissionPer'),
+              size: 'lg',
+              onclick: () => model.changeSort('commissionPer') })),
+          m('th.val-points', 'Points',
+            m(Icon, { name: model.sortIcon('eraPoints'),
+              size: 'lg',
+              onclick: () => model.changeSort('eraPoints') })),
           m('th.val-last-hash', 'last #'),
           m('th.val-action', ''),
         ]),
@@ -96,10 +116,12 @@ const PresentationComponent = (state, chain: Substrate) => {
           const hasMessage = validators[validator]?.hasMessage;
           const isOnline = validators[validator]?.isOnline;
           const otherTotal = validators[validator]?.otherTotal;
+          const commission = validators[validator]?.commissionPer;
           return m(ValidatorRow, {
             stash: validator,
             total,
             bonded,
+            commission,
             otherTotal,
             controller,
             nominators,
@@ -161,10 +183,10 @@ const PresentationComponent = (state, chain: Substrate) => {
     }]),
     model.show
     && m('span', [
-      m(Icon, { name: Icons.ARROW_LEFT_CIRCLE, size: 'lg', onclick: model.previous }),
+      m(Icon, { name: Icons.SKIP_BACK, size: 'lg', onclick: model.previous }),
       m('label', { style: { marginLeft: '20px' } },
         `${model.currentPage}/${Math.ceil(model.total[model.currentTab] / model.perPage)}`),
-      m(Icon, { name: Icons.ARROW_RIGHT_CIRCLE, size: 'lg', onclick: model.next }),
+      m(Icon, { name: Icons.SKIP_FORWARD, size: 'lg', onclick: model.next }),
     ]));
 };
 

--- a/client/scripts/views/pages/validators/substrate/recent_block.ts
+++ b/client/scripts/views/pages/validators/substrate/recent_block.ts
@@ -1,8 +1,10 @@
 import m from 'mithril';
 import app from 'state';
+import { Tooltip } from 'construct-ui';
 import User from 'views/components/widgets/user';
 import { makeDynamicComponent } from 'models/mithril';
 import { AccountId } from '@polkadot/types/interfaces';
+import Identity from './identity';
 
 interface IRecentBlockState {
   dynamic: { }
@@ -24,10 +26,9 @@ const RecentBlock = makeDynamicComponent<IRecentBlockAttrs, IRecentBlockState>({
     return m('tr.ValidatorRow', [
       m('td.val-number', number),
       m('td.val-hash.cut-text', hash),
-      m('td.val-author', m(User, {
-        user: app.chain.accounts.get(author.toString()),
-        linkify: true
-      })),
+      m('td.val-author', m(Tooltip, { content: m(Identity, { stash: author.toString() }),
+        trigger:  m('div', m(User, { user: app.chain.accounts.get(author.toString()), linkify: true }))
+      }))
     ]);
   }
 });

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -86,7 +86,7 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
     return m('tr.ValidatorRow', [
       m('td.val-controller', m(User, { user: app.chain.accounts.get(vnode.attrs.controller), linkify: true })),
       m('td.val-stash', m(Tooltip, { content: m(Identity, { ...info }),
-        trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true })) 
+        trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }))
       })),
       m('td.val-total', [
         formatCoin(app.chain.chain.coins(stakingInfo?.stakeTotal), true), ' ',

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -86,7 +86,11 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
         trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }))
       })),
       m('td.val-total', [
-        formatCoin(app.chain.chain.coins(stakingInfo?.stakeTotal), true), ' ',
+        formatCoin(app.chain.chain.coins(stakingInfo?.stakeTotal), true), ' '
+      ]),
+      m('td.val-own', formatCoin(app.chain.chain.coins(stakingInfo?.stakeOwn), true)),
+      m('td.val-other', [
+        formatCoin(app.chain.chain.coins(stakingInfo?.stakeOther), true),
         nominatorsList.length > 0 && [ '(',
           m('a.val-nominators', {
             href: '#',
@@ -100,8 +104,6 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
           }, nominatorsList.length),
           ')'],
       ]),
-      m('td.val-own', formatCoin(app.chain.chain.coins(stakingInfo?.stakeOwn), true)),
-      m('td.val-other', formatCoin(app.chain.chain.coins(stakingInfo?.stakeOther), true)),
       m('td.val-commission', stakingInfo?.commission || ' '),
       m('td.val-points', vnode.attrs.eraPoints || ' '),
       m('td.val-last-hash', byAuthor[vnode.attrs.stash] || ' '),

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -73,7 +73,6 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
     const nominatorsList = vnode.attrs.nominators;
 
     return m('tr.ValidatorRow', [
-      m('td.val-controller', m(User, { user: app.chain.accounts.get(vnode.attrs.controller), linkify: true })),
       m('td.val-stash', m(Tooltip, { content: m(Identity, { stash: vnode.attrs.stash }),
         trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }))
       })),

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -86,11 +86,11 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
         trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }))
       })),
       m('td.val-total', [
-        formatCoin(app.chain.chain.coins(stakingInfo?.stakeTotal), true), ' '
+        formatCoin(app.chain.chain.coins(vnode.attrs.total), true), ' '
       ]),
-      m('td.val-own', formatCoin(app.chain.chain.coins(stakingInfo?.stakeOwn), true)),
+      m('td.val-own', formatCoin(app.chain.chain.coins(vnode.attrs.bonded), true)),
       m('td.val-other', [
-        formatCoin(app.chain.chain.coins(stakingInfo?.stakeOther), true),
+        formatCoin(app.chain.chain.coins(vnode.attrs.otherTotal), true),
         nominatorsList.length > 0 && [ '(',
           m('a.val-nominators', {
             href: '#',

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -64,19 +64,11 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
   getObservables: (attrs) => ({
     // we need a group key to satisfy the dynamic object constraints, so here we use the chain class
     groupKey: app.chain.class.toString(),
-    // info: (app.chain.base === ChainBase.Substrate) ? (app.chain as Substrate).staking.info(attrs.stash) : null,
-    query: (app.chain.base === ChainBase.Substrate)
-      ? (app.chain as Substrate).staking.query(attrs.stash)
-      : null
   }),
   view: (vnode) => {
-    const { query } = vnode.state.dynamic;
     const byAuthor = (app.chain.base === ChainBase.Substrate)
       ? (app.chain as Substrate).staking.byAuthor
       : {};
-    const stakingInfo = query
-      ? expandInfo(query)
-      : null;
 
     const nominatorsList = vnode.attrs.nominators;
 
@@ -104,8 +96,8 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
           }, nominatorsList.length),
           ')'],
       ]),
-      m('td.val-commission', stakingInfo?.commission || ' '),
-      m('td.val-points', vnode.attrs.eraPoints || ' '),
+      m('td.val-commission', `${vnode.attrs.commission?.toFixed(2)}%` || ' '),
+      m('td.val-points', vnode.attrs.eraPoints || '0'),
       m('td.val-last-hash', byAuthor[vnode.attrs.stash] || ' '),
       m(ImOnline, {
         toBeElected: vnode.attrs.toBeElected,

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -8,7 +8,6 @@ import User from 'views/components/widgets/user';
 import { Balance } from '@polkadot/types/interfaces';
 import Substrate from 'controllers/chain/substrate/main';
 import { makeDynamicComponent } from 'models/mithril';
-import { IAccountInfo } from 'controllers/chain/substrate/staking';
 import { DeriveStakingQuery } from '@polkadot/api-derive/types';
 import { IValidatorAttrs, ViewNominatorsModal } from '..';
 import ImOnline from './im_online';
@@ -18,7 +17,6 @@ const PERBILL_PERCENT = 10_000_000;
 
 export interface IValidatorState {
   dynamic: {
-    info: IAccountInfo;
     query: DeriveStakingQuery;
     byAuthor: Record<string, string>;
   },
@@ -69,23 +67,22 @@ const ValidatorRow = makeDynamicComponent<IValidatorAttrs, IValidatorState>({
     // info: (app.chain.base === ChainBase.Substrate) ? (app.chain as Substrate).staking.info(attrs.stash) : null,
     query: (app.chain.base === ChainBase.Substrate)
       ? (app.chain as Substrate).staking.query(attrs.stash)
-      : null,
-    info: (app.chain.base === ChainBase.Substrate)
-      ? (app.chain as Substrate).staking.info(attrs.stash)
       : null
   }),
   view: (vnode) => {
-    const { query, info } = vnode.state.dynamic;
+    const { query } = vnode.state.dynamic;
     const byAuthor = (app.chain.base === ChainBase.Substrate)
       ? (app.chain as Substrate).staking.byAuthor
       : {};
     const stakingInfo = query
       ? expandInfo(query)
       : null;
+
     const nominatorsList = vnode.attrs.nominators;
+
     return m('tr.ValidatorRow', [
       m('td.val-controller', m(User, { user: app.chain.accounts.get(vnode.attrs.controller), linkify: true })),
-      m('td.val-stash', m(Tooltip, { content: m(Identity, { ...info }),
+      m('td.val-stash', m(Tooltip, { content: m(Identity, { stash: vnode.attrs.stash }),
         trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true }))
       })),
       m('td.val-total', [

--- a/client/scripts/views/pages/validators/substrate/validator_row_waiting.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row_waiting.ts
@@ -20,13 +20,10 @@ const ValidatorRowWaiting = makeDynamicComponent<IValidatorAttrs, IValidatorStat
     groupKey: app.chain.class.toString(),
     query: (app.chain.base === ChainBase.Substrate)
       ? (app.chain as Substrate).staking.query(attrs.stash)
-      : null,
-    info: (app.chain.base === ChainBase.Substrate)
-      ? (app.chain as Substrate).staking.info(attrs.stash)
       : null
   }),
   view: (vnode) => {
-    const { query, info } = vnode.state.dynamic;
+    const { query } = vnode.state.dynamic;
 
     const nominations = (app.chain.base === ChainBase.Substrate)
       ? (app.chain as Substrate).staking.nominations
@@ -37,7 +34,7 @@ const ValidatorRowWaiting = makeDynamicComponent<IValidatorAttrs, IValidatorStat
     const nominatorsList = nominations[vnode.attrs.stash] || [];
 
     return m('tr.ValidatorRow', [
-      m('td.val-stash', m(Tooltip, { content: m(Identity, { ...info }),
+      m('td.val-stash', m(Tooltip, { content: m(Identity, { stash : vnode.attrs.stash }),
         trigger: m('div', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true })) 
       })),
       m('td.val-nominations', [

--- a/client/styles/pages/validators.scss
+++ b/client/styles/pages/validators.scss
@@ -8,10 +8,6 @@
     letter-spacing: 0.2px;
 }
 
-.pointer {
-    cursor: pointer;
-}
-
 .NewStashForm {
     margin: 16px 0 10px;
     .form-group {

--- a/client/styles/pages/validators.scss
+++ b/client/styles/pages/validators.scss
@@ -8,6 +8,10 @@
     letter-spacing: 0.2px;
 }
 
+.pointer {
+    cursor: pointer;
+}
+
 .NewStashForm {
     margin: 16px 0 10px;
     .form-group {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are now displaying identity data, but aren't using some UI primitives that exist for verifying identities and judgements (such as showing the green checkmark, grey minus, etc.).
Sort validators by stake

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no