### PR TITLE
Admin Panel upgradeMembership UI improvements

### DIFF
--- a/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
+++ b/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
@@ -194,6 +194,9 @@ const UpgradeRolesForm: m.Component<IUpgradeRolesFormAttrs, IUpgradeRolesFormSta
             }).then((r) => {
               if (r.status === 'Success') {
                 notifySuccess('Member upgraded');
+                delete vnode.state.user;
+                delete vnode.state.role;
+                m.redraw();
               } else {
                 notifyError('Upgrade failed');
               }

--- a/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
+++ b/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
@@ -178,12 +178,14 @@ const UpgradeRolesForm: m.Component<IUpgradeRolesFormAttrs, IUpgradeRolesFormSta
         m(Button, {
           class: 'admin-panel-tab-button',
           label: 'Upgrade Member',
+          disabled: (!vnode.state.role || !vnode.state.user),
           onclick: () => {
             const indexOfName = names.indexOf(vnode.state.user);
             const user = noAdmins[indexOfName];
             const newRole = (vnode.state.role === 'Admin') ? 'admin'
               : (vnode.state.role === 'Moderator') ? 'moderator' : '';
             if (!user) return;
+            if (!newRole) return;
             $.post(`${app.serverUrl()}/upgradeMember`, {
               new_role: newRole,
               address: user.Address.address,

--- a/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
+++ b/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
@@ -190,6 +190,11 @@ const UpgradeRolesForm: m.Component<IUpgradeRolesFormAttrs, IUpgradeRolesFormSta
               ...chainOrCommObj,
               jwt: app.user.jwt,
             }).then((r) => {
+              if (r.status === 'Success') {
+                notifySuccess('Member upgraded');
+              } else {
+                notifyError('Upgrade failed');
+              }
               onRoleUpgrade(user, r.result);
             });
           },


### PR DESCRIPTION
Closes #721.

## Description

This branch fixes inadequacies in the admin panel's upgradeMember UI. 
* Previously, incomplete forms could be sent to a backend request, resulting in a 500 error; this branch disables both the button and also the backend request until both a user and role have been selected. 
* Previously, it was unclear whether a member upgrade had succeeded or failed; this adds a notifySuccess() call
* Previously, the form was not "cleaned" on submission, resulting in sticky values.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes