### PR TITLE
Ensure comments refresh

### DIFF
--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -485,6 +485,17 @@ const ViewProposalPage: m.Component<{ identifier: string, type: string }, {
         });
       vnode.state.commentsPrefetchStarted = true;
     }
+
+    if (vnode.state.comments?.length) {
+      const mismatchedComments = vnode.state.comments.filter((c) => {
+        return c.rootProposal !== `${vnode.attrs.type}_${vnode.attrs.identifier.split('-')[0]}`;
+      });
+      if (mismatchedComments.length) {
+        vnode.state.commentsPrefetchStarted = false;
+      }
+    }
+
+
     const createdCommentCallback = () => {
       vnode.state.comments = app.comments.getByProposal(proposal).filter((c) => c.parentComment === null);
       m.redraw();


### PR DESCRIPTION
Closes #392.

The prefetchComments function that was added to proposal pages did not check to see whether the prefetchedComments were for the proper proposal. As a result, the state would persevere during the creation of a new thread in the new thread modal, and the page would not fetch the newly submitted proposal's comments. This branch adds a check of proposal type/identifier against comments' rootProposal properties.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no