### PR TITLE
Persist scroll position when returning to discussions listing via back button

### DIFF
--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -96,7 +96,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       rightColSpacing: app.isLoggedIn() ?  [4, 4, 3, 1] : [4, 4, 4],
       onclick: (e) => {
         e.preventDefault();
-        localStorage.discussionsListingScrollY = window.scrollY;
+        localStorage[`${app.activeId()}-scrollY`] = window.scrollY;
         m.route.set(discussionLink);
       },
     });

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -95,8 +95,8 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       contentRight: rowMetadata,
       rightColSpacing: app.isLoggedIn() ?  [4, 4, 3, 1] : [4, 4, 4],
       onclick: (e) => {
-        debugger
         e.preventDefault();
+        localStorage.discussionsListingScrollY = window.scrollY;
         m.route.set(discussionLink);
       },
     });

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -95,6 +95,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       contentRight: rowMetadata,
       rightColSpacing: app.isLoggedIn() ?  [4, 4, 3, 1] : [4, 4, 4],
       onclick: (e) => {
+        debugger
         e.preventDefault();
         m.route.set(discussionLink);
       },

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -44,6 +44,14 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       if (scrollPos > (scrollHeight - 400)) {
         if (vnode.state.hasOlderPosts && !vnode.state.postsDepleted) {
           vnode.state.lookback += vnode.state.defaultLookback;
+          // const x = m.route.get();
+          // const y = m.route.param('topic');
+          // // debugger
+          // const params = m.route.param('topic')
+          //   ? { topic: m.route.param('topic'), lookback: vnode.state.lookback }
+          //   : { lookback: vnode.state.lookback };
+          localStorage.discussionsLookback = vnode.state.lookback;
+          // m.route.set(`${m.route.get()}`,  { replace: true, state: params });
           m.redraw();
         }
       }
@@ -51,6 +59,9 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     $(window).on('scroll', onscroll);
   },
   view: (vnode) => {
+    // if (localStorage.discussionsLookback) {
+    //   window.scrollTo(0, localStorage.scrollY);
+    // }
     const { topic } = vnode.attrs;
     const activeEntity = app.community ? app.community : app.chain;
     // add chain compatibility (node info?)
@@ -194,10 +205,12 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       // determine lookback length
       vnode.state.defaultLookback = 20;
       const { defaultLookback } = vnode.state;
-      vnode.state.lookback = (!vnode.state.lookback || isNaN(vnode.state.lookback))
-        ? defaultLookback
-        : vnode.state.lookback;
-
+      vnode.state.lookback = localStorage.discussionsLookback
+        ? Number(localStorage.discussionsLookback)
+        : Number.isInteger(vnode.state.lookback)
+          ? vnode.state.lookback
+          : defaultLookback;
+      console.log(vnode.state.lookback);
       let isFirstWeek = true;
 
       // render proposals by week

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -52,6 +52,22 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     $(window).on('scroll', onscroll);
   },
   view: (vnode) => {
+    // determine lookback length
+    vnode.state.defaultLookback = 20;
+
+    const returningFromThread = (app.lastNavigatedBack() && app.lastNavigatedFrom().includes('/proposal/discussion/'));
+    vnode.state.lookback = (returningFromThread && localStorage.discussionsLookback)
+      ? Number(localStorage.discussionsLookback)
+      : Number.isInteger(vnode.state.lookback)
+        ? vnode.state.lookback
+        : vnode.state.defaultLookback;
+
+    if (returningFromThread && localStorage.discussionsListingScrollY) {
+      setTimeout(() => {
+        window.scrollTo(0, Number(localStorage.discussionsListingScrollY));
+      }, 1);
+    }
+
     const { topic } = vnode.attrs;
     const activeEntity = app.community ? app.community : app.chain;
     // add chain compatibility (node info?)
@@ -192,19 +208,6 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
         .filter((idx) => Number(idx) < lastVisitedAgo)
         .map((str) => Number(str)));
 
-      // determine lookback length
-      vnode.state.defaultLookback = 20;
-
-      // TODO: add check app.lastNavigatedBack module checks
-      // vnode.state.lookback = (backButton
-      //  && lastPage.includes('/proposal/discussion/'
-      //  && localStorage.discussionsLookback)
-      vnode.state.lookback = localStorage.discussionsLookback
-        ? Number(localStorage.discussionsLookback)
-        : Number.isInteger(vnode.state.lookback)
-          ? vnode.state.lookback
-          : vnode.state.defaultLookback;
-      console.log(vnode.state.lookback);
       let isFirstWeek = true;
 
       // render proposals by week

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -10,7 +10,7 @@ import { Spinner } from 'construct-ui';
 
 import app from 'state';
 import { pluralize } from 'helpers';
-import { OffchainThreadKind, NodeInfo, CommunityInfo, AddressInfo } from 'models';
+import { OffchainThreadKind, NodeInfo, CommunityInfo } from 'models';
 
 import { updateLastVisited } from 'controllers/app/login';
 import Sublayout from 'views/sublayout';
