### PR TITLE
Restrict argument length in proposal title.

### DIFF
--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -4,7 +4,7 @@ import { takeWhile } from 'rxjs/operators';
 import { ApiRx } from '@polkadot/api';
 import { Votes } from '@polkadot/types/interfaces';
 import { Option } from '@polkadot/types';
-import { ISubstrateCollectiveProposal, SubstrateCoin } from 'adapters/chain/substrate/types';
+import { ISubstrateCollectiveProposal, SubstrateCoin, formatCall } from 'adapters/chain/substrate/types';
 import {
   Proposal, ProposalStatus, ProposalEndTime, BinaryVote, VotingType,
   VotingUnit, ChainEntity, ChainEvent
@@ -78,7 +78,7 @@ export class SubstrateCollectiveProposal
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
     this._Collective = Collective;
-    this._title = `${eventData.call.section}.${eventData.call.method}(${eventData.call.args.join(', ')})`;
+    this._title = formatCall(eventData.call);
 
     entity.chainEvents.forEach((e) => this.update(e));
 

--- a/client/scripts/controllers/chain/substrate/democracy_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposal.ts
@@ -7,7 +7,7 @@ import { Vec } from '@polkadot/types';
 import { ITuple } from '@polkadot/types/types';
 import { AccountId, BalanceOf } from '@polkadot/types/interfaces';
 import { isFunction } from '@polkadot/util';
-import { ISubstrateDemocracyProposal, SubstrateCoin } from 'adapters/chain/substrate/types';
+import { ISubstrateDemocracyProposal, SubstrateCoin, formatCall } from 'adapters/chain/substrate/types';
 import {
   Proposal, ProposalStatus, ProposalEndTime, DepositVote,
   VotingType, VotingUnit, ChainBase, Account, ChainEntity, ChainEvent
@@ -150,7 +150,7 @@ class SubstrateDemocracyProposal extends Proposal<
         if (preimage) {
           this._method = preimage.method;
           this._section = preimage.section;
-          this._title = `${this._section}.${this.method}(${preimage.args.join(', ')})`;
+          this._title = formatCall(preimage);
         }
         break;
       }

--- a/client/scripts/controllers/chain/substrate/democracy_referendum.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_referendum.ts
@@ -6,7 +6,8 @@ import BN from 'bn.js';
 import {
   ISubstrateDemocracyReferendum,
   SubstrateCoin,
-  DemocracyThreshold
+  DemocracyThreshold,
+  formatCall,
 } from 'adapters/chain/substrate/types';
 import {
   Proposal, ProposalStatus, ProposalEndTime, BinaryVote, VotingType, VotingUnit,
@@ -222,7 +223,7 @@ export class SubstrateDemocracyReferendum
       case SubstrateTypes.EventKind.PreimageNoted: {
         const preimage = this._Democracy.app.chain.chainEntities.getPreimage(this.hash);
         if (preimage) {
-          this._title = `${preimage.section}.${preimage.method}(${preimage.args.join(', ')})`;
+          this._title = formatCall(preimage);
         }
         break;
       }

--- a/client/scripts/views/components/proposal_row.ts
+++ b/client/scripts/views/components/proposal_row.ts
@@ -256,7 +256,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
         (slug !== ProposalType.SubstrateTreasuryProposal
           && slug !== ProposalType.SubstrateDemocracyProposal
           && slug !== ProposalType.SubstrateCollectiveProposal) && [
-          m('.proposal-row-title', (app.chain?.base === ChainBase.Substrate) ? proposal.title.split('(')[0] : proposal.title),
+          m('.proposal-row-title', proposal.title),
           m('.proposal-row-metadata', [
             statusText && m('span.proposal-status', { class: statusClass }, statusText),
           ]),
@@ -266,8 +266,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
           m('.proposal-row-main-large.item', [
             m('.proposal-row-subheading', 'Action'),
             m('.proposal-row-metadata', formatProposalHashShort((proposal as SubstrateDemocracyProposal)
-              .title
-              .split('(')[0])),
+              .title)),
           ]),
           m('.proposal-row-main.item', [
             m('.proposal-row-subheading', 'Seconds'),

--- a/shared/adapters/chain/substrate/types.ts
+++ b/shared/adapters/chain/substrate/types.ts
@@ -1,7 +1,23 @@
 import BN from 'bn.js';
 import { u128, Compact } from '@polkadot/types';
+import { Codec } from '@polkadot/types/types';
+import { Call } from '@polkadot/types/interfaces';
 import { IIdentifiable, ICompletable } from '../../shared';
 import { Coin } from '../../currency';
+
+export function formatCall(c: Call | { section: string, method: string, args: string[] }): string {
+  // build args string
+  const args: (string | Codec)[] = c.args;
+  const argsStr = args.map((v: Codec | string): string => {
+    if (!v) return '[unknown]';
+    const vStr = v.toString();
+    if (vStr.length < 16) return vStr;
+    return `${vStr.slice(0, 5)}…${vStr.slice(vStr.length - 3)}`;
+  }).join(', ');
+
+  // finish format
+  return `${c.section}.${c.method}(${argsStr})`;
+}
 
 export class SubstrateCoin extends Coin {
   constructor(


### PR DESCRIPTION
## Description
Closes #536. Slices down the length of call arguments inside proposals if they get too large.

## Motivation and Context
We want to display arguments to proposals in their titles, but we don't want "setCode" e.g. calls to take up a huge amount of horizontal space.

## How has this been tested?
Ran the code, checked the proposal titles.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no