### PR TITLE
Add CHAIN_EVENTS configuration variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Environment variables used for external services include:
 - JWT_SECRET
 - SESSION_SECRET
 
+We also use certain environment variables to configure the application itself:
+
+- CHAIN_EVENTS: select chains for event listening. Must be "all", "none", or a comma-separated list of chains (e.g. "edgeware,edgeware-local")
+- NO_EVENTS: disable chain-event functionality entirely
+- NO_CLIENT: set to true to disable the front-end build
+
 ## Migrations
 
 If you are making changes to the database models, you must also write

--- a/client/scripts/views/pages/subscriptions/chainEventSettings.ts
+++ b/client/scripts/views/pages/subscriptions/chainEventSettings.ts
@@ -4,7 +4,7 @@ import m from 'mithril';
 import _ from 'lodash';
 import { Checkbox, Table, SelectList, Icons, Button, ListItem } from 'construct-ui';
 import {
-  SubstrateEvents, SubstrateTypes, IChainEventKind, EventSupportingChains, TitlerFilter
+  SubstrateEvents, SubstrateTypes, IChainEventKind, TitlerFilter
 } from '@commonwealth/chain-events';
 import { ChainInfo, CommunityInfo, ChainNetwork } from 'models';
 import app from 'state';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.2.9",
+    "@commonwealth/chain-events": "0.2.10",
     "@edgeware/node-types": "2.4.1",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.0.11",

--- a/server.ts
+++ b/server.ts
@@ -52,6 +52,7 @@ const SKIP_EVENT_CATCHUP = process.env.SKIP_EVENT_CATCHUP === 'true';
 const ENTITY_MIGRATION = process.env.ENTITY_MIGRATION;
 const IDENTITY_MIGRATION = process.env.IDENTITY_MIGRATION;
 const NO_EVENTS = process.env.NO_EVENTS === 'true';
+const CHAIN_EVENTS = process.env.CHAIN_EVENTS;
 
 const rollbar = process.env.NODE_ENV === 'production' && new Rollbar({
   accessToken: ROLLBAR_SERVER_TOKEN,
@@ -195,7 +196,14 @@ async function main() {
 
       let exitCode = 0;
       try {
-        const subscribers = await setupChainEventListeners(models, wss, SKIP_EVENT_CATCHUP);
+        // configure chain list from events
+        let chains: string[] | 'all' | 'none' = [ 'edgeware' ];
+        if (CHAIN_EVENTS === 'none' || CHAIN_EVENTS === 'all') {
+          chains = CHAIN_EVENTS;
+        } else if (CHAIN_EVENTS) {
+          chains = CHAIN_EVENTS.split(',');
+        }
+        const subscribers = await setupChainEventListeners(models, wss, chains, SKIP_EVENT_CATCHUP);
 
         // construct storageFetchers needed for the identity cache
         const fetchers = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.9.tgz#ada46ba0c5ba4c322f73b2f6f5027a4d27f7e483"
-  integrity sha512-BQrMP+s+32vFI/wGSB5ubDcM/3TTyraJoxoucztP2Xq+S6Ey6Ndu9uXki1tQqmtoni64tId1faXulOPe1iAUQQ==
+"@commonwealth/chain-events@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.2.10.tgz#81048604c17eeb82a92170b6b1f499a4363d88b2"
+  integrity sha512-Y5uj8ZgudiD/kPVYAdnnrOv3E+rud0cX99PesWbzAnlgKMv3MKgVLcgvab7LG+B/+rtCdjuCVMl/Ci3FwThHcg==
   dependencies:
     "@edgeware/node-types" "2.4.1"
     "@polkadot/api" "1.24.1"


### PR DESCRIPTION
## Description
Adds a "CHAIN_EVENTS" environment variable, which can be "all", "none" or a comma-separated list of chains, that configures which chain event listeners are created at server startup. Defaults to "edgeware".

## Open Questions

* The current database dump from production only includes "ChainEventTypes" for edgeware and kusama. In order to test with edgeware-local, we will need ChainEventTypes for edgeware-local as well. How should we add these? A migration? Enforce server reset for local testing?
* The master branch of edgeware has been updated vs the production edgeware version. What additional work is needed for this upgrade?

## Motivation and Context
Allows more configuration of chain event listening, in order to avoid using too much memory when spawning polkadot-js API listeners.

## How has this been tested?
Ran with multiple argument combinations and verified expected behaviors.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no