### PR TITLE
Notify user of email update success with toast on link redirect

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -120,7 +120,7 @@ export function handleUpdateEmailConfirmation() {
       'Step': m.route.param('confirmation'),
     });
     if (m.route.param('confirmation') === 'success') {
-      notifySuccess('Updated email confirmed');
+      notifySuccess('Success! Email confirmed');
     }
   }
 }

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -113,6 +113,18 @@ export function handleInviteLinkRedirect() {
   }
 }
 
+export function handleUpdateEmailConfirmation() {
+  if (m.route.param('confirmation')) {
+    mixpanel.track('Update Email Verification Redirect', {
+      'Step No': 1,
+      'Step': m.route.param('confirmation'),
+    });
+    if (m.route.param('confirmation') === 'success') {
+      notifySuccess('Updated email confirmed');
+    }
+  }
+}
+
 export async function selectCommunity(c?: CommunityInfo): Promise<void> {
   // Check for valid community selection, and that we need to switch
   if (app.community && c === app.community.meta) return;
@@ -526,6 +538,9 @@ $(() => {
       }
 
       handleInviteLinkRedirect();
+
+      // If the user updates their email
+      handleUpdateEmailConfirmation();
 
       app.socket = new WebsocketController(wsUrl, jwt, null);
       if (app.loginState === LoginState.LoggedIn) {

--- a/client/scripts/views/modals/confirm_invite_modal.ts
+++ b/client/scripts/views/modals/confirm_invite_modal.ts
@@ -4,6 +4,7 @@ import m from 'mithril';
 import $ from 'jquery';
 import app from 'state';
 import mixpanel from 'mixpanel-browser';
+import { Button } from 'construct-ui';
 
 import { orderAccountsByAddress } from 'helpers';
 
@@ -86,13 +87,15 @@ const ConfirmInviteModal = {
             m('.community-block-bottom', `commonwealth.im/${invites[vnode.state.location].community_id}`)
           ]),
           vnode.state.accepted.includes(vnode.state.location) ? [
-            m('h4', 'You\'ve already accepted this invite!')
+            m('h4', 'You\'ve accepted this invite!')
           ] : [
             addresses.length > 0
               && m('p', 'Accept the invite with any of your addresses:'),
             addresses,
             addresses.length > 0
-              && m('button.formular-button-primary.submit', {
+              && m(Button, {
+                class: 'submit',
+                intent: 'primary',
                 disabled: vnode.state.accepted.includes(vnode.state.location) || !vnode.state.selectedAddress,
                 onclick: (e) => {
                   e.preventDefault();
@@ -114,12 +117,15 @@ const ConfirmInviteModal = {
                       console.error('Error accepting invite');
                     });
                   }
-                }
-              }, 'Accept invite'),
+                },
+                label: 'Accept invite',
+              }),
             addresses.length > 0
               && m('p', 'Or, reject the invite (you will need to be invited again to join the community):'),
             addresses.length > 0
-              && m('button.formular-button-negative.reject', {
+              && m(Button, {
+                class: 'reject',
+                intent: 'negative',
                 disabled: vnode.state.accepted.includes(vnode.state.location),
                 onclick: (e) => {
                   e.preventDefault();
@@ -140,8 +146,9 @@ const ConfirmInviteModal = {
                   }, (err) => {
                     console.error('Error accepting invite.');
                   });
-                }
-              }, 'Reject invite'),
+                },
+                label: 'Reject invite'
+              }),
             addresses.length === 0
               && m('.no-accounts', 'You must link a new address to join this community.'),
             addresses.length === 0

--- a/server/routes/updateEmail.ts
+++ b/server/routes/updateEmail.ts
@@ -60,9 +60,8 @@ const updateEmail = async (models, req: Request, res: Response, next: NextFuncti
   }
 
   // create and email the token
-  const path = '/';
-  const tokenObj = await models.LoginToken.createForEmail(email, path);
-  const loginLink = `${SERVER_URL}/api/finishLogin?token=${tokenObj.token}&email=${encodeURIComponent(email)}`;
+  const tokenObj = await models.LoginToken.createForEmail(email);
+  const loginLink = `${SERVER_URL}/api/finishLogin?token=${tokenObj.token}&email=${encodeURIComponent(email)}&confirmation=success`;
   const msg = {
     to: email,
     from: 'Commonwealth <no-reply@commonwealth.im>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When confirming their email update via email link redirect, users were not prompted of the success. Now, a `NotifySuccess` toast appears upon successful redirect.
Closes #641.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Give the user some feedback on a confirmation action they're performing. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Change email, receive email, click link, see toast!

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are **not** tested.