### PR TITLE
Edit Profile Modal populates with existing information

### DIFF
--- a/client/scripts/views/modals/edit_profile_modal.ts
+++ b/client/scripts/views/modals/edit_profile_modal.ts
@@ -10,7 +10,6 @@ import AvatarUpload from 'views/components/avatar_upload';
 const EditProfileModal = {
   view: (vnode) => {
     const { account } = vnode.attrs;
-    console.dir(account);
 
     return m('.EditProfileModal', [
       m('.compact-modal-title', [

--- a/client/scripts/views/modals/edit_profile_modal.ts
+++ b/client/scripts/views/modals/edit_profile_modal.ts
@@ -10,6 +10,7 @@ import AvatarUpload from 'views/components/avatar_upload';
 const EditProfileModal = {
   view: (vnode) => {
     const { account } = vnode.attrs;
+    console.dir(account);
 
     return m('.EditProfileModal', [
       m('.compact-modal-title', [
@@ -42,6 +43,7 @@ const EditProfileModal = {
         m('.text-input-wrapper', [
           m(Input, {
             name: 'name',
+            defaultValue: account.name,
             placeholder: 'Display name',
             fluid: true,
             autocomplete: 'off',
@@ -52,6 +54,7 @@ const EditProfileModal = {
           }),
           m(Input, {
             name: 'headline',
+            defaultValue: account.profile.headline,
             placeholder: 'Headline',
             fluid: true,
             autocomplete: 'off',
@@ -59,6 +62,7 @@ const EditProfileModal = {
           }),
           m(TextArea, {
             name: 'bio',
+            defaultValue: account.profile.bio,
             placeholder: 'Enter bio...',
             fluid: true,
             oncreate: (vvnode) => account.profile && $(vvnode.dom).val(account.profile.bio)

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -35,29 +35,41 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
 
     const pinned = proposal.pinned;
 
-    const rowSubheader = [
-      proposal.readOnly && m('.discussion-locked', [
-        m(Tag, {
-          size: 'xs',
-          label: [
-            m(Icon, { name: Icons.LOCK, size: 'xs' }),
-          ],
-        }),
-      ]),
-      proposal.topic && link('a.proposal-topic', `/${app.activeId()}/discussions/${proposal.topic.name}`, [
-        m('span.proposal-topic-icon'),
-        m('span.proposal-topic-name', `${proposal.topic.name}`),
-      ]),
-      (propType === OffchainThreadKind.Link && proposal.url) && m('.discussion-link', [
-        `Link: ${extractDomain(proposal.url)}`
-      ]),
-      m(User, {
-        user: new AddressInfo(null, proposal.author, proposal.authorChain, null),
-        linkify: true,
-        tooltip: true,
-        hideAvatar: true,
-      }),
-    ];
+    // const rowSubheader = [
+    //   proposal.readOnly && m('.discussion-locked', [
+    //     m(Tag, {
+    //       size: 'xs',
+    //       label: [
+    //         m(Icon, { name: Icons.LOCK, size: 'xs' }),
+    //       ],
+    //     }),
+    //   ]),
+    //   proposal.topic && link('a.proposal-topic', `/${app.activeId()}/discussions/${proposal.topic.name}`, [
+    //     m('span.proposal-topic-icon'),
+    //     m('span.proposal-topic-name', `${proposal.topic.name}`),
+    //   ]),
+    //   (propType === OffchainThreadKind.Link && proposal.url) && m('.discussion-link', [
+    //     `Link: ${extractDomain(proposal.url)}`
+    //   ]),
+    //   m(User, {
+    //     user: new AddressInfo(null, proposal.author, proposal.authorChain, null),
+    //     linkify: true,
+    //     tooltip: true,
+    //     hideAvatar: true,
+    //   }),
+    // ];
+
+    const rowSubheader = m('.proposal-topic-name', {
+      style: 'color: #999'
+    }, [
+      (() => {
+        try {
+          return JSON.parse(proposal.body).ops[0].insert.split('\n')[0];
+        } catch (e) {
+          return proposal?.body?.split('\n')[0];
+        }
+      })(),
+    ]);
 
     const rowMetadata = [
       m(UserGallery, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Edit Profile Modal previously only showed placeholder content when opened, not including previously existing information in the inputs. Now it does!
Closes #611.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Open 'Edit Profile Modal' via the "edit profile" button on the profile page with no previous information added, modal shows up empty with just placeholder values. Add name only, save. Open modal again, see default value as previously input value. (Refresh test). Add more information and rinse/repeat. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no