### PR TITLE
Bug fix: Edit Profile prepopulated data not rehydrating

### DIFF
--- a/client/scripts/views/modals/edit_profile_modal.ts
+++ b/client/scripts/views/modals/edit_profile_modal.ts
@@ -9,7 +9,7 @@ import AvatarUpload from 'views/components/avatar_upload';
 
 const EditProfileModal = {
   view: (vnode) => {
-    const { account } = vnode.attrs;
+    const { account, refreshCallback } = vnode.attrs;
 
     return m('.EditProfileModal', [
       m('.compact-modal-title', [
@@ -84,6 +84,7 @@ const EditProfileModal = {
                 app.profiles.updateProfileForAccount(account, data).then((result) => {
                   vnode.state.saving = false;
                   m.redraw();
+                  refreshCallback();
                   $(vnode.dom).trigger('modalexit');
                 }).catch((error: any) => {
                   vnode.state.saving = false;

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -96,6 +96,7 @@ interface IProfilePageState {
   comments: OffchainComment<any>[];
   loaded: boolean;
   loading: boolean;
+  refresh: boolean;
 }
 
 const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
@@ -105,6 +106,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
     vnode.state.loading = false;
     vnode.state.threads = [];
     vnode.state.comments = [];
+    vnode.state.refresh = false;
   },
   oncreate: async (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'LoginPage' });
@@ -160,7 +162,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       });
     };
 
-    const { account, loaded, loading } = vnode.state;
+    const { account, loaded, loading, refresh } = vnode.state;
     if (!loading && !loaded) {
       loadProfile();
       vnode.state.loading = true;
@@ -173,6 +175,10 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
     if (loading || !loaded) return m(PageLoading);
     if (!account) {
       return m(PageNotFound, { message: 'This address does not have a Commonwealth profile' });
+    }
+    if (refresh) {
+      loadProfile();
+      vnode.state.refresh = false;
     }
 
     // TODO: search for cosmos proposals, if ChainClass is Cosmos
@@ -197,7 +203,10 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       class: 'ProfilePage',
     }, [
       m('.forum-container-alt', [
-        m(ProfileHeader, { account }),
+        m(ProfileHeader, {
+          account,
+          refreshCallback: () => { vnode.state.refresh = true; },
+        }),
         m('.row.row-narrow.forum-row', [
           m('.col-xs-8', [
             m(Tabs, [{

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -96,7 +96,7 @@ interface IProfilePageState {
   comments: OffchainComment<any>[];
   loaded: boolean;
   loading: boolean;
-  refresh: boolean;
+  refreshProfile: boolean;
 }
 
 const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
@@ -106,7 +106,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
     vnode.state.loading = false;
     vnode.state.threads = [];
     vnode.state.comments = [];
-    vnode.state.refresh = false;
+    vnode.state.refreshProfile = false;
   },
   oncreate: async (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'LoginPage' });
@@ -162,7 +162,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       });
     };
 
-    const { account, loaded, loading, refresh } = vnode.state;
+    const { account, loaded, loading, refreshProfile } = vnode.state;
     if (!loading && !loaded) {
       loadProfile();
       vnode.state.loading = true;
@@ -176,9 +176,9 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
     if (!account) {
       return m(PageNotFound, { message: 'This address does not have a Commonwealth profile' });
     }
-    if (refresh) {
+    if (refreshProfile) {
       loadProfile();
-      vnode.state.refresh = false;
+      vnode.state.refreshProfile = false;
       m.redraw();
     }
 
@@ -206,7 +206,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
       m('.forum-container-alt', [
         m(ProfileHeader, {
           account,
-          refreshCallback: () => { vnode.state.refresh = true; },
+          refreshCallback: () => { vnode.state.refreshProfile = true; },
         }),
         m('.row.row-narrow.forum-row', [
           m('.col-xs-8', [

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -179,6 +179,7 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
     if (refresh) {
       loadProfile();
       vnode.state.refresh = false;
+      m.redraw();
     }
 
     // TODO: search for cosmos proposals, if ChainClass is Cosmos

--- a/client/scripts/views/pages/profile/profile_header.ts
+++ b/client/scripts/views/pages/profile/profile_header.ts
@@ -41,6 +41,7 @@ const editIdentityAction = (account, currentIdentity: SubstrateIdentity) => {
 
 export interface IProfileHeaderAttrs {
   account;
+  refreshCallback: Function;
 }
 
 export interface IProfileHeaderState {
@@ -51,7 +52,7 @@ export interface IProfileHeaderState {
 
 const ProfileHeader: m.Component<IProfileHeaderAttrs, IProfileHeaderState> = {
   view: (vnode) => {
-    const { account } = vnode.attrs;
+    const { account, refreshCallback } = vnode.attrs;
     const onOwnProfile = account.chain === app.user.activeAccount?.chain?.id
       && account.address === app.user.activeAccount?.address;
 
@@ -97,7 +98,7 @@ const ProfileHeader: m.Component<IProfileHeaderAttrs, IProfileHeaderState> = {
               onclick: () => {
                 app.modals.create({
                   modal: EditProfileModal,
-                  data: { account },
+                  data: { account, refreshCallback },
                 });
               },
               label: 'Edit profile'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added callback on the profile page to refresh the profile loading. It was an issue of mixing component state and app state.
Closes #646.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Silly bug!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Go to profile page
- Edit your profile (eg change your name)
- Reopen edit profile form
- new data is prefilled, not the old data

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no