### PR TITLE
Correct runners-up count in council stats

### DIFF
--- a/client/scripts/views/pages/council/index.ts
+++ b/client/scripts/views/pages/council/index.ts
@@ -196,7 +196,7 @@ const CouncilPage: m.Component<{}> = {
         ]),
         m(Col, { span: { xs: 6, md: 3 } }, [
           m('.stats-heading', 'Runners-up'),
-          m('.stats-tile', `${candidates?.length - councillors?.length} / ${nRunnersUpSeats}`),
+          m('.stats-tile', `${Math.min((candidates?.length - councillors?.length), nRunnersUpSeats)} / ${nRunnersUpSeats}`),
         ]),
         m(Col, { span: { xs: 6, md: 3 } }, [
           m('.stats-heading', 'Next council'),


### PR DESCRIPTION
Closes #670.

## Description

Previously, the count of runners-up was exceeding the total count of possible runners-up. For context on the problem, see [comments left on #670](https://github.com/hicommonwealth/commonwealth/issues/670).

This branch ensures that the actual displayed count will never exceed the possible total count.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no