### PR TITLE
Admins User Component not loading in Admin Panel

### DIFF
--- a/client/scripts/views/modals/manage_community_modal/metadata_rows.ts
+++ b/client/scripts/views/modals/manage_community_modal/metadata_rows.ts
@@ -4,6 +4,7 @@ import { Input, TextArea, Icon, Icons, Switch } from 'construct-ui';
 
 import app from 'state';
 import User from 'views/components/widgets/user';
+import { AddressInfo } from 'models';
 
 export const ManageRolesRow: m.Component<{ roledata?, onRoleUpdate?: Function }> = {
   view: (vnode) => {
@@ -14,12 +15,15 @@ export const ManageRolesRow: m.Component<{ roledata?, onRoleUpdate?: Function }>
 
     return m('.ManageRoleRow', [
       vnode.attrs.roledata?.map((role) => {
+        const addr = role.Address;
         const isSelf = role.Address.address === app.user.activeAccount?.address
           && role.Address.chain === app.user.activeAccount?.chain.id;
         return m('.RoleChild', [
           m(User, {
-            user: role.Address,
+            user: new AddressInfo(addr.id, addr.address, addr.chain, null), //role.Address, // make AddressInfo?
             tooltip: true,
+            linkify: false,
+            hideAvatar: false,
           }),
           !isSelf && m(Icon, {
             name: Icons.X,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #754, which identified this issue as a Kulupu specific issue, but it was an unidentified bug from a previous change in User Component from a past PR. All admins were not loading in the admin panel, now they are!
- Rather than passing in the raw address to the User Component, make instance of AddressInfo from the Role.Address being iterated on to pass in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
BUG 🐛 🐞 🐝 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Checked Edgeware/Kulupu/Internal admin panels and it works as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no