### PR TITLE
Added Migration for new session event enriched in chain-events-#11

### DIFF
--- a/server/migrations/20200821080425-add-new-session-event.js
+++ b/server/migrations/20200821080425-add-new-session-event.js
@@ -1,0 +1,39 @@
+const SequelizeLib = require('sequelize');
+const Op = SequelizeLib.Op;
+
+const SubstrateEventKinds = {
+  NewSession: 'new-session'
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      const buildObject = (event_name, chain) => ({
+        id: `${chain}-${event_name}`,
+        chain,
+        event_name
+      });
+      const kusamaObjs = Object.values(SubstrateEventKinds).map((s) => buildObject(s, 'kusama'));
+      const edgewareObjs = Object.values(SubstrateEventKinds).map((s) => buildObject(s, 'edgeware'));
+      const objs = kusamaObjs.concat(edgewareObjs);
+
+      return queryInterface.bulkInsert(
+        'ChainEventTypes',
+        [
+          ...objs,
+        ],
+        { transaction: t }
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkDelete('ChainEventTypes', {
+        '$or' : [{
+          event_name: SubstrateEventKinds.NewSession
+        }]
+      }, { transaction: t });
+    });
+  }
+};

--- a/server/migrations/20200821080425-add-new-session-event.js
+++ b/server/migrations/20200821080425-add-new-session-event.js
@@ -1,9 +1,7 @@
 const SequelizeLib = require('sequelize');
 const Op = SequelizeLib.Op;
 
-const SubstrateEventKinds = {
-  NewSession: 'new-session'
-};
+const EventsToAdd = ['new-session'];
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
@@ -13,8 +11,8 @@ module.exports = {
         chain,
         event_name
       });
-      const kusamaObjs = Object.values(SubstrateEventKinds).map((s) => buildObject(s, 'kusama'));
-      const edgewareObjs = Object.values(SubstrateEventKinds).map((s) => buildObject(s, 'edgeware'));
+      const kusamaObjs = EventsToAdd.map((s) => buildObject(s, 'kusama'));
+      const edgewareObjs = EventsToAdd.map((s) => buildObject(s, 'edgeware'));
       const objs = kusamaObjs.concat(edgewareObjs);
 
       return queryInterface.bulkInsert(
@@ -30,9 +28,7 @@ module.exports = {
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
       await queryInterface.bulkDelete('ChainEventTypes', {
-        '$or' : [{
-          event_name: SubstrateEventKinds.NewSession
-        }]
+        event_name: EventsToAdd[0] // new-session
       }, { transaction: t });
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Have Enriched new session event with validators, their exposure and eraIndex, to be able to add new event types in the database, this migration has been written.

## Motivation and Context
Enrich the session event with validators and their exposures. [#11](https://github.com/hicommonwealth/chain-events/issues/11)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no