### PR TITLE
Remove category_id from OffchainThreads

### DIFF
--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -126,11 +126,12 @@ const NewProposalForm = {
         app.threads.create(
           author.address,
           OffchainThreadKind.Forum,
+          app.activeChainId(),
+          app.activeCommunityId(),
+          vnode.state.form.title,
           vnode.state.form.topicName,
           vnode.state.form.topicId,
-          vnode.state.form.title,
           vnode.state.form.description,
-          vnode.state.form.categoryId,
         ).then(done)
           .then(() => { m.redraw(); })
           .catch((err) => { console.error(err); });

--- a/server/migrations/20200825164046-remove-thread-category-ids.js
+++ b/server/migrations/20200825164046-remove-thread-category-ids.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('OffchainThreads', 'category_id');
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('OffchainThreads', 'category_id', {
+      type: DataTypes.INTEGER, allowNull: false,
+    });
+  }
+};

--- a/server/migrations/20200825164046-remove-thread-category-ids.js
+++ b/server/migrations/20200825164046-remove-thread-category-ids.js
@@ -1,13 +1,13 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
+  up: (queryInterface, DataTypes) => {
     return queryInterface.removeColumn('OffchainThreads', 'category_id');
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface, DataTypes) => {
     return queryInterface.addColumn('OffchainThreads', 'category_id', {
-      type: DataTypes.INTEGER, allowNull: false,
+      type: DataTypes.INTEGER,
     });
   }
 };


### PR DESCRIPTION
Closes #648.

## Description
There was a lingering category_id column on OffchainThreads that was no longer being used. This branch introduces a migration to remove this column, as well as any necessary frontend changes where categoryIds were referenced.

## How has this been tested?
Ran and reverted the migration; ensured that threads were properly fetched/loaded/rendered and nothing broke using the site.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no