### PR TITLE
Bug fix: Invite modal opens with url even if no invites

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -106,6 +106,7 @@ export function handleInviteLinkRedirect() {
       const message = m.route.param('message');
       notifyError(message);
     } else if (m.route.param('invitemessage') === 'success') {
+      if (app.config.invites.length === 0) return;
       app.modals.create({ modal: ConfirmInviteModal });
     } else {
       notifyError('Hmmmm... URL not constructed properly');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a check to make sure there are invites prior to opening the `Confirm Invite Modal`.
This is strategy No.2 proposed in issue #644. 

Closes #644.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
UX bug.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no