### PR TITLE
Add title-editing capabilities to thread

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -104,9 +104,11 @@ class ThreadsController {
   public async edit(
     proposal: OffchainThread,
     body?: string,
+    title?: string,
     attachments?: string[],
   ) {
     const newBody = body || proposal.body;
+    const newTitle = title || proposal.title;
     const recentEdit : any = { timestamp: moment(), body };
     const versionHistory = JSON.stringify(recentEdit);
     await $.ajax({
@@ -116,6 +118,7 @@ class ThreadsController {
         'thread_id': proposal.id,
         'kind': proposal.kind,
         'body': encodeURIComponent(newBody),
+        'title': newTitle,
         'version_history': versionHistory,
         'attachments[]': attachments,
         'jwt': app.user.jwt

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -330,7 +330,7 @@ export const ProposalBodySaveEdit: m.Component<{
             : JSON.stringify(parentState.quillEditorState.editor.getContents());
           parentState.saving = true;
           if (item instanceof OffchainThread) {
-            app.threads.edit(item, itemText).then(() => {
+            app.threads.edit(item, itemText, parentState.updatedTitle).then(() => {
               m.route.set(`/${app.activeId()}/proposal/${item.slug}/${item.id}`);
               parentState.editing = false;
               parentState.saving = false;

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -105,6 +105,9 @@ export const ProposalHeaderViewCount: m.Component<{ viewCount: number }> = {
 };
 
 export const ProposalTitleEditor: m.Component<{ item: OffchainThread | AnyProposal, parentState }> = {
+  oninit: (vnode) => {
+    vnode.attrs.parentState.updatedTitle = vnode.attrs.item.title;
+  },
   view: (vnode) => {
     const { item, parentState } = vnode.attrs;
     if (!item) return;
@@ -118,13 +121,13 @@ export const ProposalTitleEditor: m.Component<{ item: OffchainThread | AnyPropos
 
     return m(Input, {
       name: 'edit-thread-title',
-      placeholder: item.title,
+      // placeholder: item.title,
       autocomplete: 'off',
       oninput: (e) => {
         const { value } = (e as any).target;
         parentState.updatedTitle = value;
       },
-      // defaultValue: parentState.updatedTitle,
+      defaultValue: parentState.updatedTitle,
       tabindex: 1,
     });
   }

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -2,7 +2,7 @@ import m from 'mithril';
 import moment from 'moment';
 import app from 'state';
 
-import { Button, Icon, Icons, Tag, MenuItem } from 'construct-ui';
+import { Button, Icon, Icons, Tag, MenuItem, Input } from 'construct-ui';
 
 import { pluralize, link, externalLink, isSameAccount, extractDomain } from 'helpers';
 import { proposalSlugToFriendlyName } from 'identifiers';
@@ -101,6 +101,32 @@ export const ProposalHeaderViewCount: m.Component<{ viewCount: number }> = {
   view: (vnode) => {
     const { viewCount } = vnode.attrs;
     return m('.ViewCountBlock', pluralize(viewCount, 'view'));
+  }
+};
+
+export const ProposalTitleEditor: m.Component<{ item: OffchainThread | AnyProposal, parentState }> = {
+  view: (vnode) => {
+    const { item, parentState } = vnode.attrs;
+    if (!item) return;
+    const isThread = item instanceof OffchainThread;
+    const body = item instanceof OffchainComment
+      ? item.text
+      : (item instanceof OffchainThread
+        ? item.body
+        : null);
+    if (!body) return;
+
+    return m(Input, {
+      name: 'edit-thread-title',
+      placeholder: item.title,
+      autocomplete: 'off',
+      oninput: (e) => {
+        const { value } = (e as any).target;
+        parentState.updatedTitle = value;
+      },
+      // defaultValue: parentState.updatedTitle,
+      tabindex: 1,
+    });
   }
 };
 

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -121,7 +121,6 @@ export const ProposalTitleEditor: m.Component<{ item: OffchainThread | AnyPropos
 
     return m(Input, {
       name: 'edit-thread-title',
-      // placeholder: item.title,
       autocomplete: 'off',
       oninput: (e) => {
         const { value } = (e as any).target;

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -144,7 +144,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
             m(ProposalBodyAuthor, { item: proposal }),
             m(ProposalHeaderViewCount, { viewCount }),
             m(ProposalBodyReaction, { item: proposal }),
-            // TODO: PROPOSAL EDITING
           ]),
           proposal instanceof OffchainThread
             && proposal.kind === OffchainThreadKind.Link
@@ -157,40 +156,6 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
           m(ProposalBodyAvatar, { item: proposal }),
         ]),
         m('.proposal-content-right', [
-          // m('.proposal-content-meta', [
-          //   m(ProposalBodyAuthor, { item: proposal }),
-          //   m(ProposalBodyCreated, { item: proposal, link: proposalLink }),
-          //   m(ProposalBodyLastEdited, { item: proposal }),
-          //   app.isLoggedIn() && !getSetGlobalEditingStatus(GlobalStatus.Get) && m(PopoverMenu, {
-          //     transitionDuration: 0,
-          //     closeOnOutsideClick: true,
-          //     closeOnContentClick: true,
-          //     menuAttrs: { size: 'default' },
-          //     content: [
-          //       canEdit && m(ProposalBodyEditMenuItem, {
-          //         item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state,
-          //       }),
-          //       canEdit && m(ProposalBodyDeleteMenuItem, { item: proposal }),
-          //       canEdit && proposal instanceof OffchainThread && m(TopicEditorButton, {
-          //         openTopicEditor: () => {
-          //           vnode.state.topicEditorIsOpen = true;
-          //         }
-          //       }),
-          //       canEdit && m(ProposalHeaderPrivacyButtons, { proposal }),
-          //       canEdit && m(MenuDivider),
-          //       m(ThreadSubscriptionButton, { proposal: proposal as OffchainThread }),
-          //     ],
-          //     inline: true,
-          //     trigger: m(Icon, { name: Icons.CHEVRON_DOWN }),
-          //   }),
-          //   vnode.state.topicEditorIsOpen && proposal instanceof OffchainThread && m(TopicEditor, {
-          //     thread: vnode.attrs.proposal as OffchainThread,
-          //     popoverMenu: true,
-          //     onChangeHandler: (topic: OffchainTopic) => { proposal.topic = topic; m.redraw(); },
-          //     openStateHandler: (v) => { vnode.state.topicEditorIsOpen = v; m.redraw(); },
-          //   })
-          // ]),
-
           !vnode.state.editing
             && m(ProposalBodyText, { item: proposal }),
 

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -34,7 +34,8 @@ import PageNotFound from 'views/pages/404';
 import {
   ProposalHeaderExternalLink, ProposalHeaderTopics, ProposalHeaderTitle,
   ProposalHeaderOnchainId, ProposalHeaderOnchainStatus, ProposalHeaderSpacer, ProposalHeaderViewCount,
-  ProposalHeaderPrivacyButtons
+  ProposalHeaderPrivacyButtons,
+  ProposalTitleEditor,
 } from './header';
 import {
   activeQuillEditorHasText, GlobalStatus, ProposalBodyAvatar, ProposalBodyAuthor, ProposalBodyCreated,
@@ -57,6 +58,7 @@ interface IProposalHeaderState {
   saving: boolean;
   quillEditorState: any;
   currentText: any;
+  updatedTitle: string;
   topicEditorIsOpen: boolean;
 }
 
@@ -98,34 +100,16 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
     }, [
       m('.proposal-top', [
         m('.proposal-top-left', [
-          m('.proposal-title', m(ProposalHeaderTitle, { proposal })),
+          !vnode.state.editing
+            && m('.proposal-title', m(ProposalHeaderTitle, { proposal })),
+          vnode.state.editing
+            && m(ProposalTitleEditor, { item: proposal, parentState: vnode.state }),
           m('.proposal-body-meta', proposal instanceof OffchainThread ? [
             m(ProposalHeaderTopics, { proposal }),
             m(ProposalBodyAuthor, { item: proposal }),
             m(ProposalBodyCreated, { item: proposal, link: proposalLink }),
-            m(ProposalHeaderViewCount, { viewCount }),
-          ] : [
-            m(ProposalHeaderOnchainId, { proposal }),
-            m(ProposalHeaderOnchainStatus, { proposal }),
-            m(ProposalBodyAuthor, { item: proposal }),
-            m(ProposalHeaderViewCount, { viewCount }),
-            m(ProposalBodyReaction, { item: proposal }),
-          ]),
-          proposal instanceof OffchainThread
-            && proposal.kind === OffchainThreadKind.Link
-            && m('.proposal-body-link', m(ProposalHeaderExternalLink, { proposal })),
-        ]),
-      ]),
-      proposal instanceof OffchainThread && m('.proposal-content', [
-        (commentCount > 0 || app.user.activeAccount) && m('.thread-connector'),
-        m('.proposal-content-left', [
-          m(ProposalBodyAvatar, { item: proposal }),
-        ]),
-        m('.proposal-content-right', [
-          m('.proposal-content-meta', [
-            m(ProposalBodyAuthor, { item: proposal }),
-            m(ProposalBodyCreated, { item: proposal, link: proposalLink }),
             m(ProposalBodyLastEdited, { item: proposal }),
+            m(ProposalHeaderViewCount, { viewCount }),
             app.isLoggedIn() && !getSetGlobalEditingStatus(GlobalStatus.Get) && m(PopoverMenu, {
               transitionDuration: 0,
               closeOnOutsideClick: true,
@@ -154,7 +138,58 @@ const ProposalHeader: m.Component<IProposalHeaderAttrs, IProposalHeaderState> = 
               onChangeHandler: (topic: OffchainTopic) => { proposal.topic = topic; m.redraw(); },
               openStateHandler: (v) => { vnode.state.topicEditorIsOpen = v; m.redraw(); },
             })
+          ] : [
+            m(ProposalHeaderOnchainId, { proposal }),
+            m(ProposalHeaderOnchainStatus, { proposal }),
+            m(ProposalBodyAuthor, { item: proposal }),
+            m(ProposalHeaderViewCount, { viewCount }),
+            m(ProposalBodyReaction, { item: proposal }),
+            // TODO: PROPOSAL EDITING
           ]),
+          proposal instanceof OffchainThread
+            && proposal.kind === OffchainThreadKind.Link
+            && m('.proposal-body-link', m(ProposalHeaderExternalLink, { proposal })),
+        ]),
+      ]),
+      proposal instanceof OffchainThread && m('.proposal-content', [
+        (commentCount > 0 || app.user.activeAccount) && m('.thread-connector'),
+        m('.proposal-content-left', [
+          m(ProposalBodyAvatar, { item: proposal }),
+        ]),
+        m('.proposal-content-right', [
+          // m('.proposal-content-meta', [
+          //   m(ProposalBodyAuthor, { item: proposal }),
+          //   m(ProposalBodyCreated, { item: proposal, link: proposalLink }),
+          //   m(ProposalBodyLastEdited, { item: proposal }),
+          //   app.isLoggedIn() && !getSetGlobalEditingStatus(GlobalStatus.Get) && m(PopoverMenu, {
+          //     transitionDuration: 0,
+          //     closeOnOutsideClick: true,
+          //     closeOnContentClick: true,
+          //     menuAttrs: { size: 'default' },
+          //     content: [
+          //       canEdit && m(ProposalBodyEditMenuItem, {
+          //         item: proposal, getSetGlobalReplyStatus, getSetGlobalEditingStatus, parentState: vnode.state,
+          //       }),
+          //       canEdit && m(ProposalBodyDeleteMenuItem, { item: proposal }),
+          //       canEdit && proposal instanceof OffchainThread && m(TopicEditorButton, {
+          //         openTopicEditor: () => {
+          //           vnode.state.topicEditorIsOpen = true;
+          //         }
+          //       }),
+          //       canEdit && m(ProposalHeaderPrivacyButtons, { proposal }),
+          //       canEdit && m(MenuDivider),
+          //       m(ThreadSubscriptionButton, { proposal: proposal as OffchainThread }),
+          //     ],
+          //     inline: true,
+          //     trigger: m(Icon, { name: Icons.CHEVRON_DOWN }),
+          //   }),
+          //   vnode.state.topicEditorIsOpen && proposal instanceof OffchainThread && m(TopicEditor, {
+          //     thread: vnode.attrs.proposal as OffchainThread,
+          //     popoverMenu: true,
+          //     onChangeHandler: (topic: OffchainTopic) => { proposal.topic = topic; m.redraw(); },
+          //     openStateHandler: (v) => { vnode.state.topicEditorIsOpen = v; m.redraw(); },
+          //   })
+          // ]),
 
           !vnode.state.editing
             && m(ProposalBodyText, { item: proposal }),

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -66,6 +66,10 @@ $discussion-title-font-size: 1.45rem;
         }
         .proposal-top-left {
             flex: 1;
+            .cui-input {
+                width: 70%;
+                padding-bottom: 10px;
+            }
         }
         .proposal-content {
             display: flex;

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -264,7 +264,7 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
       [ finalThread.Address.address ],
     );
   }));
-
+  console.log(finalThread.id);
   return res.json({ status: 'Success', result: finalThread.toJSON() });
 };
 

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -264,7 +264,7 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
       [ finalThread.Address.address ],
     );
   }));
-  console.log(finalThread.id);
+
   return res.json({ status: 'Success', result: finalThread.toJSON() });
 };
 

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -15,7 +15,8 @@ export const Errors = {
 
 const editThread = async (models, req: Request, res: Response, next: NextFunction) => {
   const { body, title, kind, thread_id, version_history, } = req.body;
-
+  console.log(thread_id);
+  console.log(req.user);
   if (!thread_id) {
     return next(new Error(Errors.NoThreadId));
   }
@@ -45,18 +46,22 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
 
   try {
     const userOwnedAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
+    console.log(userOwnedAddressIds);
     const thread = await models.OffchainThread.findOne({
       where: {
         id: thread_id,
         address_id: { [Op.in]: userOwnedAddressIds },
       },
     });
+    console.log(thread);
     if (!thread) return next(new Error('No thread with that id found'));
     const arr = thread.version_history;
     arr.unshift(version_history);
     thread.version_history = arr;
     thread.body = body;
-    thread.title = title;
+    if (title) {
+      thread.title = title;
+    }
     await thread.save();
     await attachFiles();
     const finalThread = await models.OffchainThread.findOne({

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -15,8 +15,7 @@ export const Errors = {
 
 const editThread = async (models, req: Request, res: Response, next: NextFunction) => {
   const { body, title, kind, thread_id, version_history, } = req.body;
-  console.log(thread_id);
-  console.log(req.user);
+
   if (!thread_id) {
     return next(new Error(Errors.NoThreadId));
   }
@@ -46,14 +45,12 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
 
   try {
     const userOwnedAddressIds = await req.user.getAddresses().filter((addr) => !!addr.verified).map((addr) => addr.id);
-    console.log(userOwnedAddressIds);
     const thread = await models.OffchainThread.findOne({
       where: {
         id: thread_id,
         address_id: { [Op.in]: userOwnedAddressIds },
       },
     });
-    console.log(thread);
     if (!thread) return next(new Error('No thread with that id found'));
     const arr = thread.version_history;
     arr.unshift(version_history);

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -14,7 +14,7 @@ export const Errors = {
 };
 
 const editThread = async (models, req: Request, res: Response, next: NextFunction) => {
-  const { body, kind, thread_id, version_history, } = req.body;
+  const { body, title, kind, thread_id, version_history, } = req.body;
 
   if (!thread_id) {
     return next(new Error(Errors.NoThreadId));
@@ -56,6 +56,7 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
     arr.unshift(version_history);
     thread.version_history = arr;
     thread.body = body;
+    thread.title = title;
     await thread.save();
     await attachFiles();
     const finalThread = await models.OffchainThread.findOne({

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -303,7 +303,6 @@ describe('Thread Tests', () => {
   });
 
   describe('/createComment', () => {
-
     beforeEach(async () => {
       const res2 = await modelUtils.createThread({
         address: userAddress,
@@ -517,7 +516,8 @@ describe('Thread Tests', () => {
     it('should succeed in updating a thread body', async () => {
       const thread_id = thread.id;
       const thread_kind = thread.kind;
-      const recentEdit : any = { timestamp: moment(), body: thread.body };
+      const newBody = 'new Body';
+      const recentEdit : any = { timestamp: moment(), body: newBody };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
       const privacy = true;
@@ -527,16 +527,15 @@ describe('Thread Tests', () => {
         .send({
           'thread_id': thread_id,
           'kind': thread_kind,
-          'body': thread.body,
+          'body': newBody,
           'version_history': versionHistory,
           'attachments[]': null,
           'privacy': privacy,
           'read_only': readOnly,
           'jwt': adminJWT,
         });
-      expect(res.body.error).to.be.null;
-      expect(res.body.result.body).to.be.equal(thread.body);
       expect(res.status).to.be.equal(200);
+      expect(res.body.result.body).to.be.equal(newBody);
     });
 
     it('should succeed in updating a thread title', async () => {
@@ -561,9 +560,8 @@ describe('Thread Tests', () => {
           'read_only': readOnly,
           'jwt': adminJWT,
         });
-      expect(res.body.error).to.be.null;
-      expect(res.body.result.title).to.be.equal(newTitle);
       expect(res.status).to.be.equal(200);
+      expect(res.body.result.title).to.be.equal(newTitle);
     });
 
     it.skip('should fail to show private threads to a user without access', async () => {
@@ -622,65 +620,64 @@ describe('Thread Tests', () => {
     });
 
     it('should fail without read_only or privacy', async () => {
-      let res = await chai.request(app)
-      .post('/api/setPrivacy')
-      .set('Accept', 'application/json')
-      .send({
-        thread_id: tempThread.id,
-        jwt: adminJWT,
-      });
+      const res = await chai.request(app)
+        .post('/api/setPrivacy')
+        .set('Accept', 'application/json')
+        .send({
+          thread_id: tempThread.id,
+          jwt: adminJWT,
+        });
       expect(res.status).to.be.equal(500);
       expect(res.body.error).to.be.equal(setPrivacyErrors.PrivateOrReadOnly);
     });
 
 
     it('should fail without thread_id', async () => {
-      let res = await chai.request(app)
-      .post('/api/setPrivacy')
-      .set('Accept', 'application/json')
-      .send({
-        privacy: 'true',
-        read_only: 'true',
-        jwt: adminJWT,
-      });
+      const res = await chai.request(app)
+        .post('/api/setPrivacy')
+        .set('Accept', 'application/json')
+        .send({
+          privacy: 'true',
+          read_only: 'true',
+          jwt: adminJWT,
+        });
       expect(res.status).to.be.equal(500);
       expect(res.body.error).to.be.equal(setPrivacyErrors.NoThreadId);
     });
 
     it('should fail with an invalid thread_id', async () => {
-      let res = await chai.request(app)
-      .post('/api/setPrivacy')
-      .set('Accept', 'application/json')
-      .send({
-        thread_id: 123458,
-        privacy: 'true',
-        read_only: 'true',
-        jwt: adminJWT,
-      });
+      const res = await chai.request(app)
+        .post('/api/setPrivacy')
+        .set('Accept', 'application/json')
+        .send({
+          thread_id: 123458,
+          privacy: 'true',
+          read_only: 'true',
+          jwt: adminJWT,
+        });
       expect(res.status).to.be.equal(500);
       expect(res.body.error).to.be.equal(setPrivacyErrors.NoThread);
     });
 
     it('should fail if not an admin or author', async () => {
       // create new user + jwt
-      let res = await modelUtils.createAndVerifyAddress({ chain });
+      const res = await modelUtils.createAndVerifyAddress({ chain });
       const newUserJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
-      let res2 = await chai.request(app)
-      .post('/api/setPrivacy')
-      .set('Accept', 'application/json')
-      .send({
-        thread_id: tempThread.id,
-        privacy: 'true',
-        read_only: 'true',
-        jwt: newUserJWT,
-      });
+      const res2 = await chai.request(app)
+        .post('/api/setPrivacy')
+        .set('Accept', 'application/json')
+        .send({
+          thread_id: tempThread.id,
+          privacy: 'true',
+          read_only: 'true',
+          jwt: newUserJWT,
+        });
       expect(res2.status).to.be.equal(500);
       expect(res2.body.error).to.be.equal(setPrivacyErrors.NotAdmin);
-    })
+    });
   });
 
   describe('/editComment', () => {
-
     it('should edit a comment', async () => {
       const text = 'tes text';
       const tRes = await modelUtils.createThread({
@@ -718,7 +715,6 @@ describe('Thread Tests', () => {
   });
 
   describe('/viewCount', () => {
-
     it('should track views on chain', async () => {
       let res = await modelUtils.createThread({
         address: userAddress,

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -482,7 +482,7 @@ describe('Thread Tests', () => {
           'attachments[]': null,
           'privacy': privacy,
           'read_only': readOnly,
-          'jwt': userJWT,
+          'jwt': adminJWT,
         });
       expect(res.body.error).to.not.be.null;
       expect(res.status).to.be.equal(500);
@@ -507,43 +507,17 @@ describe('Thread Tests', () => {
           'attachments[]': null,
           'privacy': privacy,
           'read_only': readOnly,
-          'jwt': userJWT,
+          'jwt': adminJWT,
         });
       expect(res.body.error).to.not.be.null;
       expect(res.status).to.be.equal(500);
       expect(res.body.error).to.be.equal(EditThreadErrors.NoBodyOrAttachment);
     });
 
-    it('should fail to edit a thread without passing a thread id', async () => {
-      const thread_kind = thread.kind;
-      const newBody = thread.body;
-      const recentEdit : any = { timestamp: moment(), body: newBody };
-      const versionHistory = JSON.stringify(recentEdit);
-      const readOnly = false;
-      const privacy = true;
-      const res = await chai.request(app)
-        .put('/api/editThread')
-        .set('Accept', 'application/json')
-        .send({
-          'thread_id': null,
-          'kind': thread_kind,
-          'body': encodeURIComponent(newBody),
-          'version_history': versionHistory,
-          'attachments[]': null,
-          'privacy': privacy,
-          'read_only': readOnly,
-          'jwt': userJWT,
-        });
-      expect(res.body.error).to.not.be.null;
-      expect(res.status).to.be.equal(500);
-      expect(res.body.error).to.be.equal(EditThreadErrors.NoThreadId);
-    });
-
     it('should succeed in updating a thread body', async () => {
       const thread_id = thread.id;
       const thread_kind = thread.kind;
-      const newBody = thread.body;
-      const recentEdit : any = { timestamp: moment(), newBody };
+      const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
       const privacy = true;
@@ -553,24 +527,23 @@ describe('Thread Tests', () => {
         .send({
           'thread_id': thread_id,
           'kind': thread_kind,
-          'body': encodeURIComponent(body),
+          'body': thread.body,
           'version_history': versionHistory,
           'attachments[]': null,
           'privacy': privacy,
           'read_only': readOnly,
-          'jwt': userJWT,
+          'jwt': adminJWT,
         });
       expect(res.body.error).to.be.null;
-      expect(res.body.result.body).to.be.equal(newBody);
+      expect(res.body.result.body).to.be.equal(thread.body);
       expect(res.status).to.be.equal(200);
     });
 
     it('should succeed in updating a thread title', async () => {
       const thread_id = thread.id;
       const thread_kind = thread.kind;
-      const newBody = thread.body;
       const newTitle = 'new Title';
-      const recentEdit : any = { timestamp: moment(), newBody };
+      const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
       const privacy = true;
@@ -580,13 +553,13 @@ describe('Thread Tests', () => {
         .send({
           'thread_id': thread_id,
           'kind': thread_kind,
-          'body': encodeURIComponent(body),
+          'body': thread.body,
           'title': newTitle,
           'version_history': versionHistory,
           'attachments[]': null,
           'privacy': privacy,
           'read_only': readOnly,
-          'jwt': userJWT,
+          'jwt': adminJWT,
         });
       expect(res.body.error).to.be.null;
       expect(res.body.result.title).to.be.equal(newTitle);


### PR DESCRIPTION
Closes #674.

## Description

Previously, users were unable to edit their threads' titles once submitted. This branch adds that functionality, moving the dropdown menu & corresponding chevron up to the thread header, and making the title editable simultaneous with the body. 

In addition, this branch fixes broken editThread tests, which had not been properly or fully implemented, and therefore were not catching improper JWT passing. 

## How has this been tested?

I've edited thread bodies and titles on- and off-chain, with different combinations of edited/unedited titles, and edited/unedited bodies. I've also written the relevant tests and ensured they pass.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no