### PR TITLE
Quill Mentions: Keybinding Fix

### DIFF
--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -228,6 +228,97 @@ const instantiateEditor = (
   Quill.register('modules/clipboard', CustomClipboard, true);
   Quill.register('formats/twitter', TwitterBlot, true);
   Quill.register('formats/video', VideoBlot, true);
+
+  let typingListener;
+  const queryMentions = async (searchTerm, renderList, mentionChar) => {
+    if (mentionChar !== '@') return;
+    // Optional code for tagging roles:
+    // if (app.activeCommunityId()) roleData = await searchRoles();
+    // const truncRoles = roleData.filter(
+    //   (role) => role.name.includes(searchTerm) || role.address.includes(searchTerm));
+
+    let members = [];
+    let formattedMatches;
+    if (searchTerm.length === 0) {
+      typingListener = setTimeout(() => {
+        const node = document.createElement('div');
+        const tip = document.createElement('span');
+        tip.innerText = 'Type to tag a member';
+        node.appendChild(tip);
+        formattedMatches = [{
+          link: '#',
+          name: '',
+          component: node.outerHTML,
+        }];
+        renderList(formattedMatches, searchTerm);
+      }, 300);
+    } else if (searchTerm.length > 0) {
+      if (typingListener) clearTimeout(typingListener);
+      members = await searchMentionableAddresses(searchTerm);
+      formattedMatches = members.map((addr) => {
+        const profile: Profile = app.profiles.getProfile(addr.chain, addr.address);
+        const node = document.createElement('div');
+
+        let avatar;
+        if (profile.avatarUrl) {
+          avatar = document.createElement('img');
+          (avatar as HTMLImageElement).src = profile.avatarUrl;
+          avatar.className = 'ql-mention-avatar';
+          node.appendChild(avatar);
+        } else {
+          avatar = document.createElement('div');
+          avatar.className = 'ql-mention-avatar';
+          avatar.innerHTML = Profile.getSVGAvatar(addr.address, 16);
+        }
+
+        const nameSpan = document.createElement('span');
+        nameSpan.innerText = addr.name;
+        nameSpan.className = 'ql-mention-name';
+
+        const addrSpan = document.createElement('span');
+        addrSpan.innerText = addr.chain === 'near' ? addr.address : `${addr.address.slice(0, 6)}...`;
+        addrSpan.className = 'ql-mention-addr';
+
+        const textWrap = document.createElement('div');
+        textWrap.className = 'ql-mention-text-wrap';
+
+        node.appendChild(avatar);
+        textWrap.appendChild(nameSpan);
+        textWrap.appendChild(addrSpan);
+        node.appendChild(textWrap);
+
+        return ({
+          link: `/${addr.chain}/account/${addr.address}`,
+          name: addr.name,
+          component: node.outerHTML,
+        });
+      });
+    }
+    renderList(formattedMatches, searchTerm);
+  };
+
+  const selectMention = (item) => {
+    if (item.link === '#' && item.name === '') return;
+    const text = quill.getText();
+    const cursorIdx = quill.selection.savedRange.index;
+    const mentionLength = text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
+    const beforeText = text.slice(0, cursorIdx - mentionLength);
+    const afterText = text.slice(cursorIdx).replace(/\n$/, '');
+    if (isMarkdownMode()) {
+      const fullText = `${beforeText}[@${item.name}](${item.link}) ${afterText.replace(/^ /, '')}`;
+      quill.setText(fullText);
+      quill.setSelection(fullText.length - afterText.length + (afterText.startsWith(' ') ? 1 : 0));
+    } else {
+      const delta = new Delta()
+        .retain(beforeText.length)
+        .delete(mentionLength)
+        .insert(`@${item.name}`, { link: item.link });
+      if (!afterText.startsWith(' ')) delta.insert(' ');
+      quill.updateContents(delta);
+      quill.setSelection(quill.getLength() - afterText.length - (afterText.startsWith(' ') ? 0 : 1), 0);
+    }
+  };
+
   // Setup custom keyboard bindings, override Quill default bindings where necessary
   const bindings = {
     // Don't insert hard tabs
@@ -241,6 +332,12 @@ const instantiateEditor = (
       shortKey: false,
       shiftKey: null,
       handler: (range, context) => {
+        const mentions = quill.getModule('mention');
+        if (mentions.isOpen) {
+          selectMention(mentions.getItemData());
+          mentions.escapeHandler();
+          return false;
+        }
         if (isMarkdownMode()) return true;
         const [line, offset] = quill.getLine(range.index);
         const { textContent } = line.domNode;
@@ -449,96 +546,6 @@ const instantiateEditor = (
   //   }));
   //   return res;
   // };
-
-  let typingListener;
-  const queryMentions = async (searchTerm, renderList, mentionChar) => {
-    if (mentionChar !== '@') return;
-    // Optional code for tagging roles:
-    // if (app.activeCommunityId()) roleData = await searchRoles();
-    // const truncRoles = roleData.filter(
-    //   (role) => role.name.includes(searchTerm) || role.address.includes(searchTerm));
-
-    let members = [];
-    let formattedMatches;
-    if (searchTerm.length === 0) {
-      typingListener = setTimeout(() => {
-        const node = document.createElement('div');
-        const tip = document.createElement('span');
-        tip.innerText = 'Type to tag a member';
-        node.appendChild(tip);
-        formattedMatches = [{
-          link: '#',
-          name: '',
-          component: node.outerHTML,
-        }];
-        renderList(formattedMatches, searchTerm);
-      }, 300);
-    } else if (searchTerm.length > 0) {
-      if (typingListener) clearTimeout(typingListener);
-      members = await searchMentionableAddresses(searchTerm);
-      formattedMatches = members.map((addr) => {
-        const profile: Profile = app.profiles.getProfile(addr.chain, addr.address);
-        const node = document.createElement('div');
-
-        let avatar;
-        if (profile.avatarUrl) {
-          avatar = document.createElement('img');
-          (avatar as HTMLImageElement).src = profile.avatarUrl;
-          avatar.className = 'ql-mention-avatar';
-          node.appendChild(avatar);
-        } else {
-          avatar = document.createElement('div');
-          avatar.className = 'ql-mention-avatar';
-          avatar.innerHTML = Profile.getSVGAvatar(addr.address, 16);
-        }
-
-        const nameSpan = document.createElement('span');
-        nameSpan.innerText = addr.name;
-        nameSpan.className = 'ql-mention-name';
-
-        const addrSpan = document.createElement('span');
-        addrSpan.innerText = addr.chain === 'near' ? addr.address : `${addr.address.slice(0, 6)}...`;
-        addrSpan.className = 'ql-mention-addr';
-
-        const textWrap = document.createElement('div');
-        textWrap.className = 'ql-mention-text-wrap';
-
-        node.appendChild(avatar);
-        textWrap.appendChild(nameSpan);
-        textWrap.appendChild(addrSpan);
-        node.appendChild(textWrap);
-
-        return ({
-          link: `/${addr.chain}/account/${addr.address}`,
-          name: addr.name,
-          component: node.outerHTML,
-        });
-      });
-    }
-    renderList(formattedMatches, searchTerm);
-  };
-
-  const selectMention = (item) => {
-    if (item.link === '#' && item.name === '') return;
-    const text = quill.getText();
-    const cursorIdx = quill.selection.savedRange.index;
-    const mentionLength = text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
-    const beforeText = text.slice(0, cursorIdx - mentionLength);
-    const afterText = text.slice(cursorIdx).replace(/\n$/, '');
-    if (isMarkdownMode()) {
-      const fullText = `${beforeText}[@${item.name}](${item.link}) ${afterText.replace(/^ /, '')}`;
-      quill.setText(fullText);
-      quill.setSelection(fullText.length - afterText.length + (afterText.startsWith(' ') ? 1 : 0));
-    } else {
-      const delta = new Delta()
-        .retain(beforeText.length)
-        .delete(mentionLength)
-        .insert(`@${item.name}`, { link: item.link });
-      if (!afterText.startsWith(' ')) delta.insert(' ');
-      quill.updateContents(delta);
-      quill.setSelection(quill.getLength() - afterText.length - (afterText.startsWith(' ') ? 0 : 1), 0);
-    }
-  };
 
   quill = new Quill($editor[0], {
     debug: 'error',

--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -332,18 +332,28 @@ const instantiateEditor = (
       shortKey: false,
       shiftKey: null,
       handler: (range, context) => {
-        const mentions = quill.getModule('mention');
-        if (mentions.isOpen) {
-          selectMention(mentions.getItemData());
-          mentions.escapeHandler();
-          return false;
-        }
         if (isMarkdownMode()) return true;
         const [line, offset] = quill.getLine(range.index);
         const { textContent } = line.domNode;
         const isEmbed = insertEmbeds(textContent);
         // if embed, stopPropogation; otherwise continue
         return !isEmbed;
+      }
+    },
+    // Check for mentions on return
+    'add-mention': {
+      key: 'Enter',
+      shortKey: false,
+      shiftKey: null,
+      handler: (range, context) => {
+        const mentions = quill.getModule('mention');
+        if (mentions.isOpen) {
+          selectMention(mentions.getItemData());
+          mentions.escapeHandler();
+          return false;
+        } else {
+          return true;
+        }
       }
     },
     // Submit on cmd-Enter/ctrl-Enter

--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -229,6 +229,20 @@ const instantiateEditor = (
   Quill.register('formats/twitter', TwitterBlot, true);
   Quill.register('formats/video', VideoBlot, true);
 
+  const searchMentionableAddresses = async (searchTerm: string) => {
+    const response = await $.get(`${app.serverUrl()}/bulkAddresses`, {
+      chain: app.activeChainId(),
+      community: app.activeCommunityId(),
+      limit: 6,
+      searchTerm,
+      order: ['name', 'ASC']
+    });
+    if (response.status !== 'Success') {
+      throw new Error(`got unsuccessful status: ${response.status}`);
+    }
+    return response.result;
+  };
+
   let typingListener;
   const queryMentions = async (searchTerm, renderList, mentionChar) => {
     if (mentionChar !== '@') return;
@@ -524,20 +538,6 @@ const instantiateEditor = (
       const index = (quill.getSelection() || {}).index || quill.getLength();
       if (index) quill.insertEmbed(index, 'image', response, 'user');
     }
-  };
-
-  const searchMentionableAddresses = async (searchTerm: string) => {
-    const response = await $.get(`${app.serverUrl()}/bulkAddresses`, {
-      chain: app.activeChainId(),
-      community: app.activeCommunityId(),
-      limit: 6,
-      searchTerm,
-      order: ['name', 'ASC']
-    });
-    if (response.status !== 'Success') {
-      throw new Error(`got unsuccessful status: ${response.status}`);
-    }
-    return response.result;
   };
 
   // const searchRoles = async () => {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "quill-image-drop-and-paste": "^1.0.4",
     "quill-image-uploader": "^1.0.2",
     "quill-markdown-shortcuts": "^0.0.10",
-    "quill-mention": "^2.2.4",
+    "quill-mention": "^2.2.7",
     "randomcolor": "^0.5.4",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,7 +5338,7 @@ error-stack-parser@^2.0.4:
   dependencies:
     stackframe "^1.1.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+es-abstract@^1.17.0, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -5354,6 +5354,23 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
     object.assign "^4.1.0"
     string.prototype.trimleft "^2.1.1"
     string.prototype.trimright "^2.1.1"
+
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -8027,10 +8044,10 @@ is-buffer@^2.0.0, is-buffer@^2.0.3, is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -8330,12 +8347,12 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
-is-regex@^1.0.4, is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   dependencies:
-    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 is-regexp@^2.0.0:
   version "2.1.0"
@@ -10720,14 +10737,17 @@ object-hash@^1.1.4:
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-inspect@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
 object-is@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
-  integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
+  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -12332,10 +12352,10 @@ quill-markdown-shortcuts@^0.0.10:
   dependencies:
     quill "^1.3.1"
 
-quill-mention@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/quill-mention/-/quill-mention-2.2.4.tgz#e329e607190cd066311347a6090ac45d7944f14a"
-  integrity sha512-EP64dooo8agmGvLyZEiEU08G7nCSs0FZK28oiRGfQbEyxm+j3NCRPlLofUKgXYXNXw+JJSLo0xOtf5jDkmRw4w==
+quill-mention@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/quill-mention/-/quill-mention-2.2.7.tgz#58b7d4a25894c4fcb43272dc81429fd9d6274abb"
+  integrity sha512-ey1GyRdqvPQSt/xbYEZcmQojjA3yzPqkyL6W8R/O5F0elS0CfuWfMwW8UXP7wMNvw0x/NidKXj4/jo339Evbvw==
   dependencies:
     quill "^1.3.4"
 
@@ -14020,21 +14040,39 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
-  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
+string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
   dependencies:
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+    es-abstract "^1.17.5"
+
+string.prototype.trimleft@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
+  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    string.prototype.trimstart "^1.0.0"
 
 string.prototype.trimright@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
-  integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
+  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
   dependencies:
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+    es-abstract "^1.17.5"
+    string.prototype.trimend "^1.0.0"
+
+string.prototype.trimstart@^1.0.0, string.prototype.trimstart@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
Closes #394.

With the upgrade to Quill 2, the 'Enter' keybinding in the quill-mention ceased working. This adds the functionality in quill_editor.js, via our own custom keybindings, and upgrades quill-mention to 2.2.7.

## How has this been tested?
Markdown and RichText editors both tested for proper keypress behavior.
Various Enter keybindings (e.g. for lists, codeblocks, blockquotes, new lines) tested to ensure they maintain functionality despite the fix.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no