### PR TITLE
Optimize Chain/Community loading by fetching all Offchain data in a single query

### DIFF
--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -254,6 +254,26 @@ class CommentsController {
     }
   }
 
+  public initialize(initialComments, reset = true) {
+    if (reset) {
+      this._store.clear();
+    }
+    initialComments.forEach((comment) => {
+      if (!comment.Address) {
+        console.error('Comment missing linked address');
+      }
+      const existing = this._store.getById(comment.id);
+      if (existing) {
+        this._store.remove(existing);
+      }
+      try {
+        this._store.add(modelFromServer(comment));
+      } catch (e) {
+        // Comment is on an object that was deleted or unavailable
+      }
+    });
+  };
+
   public deinit() {
     this.store.clear();
   }

--- a/client/scripts/controllers/server/reactions.ts
+++ b/client/scripts/controllers/server/reactions.ts
@@ -145,6 +145,28 @@ class ReactionsController {
     }
   }
 
+  public initialize(initialReactions, reset = true) {
+    if (reset) {
+      this._store.clear();
+    }
+    for (const reaction of initialReactions) {
+      // TODO: Reactions should always have a linked Address
+      if (!reaction.Address) {
+        console.error('Reaction missing linked address');
+      }
+      // TODO: check `response` against store and update store iff `response` is newer
+      const existing = this._store.getById(reaction.id);
+      if (existing) {
+        this._store.remove(existing);
+      }
+      try {
+        this._store.add(modelFromServer(reaction));
+      } catch (e) {
+        // console.error(e.message);
+      }
+    }
+  }
+
   public deinit() {
     this.store.clear();
   }

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -255,6 +255,28 @@ class ThreadsController {
       });
   }
 
+  public initialize(initialThreads: any[], reset = true) {
+    if (reset) {
+      this._store.clear();
+    }
+
+    for (const thread of initialThreads) {
+      if (!thread.Address) {
+        console.error('OffchainThread missing address');
+      }
+      const existing = this._store.getByIdentifier(thread.id);
+      if (existing) {
+        this._store.remove(existing);
+      }
+      try {
+        this._store.add(modelFromServer(thread));
+      } catch (e) {
+        console.error(e.message);
+      }
+    }
+    this._initialized = true;
+  }
+
   public deinit() {
     this._initialized = false;
     this.store.clear();

--- a/client/scripts/controllers/server/topics.ts
+++ b/client/scripts/controllers/server/topics.ts
@@ -143,6 +143,21 @@ class TopicsController {
     }
   }
 
+  public initialize(initialTopics, reset = true) {
+    if (reset) {
+      this._store.clear();
+    }
+    console.log(initialTopics);
+    initialTopics.forEach((t) => {
+      try {
+        this._store.add(modelFromServer(t));
+      } catch (e) {
+        // malformed topic
+      }
+    });
+    this._initialized = true;
+  }
+
   public getTopicListing = (topic, activeTopic) => {
     // Iff a topic is already in the TopicStore, e.g. due to app.topics.edit, it will be excluded from
     // addition to the TopicStore, since said store will be more up-to-date

--- a/client/scripts/controllers/server/topics.ts
+++ b/client/scripts/controllers/server/topics.ts
@@ -147,12 +147,11 @@ class TopicsController {
     if (reset) {
       this._store.clear();
     }
-    console.log(initialTopics);
     initialTopics.forEach((t) => {
       try {
         this._store.add(modelFromServer(t));
       } catch (e) {
-        // malformed topic
+        console.error(e);
       }
     });
     this._initialized = true;

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -72,7 +72,6 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
       jwt: this.app.user.jwt,
     });
     const { threads, comments, reactions, topics, admins } = response.result;
-    console.log(admins);
     this.app.threads.initialize(threads, true);
     this.app.comments.initialize(comments, true);
     this.app.reactions.initialize(reactions, true);

--- a/server/router.ts
+++ b/server/router.ts
@@ -115,8 +115,6 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   // TODO: Change to PUT /node
   router.post('/selectNode', passport.authenticate('jwt', { session: false }), selectNode.bind(this, models));
 
