### PR TITLE
Bug Fix: Not showing New Threads subscription when only subscription for community/chain

### DIFF
--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -209,13 +209,13 @@ const LoginSelector: m.Component<{ small?: boolean }, { showAddressSelectionHint
             label: 'Settings'
           }),
           m(MenuItem, {
-            onclick: () => app.activeChainId()
-              ? m.route.set(`/${app.activeChainId()}/notificationSettings`)
+            onclick: () => (app.activeChainId() || app.activeCommunityId())
+              ? m.route.set(`/${app.activeChainId() || app.activeCommunityId()}/notificationSettings`)
               : m.route.set('/notificationSettings'),
             label: 'Email notifications'
           }),
           m(MenuItem, {
-            onclick: () => app.activeChainId()
+            onclick: () => (app.activeChainId())
               ? m.route.set(`/${app.activeChainId()}/chainEventSettings`)
               : m.route.set('/chainEventSettings'),
             label: 'Chain notifications'

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -215,7 +215,7 @@ const LoginSelector: m.Component<{ small?: boolean }, { showAddressSelectionHint
             label: 'Email notifications'
           }),
           m(MenuItem, {
-            onclick: () => (app.activeChainId())
+            onclick: () => app.activeChainId()
               ? m.route.set(`/${app.activeChainId()}/chainEventSettings`)
               : m.route.set('/chainEventSettings'),
             label: 'Chain notifications'

--- a/client/scripts/views/pages/subscriptions/notificationSettings.ts
+++ b/client/scripts/views/pages/subscriptions/notificationSettings.ts
@@ -99,6 +99,9 @@ const BatchedSubscriptionRow: m.Component<IBatchedSubscriptionRowAttrs, IBatched
     vnode.state.subscriptions = vnode.attrs.subscriptions;
   },
   view: (vnode) => {
+    if (vnode.state.subscriptions[0] !== vnode.attrs.subscriptions[0]) {
+      vnode.state.subscriptions = vnode.attrs.subscriptions;
+    }
     const { label, bold } = vnode.attrs;
     const { subscriptions } = vnode.state;
     const someActive = subscriptions.some((s) => s.isActive);
@@ -171,7 +174,7 @@ const NewThreadRow: m.Component<{ subscriptions: NotificationSubscription[], com
     return subscription && m(BatchedSubscriptionRow, {
       subscriptions: [subscription],
       label: 'New threads',
-      bold: true
+      bold: true,
     });
   },
 };
@@ -191,11 +194,16 @@ const CommunitySpecificNotifications: m.Component<ICommunitySpecificNotification
         && s.category !== NotificationCategories.ChainEvent
         && !s.OffchainComment
     );
+    const newThreads = subscriptions.find(
+      (s) => (s.category === NotificationCategories.NewThread && s.objectId === community.id)
+    );
+    console.log('new threads', newThreads);
     const onComments = subscriptions.filter((s) => {
       return (s.OffchainCommunity?.id === community.id || s.Chain?.id === community.id) && s.OffchainComment;
     });
     const batchedSubscriptions = sortSubscriptions(filteredSubscriptions, 'objectId');
     return [
+      // m(BatchedSubscriptionRow, { subscriptions: [newThreads], label: 'New Threads2', }),
       m(NewThreadRow, { community, subscriptions }),
       onComments.length > 0 && m(BatchedSubscriptionRow, {
         label: 'Notifications on Comments',

--- a/client/scripts/views/pages/subscriptions/notificationSettings.ts
+++ b/client/scripts/views/pages/subscriptions/notificationSettings.ts
@@ -107,10 +107,13 @@ const BatchedSubscriptionRow: m.Component<IBatchedSubscriptionRowAttrs, IBatched
     const someActive = subscriptions.some((s) => s.isActive);
     const everyActive = subscriptions.every((s) => s.isActive);
     const someEmail = subscriptions.some((s) => s.immediateEmail);
-    if (everyActive && someEmail) {
+    const everyEmail = subscriptions.some((s) => s.immediateEmail);
+    if (everyActive && everyEmail) {
       vnode.state.option = 'Notifications on (app + email)';
-    } else if (everyActive) {
+    } else if (everyActive && !someEmail) {
       vnode.state.option = 'Notifications on (app only)';
+    } else if (someActive) {
+      vnode.state.option = 'Some notifications on';
     } else {
       vnode.state.option = 'Notifications off';
     }

--- a/client/scripts/views/pages/subscriptions/notificationSettings.ts
+++ b/client/scripts/views/pages/subscriptions/notificationSettings.ts
@@ -195,7 +195,6 @@ const CommunitySpecificNotifications: m.Component<ICommunitySpecificNotification
       return (s.OffchainCommunity?.id === community.id || s.Chain?.id === community.id) && s.OffchainComment;
     });
     const batchedSubscriptions = sortSubscriptions(filteredSubscriptions, 'objectId');
-    if (filteredSubscriptions.length < 1 && onComments.length < 1) return;
     return [
       m(NewThreadRow, { community, subscriptions }),
       onComments.length > 0 && m(BatchedSubscriptionRow, {
@@ -203,7 +202,7 @@ const CommunitySpecificNotifications: m.Component<ICommunitySpecificNotification
         subscriptions: onComments,
       }),
       // TODO: Filter community past-thread/comment subscriptions here into SubscriptionRows.
-      batchedSubscriptions.map((subscriptions2: NotificationSubscription[]) => {
+      batchedSubscriptions.length > 0 && batchedSubscriptions.map((subscriptions2: NotificationSubscription[]) => {
         return m(BatchedSubscriptionRow, {
           subscriptions: subscriptions2,
           key: subscriptions2[0].id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Closes #617, if the user only had one subscription (the community wide New Threads one), nothing would show up. 
I also made the menu link to the community's `/:scope/notificationSettings` rather than default to a chain.
Closes #618, by adding an indeterminate state to the notification subscription row.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
UI 🐛 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Join new community and check notificationSettings specific for new community.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no