### PR TITLE
Sign-in/Sign-up distinct emails and factor out template ids to shared/types

### DIFF
--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { SERVER_URL, SENDGRID_API_KEY } from '../config';
 import { factory, formatFilename } from '../../shared/logging';
+import { DynamicTemplate } from '../../shared/types';
 const log = factory.getLogger(formatFilename(__filename));
 const sgMail = require('@sendgrid/mail');
 sgMail.setApiKey(SENDGRID_API_KEY);
@@ -113,7 +114,7 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   const msg = {
     to: invitedEmail,
     from: 'Commonwealth <no-reply@commonwealth.im>',
-    templateId: 'd-000c08160c07459798b46c927b638b9a',
+    templateId: DynamicTemplate.EmailInvite,
     dynamic_template_data: {
       community_name: invite.community_id,
       inviter: address.name,

--- a/server/routes/updateEmail.ts
+++ b/server/routes/updateEmail.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import moment from 'moment';
 import { LOGIN_RATE_LIMIT_MINS, SERVER_URL, SENDGRID_API_KEY } from '../config';
 import { factory, formatFilename } from '../../shared/logging';
+import { DynamicTemplate } from '../../shared/types';
 const sgMail = require('@sendgrid/mail');
 sgMail.setApiKey(SENDGRID_API_KEY);
 
@@ -66,7 +67,7 @@ const updateEmail = async (models, req: Request, res: Response, next: NextFuncti
     to: email,
     from: 'Commonwealth <no-reply@commonwealth.im>',
     subject: 'Verify your Commonwealth email',
-    templateId: 'd-a0c28546fecc49fb80a3ba9e535bff48',
+    templateId: DynamicTemplate.UpdateEmail,
     dynamic_template_data: {
       loginLink,
     },

--- a/server/routes/verifyAddress.ts
+++ b/server/routes/verifyAddress.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { factory, formatFilename } from '../../shared/logging';
+import { DynamicTemplate } from '../../shared/types';
 const sgMail = require('@sendgrid/mail');
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -71,7 +72,7 @@ const verifyAddress = async (models, req: Request, res: Response, next: NextFunc
         const msg = {
           to: user.email,
           from: 'Commonwealth <no-reply@commonwealth.im>',
-          templateId: 'd-292c161f1aec4d0e98a0bf8d6d8e42c2',
+          templateId: DynamicTemplate.VerifyAddress,
           dynamic_template_data: {
             address: req.body.address,
             chain: req.body.chain,

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -88,7 +88,7 @@ export const createRegularNotificationEmailObject = async (user, notifications) 
   const msg = {
     to: 'zak@commonwealth.im', // TODO user.email
     from: 'Commonwealth <no-reply@commonwealth.im>',
-    templateId: 'd-468624f3c2d7434c86ae0ed0e1d2227e',
+    templateId: DynamicTemplate.BatchNotifications,
     dynamic_template_data: {
       notifications: emailObjArray,
       subject,

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -5,7 +5,7 @@ import { getProposalUrl } from '../../shared/utils';
 const { Op } = Sequelize;
 const log = factory.getLogger(formatFilename(__filename));
 
-import { IPostNotificationData, NotificationCategories } from '../../shared/types';
+import { IPostNotificationData, NotificationCategories, DynamicTemplate } from '../../shared/types';
 const sgMail = require('@sendgrid/mail');
 sgMail.setApiKey(SENDGRID_API_KEY);
 
@@ -45,7 +45,7 @@ export const createNotificationEmailObject = (notification_data: IPostNotificati
     to: 'zak@commonwealth.im',
     from: 'Commonwealth <no-reply@commonwealth.im>',
     subject: subjectLine,
-    templateId: 'd-3f30558a95664528a2427b40292fec51',
+    templateId: DynamicTemplate.ImmediateEmailNotification, // 'd-3f30558a95664528a2427b40292fec51',
     dynamic_template_data: {
       notification: {
         subject: subjectLine,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -87,6 +87,10 @@ export const PROFILE_NAME_MIN_CHARS = 3;
 
 export const DynamicTemplate = {
   ImmediateEmailNotification: 'd-3f30558a95664528a2427b40292fec51',
+  BatchNotifications: 'd-468624f3c2d7434c86ae0ed0e1d2227e',
   SignIn: 'd-db52815b5f8647549d1fe6aa703d7274',
   SignUp: 'd-2b00abbf123e4b5981784d17151e86be',
+  EmailInvite: 'd-000c08160c07459798b46c927b638b9a',
+  UpdateEmail: 'd-a0c28546fecc49fb80a3ba9e535bff48',
+  VerifyAddress: 'd-292c161f1aec4d0e98a0bf8d6d8e42c2',
 };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -84,3 +84,9 @@ export const PROFILE_NAME_MAX_CHARS = 40;
 export const PROFILE_HEADLINE_MAX_CHARS = 80;
 export const PROFILE_BIO_MAX_CHARS = 1000;
 export const PROFILE_NAME_MIN_CHARS = 3;
+
+export const DynamicTemplate = {
+  ImmediateEmailNotification: 'd-3f30558a95664528a2427b40292fec51',
+  SignIn: 'd-db52815b5f8647549d1fe6aa703d7274',
+  SignUp: 'd-2b00abbf123e4b5981784d17151e86be',
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR began as a check to see if we were sending two different emails for signing in vs signing up (we are now!). I also factored out the TemplateIds into an object in types so that it's easier to debug/change templates.

Closes #413 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clarity of emails for the users and clarity for us debugging.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested about half of the emails template imports (signin/signup/batchNotification/updateEmail) and they all worked as expected. Spent a bit of time in sendgrid making sure everything was matching as well. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no