-  router.get('/bulkOffchain', passport.authenticate('jwt', { session: false }), bulkOffchain.bind(this, models));
-
   // chains
   // TODO: Change to POST /chainNode
   router.post('/addChainNode', passport.authenticate('jwt', { session: false }), addChainNode.bind(this, models));
@@ -158,6 +156,8 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   router.get('/drafts', getDrafts.bind(this, models));
   router.delete('/drafts', passport.authenticate('jwt', { session: false }), deleteDraft.bind(this, models));
   router.patch('/drafts', passport.authenticate('jwt', { session: false }), editDraft.bind(this, models));
+
+  router.get('/bulkOffchain', bulkOffchain.bind(this, models));
 
   // offchain comments
   // TODO: Change to POST /comment

--- a/server/router.ts
+++ b/server/router.ts
@@ -87,6 +87,7 @@ import deleteTopic from './routes/deleteTopic';
 import bulkTopics from './routes/bulkTopics';
 import setPrivacy from './routes/setPrivacy';
 import pinThread from './routes/pinThread';
+import bulkOffchain from './routes/bulkOffchain';
 
 import edgewareLockdropLookup from './routes/getEdgewareLockdropLookup';
 import edgewareLockdropStats from './routes/getEdgewareLockdropStats';
@@ -113,6 +114,8 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   router.post('/deleteAddress', passport.authenticate('jwt', { session: false }), deleteAddress.bind(this, models));
   // TODO: Change to PUT /node
   router.post('/selectNode', passport.authenticate('jwt', { session: false }), selectNode.bind(this, models));
+
+  router.get('/bulkOffchain', passport.authenticate('jwt', { session: false }), bulkOffchain.bind(this, models));
 
   // chains
   // TODO: Change to POST /chainNode

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -14,31 +14,6 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
   if (!chain && !community) return next(new Error(Errors.NeedChainOrCommunity));
 
-  // Threads
-  if (!req.user) { // if not logged in, return public threads
-    const publicThreadsQuery = (community)
-      ? { community: community.id, private: false, }
-      : { chain: chain.id, private: false, };
-
-    const publicThreads = await models.OffchainThread.findAll({
-      where: publicThreadsQuery,
-      include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
-      order: [['created_at', 'DESC']],
-    });
-
-    return res.json({ status: 'Success', result: publicThreads.map((c) => c.toJSON()) });
-  }
-
-  const allThreadsQuery = (community)
-    ? { community: community.id, }
-    : { chain: chain.id, };
-
-  const allThreads = await models.OffchainThread.findAll({
-    where: allThreadsQuery,
-    include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
-    order: [['created_at', 'DESC']],
-  });
-
   const userAddresses = await req.user.getAddresses();
   const userAddressIds = Array.from(userAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id));
   const rolesQuery = (community)
@@ -50,17 +25,41 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
 
   const adminRoles = roles.filter((r) => r.permission === 'admin' || r.permission === 'moderator');
 
