### PR TITLE
Profile Refreshes on Update 

### DIFF
--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -63,9 +63,9 @@ const User: m.Component<{
       account = vnode.attrs.user;
       // TODO: we should remove this, since account should always be of type Account,
       // but we currently inject objects of type 'any' on the profile page
-      const chainId = typeof account.chain === 'string' ? account.chain : account.chain.id;
-      profile = app.profiles.getProfile(chainId, account.address);
-      role = adminsAndMods.find((r) => r.address === account.address && r.address_chain === chainId);
+      // const chainId = typeof account.chain === 'string' ? account.chain : account.chain.id;
+      profile = account.profile;
+      role = adminsAndMods.find((r) => r.address === account.address && r.address_chain === account.chain.id);
     }
     const roleTag = role ? m(Tag, {
       class: 'role-tag',
@@ -101,8 +101,8 @@ const User: m.Component<{
                 profile
                   ? `/${m.route.param('scope') || profile.chain}/account/${profile.address}?base=${profile.chain}`
                   : 'javascript:',
-                profile ? profile.displayName : '--',)
-              : m('a.user-display-name.username', profile ? profile.displayName : '--')
+                profile ? profile.name : '--',)
+              : m('a.user-display-name.username', profile ? profile.name : '--')
           ],
         showRole && roleTag,
       ]);
@@ -122,11 +122,11 @@ const User: m.Component<{
         (app.chain && app.chain.base === ChainBase.Substrate && vnode.state.IdentityWidget)
           ? m(vnode.state.IdentityWidget, { account, linkify: true, profile, hideIdentityIcon })
           : link(`a.user-display-name${
-            (profile && profile.displayName !== 'Anonymous') ? '.username' : '.anonymous'}`,
+            (profile && profile.name !== 'Anonymous') ? '.username' : '.anonymous'}`,
           profile
             ? `/${m.route.param('scope') || profile.chain}/account/${profile.address}?base=${profile.chain}`
             : 'javascript:',
-          profile ? profile.displayName : '--',)
+          profile ? profile.name : '--',)
       ]),
       m('.user-address', formatAddressShort(profile.address, profile.chain)),
       showRole && roleTag,

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -63,9 +63,9 @@ const User: m.Component<{
       account = vnode.attrs.user;
       // TODO: we should remove this, since account should always be of type Account,
       // but we currently inject objects of type 'any' on the profile page
-      // const chainId = typeof account.chain === 'string' ? account.chain : account.chain.id;
+      const chainId = typeof account.chain === 'string' ? account.chain : account.chain.id;
       profile = account.profile;
-      role = adminsAndMods.find((r) => r.address === account.address && r.address_chain === account.chain.id);
+      role = adminsAndMods.find((r) => r.address === account.address && r.address_chain === chainId);
     }
     const roleTag = role ? m(Tag, {
       class: 'role-tag',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue just said: "Edits to a profile are not reflected on the profile page until refresh"
I found that updating the avatar, bio, and headline to work just fine, but the name wasn't updating.
The fix was simply to use the passed in profile attached to the passed in account (when not an AddressInfo) directly, as well as change name shown from `profile.displayName` to `profile.name`.
Closes #738 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
UI Bug

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tried updating all the various fields one at a time.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no