### PR TITLE
[WIP] Use on-chain identities from server.

### DIFF
--- a/client/scripts/controllers/server/profiles.ts
+++ b/client/scripts/controllers/server/profiles.ts
@@ -87,7 +87,12 @@ class ProfilesController {
           const {
             name, headline, bio, avatarUrl,
           } = JSON.parse(profileData.data);
-          profile.initialize(name, headline, bio, avatarUrl);
+          // ignore off-chain name if substrate id exists
+          if (profileData.identity) {
+            profile.initializeWithChain(profileData.identity, headline, bio, avatarUrl, profileData.judgements);
+          } else {
+            profile.initialize(name, headline, bio, avatarUrl);
+          }
           return profile;
         }).filter((p) => p !== null);
       } catch (e) {

--- a/client/scripts/models/Profile.ts
+++ b/client/scripts/models/Profile.ts
@@ -9,11 +9,15 @@ class Profile {
   private _bio: string;
   private _avatarUrl: string;
   private _initialized: boolean;
+  private _judgements: { [registrar: string]: string } = {};
+  private _isOnchain: boolean = false;
   get name() { return this._name; }
   get headline() { return this._headline; }
   get bio() { return this._bio; }
   get avatarUrl() { return this._avatarUrl; }
   get initialized() { return this._initialized; }
+  get judgements() { return this._judgements; }
+  get isOnchain() { return this._isOnchain; }
 
   public readonly chain: string;
   public readonly address: string;
@@ -26,6 +30,17 @@ class Profile {
   public initializeEmpty() {
     this._initialized = true;
   }
+
+  public initializeWithChain(name, headline, bio, avatarUrl, judgements) {
+    this._initialized = true;
+    this._isOnchain = true;
+    this._name = name;
+    this._headline = headline;
+    this._bio = bio;
+    this._avatarUrl = avatarUrl;
+    this._judgements = judgements;
+  }
+
   public initialize(name, headline, bio, avatarUrl) {
     this._initialized = true;
     this._name = name;

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -133,7 +133,18 @@ const ProfilePage: m.Component<{ address: string }, IProfilePageState> = {
           const profile = new Profile(a.chain, a.address);
           if (a.OffchainProfile) {
             const profileData = JSON.parse(a.OffchainProfile.data);
-            profile.initialize(profileData.name, profileData.headline, profileData.bio, profileData.avatarUrl);
+            // ignore off-chain name if substrate id exists
+            if (a.OffchainProfile.identity) {
+              profile.initializeWithChain(
+                a.OffchainProfile.identity,
+                profileData.headline,
+                profileData.bio,
+                profileData.avatarUrl,
+                a.OffchianProfile.judgements
+              );
+            } else {
+              profile.initialize(profileData.name, profileData.headline, profileData.bio, profileData.avatarUrl);
+            }
           } else {
             profile.initializeEmpty();
           }


### PR DESCRIPTION
## Description
Currently we don't use the on-chain identities fetched by the server migration. This PR adds logic to use those over the "offchain" display names, if available.

However, I'm not sure the entire scope of this change, so I'm submitting as a WIP for @raykyri to comment on.

## How has this been tested?
Ran it and verified that the updated displayNames appear.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no