### PR TITLE
Community Visibility Boolean

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -40,6 +40,7 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
         }));
       });
       data.communities.map((community) => {
+        console.log(community);
         return app.config.communities.add(CommunityInfo.fromJSON({
           id: community.id,
           name: community.name,
@@ -49,6 +50,7 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
           telegram: community.telegram,
           github: community.github,
           default_chain: app.config.chains.getById(community.default_chain),
+          visible: community.visible,
           invitesEnabled: community.invitesEnabled,
           privacyEnabled: community.privacyEnabled,
           featuredTags: community.featured_tags,

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -40,7 +40,6 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
         }));
       });
       data.communities.map((community) => {
-        console.log(community);
         return app.config.communities.add(CommunityInfo.fromJSON({
           id: community.id,
           name: community.name,

--- a/client/scripts/models/CommunityInfo.ts
+++ b/client/scripts/models/CommunityInfo.ts
@@ -11,6 +11,7 @@ interface CommunityData {
   chat: string,
   telegram: string,
   github: string,
+  visible: boolean;
   invitesEnabled: boolean,
   privacyEnabled: boolean,
 }
@@ -24,6 +25,7 @@ class CommunityInfo {
   public telegram: string;
   public github: string;
   public readonly defaultChain: ChainInfo;
+  public readonly visible: boolean;
   public invitesEnabled: boolean;
   public privacyEnabled: boolean;
   public readonly featuredTags: string[];
@@ -32,7 +34,7 @@ class CommunityInfo {
 
   constructor(
     id, name, description, website, chat, telegram, github, defaultChain,
-    invitesEnabled, privacyEnabled, featuredTags, tags, adminsAndMods?
+    visible, invitesEnabled, privacyEnabled, featuredTags, tags, adminsAndMods?
   ) {
     this.id = id;
     this.name = name;
@@ -42,6 +44,7 @@ class CommunityInfo {
     this.telegram = telegram;
     this.github = github;
     this.defaultChain = defaultChain;
+    this.visible = visible;
     this.invitesEnabled = invitesEnabled;
     this.privacyEnabled = privacyEnabled;
     this.featuredTags = featuredTags || [];
@@ -59,6 +62,7 @@ class CommunityInfo {
       json.telegram,
       json.github,
       json.default_chain,
+      json.visible,
       json.invitesEnabled,
       json.privacyEnabled,
       json.featuredTags,

--- a/client/scripts/views/modals/create_community_modal.ts
+++ b/client/scripts/views/modals/create_community_modal.ts
@@ -129,6 +129,7 @@ const CreateCommunityModal: m.Component<IAttrs, IState> = {
                 null,
                 null,
                 result.result.default_chain,
+                false,
                 result.result.invitesEnabled,
                 result.result.privacyEnabled,
                 result.featured_tags,

--- a/client/scripts/views/pages/home/community_cards.ts
+++ b/client/scripts/views/pages/home/community_cards.ts
@@ -139,7 +139,7 @@ const HomepageCommunityCards: m.Component<{}, { justJoinedChains, justJoinedComm
         .filter(([c, nodeList]) => !app.user.isMember({ account: app.user.activeAccount, chain: c }) || vnode.state.justJoinedChains.indexOf(c) !== -1);
 
       otherCommunities = app.config.communities.getAll()
-        .filter((c) => c.visible)
+        .filter((c) => { debugger; console.log(c.visible); return c.visible; })
         .filter((c) => !app.user.isMember({ account: app.user.activeAccount, community: c.id }) || vnode.state.justJoinedCommunities.indexOf(c.id) !== -1);
     }
 

--- a/client/scripts/views/pages/home/community_cards.ts
+++ b/client/scripts/views/pages/home/community_cards.ts
@@ -139,6 +139,7 @@ const HomepageCommunityCards: m.Component<{}, { justJoinedChains, justJoinedComm
         .filter(([c, nodeList]) => !app.user.isMember({ account: app.user.activeAccount, chain: c }) || vnode.state.justJoinedChains.indexOf(c) !== -1);
 
       otherCommunities = app.config.communities.getAll()
+        .filter((c) => c.visible)
         .filter((c) => !app.user.isMember({ account: app.user.activeAccount, community: c.id }) || vnode.state.justJoinedCommunities.indexOf(c.id) !== -1);
     }
 

--- a/client/scripts/views/pages/home/community_cards.ts
+++ b/client/scripts/views/pages/home/community_cards.ts
@@ -139,7 +139,7 @@ const HomepageCommunityCards: m.Component<{}, { justJoinedChains, justJoinedComm
         .filter(([c, nodeList]) => !app.user.isMember({ account: app.user.activeAccount, chain: c }) || vnode.state.justJoinedChains.indexOf(c) !== -1);
 
       otherCommunities = app.config.communities.getAll()
-        .filter((c) => { debugger; console.log(c.visible); return c.visible; })
+        .filter((c) => c.visible)
         .filter((c) => !app.user.isMember({ account: app.user.activeAccount, community: c.id }) || vnode.state.justJoinedCommunities.indexOf(c.id) !== -1);
     }
 

--- a/server/migrations/20200723192319-add-visibility-boolean-to-communities-and-manually-set.js
+++ b/server/migrations/20200723192319-add-visibility-boolean-to-communities-and-manually-set.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    await queryInterface.addColumn(
+      'OffchainCommunities',
+      'visible',
+      {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+    );
+    const query = 'UPDATE "OffchainCommunities" SET visible=true;';
+    return queryInterface.sequelize.query(query);
+  },
+
+  down: async (queryInterface, DataTypes) => {
+    return queryInterface.removeColumn(
+      'OffchainCommunities',
+      'visible',
+      {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+    );
+  }
+};

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -17,6 +17,7 @@ export interface OffchainCommunityAttributes {
   telegram?: string;
   github?: string;
   featured_tags?: string[];
+  visible: boolean;
   privacyEnabled?: boolean;
   invitesEnabled?: boolean;
   created_at?: Date;
@@ -50,6 +51,7 @@ export default (
       name: { type: dataTypes.STRING, allowNull: false },
       creator_id: { type: dataTypes.INTEGER, allowNull: false },
       default_chain: { type: dataTypes.STRING, allowNull: false },
+      visible: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
       description: { type: dataTypes.TEXT, allowNull: true },
       website: { type: dataTypes.STRING, allowNull: true },
       chat: { type: dataTypes.STRING, allowNull: true },

--- a/server/routes/createCommunity.ts
+++ b/server/routes/createCommunity.ts
@@ -68,6 +68,7 @@ const createCommunity = async (models, req: Request, res: Response, next: NextFu
     name: req.body.name,
     description: req.body.description,
     default_chain: (req.body.default_chain) ? req.body.default_chain : 'ethereum',
+    visible: false,
     isAuthenticatedForum,
     privacyEnabled,
     invitesEnabled,


### PR DESCRIPTION
Closes #496.

## Description

OffchainCommunities now have a boolean `visibility` column that is, by default, set to false, but has been manually migrated to true for all current communities. 

Communities with visibility=false are filtered out on the homepage and will not be rendered.

## How has this been tested?

I've manually set different communities' visibilities, ensuring that they are properly shown or hidden depending on the visibility value.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [x] yes, and they are not tested: At the moment, we have no test file for creating a community, and this did not seem the appropriate time to add it. (Nor is there any logic here for updating visibility.)
- [ ] yes, but I did not run tests
- [ ] no