### PR TITLE
Fix refresh bug on comment deletion

### DIFF
--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -265,7 +265,7 @@ export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | Of
           isThread ? 'Delete this entire thread?' : 'Delete this comment?'
         )();
         if (!confirmed) return;
-        (isThread ? app.threads : app.comments).delete(item).then((r) => {
+        (isThread ? app.threads : app.comments).delete(item).then(() => {
           if (isThread) m.route.set(`/${app.activeId()}/`);
           refresh();
           m.redraw();

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -251,9 +251,9 @@ export const ProposalBodyDelete: m.Component<{ item: OffchainThread | OffchainCo
   }
 };
 
-export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | OffchainComment<any> }> = {
+export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | OffchainComment<any>, refresh?: Function, }> = {
   view: (vnode) => {
-    const { item } = vnode.attrs;
+    const { item, refresh } = vnode.attrs;
     if (!item) return;
     const isThread = item instanceof OffchainThread;
 
@@ -265,8 +265,9 @@ export const ProposalBodyDeleteMenuItem: m.Component<{ item: OffchainThread | Of
           isThread ? 'Delete this entire thread?' : 'Delete this comment?'
         )();
         if (!confirmed) return;
-        (isThread ? app.threads : app.comments).delete(item).then(() => {
+        (isThread ? app.threads : app.comments).delete(item).then((r) => {
           if (isThread) m.route.set(`/${app.activeId()}/`);
+          refresh();
           m.redraw();
           // TODO: set notification bar for 'thread deleted/comment deleted'
         });

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -256,7 +256,7 @@ const ProposalComment: m.Component<IProposalCommentAttrs, IProposalCommentState>
                 m(ProposalBodyEditMenuItem, {
                   item: comment, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state,
                 }),
-                m(ProposalBodyDeleteMenuItem, { item: comment }),
+                m(ProposalBodyDeleteMenuItem, { item: comment, refresh: () => callback(), }),
                 // parentType === CommentParent.Proposal // For now, we are limiting threading to 1 level deep
                 // && m(ProposalBodyReplyMenuItem, {
                 //   item: comment,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bug: Deleting a comment was not refreshing in the client.
Fix: Refresh callback.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Clicking through the ui, making a comment, and deleting it. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no