### PR TITLE
Pinned Threads

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -178,6 +178,28 @@ class ThreadsController {
     });
   }
 
+  public async pin(args: {proposal: OffchainThread, }) {
+    return $.ajax({
+      url: `${app.serverUrl()}/pinThread`,
+      type: 'POST',
+      data: {
+        'jwt': app.user.jwt,
+        'thread_id': args.proposal.id,
+      },
+      success: (response) => {
+        const result = modelFromServer(response.result);
+        if (this._store.getByIdentifier(result.id)) {
+          this._store.remove(this._store.getByIdentifier(result.id));
+        }
+        this._store.add(result);
+        return result;
+      },
+      error: (err) => {
+        console.error(err);
+      }
+    });
+  }
+
   public refreshAll(chainId: string, communityId: string, reset = false) {
     // TODO: Change to GET /threads
     return $.get(`${app.serverUrl()}/bulkThreads`, {

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -173,6 +173,7 @@ class ThreadsController {
         return result;
       },
       error: (err) => {
+        notifyError('Could not update thread privacy');
         console.error(err);
       },
     });
@@ -195,6 +196,7 @@ class ThreadsController {
         return result;
       },
       error: (err) => {
+        notifyError('Could not update pinned state');
         console.error(err);
       }
     });

--- a/client/scripts/views/components/listing_row.ts
+++ b/client/scripts/views/components/listing_row.ts
@@ -5,11 +5,12 @@ import Chart from 'chart.js';
 import moment from 'moment-twitter';
 
 import app from 'state';
