### PR TITLE
Update Invite Members module to support chains

### DIFF
--- a/client/scripts/views/components/sidebar/community_info_module.ts
+++ b/client/scripts/views/components/sidebar/community_info_module.ts
@@ -25,6 +25,7 @@ const CommunityInfoModule: m.Component<{ communityName: string, communityDescrip
 
     const meta = app.chain ? app.chain.meta.chain : app.community.meta;
     const { name, description, website, chat, telegram, github } = meta;
+    console.log(isAdmin)
 
     return m('.CommunityInfoModule.SidebarModule', [
       m('.community-name', [
@@ -38,19 +39,17 @@ const CommunityInfoModule: m.Component<{ communityName: string, communityDescrip
           m(Icon, { name: Icons.SETTINGS }),
         ]),
         // TODO: get this working for chains
-        !app.chain
-          && app.community
-          && app.user?.activeAccount
-          && (app.community.meta.invitesEnabled
-              || app.user.isAdminOrModOfEntity({ community: app.activeCommunityId() }))
+        (app.community?.meta.invitesEnabled
+              || isAdmin)
           && m('.community-info-action', {
             onclick: (e) => {
               e.preventDefault();
+              const data = app.activeCommunityId()
+                ? { communityInfo: app.community.meta }
+                : { chainInfo: app.chain.meta.chain }
               app.modals.create({
                 modal: CreateInviteModal,
-                data: {
-                  communityInfo: app.community.meta,
-                },
+                data,
               });
             },
           }, [

--- a/client/scripts/views/components/sidebar/community_info_module.ts
+++ b/client/scripts/views/components/sidebar/community_info_module.ts
@@ -25,7 +25,6 @@ const CommunityInfoModule: m.Component<{ communityName: string, communityDescrip
 
     const meta = app.chain ? app.chain.meta.chain : app.community.meta;
     const { name, description, website, chat, telegram, github } = meta;
-    console.log(isAdmin)
 
     return m('.CommunityInfoModule.SidebarModule', [
       m('.community-name', [

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -6,7 +6,7 @@ import mixpanel from 'mixpanel-browser';
 import { Button, Input, Form, FormGroup, FormLabel, Select, CustomSelect } from 'construct-ui';
 
 import app from 'state';
-import { CommunityInfo } from 'models';
+import { CommunityInfo, ChainInfo } from 'models';
 import { CompactModalExitButton } from 'views/modal';
 
 interface IInviteButtonAttrs {
@@ -16,7 +16,8 @@ interface IInviteButtonAttrs {
   invitedAddress?: string,
   invitedEmail?: string,
   invitedAddressChain?: string,
-  community: CommunityInfo,
+  community?: CommunityInfo,
+  chain?: ChainInfo,
 }
 
 const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
@@ -25,7 +26,7 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
   },
   view: (vnode) => {
     const { selection, successCallback, failureCallback,
-      invitedAddress, invitedEmail, invitedAddressChain, community } = vnode.attrs;
+      invitedAddress, invitedEmail, invitedAddressChain, community, chain } = vnode.attrs;
     return m(Button, {
       class: 'create-invite-button',
       intent: 'primary',
@@ -58,10 +59,15 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
           return;
         }
 
+        const chainOrCommunityObj = chain ? { chain: chain.id }
+          : community ? { community:  community.id }
+            : null;
+        if (!chainOrCommunityObj) return;
+
         $.post(app.serverUrl() + postType, {
           address: app.user.activeAccount.address,
           author_chain: app.user.activeAccount.chain,
-          community: community.id,
+          ...chainOrCommunityObj,
           invitedAddress: selection === 'address' ? address : '',
           invitedAddressChain: selection === 'address' ? selectedChain : '',
           invitedEmail: selection === 'email' ? emailAddress : '',
@@ -171,7 +177,8 @@ const CreateInviteLink: m.Component<{ onChangeHandler?: Function }, {
 };
 
 const CreateInviteModal: m.Component<{
-  communityInfo: CommunityInfo;
+  communityInfo?: CommunityInfo;
+  chainInfo?: ChainInfo;
 }, {
   success: boolean;
   failure: boolean;
@@ -189,9 +196,11 @@ const CreateInviteModal: m.Component<{
     });
   },
   view: (vnode) => {
-    const { communityInfo } = vnode.attrs;
-    const { name, id, privacyEnabled, invitesEnabled, defaultChain } = communityInfo;
-
+    const { communityInfo, chainInfo } = vnode.attrs;
+    const chainOrCommunityObj = chainInfo ? { chain: chainInfo }
+      : communityInfo ? { community: communityInfo }
+        : null;
+    if (!chainOrCommunityObj) return;
     return m('.CreateInviteModal', [
       m('.compact-modal-title', [
         m('h3', 'Invite members'),
@@ -241,7 +250,7 @@ const CreateInviteModal: m.Component<{
             },
             invitedAddress: vnode.state.invitedAddress,
             invitedAddressChain: vnode.state.invitedAddressChain,
-            community: communityInfo,
+            ...chainOrCommunityObj
           }),
         ]),
         m(Form, [
@@ -269,10 +278,10 @@ const CreateInviteModal: m.Component<{
               m.redraw();
             },
             invitedEmail: vnode.state.invitedEmail,
-            community: communityInfo,
+            ...chainOrCommunityObj
           }),
         ]),
-        m(CreateInviteLink),
+        communityInfo && m(CreateInviteLink), // TODO: Allow chains to make invite link
         vnode.state.success && m('.success-message', [
           'Success! Your invite was sent',
         ]),

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -209,14 +209,16 @@ const CreateInviteModal: m.Component<{
       m('.compact-modal-body', [
         m(Form, [
           m(FormGroup, { span: 4 }, [
-            m(FormLabel, 'Chain'),
+            m(FormLabel, { class: 'formLabel' }, 'Chain'),
             m(Select, {
               name: 'invitedAddressChain',
-              defaultValue: app.config.chains.getAll()[0].id,
-              options: app.config.chains.getAll().map((chain) => ({
-                label: chain.name.toString(),
-                value: chain.id.toString(),
-              })),
+              defaultValue: chainInfo ? chainInfo.id : app.config.chains.getAll()[0].id,
+              options: chainInfo
+                ? [{ label: chainInfo.name, value: chainInfo.id, }]
+                : app.config.chains.getAll().map((chain) => ({
+                  label: chain.name.toString(),
+                  value: chain.id.toString(),
+                })),
               oncreate: (vvnode) => {
                 vnode.state.invitedAddressChain = (vvnode.dom as any).value;
               },

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -209,7 +209,7 @@ const CreateInviteModal: m.Component<{
       m('.compact-modal-body', [
         m(Form, [
           m(FormGroup, { span: 4 }, [
-            m(FormLabel, { class: 'formLabel' }, 'Chain'),
+            m(FormLabel, { class: 'chainSelectLabel' }, 'Chain'),
             m(Select, {
               name: 'invitedAddressChain',
               defaultValue: chainInfo ? chainInfo.id : app.config.chains.getAll()[0].id,
@@ -255,7 +255,7 @@ const CreateInviteModal: m.Component<{
             ...chainOrCommunityObj
           }),
         ]),
-        m(Form, [
+        communityInfo && m(Form, [
           m(FormGroup, [
             m(FormLabel, 'Email'),
             m(Input, {

--- a/client/styles/modals/create_invite_modal.scss
+++ b/client/styles/modals/create_invite_modal.scss
@@ -9,6 +9,9 @@
             margin-bottom: 16px;
         }
     }
+    .formLabel {
+        display: block;
+    }
     form + form {
         margin-top: 40px;
     }

--- a/client/styles/modals/create_invite_modal.scss
+++ b/client/styles/modals/create_invite_modal.scss
@@ -9,7 +9,7 @@
             margin-bottom: 16px;
         }
     }
-    .formLabel {
+    .chainSelectLabel {
         display: block;
     }
     form + form {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Allows the modal to open in a chain community. 
- Only currently allows addresses to be invited to a chain directly. This is limited to addresses of said chain that have been previously linked to an account.
  - InviteLinks and Invite via Email are currently disabled within the chain community as their respective routes require more modification and testing. 

Closes #664.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow admins to add addresses directly to a chain community!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Access chain community as not-admin, see that the mail icon is not available. Access as admin, click icon, modal opens but only option for invite is by address.  Add address that is linked to a User but does not have a role in chain community, should work and create the role for that address directly.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are not tested: [enter the % coverage here]