### PR TITLE
Specify secure nodes in one place

### DIFF
--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -58,9 +58,7 @@ export type HandlerId = number;
 
 // creates a substrate API provider and waits for it to emit a connected event
 async function createApiProvider(node: NodeInfo): Promise<WsProvider> {
-  const nodeUrl = constructSubstrateUrl(node.url, [
-    'edgewa.re', 'kusama-rpc.polkadot.io', 'rpc.polkadot.io',
-  ]);
+  const nodeUrl = constructSubstrateUrl(node.url);
   const provider = new WsProvider(nodeUrl, 10 * 1000);
   let unsubscribe: () => void;
   await new Promise((resolve) => {

--- a/shared/substrate.ts
+++ b/shared/substrate.ts
@@ -1,7 +1,5 @@
-export function constructSubstrateUrl(
-  url: string,
-  secureNodes = [ 'kusama-rpc.polkadot.io', 'rpc.polkadot.io', 'rpc.kulupu.corepaper.org' ],
-): string {
+export function constructSubstrateUrl(url: string): string {
+  const secureNodes = [ 'edgewa.re', 'kusama-rpc.polkadot.io', 'rpc.polkadot.io', 'rpc.kulupu.corepaper.org' ];
   const hasProtocol = url.indexOf('wss://') !== -1 || url.indexOf('ws://') !== -1;
   url = hasProtocol ? url.split('://')[1] : url;
   const isInsecureProtocol = !secureNodes.find((path) => url.indexOf(path) !== -1);


### PR DESCRIPTION
@jnaviask Was there a reason we had the default arguments specifying one set of nodes, and substrate.ts specifying a different set of nodes?

(If so we should revert and redo this commit, but it seems like it only affects one-time server side ops and I can't figure out the effective difference...)