### PR TITLE
Bump sendgrid version + Edit copy on New Thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@polkadot/util": "^2.18.0",
     "@polkadot/util-crypto": "^2.18.0",
     "@popperjs/core": "^2.0.6",
-    "@sendgrid/mail": "^6.3.1",
+    "@sendgrid/mail": "^6.5.0",
     "@tendermint/amino-js": "npm:@tendermint/amino-js@0.5.1",
     "@typechain/ethers-v4": "^1.0.0",
     "@types/bn.js": "^4.11.6",

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -13,7 +13,7 @@ sgMail.setApiKey(SENDGRID_API_KEY);
 
 export const sendImmediateNotificationEmail = async (subscription, emailObject) => {
   const user = await subscription.getUser();
-  emailObject.to = (process.env.NODE_ENV === 'development') ? user.email : user.email;
+  emailObject.to = (process.env.NODE_ENV === 'development') ? 'test@commonwealth.im' : user.email;
 
   try {
     await sgMail.send(emailObject);

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -13,7 +13,7 @@ sgMail.setApiKey(SENDGRID_API_KEY);
 
 export const sendImmediateNotificationEmail = async (subscription, emailObject) => {
   const user = await subscription.getUser();
-  emailObject.to = (process.env.NODE_ENV === 'development') ? 'test@commonwealth.im' : user.email;
+  emailObject.to = (process.env.NODE_ENV === 'development') ? user.email : user.email;
 
   try {
     await sgMail.send(emailObject);
@@ -29,7 +29,7 @@ export const createNotificationEmailObject = (notification_data: IPostNotificati
   const subjectLine = (category_id === NotificationCategories.NewComment) ? `New comment on '${decodedTitle}'`
     : (category_id === NotificationCategories.NewMention) ? `New mention on '${decodedTitle}'`
       : (category_id === NotificationCategories.NewReaction) ? `New reaction on '${decodedTitle}'`
-        : (category_id === NotificationCategories.NewThread) ? `New Thread in '${decodedTitle}'`
+        : (category_id === NotificationCategories.NewThread) ? `New thread called '${decodedTitle}'`
           : (category_id === NotificationCategories.ThreadEdit) ? `'${decodedTitle}' edited`
             : 'New notification on Commonwealth';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,7 +1245,7 @@
     chalk "^2.0.1"
     deepmerge "^4.2.2"
 
-"@sendgrid/mail@^6.3.1":
+"@sendgrid/mail@^6.5.0":
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-6.5.5.tgz#45bef4e4878144304b6688867baa13179deecc4b"
   integrity sha512-DSu8oTPI0BJFH60jMOG9gM+oeNMoRALFmdAYg2PIXpL+Zbxd7L2GzQZtmf1jLy/8UBImkbB3D74TjiOBiLRK1w==


### PR DESCRIPTION
Two small changes.

1. Bumping the version of sendgrid from 6.3.1 to 6.5.0
2. Updating the copy from 'New Thread on {{post_title}}' to 'New thread called {{post_title}}'.

The latter change has been made because the word **on** implies that the thread was created on _a community_. Making Thread lowercase also brings this in line with other the copy for other notifications (comments, mentions and more)

This is confusing in notification emails. For example. 

New Thread on 'Solving Problems` vs New thread called 'Solving Problems". 
