### PR TITLE
Extend scroll-saving logic to proposal pages

### DIFF
--- a/client/scripts/views/components/proposal_row.ts
+++ b/client/scripts/views/components/proposal_row.ts
@@ -306,6 +306,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
         onclick: (e) => {
           e.stopPropagation();
           e.preventDefault();
+          localStorage[`${app.activeId()}-scrollY`] = window.scrollY;
           m.route.set(proposalLink);
         },
       }, [

--- a/client/scripts/views/components/proposal_row.ts
+++ b/client/scripts/views/components/proposal_row.ts
@@ -296,6 +296,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
         onclick: (e) => {
           e.stopPropagation();
           e.preventDefault();
+          localStorage[`${app.activeId()}-proposals-scrollY`] = window.scrollY;
           m.route.set(proposalLink);
         },
       })
@@ -306,7 +307,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
         onclick: (e) => {
           e.stopPropagation();
           e.preventDefault();
-          localStorage[`${app.activeId()}-scrollY`] = window.scrollY;
+          localStorage[`${app.activeId()}-proposals-scrollY`] = window.scrollY;
           m.route.set(proposalLink);
         },
       }, [

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -97,7 +97,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread }, { expanded: boole
       rightColSpacing: app.isLoggedIn() ?  [4, 4, 3, 1] : [4, 4, 4],
       onclick: (e) => {
         e.preventDefault();
-        localStorage[`${app.activeId()}-scrollY`] = window.scrollY;
+        localStorage[`${app.activeId()}-discussions-scrollY`] = window.scrollY;
         updateRoute(discussionLink);
       },
     });

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -40,9 +40,9 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
     });
 
     const returningFromThread = (app.lastNavigatedBack() && app.lastNavigatedFrom().includes('/proposal/discussion/'));
-    if (returningFromThread && localStorage[`${app.activeId()}-scrollY`]) {
+    if (returningFromThread && localStorage[`${app.activeId()}-discussions-scrollY`]) {
       setTimeout(() => {
-        window.scrollTo(0, Number(localStorage[`${app.activeId()}-scrollY`]));
+        window.scrollTo(0, Number(localStorage[`${app.activeId()}-discussions-scrollY`]));
       }, 1);
     }
 

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -105,9 +105,12 @@ const ProposalsPage: m.Component<{}> = {
         returningFromThread = true;
       }
     });
-    if (returningFromThread && localStorage[`${app.activeId()}-scrollY`]) {
+    console.log(returningFromThread);
+    console.log(Number(localStorage[`${app.activeId()}-proposals-scrollY`]));
+    if (returningFromThread && localStorage[`${app.activeId()}-proposals-scrollY`]) {
       setTimeout(() => {
-        window.scrollTo(0, Number(localStorage[`${app.activeId()}-scrollY`]));
+        console.log('SCROLLING');
+        window.scrollTo(0, Number(localStorage[`${app.activeId()}-proposals-scrollY`]));
       }, 1);
     }
   },

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -99,6 +99,17 @@ const SubstrateProposalStats: m.Component<{}, {}> = {
 const ProposalsPage: m.Component<{}> = {
   oncreate: (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'ProposalsPage' });
+    let returningFromThread = false;
+    Object.values(ProposalType).forEach((type) => {
+      if (app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/${type}/`)) {
+        returningFromThread = true;
+      }
+    });
+    if (returningFromThread && localStorage[`${app.activeId()}-scrollY`]) {
+      setTimeout(() => {
+        window.scrollTo(0, Number(localStorage[`${app.activeId()}-scrollY`]));
+      }, 1);
+    }
   },
   view: (vnode) => {
     if (!app.chain || !app.chain.loaded) return m(PageLoading, { message: 'Connecting to chain (may take up to 30s)...', title: 'Proposals' });

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -105,11 +105,8 @@ const ProposalsPage: m.Component<{}> = {
         returningFromThread = true;
       }
     });
-    console.log(returningFromThread);
-    console.log(Number(localStorage[`${app.activeId()}-proposals-scrollY`]));
     if (returningFromThread && localStorage[`${app.activeId()}-proposals-scrollY`]) {
       setTimeout(() => {
-        console.log('SCROLLING');
         window.scrollTo(0, Number(localStorage[`${app.activeId()}-proposals-scrollY`]));
       }, 1);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, when users returned to the main proposals listing, after clicking on a proposal row and viewing an individual proposal, then returning to the listing, they would be bounced back to the top of the page. This branch introduces code that, during the oncreate lifecycle of the proposals listing component, restores saved scroll positions from localStorage.

## How has this been tested?

I have tested various combinations of navigating around and between pages, on both on-chain and offchain communities. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no