### PR TITLE
Add on-chain identity to OffchainProfiles.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,6 +56,7 @@
     "dot-notation": 0,
     "no-lonely-if": 0,
     "no-multi-spaces": 0,
-    "strict": 0
+    "strict": 0,
+    "no-await-in-loop": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
     "import/prefer-default-export": 0,
     "dot-notation": 0,
     "no-lonely-if": 0,
-    "no-multi-spaces": 0
+    "no-multi-spaces": 0,
+    "strict": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.2.2",
+    "@commonwealth/chain-events": "0.2.6",
     "@edgeware/node-types": "2.3.5",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.2.1",
+    "@commonwealth/chain-events": "0.2.2",
     "@edgeware/node-types": "2.3.5",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start-prerender": "ts-node --project tsconfig.node.json server/scripts/runPrerenderService.ts",
     "migrate-events": "NO_CLIENT=true RUN_ENTITY_MIGRATION=all ts-node --project tsconfig.node.json server.ts",
     "migrate-server": "heroku run npx sequelize db:migrate --debug",
+    "migrate-identities": "NO_CLIENT=true IDENTITY_MIGRATION=true ts-node --project tsconfig.node.json server.ts",
     "reset-server": "NO_CLIENT=true RESET_DB=true ts-node --project tsconfig.node.json server.ts",
     "update-events": "UPDATE_EVENTS=true ts-node --project tsconfig.node.json server.ts",
     "update-balances": "UPDATE_BALANCES=true ts-node --project tsconfig.node.json server.ts",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.2.0",
+    "@commonwealth/chain-events": "0.2.1",
     "@edgeware/node-types": "2.3.5",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.0.11",

--- a/server-test.ts
+++ b/server-test.ts
@@ -19,6 +19,7 @@ import models from './server/database';
 import setupWebsocketServer from './server/socket';
 import { NotificationCategories } from './shared/types';
 import ViewCountCache from './server/util/viewCountCache';
+import IdentityFetchCache from './server/util/identityFetchCache';
 
 require('express-async-errors');
 
@@ -26,6 +27,7 @@ const app = express();
 const SequelizeStore = SessionSequelizeStore(session.Store);
 // set cache TTL to 1 second to test invalidation
 const viewCountCache = new ViewCountCache(1, 10 * 60);
+const identityFetchCache = new IdentityFetchCache(0);
 const wss = new WebSocket.Server({ clientTracking: false, noServer: true });
 let server;
 
@@ -238,10 +240,11 @@ const setupServer = () => {
 };
 
 setupPassport(models);
-setupAPI(app, models, viewCountCache);
+setupAPI(app, models, viewCountCache, identityFetchCache);
 setupErrorHandlers();
 setupServer();
 
 export const resetDatabase = () => resetServer();
+export const getIdentityFetchCache = () => identityFetchCache;
 
 export default app;

--- a/server.ts
+++ b/server.ts
@@ -35,7 +35,7 @@ import setupAPI from './server/router';
 import setupPassport from './server/passport';
 import setupChainEventListeners from './server/scripts/setupChainEventListeners';
 import { fetchStats } from './server/routes/getEdgewareLockdropStats';
-import { migrateIdentities } from './server/scripts/migrateIdentities.js';
+import { migrateIdentities } from './server/scripts/migrateIdentities';
 
 // set up express async error handling hack
 require('express-async-errors');
@@ -157,57 +157,60 @@ setupAppRoutes(app, models, devMiddleware, templateFile, sendFile);
 setupErrorHandlers(app, rollbar);
 sendBatchedNotificationEmails(models, 'monthly');
 
