### PR TITLE
New Threads batched notif has space typo

### DIFF
--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -137,7 +137,7 @@ const getBatchNotificationFields = (category, data: IPostNotificationData[]) => 
     notificationHeader = m('span', [
       actorName,
       length > 0 && ` and ${length} others`,
-      'created new threads in ',
+      ' created new threads in ',
       m('span.commented-obj', community_name)
     ]);
   } else if (category === `${NotificationCategories.NewMention}`) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Space typo!

<img width="330" alt="Screen Shot 2020-09-08 at 10 24 38 AM" src="https://user-images.githubusercontent.com/16248081/92509877-d272ae00-f1bf-11ea-807c-e29385020180.png">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug


## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no