### PR TITLE
Filter out preimages from default /bulkEntities

### DIFF
--- a/server/routes/bulkEntities.ts
+++ b/server/routes/bulkEntities.ts
@@ -1,4 +1,5 @@
 import { Response, NextFunction, Request } from 'express';
+import { Op } from 'sequelize';
 
 export const Errors = {
   NeedChain: 'Must provide a chain to fetch entities from',
@@ -41,6 +42,10 @@ const bulkEntities = async (models, req: Request, res: Response, next: NextFunct
   }
   if (req.query.completed) {
     entityFindOptions.where.completed = true;
+  }
+  if (!req.query.include_preimage) {
+    console.log('default');
+    entityFindOptions.where.type = { [Op.notLike]: '%preimage%' };
   }
   const entities = await models.ChainEntity.findAll(entityFindOptions);
   return res.json({ status: 'Success', result: entities.map((e) => e.toJSON()) });

--- a/server/routes/bulkEntities.ts
+++ b/server/routes/bulkEntities.ts
@@ -44,7 +44,6 @@ const bulkEntities = async (models, req: Request, res: Response, next: NextFunct
     entityFindOptions.where.completed = true;
   }
   if (!req.query.include_preimage) {
-    console.log('default');
     entityFindOptions.where.type = { [Op.notLike]: '%preimage%' };
   }
   const entities = await models.ChainEntity.findAll(entityFindOptions);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Preimages are the largest entities being passed to the user. Filter them out of `/bulkEntities` request on chain-community initialization to load chain-community faster. Can be requested using the option `include_preimage`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Optimizing website loadtimes. 
Closes #793.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All proposals/referenda/treasury entities load properly as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run tests