### PR TITLE
Fix nonce error for CLI signing.

### DIFF
--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -19,7 +19,8 @@ import {
   DispatchError,
   ActiveEraInfo,
   EraIndex,
-  SessionIndex
+  SessionIndex,
+  AccountInfo
 } from '@polkadot/types/interfaces';
 
 import { Vec, Compact } from '@polkadot/types/codec';
@@ -593,7 +594,9 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
               switchMap((api: ApiRx) => {
                 return combineLatest(
                   of(txFunc(api).method.toHex()),
-                  api.query.system.accountNonce(author.address),
+                  api.query.system.accountNonce
+                    ? api.query.system.accountNonce(author.address)
+                    : api.query.system.account(author.address).pipe(map((a) => a.nonce)),
                   of(api.genesisHash)
                 );
               }),


### PR DESCRIPTION
## Description
Fixes #677.

Nonce access was changed in later versions of substrate, this fixes that. However, the actual subkey signing still fails for me (get a subkey crash/panic) -- maybe we need a `--network` flag?

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
