### PR TITLE
Topic-scope the New Thread Form when navigating from a topic-scoped page

### DIFF
--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -161,20 +161,19 @@ export const NewThreadForm: m.Component<{
 }> = {
   oninit: (vnode) => {
     const { isModal } = vnode.attrs;
+    vnode.state.form = {};
+    vnode.state.recentlyDeletedDrafts = [];
+    vnode.state.uploadsInProgress = 0;
+    vnode.state.overwriteConfirmationModal = false;
     vnode.state.activeTopic = isModal
       ? m.route.param('topic')
       : app.lastNavigatedFrom().split('/').indexOf('discussions') !== -1
         ? app.lastNavigatedFrom().split('/')[app.lastNavigatedFrom().split('/').indexOf('discussions') + 1]
         : undefined;
-    console.log(vnode.state.activeTopic);
-    vnode.state.form = {};
-    vnode.state.recentlyDeletedDrafts = [];
-    vnode.state.uploadsInProgress = 0;
     if (localStorage.getItem(`${app.activeId()}-from-draft`)) {
       vnode.state.fromDraft = Number(localStorage.getItem(`${app.activeId()}-from-draft`));
       localStorage.removeItem(`${app.activeId()}-from-draft`);
     }
-    vnode.state.overwriteConfirmationModal = false;
     if (vnode.state.postType === undefined) {
       vnode.state.postType = localStorage.getItem(`${app.activeId()}-post-type`) || PostType.Discussion;
     }

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -160,6 +160,14 @@ export const NewThreadForm: m.Component<{
   uploadsInProgress: number,
 }> = {
   oninit: (vnode) => {
+    const { isModal } = vnode.attrs;
+    const route = isModal
+      ? m.route.get().split('/')
+      : app.lastNavigatedFrom().split('/');
+    if (route.length > 3) {
+      console.log(route[3]);
+      vnode.state.activeTopic = route[3];
+    }
     vnode.state.form = {};
     vnode.state.recentlyDeletedDrafts = [];
     vnode.state.uploadsInProgress = 0;

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -161,13 +161,12 @@ export const NewThreadForm: m.Component<{
 }> = {
   oninit: (vnode) => {
     const { isModal } = vnode.attrs;
-    const route = isModal
-      ? m.route.get().split('/')
-      : app.lastNavigatedFrom().split('/');
-    if (route.length > 3) {
-      console.log(route[3]);
-      vnode.state.activeTopic = route[3];
-    }
+    vnode.state.activeTopic = isModal
+      ? m.route.param('topic')
+      : app.lastNavigatedFrom().split('/').indexOf('discussions') !== -1
+        ? app.lastNavigatedFrom().split('/')[app.lastNavigatedFrom().split('/').indexOf('discussions')]
+        : undefined;
+
     vnode.state.form = {};
     vnode.state.recentlyDeletedDrafts = [];
     vnode.state.uploadsInProgress = 0;

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -164,9 +164,9 @@ export const NewThreadForm: m.Component<{
     vnode.state.activeTopic = isModal
       ? m.route.param('topic')
       : app.lastNavigatedFrom().split('/').indexOf('discussions') !== -1
-        ? app.lastNavigatedFrom().split('/')[app.lastNavigatedFrom().split('/').indexOf('discussions')]
+        ? app.lastNavigatedFrom().split('/')[app.lastNavigatedFrom().split('/').indexOf('discussions') + 1]
         : undefined;
-
+    console.log(vnode.state.activeTopic);
     vnode.state.form = {};
     vnode.state.recentlyDeletedDrafts = [];
     vnode.state.uploadsInProgress = 0;


### PR DESCRIPTION
Closes #639.

## Description

Users can open a New Thread Form in one of two ways: as a distinct full-page form, or as a modal. This translates to two scenarios in which a user has navigated to the form from a topic-scoped discussions page: either it is the last route in their tab's history, and they are currently on the full-page form, or else it is the current route in their history, and they are on a modal form.

This branch introduces a check for these two scenarios, pulling the route params or parsing the route history to determine whether the user has navigated to the form from a topic page. If so, the form's `activeTag` state property is set to the pulled param. This automatically updates the form to list, as the post's default tag, whatever topic page the user has navigated from. 

## How has this been tested?

I've tested on- and off-chain to ensure that both modal and page form navigations rendered the appropriate tag. I've also tested manually setting the page route to a non-existent tag, to ensure that a form opened from that route would not set a non-existent tag in the form. 

While it would be impossible to navigate through the thousands of possible page paths, to ensure no misfire/mistriggers of the activeTag setting, I've checked up on the route and param pages to check  for similarly structured routes, and updated my conditionals accordingly.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no