### PR TITLE
Hook up draft deletion

### DIFF
--- a/client/scripts/controllers/server/drafts.ts
+++ b/client/scripts/controllers/server/drafts.ts
@@ -109,7 +109,7 @@ class DraftsController {
           'jwt': app.user.jwt,
         }
       });
-      if (response.status !== 200) {
+      if (response.status !== 'Success') {
         throw new Error(`${response.status} error: Failed to delete draft`);
       }
       const draft = this._store.getById(id);

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -419,9 +419,10 @@ export const NewThreadForm: m.Component<{
                     try {
                       await app.user.discussionDrafts.delete(draft.id);
                     } catch (err) {
+                      console.log(err);
                       vnode.state.error.draft = err;
                     }
-                    return true;
+                    m.redraw();
                   }
                 }, 'Delete')
               ]),

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -413,9 +413,15 @@ export const NewThreadForm: m.Component<{
               m('.discussion-draft-actions', [
                 m('a', {
                   href: '#',
-                  onclick: (e) => {
+                  onclick: async (e) => {
                     e.preventDefault();
-                    // TODO
+                    e.stopPropagation();
+                    try {
+                      await app.user.discussionDrafts.delete(draft.id);
+                    } catch (err) {
+                      vnode.state.error.draft = err;
+                    }
+                    return true;
                   }
                 }, 'Delete')
               ]),

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -419,7 +419,6 @@ export const NewThreadForm: m.Component<{
                     try {
                       await app.user.discussionDrafts.delete(draft.id);
                     } catch (err) {
-                      console.log(err);
                       vnode.state.error.draft = err;
                     }
                     m.redraw();


### PR DESCRIPTION
This branch add's TODO'd logic to the NewThreadForm's draft sidebar delete button. If there is an error in deleting the thread, it is rendered clientside via the NewThreadForm's error handling component.

## Motivation and Context
Buttons should do what they say they do!

## How has this been tested?
Have tested on chain and offchain communities; have tested that errors correctly propagate by breaking the id logic; have watched many successful deletions, and made sure that 1) the draft sidebar disappears, 2) the draft is successfully deleted serverside, and 3) does not re-render.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no