### PR TITLE
One line bug fix to fix denom display (treasury proposal)

### DIFF
--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -390,7 +390,7 @@ const NewProposalForm = {
               }),
             ]),
             m(FormGroup, [
-              m(FormLabel, 'Amount (EDG)'),
+              m(FormLabel, `Amount (${app.chain.chain.denom})`),
               m(Input, {
                 name: 'amount',
                 autofocus: true,


### PR DESCRIPTION
Previous error (while on KLP), the Amount showed EDG in quotes

![image](https://user-images.githubusercontent.com/5334557/92545828-003b0f80-f21f-11ea-91f1-ff0bba308f9d.png)