-if (SHOULD_RESET_DB) {
-  resetServer(models, closeMiddleware);
-} else if (SHOULD_UPDATE_EVENTS) {
-  updateEvents(app, models);
-} else if (SHOULD_UPDATE_BALANCES) {
-  updateBalances(app, models);
-} else if (SHOULD_UPDATE_EDGEWARE_LOCKDROP_STATS) {
-  // Run fetchStats here to populate lockdrop stats for Edgeware Lockdrop.
-  // This only needs to run once on prod to make the necessary queries.
-  fetchStats(models, 'mainnet').then((result) => {
+async function main() {
+  if (SHOULD_RESET_DB) {
+    resetServer(models, closeMiddleware);
+  } else if (SHOULD_UPDATE_EVENTS) {
+    updateEvents(app, models);
+  } else if (SHOULD_UPDATE_BALANCES) {
+    await updateBalances(app, models);
+  } else if (SHOULD_UPDATE_EDGEWARE_LOCKDROP_STATS) {
+    // Run fetchStats here to populate lockdrop stats for Edgeware Lockdrop.
+    // This only needs to run once on prod to make the necessary queries.
+    await fetchStats(models, 'mainnet');
     log.info('Finished adding Lockdrop statistics into the DB');
     process.exit(0);
-  });
-} else if (SHOULD_UPDATE_SUPERNOVA_STATS) {
-  // MAINNET Cosmos
-  // const cosmosRestUrl = 'http://cosmoshub1.commonwealth.im:1318';
-  // const cosmosChainType = 'cosmos';
-  // TESTNET Cosmos
-  const cosmosRestUrl = 'http://gaia13k1.commonwealth.im:1318';
-  const cosmosChainType = 'gaia13k1';
-  updateSupernovaStats(models, cosmosRestUrl, cosmosChainType);
-} else {
-  if (!NO_EVENTS) {
-    // handle various chain-event cases
-    if (IDENTITY_MIGRATION) {
-      migrateIdentities(models);
+  } else if (SHOULD_UPDATE_SUPERNOVA_STATS) {
+    // MAINNET Cosmos
+    // const cosmosRestUrl = 'http://cosmoshub1.commonwealth.im:1318';
+    // const cosmosChainType = 'cosmos';
+    // TESTNET Cosmos
+    const cosmosRestUrl = 'http://gaia13k1.commonwealth.im:1318';
+    const cosmosChainType = 'gaia13k1';
+    await updateSupernovaStats(models, cosmosRestUrl, cosmosChainType);
+  } else {
+    if (NO_EVENTS) {
+      setupServer(app, wss, sessionParser);
     } else {
-      // TODO: remove the entity migration option from this call and make it another top-level function
-      setupChainEventListeners(models, wss, SKIP_EVENT_CATCHUP, RUN_ENTITY_MIGRATION)
-        .then(() => {
-          if (RUN_ENTITY_MIGRATION) {
-            models.sequelize.close()
-              .then(() => process.exit(0));
-          }
-        }, (err) => {
-          if (RUN_ENTITY_MIGRATION) {
-            console.error(`Entity migration failed: ${err.message}`);
-            models.sequelize.close()
-              .then(() => (closeMiddleware()))
-              .then(() => process.exit(1));
-          } else {
-            console.error(`Chain event listener setup failed: ${err.message}`);
-          }
-        });
-    }
-  }
+      // handle various chain-event cases
+      if (IDENTITY_MIGRATION) {
+        await migrateIdentities(models);
+        log.info('Finished migrating chain identities into the DB');
+        process.exit(0);
+      }
 
-  // finally, after chain event setup
-  if (!RUN_ENTITY_MIGRATION && !IDENTITY_MIGRATION) {
-    setupServer(app, wss, sessionParser);
+      // TODO: remove the entity migration option from this call and make it another top-level function
+      let exitCode = 0;
+      try {
+        const subscribers = await setupChainEventListeners(models, wss, SKIP_EVENT_CATCHUP, RUN_ENTITY_MIGRATION);
+      } catch (e) {
+        exitCode = 1;
+        if (RUN_ENTITY_MIGRATION) {
+          console.error(`Entity migration failed: ${e.message}`);
+        } else {
+          console.error(`Chain event listener setup failed: ${e.message}`);
+        }
+      }
+      if (RUN_ENTITY_MIGRATION || exitCode) {
+        await models.sequelize.close();
+        await closeMiddleware();
+        process.exit(exitCode);
+      }
+
+      setupServer(app, wss, sessionParser);
+    }
   }
 }
 
+main();
 export default app;

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import setupAPI from './server/router';
 import setupPassport from './server/passport';
 import setupChainEventListeners from './server/scripts/setupChainEventListeners';
 import { fetchStats } from './server/routes/getEdgewareLockdropStats';
+import { migrateIdentities } from './server/scripts/migrateIdentities.js';
 
 // set up express async error handling hack
 require('express-async-errors');
@@ -48,6 +49,7 @@ const SHOULD_UPDATE_EDGEWARE_LOCKDROP_STATS = process.env.UPDATE_EDGEWARE_LOCKDR
 const NO_CLIENT_SERVER = process.env.NO_CLIENT === 'true';
 const SKIP_EVENT_CATCHUP = process.env.SKIP_EVENT_CATCHUP === 'true';
 const RUN_ENTITY_MIGRATION = process.env.RUN_ENTITY_MIGRATION;
+const IDENTITY_MIGRATION = process.env.IDENTITY_MIGRATION;
 const NO_EVENTS = process.env.NO_EVENTS === 'true';
 
 const rollbar = process.env.NODE_ENV === 'production' && new Rollbar({
@@ -178,24 +180,34 @@ if (SHOULD_RESET_DB) {
   updateSupernovaStats(models, cosmosRestUrl, cosmosChainType);
 } else {
   if (!NO_EVENTS) {
-    setupChainEventListeners(models, wss, SKIP_EVENT_CATCHUP, RUN_ENTITY_MIGRATION)
-      .then(() => {
-        if (RUN_ENTITY_MIGRATION) {
-          models.sequelize.close()
-            .then(() => process.exit(0));
-        }
-      }, (err) => {
-        if (RUN_ENTITY_MIGRATION) {
-          console.error(`Entity migration failed: ${err.message}`);
-          models.sequelize.close()
-            .then(() => (closeMiddleware()))
-            .then(() => process.exit(1));
-        } else {
-          console.error(`Chain event listener setup failed: ${err.message}`);
-        }
-      });
+    // handle various chain-event cases
+    if (IDENTITY_MIGRATION) {
+      migrateIdentities(models);
+    } else {
+      // TODO: remove the entity migration option from this call and make it another top-level function
+      setupChainEventListeners(models, wss, SKIP_EVENT_CATCHUP, RUN_ENTITY_MIGRATION)
+        .then(() => {
+          if (RUN_ENTITY_MIGRATION) {
+            models.sequelize.close()
+              .then(() => process.exit(0));
+          }
+        }, (err) => {
+          if (RUN_ENTITY_MIGRATION) {
+            console.error(`Entity migration failed: ${err.message}`);
+            models.sequelize.close()
+              .then(() => (closeMiddleware()))
+              .then(() => process.exit(1));
+          } else {
+            console.error(`Chain event listener setup failed: ${err.message}`);
+          }
+        });
+    }
   }
-  if (!RUN_ENTITY_MIGRATION) setupServer(app, wss, sessionParser);
+
+  // finally, after chain event setup
+  if (!RUN_ENTITY_MIGRATION && !IDENTITY_MIGRATION) {
+    setupServer(app, wss, sessionParser);
+  }
 }
 
 export default app;

--- a/server/eventHandlers/identity.ts
+++ b/server/eventHandlers/identity.ts
@@ -1,0 +1,36 @@
+import {
+  IEventHandler,
+  CWEvent,
+  IChainEventData,
+  SubstrateTypes
+} from '@commonwealth/chain-events';
+
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+export default class extends IEventHandler {
+  constructor(
+    private readonly _models,
+    private readonly _chain: string,
+  ) {
+    super();
+  }
+
+
+  /**
+   * Handles an identity-related event by writing the corresponding update into
+   * the database.
+   */
+  public async handle(event: CWEvent<IChainEventData>, dbEvent) {
+    // do nothing if wrong type of event
+    if (event.data.kind !== SubstrateTypes.EventKind.IdentitySet
+        && event.data.kind !== SubstrateTypes.EventKind.IdentityCleared
+        && event.data.kind !== SubstrateTypes.EventKind.IdentityKilled) {
+      return dbEvent;
+    }
+
+    // TODO: update DB according to event
+
+    return dbEvent;
+  }
+}

--- a/server/eventHandlers/identity.ts
+++ b/server/eventHandlers/identity.ts
@@ -51,6 +51,14 @@ export default class extends IEventHandler {
       profile.identity = event.data.displayName;
       profile.judgements = _.object<{ [name: string]: SubstrateTypes.IdentityJudgement }>(event.data.judgements);
       await profile.save();
+
+      // write a comment about the new identity
+      let logName = profile.Address.address;
+      if (profile.data) {
+        const { name } = JSON.parse(profile.data);
+        logName = name;
+      }
+      log.debug(`Discovered name '${profile.identity}' for ${logName}!`);
     } else if (event.data.kind === SubstrateTypes.EventKind.JudgementGiven) {
       // if we don't have an identity saved yet for a judgement, do nothing
       // TODO: we can augment the judgement event to include all event data, but seems

--- a/server/eventHandlers/identity.ts
+++ b/server/eventHandlers/identity.ts
@@ -59,8 +59,12 @@ export default class extends IEventHandler {
         log.warn('No corresponding identity found for judgement! Needs identity-migration?');
         return dbEvent;
       }
-      const judgements = profile.judgements;
-      judgements[event.data.registrar] = event.data.judgement;
+      if (!profile.judgements) {
+        profile.set({ 'judgements': { [event.data.registrar]: event.data.judgement } });
+      } else {
+        const fieldName = `judgements.${event.data.registrar}`;
+        profile.set({ [fieldName]: event.data.judgement });
+      }
       await profile.save();
     } else {
       profile.identity = null;

--- a/server/eventHandlers/identity.ts
+++ b/server/eventHandlers/identity.ts
@@ -1,10 +1,11 @@
+import _ from 'underscore';
 import {
   IEventHandler,
   CWEvent,
   IChainEventData,
   SubstrateTypes
 } from '@commonwealth/chain-events';
-
+import { OffchainProfileInstance } from '../models/offchain_profile';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -24,6 +25,7 @@ export default class extends IEventHandler {
   public async handle(event: CWEvent<IChainEventData>, dbEvent) {
     // do nothing if wrong type of event
     if (event.data.kind !== SubstrateTypes.EventKind.IdentitySet
+        && event.data.kind !== SubstrateTypes.EventKind.JudgementGiven
         && event.data.kind !== SubstrateTypes.EventKind.IdentityCleared
         && event.data.kind !== SubstrateTypes.EventKind.IdentityKilled) {
       return dbEvent;
@@ -31,7 +33,7 @@ export default class extends IEventHandler {
 
     // fetch OffchainProfile corresponding to address
     const { who } = event.data;
-    const profile = await this._models.OffchainProfile.findOne({
+    const profile: OffchainProfileInstance = await this._models.OffchainProfile.findOne({
       include: [{
         model: this._models.Address,
         where: {
@@ -47,9 +49,15 @@ export default class extends IEventHandler {
     // update profile data depending on event
     if (event.data.kind === SubstrateTypes.EventKind.IdentitySet) {
       profile.identity = event.data.displayName;
+      profile.judgements = _.object<{ [name: string]: SubstrateTypes.IdentityJudgement }>(event.data.judgements);
+      await profile.save();
+    } else if (event.data.kind === SubstrateTypes.EventKind.JudgementGiven) {
+      const judgements = profile.judgements;
+      judgements[event.data.registrar] = event.data.judgement;
       await profile.save();
     } else {
       profile.identity = null;
+      profile.judgements = null;
       await profile.save();
     }
 

--- a/server/eventHandlers/identity.ts
+++ b/server/eventHandlers/identity.ts
@@ -29,7 +29,29 @@ export default class extends IEventHandler {
       return dbEvent;
     }
 
-    // TODO: update DB according to event
+    // fetch OffchainProfile corresponding to address
+    const { who } = event.data;
+    const profile = await this._models.OffchainProfile.findOne({
+      include: [{
+        model: this._models.Address,
+        where: {
+          // TODO: do we need to modify address case?
+          address: who,
+          chain: this._chain,
+        },
+        required: true,
+      }]
+    });
+    if (!profile) return;
+
+    // update profile data depending on event
+    if (event.data.kind === SubstrateTypes.EventKind.IdentitySet) {
+      profile.identity = event.data.displayName;
+      await profile.save();
+    } else {
+      profile.identity = null;
+      await profile.save();
+    }
 
     return dbEvent;
   }

--- a/server/migrations/20200727195810-add-identity-to-profile.js
+++ b/server/migrations/20200727195810-add-identity-to-profile.js
@@ -2,21 +2,41 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    // data will be populated later, via `yarn migrate-identities`.
-    return queryInterface.addColumn(
-      'OffchainProfiles',
-      'identity',
-      {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-    );
+    return queryInterface.sequelize.transaction(async (t) => {
+      // data will be populated later, via `yarn migrate-identities`.
+      await queryInterface.addColumn(
+        'OffchainProfiles',
+        'identity',
+        {
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        { transaction: t },
+      );
+      await queryInterface.addColumn(
+        'OffchainProfiles',
+        'judgements',
+        {
+          type: DataTypes.JSONB,
+          allowNull: true,
+        },
+        { transaction: t },
+      );
+    });
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn(
-      'OffchainProfiles',
-      'identity',
-    );
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        'OffchainProfiles',
+        'identity',
+        { transaction: t },
+      );
+      await queryInterface.removeColumn(
+        'OffchainProfiles',
+        'judgements',
+        { transaction: t },
+      );
+    });
   }
 };

--- a/server/migrations/20200727195810-add-identity-to-profile.js
+++ b/server/migrations/20200727195810-add-identity-to-profile.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    // data will be populated later, via `yarn migrate-identities`.
+    return queryInterface.addColumn(
+      'OffchainProfiles',
+      'identity',
+      {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'OffchainProfiles',
+      'identity',
+    );
+  }
+};

--- a/server/migrations/20200727195810-add-identity-to-profile.js
+++ b/server/migrations/20200727195810-add-identity-to-profile.js
@@ -8,7 +8,7 @@ module.exports = {
         'OffchainProfiles',
         'identity',
         {
-          type: DataTypes.STRING,
+          type: Sequelize.STRING,
           allowNull: true,
         },
         { transaction: t },
@@ -17,7 +17,7 @@ module.exports = {
         'OffchainProfiles',
         'judgements',
         {
-          type: DataTypes.JSONB,
+          type: Sequelize.JSONB,
           allowNull: true,
         },
         { transaction: t },

--- a/server/models/chain_entity.ts
+++ b/server/models/chain_entity.ts
@@ -54,7 +54,6 @@ export default (
   ChainEntity.associate = (models) => {
     models.ChainEntity.belongsTo(models.Chain, { foreignKey: 'chain', targetKey: 'id' });
     models.ChainEntity.belongsTo(models.OffchainThread, { foreignKey: 'thread_id', targetKey: 'id' });
-    models.ChainEntity.hasMany(models.OffchainReaction, { foreignKey: 'proposal_id' });
     models.ChainEntity.hasMany(models.ChainEvent, { foreignKey: 'entity_id' });
   };
 

--- a/server/models/offchain_profile.ts
+++ b/server/models/offchain_profile.ts
@@ -1,9 +1,12 @@
 import * as Sequelize from 'sequelize';
+
+import { SubstrateTypes } from '@commonwealth/chain-events';
 import { AddressAttributes } from './address';
 
 export interface OffchainProfileAttributes {
   address_id: number;
   identity?: string;   // display name from chain
+  judgements?: { [registrar: string]: SubstrateTypes.IdentityJudgement }
   data?: string;
 
   // associations
@@ -27,6 +30,7 @@ export default (
     'OffchainProfile', {
       address_id: { type: dataTypes.INTEGER, allowNull: false, primaryKey: true },
       identity: { type: dataTypes.STRING, allowNull: true },
+      judgements: { type: dataTypes.JSONB, allowNull: true },
       data: { type: dataTypes.TEXT, allowNull: true },
     }, {
       underscored: true,

--- a/server/models/offchain_profile.ts
+++ b/server/models/offchain_profile.ts
@@ -3,6 +3,7 @@ import { AddressAttributes } from './address';
 
 export interface OffchainProfileAttributes {
   address_id: number;
+  identity?: string;   // display name from chain
   data?: string;
 
   // associations
@@ -25,6 +26,7 @@ export default (
   const OffchainProfile = sequelize.define<OffchainProfileInstance, OffchainProfileAttributes>(
     'OffchainProfile', {
       address_id: { type: dataTypes.INTEGER, allowNull: false, primaryKey: true },
+      identity: { type: dataTypes.STRING, allowNull: true },
       data: { type: dataTypes.TEXT, allowNull: true },
     }, {
       underscored: true,

--- a/server/models/offchain_reaction.ts
+++ b/server/models/offchain_reaction.ts
@@ -35,7 +35,7 @@ export default (
 ): OffchainReactionModel => {
   const OffchainReaction = sequelize.define<OffchainReactionInstance, OffchainReactionAttributes>('OffchainReaction', {
     id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    chain: { type: dataTypes.INTEGER, allowNull: true },
+    chain: { type: dataTypes.STRING, allowNull: true },
     thread_id: { type: dataTypes.INTEGER, allowNull: true },
     proposal_id: { type: dataTypes.STRING, allowNull: true },
     comment_id: { type: dataTypes.INTEGER, allowNull: true },

--- a/server/router.ts
+++ b/server/router.ts
@@ -97,10 +97,11 @@ import createWebhook from './routes/webhooks/createWebhook';
 import deleteWebhook from './routes/webhooks/deleteWebhook';
 import getWebhooks from './routes/webhooks/getWebhooks';
 import ViewCountCache from './util/viewCountCache';
+import IdentityFetchCache from './util/identityFetchCache';
 
 import bulkEntities from './routes/bulkEntities';
 
-function setupRouter(app, models, viewCountCache: ViewCountCache) {
+function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchCache: IdentityFetchCache) {
   const router = express.Router();
   router.get('/status', status.bind(this, models));
 
@@ -239,7 +240,7 @@ function setupRouter(app, models, viewCountCache: ViewCountCache) {
 
   // offchain profiles
   // TODO: Change to PUT /profile
-  router.post('/updateProfile', passport.authenticate('jwt', { session: false }), updateProfile.bind(this, models));
+  router.post('/updateProfile', passport.authenticate('jwt', { session: false }), updateProfile.bind(this, models, identityFetchCache));
   // TODO: Change to GET /profiles
   router.post('/bulkProfiles', bulkProfiles.bind(this, models));
 

--- a/server/scripts/migrateIdentities.ts
+++ b/server/scripts/migrateIdentities.ts
@@ -4,6 +4,7 @@
  * from the chain, writing the results back into the database.
  */
 
+import _ from 'underscore';
 import { SubstrateTypes, SubstrateEvents } from '@commonwealth/chain-events';
 import { OffchainProfileAttributes, OffchainProfileInstance } from '../models/offchain_profile';
 
@@ -71,6 +72,9 @@ export async function migrateIdentities(models, chain?: string): Promise<Offchai
       const profile = profiles.find((p) => p.Address.address === identityEvent.data.who);
       if (profile) {
         profile.identity = identityEvent.data.displayName;
+        profile.judgements = _.object<{ [name: string]: SubstrateTypes.IdentityJudgement }>(
+          identityEvent.data.judgements
+        );
         await profile.save();
         log.debug(`Discovered name '${profile.identity}' for ${profile.Address.address}!`);
         updatedProfiles.push(profile);

--- a/server/scripts/migrateIdentities.ts
+++ b/server/scripts/migrateIdentities.ts
@@ -40,7 +40,7 @@ export async function migrateIdentities(models, chain?: string): Promise<Offchai
     log.info(`Querying all profiles on chain ${node.chain}...`);
     const profiles: OffchainProfileInstance[] = await models.OffchainProfile.findAll({
       include: [{
-        model: this._models.Address,
+        model: models.Address,
         where: {
           chain: node.chain,
         },
@@ -76,7 +76,12 @@ export async function migrateIdentities(models, chain?: string): Promise<Offchai
           identityEvent.data.judgements
         );
         await profile.save();
-        log.debug(`Discovered name '${profile.identity}' for ${profile.Address.address}!`);
+        let logName = profile.Address.address;
+        if (profile.data) {
+          const { name } = JSON.parse(profile.data);
+          logName = name;
+        }
+        log.debug(`Discovered name '${profile.identity}' for ${logName}!`);
         updatedProfiles.push(profile);
       }
     }

--- a/server/scripts/migrateIdentities.ts
+++ b/server/scripts/migrateIdentities.ts
@@ -1,0 +1,17 @@
+/**
+ * This script "migrates" identities from the chain into the database, by first
+ * querying all addresses, and then attempting to fetch corresponding identities
+ * from the chain, writing the results back into the database.
+ */
+
+import { SubstrateTypes } from '@commonwealth/chain-events';
+
+export async function migrateIdentities(models, chain?: string) {
+  // TODO: query all valid chains for identity migrations, or query nodes for provided
+
+  // TODO: query all addresses
+
+  // TODO: connect to chain and query all identities
+
+  // TODO: write identities back to db
+}

--- a/server/scripts/migrateIdentities.ts
+++ b/server/scripts/migrateIdentities.ts
@@ -4,14 +4,78 @@
  * from the chain, writing the results back into the database.
  */
 
-import { SubstrateTypes } from '@commonwealth/chain-events';
+import { SubstrateTypes, SubstrateEvents } from '@commonwealth/chain-events';
+import { OffchainProfileAttributes, OffchainProfileInstance } from '../models/offchain_profile';
 
-export async function migrateIdentities(models, chain?: string) {
-  // TODO: query all valid chains for identity migrations, or query nodes for provided
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
 
-  // TODO: query all addresses
+export async function migrateIdentities(models, chain?: string): Promise<OffchainProfileAttributes[]> {
+  // 1. fetch the node and url of supported/selected chains
+  log.info('Fetching node info for identity migrations...');
+  const nodes = [];
+  if (!chain) {
+    // query one node for each supported chain
+    for (const supportedChain of SubstrateTypes.EventChains) {
+      // eslint-disable-next-line no-await-in-loop
+      nodes.push(await models.ChainNode.findOne({
+        where: { chain: supportedChain }
+      }));
+    }
+  } else {
+    // query one node for provided chain
+    nodes.push(await models.ChainNode.findOne({
+      where: { chain }
+    }));
+  }
+  if (!nodes) {
+    throw new Error('no nodes found for identity migration');
+  }
 
-  // TODO: connect to chain and query all identities
+  // 2. for each node, fetch and migrate identities
+  const updatedProfiles: OffchainProfileAttributes[] = [];
+  for (const node of nodes) {
+    // 2a. query all available addresses in the db on the chain
+    log.info(`Querying all profiles on chain ${node.chain}...`);
+    const profiles: OffchainProfileInstance[] = await models.OffchainProfile.findAll({
+      include: [{
+        model: this._models.Address,
+        where: {
+          chain: node.chain,
+        },
+        required: true,
+      }]
+    });
+    const addresses = profiles.map((p) => p.Address.address);
 
-  // TODO: write identities back to db
+    // 2b. connect to chain and query all identities of found addresses
+    log.info(`Fetching identities on chain ${node.chain} at url ${node.url}...`);
+    let nodeUrl = node.url;
+    const hasProtocol = nodeUrl.indexOf('wss://') !== -1 || nodeUrl.indexOf('ws://') !== -1;
+    nodeUrl = hasProtocol ? nodeUrl.split('://')[1] : nodeUrl;
+    const isInsecureProtocol = nodeUrl.indexOf('kusama-rpc.polkadot.io') === -1
+      && nodeUrl.indexOf('rpc.polkadot.io') === -1;
+    const protocol = isInsecureProtocol ? 'ws://' : 'wss://';
+    if (nodeUrl.indexOf(':9944') !== -1) {
+      nodeUrl = isInsecureProtocol ? nodeUrl : nodeUrl.split(':9944')[0];
+    }
+    nodeUrl = protocol + nodeUrl;
+    const provider = await SubstrateEvents.createProvider(nodeUrl);
+    const api = await SubstrateEvents.createApi(provider, node.chain).isReady;
+    const fetcher = new SubstrateEvents.StorageFetcher(api);
+    const identityEvents = await fetcher.fetchIdentities(addresses);
+
+    // 2c. write the found identities back to db
+    log.info(`Writing identities for chain ${node.chain} back to db...`);
+    for (const identityEvent of identityEvents) {
+      const profile = profiles.find((p) => p.Address.address === identityEvent.data.who);
+      if (profile) {
+        profile.identity = identityEvent.data.displayName;
+        await profile.save();
+        log.debug(`Discovered name '${profile.identity}' for ${profile.Address.address}!`);
+        updatedProfiles.push(profile);
+      }
+    }
+  }
+  return updatedProfiles;
 }

--- a/server/util/cacheJobRunner.ts
+++ b/server/util/cacheJobRunner.ts
@@ -1,0 +1,46 @@
+import RWLock from 'async-rwlock';
+
+// Maintains a cache with periodic, atomic jobs that also permits direct,
+// non-atomic, write access to the cache.
+export default abstract class JobRunner<CacheT> {
+  private _timeoutHandle: NodeJS.Timeout;
+
+  // we use a mutex here to avoid updating views while pruning, as it could cause errors
+  // due to object deletion.
+  // we use an RW lock because multiple async accesses are fine (read behavior) whereas
+  // jobs cannot overlap with themselves or reads (write behavior)
+  private _lock = new RWLock();
+
+  constructor(
+    private _cache: CacheT,
+    private _jobTimeS: number,
+  ) {
+  }
+
+  public start(...args) {
+    if (this._jobTimeS > 0) {
+      this._timeoutHandle = setInterval(() => this.run(), this._jobTimeS * 1000);
+    }
+  }
+
+  public close() {
+    clearInterval(this._timeoutHandle);
+    this._timeoutHandle = undefined;
+  }
+
+  // viewFn may manipulate the cache, but it must do so atomically
+  public async access<ReturnT>(viewFn: (c: CacheT) => Promise<ReturnT>): Promise<ReturnT> {
+    await this._lock.readLock();
+    const result = await viewFn(this._cache);
+    this._lock.unlock();
+    return result;
+  }
+
+  // job can be run manually as well, if desired -- will not reset timer
+  protected abstract async _job(c: CacheT): Promise<void>;
+  public async run(): Promise<void> {
+    await this._lock.writeLock();
+    await this._job(this._cache);
+    this._lock.unlock();
+  }
+}

--- a/server/util/identityFetchCache.ts
+++ b/server/util/identityFetchCache.ts
@@ -1,0 +1,61 @@
+import { SubstrateEvents } from '@commonwealth/chain-events';
+import IdentityEventHandler from '../eventHandlers/identity';
+import JobRunner from './cacheJobRunner';
+
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+// list of identities to fetch
+type CacheT = { [chain: string]: string[] }
+
+export default class IdentityFetchCache extends JobRunner<CacheT> {
+  private _fetchers: { [chain: string]: SubstrateEvents.StorageFetcher };
+  private _models;
+
+  constructor(_jobTimeS: number) {
+    super({}, _jobTimeS);
+  }
+
+  public start(models, fetchers: { [chain: string]: SubstrateEvents.StorageFetcher }) {
+    this._models = models;
+    this._fetchers = fetchers;
+    this.access(async (c) => {
+      // write empty arrays for all available chains
+      Object.keys(fetchers).reduce((res, chain) => Object.assign(c, { [chain]: [] }), c);
+    });
+
+    // kick off job
+    super.start();
+  }
+
+  public async add(chain: string, address: string) {
+    if (this._fetchers[chain]) {
+      await this.access(async (c) => {
+        c[chain].push(address);
+      });
+    }
+  }
+
+  protected async _job(c: CacheT): Promise<void> {
+    // for each chain, clear cache and fetch all events
+    // TODO: part of this can be removed from the job proper, the only atomic piece needed
+    //   is copying and clearing the address list for each chain
+    await Promise.all(Object.keys(c).map(async (chain) => {
+      try {
+        // fetch all identities for the chain
+        const identityEvents = await this._fetchers[chain].fetchIdentities(c[chain]);
+
+        // write the found identities back to db using the event handler
+        log.info(`Writing identities for chain ${chain} back to db...`);
+        const handler = new IdentityEventHandler(this._models, chain);
+        await Promise.all(identityEvents.map((e) => handler.handle(e, null)));
+
+        // clear the cache for this chain
+        c[chain].splice(0, c[chain].length);
+        log.debug(`Succeeded in updating identities for ${chain}.`);
+      } catch (e) {
+        log.error(`Failed to update identities for ${chain}: ${e.message}!`);
+      }
+    }));
+  }
+}

--- a/server/util/viewCountCache.ts
+++ b/server/util/viewCountCache.ts
@@ -1,55 +1,43 @@
-import RWLock from 'async-rwlock';
+import JobRunner from './cacheJobRunner';
 
-export default class ViewCountCache {
-  private _cache: { [viewerId: string]: { [objectId: string]: number } } = {};
-  private _timeoutHandle: NodeJS.Timeout;
+type CacheT = { [viewerId: string]: { [objectId: string]: number } };
 
-  // we use a mutex here to avoid updating views while pruning, as it could cause errors
-  // due to object deletion.
-  // we use an RW lock because multiple async views are fine (read behavior) whereas
-  // prunes cannot overlap with themselves or reads (write behavior)
-  private _lock = new RWLock();
-
+export default class ViewCountCache extends JobRunner<CacheT> {
   constructor(
     private _ttlS: number,
-    private _pruningJobTimeS: number,
+    _pruningJobTimeS: number,
   ) {
-    this._timeoutHandle = setInterval(() => this._prune(), this._pruningJobTimeS * 1000);
-  }
-
-  public close() {
-    clearInterval(this._timeoutHandle);
-    this._timeoutHandle = undefined;
+    super({}, _pruningJobTimeS);
+    this.start();
   }
 
   // registers a page view, returning true if it's a new view,
   // or false if already seen in last ttlS seconds
   public async view(viewerId: string, objectId: string): Promise<boolean> {
-    await this._lock.readLock();
-    if (!this._cache[viewerId]) {
-      this._cache[viewerId] = {};
-    }
-    const now = Date.now() / 1000;
-    const oldestPermittedTime = now - this._ttlS;
+    return this.access(async (c: CacheT) => {
+      if (!c[viewerId]) {
+        c[viewerId] = {};
+      }
+      const now = Date.now() / 1000;
+      const oldestPermittedTime = now - this._ttlS;
 
-    // if item doesn't exist or is too old, register a view. otherwise, ignore
-    let isNewView: boolean;
-    if (!this._cache[viewerId][objectId] || (this._cache[viewerId][objectId] < oldestPermittedTime)) {
-      this._cache[viewerId][objectId] = now;
-      isNewView = true;
-    } else {
-      isNewView = false;
-    }
-    this._lock.unlock();
-    return isNewView;
+      // if item doesn't exist or is too old, register a view. otherwise, ignore
+      let isNewView: boolean;
+      if (!c[viewerId][objectId] || (c[viewerId][objectId] < oldestPermittedTime)) {
+        c[viewerId][objectId] = now;
+        isNewView = true;
+      } else {
+        isNewView = false;
+      }
+      return isNewView;
+    });
   }
 
   // prunes all expired cache entries based on initialized time-to-live
-  private async _prune(): Promise<void> {
-    await this._lock.writeLock();
+  protected async _job(c: CacheT): Promise<void> {
     const oldestPermittedTime = (Date.now() / 1000) - this._ttlS;
-    for (const viewerId of Object.keys(this._cache)) {
-      const views = this._cache[viewerId];
+    for (const viewerId of Object.keys(c)) {
+      const views = c[viewerId];
       for (const objectId of Object.keys(views)) {
         if (views[objectId] < oldestPermittedTime) {
           delete views[objectId];
@@ -58,11 +46,10 @@ export default class ViewCountCache {
 
       // delete the entire session entry if no views remain
       if (Object.keys(views).length === 0) {
-        delete this._cache[viewerId];
+        delete c[viewerId];
       } else {
-        this._cache[viewerId] = views;
+        c[viewerId] = views;
       }
     }
-    this._lock.unlock();
   }
 }

--- a/test/unit/events/identityHandler.spec.ts
+++ b/test/unit/events/identityHandler.spec.ts
@@ -1,0 +1,214 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable dot-notation */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import 'chai/register-should';
+
+import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+
+import * as modelUtils from '../../util/modelUtils';
+import { resetDatabase } from '../../../server-test';
+import models from '../../../server/database';
+import IdentityHandler from '../../../server/eventHandlers/identity';
+
+chai.use(chaiHttp);
+const { assert } = chai;
+
+describe('Identity Migration Handler Tests', () => {
+  let address_id;
+  let address;
+
+  beforeEach('reset database', async () => {
+    await resetDatabase();
+    let res = await modelUtils.createAndVerifyAddress({ chain: 'edgeware' });
+    address_id = res.address_id;
+    address = res.address;
+
+    const data = {
+      bio: 'test bio',
+      headline: 'test headline',
+      name: 'test name',
+    };
+    res = await modelUtils.updateProfile({ chain: 'edgeware', address, data: JSON.stringify(data), });
+  });
+
+  it('should add identity to existing offchain profile', async () => {
+    const event: CWEvent<SubstrateTypes.IIdentitySet> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentitySet,
+        who: address,
+        displayName: 'alice',
+        judgements: [
+          [ 'bob', SubstrateTypes.IdentityJudgement.KnownGood ],
+          [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+        ],
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(event, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.equal(profile.identity, 'alice');
+    assert.equal(profile.judgements, {
+      'bob': SubstrateTypes.IdentityJudgement.KnownGood,
+      'charlie': SubstrateTypes.IdentityJudgement.LowQuality
+    });
+  });
+
+  it('should add judgement to existing offchain profile', async () => {
+    const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentitySet,
+        who: address,
+        displayName: 'alice',
+        judgements: [
+          [ 'bob', SubstrateTypes.IdentityJudgement.KnownGood ],
+          [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+        ],
+      }
+    };
+    const judgementEvent: CWEvent<SubstrateTypes.IJudgementGiven> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.JudgementGiven,
+        who: address,
+        registrar: 'dave',
+        judgement: SubstrateTypes.IdentityJudgement.Reasonable,
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(setEvent, null);
+    await handler.handle(judgementEvent, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.equal(profile.identity, 'alice');
+    assert.equal(profile.judgements, {
+      'bob': SubstrateTypes.IdentityJudgement.KnownGood,
+      'charlie': SubstrateTypes.IdentityJudgement.LowQuality,
+      'dave': SubstrateTypes.IdentityJudgement.Reasonable,
+    });
+  });
+
+  it('should remove identity on identity-cleared', async () => {
+    const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentitySet,
+        who: address,
+        displayName: 'alice',
+        judgements: [
+          [ 'bob', SubstrateTypes.IdentityJudgement.KnownGood ],
+          [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+        ],
+      }
+    };
+    const clearEvent: CWEvent<SubstrateTypes.IIdentityCleared> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentityCleared,
+        who: address,
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(setEvent, null);
+    await handler.handle(clearEvent, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.notExists(profile.identity);
+    assert.notExists(profile.judgements);
+  });
+
+  it('should remove identity on identity-killed', async () => {
+    const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentitySet,
+        who: address,
+        displayName: 'alice',
+        judgements: [
+          [ 'bob', SubstrateTypes.IdentityJudgement.KnownGood ],
+          [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+        ],
+      }
+    };
+    const killedEvent: CWEvent<SubstrateTypes.IIdentityKilled> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentityKilled,
+        who: address,
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(setEvent, null);
+    await handler.handle(killedEvent, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.notExists(profile.identity);
+    assert.notExists(profile.judgements);
+  });
+
+  it('should do nothing if no corresponding profile found', async () => {
+    const event: CWEvent<SubstrateTypes.IIdentitySet> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.IdentitySet,
+        who: 'bob',
+        displayName: 'bob',
+        judgements: [
+          [ 'alice', SubstrateTypes.IdentityJudgement.KnownGood ],
+          [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+        ],
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(event, null);
+    const profiles = await models['OffchainProfile'].findAll();
+    assert.lengthOf(profiles, 1);
+    assert.equal(profiles[0].address_id, address_id);
+  });
+
+  it('should not add judgement to offchain profile without identity', async () => {
+    const judgementEvent: CWEvent<SubstrateTypes.IJudgementGiven> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.JudgementGiven,
+        who: address,
+        registrar: 'dave',
+        judgement: SubstrateTypes.IdentityJudgement.Reasonable,
+      }
+    };
+
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(judgementEvent, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.notExists(profile.identity);
+    assert.notExists(profile.judgements);
+  });
+
+  it('should do nothing on unrelated events', async () => {
+    const event: CWEvent = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.DemocracyStarted,
+        referendumIndex: 0,
+        endBlock: 100,
+        proposalHash: 'hash',
+        voteThreshold: 'Supermajorityapproval',
+      }
+    };
+    const handler = new IdentityHandler(models, 'edgeware');
+    await handler.handle(event, null);
+    const profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.notExists(profile.identity);
+    assert.notExists(profile.judgements);
+  });
+});

--- a/test/unit/events/identityHandler.spec.ts
+++ b/test/unit/events/identityHandler.spec.ts
@@ -5,24 +5,99 @@ import chaiHttp from 'chai-http';
 import 'chai/register-should';
 import jwtLib from 'jsonwebtoken';
 
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import { CWEvent, SubstrateTypes, SubstrateEvents } from '@commonwealth/chain-events';
 
 import * as modelUtils from '../../util/modelUtils';
-import { resetDatabase } from '../../../server-test';
+import { resetDatabase, getIdentityFetchCache } from '../../../server-test';
 import models from '../../../server/database';
 import IdentityHandler from '../../../server/eventHandlers/identity';
 import { JWT_SECRET } from '../../../server/config';
+import IdentityFetchCache from '../../../server/util/identityFetchCache';
 
 chai.use(chaiHttp);
 const { assert } = chai;
 
-describe('Identity Migration Handler Tests', () => {
-  let address_id;
-  let address;
-  let jwt;
+let address_id;
+let address;
+let jwt;
+
+describe('Update Profile Identity Tests', () => {
+  let fetchCache: IdentityFetchCache;
 
   beforeEach('reset database', async () => {
     await resetDatabase();
+    fetchCache = getIdentityFetchCache();
+
+    const res = await modelUtils.createAndVerifyAddress({ chain: 'edgeware' });
+    address_id = res.address_id;
+    address = res.address;
+    jwt = jwtLib.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
+  });
+
+  it('should discover chain identity on /updateProfile', async () => {
+    // Fake the fetcher object and then start the cache (set to 0 job time so we will manually
+    // trigger the job event)
+    const fakeFetcher = {
+      fetchIdentities: async (addresses: string[]): Promise<CWEvent<SubstrateTypes.IIdentitySet>[]> => {
+        if (addresses.includes(address)) {
+          return [{
+            blockNumber: 5,
+            data: {
+              kind: SubstrateTypes.EventKind.IdentitySet,
+              who: address,
+              displayName: 'alice',
+              judgements: [
+                [ 'bob', SubstrateTypes.IdentityJudgement.KnownGood ],
+                [ 'charlie', SubstrateTypes.IdentityJudgement.LowQuality ],
+              ]
+            }
+          }];
+        } else {
+          return [ ];
+        }
+      }
+    } as unknown as SubstrateEvents.StorageFetcher;
+    fetchCache.start(models, { edgeware: fakeFetcher });
+
+    // perform the updateProfile call with the previously registered address
+    const data = {
+      bio: 'test bio',
+      headline: 'test headline',
+      name: 'test name',
+    };
+    await modelUtils.updateProfile({
+      chain: 'edgeware', address, data: JSON.stringify(data), jwt, skipChainFetch: false
+    });
+
+    let profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.address_id, address_id);
+    assert.notExists(profile.identity);
+    assert.notExists(profile.judgements);
+
+    // verify that the object made it into the cache
+    await fetchCache.access(async (c) => {
+      assert.deepEqual(c, { edgeware: [ address ] });
+    });
+
+    // run the cache and verify the identity was found and created
+    await fetchCache.run();
+    await fetchCache.access(async (c) => {
+      assert.deepEqual(c, { edgeware: [ ] });
+    });
+
+    profile = await models['OffchainProfile'].findOne();
+    assert.equal(profile.identity, 'alice');
+    assert.deepEqual(profile.judgements, {
+      'bob': SubstrateTypes.IdentityJudgement.KnownGood,
+      'charlie': SubstrateTypes.IdentityJudgement.LowQuality
+    });
+  });
+});
+
+describe('Identity Chain Event Handler Tests', () => {
+  beforeEach('reset database', async () => {
+    await resetDatabase();
+
     let res = await modelUtils.createAndVerifyAddress({ chain: 'edgeware' });
     address_id = res.address_id;
     address = res.address;
@@ -33,7 +108,9 @@ describe('Identity Migration Handler Tests', () => {
       headline: 'test headline',
       name: 'test name',
     };
-    res = await modelUtils.updateProfile({ chain: 'edgeware', address, data: JSON.stringify(data), jwt });
+    res = await modelUtils.updateProfile({
+      chain: 'edgeware', address, data: JSON.stringify(data), jwt, skipChainFetch: true
+    });
   });
 
   it('should add identity to existing offchain profile', async () => {

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -3,6 +3,8 @@ import chai from 'chai';
 import 'chai/register-should';
 import moment from 'moment';
 import wallet from 'ethereumjs-wallet';
+import { Keyring } from '@polkadot/api';
+import { stringToU8a, u8aToHex } from '@polkadot/util';
 import { NotificationCategory } from 'models';
 import { factory, formatFilename } from '../../shared/logging';
 import app from '../../server-test';
@@ -16,24 +18,57 @@ export const generateEthAddress = () => {
   return { keypair, address };
 };
 
-export const createAndVerifyAddress = async ({ chain }) => {
-  const { keypair, address } = generateEthAddress();
-  let res = await chai.request.agent(app)
-    .post('/api/createAddress')
+export const createAndVerifyAddress = async ({ chain }, mnemonic = 'Alice') => {
+  if (chain === 'ethereum') {
+    const { keypair, address } = generateEthAddress();
+    let res = await chai.request.agent(app)
+      .post('/api/createAddress')
+      .set('Accept', 'application/json')
+      .send({ address, chain });
+    const address_id = res.body.result.id;
+    const token = res.body.result.verification_token;
+    const msgHash = ethUtil.hashPersonalMessage(Buffer.from(token));
+    const sig = ethUtil.ecsign(msgHash, Buffer.from(keypair.getPrivateKey(), 'hex'));
+    const signature = ethUtil.toRpcSig(sig.v, sig.r, sig.s);
+    res = await chai.request.agent(app)
+      .post('/api/verifyAddress')
+      .set('Accept', 'application/json')
+      .send({ address, chain, signature });
+    const user_id = res.body.result.user.id;
+    const email = res.body.result.user.email;
+    return { address_id, address, user_id, email };
+  }
+  if (chain === 'edgeware') {
+    const keyPair = new Keyring({
+      type: 'sr25519',
+      ss58Format: 42,
+    }).addFromMnemonic(mnemonic);
+    const address = keyPair.address;
+    let res = await chai.request.agent(app)
+      .post('/api/createAddress')
+      .set('Accept', 'application/json')
+      .send({ address: keyPair.address, chain });
+    const address_id = res.body.result.id;
+    const token = res.body.result.verification_token;
+    const u8aSignature = keyPair.sign(stringToU8a(token));
+    const signature = u8aToHex(u8aSignature).slice(2);
+    res = await chai.request.agent(app)
+      .post('/api/verifyAddress')
+      .set('Accept', 'application/json')
+      .send({ address, chain, signature });
+    const user_id = res.body.result.user.id;
+    const email = res.body.result.user.email;
+    return { address_id, address, user_id, email };
+  }
+  throw new Error('invalid chain');
+};
+
+export const updateProfile = async ({ chain, address, data }) => {
+  const res = await chai.request.agent(app)
+    .post('/api/updateProfile')
     .set('Accept', 'application/json')
-    .send({ address, chain });
-  const address_id = res.body.result.id;
-  const token = res.body.result.verification_token;
-  const msgHash = ethUtil.hashPersonalMessage(Buffer.from(token));
-  const sig = ethUtil.ecsign(msgHash, Buffer.from(keypair.getPrivateKey(), 'hex'));
-  const signature = ethUtil.toRpcSig(sig.v, sig.r, sig.s);
-  res = await chai.request.agent(app)
-    .post('/api/verifyAddress')
-    .set('Accept', 'application/json')
-    .send({ address, chain, signature });
-  const user_id = res.body.result.user.id;
-  const email = res.body.result.user.email;
-  return { address_id, address, user_id, email };
+    .send({ address, chain, data });
+  return res.body;
 };
 
 export interface ThreadArgs {

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -63,11 +63,11 @@ export const createAndVerifyAddress = async ({ chain }, mnemonic = 'Alice') => {
   throw new Error('invalid chain');
 };
 
-export const updateProfile = async ({ chain, address, data }) => {
+export const updateProfile = async ({ chain, address, data, jwt }) => {
   const res = await chai.request.agent(app)
     .post('/api/updateProfile')
     .set('Accept', 'application/json')
-    .send({ address, chain, data });
+    .send({ address, chain, data, jwt });
   return res.body;
 };
 

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -63,11 +63,11 @@ export const createAndVerifyAddress = async ({ chain }, mnemonic = 'Alice') => {
   throw new Error('invalid chain');
 };
 
-export const updateProfile = async ({ chain, address, data, jwt }) => {
+export const updateProfile = async ({ chain, address, data, jwt, skipChainFetch }) => {
   const res = await chai.request.agent(app)
     .post('/api/updateProfile')
     .set('Accept', 'application/json')
-    .send({ address, chain, data, jwt });
+    .send({ address, chain, data, jwt, skipChainFetch });
   return res.body;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.1.tgz#9006daffabd4fcd53995790d13d168d2916670f1"
-  integrity sha512-Wz9u0iC2roqrPDft2iwC8xFk2VxDYDvvKiV8gJhD/5jm0CRR8rQJ1UmIWxes94eFHm0hjHbgkDttTFefBebYHA==
+"@commonwealth/chain-events@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.2.tgz#3e9e8f080d7b873fe265e6d0f31b08cf1574b7cb"
+  integrity sha512-yhxT/YiU1FQIYNDBTTPgnyEuniRp60ZlR15XT9OgT+QBnDk1ZJVCoaccr66rCIQV6KXohbE0ebaiJ9gfCZJLmw==
   dependencies:
     "@edgeware/node-types" "2.3.5"
     "@polkadot/api" "1.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.0.tgz#892be97f7a67e43606e5eba57536c0577402a9d0"
-  integrity sha512-DVqXF5UBquNV4eMZwQnnItvBdCvcljioFhsr6lfWCG9Tjs3sec5A0orVxmPe2zyeDrS6RUHqVOe+KyuYYof6mQ==
+"@commonwealth/chain-events@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.1.tgz#9006daffabd4fcd53995790d13d168d2916670f1"
+  integrity sha512-Wz9u0iC2roqrPDft2iwC8xFk2VxDYDvvKiV8gJhD/5jm0CRR8rQJ1UmIWxes94eFHm0hjHbgkDttTFefBebYHA==
   dependencies:
     "@edgeware/node-types" "2.3.5"
     "@polkadot/api" "1.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.2.tgz#3e9e8f080d7b873fe265e6d0f31b08cf1574b7cb"
-  integrity sha512-yhxT/YiU1FQIYNDBTTPgnyEuniRp60ZlR15XT9OgT+QBnDk1ZJVCoaccr66rCIQV6KXohbE0ebaiJ9gfCZJLmw==
+"@commonwealth/chain-events@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.6.tgz#50eff4a2835872cb170724530c888798c898d0e4"
+  integrity sha512-jUPuqAs9ZKD9/dlvlMCsZ+xrBhwojIZoPaaWWSzh4eX4L0SepG4TBFQnat1a7DP9hJGMrAeQNdVDTP+iwQauvw==
   dependencies:
     "@edgeware/node-types" "2.3.5"
     "@polkadot/api" "1.24.1"


### PR DESCRIPTION
## Description
Adds on-chain identity fetching for Substrate-based chains, based on updates to the chain-events project. This PR adds the following:

* New columns for OffchainProfiles, returned on queries like `/bulkEntities`
* An identity chain-event handler which sets or clears identities and judgements based on incoming chain data.
* An identity migration, invokable with `yarn migrate-identities`, which synchronizes the state of OffchainProfile identities with the chain's current state.
* An IdentityFetchCache, based on a new component `JobRunner`, which stores addresses that create new profiles via the `/updateProfile` route, and fetches their corresponding identities 10 minutes.

## Motivation and Context
Fixes #493.

## How has this been tested?
* Manual QA for front-end (no changes made), and migration.
* Wrote an `identityHandler.spec.ts` which tests the event handler and the functionality of the `/updateProfile` route and corresponding cache.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: [73% on updateProfile, but all new lines tested, 97.22% on the identity eventHandler, 96.43% on the identityFetchCache]