### PR TITLE
Bug fix: Pinned threads are not showing in topic pages.

### DIFF
--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -125,7 +125,7 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     const allThreads = topic
       ? app.threads
         .getType(OffchainThreadKind.Forum, OffchainThreadKind.Link)
-        .filter((thread) => thread.topic && thread.topic.name === topic && !thread.pinned)
+        .filter((thread) => thread.topic && thread.topic.name === topic)
         .sort(orderDiscussionsbyLastComment)
       : app.threads
         .getType(OffchainThreadKind.Forum, OffchainThreadKind.Link)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pinned threads are not being shown in topic pages!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Disappearing threads are spooky 👻 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Pin some threads, go check their related topic page.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no