### PR TITLE
Make Entity Migration properly re-entrant.

### DIFF
--- a/server/scripts/migrateChainEntities.ts
+++ b/server/scripts/migrateChainEntities.ts
@@ -44,8 +44,9 @@ export default async function (models, chain?: string): Promise<void> {
     log.info('Fetching chain events...');
     const fetcher = new SubstrateEvents.StorageFetcher(api);
     const events = await fetcher.fetch();
+
     log.info(`Writing chain events to db... (count: ${events.length})`);
-    await Promise.all(events.map(async (event) => {
+    for (const event of events) {
       try {
         // eslint-disable-next-line no-await-in-loop
         const dbEvent = await migrationHandler.handle(event);
@@ -53,6 +54,6 @@ export default async function (models, chain?: string): Promise<void> {
       } catch (e) {
         log.error(`Event handle failure: ${e.message}`);
       }
-    }));
+    }
   }
 }

--- a/test/unit/events/entityArchivalHandler.spec.ts
+++ b/test/unit/events/entityArchivalHandler.spec.ts
@@ -158,4 +158,31 @@ describe('Edgeware Archival Event Handler Tests', () => {
     assert.deepEqual(dbEvent, handledDbEvent);
     assert.isNull(dbEvent.entity_id);
   });
+
+  it('should ignore duplicate entities', async () => {
+    const event: CWEvent<SubstrateTypes.IEventData> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.DemocracyStarted,
+        referendumIndex: 3,
+        endBlock: 100,
+        proposalHash: 'hash',
+        voteThreshold: 'Supermajorityapproval',
+      }
+    };
+
+    const dbEvent = await setupDbEvent(event);
+    const eventHandler = new EntityArchivalHandler(models, 'edgeware');
+
+    // process event twice
+    const handledDbEvent = await eventHandler.handle(event, dbEvent);
+    const duplicateEvent = await eventHandler.handle(event, dbEvent);
+
+    // verify outputs
+    assert.deepEqual(handledDbEvent, duplicateEvent);
+    const chainEntities = await models['ChainEntity'].findAll();
+    assert.lengthOf(chainEntities, 1);
+    const entity = await handledDbEvent.getChainEntity();
+    assert.deepEqual(entity.toJSON(), chainEntities[0].toJSON());
+  });
 });


### PR DESCRIPTION
## Description
Previously the entity migration would duplicate chain entities in the database. This PR solves that issue by using `findOrCreate`. The migration also used `map` to update entities, which resulted in race conditions involving the order that events are processed. This is fixed by changing it to a loop.

## How has this been tested?
Wrote a test case for the duplicates issue + ran the migration and manually verified output.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no