### PR TITLE
Fix ShowRole bug.

### DIFF
--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -121,7 +121,7 @@ const User: m.Component<{
           profile ? profile.displayName : '--',)
       ]),
       m('.user-address', formatAddressShort(profile.address)),
-      // roleTag,
+      showRole && roleTag,
     ]);
 
     return tooltip

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -33,6 +33,7 @@ const User: m.Component<{
     let account : Account<any>;
     let profile; // profile is used to retrieve the chain and address later
     let role;
+    const adminsAndMods = (app.chain ? app.chain.meta.chain : app.community.meta).adminsAndMods;
 
     if (app.chain?.base === ChainBase.Substrate && !vnode.state.identityWidgetLoading && !vnode.state.IdentityWidget) {
       vnode.state.identityWidgetLoading = true;
@@ -55,18 +56,18 @@ const User: m.Component<{
         account = app.chain.accounts.get(address);
       }
       profile = app.profiles.getProfile(chainId, address);
-      role = app.user.isAdminOrMod({ account: vnode.attrs.user });
+      role = adminsAndMods.find((r) => r.address === address);
     } else {
       account = vnode.attrs.user;
       profile = app.profiles.getProfile(account.chain.id, account.address);
-      role = app.user.isAdminOrMod({ account });
+      role = adminsAndMods.find((r) => r.address === account.address);
     }
-    // const roleTag = role ? m(Tag, {
-    //   class: 'roleTag',
-    //   label: role.permission,
-    //   rounded: true,
-    //   size: 'sm',
-    // }) : null;
+    const roleTag = role ? m(Tag, {
+      class: 'roleTag',
+      label: role.permission,
+      rounded: true,
+      size: 'sm',
+    }) : null;
 
     const userFinal = avatarOnly
       ? m('.User.avatar-only', {
@@ -97,7 +98,7 @@ const User: m.Component<{
               profile ? profile.displayName : '--',)
               : m('a.user-display-name.username', profile ? profile.displayName : '--')
           ],
-        // showRole && roleTag,
+        showRole && roleTag,
       ]);
 
     const tooltipPopover = m('.UserTooltip', {

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -56,11 +56,11 @@ const User: m.Component<{
         account = app.chain.accounts.get(address);
       }
       profile = app.profiles.getProfile(chainId, address);
-      role = adminsAndMods.find((r) => r.address === address && r.chain_id === chainId);
+      role = adminsAndMods.find((r) => r.address === address && r.address_chain === chainId);
     } else {
       account = vnode.attrs.user;
       profile = app.profiles.getProfile(account.chain.id, account.address);
-      role = adminsAndMods.find((r) => r.address === account.address && r.chain_id === account.chain.id);
+      role = adminsAndMods.find((r) => r.address === account.address && r.address_chain == account.chain.id);
     }
     const roleTag = role ? m(Tag, {
       class: 'roleTag',

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -56,11 +56,11 @@ const User: m.Component<{
         account = app.chain.accounts.get(address);
       }
       profile = app.profiles.getProfile(chainId, address);
-      role = adminsAndMods.find((r) => r.address === address);
+      role = adminsAndMods.find((r) => r.address === address && r.chain_id === chainId);
     } else {
       account = vnode.attrs.user;
       profile = app.profiles.getProfile(account.chain.id, account.address);
-      role = adminsAndMods.find((r) => r.address === account.address);
+      role = adminsAndMods.find((r) => r.address === account.address && r.chain_id === account.chain.id);
     }
     const roleTag = role ? m(Tag, {
       class: 'roleTag',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, in the `User` component, the Roles Controller was checking the active roles, but it turns out that the controller only has the active user's roles.
However, Admins/Mods by chain/community are here: `app.(chain.meta.chain/community.meta).adminsAndMods`. 
So that's all fixed!

I also added the ShowRole check to the Tooltip, so it only shows there conditionally as well. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ShowRole broke at some point and needed to be fixed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Load both private and chain community and see the role tag as expected!

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no