### PR TITLE
Update user's lastVisited timestamp on thread & comment creation

### DIFF
--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -6,8 +6,9 @@ import app from 'state';
 import { uniqueIdToProposal } from 'identifiers';
 
 import { CommentsStore } from 'stores';
-import { OffchainComment, OffchainAttachment, IUniqueId, AnyProposal, OffchainThread, AddressInfo } from 'models';
+import { OffchainComment, OffchainAttachment, IUniqueId, AddressInfo, CommunityInfo, NodeInfo } from 'models';
 import { notifyError } from 'controllers/app/notifications';
+import { updateLastVisited } from '../app/login';
 // tslint:disable: object-literal-key-quotes
 
 export enum CommentParent {
@@ -148,6 +149,10 @@ class CommentsController {
         this._store.remove(this._store.getById(result.id));
       }
       this._store.add(result);
+      const activeEntity = app.activeCommunityId() ? app.community : app.chain;
+      updateLastVisited(app.activeCommunityId()
+        ? (activeEntity.meta as CommunityInfo)
+        : (activeEntity.meta as NodeInfo).chain, true);
       return result;
     } catch (err) {
       console.log('Failed to edit comment');

--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -114,6 +114,10 @@ class CommentsController {
       });
       const { result } = res;
       this._store.add(modelFromServer(result));
+      const activeEntity = app.activeCommunityId() ? app.community : app.chain;
+      updateLastVisited(app.activeCommunityId()
+        ? (activeEntity.meta as CommunityInfo)
+        : (activeEntity.meta as NodeInfo).chain, true);
       // update childComments of parent, if necessary
       if (result.parent_id) {
         const parent = this._store.getById(+result.parent_id);
@@ -149,10 +153,6 @@ class CommentsController {
         this._store.remove(this._store.getById(result.id));
       }
       this._store.add(result);
-      const activeEntity = app.activeCommunityId() ? app.community : app.chain;
-      updateLastVisited(app.activeCommunityId()
-        ? (activeEntity.meta as CommunityInfo)
-        : (activeEntity.meta as NodeInfo).chain, true);
       return result;
     } catch (err) {
       console.log('Failed to edit comment');

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -2,11 +2,12 @@
 import _ from 'lodash';
 import moment from 'moment-twitter';
 import { ProposalStore, TopicStore } from 'stores';
-import { OffchainThread, OffchainAttachment, CommunityInfo } from 'models';
+import { OffchainThread, OffchainAttachment, CommunityInfo, NodeInfo } from 'models';
 
 import $ from 'jquery';
 import app from 'state';
 import { notifyError } from 'controllers/app/notifications';
+import { updateLastVisited } from '../app/login';
 
 const modelFromServer = (thread) => {
   const attachments = thread.OffchainAttachments
@@ -93,6 +94,10 @@ class ThreadsController {
       });
       const result = modelFromServer(response.result);
       this._store.add(result);
+      const activeEntity = app.activeCommunityId() ? app.community : app.chain;
+      updateLastVisited(app.activeCommunityId()
+        ? (activeEntity.meta as CommunityInfo)
+        : (activeEntity.meta as NodeInfo).chain, true);
       return result;
     } catch (err) {
       console.log('Failed to create thread');

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -332,7 +332,7 @@ export const NewThreadForm: m.Component<{
               featuredTopics: app.topics.getByCommunity(app.activeId())
                 .filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
               updateFormData: updateTopicState,
-              tabindex: 2,
+              tabindex: 1,
             }),
           ]),
           m(FormGroup, { span: { xs: 12, sm: 8 }, order: 2 }, [
@@ -345,7 +345,7 @@ export const NewThreadForm: m.Component<{
                 if (detectURL(value)) getUrlForLinkPost();
               },
               defaultValue: vnode.state.form.url,
-              tabindex: 1,
+              tabindex: 2,
             }),
           ]),
           m(FormGroup, { order: 3 },  [
@@ -433,7 +433,7 @@ export const NewThreadForm: m.Component<{
               featuredTopics: app.topics.getByCommunity(app.activeId())
                 .filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
               updateFormData: updateTopicState,
-              tabindex: 2,
+              tabindex: 1,
             }),
           ]),
           m(FormGroup, { span: { xs: 12, sm: (fromDraft ? 6 : 8) }, order: 3 }, [
@@ -450,7 +450,7 @@ export const NewThreadForm: m.Component<{
                 localStorage.setItem(`${app.activeId()}-new-discussion-storedTitle`, vnode.state.form.threadTitle);
               },
               defaultValue: vnode.state.form.threadTitle,
-              tabindex: 1,
+              tabindex: 2,
             }),
           ]),
           m(FormGroup, { order: 4 }, [


### PR DESCRIPTION
Closes #671 

## Description

Previously, if users were to create a new comment or thread, it would show above (i.e. "after") their last-visited divider on the discussions page. In other words, users were being shown their own content as "new" or "unread." This fix updates the user's lastVisited timestamp in the event of content creation, so that such threads are marked "read."

Additionally, this fix updates the tabIndexes on the new thread form to reflect the repositioning of the Topic selection dropdown, so that non-mouse users flow logically from upper left to bottom right in filling out the form.

## How has this been tested?

I log'd out timestamps, ensuring they were properly updated, and checked the position of the lastVisited divider. Both coordinated correctly for both thread and comment creation.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no