### PR TITLE
Near Accounts not loading

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -222,7 +222,7 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<void> 
       './controllers/chain/near/main'
     )).default;
     app.chain = new Near(n, app);
-    app.chain.initApi();
+    app.chain.initApi(); // required for loading NearAccounts
   } else if (n.chain.network === ChainNetwork.Moloch || n.chain.network === ChainNetwork.Metacartel) {
     const Moloch = (await import(
       /* webpackMode: "lazy" */

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -222,6 +222,7 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<void> 
       './controllers/chain/near/main'
     )).default;
     app.chain = new Near(n, app);
+    app.chain.initApi();
   } else if (n.chain.network === ChainNetwork.Moloch || n.chain.network === ChainNetwork.Metacartel) {
     const Moloch = (await import(
       /* webpackMode: "lazy" */

--- a/client/scripts/controllers/chain/near/main.ts
+++ b/client/scripts/controllers/chain/near/main.ts
@@ -15,7 +15,6 @@ export default class Near extends IChainAdapter<NearToken, any> {
     super(meta, app);
     this.chain = new NearChain(this.app);
     this.accounts = new NearAccounts(this.app);
-    this.initApi();
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/near/main.ts
+++ b/client/scripts/controllers/chain/near/main.ts
@@ -15,6 +15,7 @@ export default class Near extends IChainAdapter<NearToken, any> {
     super(meta, app);
     this.chain = new NearChain(this.app);
     this.accounts = new NearAccounts(this.app);
+    this.initApi();
   }
 
   public async initApi() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The reason NEAR accounts weren't loading was because we need to have the chainAPI initialized to create `NearAccount` objects. Without starting the chain, we were just forcing `null` to be returned for each `app.chain.account.get()` call.
I decided to initialize the chain after the construction of the near controller in `selectNode` in `app.ts`, but this can be moved elsewhere.

Closes #653 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Near Accounts weren't loading within the community. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Open threads and accounts populate correctly now.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no