### PR TITLE
Implemented /getOffences route

### DIFF
--- a/server/routes/getOffences.ts
+++ b/server/routes/getOffences.ts
@@ -38,14 +38,13 @@ const getOffences = async (models, req: Request, res: Response, next: NextFuncti
     startDate.setDate(startDate.getDate() - 30);
     startDate = startDate.toISOString(); // 2020-08-08T12:46:32.276Z FORMAT // 30 days ago date
   }
-  const where: any = {
+  let where: any = {
     chain_event_type_id: `${chain}-offences-offence`
   };
 
   if (stash) {
-    where.event_data = {
-      [Op.like]: `%${stash}%`
-    }
+    const stashCheck = { [Op.and]: Sequelize.literal(`event_data->>'offenders' LIKE '%${stash}%'`) };
+    where = Object.assign(where, stashCheck);
   }
 
   if (startDate && endDate) {
@@ -70,7 +69,7 @@ const getOffences = async (models, req: Request, res: Response, next: NextFuncti
         validators[key] = {};
         validators[key][ofc.block_number.toString()] = event_data.kind;
       }
-    })    
+    })
   });
 
   return res.json({ status: 'Success', result: { validators: validators || [] } });

--- a/server/routes/getOffences.ts
+++ b/server/routes/getOffences.ts
@@ -39,7 +39,7 @@ const getOffences = async (models, req: Request, res: Response, next: NextFuncti
     startDate = startDate.toISOString(); // 2020-08-08T12:46:32.276Z FORMAT // 30 days ago date
   }
   const where: any = {
-    chain_event_type_id: `${chain}-some-offline`
+    chain_event_type_id: `${chain}-offences-offence`
   };
 
   if (stash) {

--- a/server/routes/getOffences.ts
+++ b/server/routes/getOffences.ts
@@ -10,6 +10,13 @@ export const Errors = {
   NoRecordsFound: 'No records found',
 };
 
+interface ISomeOfflineEventData {
+  kind: string;
+  sessionIndex: number;
+  validators: Array<string>;
+}
+
+
 const getOffences = async (models, req: Request, res: Response, next: NextFunction) => {
   const { chain, stash } = req.query;
   let { startDate, endDate } = req.query;
@@ -31,24 +38,43 @@ const getOffences = async (models, req: Request, res: Response, next: NextFuncti
     startDate.setDate(startDate.getDate() - 30);
     startDate = startDate.toISOString(); // 2020-08-08T12:46:32.276Z FORMAT // 30 days ago date
   }
-
   const where: any = {
-    '$ChainEventType.chain$': chain,
-    '$ChainEventType.event_name$': 'offence'
+    chain_event_type_id: `${chain}-some-offline`
   };
+
+  if (stash) {
+    where.event_data = {
+      [Op.like]: `%${stash}%`
+    }
+  }
+
   if (startDate && endDate) {
     where.created_at = {
       [Op.between]: [startDate, endDate]
     };
   }
   const offences = await models.ChainEvent.findAll({
-    where,
-    include: [
-      { model: models.ChainEventType }
-    ]
+    where
   });
 
-  return res.json({ status: 'Success', result: { validatorOffences: offences || [] } });
+  const validators: { [key: string]: any[] } = {};
+
+  offences.forEach((ofc) => {
+    const event_data: ISomeOfflineEventData = ofc.dataValues.event_data;
+
+    const keys = event_data.validators || chain;
+    keys.array.forEach(key => {
+      if (key in validators) {
+        if (validators.hasOwnProperty(key)) {
+          validators[key].push(ofc.block_number);
+        }
+      } else {
+        validators[key] = [ofc.block_number];
+      }
+    });
+  });
+
+  return res.json({ status: 'Success', result: { validatorOffences: validators || [] } });
 };
 
 export default getOffences;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
/getOffence now returns offences for a validator w.r.t to start and end date provided.

## Motivation and Context
/getOffence route [here](https://github.com/hicommonwealth/commonwealth/pull/422/files) wasn't returning offences for a _specific_ validator.
#555 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no