### PR TITLE
Proposal Reactions

### DIFF
--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -42,6 +42,7 @@ class ReactionsController {
       reaction,
       jwt: app.user.jwt,
     };
+    console.log(options);
     console.log({ 'post instanceof Proposal': (post instanceof Proposal) });
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
     else if (post instanceof Proposal) options['proposal_id'] = (post as AnyProposal).identifier;

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -44,7 +44,7 @@ class ReactionsController {
     console.log(options);
     console.log({ 'post instanceof Proposal': (post instanceof Proposal) });
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
-    else if (post instanceof Proposal) options['proposal_id'] = ((post as unknown) as ChainEntity).type + ((post as unknown) as ChainEntity).id;
+    else if (post instanceof Proposal) options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
     else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -43,7 +43,7 @@ class ReactionsController {
 
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
     else if (post instanceof Proposal) {
-      options['proposal_id'] = `${(post as AnyProposal).slug}-${(post as AnyProposal).identifier}`;
+      options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
     } else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {
@@ -64,7 +64,7 @@ class ReactionsController {
     // TODO: ensure identifier vs id use is correct; see also create method
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
     else if (post instanceof Proposal) {
-      options['proposal_id'] = `${(post as AnyProposal).slug}-${(post as AnyProposal).identifier}`;
+      options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
     } else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -32,7 +32,6 @@ class ReactionsController {
   }
 
   public async create(address: string, post: any, reaction: string, chainId: string, communityId: string) {
-    debugger
     const options = {
       author_chain: app.user.activeAccount.chain.id,
       chain: chainId,
@@ -44,8 +43,9 @@ class ReactionsController {
     console.log(options);
     console.log({ 'post instanceof Proposal': (post instanceof Proposal) });
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
-    else if (post instanceof Proposal) options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
-    else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
+    else if (post instanceof Proposal) {
+      options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
+    } else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {
       // TODO: Change to POST /reaction

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -40,11 +40,10 @@ class ReactionsController {
       reaction,
       jwt: app.user.jwt,
     };
-    console.log(options);
-    console.log({ 'post instanceof Proposal': (post instanceof Proposal) });
+
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
     else if (post instanceof Proposal) {
-      options['proposal_id'] = `${(post as AnyProposal).slug}_${(post as AnyProposal).identifier}`;
+      options['proposal_id'] = `${(post as AnyProposal).slug}-${(post as AnyProposal).identifier}`;
     } else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {
@@ -64,8 +63,9 @@ class ReactionsController {
     const options = { chain: chainId, community: communityId };
     // TODO: ensure identifier vs id use is correct; see also create method
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
-    else if (post instanceof Proposal) options['proposal_id'] = (post as AnyProposal).identifier;
-    else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
+    else if (post instanceof Proposal) {
+      options['proposal_id'] = `${(post as AnyProposal).slug}-${(post as AnyProposal).identifier}`;
+    } else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {
       // TODO: Remove any verbs from these route names '/reactions'

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -2,13 +2,11 @@
 /* eslint-disable no-restricted-syntax */
 import $ from 'jquery';
 import _ from 'lodash';
-import moment from 'moment-twitter';
 
 import app from 'state';
-import { uniqueIdToProposal } from 'identifiers';
 
 import { ReactionStore } from 'stores';
-import { OffchainReaction, IUniqueId, AnyProposal, OffchainComment, OffchainThread, Proposal } from 'models';
+import { OffchainReaction, AnyProposal, OffchainComment, OffchainThread, Proposal, ChainEntity } from 'models';
 import { notifyError } from 'controllers/app/notifications';
 
 const modelFromServer = (reaction) => {
@@ -34,6 +32,7 @@ class ReactionsController {
   }
 
   public async create(address: string, post: any, reaction: string, chainId: string, communityId: string) {
+    debugger
     const options = {
       author_chain: app.user.activeAccount.chain.id,
       chain: chainId,
@@ -45,7 +44,7 @@ class ReactionsController {
     console.log(options);
     console.log({ 'post instanceof Proposal': (post instanceof Proposal) });
     if (post instanceof OffchainThread) options['thread_id'] = (post as OffchainThread).id;
-    else if (post instanceof Proposal) options['proposal_id'] = (post as AnyProposal).identifier;
+    else if (post instanceof Proposal) options['proposal_id'] = ((post as unknown) as ChainEntity).type + ((post as unknown) as ChainEntity).id;
     else if (post instanceof OffchainComment) options['comment_id'] = (post as OffchainComment<any>).id;
 
     try {

--- a/client/scripts/models/OffchainReaction.ts
+++ b/client/scripts/models/OffchainReaction.ts
@@ -8,16 +8,18 @@ class OffchainReaction<T extends IUniqueId> {
   public readonly reaction: string;
   public readonly threadId: number | string;
   public readonly commentId: number | string;
+  public readonly proposalId: string;
   public readonly author_chain: string;
 
-  constructor(id, author, chain, community, reaction, threadId, communityId, author_chain) {
+  constructor(id, author, chain, community, reaction, threadId, proposalId, commentId, author_chain) {
     this.id = id;
     this.author = author;
     this.chain = chain;
     this.community = community;
     this.reaction = reaction;
     this.threadId = threadId;
-    this.commentId = communityId;
+    this.commentId = commentId;
+    this.proposalId = proposalId;
     this.author_chain = author_chain;
   }
 }

--- a/client/scripts/models/OffchainReaction.ts
+++ b/client/scripts/models/OffchainReaction.ts
@@ -8,8 +8,9 @@ class OffchainReaction<T extends IUniqueId> {
   public readonly reaction: string;
   public readonly threadId: number | string;
   public readonly commentId: number | string;
-  public readonly proposalId: string;
+  public readonly proposalId: number | string;
   public readonly author_chain: string;
+  // TODO: Do thread/comment/proposal ids ever appear as strings?
 
   constructor(id, author, chain, community, reaction, threadId, proposalId, commentId, author_chain) {
     this.id = id;

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -60,7 +60,6 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
   }
 
   public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | AnyProposal | OffchainComment<any>) {
-    debugger
     if (rxnOrPost instanceof OffchainReaction) {
       const { threadId, commentId, proposalId } = rxnOrPost;
       return threadId
@@ -71,7 +70,6 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
     } else if (rxnOrPost instanceof OffchainThread) {
       return `discussion-${rxnOrPost.id}`;
     } else if (rxnOrPost instanceof Proposal) {
-      debugger
       return `${(rxnOrPost as AnyProposal).slug}_${(rxnOrPost as AnyProposal).identifier}`;
     } else if (rxnOrPost instanceof OffchainComment) {
       return `comment-${rxnOrPost.id}`;

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -54,18 +54,18 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
     return this;
   }
 
-  public getByPost(post: OffchainThread | OffchainComment<any>): Array<OffchainReaction<any>> {
+  public getByPost(post: OffchainThread | AnyProposal | OffchainComment<any>): Array<OffchainReaction<any>> {
     const identifier = this.getPostIdentifier(post);
     return this._storePost[identifier] || [];
   }
 
-  public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | OffchainComment<any>) {
+  public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | AnyProposal | OffchainComment<any>) {
     if (rxnOrPost instanceof OffchainReaction) {
       const { threadId, commentId, proposalId } = rxnOrPost;
       return threadId
         ? `discussion-${threadId}`
         : proposalId
-          ? `PLACEHOLDER`
+          ? 'PLACEHOLDER'
           : `comment-${commentId}`;
     } else if (rxnOrPost instanceof OffchainThread) {
       return `discussion-${rxnOrPost.id}`;

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -16,7 +16,7 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
     super.add(reaction);
     this.getAll().sort(byAscendingCreationDate);
     const identifier = this.getPostIdentifier(reaction);
-
+    console.log(identifier);
     if (!this._storePost[identifier]) {
       this._storePost[identifier] = [];
     }
@@ -60,16 +60,19 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
   }
 
   public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | AnyProposal | OffchainComment<any>) {
+    debugger
     if (rxnOrPost instanceof OffchainReaction) {
       const { threadId, commentId, proposalId } = rxnOrPost;
       return threadId
         ? `discussion-${threadId}`
-        : `${proposalId}` || `comment-${commentId}`;
+        : proposalId
+          ? `${proposalId}`
+          : `comment-${commentId}`;
     } else if (rxnOrPost instanceof OffchainThread) {
       return `discussion-${rxnOrPost.id}`;
     } else if (rxnOrPost instanceof Proposal) {
       debugger
-      return `${(rxnOrPost as AnyProposal).slug}-${(rxnOrPost as AnyProposal).identifier}`;
+      return `${(rxnOrPost as AnyProposal).slug}_${(rxnOrPost as AnyProposal).identifier}`;
     } else if (rxnOrPost instanceof OffchainComment) {
       return `comment-${rxnOrPost.id}`;
     }

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -1,5 +1,5 @@
 import IdStore from './IdStore';
-import { OffchainReaction, AnyProposal, OffchainThread, OffchainComment } from '../models';
+import { OffchainReaction, AnyProposal, OffchainThread, OffchainComment, Proposal } from '../models';
 import { byAscendingCreationDate } from '../helpers';
 import { IUniqueId } from '../models/interfaces';
 
@@ -64,11 +64,12 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
       const { threadId, commentId, proposalId } = rxnOrPost;
       return threadId
         ? `discussion-${threadId}`
-        : proposalId
-          ? 'PLACEHOLDER'
-          : `comment-${commentId}`;
+        : `${proposalId}` || `comment-${commentId}`;
     } else if (rxnOrPost instanceof OffchainThread) {
       return `discussion-${rxnOrPost.id}`;
+    } else if (rxnOrPost instanceof Proposal) {
+      debugger
+      return `${(rxnOrPost as AnyProposal).slug}-${(rxnOrPost as AnyProposal).identifier}`;
     } else if (rxnOrPost instanceof OffchainComment) {
       return `comment-${rxnOrPost.id}`;
     }

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -61,8 +61,12 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
 
   public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | OffchainComment<any>) {
     if (rxnOrPost instanceof OffchainReaction) {
-      const { threadId, commentId } = rxnOrPost;
-      return threadId ? `discussion-${threadId}` : `comment-${commentId}`;
+      const { threadId, commentId, proposalId } = rxnOrPost;
+      return threadId
+        ? `discussion-${threadId}`
+        : proposalId
+          ? `PLACEHOLDER`
+          : `comment-${commentId}`;
     } else if (rxnOrPost instanceof OffchainThread) {
       return `discussion-${rxnOrPost.id}`;
     } else if (rxnOrPost instanceof OffchainComment) {

--- a/client/scripts/stores/ReactionStore.ts
+++ b/client/scripts/stores/ReactionStore.ts
@@ -16,7 +16,6 @@ class ReactionStore extends IdStore<OffchainReaction<any>> {
     super.add(reaction);
     this.getAll().sort(byAscendingCreationDate);
     const identifier = this.getPostIdentifier(reaction);
-    console.log(identifier);
     if (!this._storePost[identifier]) {
       this._storePost[identifier] = [];
     }

--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -16,7 +16,7 @@ export enum ReactionType {
 }
 
 interface IAttrs {
-  post: OffchainThread | OffchainComment<any>;
+  post: OffchainThread | AnyProposal | OffchainComment<any>;
   type: ReactionType;
   displayAsLink?: boolean;
   tooltip?: boolean;

--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -105,6 +105,8 @@ const ReactionButton: m.Component<IAttrs, IState> = {
       m('.reactions-icon', '👍'),
       m('.reactions-count', likes.length),
     ]);
+    // const a = app;
+    // debugger
 
     return (tooltip && reactors.length)
       ? m(Tooltip, {

--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -105,8 +105,6 @@ const ReactionButton: m.Component<IAttrs, IState> = {
       m('.reactions-icon', '👍'),
       m('.reactions-count', likes.length),
     ]);
-    // const a = app;
-    // debugger
 
     return (tooltip && reactors.length)
       ? m(Tooltip, {

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -444,7 +444,7 @@ export const ProposalBodyEditor: m.Component<{ item: OffchainThread | OffchainCo
   }
 };
 
-export const ProposalBodyReaction: m.Component<{ item: OffchainThread | OffchainComment<any> }> = {
+export const ProposalBodyReaction: m.Component<{ item: OffchainThread | AnyProposal | OffchainComment<any> }> = {
   view: (vnode) => {
     const { item } = vnode.attrs;
     if (!item) return;

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -43,7 +43,6 @@ import {
   ProposalBodyReaction, ProposalBodyEditMenuItem, ProposalBodyDeleteMenuItem, ProposalBodyReplyMenuItem
 } from './body';
 import CreateComment from './create_comment';
-import ReactionButton, { ReactionType } from '../../components/reaction_button';
 
 interface IProposalHeaderAttrs {
   commentCount: number;
@@ -110,6 +109,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             m(ProposalHeaderOnchainStatus, { proposal }),
             m(ProposalBodyAuthor, { item: proposal }),
             m(ProposalHeaderViewCount, { viewCount }),
+            m(ProposalBodyReaction, { item: proposal }),
           ]),
           proposal instanceof OffchainThread
             && proposal.kind === OffchainThreadKind.Link
@@ -171,7 +171,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             && m('.proposal-body-button-group', [
               m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
               m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state }),
-              m(ReactionButton, { post: proposal, type: ReactionType.Like }),
             ]),
 
           !vnode.state.editing

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -43,6 +43,7 @@ import {
   ProposalBodyReaction, ProposalBodyEditMenuItem, ProposalBodyDeleteMenuItem, ProposalBodyReplyMenuItem
 } from './body';
 import CreateComment from './create_comment';
+import ReactionButton, { ReactionType } from '../../components/reaction_button';
 
 interface IProposalHeaderAttrs {
   commentCount: number;
@@ -170,6 +171,7 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             && m('.proposal-body-button-group', [
               m(ProposalBodyCancelEdit, { getSetGlobalEditingStatus, parentState: vnode.state }),
               m(ProposalBodySaveEdit, { item: proposal, getSetGlobalEditingStatus, parentState: vnode.state }),
+              m(ReactionButton, { post: proposal, type: ReactionType.Like }),
             ]),
 
           !vnode.state.editing

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -1,11 +1,54 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface) => {
-    await queryInterface.addColumn('OffchainReactions', 'proposal_id');
+  up: async (queryInterface, DataTypes) => {
+    await queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'OffchainReactions',
+        'proposal_id',
+        {
+          type: DataTypes.STRING,
+          allowNull: true,
+          unique: true,
+          references: {
+            model: 'Proposals',
+            key: 'identifier',
+          }
+        },
+        { transaction: t }
+      );
+      await queryInterface.removeIndex(
+        'Proposals', {
+          fields: ['chain', 'address_id', 'thread_id', 'comment_id', 'reaction'],
+          unique: true
+        },
+        { transaction: t }
+      );
+      await queryInterface.addIndex(
+        'Proposals', {
+          fields: ['chain', 'address_id', 'thread_id', 'proposal_id', 'comment_id', 'reaction'],
+          unique: true
+        },
+        { transaction: t }
+      );
+    });
   },
 
-  down: (queryInterface) => {
-    await queryInterface.removeColum('OffchainReactions', 'proposal_id');
+  down: async (queryInterface, DataTypes) => {
+    await queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColum(
+        'OffchainReactions',
+        'proposal_id',
+        {
+          type: DataTypes.STRING,
+          allowNull: true,
+          unique: true,
+          references: {
+            model: 'Proposals',
+            key: 'identifier'
+          }
+        }
+      );
+    });
   }
 };

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -6,12 +6,8 @@ module.exports = {
       'OffchainReactions',
       'proposal_id',
       {
-        type: DataTypes.INTEGER,
+        type: DataTypes.STRING,
         allowNull: true,
-        references: {
-          model: 'ChainEntities',
-          key: 'id',
-        }
       },
     );
     await queryInterface.addIndex(
@@ -28,12 +24,8 @@ module.exports = {
         'OffchainReactions',
         'proposal_id',
         {
-          type: DataTypes.INTEGER,
+          type: DataTypes.STRING,
           allowNull: true,
-          references: {
-            model: 'ChainEntities',
-            key: 'id'
-          }
         }
       );
     });

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -9,7 +9,7 @@ module.exports = {
         type: DataTypes.INTEGER,
         allowNull: true,
         references: {
-          model: 'ChainEntity',
+          model: 'ChainEntities',
           key: 'id',
         }
       },
@@ -31,7 +31,7 @@ module.exports = {
           type: DataTypes.INTEGER,
           allowNull: true,
           references: {
-            model: 'ChainEntity',
+            model: 'ChainEntities',
             key: 'id'
           }
         }

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -2,50 +2,37 @@
 
 module.exports = {
   up: async (queryInterface, DataTypes) => {
-    await queryInterface.sequelize.transaction(async (t) => {
-      await queryInterface.addColumn(
-        'OffchainReactions',
-        'proposal_id',
-        {
-          type: DataTypes.STRING,
-          allowNull: true,
-          unique: true,
-          references: {
-            model: 'Proposals',
-            key: 'identifier',
-          }
-        },
-        { transaction: t }
-      );
-      await queryInterface.removeIndex(
-        'Proposals', {
-          fields: ['chain', 'address_id', 'thread_id', 'comment_id', 'reaction'],
-          unique: true
-        },
-        { transaction: t }
-      );
-      await queryInterface.addIndex(
-        'Proposals', {
-          fields: ['chain', 'address_id', 'thread_id', 'proposal_id', 'comment_id', 'reaction'],
-          unique: true
-        },
-        { transaction: t }
-      );
-    });
+    await queryInterface.addColumn(
+      'OffchainReactions',
+      'proposal_id',
+      {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        references: {
+          model: 'Proposals',
+          key: 'id',
+        }
+      },
+    );
+    await queryInterface.addIndex(
+      'OffchainReactions', {
+        fields: ['chain', 'address_id', 'thread_id', 'proposal_id', 'comment_id', 'reaction'],
+        unique: true,
+      },
+    );
   },
 
   down: async (queryInterface, DataTypes) => {
     await queryInterface.sequelize.transaction(async (t) => {
-      await queryInterface.removeColum(
+      await queryInterface.removeColumn(
         'OffchainReactions',
         'proposal_id',
         {
-          type: DataTypes.STRING,
+          type: DataTypes.INTEGER,
           allowNull: true,
-          unique: true,
           references: {
             model: 'Proposals',
-            key: 'identifier'
+            key: 'id'
           }
         }
       );

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -9,7 +9,7 @@ module.exports = {
         type: DataTypes.INTEGER,
         allowNull: true,
         references: {
-          model: 'Proposals',
+          model: 'ChainEntity',
           key: 'id',
         }
       },
@@ -31,7 +31,7 @@ module.exports = {
           type: DataTypes.INTEGER,
           allowNull: true,
           references: {
-            model: 'Proposals',
+            model: 'ChainEntity',
             key: 'id'
           }
         }

--- a/server/migrations/20200721141800-add-proposal-id-to-reactions.js
+++ b/server/migrations/20200721141800-add-proposal-id-to-reactions.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface) => {
+    await queryInterface.addColumn('OffchainReactions', 'proposal_id');
+  },
+
+  down: (queryInterface) => {
+    await queryInterface.removeColum('OffchainReactions', 'proposal_id');
+  }
+};

--- a/server/models/chain_entity.ts
+++ b/server/models/chain_entity.ts
@@ -54,6 +54,7 @@ export default (
   ChainEntity.associate = (models) => {
     models.ChainEntity.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
     models.ChainEntity.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
+    models.ChainEntity.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'id' });
     models.ChainEntity.hasMany(models.ChainEvent, { foreignKey: 'entity_id' });
   };
 

--- a/server/models/chain_entity.ts
+++ b/server/models/chain_entity.ts
@@ -54,7 +54,7 @@ export default (
   ChainEntity.associate = (models) => {
     models.ChainEntity.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
     models.ChainEntity.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
-    models.ChainEntity.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'id' });
+    models.ChainEntity.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id' });
     models.ChainEntity.hasMany(models.ChainEvent, { foreignKey: 'entity_id' });
   };
 

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -35,9 +35,9 @@ export default (
 ): OffchainReactionModel => {
   const OffchainReaction = sequelize.define<OffchainReactionInstance, OffchainReactionAttributes>('OffchainReaction', {
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    chain: { type: dataTypes.STRING, allowNull: true },
+    chain: { type: dataTypes.INTEGER, allowNull: true },
     thread_id: { type: dataTypes.INTEGER, allowNull: true },
-    proposal_id: { type: dataTypes.INTEGER, allowNull: true },
+    proposal_id: { type: dataTypes.STRING, allowNull: true },
     comment_id: { type: dataTypes.INTEGER, allowNull: true },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     reaction: { type: dataTypes.STRING, allowNull: false },
@@ -58,7 +58,7 @@ export default (
     models.OffchainReaction.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainComment, { foreignKey: 'comment_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
-    models.OffchainReaction.belongsTo(models.Proposal, { foreignKey: 'proposal_id', targetKey: 'identifier' });
+    models.OffchainReaction.belongsTo(models.Proposal, { foreignKey: 'proposal_id', targetKey: 'id' });
   };
 
   return OffchainReaction;

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -58,7 +58,7 @@ export default (
     models.OffchainReaction.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainComment, { foreignKey: 'comment_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
-    models.OffchainReaction.belongsTo(models.Proposal, { foreignKey: 'proposal_id', targetKey: 'id' });
+    models.OffchainReaction.belongsTo(models.ChainEntity, { foreignKey: 'proposal_id', targetKey: 'id' });
   };
 
   return OffchainReaction;

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -8,6 +8,7 @@ export interface OffchainReactionAttributes {
   id?: number;
   chain?: string;
   thread_id?: number;
+  proposal_id?: number;
   comment_id?: number;
   address_id: number;
   reaction: string;
@@ -36,6 +37,7 @@ export default (
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     chain: { type: dataTypes.STRING, allowNull: true },
     thread_id: { type: dataTypes.INTEGER, allowNull: true },
+    proposal_id: { type: dataTypes.INTEGER, allowNull: true },
     comment_id: { type: dataTypes.INTEGER, allowNull: true },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     reaction: { type: dataTypes.STRING, allowNull: false },
@@ -44,9 +46,9 @@ export default (
     underscored: true,
     indexes: [
       { fields: ['id'] },
-      { fields: ['chain', 'thread_id', 'comment_id'] },
+      { fields: ['chain', 'thread_id', 'proposal_id', 'comment_id'] },
       { fields: ['address_id'] },
-      { fields: ['chain', 'address_id', 'thread_id', 'comment_id', 'reaction'], unique: true },
+      { fields: ['chain', 'address_id', 'thread_id', 'proposal_id', 'comment_id', 'reaction'], unique: true },
     ],
   });
 
@@ -56,6 +58,7 @@ export default (
     models.OffchainReaction.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainComment, { foreignKey: 'comment_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
+    models.OffchainReaction.belongsTo(models.Proposal, { foreignKey: 'proposal_id', targetKey: 'identifier' });
   };
 
   return OffchainReaction;

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -37,7 +37,7 @@ export default (
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     chain: { type: dataTypes.INTEGER, allowNull: true },
     thread_id: { type: dataTypes.INTEGER, allowNull: true },
-    proposal_id: { type: dataTypes.STRING, allowNull: true },
+    proposal_id: { type: dataTypes.INTEGER, allowNull: true },
     comment_id: { type: dataTypes.INTEGER, allowNull: true },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     reaction: { type: dataTypes.STRING, allowNull: false },

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -37,7 +37,7 @@ export default (
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     chain: { type: dataTypes.INTEGER, allowNull: true },
     thread_id: { type: dataTypes.INTEGER, allowNull: true },
-    proposal_id: { type: dataTypes.INTEGER, allowNull: true },
+    proposal_id: { type: dataTypes.STRING, allowNull: true },
     comment_id: { type: dataTypes.INTEGER, allowNull: true },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     reaction: { type: dataTypes.STRING, allowNull: false },
@@ -58,7 +58,6 @@ export default (
     models.OffchainReaction.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainComment, { foreignKey: 'comment_id', targetKey: 'id' });
     models.OffchainReaction.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
-    models.OffchainReaction.belongsTo(models.ChainEntity, { foreignKey: 'proposal_id', targetKey: 'id' });
   };
 
   return OffchainReaction;

--- a/server/models/proposal.ts
+++ b/server/models/proposal.ts
@@ -21,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
 
   Proposal.associate = (models) => {
     models.Proposal.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
-    models.Proposal.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'identifier' })
+    models.Proposal.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'id' });
   };
 
   return Proposal;

--- a/server/models/proposal.ts
+++ b/server/models/proposal.ts
@@ -21,6 +21,7 @@ module.exports = (sequelize, DataTypes) => {
 
   Proposal.associate = (models) => {
     models.Proposal.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
+    models.Proposal.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'identifier' })
   };
 
   return Proposal;

--- a/server/models/proposal.ts
+++ b/server/models/proposal.ts
@@ -21,7 +21,6 @@ module.exports = (sequelize, DataTypes) => {
 
   Proposal.associate = (models) => {
     models.Proposal.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
-    models.Proposal.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id', targetKey: 'id' });
   };
 
   return Proposal;

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -42,6 +42,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   else if (proposal_id) {
     proposal = await proposalIdToEntity(models, chain.id, proposal_id);
     console.log(proposal);
+    if (!proposal) return next(new Error(Errors.NoProposalMatch));
     root_type = proposal_id.split('_')[0];
     options['proposal_id'] = proposal.id;
   } else if (comment_id) options['comment_id'] = comment_id;

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -42,7 +42,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   else if (proposal_id) {
     proposal = await proposalIdToEntity(models, chain.id, proposal_id);
     console.log(proposal);
-    root_type = 'PLACEHOLDER';
+    root_type = proposal_id.split('_')[0];
     options['proposal_id'] = proposal.id;
   } else if (comment_id) options['comment_id'] = comment_id;
 
@@ -106,9 +106,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
 
   const location = thread_id
     ? `discussion_${thread_id}`
-    : proposal_id
-      ? `PLACEHOLDER_${proposal_id}`
-      : `comment-${comment_id}`;
+    : proposal_id || `comment-${comment_id}`;
   await models.Subscription.emitNotifications(
     models,
     NotificationCategories.NewReaction,

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -41,7 +41,6 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   if (thread_id) options['thread_id'] = thread_id;
   else if (proposal_id) {
     proposal = await proposalIdToEntity(models, chain.id, proposal_id);
-    console.log(proposal);
     if (!proposal) return next(new Error(Errors.NoProposalMatch));
     root_type = proposal_id.split('_')[0];
     options['proposal_id'] = proposal_id;

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -21,11 +21,21 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   const author = await lookupAddressIsOwnedByUser(models, req, next);
   const { reaction, comment_id, proposal_id, thread_id } = req.body;
 
-  if (!thread_id && !comment_id) {
+  if (!thread_id && !proposal_id && !comment_id) {
     return next(new Error(Errors.NoPostId));
   }
   if (!reaction) {
     return next(new Error(Errors.NoReaction));
+  }
+
+  let proposal;
+  if (proposal_id) {
+    proposal = await models.Proposal.find({
+      where: { identifier: proposal_id }
+    });
+    if (!proposal) {
+      return next(new Error(Errors.NoProposalMatch));
+    }
   }
 
   const options = {
@@ -35,6 +45,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
 
   if (community) options['community'] = community.id;
   else if (chain) options['chain'] = chain.id;
+
   if (thread_id) options['thread_id'] = thread_id;
   else if (proposal_id) options['proposal_id'] = proposal_id;
   else if (comment_id) options['comment_id'] = comment_id;
@@ -58,72 +69,71 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   let comment;
   let cwUrl;
   let root_type;
-  let proposal;
-  try {
-    if (comment_id) {
-      comment = await models.OffchainComment.findByPk(Number(comment_id));
-      // Test on variety of comments to ensure root relation + type
-      const [prefix, id] = comment.root_id.split('_');
-      if (prefix === 'discussion') {
-        proposal = await models.OffchainThread.findOne({
-          where: { id }
-        });
-      } else {
-        proposal = await proposalIdToEntity(models, chain.id, comment.root_id);
-      }
-      cwUrl = getProposalUrl(prefix, proposal, comment);
-      root_type = prefix;
-    } else if (proposal_id) {
-      proposal = await proposalIdToEntity(models, chain.id, proposal_id);
-      cwUrl = getProposalUrl('discussion', proposal);
-      console.log(cwUrl);
+  // let proposal;
+  // try {
+  //   if (comment_id) {
+  //     comment = await models.OffchainComment.findByPk(Number(comment_id));
+  //     // Test on variety of comments to ensure root relation + type
+  //     const [prefix, id] = comment.root_id.split('_');
+  //     if (prefix === 'discussion') {
+  //       proposal = await models.OffchainThread.findOne({
+  //         where: { id }
+  //       });
+  //     } else {
+  //       proposal = await proposalIdToEntity(models, chain.id, comment.root_id);
+  //     }
+  //     cwUrl = getProposalUrl(prefix, proposal, comment);
+  //     root_type = prefix;
+  //   } else if (proposal_id) {
+      // proposal = await proposalIdToEntity(models, chain.id, proposal_id);
+      // console.log(proposal);
       // root_type = PLACEHOLDER
-    } else if (thread_id) {
-      proposal = await models.OffchainThread.findByPk(Number(thread_id));
-      cwUrl = getProposalUrl('discussion', proposal, comment);
-      root_type = 'discussion';
-    }
-  } catch (err) {
-    return next(new Error(Errors.NoProposalMatch));
-  }
+  //   } else if (thread_id) {
+  //     proposal = await models.OffchainThread.findByPk(Number(thread_id));
+  //     cwUrl = getProposalUrl('discussion', proposal, comment);
+  //     root_type = 'discussion';
+  //   }
+  // } catch (err) {
+  //   return next(new Error(Errors.NoProposalMatch));
+  // }
 
-  // dispatch notifications
-  const notification_data = {
-    created_at: new Date(),
-    root_id: Number(proposal.id),
-    root_title: proposal.title || '',
-    root_type,
-    chain_id: finalReaction.chain,
-    community_id: finalReaction.community,
-    author_address: finalReaction.Address.address,
-    author_chain: finalReaction.Address.chain,
-  };
+  // // dispatch notifications
+  // const notification_data = {
+  //   created_at: new Date(),
+  //   root_id: Number(proposal.id),
+  //   root_title: proposal.title || '',
+  //   root_type,
+  //   chain_id: finalReaction.chain,
+  //   community_id: finalReaction.community,
+  //   author_address: finalReaction.Address.address,
+  //   author_chain: finalReaction.Address.chain,
+  // };
 
-  if (comment_id) {
-    notification_data['comment_id'] = Number(comment.id);
-    notification_data['comment_text'] = comment.text;
-  }
+  // if (comment_id) {
+  //   notification_data['comment_id'] = Number(comment.id);
+  //   notification_data['comment_text'] = comment.text;
+  // }
 
-  const location = thread_id
-    ? `discussion_${thread_id}`
-    : proposal_id
-      ? `PLACEHOLDER_${proposal_id}`
-      : `comment-${comment_id}`;
-  await models.Subscription.emitNotifications(
-    models,
-    NotificationCategories.NewReaction,
-    location,
-    notification_data,
-    {
-      user: finalReaction.Address.address,
-      url: cwUrl,
-      title: proposal.title || '',
-      chain: finalReaction.chain,
-      community: finalReaction.community,
-    },
-    req.wss,
-    [ finalReaction.Address.address ],
-  );
+  // const location = thread_id
+  //   ? `discussion_${thread_id}`
+  //   : proposal_id
+  //     ? `PLACEHOLDER_${proposal_id}`
+  //     : `comment-${comment_id}`;
+  // await models.Subscription.emitNotifications(
+  //   models,
+  //   NotificationCategories.NewReaction,
+  //   location,
+  //   notification_data,
+  //   {
+  //     user: finalReaction.Address.address,
+  //     url: cwUrl,
+  //     title: proposal.title || '',
+  //     chain: finalReaction.chain,
+  //     community: finalReaction.community,
+  //   },
+  //   req.wss,
+  //   [ finalReaction.Address.address ],
+  // );
 
   return res.json({ status: 'Success', result: finalReaction.toJSON() });
 };

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -28,16 +28,6 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
     return next(new Error(Errors.NoReaction));
   }
 
-  let proposal;
-  if (proposal_id) {
-    proposal = await models.Proposal.find({
-      where: { identifier: proposal_id }
-    });
-    if (!proposal) {
-      return next(new Error(Errors.NoProposalMatch));
-    }
-  }
-
   const options = {
     reaction,
     address_id: author.id,
@@ -69,71 +59,71 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
   let comment;
   let cwUrl;
   let root_type;
-  // let proposal;
-  // try {
-  //   if (comment_id) {
-  //     comment = await models.OffchainComment.findByPk(Number(comment_id));
-  //     // Test on variety of comments to ensure root relation + type
-  //     const [prefix, id] = comment.root_id.split('_');
-  //     if (prefix === 'discussion') {
-  //       proposal = await models.OffchainThread.findOne({
-  //         where: { id }
-  //       });
-  //     } else {
-  //       proposal = await proposalIdToEntity(models, chain.id, comment.root_id);
-  //     }
-  //     cwUrl = getProposalUrl(prefix, proposal, comment);
-  //     root_type = prefix;
-  //   } else if (proposal_id) {
-      // proposal = await proposalIdToEntity(models, chain.id, proposal_id);
-      // console.log(proposal);
-      // root_type = PLACEHOLDER
-  //   } else if (thread_id) {
-  //     proposal = await models.OffchainThread.findByPk(Number(thread_id));
-  //     cwUrl = getProposalUrl('discussion', proposal, comment);
-  //     root_type = 'discussion';
-  //   }
-  // } catch (err) {
-  //   return next(new Error(Errors.NoProposalMatch));
-  // }
+  let proposal;
+  try {
+    if (comment_id) {
+      comment = await models.OffchainComment.findByPk(Number(comment_id));
+      // Test on variety of comments to ensure root relation + type
+      const [prefix, id] = comment.root_id.split('_');
+      if (prefix === 'discussion') {
+        proposal = await models.OffchainThread.findOne({
+          where: { id }
+        });
+      } else {
+        proposal = await proposalIdToEntity(models, chain.id, comment.root_id);
+      }
+      cwUrl = getProposalUrl(prefix, proposal, comment);
+      root_type = prefix;
+    } else if (proposal_id) {
+      proposal = await proposalIdToEntity(models, chain.id, proposal_id);
+      console.log(proposal);
+      root_type = 'PLACEHOLDER';
+    } else if (thread_id) {
+      proposal = await models.OffchainThread.findByPk(Number(thread_id));
+      cwUrl = getProposalUrl('discussion', proposal, comment);
+      root_type = 'discussion';
+    }
+  } catch (err) {
+    return next(new Error(Errors.NoProposalMatch));
+  }
 
-  // // dispatch notifications
-  // const notification_data = {
-  //   created_at: new Date(),
-  //   root_id: Number(proposal.id),
-  //   root_title: proposal.title || '',
-  //   root_type,
-  //   chain_id: finalReaction.chain,
-  //   community_id: finalReaction.community,
-  //   author_address: finalReaction.Address.address,
-  //   author_chain: finalReaction.Address.chain,
-  // };
+  // dispatch notifications
+  const notification_data = {
+    created_at: new Date(),
+    root_id: Number(proposal.id),
+    root_title: proposal.title || '',
+    root_type,
+    chain_id: finalReaction.chain,
+    community_id: finalReaction.community,
+    author_address: finalReaction.Address.address,
+    author_chain: finalReaction.Address.chain,
+  };
 
-  // if (comment_id) {
-  //   notification_data['comment_id'] = Number(comment.id);
-  //   notification_data['comment_text'] = comment.text;
-  // }
+  if (comment_id) {
+    notification_data['comment_id'] = Number(comment.id);
+    notification_data['comment_text'] = comment.text;
+  }
 
-  // const location = thread_id
-  //   ? `discussion_${thread_id}`
-  //   : proposal_id
-  //     ? `PLACEHOLDER_${proposal_id}`
-  //     : `comment-${comment_id}`;
-  // await models.Subscription.emitNotifications(
-  //   models,
-  //   NotificationCategories.NewReaction,
-  //   location,
-  //   notification_data,
-  //   {
-  //     user: finalReaction.Address.address,
-  //     url: cwUrl,
-  //     title: proposal.title || '',
-  //     chain: finalReaction.chain,
-  //     community: finalReaction.community,
-  //   },
-  //   req.wss,
-  //   [ finalReaction.Address.address ],
-  // );
+  const location = thread_id
+    ? `discussion_${thread_id}`
+    : proposal_id
+      ? `PLACEHOLDER_${proposal_id}`
+      : `comment-${comment_id}`;
+  await models.Subscription.emitNotifications(
+    models,
+    NotificationCategories.NewReaction,
+    location,
+    notification_data,
+    {
+      user: finalReaction.Address.address,
+      url: cwUrl,
+      title: proposal.title || '',
+      chain: finalReaction.chain,
+      community: finalReaction.community,
+    },
+    req.wss,
+    [ finalReaction.Address.address ],
+  );
 
   return res.json({ status: 'Success', result: finalReaction.toJSON() });
 };

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -44,7 +44,7 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
     console.log(proposal);
     if (!proposal) return next(new Error(Errors.NoProposalMatch));
     root_type = proposal_id.split('_')[0];
-    options['proposal_id'] = proposal.id;
+    options['proposal_id'] = proposal_id;
   } else if (comment_id) options['comment_id'] = comment_id;
 
   let finalReaction;

--- a/server/util/proposalIdToEntity.ts
+++ b/server/util/proposalIdToEntity.ts
@@ -4,16 +4,9 @@ import { MolochEntityKind } from '../../shared/events/moloch/types';
 // this function can take either an "old style" identifier such as treasuryproposal_4,
 // or a "new style" identifier/type combination such as 4 and treasuryproposal, and attempts
 // fetch the corresponding chain entity from the database
-export default async function (models, chain: string, identifier: string, type?) {
+export default async function (models, chain: string, identifier: string) {
   console.log(`Looking up proposal: ${chain}: ${identifier}`);
-  let prefix;
-  let type_id;
-  if (type) {
-    prefix = type;
-    type_id = identifier;
-  } else {
-    [ prefix, type_id ] = identifier.split('_');
-  }
+  const [ prefix, type_id ] = identifier.split('_');
   const findEntity = (type_) => {
     return models.ChainEntity.findOne({ where: { chain, type: type_, type_id } });
   };

--- a/server/util/proposalIdToEntity.ts
+++ b/server/util/proposalIdToEntity.ts
@@ -7,8 +7,8 @@ import { MolochEntityKind } from '../../shared/events/moloch/types';
 export default async function (models, chain: string, identifier: string) {
   console.log(`Looking up proposal: ${chain}: ${identifier}`);
   const [ prefix, type_id ] = identifier.split('_');
-  const findEntity = (type_) => {
-    return models.ChainEntity.findOne({ where: { chain, type: type_, type_id } });
+  const findEntity = (type) => {
+    return models.ChainEntity.findOne({ where: { chain, type, type_id } });
   };
   switch (prefix) {
     case 'referendum': {

--- a/server/util/proposalIdToEntity.ts
+++ b/server/util/proposalIdToEntity.ts
@@ -1,13 +1,21 @@
 import { SubstrateEntityKind } from '../../shared/events/substrate/types';
 import { MolochEntityKind } from '../../shared/events/moloch/types';
 
-// given an "old style" identifier such as treasuryproposal_4, attempts to
+// this function can take either an "old style" identifier such as treasuryproposal_4,
+// or a "new style" identifier/type combination such as 4 and treasuryproposal, and attempts
 // fetch the corresponding chain entity from the database
-export default async function (models, chain: string, identifier: string) {
+export default async function (models, chain: string, identifier: string, type?) {
   console.log(`Looking up proposal: ${chain}: ${identifier}`);
-  const [ prefix, type_id ] = identifier.split('_');
-  const findEntity = (type) => {
-    return models.ChainEntity.findOne({ where: { chain, type, type_id } });
+  let prefix;
+  let type_id;
+  if (type) {
+    prefix = type;
+    type_id = identifier;
+  } else {
+    [ prefix, type_id ] = identifier.split('_');
+  }
+  const findEntity = (type_) => {
+    return models.ChainEntity.findOne({ where: { chain, type: type_, type_id } });
   };
   switch (prefix) {
     case 'referendum': {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This branch adds support for reactions on proposals, by saving an identifier (e.g. `referendum_6`) to a newly added `proposal_id` column in the OffchainReactions table. This identifier allows a lookup, on the backend, of the correct corresponding ChainEntity.

## How has this been tested?
Little tricky QAing this one, if only because a decent number of proposals appear to be broken in the database (don't have corresponding ChainEntities), and because I'm experiencing some issues adding addresses/connecting to Kusama/Moloch. Might keep this as a draft until it's been QA'd a little more.

Reactions appear to be correctly created and deleted on ChainEntities, and this state is preserved on refresh as well as immediately added to the reactions store. I've inspected the database to ensure that entries are being properly created.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no