### PR TITLE
New Mention notification always includes thread title

### DIFF
--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -65,9 +65,7 @@ const getNotificationFields = (category, data: IPostNotificationData) => {
   } else if (category === NotificationCategories.NewThread) {
     notificationHeader = m('span', [ actorName, ' created a new thread ', m('span.commented-obj', decoded_title) ]);
   } else if (category === `${NotificationCategories.NewMention}`) {
-    notificationHeader = (!comment_id)
-      ? m('span', [ actorName, ' mentioned you in ', m('span.commented-obj', community_name) ])
-      : m('span', [ actorName, ' mentioned you in ', m('span.commented-obj', decoded_title || community_name) ]);
+    notificationHeader = m('span', [ actorName, ' mentioned you in ', m('span.commented-obj', decoded_title) ]);
   } else if (category === `${NotificationCategories.NewReaction}`) {
     notificationHeader = (!comment_id)
       ? m('span', [ actorName, ' liked your post ', m('span.commented-obj', decoded_title) ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
>Mentions when creating a new comment seem to work, but mentions when creating a new thread are missing the thread title and excerpt

I was able to replicate and fix mentions on a new thread missing the thread title, but I was not able to replicate the excerpt not showing up issue (it always showed up for me).

Closes #799.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug 🐛 🐝 🐞 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Made dummy account mention @zak in a bunch of different contexts and checked the notifications.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no