### PR TITLE
Voting modal for Edgeware should auto-populate with existing council voting lock

### DIFF
--- a/client/scripts/views/modals/council_voting_modal.ts
+++ b/client/scripts/views/modals/council_voting_modal.ts
@@ -25,7 +25,7 @@ const CouncilVotingModal = {
 
     // get currently set approvals
     const currentVote = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author);
-    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars || 0;
+    const currentStake = (currentVote[0]) ? currentVote[0].stake.inDollars : 0;
     const currentApprovals = (currentVote && currentVote.length > 0 && currentVote[0].votes) || [];
     const hasApprovals = currentApprovals.length > 0;
     const defaultSelection = candidates

--- a/client/scripts/views/modals/council_voting_modal.ts
+++ b/client/scripts/views/modals/council_voting_modal.ts
@@ -25,8 +25,7 @@ const CouncilVotingModal = {
 
     // get currently set approvals
     const currentVote = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author);
-    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars || 0;
-
+    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars;
     const currentApprovals = (currentVote && currentVote.length > 0 && currentVote[0].votes) || [];
     const hasApprovals = currentApprovals.length > 0;
     const defaultSelection = candidates

--- a/client/scripts/views/modals/council_voting_modal.ts
+++ b/client/scripts/views/modals/council_voting_modal.ts
@@ -25,6 +25,8 @@ const CouncilVotingModal = {
 
     // get currently set approvals
     const currentVote = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author);
+    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars || 0;
+
     const currentApprovals = (currentVote && currentVote.length > 0 && currentVote[0].votes) || [];
     const hasApprovals = currentApprovals.length > 0;
     const defaultSelection = candidates
@@ -81,6 +83,7 @@ const CouncilVotingModal = {
             class: 'phragmen-vote-amount',
             name: 'amount',
             fluid: true,
+            defaultValue: String(currentStake),
             placeholder: 'Amount to lock',
             autocomplete: 'off',
             oninput: (e) => {

--- a/client/scripts/views/modals/council_voting_modal.ts
+++ b/client/scripts/views/modals/council_voting_modal.ts
@@ -25,7 +25,7 @@ const CouncilVotingModal = {
 
     // get currently set approvals
     const currentVote = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author);
-    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars;
+    const currentStake = (app.chain as Substrate).phragmenElections.activeElection.getVotes(author)[0].stake.inDollars || 0;
     const currentApprovals = (currentVote && currentVote.length > 0 && currentVote[0].votes) || [];
     const hasApprovals = currentApprovals.length > 0;
     const defaultSelection = candidates


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add voting stake/lock to council voting modal 

Closes #691 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better for the user 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Open the modal, see current stake.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no