### PR TITLE
Add email invite to chain community

### DIFF
--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -66,7 +66,7 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
 
         $.post(app.serverUrl() + postType, {
           address: app.user.activeAccount.address,
-          author_chain: app.user.activeAccount.chain,
+          // author_chain: app.user.activeAccount.chain,
           ...chainOrCommunityObj,
           invitedAddress: selection === 'address' ? address : '',
           invitedAddressChain: selection === 'address' ? selectedChain : '',

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -235,7 +235,7 @@ const CreateInviteModal: m.Component<{
               name: 'address',
               autocomplete: 'off',
               placeholder: 'Address',
-              onkeyup: (e) => {
+              oninput: (e) => {
                 vnode.state.invitedAddress = (e.target as any).value;
               }
             }),
@@ -264,7 +264,7 @@ const CreateInviteModal: m.Component<{
               name: 'emailAddress',
               autocomplete: 'off',
               placeholder: 'satoshi@protonmail.com',
-              onkeyup: (e) => {
+              oninput: (e) => {
                 vnode.state.invitedEmail = (e.target as any).value;
               }
             }),

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -37,7 +37,6 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
         ? 'Invite Commonwealth user' : selection === 'email' ? 'Invite email' : 'Add',
       onclick: (e) => {
         e.preventDefault();
-        console.log(vnode.attrs);
         const address = invitedAddress;
         const emailAddress = invitedEmail;
         const selectedChain = invitedAddressChain;

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -68,7 +68,6 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
 
         $.post(app.serverUrl() + postType, {
           address: app.user.activeAccount.address,
-          // author_chain: app.user.activeAccount.chain,
           ...chainOrCommunityObj,
           invitedAddress: selection === 'address' ? address : '',
           invitedAddressChain: selection === 'address' ? selectedChain : '',

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -30,12 +30,14 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
     return m(Button, {
       class: 'create-invite-button',
       intent: 'primary',
+      name: selection,
       loading: vnode.state.disabled,
       type: 'submit',
       label: selection === 'address'
         ? 'Invite Commonwealth user' : selection === 'email' ? 'Invite email' : 'Add',
       onclick: (e) => {
         e.preventDefault();
+        console.log(vnode.attrs);
         const address = invitedAddress;
         const emailAddress = invitedEmail;
         const selectedChain = invitedAddressChain;
@@ -234,7 +236,7 @@ const CreateInviteModal: m.Component<{
               name: 'address',
               autocomplete: 'off',
               placeholder: 'Address',
-              onchange: (e) => {
+              onkeyup: (e) => {
                 vnode.state.invitedAddress = (e.target as any).value;
               }
             }),
@@ -263,7 +265,7 @@ const CreateInviteModal: m.Component<{
               name: 'emailAddress',
               autocomplete: 'off',
               placeholder: 'satoshi@protonmail.com',
-              onchange: (e) => {
+              onkeyup: (e) => {
                 vnode.state.invitedEmail = (e.target as any).value;
               }
             }),

--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -255,7 +255,7 @@ const CreateInviteModal: m.Component<{
             ...chainOrCommunityObj
           }),
         ]),
-        communityInfo && m(Form, [
+        m(Form, [
           m(FormGroup, [
             m(FormLabel, 'Email'),
             m(Input, {

--- a/server/migrations/20200902215741-add-chain-info-to-invite-code.js
+++ b/server/migrations/20200902215741-add-chain-info-to-invite-code.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};

--- a/server/migrations/20200902215741-add-chain-info-to-invite-code.js
+++ b/server/migrations/20200902215741-add-chain-info-to-invite-code.js
@@ -1,23 +1,21 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    /*
-      Add altering commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
-    */
+  up: (queryInterface, DataTypes) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn('InviteCodes', 'chain_id', {
+          type: DataTypes.STRING, allowNull: true,
+        }, { transaction: t }),
+      ]);
+    });
   },
 
-  down: (queryInterface, Sequelize) => {
-    /*
-      Add reverting commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.dropTable('users');
-    */
+  down: (queryInterface, DataTypes) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('InviteCodes', 'chain_id', { transaction: t }),
+      ]);
+    });
   }
 };

--- a/server/migrations/20200902215741-add-chain-info-to-invite-code.js
+++ b/server/migrations/20200902215741-add-chain-info-to-invite-code.js
@@ -7,6 +7,7 @@ module.exports = {
         queryInterface.addColumn('InviteCodes', 'chain_id', {
           type: DataTypes.STRING, allowNull: true,
         }, { transaction: t }),
+        queryInterface.changeColumn('InviteCodes', 'community_id', { type: DataTypes.STRING, allowNull: true }, { transaction: t })
       ]);
     });
   },

--- a/server/models/invite_code.ts
+++ b/server/models/invite_code.ts
@@ -1,17 +1,20 @@
 import * as Sequelize from 'sequelize';
 
 import { OffchainCommunityAttributes } from './offchain_community';
+import { ChainAttributes } from './chain';
 
 export interface InviteCodeAttributes {
   id?: string;
-  community_id: string;
+  community_id?: string;
   community_name?: string;
+  chain_id?: string;
   creator_id: number;
   invited_email?: string;
   used?: boolean;
   created_at?: Date;
   updated_at?: Date;
   OffchainCommunity?: OffchainCommunityAttributes;
+  Chain?: ChainAttributes;
 }
 
 export interface InviteCodeInstance
