### PR TITLE
Fix disable state for construct buttons

### DIFF
--- a/client/scripts/views/components/cancel_proposal_button.ts
+++ b/client/scripts/views/components/cancel_proposal_button.ts
@@ -1,6 +1,8 @@
 import 'components/cancel_proposal_button.scss';
 
 import m from 'mithril';
+import { Button } from 'construct-ui';
+
 import app, { ApiStatus } from 'state';
 
 interface IAttrs {
@@ -9,13 +11,15 @@ interface IAttrs {
 
 const CancelProposalButton: m.Component<IAttrs> = {
   view: (vnode: m.VnodeDOM<IAttrs>) => {
-    return m('.CancelProposalButton', {
-      class: app.chain.networkStatus === ApiStatus.Connected ? '' : 'disabled',
+    return m(Button, {
+      class: 'CancelProposalButton',
+      disabled: app.chain.networkStatus !== ApiStatus.Connected,
       onclick: (e) => {
         e.preventDefault();
         // TODO: check for login?
       },
-    }, vnode.attrs.label || 'Cancel Proposal');
+      label: vnode.attrs.label || 'Cancel Proposal'
+    });
   }
 };
 

--- a/client/scripts/views/components/inline_thread_composer.ts
+++ b/client/scripts/views/components/inline_thread_composer.ts
@@ -106,7 +106,7 @@ const LinkPost: m.Component<ILinkPostAttrs, ILinkPostState> = {
       m('.bottom-panel', [
         m('.actions', [
           m(Button, {
-            class: !author || formDataIncomplete(vnode.state) ? 'disabled' : '',
+            disabled: !author || !!formDataIncomplete(vnode.state),
             type: 'submit',
             intent: 'primary',
             onclick: createLink,
@@ -114,7 +114,7 @@ const LinkPost: m.Component<ILinkPostAttrs, ILinkPostState> = {
             label: 'Create thread'
           }),
           m(Button, {
-            class: !author ? 'disabled' : '',
+            disabled: !author,
             type: 'cancel',
             onclick: closeComposer,
             basic: true,
@@ -195,7 +195,7 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
       m('.bottom-panel', [
         m('.actions', [
           m(Button, {
-            class: !author || formDataIncomplete(vnode.state) ? 'disabled' : '',
+            disabled: !author || !!formDataIncomplete(vnode.state),
             type: 'submit',
             intent: 'primary',
             onclick: createThread,
@@ -203,7 +203,7 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
             label: 'Create thread'
           }),
           m(Button, {
-            class: !author ? 'disabled' : '',
+            disabled: !author,
             type: 'cancel',
             onclick: closeComposer,
             basic: true,

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -607,7 +607,7 @@ export const NewThreadForm: m.Component<{
           });
         })),
         // m(Button, {
-        //   class: !author || vnode.state.uploadsInProgress > 0 ? 'disabled' : '',
+        //   disabled: !author || vnode.state.uploadsInProgress > 0,
         //   intent: 'none',
         //   onclick: () => cancelDraft(vnode.state),
         //   label: 'Cancel editing draft',

--- a/client/scripts/views/components/proposals/voting_actions.ts
+++ b/client/scripts/views/components/proposals/voting_actions.ts
@@ -398,7 +398,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
         return m(`${cl[0]}`, [
           m(Button, {
             intent: cl[1],
-            class: canVote && !hasVotedForChoice[c.toHex()] ? '' : 'disabled',
+            disabled: !canVote || hasVotedForChoice[c.toHex()],
             onclick: (e) => voteForChoice(e, c),
             label: hasVotedForChoice[c.toHex()]
               ? `Voted ${hexToUtf8(c.toHex())}`
@@ -410,7 +410,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const yesButton = m('.yes-button', [
       m(Button, {
         intent: 'positive',
-        class: canVote && !hasVotedYes ? '' : 'disabled',
+        disabled: !canVote || hasVotedYes,
         onclick: voteYes,
         label: hasVotedYes ? 'Voted yes' : 'Vote yes'
       }),
@@ -418,7 +418,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const noButton = m('.no-button', [
       m(Button, {
         intent: 'negative',
-        class: canVote && !hasVotedNo ? '' : 'disabled',
+        disabled: !canVote || hasVotedNo,
         onclick: voteNo,
         label: hasVotedNo ? 'Voted no' : 'Vote no'
       })
@@ -427,7 +427,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const multiDepositApproveButton = m('.approve-button', [
       m(Button, {
         intent: 'positive',
-        class: canVote ? '' : 'disabled',
+        disabled: !canVote,
         onclick: voteYes,
         label: (hasVotedYes && !canVote) ? 'Already approved' : 'Second'
       }),
@@ -436,7 +436,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const abstainButton = m('.abstain-button', [
       m(Button, {
         intent: 'none',
-        class: canVote && !hasVotedAbstain ? '' : 'disabled',
+        disabled: !canVote || hasVotedAbstain,
         onclick: voteAbstain,
         label: hasVotedAbstain ? 'Voted abstain' : 'Vote abstain'
       }),
@@ -445,7 +445,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const noWithVetoButton = m('.veto-button', [
       m(Button, {
         intent: 'negative',
-        class: canVote && !hasVotedVeto ? '' : 'disabled',
+        disabled: !canVote || hasVotedVeto,
         onclick: voteVeto,
         label: hasVotedVeto ? 'Vetoed' : 'Veto'
       }),
@@ -454,7 +454,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const cancelButton = (proposal.votingType === VotingType.MolochYesNo) && m('.veto-button', [
       m(Button, {
         intent: 'negative',
-        class: (proposal as MolochProposal).canAbort(user) && !(proposal as MolochProposal).completed ? '' : 'disabled',
+        disabled: !((proposal as MolochProposal).canAbort(user) && !(proposal as MolochProposal).completed),
         onclick: cancelProposal,
         label: (proposal as MolochProposal).isAborted ? 'Cancelled' : 'Cancel'
       }),
@@ -463,9 +463,8 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     // const sponsorButton = (proposal.votingType === VotingType.MolochYesNo) && m('.yes-button', [
     //  m(Button, {
     //    intent: 'positive',
-    //    class: !(proposal as MolochProposal).state.sponsored &&
-    //    !(proposal as MolochProposal).state.processed
-    //      ? '' : 'disabled',
+    //    disabled: (proposal as MolochProposal).state.sponsored ||
+    //    (proposal as MolochProposal).state.processed,
     //    onclick: sponsorProposal,
     //    label: (proposal as MolochProposal).state.sponsored ? 'Sponsered' : 'Sponsor',
     //  }),
@@ -474,7 +473,7 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, { conviction
     const processButton = (proposal.votingType === VotingType.MolochYesNo) && m('.yes-button', [
       m(Button, {
         intent: 'none',
-        class: (proposal as MolochProposal).state === MolochProposalState.ReadyToProcess ? '' : 'disabled',
+        disabled: (proposal as MolochProposal).state !== MolochProposalState.ReadyToProcess,
         onclick: processProposal,
         label: (proposal as MolochProposal).data.processed ? 'Processed' : 'Process'
       })

--- a/client/scripts/views/modals/edit_topic_modal.ts
+++ b/client/scripts/views/modals/edit_topic_modal.ts
@@ -90,7 +90,7 @@ const EditTopicModal : m.Component<{
           m(FormGroup, [
             m(Button, {
               intent: 'primary',
-              class: vnode.state.saving ? 'disabled' : '',
+              disabled: vnode.state.saving,
               style: 'margin-right: 8px',
               onclick: async (e) => {
                 e.preventDefault();
@@ -102,7 +102,7 @@ const EditTopicModal : m.Component<{
             }),
             m(Button, {
               intent: 'negative',
-              class: vnode.state.saving ? 'disabled' : '',
+              disabled: vnode.state.saving,
               onclick: async (e) => {
                 e.preventDefault();
                 const confirmed = await confirmationModalWithText('Delete this topic?')();

--- a/client/scripts/views/modals/feedback_modal.ts
+++ b/client/scripts/views/modals/feedback_modal.ts
@@ -23,7 +23,7 @@ const FeedbackModal = {
           ]),
           m(FormGroup, [
             m(Button, {
-              class: vnode.state.sending ? 'disabled' : '',
+              disabled: vnode.state.sending,
               intent: 'primary',
               loading: vnode.state.sending,
               label: 'Send feedback',

--- a/client/scripts/views/modals/new_topic_modal.ts
+++ b/client/scripts/views/modals/new_topic_modal.ts
@@ -66,7 +66,7 @@ const NewTopicModal: m.Component<{
           ]),
           m(Button, {
             intent: 'primary',
-            class: vnode.state.saving ? 'disabled' : '',
+            disabled: vnode.state.saving,
             onclick: async (e) => {
               e.preventDefault();
               if (!vnode.state.form.name.trim()) return;

--- a/client/scripts/views/modals/token_management_modal.ts
+++ b/client/scripts/views/modals/token_management_modal.ts
@@ -125,9 +125,9 @@ const TokenManagementModal: m.Component<IAttrs, IState> = {
           name: 'token-action-switcher',
         }),
         ...content,
-        m('button', {
+        m(Button, {
           type: 'submit',
-          class: !vnode.state.tokensAvailable || !vnode.state.tokenAmount ? 'disabled' : '',
+          disabled: !vnode.state.tokensAvailable || !vnode.state.tokenAmount,
           onclick: (e) => {
             e.preventDefault();
             const tokens = new ERC20Token(vnode.attrs.tokenAddress, new BN(vnode.state.tokenAmount));
@@ -156,8 +156,9 @@ const TokenManagementModal: m.Component<IAttrs, IState> = {
                 console.error(err);
                 vnode.state.error = err.message;
               });
-          }
-        }, 'Approve'),
+          },
+          label: 'Approve',
+        }),
         vnode.state.error && m('.error', vnode.state.error),
       ]),
     ]);

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -177,15 +177,15 @@ const NewProposalForm = {
         if (!vnode.state.threshold) throw new Error('Invalid threshold');
         const threshold = vnode.state.threshold;
         if (vnode.state.councilMotionType === 'createExternalProposal') {
-          args = [author, threshold, EdgewareFunctionPicker.getMethod(), 
+          args = [author, threshold, EdgewareFunctionPicker.getMethod(),
             EdgewareFunctionPicker.getMethod().encodedLength];
           createFunc = ([a, t, m, l]) => (app.chain as Substrate).council.createExternalProposal(a, t, m, l);
         } else if (vnode.state.councilMotionType === 'createExternalProposalMajority') {
-          args = [author, threshold, EdgewareFunctionPicker.getMethod(), 
+          args = [author, threshold, EdgewareFunctionPicker.getMethod(),
             EdgewareFunctionPicker.getMethod().encodedLength];
           createFunc = ([a, t, m, l]) => (app.chain as Substrate).council.createExternalProposalMajority(a, t, m, l);
         } else if (vnode.state.councilMotionType === 'createExternalProposalDefault') {
-          args = [author, threshold, EdgewareFunctionPicker.getMethod(), 
+          args = [author, threshold, EdgewareFunctionPicker.getMethod(),
             EdgewareFunctionPicker.getMethod().encodedLength];
           createFunc = ([a, t, m, l]) => (app.chain as Substrate).council.createExternalProposalDefault(a, t, m, l);
         } else if (vnode.state.councilMotionType === 'createFastTrack') {
@@ -609,8 +609,8 @@ const NewProposalForm = {
           ],
           m(FormGroup, [
             m(Button, {
-              class: (proposalTypeEnum === ProposalType.SubstrateCollectiveProposal
-                && !(author as SubstrateAccount).isCouncillor) ? 'disabled' : '',
+              disabled: (proposalTypeEnum === ProposalType.SubstrateCollectiveProposal
+                && !(author as SubstrateAccount).isCouncillor),
               intent: 'primary',
               label: proposalTypeEnum === ProposalType.OffchainThread
                 ? 'Create thread'

--- a/client/scripts/views/pages/settings/send_edg_well.ts
+++ b/client/scripts/views/pages/settings/send_edg_well.ts
@@ -182,11 +182,12 @@ const SendEDGWell = makeDynamicComponent<IAttrs, IState>({
         ]),
         checks.map((check) => m('.send-edg-check', check)),
       ]),
-      m('button.formular-primary-button', {
-        class: (!vnode.state.recipientBalance
+      m(Button, {
+        class: 'formular-primary-button',
+        disabled: (!vnode.state.recipientBalance
                 || !vnode.state.amount
                 || !canTransfer
-                || vnode.state.sending) ? 'disabled' : '',
+                || vnode.state.sending),
         type: 'submit',
         onclick: async (e) => {
           e.preventDefault();

--- a/client/scripts/views/pages/validators/cosmos.ts
+++ b/client/scripts/views/pages/validators/cosmos.ts
@@ -44,7 +44,7 @@ export const NewCosmosDelegationModal : m.Component<{ validatorAddr }, ICosmosDe
           ]),
           m(Button, {
             intent: 'primary',
-            class: app.user.activeAccount ? '' : 'disabled',
+            disabled: !app.user.activeAccount,
             onclick: (e) => {
               e.preventDefault();
               try {
@@ -100,8 +100,10 @@ export const CosmosValidatorRow: m.Component<IValidatorAttrs> = {
       m('td.val-stash', m(User, { user: app.chain.accounts.get(vnode.attrs.stash), linkify: true })),
       m('td.val-total', formatCoin(vnode.attrs.total, true)),
       m('td.val-action', [
-        !isDelegated && m('button.nominate-validator.formular-button-primary', {
-          class: app.user.activeAccount ? '' : 'disabled',
+        !isDelegated && m(Button, {
+          class: 'nominate-validator',
+          intent: 'primary',
+          disabled: !app.user.activeAccount,
           onclick: (e) => {
             e.preventDefault();
             app.modals.create({
@@ -110,8 +112,10 @@ export const CosmosValidatorRow: m.Component<IValidatorAttrs> = {
             });
           }
         }, 'Delegate'),
-        isDelegated && m('button.nominate-validator.formular-button-primary', {
-          class: app.user.activeAccount ? '' : 'disabled',
+        isDelegated && m(Button, {
+          class: 'nominate-validator',
+          intent: 'primary',
+          disabled: !app.user.activeAccount,
           onclick: (e) => {
             e.preventDefault();
             app.modals.create({

--- a/client/scripts/views/pages/validators/substrate/action_form.ts
+++ b/client/scripts/views/pages/validators/substrate/action_form.ts
@@ -1,6 +1,6 @@
 import m from 'mithril';
 import app from 'state';
-import { FormLabel, FormGroup, Input } from 'construct-ui';
+import { Button, FormLabel, FormGroup, Input } from 'construct-ui';
 
 import { SubstrateAccount } from 'controllers/chain/substrate/account';
 import { DropdownFormField } from 'views/components/forms';
@@ -47,8 +47,9 @@ const ActionForm: m.Component<IActionFormAttrs, IActionFormState> = {
 
     return m('.NewStashForm', [
       (vnode.attrs.onChangeHandler) ? inputComponent : m('h4', vnode.attrs.titleMsg),
-      (vnode.attrs.actionHandler) && m('button.formular-button-primary', {
-        class: app.user.activeAccount ? '' : 'disabled',
+      (vnode.attrs.actionHandler) && m(Button, {
+        class: 'formular-button-primary',
+        disabled: !app.user.activeAccount,
         onclick: (e) => {
           e.preventDefault();
           const value = vnode.state.data || vnode.attrs.defaultValue;
@@ -62,20 +63,21 @@ const ActionForm: m.Component<IActionFormAttrs, IActionFormState> = {
                   vnode.state.sending = false;
                   m.redraw();
                 })
-                .catch(e => {
+                .catch((err) => {
                   vnode.state.sending = false;
                   m.redraw();
                 });
             } else {
               throw new Error(vnode.attrs.errorMsg);
             }
-          } catch (e) {
-            vnode.state.error = e.message;
+          } catch (err) {
+            vnode.state.error = err.message;
             vnode.state.sending = false;
             m.redraw();
           }
         },
-      }, vnode.attrs.actionName),
+        label: vnode.attrs.actionName
+      }),
     ]);
   },
 };

--- a/client/scripts/views/pages/validators/substrate/validator_row.ts
+++ b/client/scripts/views/pages/validators/substrate/validator_row.ts
@@ -38,14 +38,17 @@ const ValidatorRow: m.Component<IValidatorAttrs, IValidatorState> = {
       ]),
       // m('td.val-age', '--'),
       // m('td.val-action', [
-      //   m('button.nominate-validator.formular-button-primary', {
-      //     class: app.user.activeAccount ? '' : 'disabled',
+      //   m(Button, {
+      //     class: 'nominate-validator',
+      //     intent: 'primary',
+      //     disabled: !app.user.activeAccount,
       //     onclick: (e) => {
       //       e.preventDefault();
       //       vnode.state.isNominating = !vnode.state.isNominating;
       //       vnode.attrs.onChangeHandler(vnode.attrs.stash);
-      //     }
-      //   }, vnode.state.isNominating ? 'Un-Nominate' : 'Nominate'),
+      //     },
+      //     label: vnode.state.isNominating ? 'Un-Nominate' : 'Nominate'
+      //   }),
       // ]),
     ]);
   }

--- a/client/scripts/views/stats/edgeware.ts
+++ b/client/scripts/views/stats/edgeware.ts
@@ -598,7 +598,7 @@ const EdgewareStatsPage = {
               m(Button, {
                 id: 'LOCK_LOOKUP_BTN',
                 intent: 'primary',
-                class: vnode.state.lookupLoading ? 'disabled' : '',
+                disabled: vnode.state.lookupLoading,
                 onclick: async (e) => {
                   e.preventDefault();
                   const addrText = `${$('#LOCKDROP_PARTICIPANT_ADDRESS').val()}`;


### PR DESCRIPTION
Setting class=disabled on construct buttons doesn't disable them. This updates them to set disabled=true instead.