### PR TITLE
Un-batch certain notifications

### DIFF
--- a/client/scripts/helpers/notifications.ts
+++ b/client/scripts/helpers/notifications.ts
@@ -1,4 +1,5 @@
 import { Notification, NotificationSubscription } from 'models';
+import { NotificationCategories } from 'types';
 
 export const batchNotifications = (n: Notification[], prop: string, prop2: string) => {
   return Object.values(n.reduce((acc, obj) => {
@@ -13,7 +14,10 @@ export const sortNotifications = (n: Notification[]) => {
   const batched =  batchNotifications(n, 'subscription', 'objectId');
   const unbatchChainEvents = [];
   batched.forEach((a: Notification[]) => {
-    if (a[0].chainEvent) {
+    if (a[0].chainEvent
+      || a[0].subscription.category === NotificationCategories.NewComment
+      || a[0].subscription.category === NotificationCategories.NewMention
+    ) {
       a.forEach((n2) => unbatchChainEvents.push([n2]));
     } else {
       unbatchChainEvents.push(a);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR ended up being a lot simpler than my first attempts after a moment of clarity 🤦 
Un-batching happens in `sortNotifications()` simply when various conditions are met (`notification.subscription.category` was either `NewComment` or `NewMention`). 

Closes #698 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's clearer to have all new comments notified to encourage conversation like Twitter, not batched like Facebook.
It's also good to know each time someone specifically mentions you and where, not obfuscate that.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran on current latest.dump and the looks good to my notifications. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no