@@ -30,7 +33,8 @@ export default (
 ): InviteCodeModel => {
   const InviteCode = sequelize.define<InviteCodeInstance, InviteCodeAttributes>('InviteCode', {
     id: { type: dataTypes.STRING, primaryKey: true },
-    community_id: { type: dataTypes.STRING, allowNull: false },
+    community_id: { type: dataTypes.STRING, allowNull: true },
+    chain_id: { type: dataTypes.STRING, allowNull: true },
     community_name: { type: dataTypes.STRING, allowNull: true },
     creator_id: { type: dataTypes.INTEGER, allowNull: false },
     invited_email: { type: dataTypes.STRING, allowNull: true, defaultValue: null },
@@ -46,6 +50,7 @@ export default (
 
   InviteCode.associate = (models) => {
     models.InviteCode.belongsTo(models.OffchainCommunity, { foreignKey: 'community_id', targetKey: 'id' });
+    models.InviteCode.belongsTo(models.Chain, { foreignKey: 'chain_id', targetKey: 'id' });
   };
 
   return InviteCode;

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -26,7 +26,7 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   }
   if (req.body.invitedAddress && req.body.invitedEmail) {
     return next(new Error(Errors.NoEmailAndAddress));
-  } 
+  }
 
   const chainOrCommObj = chain
     ? { chain_id: chain.id }

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -22,7 +22,7 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   if (!req.user) return next(new Error('Not logged in'));
 
-  if (!req.body.invitedAddress && !req.body.invitedEmail) {
+  if (req.body.invitedAddress || req.body.invitedEmail) {
     return next(new Error(Errors.NoEmailOrAddress));
   }
 
@@ -122,7 +122,7 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
     from: 'Commonwealth <no-reply@commonwealth.im>',
     templateId: DynamicTemplate.EmailInvite,
     dynamic_template_data: {
-      community_name: invite.community_id || invite.chain_id,
+      community_name: inviteChainOrCommObj.community_name,
       inviter: address.name,
       joinOrLogIn,
       invite_link: signupLink,

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -22,12 +22,8 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   if (!req.user) return next(new Error('Not logged in'));
 
-  if (req.body.invitedAddress || req.body.invitedEmail) {
+  if (!req.body.invitedAddress && !req.body.invitedEmail) {
     return next(new Error(Errors.NoEmailOrAddress));
-  }
-
-  if (req.body.invitedAddress && req.body.invitedEmail) {
-    return next(new Error(Errors.NoEmailAndAddress));
   }
 
   const chainOrCommObj = chain

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -88,10 +88,15 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
       email: invitedEmail,
     },
   });
+
+  const inviteChainOrCommObj = chain
+    ? { chain_id: chain.id, community_name: chain.name }
+    : { community_id: community.id, community_name: community.name }
   const previousInvite = await models.InviteCode.findOne({
     where: {
       invited_email: invitedEmail,
-      community_id: community.id,
+      // community_id: community.id,
+      ...inviteChainOrCommObj
     }
   });
   if (previousInvite && previousInvite.used === true) { await previousInvite.update({ used: false, }); }
@@ -100,8 +105,9 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
     const inviteCode = crypto.randomBytes(24).toString('hex');
     invite = await models.InviteCode.create({
       id: inviteCode,
-      community_id: community.id,
-      community_name: community.name,
+      // community_id: community.id,
+      // community_name: community.name,
+      ...inviteChainOrCommObj,
       creator_id: req.user.id,
       invited_email: invitedEmail,
       used: false,
@@ -116,7 +122,7 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
     from: 'Commonwealth <no-reply@commonwealth.im>',
     templateId: DynamicTemplate.EmailInvite,
     dynamic_template_data: {
-      community_name: invite.community_id,
+      community_name: invite.community_id || invite.chain_id,
       inviter: address.name,
       joinOrLogIn,
       invite_link: signupLink,

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -24,6 +24,9 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   if (!req.body.invitedAddress && !req.body.invitedEmail) {
     return next(new Error(Errors.NoEmailOrAddress));
   }
+  if (req.body.invitedAddress && req.body.invitedEmail) {
+    return next(new Error(Errors.NoEmailAndAddress));
+  } 
 
   const chainOrCommObj = chain
     ? { chain_id: chain.id }

--- a/server/routes/createInvite.ts
+++ b/server/routes/createInvite.ts
@@ -94,7 +94,6 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
   const previousInvite = await models.InviteCode.findOne({
     where: {
       invited_email: invitedEmail,
-      // community_id: community.id,
       ...inviteChainOrCommObj
     }
   });
@@ -105,8 +104,6 @@ const createInvite = async (models, req: Request, res: Response, next: NextFunct
     const inviteCode = crypto.randomBytes(24).toString('hex');
     invite = await models.InviteCode.create({
       id: inviteCode,
-      // community_id: community.id,
-      // community_name: community.name,
       ...inviteChainOrCommObj,
       creator_id: req.user.id,
       invited_email: invitedEmail,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `chain_id` to `InviteCode` model
- Created migration to add `chain_id` column and remove not-null constraint on `community_id`.
- Modified invite modal to show email invite field on chains.

Closes: #702 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Inviting to chains should be identical to inviting to communities. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Attempted to invite myself in both chain and communities via address and email address and everything still works.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes: 96% coverage