@@ -44,14 +44,7 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       if (scrollPos > (scrollHeight - 400)) {
         if (vnode.state.hasOlderPosts && !vnode.state.postsDepleted) {
           vnode.state.lookback += vnode.state.defaultLookback;
-          // const x = m.route.get();
-          // const y = m.route.param('topic');
-          // // debugger
-          // const params = m.route.param('topic')
-          //   ? { topic: m.route.param('topic'), lookback: vnode.state.lookback }
-          //   : { lookback: vnode.state.lookback };
           localStorage.discussionsLookback = vnode.state.lookback;
-          // m.route.set(`${m.route.get()}`,  { replace: true, state: params });
           m.redraw();
         }
       }
@@ -59,9 +52,6 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     $(window).on('scroll', onscroll);
   },
   view: (vnode) => {
-    // if (localStorage.discussionsLookback) {
-    //   window.scrollTo(0, localStorage.scrollY);
-    // }
     const { topic } = vnode.attrs;
     const activeEntity = app.community ? app.community : app.chain;
     // add chain compatibility (node info?)
@@ -204,12 +194,16 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
 
       // determine lookback length
       vnode.state.defaultLookback = 20;
-      const { defaultLookback } = vnode.state;
+
+      // TODO: add check app.lastNavigatedBack module checks
+      // vnode.state.lookback = (backButton
+      //  && lastPage.includes('/proposal/discussion/'
+      //  && localStorage.discussionsLookback)
       vnode.state.lookback = localStorage.discussionsLookback
         ? Number(localStorage.discussionsLookback)
         : Number.isInteger(vnode.state.lookback)
           ? vnode.state.lookback
-          : defaultLookback;
+          : vnode.state.defaultLookback;
       console.log(vnode.state.lookback);
       let isFirstWeek = true;
 

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -44,7 +44,7 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       if (scrollPos > (scrollHeight - 400)) {
         if (vnode.state.hasOlderPosts && !vnode.state.postsDepleted) {
           vnode.state.lookback += vnode.state.defaultLookback;
-          localStorage.discussionsLookback = vnode.state.lookback;
+          localStorage[`${app.activeId()}-lookback`] = vnode.state.lookback;
           m.redraw();
         }
       }
@@ -56,15 +56,15 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     vnode.state.defaultLookback = 20;
 
     const returningFromThread = (app.lastNavigatedBack() && app.lastNavigatedFrom().includes('/proposal/discussion/'));
-    vnode.state.lookback = (returningFromThread && localStorage.discussionsLookback)
-      ? Number(localStorage.discussionsLookback)
+    vnode.state.lookback = (returningFromThread && localStorage[`${app.activeId()}-lookback`])
+      ? Number(localStorage[`${app.activeId()}-lookback`])
       : Number.isInteger(vnode.state.lookback)
         ? vnode.state.lookback
         : vnode.state.defaultLookback;
 
-    if (returningFromThread && localStorage.discussionsListingScrollY) {
+    if (returningFromThread && localStorage[`${app.activeId()}-scrollY`]) {
       setTimeout(() => {
-        window.scrollTo(0, Number(localStorage.discussionsListingScrollY));
+        window.scrollTo(0, Number(localStorage[`${app.activeId()}-scrollY`]));
       }, 1);
     }
 

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -44,7 +44,6 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       if (scrollPos > (scrollHeight - 400)) {
         if (vnode.state.hasOlderPosts && !vnode.state.postsDepleted) {
           vnode.state.lookback += vnode.state.defaultLookback;
-          localStorage[`${app.activeId()}-lookback`] = vnode.state.lookback;
           m.redraw();
         }
       }
@@ -52,6 +51,8 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     $(window).on('scroll', onscroll);
   },
   view: (vnode) => {
+    if (!app.activeId()) return;
+
     // determine lookback length
     vnode.state.defaultLookback = 20;
 
@@ -61,6 +62,8 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       : Number.isInteger(vnode.state.lookback)
         ? vnode.state.lookback
         : vnode.state.defaultLookback;
+
+    localStorage[`${app.activeId()}-lookback`] = vnode.state.lookback;
 
     if (returningFromThread && localStorage[`${app.activeId()}-scrollY`]) {
       setTimeout(() => {


### PR DESCRIPTION
Closes #546.

## Description

Previously, when users returned to the main discussion listing, after clicking on a discussion row and viewing an individual thread, they would be bounced back to the top of the page, with only the first page of posts rendered.

This branch ensures that when a thread is clicked, the current scroll position and lookback count (# of posts, i.e. "pages") of the discussion listing. When the user navigates back to the discussion listing, via the back button, their exact position in the listing is returned to.

## How has this been tested?

I have tested various combinations of navigating around and between pages, on both on-chain and offchain communities. This QAing led me to community-scope the localstorage keys used for saving scroll positions, as well as ensuring that the initial lookback count is saved (and not merely the updated lookback when the next page of posts is triggered via infinite scroll).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no