### PR TITLE
Create NewComment/Reaction subscriptions for all NewThread subscribers

### DIFF
--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -175,7 +175,41 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
   } catch (err) {
     return next(new Error(err));
   }
+  // auto-subscribe NewThread subscribers to NewComment/NewReaction as well
+  // findOrCreate because redundant creation if author is also subscribed to NewThreads
   const location = finalThread.community || finalThread.chain;
+  const subscribers = await models.Subscription.findAll({
+    where: {
+      category_id: NotificationCategories.NewThread,
+      object_id: location,
+    }
+  });
+  await Promise.all(subscribers.map((s) => {
+    return models.Subscription.findOrCreate({
+      where: {
+        subscriber_id: s.subscriber_id,
+        category_id: NotificationCategories.NewComment,
+        object_id: `discussion_${finalThread.id}`,
+        offchain_thread_id: finalThread.id,
+        community_id: finalThread.community || null,
+        chain_id: finalThread.chain || null,
+        is_active: true,
+      },
+    });
+  }));
+  await Promise.all(subscribers.map((s) => {
+    return models.Subscription.findOrCreate({
+      where: {
+        subscriber_id: s.subscriber_id,
+        category_id: NotificationCategories.NewReaction,
+        object_id: `discussion_${finalThread.id}`,
+        offchain_thread_id: finalThread.id,
+        community_id: finalThread.community || null,
+        chain_id: finalThread.chain || null,
+        is_active: true,
+      },
+    });
+  }));
   // dispatch notifications to subscribers of the given chain/community
   await models.Subscription.emitNotifications(
     models,


### PR DESCRIPTION
Description
<!--- Describe your changes in detail -->
When running `/createThread`, make `NewComment` & `NewReaction` subscriptions for each subscriber of `NewThreads` within the community/chain. I use `findOrCreate` method just in case there are redundancies in subscribers to NewThreads (there shouldn't be) or if the author of the thread, who is already auto-subscribed to their thread, is also a NewThreads subscriber.
Closes #805.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Network effects!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Logged into two accounts in two browsers and made new threads, comments, and reactions to test the auto-subscription functionality.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested: 72.63%