### PR TITLE
Display "Could not connect to chain" in login modal when chain fails to connect

### DIFF
--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -278,7 +278,6 @@ const LinkNewAddressModal: m.Component<{
   enteredAddress?: string;
   cosmosStdTx?: object;
   initializingWallet: boolean;
-  initializeFailed: boolean;
   onpopstate;
 }> = {
   // close the modal if the user moves away from the page
@@ -586,20 +585,15 @@ const LinkNewAddressModal: m.Component<{
               },
               onclick: async (vvnode) => {
                 // initialize API if needed before starting webwallet
-                try {
-                  vnode.state.initializingWallet = true;
-                  await app.chain.initApi();
-                  await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
-                  vnode.state.initializingWallet = false;
-                } catch (e) {
-                  vnode.state.initializeFailed = true;
-                  console.log('failed to initialize chain/wallet');
-                }
+                vnode.state.initializingWallet = true;
+                await app.chain.initApi();
+                await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
+                vnode.state.initializingWallet = false;
                 m.redraw();
               },
               label: vnode.state.initializingWallet !== false && app.chain.networkStatus !== ApiStatus.Disconnected
                 ? [ m(Spinner, { size: 'xs', active: true }), ' Connecting to chain (may take up to 30s)...' ]
-                : /* vnode.state.initializeFailed === true */ app.chain.networkStatus === ApiStatus.Disconnected ?  'Could not connect to chain'
+                : app.chain.networkStatus === ApiStatus.Disconnected ?  'Could not connect to chain'
                 : (app.chain as Substrate || app.chain as Ethereum).webWallet.available
                   ? 'Connect to wallet' : 'No wallet detected',
             }),

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -278,6 +278,7 @@ const LinkNewAddressModal: m.Component<{
   enteredAddress?: string;
   cosmosStdTx?: object;
   initializingWallet: boolean;
+  initializeFailed: boolean;
   onpopstate;
 }> = {
   // close the modal if the user moves away from the page
@@ -585,14 +586,20 @@ const LinkNewAddressModal: m.Component<{
               },
               onclick: async (vvnode) => {
                 // initialize API if needed before starting webwallet
-                vnode.state.initializingWallet = true;
-                await app.chain.initApi();
-                await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
-                vnode.state.initializingWallet = false;
+                try {
+                  vnode.state.initializingWallet = true;
+                  await app.chain.initApi();
+                  await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
+                  vnode.state.initializingWallet = false;
+                } catch (e) {
+                  vnode.state.initializeFailed = true;
+                  console.log('failed to initialize chain/wallet');
+                }
                 m.redraw();
               },
               label: vnode.state.initializingWallet !== false
                 ? [ m(Spinner, { size: 'xs', active: true }), ' Connecting to chain (may take up to 30s)...' ]
+                : vnode.state.initializeFailed === true ?  'Could not connect to chain'
                 : (app.chain as Substrate || app.chain as Ethereum).webWallet.available
                   ? 'Connect to wallet' : 'No wallet detected',
             }),

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -597,9 +597,9 @@ const LinkNewAddressModal: m.Component<{
                 }
                 m.redraw();
               },
-              label: vnode.state.initializingWallet !== false
+              label: vnode.state.initializingWallet !== false && app.chain.networkStatus !== ApiStatus.Disconnected
                 ? [ m(Spinner, { size: 'xs', active: true }), ' Connecting to chain (may take up to 30s)...' ]
-                : vnode.state.initializeFailed === true ?  'Could not connect to chain'
+                : /* vnode.state.initializeFailed === true */ app.chain.networkStatus === ApiStatus.Disconnected ?  'Could not connect to chain'
                 : (app.chain as Substrate || app.chain as Ethereum).webWallet.available
                   ? 'Connect to wallet' : 'No wallet detected',
             }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Uses ApiStatus and app.chain.networkStatus to check if the chain failed to connect, if so, change the label of the button in the modal.

Closes #583,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Give more descriptive failure to the client.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- yarn reset-server and connect to local-testnet
- turn off wifi mid-login attempt.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no