-import { Grid, Col } from 'construct-ui';
+import { Grid, Col, Icon, Icons } from 'construct-ui';
 
 interface IContentLeft {
   header: Vnode | Vnode[];
   subheader: Vnode | Vnode[];
+  pinned?: boolean;
 }
 
 const ListingRow: m.Component<{
@@ -28,6 +29,10 @@ const ListingRow: m.Component<{
     if (vnode.attrs.class) attrs['class'] = vnode.attrs.class;
     const initialOffset = 12 - rightColSpacing.reduce((t, n) => t + n);
     return m('.ListingRow', attrs, [
+      contentLeft.pinned && m(Icon, {
+        name: Icons.PAPERCLIP,
+        class: 'pinned',
+      }),
       m('.row-left', [
         m('.row-header', contentLeft.header),
         m('.row-subheader', contentLeft.subheader),

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -47,6 +47,8 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       ])
       : link('a', discussionLink, proposal.title);
 
+    const pinned = proposal.pinned;
+
     const rowSubheader = [
       proposal.readOnly && m('.discussion-locked', [
         m(Tag, {
@@ -102,6 +104,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       contentLeft: {
         header: rowHeader,
         subheader: rowSubheader,
+        pinned,
       },
       key: proposal.id,
       contentRight: rowMetadata,

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -109,7 +109,6 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
             class: 'pin-thread-toggle',
             onclick: (e) => {
               e.preventDefault();
-              console.log('hi zak');
               app.threads.pin({ proposal }).then(() => m.redraw());
             },
             label: proposal.pinned ? 'Unpin thread' : 'Pin thread',

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -6,7 +6,7 @@ import app from 'state';
 import { NotificationCategories } from 'types';
 import { OffchainThread, OffchainTopic } from 'models';
 import TopicEditor from 'views/components/topic_editor';
-import { MenuItem, PopoverMenu, Icon, Icons } from 'construct-ui';
+import { MenuItem, PopoverMenu, Icon, Icons, MenuDivider } from 'construct-ui';
 import { confirmationModalWithText } from '../../modals/confirm_modal';
 
 export const ThreadSubscriptionButton: m.Component<{ proposal: OffchainThread }> = {
@@ -114,8 +114,6 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
             },
             label: proposal.pinned ? 'Unpin thread' : 'Pin thread',
           }),
-          isAuthor && m(TopicEditorButton, { openTopicEditor: () => { vnode.state.topicEditorIsOpen = true; } }),
-          (isAuthor || hasAdminPermissions) && m(ThreadDeletionButton, { proposal }),
           hasAdminPermissions && m(MenuItem, {
             class: 'read-only-toggle',
             onclick: (e) => {
@@ -128,6 +126,9 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
             },
             label: proposal.readOnly ? 'Unlock thread' : 'Lock thread',
           }),
+          isAuthor && m(TopicEditorButton, { openTopicEditor: () => { vnode.state.topicEditorIsOpen = true; } }),
+          (isAuthor || hasAdminPermissions) && m(ThreadDeletionButton, { proposal }),
+          (isAuthor || hasAdminPermissions) && m(MenuDivider),
           m(ThreadSubscriptionButton, { proposal }),
         ],
         inline: true,

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -103,6 +103,15 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
         closeOnContentClick: true,
         menuAttrs: {},
         content: [
+          canEditThread && m(MenuItem, {
+            class: 'pin-thread-toggle',
+            onclick: (e) => {
+              e.preventDefault();
+              console.log('hi zak');
+              app.threads.pin({ proposal }).then(() => m.redraw());
+            },
+            label: proposal.pinned ? 'Unpin thread' : 'Pin thread',
+          }),
           canEditThread && m(TopicEditorButton, { openTopicEditor: () => { vnode.state.topicEditorIsOpen = true; } }),
           canEditThread && m(ThreadDeletionButton, { proposal }),
           canEditThread && m(MenuItem, {

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -77,18 +77,20 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
     if (!app.isLoggedIn()) return;
     const { proposal } = vnode.attrs;
 
-    const canEditThread = app.user.activeAccount
-      && (app.user.isRoleOfCommunity({
-        role: 'admin',
-        chain: app.activeChainId(),
-        community: app.activeCommunityId()
-      })
-      || app.user.isRoleOfCommunity({
-        role: 'moderator',
-        chain: app.activeChainId(),
-        community: app.activeCommunityId()
-      })
-      || proposal.author === app.user.activeAccount.address);
+    const hasAdminPermissions = app.user.activeAccount
+    && (app.user.isRoleOfCommunity({
+      role: 'admin',
+      chain: app.activeChainId(),
+      community: app.activeCommunityId()
+    })
+    || app.user.isRoleOfCommunity({
+      role: 'moderator',
+      chain: app.activeChainId(),
+      community: app.activeCommunityId()
+    }));
+
+    const isAuthor = app.user.activeAccount
+      && (proposal.author === app.user.activeAccount.address);
 
     return m('.DiscussionRowMenu', {
       onclick: (e) => {
@@ -103,7 +105,7 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
         closeOnContentClick: true,
         menuAttrs: {},
         content: [
-          canEditThread && m(MenuItem, {
+          hasAdminPermissions && m(MenuItem, {
             class: 'pin-thread-toggle',
             onclick: (e) => {
               e.preventDefault();
@@ -112,9 +114,9 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
             },
             label: proposal.pinned ? 'Unpin thread' : 'Pin thread',
           }),
-          canEditThread && m(TopicEditorButton, { openTopicEditor: () => { vnode.state.topicEditorIsOpen = true; } }),
-          canEditThread && m(ThreadDeletionButton, { proposal }),
-          canEditThread && m(MenuItem, {
+          isAuthor && m(TopicEditorButton, { openTopicEditor: () => { vnode.state.topicEditorIsOpen = true; } }),
+          (isAuthor || hasAdminPermissions) && m(ThreadDeletionButton, { proposal }),
+          hasAdminPermissions && m(MenuItem, {
             class: 'read-only-toggle',
             onclick: (e) => {
               e.preventDefault();

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -21,6 +21,7 @@ import DiscussionRow from 'views/pages/discussions/discussion_row';
 
 import WeeklyDiscussionListing, { getLastUpdate } from './weekly_listing';
 import Listing from '../listing';
+import PinnedListing from './pinned_listing';
 
 interface IDiscussionPageState {
   lookback?: number;
@@ -186,6 +187,8 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       const getRecentPostsSortedByWeek = () => {
         const arr = [];
         let count = 0;
+        const pinnedThreads = allProposals.filter((t) => t.pinned);
+        arr.push(m(PinnedListing, { proposals: pinnedThreads }));
         weekIndexes.sort((a, b) => Number(a) - Number(b)).forEach((msecAgo) => {
           let proposals;
           if (allProposals.length < vnode.state.lookback) {

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -88,6 +88,13 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       return tsB - tsA;
     };
 
+    const orderByDateReverseChronological = (a, b) => {
+      // tslint:disable-next-line
+      const tsB = Math.max(+b.createdAt);
+      const tsA = Math.max(+a.createdAt);
+      return tsA - tsB;
+    };
+
     const getSingleTopicListing = (topic_) => {
       if (!activeEntity || !activeEntity.serverLoaded) {
         return m('.discussions-main', [
@@ -103,8 +110,13 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       let list = [];
       const divider = m('.LastSeenDivider', [ m('hr'), m('span', 'Last Visited'), m('hr') ]);
       const sortedThreads = app.threads.getType(OffchainThreadKind.Forum, OffchainThreadKind.Link)
-        .filter((thread) => thread.topic && thread.topic.name === topic_)
+        .filter((thread) => thread.topic && thread.topic.name === topic_ && !thread.pinned)
         .sort(orderDiscussionsbyLastComment);
+
+      const pinnedThreads = app.threads.getType(OffchainThreadKind.Forum, OffchainThreadKind.Link)
+        .filter((thread) => thread.topic && thread.topic.name === topic_ && thread.pinned)
+        .sort(orderByDateReverseChronological);
+      list.push(m(PinnedListing, { proposals: pinnedThreads }));
 
       if (sortedThreads.length > 0) {
         const firstThread = sortedThreads[0];

--- a/client/scripts/views/pages/discussions/pinned_listing.ts
+++ b/client/scripts/views/pages/discussions/pinned_listing.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-unused-expressions */
+
+import _ from 'lodash';
+import m from 'mithril';
+
+import app from 'state';
+import DiscussionRow from 'views/pages/discussions/discussion_row';
+
+interface IPinnedListingAttrs {
+  proposals: any;
+}
+
+interface IPinnedListingState {
+  expanded: boolean;
+  visitMarkerPlaced: boolean ;
+}
+
+export const getLastUpdate = (proposal) => {
+  const lastComment = Number(app.comments.lastCommented(proposal));
+  const createdAt = Number(proposal.createdAt.utc());
+  const lastUpdate = Math.max(createdAt, lastComment);
+  return lastUpdate;
+};
+
+const PinnedListing: m.Component<IPinnedListingAttrs, IPinnedListingState> = {
+  view: (vnode) => {
+    vnode.state.visitMarkerPlaced = false;
+    // comparators
+    const orderDiscussionsbyDate = (a, b) => {
+      // tslint:disable-next-line
+      const tsB = Math.max(+b.createdAt);
+      const tsA = Math.max(+a.createdAt);
+      return tsA - tsB;
+    };
+
+    const proposals = vnode.attrs.proposals.sort(orderDiscussionsbyDate);
+
+    const threadGroup = '.pinned-group.discussion-group-wrap';
+
+    if (proposals.length === 0) {
+      return;
+    }
+    return m('.WeeklyDiscussionListing', [
+      m(threadGroup, proposals.map((proposal) => {
+        return m(DiscussionRow, { proposal });
+      }))
+    ]);
+  },
+};
+
+export default PinnedListing;

--- a/client/scripts/views/pages/discussions/weekly_listing.ts
+++ b/client/scripts/views/pages/discussions/weekly_listing.ts
@@ -39,7 +39,7 @@ const WeeklyDiscussionListing: m.Component<IWeeklyDiscussionListingAttrs, IWeekl
       return tsB - tsA;
     };
 
-    const proposals = vnode.attrs.proposals.sort(orderDiscussionsbyLastComment);
+    const proposals = vnode.attrs.proposals.sort(orderDiscussionsbyLastComment).filter((p) => !p.pinned);
     const firstProposal = proposals[0];
     const lastProposal = proposals[proposals.length - 1];
     const isEntireWeekSeen = () => getLastUpdate(firstProposal) < lastVisited;

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -2,6 +2,10 @@
 
 .ListingRow {
     @include listing-row-base;
+
+    .pinned {
+        margin: 13px 13px 0 0;
+    }
     .row-left {
         line-height: 1.1;
         flex: $listing-left-flex;

--- a/server/router.ts
+++ b/server/router.ts
@@ -90,6 +90,7 @@ import editTopic from './routes/editTopic';
 import deleteTopic from './routes/deleteTopic';
 import bulkTopics from './routes/bulkTopics';
 import setPrivacy from './routes/setPrivacy';
+import pinThread from './routes/pinThread';
 
 import edgewareLockdropLookup from './routes/getEdgewareLockdropLookup';
 import edgewareLockdropStats from './routes/getEdgewareLockdropStats';
@@ -150,7 +151,7 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   router.get('/profile', getProfile.bind(this, models));
 
   router.post('/setPrivacy', passport.authenticate('jwt', { session: false }), setPrivacy.bind(this, models));
-
+  router.post('/pinThread', passport.authenticate('jwt', { session: false }), pinThread.bind(this, models));
 
   // offchain discussion drafts
   router.post('/drafts', passport.authenticate('jwt', { session: false }), createDraft.bind(this, models));

--- a/server/routes/pinThread.ts
+++ b/server/routes/pinThread.ts
@@ -1,0 +1,55 @@
+import { Request, Response, NextFunction } from 'express';
+import { Op } from 'sequelize';
+
+import { factory, formatFilename } from '../../shared/logging';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+export const Errors = {
+  MustBeAdmin: 'Must be admin or mod',
+  NeedThread: 'Must provide thread',
+};
+
+const pinThread = async (models, req: Request, res: Response, next: NextFunction) => {
+  const { thread_id } = req.body;
+  if (!thread_id) return next(new Error(Errors.NeedThread));
+
+  try {
+    const thread = await models.OffchainThread.findOne({
+      where: {
+        id: thread_id,
+      },
+    });
+    const user = await models.User.findOne({
+      where: {
+        id: req.user.id,
+      },
+    });
+    const userAddressIds = await user.getAddresses().map((a) => a.id);
+    const roles = await models.Role.findAll({
+      where: {
+        address_id: { [Op.in]: userAddressIds, },
+        permission: { [Op.in]: ['admin', 'moderator'], },
+      },
+    });
+
+    const adminRoles = roles.filter((r) => ['admin', 'moderator'].includes(r.permission));
+    const roleCommunities = adminRoles.map((r) => r.offchain_community_id || r.chain_id);
+    const isAdminOfCommunity = roleCommunities.includes(thread.community);
+    const isAdminOfChain = roleCommunities.includes(thread.chain);
+    if (!isAdminOfCommunity && !isAdminOfChain) return next(new Error(Errors.MustBeAdmin));
+
+    await thread.update({ pinned: !thread.pinned });
+
+    const finalThread = await models.OffchainThread.findOne({
+      where: { id: thread.id, },
+      include: [ models.Address, models.OffchainAttachment, { model: models.OffchainTopic, as: 'topic' } ],
+    });
+
+    return res.json({ status: 'Success', result: finalThread.toJSON() });
+  } catch (e) {
+    return next(new Error(e));
+  }
+};
+
+export default pinThread;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #489. 
- [x] Add a menu item for pinning or unpinning threads. Menu item should read "Pin thread" or "Unpin thread"
- [x] Add a divider to the discussion row menu to differentiate admin/author actions from general actions. 
- [x] When a thread is pinned, we should show a pinned icon on the left of the DiscussionRow. No change to the view_proposal page is necessary (I implemented a paperclip icon)
- [x] Pinning a thread makes it appear at the top of the community homepage, as well as at the top of the tag it is pinned to
- [x] Pinned threads should be ordered by the date they were created, with oldest threads first
- [x] Only admins and mods should be able to pin threads

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow admins to organize threads! 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Clicked around the UI, new pins pop up into the pinned group, unpinned threads drop down to their ordered spot.
`yarn test-api` passes tests for `/pinThread`.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, 96.43%
