### PR TITLE
Bug Fix: Discussion Row Pin misaligns rest of row slightly

### DIFF
--- a/client/scripts/views/components/listing_row.ts
+++ b/client/scripts/views/components/listing_row.ts
@@ -32,7 +32,6 @@ const ListingRow: m.Component<{
       m('.row-left', [
         contentLeft.pinned && m('.pinned', [
           m('span.icon-pin-outline'),
-          m('.visible-xs', 'Pinned'),
         ]),
         m('.title-container', [
           m('.row-header', contentLeft.header),

--- a/client/scripts/views/components/listing_row.ts
+++ b/client/scripts/views/components/listing_row.ts
@@ -29,13 +29,15 @@ const ListingRow: m.Component<{
     if (vnode.attrs.class) attrs['class'] = vnode.attrs.class;
     const initialOffset = 12 - rightColSpacing.reduce((t, n) => t + n);
     return m('.ListingRow', attrs, [
-      contentLeft.pinned && m('.pinned', [
-        m('span.icon-pin-outline'),
-        m('.visible-xs', 'Pinned'),
-      ]),
       m('.row-left', [
-        m('.row-header', contentLeft.header),
-        m('.row-subheader', contentLeft.subheader),
+        contentLeft.pinned && m('.pinned', [
+          m('span.icon-pin-outline'),
+          m('.visible-xs', 'Pinned'),
+        ]),
+        m('.title-container', [
+          m('.row-header', contentLeft.header),
+          m('.row-subheader', contentLeft.subheader),
+        ]),
       ]),
       m('.row-right', [
         m(Grid, contentRight.map((ele, idx) => {

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -3,42 +3,54 @@
 .ListingRow {
     @include listing-row-base;
 
-    .pinned {
-        margin: 8px 15px 0 0;
-        .visible-xs {
-            display: none;
-        }
-        @include xs-max {
-            margin: 0 0 2px 0;
-            .visible-xs {
-                display: inline-block;
-                margin-left: 4px;
-                font-size: 15px;
-                color: #999;
-            }
-            .icon-pin-outline {
-                font-size: 12px;
-                color: #999;
-            }
-        }
-    }
     .row-left {
         line-height: 1.1;
         flex: $listing-left-flex;
-        .row-header,
-        .row-header a {
-            color: $text-color-dark;
-            font-size: $text-size-item-header;
-            text-decoration: none;
-            font-weight: 500;
+        flex-direction: row;
+        align-items: center;
+        .pinned {
+            display: inline-block;
+            // margin: 15px 8px 0 0;
+            .visible-xs {
+                display: none;
+            }
+            .icon-pin-outline {
+                display: block;
+            }
+            @include xs-max {
+                margin: 0 0 2px 0;
+                .visible-xs {
+                    display: inline-block;
+                    margin-left: 4px;
+                    font-size: 15px;
+                    color: #999;
+                }
+                .icon-pin-outline {
+                    font-size: 12px;
+                    color: #999;
+                    margin: 0 15px;
+                }
+            }
         }
-        .row-subheader {
-            display: flex;
-            margin-top: 3px;
-        }
-        .row-subheader a, span {
-            color: $text-color-light;
-            font-size: $text-size-item-meta;
+        .title-container {
+            display: inline-flex;
+            flex-direction: column;
+            align-self: center;
+            .row-header,
+            .row-header a {
+                color: $text-color-dark;
+                font-size: $text-size-item-header;
+                text-decoration: none;
+                font-weight: 500;
+            }
+            .row-subheader {
+                display: flex;
+                margin-top: 3px;
+            }
+            .row-subheader a, span {
+                color: $text-color-light;
+                font-size: $text-size-item-meta;
+            }
         }
     }
     .row-right {

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -6,30 +6,16 @@
     .row-left {
         line-height: 1.1;
         flex: $listing-left-flex;
+        display: flex;
         flex-direction: row;
         align-items: center;
+        position: relative;
         .pinned {
-            display: inline-block;
-            // margin: 15px 8px 0 0;
-            .visible-xs {
-                display: none;
-            }
+            width: 34px;
             .icon-pin-outline {
                 display: block;
-            }
-            @include xs-max {
-                margin: 0 0 2px 0;
-                .visible-xs {
-                    display: inline-block;
-                    margin-left: 4px;
-                    font-size: 15px;
-                    color: #999;
-                }
-                .icon-pin-outline {
-                    font-size: 12px;
-                    color: #999;
-                    margin: 0 15px;
-                }
+                font-size: 15px;
+                color: #aaa;
             }
         }
         .title-container {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I moved the pin into the `.row-left` and put the headers in a `.title-container` so they sit side-by-side as before, but their entire row-left is constrained by flex values.
Closes #660.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Minor visual glitch.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no