### PR TITLE
Batched Notification unread count fix

### DIFF
--- a/client/scripts/views/components/header/notifications_menu.ts
+++ b/client/scripts/views/components/header/notifications_menu.ts
@@ -40,8 +40,8 @@ const NotificationsMenu: m.Component<{ small?: boolean }> = {
     const notifications = app.user.notifications
       ? app.user.notifications.notifications.sort((a, b) => b.createdAt.unix() - a.createdAt.unix())
       : [];
-    const unreadNotifications = notifications.filter((n) => !n.isRead).length;
     const sortedNotifications = sortNotifications(notifications).reverse();
+    const unreadNotifications = sortedNotifications.filter((n) => !n[0].isRead).length;
     return m(PopoverMenu, {
       hasArrow: false,
       transitionDuration: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rather than counting all the notifications read/unread individually, only count the first (newest) notification in the batched arrays. 
Closes #744 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes more sense to the UX.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no