### PR TITLE
Bug Fix: Switch Profiles while on Profile Page, edit profile

### DIFF
--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -102,11 +102,14 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
   oninit: (vnode) => {
     vnode.state.account = null;
     vnode.state.loaded = false;
-    vnode.state.loading = true;
+    vnode.state.loading = false;
     vnode.state.threads = [];
     vnode.state.comments = [];
   },
   oncreate: async (vnode) => {
+    mixpanel.track('PageVisit', { 'Page Name': 'LoginPage' });
+  },
+  view: (vnode) => {
     const loadProfile = async () => {
       const chain = (m.route.param('base'))
         ? m.route.param('base')
@@ -156,15 +159,23 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
         }
       });
     };
-    mixpanel.track('PageVisit', { 'Page Name': 'LoginPage' });
-    loadProfile();
-  },
-  view: (vnode) => {
+
     const { account, loaded, loading } = vnode.state;
+    if (!loading && !loaded) {
+      loadProfile();
+      vnode.state.loading = true;
+    }
+    if (account && account.address !== vnode.attrs.address) {
+      vnode.state.loading = true;
+      vnode.state.loaded = false;
+      loadProfile();
+    }
     if (loading) return m(PageLoading);
     if (!account) {
       return m(PageNotFound, { message: 'Make sure the profile address is valid.' });
     }
+
+
     // TODO: search for cosmos proposals, if ChainClass is Cosmos
     // TODO: search for signaling proposals ->
     // Commented-out lines from previous version which included signaling proposals in proposals var:

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -175,7 +175,6 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       return m(PageNotFound, { message: 'Make sure the profile address is valid.' });
     }
 
-
     // TODO: search for cosmos proposals, if ChainClass is Cosmos
     // TODO: search for signaling proposals ->
     // Commented-out lines from previous version which included signaling proposals in proposals var:

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -170,9 +170,9 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       vnode.state.loaded = false;
       loadProfile();
     }
-    if (loading) return m(PageLoading);
+    if (loading || !loaded) return m(PageLoading);
     if (!account) {
-      return m(PageNotFound, { message: 'Make sure the profile address is valid.' });
+      return m(PageNotFound, { message: 'This address does not have a Commonwealth profile' });
     }
 
     // TODO: search for cosmos proposals, if ChainClass is Cosmos


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I refactored the `loadProfile()` function into the view so that it could be called when the address in the attributes (url) changes, retriggering a page load. I also added a check in view that calls `loadProfile()` when the address/account in the Profile Page state doesn't match the address in the url attributes.
Closes #610.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Link 2 Edgeware addresses
- Go to the profile page of one
- Use the login menu to switch to another
- Click "Edit Profile" in the login menu
- URL changes, ~but~ AND the profile displayed does ~not~ change

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no