### PR TITLE
'Edit Tag' modal now closes

### DIFF
--- a/client/scripts/views/components/tag_editor.ts
+++ b/client/scripts/views/components/tag_editor.ts
@@ -9,7 +9,7 @@ interface ITagEditorAttrs {
   thread: OffchainThread;
   popoverMenu?: boolean;
   onChangeHandler: Function;
-  openStateHandler?: Function;
+  openStateHandler: Function;
 }
 
 interface ITagEditorState {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -150,6 +150,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
               thread: vnode.attrs.proposal as OffchainThread,
               popoverMenu: true,
               onChangeHandler: (tag: OffchainTag) => { proposal.tag = tag; m.redraw(); },
+              openStateHandler: (v) => { vnode.state.tagEditorIsOpen = v; m.redraw(); },
             })
           ]),
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a bug in which the 'Edit Tag' modal, when trying to close, would fail to do so. This fix solves that problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug broke user flow.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Opening and closing the Edit Tag modal, from both the `discussion row carat menu` and the `view proposal carat menu` seem to work as expected. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no