### PR TITLE
Fix Vote and Council Motion arg length

### DIFF
--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -106,8 +106,12 @@ class SubstrateCollective extends ProposalModule<
     // TODO: check council status
     const title = this._Chain.methodToTitle(action);
     const txFunc = fromTechnicalCommittee
-      ? ((api: ApiRx) => api.tx.technicalCommittee.propose(threshold, action, length))
-        : ((api: ApiRx) => api.tx.council.propose(threshold, action, length));
+      ? ((api: ApiRx) => api.tx.technicalCommittee.propose.meta.args.length === 3 ?
+          api.tx.technicalCommittee.propose(threshold, action, length) : 
+            api.tx.technicalCommittee.propose(threshold, action))
+        : ((api: ApiRx) => api.tx.council.propose.meta.args.length === 3 ?
+        api.tx.council.propose(threshold, action, length) : 
+          api.tx.council.propose(threshold, action, null));
     return this._Chain.createTXModalData(
       author,
       txFunc,

--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -9,6 +9,7 @@ import { Vec } from '@polkadot/types';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateCollectiveProposal } from './collective_proposal';
+import { AnyKindOfDictionary } from 'lodash';
 
 class SubstrateCollective extends ProposalModule<
   ApiRx,
@@ -111,7 +112,7 @@ class SubstrateCollective extends ProposalModule<
             api.tx.technicalCommittee.propose(threshold, action))
         : ((api: ApiRx) => api.tx.council.propose.meta.args.length === 3 ?
         api.tx.council.propose(threshold, action, length) : 
-          api.tx.council.propose(threshold, action, null));
+          (api.tx.council.propose as any)(threshold, action, null));
     return this._Chain.createTXModalData(
       author,
       txFunc,

--- a/client/scripts/controllers/chain/substrate/democracy_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposal.ts
@@ -214,11 +214,17 @@ class SubstrateDemocracyProposal extends Proposal<
   // TRANSACTIONS
   public submitVoteTx(vote: DepositVote<SubstrateCoin>) {
     // deposit parameter is ignored
-    const params = (api: ApiRx) => (api.tx.democracy.second as any).meta.args.length === 2 ? 
-    [this.data.index, this.getVoters().length] : [this.data.index];
+
+    const txFunc = (api: ApiRx) => {
+      if ((api.tx.democracy.second as any).meta.args.length === 2) {
+        return api.tx.democracy.second(this.data.index, this.getVoters().length);
+      } else {
+        return (api.tx.democracy.second as any)(this.data.index);
+      }
+    };
     return this._Chain.createTXModalData(
       vote.account as SubstrateAccount,
-      (api: ApiRx) => (api.tx.democracy.second as any)(params),
+      txFunc,
       'secondDemocracyProposal',
       this.title
     );


### PR DESCRIPTION
This follow's Jake's Pattern in #687 to fix calls for differing arg lengths across chains.