### PR TITLE
Removed thread privacy from the repo

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -26,7 +26,6 @@ export const modelFromServer = (thread) => {
     thread.version_history,
     thread.community,
     thread.chain,
-    thread.private,
     thread.read_only,
     decodeURIComponent(thread.body),
     thread.url,
@@ -90,7 +89,6 @@ class ThreadsController {
         'topic_name': topicName,
         'topic_id': topicId,
         'url': url,
-        'privacy': privacy,
         'readOnly': readOnly,
         'jwt': app.user.jwt,
       });
@@ -170,14 +168,13 @@ class ThreadsController {
     });
   }
 
-  public async setPrivacy(args: { threadId: number, privacy: boolean, readOnly: boolean, }) {
+  public async setPrivacy(args: { threadId: number, readOnly: boolean, }) {
     return $.ajax({
       url: `${app.serverUrl()}/setPrivacy`,
       type: 'POST',
       data: {
         'jwt': app.user.jwt,
         'thread_id': args.threadId,
-        'privacy': args.privacy,
         'read_only': args.readOnly,
       },
       success: (response) => {

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -66,7 +66,6 @@ class ThreadsController {
     url?: string,
     attachments?: string[],
     mentions?: string[],
-    privacy?: boolean,
     readOnly?: boolean
   ) {
     const timestamp = moment();
@@ -186,7 +185,7 @@ class ThreadsController {
         return result;
       },
       error: (err) => {
-        notifyError('Could not update thread privacy');
+        notifyError('Could not update thread read_only');
         console.error(err);
       },
     });

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -12,7 +12,6 @@ class OffchainThread implements IUniqueId {
   public readonly pinned: boolean;
   public readonly kind: OffchainThreadKind;
   public readonly attachments: OffchainAttachment[];
-  public readonly privacy: boolean;
   public readonly readOnly: boolean;
 
   // TODO: it is a bit clunky to have a numeric id and a string identifier here
@@ -42,7 +41,6 @@ class OffchainThread implements IUniqueId {
     versionHistory: string[],
     community: string,
     chain: string,
-    privacy: boolean,
     readOnly: boolean,
     body?: string,
     url?: string,
@@ -64,7 +62,6 @@ class OffchainThread implements IUniqueId {
     this.versionHistory = versionHistory;
     this.community = community;
     this.chain = chain;
-    this.privacy = privacy;
     this.readOnly = readOnly;
   }
 }

--- a/client/scripts/views/components/inline_thread_composer.ts
+++ b/client/scripts/views/components/inline_thread_composer.ts
@@ -96,7 +96,8 @@ const LinkPost: m.Component<ILinkPostAttrs, ILinkPostState> = {
       }),
       m(TopicSelector, {
         topics: app.topics.getByCommunity(app.activeId()),
-        featuredTopics: app.topics.getByCommunity(app.activeId()).filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
+        featuredTopics: app.topics.getByCommunity(app.activeId())
+          .filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
         updateFormData: (topicName: string, topicId?: number) => {
           vnode.state.form.topicName = topicName;
           vnode.state.form.topicId = topicId;
@@ -140,7 +141,6 @@ interface ITextPostAttrs {
 
 interface ITextPostState {
   readOnly: boolean;
-  privacy: boolean;
   topics: string[];
   uploadsInProgress: number;
   closed: boolean;
@@ -151,7 +151,6 @@ interface ITextPostState {
 
 const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
   oninit: (vnode: m.VnodeDOM<ITextPostAttrs, ITextPostState>) => {
-    vnode.state.privacy = false;
     vnode.state.readOnly = false;
   },
   view: (vnode: m.VnodeDOM<ITextPostAttrs, ITextPostState>) => {
@@ -166,8 +165,7 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
       if (e) e.preventDefault();
       const { form, quillEditorState } = vnode.state;
       const readOnly = vnode.state.readOnly || false;
-      const privacy = vnode.state.privacy || false;
-      vnode.state.error = newThread(form, quillEditorState, author, OffchainThreadKind.Forum, privacy, readOnly);
+      vnode.state.error = newThread(form, quillEditorState, author, OffchainThreadKind.Forum, readOnly);
       m.redraw();
     };
 
@@ -185,7 +183,8 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
       }),
       m(TopicSelector, {
         topics: app.topics.getByCommunity(app.activeId()),
-        featuredTopics: app.topics.getByCommunity(app.activeId()).filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
+        featuredTopics: app.topics.getByCommunity(app.activeId())
+          .filter((ele) => activeEntityInfo.featuredTopics.includes(`${ele.id}`)),
         updateFormData: (topicName: string, topicId?: number) => {
           vnode.state.form.topicName = topicName;
           vnode.state.form.topicId = topicId;
@@ -216,22 +215,11 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
               name: 'properties',
               value: 'public',
               id: 'public-thread',
-              checked: (vnode.state.readOnly === false && vnode.state.privacy === false),
+              checked: (vnode.state.readOnly === false),
               onclick: () => {
                 vnode.state.readOnly = false;
-                vnode.state.privacy = false;
               },
               label: 'Public',
-            }),
-            m(Radio, {
-              name: 'properties',
-              value: 'private',
-              id: 'private-thread',
-              onclick: () => {
-                vnode.state.readOnly = false;
-                vnode.state.privacy = true;
-              },
-              label: 'Private (Only admins/mods)',
             }),
             m(Radio, {
               name: 'properties',
@@ -239,7 +227,6 @@ const TextPost: m.Component<ITextPostAttrs, ITextPostState> = {
               id: 'read-only',
               onclick: () => {
                 vnode.state.readOnly = true;
-                vnode.state.privacy = false;
               },
               label: 'Read-Only',
             }),

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -126,7 +126,6 @@ const DiscussionRowMenu: m.Component<{ proposal: OffchainThread }, { topicEditor
               e.preventDefault();
               app.threads.setPrivacy({
                 threadId: proposal.id,
-                privacy: null,
                 readOnly: !proposal.readOnly,
               }).then(() => m.redraw());
             },

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -85,7 +85,6 @@ const threadModelFromServer = (thread) => {
     thread.version_history,
     thread.community,
     thread.chain,
-    thread.private,
     thread.read_only,
     decodeURIComponent(thread.body),
     thread.url,

--- a/client/scripts/views/pages/threads/index.ts
+++ b/client/scripts/views/pages/threads/index.ts
@@ -106,7 +106,6 @@ export const newThread = async (
   quillEditorState,
   author,
   kind = OffchainThreadKind.Forum,
-  privacy?: boolean,
   readOnly?: boolean
 ) => {
   const topics = app.chain
@@ -166,7 +165,6 @@ export const newThread = async (
       url,
       attachments,
       mentions,
-      privacy,
       readOnly,
     );
   } catch (e) {

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -148,24 +148,10 @@ export const ProposalHeaderPrivacyButtons: m.Component<{ proposal: AnyProposal |
           e.preventDefault();
           app.threads.setPrivacy({
             threadId: proposal.id,
-            privacy: null,
             readOnly: !proposal.readOnly,
           }).then(() => m.redraw());
         },
         label: proposal.readOnly ? 'Unlock thread' : 'Lock thread',
-      }),
-      // privacy toggle, show only if thread is private
-      (proposal as OffchainThread).privacy && m(MenuItem, {
-        class: 'privacy-to-public-toggle',
-        onclick: (e) => {
-          e.preventDefault();
-          app.threads.setPrivacy({
-            threadId: proposal.id,
-            privacy: false,
-            readOnly: null,
-          }).then(() => m.redraw());
-        },
-        label: 'Reveal to public',
       }),
     ];
   }

--- a/server/migrations/20200414143124-add-privacy-features-to-threads.js
+++ b/server/migrations/20200414143124-add-privacy-features-to-threads.js
@@ -55,6 +55,5 @@ module.exports = {
         defaultValue: false
       }
     );
-
   }
 };

--- a/server/migrations/20200929202011-remove-privacy-from-threads.js
+++ b/server/migrations/20200929202011-remove-privacy-from-threads.js
@@ -3,15 +3,33 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
-      return queryInterface.removeColumn(
+      await queryInterface.removeColumn(
         'OffchainThreads', 'private', { transaction: t },
       );
+      await queryInterface.dropTable('read_only_roles_threads', { transaction: t });
+      await queryInterface.dropTable('private_threads_roles', { transaction: t });
     });
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn(
-      'OffchainThreads', 'private', { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
-    );
+  down: (queryInterface, DataTypes) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'OffchainThreads', 'private',
+        { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+        { transaction: t },
+      );
+      await queryInterface.createTable('read_only_roles_threads', {
+        id: { type: DataTypes.INTEGER, allowNull: false },
+        thread_id: { type: DataTypes.INTEGER, allowNull: false },
+        created_at: { type: DataTypes.DATE, allowNull: false },
+        updated_at: { type: DataTypes.DATE, allowNull: false },
+      }, { transaction: t });
+      await queryInterface.createTable('private_threads_roles', {
+        id: { type: DataTypes.INTEGER, allowNull: false },
+        thread_id: { type: DataTypes.INTEGER, allowNull: false },
+        created_at: { type: DataTypes.DATE, allowNull: false },
+        updated_at: { type: DataTypes.DATE, allowNull: false },
+      }, { transaction: t });
+    });
   }
 };

--- a/server/migrations/20200929202011-remove-privacy-from-threads.js
+++ b/server/migrations/20200929202011-remove-privacy-from-threads.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      return queryInterface.removeColumn(
+        'OffchainThreads', 'private', { transaction: t },
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      'OffchainThreads', 'private', { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+    );
+  }
+};

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -17,7 +17,7 @@ export interface OffchainThreadAttributes {
   pinned?: boolean;
   chain?: string;
   community?: string;
-  private?: boolean;
+
   read_only?: boolean;
   version_history?: string[];
   created_at?: Date;
@@ -54,7 +54,6 @@ export default (
     pinned: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
     chain: { type: dataTypes.STRING, allowNull: true },
     community: { type: dataTypes.STRING, allowNull: true },
-    private: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
     read_only: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
     version_history: { type: dataTypes.ARRAY(dataTypes.TEXT), defaultValue: [], allowNull: false },
     created_at: { type: dataTypes.DATE, allowNull: false },
@@ -84,12 +83,6 @@ export default (
     models.OffchainThread.belongsToMany(models.Role, {
       through: 'read_only_roles_threads',
       as: 'read_only_roles',
-      foreignKey: 'thread_id',
-      otherKey: 'id',
-    });
-    models.OffchainThread.belongsToMany(models.Role, {
-      through: 'private_thread_roles',
-      as: 'private_roles',
       foreignKey: 'thread_id',
       otherKey: 'id',
     });

--- a/server/models/role.ts
+++ b/server/models/role.ts
@@ -70,18 +70,6 @@ export default (
     models.Role.belongsTo(models.Address, { foreignKey: 'address_id', targetKey: 'id' });
     models.Role.belongsTo(models.OffchainCommunity, { foreignKey: 'offchain_community_id', targetKey: 'id' });
     models.Role.belongsTo(models.Chain, { foreignKey: 'chain_id', targetKey: 'id' });
-    models.Role.belongsToMany(models.OffchainThread, {
-      through: 'read_only_roles_threads',
-      as: 'read_only_threads',
-      foreignKey: 'id',
-      otherKey: 'thread_id'
-    });
-    models.Role.belongsToMany(models.OffchainThread, {
-      through: 'private_thread_roles',
-      as: 'private_threads',
-      foreignKey: 'id',
-      otherKey: 'thread_id',
-    });
   };
 
   return Role;

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -30,8 +30,8 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
 
   // Threads
   const publicThreadsQuery = (community)
-    ? { community: community.id, private: false, }
-    : { chain: chain.id, private: false, };
+    ? { community: community.id }
+    : { chain: chain.id };
 
   const filteredThreads = await models.OffchainThread.findAll({
     where: publicThreadsQuery,

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -10,8 +10,8 @@ const bulkThreads = async (models, req: Request, res: Response, next: NextFuncti
 
   if (!req.user) { // if not logged in, return public threads
     const publicThreadsQuery = (community)
-      ? { community: community.id, private: false, }
-      : { chain: chain.id, private: false, };
+      ? { community: community.id }
+      : { chain: chain.id, };
 
     const publicThreads = await models.OffchainThread.findAll({
       where: publicThreadsQuery,
@@ -44,9 +44,7 @@ const bulkThreads = async (models, req: Request, res: Response, next: NextFuncti
   const adminRoles = roles.filter((r) => r.permission === 'admin' || r.permission === 'moderator');
 
   const filteredThreads = await allThreads.filter((thread) => {
-    if (thread.private === false) {
-      return true;
-    } else if (userAddressIds.includes(thread.address_id)) {
+    if (userAddressIds.includes(thread.address_id)) {
       return true;
     } else if (adminRoles.length > 0) {
       return true;

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -20,7 +20,7 @@ export const Errors = {
 const createThread = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, next);
   const author = await lookupAddressIsOwnedByUser(models, req, next);
-  const { topic_name, topic_id, title, body, kind, url, privacy, readOnly } = req.body;
+  const { topic_name, topic_id, title, body, kind, url, readOnly } = req.body;
 
   const mentions = typeof req.body['mentions[]'] === 'string'
     ? [req.body['mentions[]']]
@@ -73,7 +73,6 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     version_history: versionHistory,
     kind,
     url,
-    private: privacy,
     read_only: readOnly,
   } : {
     chain: chain.id,
@@ -83,7 +82,6 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     version_history: versionHistory,
     kind,
     url,
-    private: privacy || false,
     read_only: readOnly || false,
   };
 

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -587,6 +587,19 @@ describe('Thread Tests', () => {
     let tempThread;
 
     it('should turn on readonly', async () => {
+      const res1 = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        chainId: chain,
+        communityId: community,
+        title,
+        topicName,
+        topicId,
+        body,
+        jwt: userJWT,
+      });
+      expect(res1.result).to.not.be.null;
+      tempThread = res1.result;
       const res = await chai.request(app)
         .post('/api/setPrivacy')
         .set('Accept', 'application/json')

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -612,6 +612,22 @@ describe('Thread Tests', () => {
       expect(res.body.result.read_only).to.be.true;
     });
 
+    it('should fail to comment on a read_only thread', async () => {
+      // create new user + jwt
+      const res = await modelUtils.createAndVerifyAddress({ chain });
+      const newUserJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
+      // try to comment and fail
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: res.address,
+        jwt: newUserJWT,
+        text: 'hello world',
+        root_id: `discussion_${tempThread.id}`,
+      });
+      expect(cRes.result).to.be.undefined;
+      expect(cRes.error).to.be.equal(CreateCommentErrors.CantCommentOnReadOnly);
+    });
+
     it('should turn off readonly as an admin of community', async () => {
       const res = await chai.request(app)
         .post('/api/setPrivacy')

--- a/test/unit/api/threads.spec.ts
+++ b/test/unit/api/threads.spec.ts
@@ -474,7 +474,6 @@ describe('Thread Tests', () => {
       const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
-      const privacy = true;
       const res = await chai.request(app)
         .put('/api/editThread')
         .set('Accept', 'application/json')
@@ -484,7 +483,6 @@ describe('Thread Tests', () => {
           'body': thread.body,
           'version_history': versionHistory,
           'attachments[]': null,
-          'privacy': privacy,
           'read_only': readOnly,
           'jwt': userJWT,
         });
@@ -497,7 +495,6 @@ describe('Thread Tests', () => {
       const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
-      const privacy = true;
       const res = await chai.request(app)
         .put('/api/editThread')
         .set('Accept', 'application/json')
@@ -507,7 +504,6 @@ describe('Thread Tests', () => {
           'body': thread.body,
           'version_history': versionHistory,
           'attachments[]': null,
-          'privacy': privacy,
           'read_only': readOnly,
           'jwt': adminJWT,
         });
@@ -522,7 +518,6 @@ describe('Thread Tests', () => {
       const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
-      const privacy = true;
       const res = await chai.request(app)
         .put('/api/editThread')
         .set('Accept', 'application/json')
@@ -532,7 +527,6 @@ describe('Thread Tests', () => {
           'body': null,
           'version_history': versionHistory,
           'attachments[]': null,
-          'privacy': privacy,
           'read_only': readOnly,
           'jwt': adminJWT,
         });
@@ -548,7 +542,6 @@ describe('Thread Tests', () => {
       const recentEdit : any = { timestamp: moment(), body: newBody };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
-      const privacy = true;
       const res = await chai.request(app)
         .put('/api/editThread')
         .set('Accept', 'application/json')
@@ -558,7 +551,6 @@ describe('Thread Tests', () => {
           'body': newBody,
           'version_history': versionHistory,
           'attachments[]': null,
-          'privacy': privacy,
           'read_only': readOnly,
           'jwt': adminJWT,
         });
@@ -573,7 +565,6 @@ describe('Thread Tests', () => {
       const recentEdit : any = { timestamp: moment(), body: thread.body };
       const versionHistory = JSON.stringify(recentEdit);
       const readOnly = false;
-      const privacy = true;
       const res = await chai.request(app)
         .put('/api/editThread')
         .set('Accept', 'application/json')
@@ -584,52 +575,27 @@ describe('Thread Tests', () => {
           'title': newTitle,
           'version_history': versionHistory,
           'attachments[]': null,
-          'privacy': privacy,
           'read_only': readOnly,
           'jwt': adminJWT,
         });
       expect(res.status).to.be.equal(200);
       expect(res.body.result.title).to.be.equal(newTitle);
     });
-
-    it.skip('should fail to show private threads to a user without access', async () => {
-      // TODO: Use /bulkThreads to fetch threads for a user without access
-      // TODO: and ensure that a created private thread is not shown to the user
-    });
   });
 
   describe('/setPrivacy', () => {
     let tempThread;
-    it('should create a private thread as non-admin', async () => {
-      const res = await modelUtils.createThread({
-        address: userAddress,
-        kind,
-        chainId: chain,
-        communityId: community,
-        title,
-        topicName,
-        topicId,
-        body,
-        jwt: userJWT,
-        privacy: true,
-      });
-      expect(res.status).to.be.equal('Success');
-      expect(res.result.private).to.be.true;
-      tempThread = res.result;
-    });
 
-    it('should turn off privacy as non-admin and turn on readonly', async () => {
+    it('should turn on readonly', async () => {
       const res = await chai.request(app)
         .post('/api/setPrivacy')
         .set('Accept', 'application/json')
         .send({
           thread_id: tempThread.id,
-          privacy: false,
           read_only: 'true',
           jwt: userJWT,
         });
       expect(res.status).to.be.equal(200);
-      expect(res.body.result.private).to.be.false;
       expect(res.body.result.read_only).to.be.true;
     });
 
@@ -643,11 +609,10 @@ describe('Thread Tests', () => {
           jwt: adminJWT,
         });
       expect(res.status).to.be.equal(200);
-      expect(res.body.result.private).to.be.false;
       expect(res.body.result.read_only).to.be.false;
     });
 
-    it('should fail without read_only or privacy', async () => {
+    it('should fail without read_only', async () => {
       const res = await chai.request(app)
         .post('/api/setPrivacy')
         .set('Accept', 'application/json')
@@ -656,7 +621,7 @@ describe('Thread Tests', () => {
           jwt: adminJWT,
         });
       expect(res.status).to.be.equal(500);
-      expect(res.body.error).to.be.equal(setPrivacyErrors.PrivateOrReadOnly);
+      expect(res.body.error).to.be.equal(setPrivacyErrors.NoReadOnly);
     });
 
 
@@ -665,7 +630,6 @@ describe('Thread Tests', () => {
         .post('/api/setPrivacy')
         .set('Accept', 'application/json')
         .send({
-          privacy: 'true',
           read_only: 'true',
           jwt: adminJWT,
         });
@@ -679,7 +643,6 @@ describe('Thread Tests', () => {
         .set('Accept', 'application/json')
         .send({
           thread_id: 123458,
-          privacy: 'true',
           read_only: 'true',
           jwt: adminJWT,
         });
@@ -696,7 +659,6 @@ describe('Thread Tests', () => {
         .set('Accept', 'application/json')
         .send({
           thread_id: tempThread.id,
-          privacy: 'true',
           read_only: 'true',
           jwt: newUserJWT,
         });

--- a/test/unit/api/user.spec.ts
+++ b/test/unit/api/user.spec.ts
@@ -42,7 +42,7 @@ describe('User Model Routes', () => {
     });
 
     it('should add an email to user with just an address', async () => {
-      const email = 'test2@commonwealth.im';
+      const email = 'test@commonwealth.im';
       const res = await chai.request(app)
         .post('/api/updateEmail')
         .set('Accept', 'application/json')

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -84,12 +84,11 @@ export interface ThreadArgs {
   url?: string,
   attachments?: string[],
   mentions?: string[],
-  privacy?: boolean,
   readOnly?: boolean
 }
 export const createThread = async (args: ThreadArgs) => {
   const { chainId, communityId, address, jwt, title, body, topicName, topicId,
-    privacy, readOnly, kind, url, mentions, attachments } = args;
+    readOnly, kind, url, mentions, attachments } = args;
   const timestamp = moment();
   const firstVersion : any = { timestamp, body };
   const versionHistory : string = JSON.stringify(firstVersion);
@@ -110,7 +109,6 @@ export const createThread = async (args: ThreadArgs) => {
       'topic_id': topicId,
       'mentions[]': mentions,
       'url': url,
-      'privacy': privacy || false,
       'readOnly': readOnly || false,
       'jwt': jwt,
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fully removed every remnant of privacy threads in the codebase. 
- Controllers,
- Tests,
- UI,
- Models,
- +Added migrations to remove excess columns and tables,

Grep'd through the whole repo with `priva` to check for alternative cases of `private` and `privacy` to not miss any uses!

Closes #822, closes #160, closes #827 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Leaky feature not currently supported well. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Ran tests to make sure they still work
- Created new threads and made the readonly to make sure that still works. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested