### PR TITLE
Bug Fix: Multiple Invites generated by infinite invite link

### DIFF
--- a/server/routes/acceptInviteLink.ts
+++ b/server/routes/acceptInviteLink.ts
@@ -81,7 +81,7 @@ const acceptInviteLink = async (models, req, res, next) => {
     }
   });
   if (prevInviteCode) {
-    redirectWithSuccess(res);
+    return redirectWithSuccess(res);
   }
 
   const community = await models.OffchainCommunity.findOne({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Turns out a single return was missing from the logic prior to creating a new invite code.
Closes #643.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Multiple open invite codes to the same community for the same user is not intended behavior!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Create new infinite invite link.
- Use once, don't do anything with it. 
- Use again, in `Accept Invite Link` modal you should only see one invite for that community, not 2.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are not tested