### PR TITLE
Move initial Substrate API connect to modal.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -216,11 +216,7 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<void> 
   app.chain.deferred = deferred;
 
   // Load server data without initializing modules/chain connection.
-  // Also, load basic API data immediately (connected/disconnected, etc)
-  await Promise.all([
-    app.chain.initServer(),
-    app.chain.initApi(),
-  ]);
+  await app.chain.initServer();
 
   // Instantiate active addresses before chain fully loads
   updateActiveAddresses(n.chain);
@@ -244,6 +240,9 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<void> 
 // and not already initialized.
 export async function initChain(): Promise<void> {
   if (!app.chain || !app.chain.meta || app.chain.loaded) return;
+  if (!app.chain.apiInitialized) {
+    await app.chain.initApi();
+  }
   app.chain.deferred = false;
   const n = app.chain.meta;
   await app.chain.initData();

--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -48,6 +48,7 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   }
 
   public async initApi() {
+    if (this.apiInitialized) return;
     await this.chain.resetApi(this.meta);
     await this.chain.initMetadata();
     await this.accounts.init(this.chain);

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -466,11 +466,17 @@ const LinkNewAddressModal = {
             m('button.account-adder', {
               type: 'submit',
               class: (app.chain as Substrate || app.chain as Ethereum).webWallet.available ? '' : 'disabled',
-              oncreate: (e) => {
-                (app.chain as Substrate || app.chain as Ethereum).webWallet.enable().then(() => m.redraw());
+              oncreate: async (e) => {
+                // initialize API if needed before starting webwallet
+                await app.chain.initApi();
+                await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
+                m.redraw();
               },
-              onclick: (e) => {
-                (app.chain as Substrate || app.chain as Ethereum).webWallet.enable().then(() => m.redraw());
+              onclick: async (e) => {
+                // initialize API if needed before starting webwallet
+                await app.chain.initApi();
+                await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
+                m.redraw();
               }
             }, [
               (app.chain as Substrate || app.chain as Ethereum).webWallet.available


### PR DESCRIPTION
## Description
Fixes #540. Previously we initialized the Substrate API immediately, but did not load any data. The reason for this was to enable the link_new_address_modal to have an API connection in order to connect to the wallet.

This change shifts API init to just before the wallet enable, which should reduce discussion page loading time.

## How has this been tested?
Ran it and attempted the link new address flow with wallet, seemed to work.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no