-  const filteredThreads = await allThreads.filter((thread) => {
-    if (thread.private === false) {
-      return true;
-    } else if (userAddressIds.includes(thread.address_id)) {
-      return true;
-    } else if (adminRoles.length > 0) {
-      return true;
-    } else {
-      return false;
-    }
-  });
+  // Threads
+  let filteredThreads;
+  if (!req.user) { // if not logged in, return public threads
+    const publicThreadsQuery = (community)
+      ? { community: community.id, private: false, }
+      : { chain: chain.id, private: false, };
+
+    filteredThreads = await models.OffchainThread.findAll({
+      where: publicThreadsQuery,
+      include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
+      order: [['created_at', 'DESC']],
+    });
+  } else { // if logged in, return public threads and owned private threads
+    const allThreadsQuery = (community)
+      ? { community: community.id, }
+      : { chain: chain.id, };
+
+    const allThreads = await models.OffchainThread.findAll({
+      where: allThreadsQuery,
+      include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
+      order: [['created_at', 'DESC']],
+    });
+
+    filteredThreads = await allThreads.filter((thread) => {
+      if (thread.private === false) {
+        return true;
+      } else if (userAddressIds.includes(thread.address_id)) {
+        return true;
+      } else if (adminRoles.length > 0) {
+        return true;
+      } else {
+        return false;
+      }
+    });
+  }
 
   // Topics
   const topics = await models.OffchainTopic.findAll({

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -1,0 +1,120 @@
+import { Response, NextFunction, Request } from 'express';
+import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
+import { factory, formatFilename } from '../../shared/logging';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+export const Errors = {
+  NeedChainOrCommunity: 'Must provide a chain or community',
+};
+
+// Topics, comments, reactions, members+admins, threads
+const bulkOffchain = async (models, req: Request, res: Response, next: NextFunction) => {
+  const { Op } = models.sequelize;
+  const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
+  if (!chain && !community) return next(new Error(Errors.NeedChainOrCommunity));
+
+  // Threads
+  if (!req.user) { // if not logged in, return public threads
+    const publicThreadsQuery = (community)
+      ? { community: community.id, private: false, }
+      : { chain: chain.id, private: false, };
+
+    const publicThreads = await models.OffchainThread.findAll({
+      where: publicThreadsQuery,
+      include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
+      order: [['created_at', 'DESC']],
+    });
+
+    return res.json({ status: 'Success', result: publicThreads.map((c) => c.toJSON()) });
+  }
+
+  const allThreadsQuery = (community)
+    ? { community: community.id, }
+    : { chain: chain.id, };
+
+  const allThreads = await models.OffchainThread.findAll({
+    where: allThreadsQuery,
+    include: [ models.Address, { model: models.OffchainTopic, as: 'topic' } ],
+    order: [['created_at', 'DESC']],
+  });
+
+  const userAddresses = await req.user.getAddresses();
+  const userAddressIds = Array.from(userAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id));
+  const rolesQuery = (community)
+    ? { address_id: { [Op.in]: userAddressIds }, offchain_community_id: community.id, }
+    : { address_id: { [Op.in]: userAddressIds }, chain_id: chain.id };
+  const roles = await models.Role.findAll({
+    where: rolesQuery
+  });
+
+  const adminRoles = roles.filter((r) => r.permission === 'admin' || r.permission === 'moderator');
+
+  const filteredThreads = await allThreads.filter((thread) => {
+    if (thread.private === false) {
+      return true;
+    } else if (userAddressIds.includes(thread.address_id)) {
+      return true;
+    } else if (adminRoles.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  // Topics
+  const topics = await models.OffchainTopic.findAll({
+    where: community
+      ? { community_id: community.id }
+      : { chain_id: chain.id },
+  });
+
+  // Comments
+  const whereOptions: any = {};
+  if (community) {
+    whereOptions.community = community.id;
+  } else {
+    whereOptions.chain = chain.id;
+    whereOptions.root_id = { [Op.like]: 'discussion%' };
+  }
+  const comments = await models.OffchainComment.findAll({
+    where: whereOptions,
+    include: [ models.Address, models.OffchainAttachment ],
+    order: [['created_at', 'DESC']],
+  });
+
+  // Reactions
+  const reactions = await models.OffchainReaction.findAll({
+    where: community
+      ? { community: community.id }
+      : { chain: chain.id },
+    include: [ models.Address ],
+    order: [['created_at', 'DESC']],
+  });
+
+  // Members
+  const admins = await models.Role.findAll({
+    where: chain ? {
+      chain_id: chain.id,
+      permission: { [Op.in]: ['admin', 'moderator'] },
+    } : {
+      offchain_community_id: community.id,
+      permission: { [Op.in]: ['admin', 'moderator'] },
+    },
+    include: [ models.Address ],
+    order: [['created_at', 'DESC']],
+  });
+
+  return res.json({
+    status: 'Success',
+    result: {
+      topics: topics.map((c) => c.toJSON()),
+      comments: comments.map((c) => c.toJSON()),
+      reactions: reactions.map((c) => c.toJSON()),
+      admins: admins.map((p) => p.toJSON()),
+      threads: filteredThreads.map((c) => c.toJSON()),
+    }
+  });
+};
+
+export default bulkOffchain;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Created `/bulkOffchain` which returns all offchain data (threads, comments, reactions, topics, admins). Run at chain/comm initialization.
- Added an `initialize(state)` method to all the relevant controllers which takes in an initial state rather than sending an independent request.

NOT MODIFIED: `/bulkEntities` request when initializing a chain community.
Closes #792. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to speed up load times!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tried opening various communities and testing that everything loads accordingly. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run or write tests
