### PR TITLE
Add redraw after account switch in login selector.

### DIFF
--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -169,7 +169,12 @@ const LoginSelector : m.Component<{}, { showAddressSelectionHint: boolean }> = {
               align: 'left',
               basic: true,
               onclick: (e) => {
-                setActiveAccount(account);
+                const currentActive = app.user.activeAccount;
+                setActiveAccount(account).then(() => {
+                  if (!isSameAccount(currentActive, app.user.activeAccount)) {
+                    m.redraw();
+                  }
+                });
               },
               label: m(UserBlock, {
                 user: account,


### PR DESCRIPTION
## Description
Fixes #539 by adding necessary redraw after activeAccount update.

## How has this been tested?
Reproduced bug, made change, ensured I could not reproduce.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no