### PR TITLE
Add exclusion list for chain event db storage.

### DIFF
--- a/server/eventHandlers/storage.ts
+++ b/server/eventHandlers/storage.ts
@@ -1,7 +1,7 @@
 /**
  * Generic handler that stores the event in the database.
  */
-import { IEventHandler, CWEvent } from '@commonwealth/chain-events';
+import { IEventHandler, CWEvent, IChainEventKind } from '@commonwealth/chain-events';
 
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
@@ -10,6 +10,7 @@ export default class extends IEventHandler {
   constructor(
     private readonly _models,
     private readonly _chain: string,
+    private readonly _excludedEvents: IChainEventKind[] = [],
   ) {
     super();
   }
@@ -19,6 +20,11 @@ export default class extends IEventHandler {
    */
   public async handle(event: CWEvent) {
     log.trace(`Received event: ${JSON.stringify(event, null, 2)}`);
+    if (this._excludedEvents.includes(event.data.kind)) {
+      log.trace('Skipping event!');
+      return;
+    }
+
     // locate event type and add event to database
     const dbEventType = await this._models.ChainEventType.findOne({ where: {
       chain: this._chain,

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -68,7 +68,12 @@ const setupChainEventListeners = async (
 
   log.info('Setting up event listeners...');
   const subscribers = await Promise.all(nodes.map(async (node) => {
-    const storageHandler = new EventStorageHandler(models, node.chain);
+    const excludedEvents = [
+      SubstrateTypes.EventKind.Reward,
+      SubstrateTypes.EventKind.TreasuryRewardMinting,
+      SubstrateTypes.EventKind.TreasuryRewardMintingV2,
+    ];
+    const storageHandler = new EventStorageHandler(models, node.chain, excludedEvents);
     const notificationHandler = new EventNotificationHandler(models, wss);
     const entityArchivalHandler = new EntityArchivalHandler(models, node.chain, wss);
     const identityHandler = new IdentityHandler(models, node.chain);

--- a/test/unit/events/storageHandler.spec.ts
+++ b/test/unit/events/storageHandler.spec.ts
@@ -117,4 +117,28 @@ describe('Event Storage Handler Tests', () => {
     });
     assert.lengthOf(chainEvents, 0);
   });
+
+  it('should not create chain event for excluded event type', async () => {
+    const event: CWEvent = {
+      blockNumber: 13,
+      data: {
+        kind: SubstrateTypes.EventKind.Reward,
+        amount: '10000',
+      }
+    };
+    const eventHandler = new StorageHandler(models, 'edgeware', [ SubstrateTypes.EventKind.Reward ]);
+
+    // process event
+    const dbEvent = await eventHandler.handle(event as unknown as CWEvent);
+
+    // confirm no event emitted
+    assert.isUndefined(dbEvent);
+    const chainEvents = await models['ChainEvent'].findAll({
+      where: {
+        chain_event_type_id: 'edgeware-reward',
+        block_number: 13,
+      }
+    });
+    assert.lengthOf(chainEvents, 0);
+  });
 });


### PR DESCRIPTION
## Description
Updates the event handler that writes chain events to db to accept a list of chain events which we will ignore.

We may also want to add a migration that drops pre-existing chain events of the excluded types, due to reasoning in section below.

## Motivation and Context
In the most recent Heroku dump of the db, I see the following chain event row counts (run `SELECT chain_event_type_id, COUNT(*) FROM "ChainEvents" GROUP BY chain_event_type_id ORDER BY count DESC;` to reproduce):
```
          chain_event_type_id          | count  
---------------------------------------+--------
 kusama-reward                         | 113770
 polkadot-reward                       |  19054
 polkadot-bonded                       |   3583
 kusama-bonded                         |   2996
 edgeware-reward                       |   2339
 kusama-unbonded                       |   1053
 polkadot-unbonded                     |    583
 kusama-collective-voted               |    259
 kusama-election-new-term              |     69
 edgeware-collective-voted             |     52
...
```

We are storing a massive number of `reward` events, relative to all other event types. It makes sense that we should begin ignoring these events in the database. We also want to prepare ourselves to ignore treasury-reward events generated every block on Beresheet, so I've included that in this PR as well.

For discussion: perhaps we also want to ignore bonded/unbonded events? But those are still an order of magnitude less common, and may be more useful than reward events.

## How has this been tested?
Wrote a unit test for the exclusion feature. Ran the server, no type errors.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no