### PR TITLE
Allow profile page without ?base query when scoped to chain

### DIFF
--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -110,7 +110,9 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
   },
   oncreate: async (vnode) => {
     const loadProfile = async () => {
-      const chain = m.route.param('base');
+      const chain = (m.route.param('base'))
+        ? m.route.param('base')
+        : m.route.param('scope');
       const { address } = vnode.attrs;
       await $.ajax({
         url: `${app.serverUrl()}/profile`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In #bugs slack, @jnaviask commented that our old links to the profile page (without the `?base` query in the route) failed to load even though their scope is a chain. I added a line to fix this so that chain community profile links don't need the query and use their scope instead. The error "no base chain provided" still will throw if scope is an offchain-community while rendering a profile page. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previous profile links break! 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Loaded profile page in `/edgeware` community without `?base` and it loads the profile from server fine.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no