### PR TITLE
Show proposal author in the "replies" column

### DIFF
--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -64,11 +64,15 @@ class CommentsController {
     return this._store.nComments(proposal);
   }
 
-  public uniqueCommenters<T extends IUniqueId>(proposal: T) {
+  public uniqueCommenters<T extends IUniqueId>(proposal: T, proposalAuthor?, proposalAuthorChain?) {
     // Returns an array of [chain, address] arrays
     // TODO: Use a better comparator to determine uniqueness
-    const comments = this._store.getByProposal(proposal);
-    return _.uniq(comments.map((c) => `${c.authorChain}#${c.author}`))
+    const comments = (proposalAuthor && proposalAuthorChain)
+      ? [`${proposalAuthorChain}#${proposalAuthor}`]
+        .concat(this._store.getByProposal(proposal).map((c) => `${c.authorChain}#${c.author}`))
+      : (this._store.getByProposal(proposal)).map((c) => `${c.authorChain}#${c.author}`);
+
+    return _.uniq((comments as string[]))
       .map((slug) => slug.split(/#/));
   }
 

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -28,12 +28,11 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
         community: app.activeCommunityId(),
       }).then(() => {
         vnode.state.loading = false;
-        // m.redraw();
+        m.redraw();
         vnode.state.selectedIndex = null;
         // select the address, and close the form
         notifySuccess(`Joined with ${formatAddressShort(addressInfo.address)}`);
         app.user.setActiveAccount(account);
-        m.redraw();
         $(e.target).trigger('modalexit');
       }).catch((err: any) => {
         vnode.state.loading = false;

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -28,11 +28,12 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
         community: app.activeCommunityId(),
       }).then(() => {
         vnode.state.loading = false;
-        m.redraw();
+        // m.redraw();
         vnode.state.selectedIndex = null;
         // select the address, and close the form
         notifySuccess(`Joined with ${formatAddressShort(addressInfo.address)}`);
         app.user.setActiveAccount(account);
+        m.redraw();
         $(e.target).trigger('modalexit');
       }).catch((err: any) => {
         vnode.state.loading = false;

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -94,7 +94,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
               }),
             ]),
             m('.discussion-commenters', [
-              m('.commenters-avatars', app.comments.uniqueCommenters(proposal)
+              m('.commenters-avatars', app.comments.uniqueCommenters(proposal, proposal.author, proposal.authorChain)
                 .map(([chain, address]) => {
                   return m(User, {
                     user: new AddressInfo(null, address, chain, null),


### PR DESCRIPTION
Closes #499.

## Description
![image](https://user-images.githubusercontent.com/22281010/88560839-a4b11b80-cffc-11ea-94fc-a5f4a967c3ad.png)

Previously, the original post author was not displayed in the avatars list, which previewed post's commenters. This branch includes the author, ensuring that, if that author also comments, their avatar is not rendered redundantly. This helps cover the user information lost when we stopped rendering the author's avatar to the left of the thread (i.e. in more standard forum format).

## How has this been tested?
I've checked thread authors/commenters against the replies preview in the discussion row listing, ensuring in different communities/circumstances that it renders as desired. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no