### PR TITLE
Move chain events listener into separate process.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: ts-node -P tsconfig.node.json -T server.ts
+worker: RUN_AS_LISTENER=true ts-node --project tsconfig.node.json server.ts
 release: npx sequelize db:migrate --debug

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "stylelint": "stylelint client/styles/*",
     "lint": "./scripts/lint-new-work.sh",
     "lint-all": "eslint client/\\**/*.ts server/\\**/*.ts",
+    "listen": "RUN_AS_LISTENER=true ts-node --project tsconfig.node.json server.ts",
     "test-client": "webpack-dev-server --config webpack/webpack.config.test.js",
     "test-events": "nyc ts-mocha --project test/tsconfig.node.json ./test/unit/events/*.spec.ts",
     "integration-test": "nyc ts-mocha --project test/tsconfig.node.json ./test/integration/**/*.spec.ts",

--- a/server.ts
+++ b/server.ts
@@ -47,7 +47,7 @@ async function main() {
   const DEV = process.env.NODE_ENV !== 'production';
 
   // CLI parameters for which task to run
-  const SHOULD_SEND_EMAILS = process.env.SEND_EMAILS;
+  const SHOULD_SEND_EMAILS = process.env.SEND_EMAILS === 'true';
   const SHOULD_RESET_DB = process.env.RESET_DB === 'true';
   const SHOULD_UPDATE_EVENTS = process.env.UPDATE_EVENTS === 'true';
   const SHOULD_UPDATE_BALANCES = process.env.UPDATE_BALANCES === 'true';
@@ -248,7 +248,7 @@ async function main() {
       }
 
       const exitCode = await listenChainEvents();
-      console.log('setup chain events listener with code ' + exitCode);
+      console.log(`setup chain events listener with code ${exitCode}`);
       if (exitCode) {
         await models.sequelize.close();
         await closeMiddleware();

--- a/server/scripts/resetServer.ts
+++ b/server/scripts/resetServer.ts
@@ -32,451 +32,448 @@ const nodes = [
   // [ 'wss://mainnet.infura.io/ws', 'moloch', '0x0372f3696fa7dc99801f435fd6737e57818239f2'],
   // [ 'ws://127.0.0.1:9545', 'moloch-local', '0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7'],
 ];
-const resetServer = (models, closeMiddleware) => {
+const resetServer = (models): Promise<number> => {
   log.debug('Resetting database...');
+  return new Promise((resolve) => {
+    models.sequelize.sync({ force: true }).then(async () => {
+      log.debug('Initializing default models...');
+      // Users
+      const [dillon, raymond, drew] = await Promise.all([
+        models.User.create({
+          email: 'dillon@commonwealth.im',
+          emailVerified: true,
+          isAdmin: true,
+          lastVisited: '{}',
+        }),
+        models.User.create({
+          email: 'raymond@commonwealth.im',
+          emailVerified: true,
+          isAdmin: true,
+          lastVisited: '{}',
+        }),
+        models.User.create({
+          email: 'drew@commonwealth.im',
+          emailVerified: true,
+          isAdmin: true,
+          lastVisited: '{}',
+        }),
+      ]);
 
-  models.sequelize.sync({ force: true }).then(async () => {
-    log.debug('Initializing default models...');
-    // Users
-    const [dillon, raymond, drew] = await Promise.all([
-      models.User.create({
-        email: 'dillon@commonwealth.im',
-        emailVerified: true,
-        isAdmin: true,
-        lastVisited: '{}',
-      }),
-      models.User.create({
-        email: 'raymond@commonwealth.im',
-        emailVerified: true,
-        isAdmin: true,
-        lastVisited: '{}',
-      }),
-      models.User.create({
-        email: 'drew@commonwealth.im',
-        emailVerified: true,
-        isAdmin: true,
-        lastVisited: '{}',
-      }),
-    ]);
+      // Initialize contract categories for all smart contract supporting chains
+      await Promise.all([
+        models.ContractCategory.create({
+          name: 'Tokens',
+          description: 'Token related contracts',
+          color: '#4a90e2',
+        }),
+        models.ContractCategory.create({
+          name: 'DAOs',
+          description: 'DAO related contracts',
+          color: '#9013fe',
+        }),
+      ]);
 
-    // Initialize contract categories for all smart contract supporting chains
-    await Promise.all([
-      models.ContractCategory.create({
-        name: 'Tokens',
-        description: 'Token related contracts',
-        color: '#4a90e2',
-      }),
-      models.ContractCategory.create({
-        name: 'DAOs',
-        description: 'DAO related contracts',
-        color: '#9013fe',
-      }),
-    ]);
+      // Initialize different chain + node URLs
+      const chains = await Promise.all([
+        models.Chain.create({
+          id: 'edgeware-local',
+          network: 'edgeware',
+          symbol: 'EDG',
+          name: 'Edgeware (local)',
+          icon_url: '/static/img/protocols/edg.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'edgeware-testnet',
+          network: 'edgeware',
+          symbol: 'EDG',
+          name: 'Edgeware (testnet)',
+          icon_url: '/static/img/protocols/edg.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'edgeware',
+          network: 'edgeware',
+          symbol: 'EDG',
+          name: 'Edgeware',
+          icon_url: '/static/img/protocols/edg.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'kusama-local',
+          network: 'kusama',
+          symbol: 'KSM',
+          name: 'Kusama (local)',
+          icon_url: '/static/img/protocols/ksm.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'kusama',
+          network: 'kusama',
+          symbol: 'KSM',
+          name: 'Kusama',
+          icon_url: '/static/img/protocols/ksm.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'polkadot-local',
+          network: 'polkadot',
+          symbol: 'DOT',
+          name: 'Polkadot (local)',
+          icon_url: '/static/img/protocols/dot.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'polkadot',
+          network: 'polkadot',
+          symbol: 'DOT',
+          name: 'Polkadot',
+          icon_url: '/static/img/protocols/dot.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'kulupu',
+          network: 'kulupu',
+          symbol: 'KLP',
+          name: 'Kulupu',
+          icon_url: '/static/img/protocols/klp.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'cosmos-local',
+          network: 'cosmos',
+          symbol: 'stake',
+          name: 'Cosmos (local)',
+          icon_url: '/static/img/protocols/atom.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'cosmos-testnet',
+          network: 'cosmos',
+          symbol: 'muon',
+          name: 'Cosmos (Gaia 13006 Testnet)',
+          icon_url: '/static/img/protocols/atom.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'cosmos',
+          network: 'cosmos',
+          symbol: 'uatom',
+          name: 'Cosmos',
+          icon_url: '/static/img/protocols/atom.png',
+          active: true,
+          type: 'chain',
+        }),
+        // models.Chain.create({
+        //   id: 'ethereum-ropsten',
+        //   network: 'ethereum',
+        //   symbol: 'ETH',
+        //   name: 'Ethereum Ropsten',
+        //   icon_url: '/static/img/protocols/eth.png',
+        //   active: false,
+        //   type: 'chain',
+        // }),
+        models.Chain.create({
+          id: 'ethereum-local',
+          network: 'ethereum',
+          symbol: 'ETH',
+          name: 'Ethereum (local)',
+          icon_url: '/static/img/protocols/eth.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'ethereum',
+          network: 'ethereum',
+          symbol: 'ETH',
+          name: 'Ethereum',
+          icon_url: '/static/img/protocols/eth.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'near-local',
+          network: 'near',
+          symbol: 'NEAR',
+          name: 'NEAR Protocol (local)',
+          icon_url: '/static/img/protocols/near.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'near',
+          network: 'near',
+          symbol: 'NEAR',
+          name: 'NEAR Protocol',
+          icon_url: '/static/img/protocols/near.png',
+          active: true,
+          type: 'chain',
+        }),
+        models.Chain.create({
+          id: 'moloch',
+          network: 'moloch',
+          symbol: 'Moloch',
+          name: 'Moloch',
+          icon_url: '/static/img/protocols/molochdao.png',
+          active: true,
+          type: 'dao',
+        }),
+        // This is the same exact as Moloch, but I want to show the picture on the front end
+        models.Chain.create({
+          id: 'metacartel',
+          network: 'metacartel',
+          symbol: 'Metacartel',
+          name: 'Metacartel',
+          icon_url: '/static/img/protocols/metacartel.png',
+          active: true,
+          type: 'dao',
+        }),
+        models.Chain.create({
+          id: 'moloch-local',
+          network: 'moloch',
+          symbol: 'Moloch',
+          name: 'Moloch (local)',
+          icon_url: '/static/img/protocols/molochdao.png',
+          active: true,
+          type: 'dao',
+        }),
+      ]);
 
-    // Initialize different chain + node URLs
-    const chains = await Promise.all([
-      models.Chain.create({
-        id: 'edgeware-local',
-        network: 'edgeware',
-        symbol: 'EDG',
-        name: 'Edgeware (local)',
-        icon_url: '/static/img/protocols/edg.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'edgeware-testnet',
-        network: 'edgeware',
-        symbol: 'EDG',
-        name: 'Edgeware (testnet)',
-        icon_url: '/static/img/protocols/edg.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'edgeware',
-        network: 'edgeware',
-        symbol: 'EDG',
-        name: 'Edgeware',
-        icon_url: '/static/img/protocols/edg.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'kusama-local',
-        network: 'kusama',
-        symbol: 'KSM',
-        name: 'Kusama (local)',
-        icon_url: '/static/img/protocols/ksm.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'kusama',
-        network: 'kusama',
-        symbol: 'KSM',
-        name: 'Kusama',
-        icon_url: '/static/img/protocols/ksm.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'polkadot-local',
-        network: 'polkadot',
-        symbol: 'DOT',
-        name: 'Polkadot (local)',
-        icon_url: '/static/img/protocols/dot.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'polkadot',
-        network: 'polkadot',
-        symbol: 'DOT',
-        name: 'Polkadot',
-        icon_url: '/static/img/protocols/dot.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'kulupu',
-        network: 'kulupu',
-        symbol: 'KLP',
-        name: 'Kulupu',
-        icon_url: '/static/img/protocols/klp.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'cosmos-local',
-        network: 'cosmos',
-        symbol: 'stake',
-        name: 'Cosmos (local)',
-        icon_url: '/static/img/protocols/atom.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'cosmos-testnet',
-        network: 'cosmos',
-        symbol: 'muon',
-        name: 'Cosmos (Gaia 13006 Testnet)',
-        icon_url: '/static/img/protocols/atom.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'cosmos',
-        network: 'cosmos',
-        symbol: 'uatom',
-        name: 'Cosmos',
-        icon_url: '/static/img/protocols/atom.png',
-        active: true,
-        type: 'chain',
-      }),
-      // models.Chain.create({
-      //   id: 'ethereum-ropsten',
-      //   network: 'ethereum',
-      //   symbol: 'ETH',
-      //   name: 'Ethereum Ropsten',
-      //   icon_url: '/static/img/protocols/eth.png',
-      //   active: false,
-      //   type: 'chain',
-      // }),
-      models.Chain.create({
-        id: 'ethereum-local',
-        network: 'ethereum',
-        symbol: 'ETH',
-        name: 'Ethereum (local)',
-        icon_url: '/static/img/protocols/eth.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'ethereum',
-        network: 'ethereum',
-        symbol: 'ETH',
-        name: 'Ethereum',
-        icon_url: '/static/img/protocols/eth.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'near-local',
-        network: 'near',
-        symbol: 'NEAR',
-        name: 'NEAR Protocol (local)',
-        icon_url: '/static/img/protocols/near.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'near',
-        network: 'near',
-        symbol: 'NEAR',
-        name: 'NEAR Protocol',
-        icon_url: '/static/img/protocols/near.png',
-        active: true,
-        type: 'chain',
-      }),
-      models.Chain.create({
-        id: 'moloch',
-        network: 'moloch',
-        symbol: 'Moloch',
-        name: 'Moloch',
-        icon_url: '/static/img/protocols/molochdao.png',
-        active: true,
-        type: 'dao',
-      }),
-      // This is the same exact as Moloch, but I want to show the picture on the front end
-      models.Chain.create({
-        id: 'metacartel',
-        network: 'metacartel',
-        symbol: 'Metacartel',
-        name: 'Metacartel',
-        icon_url: '/static/img/protocols/metacartel.png',
-        active: true,
-        type: 'dao',
-      }),
-      models.Chain.create({
-        id: 'moloch-local',
-        network: 'moloch',
-        symbol: 'Moloch',
-        name: 'Moloch (local)',
-        icon_url: '/static/img/protocols/molochdao.png',
-        active: true,
-        type: 'dao',
-      }),
-    ]);
+      // Specific chains
+      // Make sure to maintain this list if you make any changes!
+      const [
+        edgLocal, edgTest, edgMain,
+        kusamaLocal, kusamaMain, polkadotLocal, polkadotMain,
+        kulupuMain,
+        atomLocal, atomTestnet, atom,
+        // ethRopsten,
+        ethLocal, eth,
+        nearLocal, nearTestnet,
+        moloch, metacartel, molochLocal,
+      ] = chains;
 
-    // Specific chains
-    // Make sure to maintain this list if you make any changes!
-    const [
-      edgLocal, edgTest, edgMain,
-      kusamaLocal, kusamaMain, polkadotLocal, polkadotMain,
-      kulupuMain,
-      atomLocal, atomTestnet, atom,
-      // ethRopsten,
-      ethLocal, eth,
-      nearLocal, nearTestnet,
-      moloch, metacartel, molochLocal,
-    ] = chains;
+      // Admin roles for specific communities
+      await Promise.all([
+        models.Address.create({
+          user_id: 2,
+          address: '0x34C3A5ea06a3A67229fb21a7043243B0eB3e853f',
+          chain: 'ethereum',
+          selected: true,
+          verification_token: crypto.randomBytes(18).toString('hex'),
+          verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
+          verified: new Date(),
+        }),
+        models.Address.create({
+          address: '5DJA5ZCobDS3GVn8D2E5YRiotDqGkR2FN1bg6LtfNUmuadwX',
+          chain: 'edgeware',
+          verification_token: crypto.randomBytes(18).toString('hex'),
+          verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
+          verified: true,
+          keytype: 'sr25519',
+        }),
+        models.Address.create({
+          address: 'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+          chain: 'edgeware',
+          verification_token: crypto.randomBytes(18).toString('hex'),
+          verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
+          verified: true,
+          keytype: 'sr25519',
+        }),
+        models.Address.create({
+          address: 'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+          chain: 'edgeware',
+          verification_token: crypto.randomBytes(18).toString('hex'),
+          verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
+          verified: true,
+          keytype: 'sr25519',
+        }),
+      ]);
 
-    // Admin roles for specific communities
-    await Promise.all([
-      models.Address.create({
-        user_id: 2,
-        address: '0x34C3A5ea06a3A67229fb21a7043243B0eB3e853f',
-        chain: 'ethereum',
-        selected: true,
-        verification_token: crypto.randomBytes(18).toString('hex'),
-        verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
-        verified: new Date(),
-      }),
-      models.Address.create({
-        address: '5DJA5ZCobDS3GVn8D2E5YRiotDqGkR2FN1bg6LtfNUmuadwX',
-        chain: 'edgeware',
-        verification_token: crypto.randomBytes(18).toString('hex'),
-        verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
-        verified: true,
-        keytype: 'sr25519',
-      }),
-      models.Address.create({
-        address: 'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
-        chain: 'edgeware',
-        verification_token: crypto.randomBytes(18).toString('hex'),
-        verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
-        verified: true,
-        keytype: 'sr25519',
-      }),
-      models.Address.create({
-        address: 'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
-        chain: 'edgeware',
-        verification_token: crypto.randomBytes(18).toString('hex'),
-        verification_token_expires: new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000),
-        verified: true,
-        keytype: 'sr25519',
-      }),
-    ]);
+      // Notification Categories
+      await Promise.all([
+        models.NotificationCategory.create({
+          name: NotificationCategories.NewCommunity,
+          description: 'someone makes a new community'
+        }),
+        models.NotificationCategory.create({
+          name: NotificationCategories.NewThread,
+          description: 'someone makes a new thread'
+        }),
+        models.NotificationCategory.create({
+          name: NotificationCategories.NewComment,
+          description: 'someone makes a new comment',
+        }),
+        models.NotificationCategory.create({
+          name: NotificationCategories.NewMention,
+          description: 'someone @ mentions a user',
+        }),
+        models.NotificationCategory.create({
+          name: NotificationCategories.NewReaction,
+          description: 'someone reacts to a post',
+        }),
+        models.NotificationCategory.create({
+          name: NotificationCategories.ChainEvent,
+          description: 'a chain event occurs',
+        }),
+      ]);
 
-    // Notification Categories
-    await Promise.all([
-      models.NotificationCategory.create({
-        name: NotificationCategories.NewCommunity,
-        description: 'someone makes a new community'
-      }),
-      models.NotificationCategory.create({
-        name: NotificationCategories.NewThread,
-        description: 'someone makes a new thread'
-      }),
-      models.NotificationCategory.create({
-        name: NotificationCategories.NewComment,
-        description: 'someone makes a new comment',
-      }),
-      models.NotificationCategory.create({
-        name: NotificationCategories.NewMention,
-        description: 'someone @ mentions a user',
-      }),
-      models.NotificationCategory.create({
-        name: NotificationCategories.NewReaction,
-        description: 'someone reacts to a post',
-      }),
-      models.NotificationCategory.create({
-        name: NotificationCategories.ChainEvent,
-        description: 'a chain event occurs',
-      }),
-    ]);
+      // Admins need to be subscribed to mentions
+      await Promise.all([
+        models.Subscription.create({
+          subscriber_id: dillon.id,
+          category_id: NotificationCategories.NewMention,
+          object_id: `user-${dillon.id}`,
+          is_active: true,
+          immediate_email: true,
+        }),
+        models.Subscription.create({
+          subscriber_id: raymond.id,
+          category_id: NotificationCategories.NewMention,
+          object_id: `user-${raymond.id}`,
+          is_active: true,
+          immediate_email: true,
+        }),
+        models.Subscription.create({
+          subscriber_id: drew.id,
+          category_id: NotificationCategories.NewMention,
+          object_id: `user-${drew.id}`,
+          is_active: true,
+          immediate_email: true,
+        }),
+      ]);
 
-    // Admins need to be subscribed to mentions
-    await Promise.all([
-      models.Subscription.create({
-        subscriber_id: dillon.id,
-        category_id: NotificationCategories.NewMention,
-        object_id: `user-${dillon.id}`,
-        is_active: true,
-        immediate_email: true,
-      }),
-      models.Subscription.create({
-        subscriber_id: raymond.id,
-        category_id: NotificationCategories.NewMention,
-        object_id: `user-${raymond.id}`,
-        is_active: true,
-        immediate_email: true,
-      }),
-      models.Subscription.create({
-        subscriber_id: drew.id,
-        category_id: NotificationCategories.NewMention,
-        object_id: `user-${drew.id}`,
-        is_active: true,
-        immediate_email: true,
-      }),
-    ]);
+      // Communities
+      const communities = await Promise.all([
+        models.OffchainCommunity.create({
+          id: 'staking',
+          name: 'Staking',
+          creator_id: 1,
+          description: 'All things staking',
+          default_chain: 'ethereum',
+          visible: true,
+        }),
+        models.OffchainCommunity.create({
+          id: 'governance',
+          name: 'Governance',
+          creator_id: 1,
+          description: 'All things governance',
+          default_chain: 'ethereum',
+          visible: false,
+        }),
+        models.OffchainCommunity.create({
+          id: 'meta',
+          name: 'Commonwealth Meta',
+          creator_id: 1,
+          description: 'All things Commonwealth',
+          default_chain: 'edgeware',
+          visible: true,
+        })
+      ]);
 
-    // Communities
-    const communities = await Promise.all([
-      models.OffchainCommunity.create({
-        id: 'staking',
-        name: 'Staking',
-        creator_id: 1,
-        description: 'All things staking',
-        default_chain: 'ethereum',
-        visible: true,
-      }),
-      models.OffchainCommunity.create({
-        id: 'governance',
-        name: 'Governance',
-        creator_id: 1,
-        description: 'All things governance',
-        default_chain: 'ethereum',
-        visible: false,
-      }),
-      models.OffchainCommunity.create({
-        id: 'meta',
-        name: 'Commonwealth Meta',
-        creator_id: 1,
-        description: 'All things Commonwealth',
-        default_chain: 'edgeware',
-        visible: true,
-      })
-    ]);
+      // Specific communities
+      // Make sure to maintain this list if you make any changes!
+      const [staking, governance, meta] = communities;
 
-    // Specific communities
-    // Make sure to maintain this list if you make any changes!
-    const [staking, governance, meta] = communities;
+      // OffchainTopics
+      await Promise.all(
+        chains.map((chain) => models.OffchainTopic.create({
+          name: 'General',
+          description: 'General discussion about this blockchain\'s chain development and governance',
+          chain_id: chain.id,
+        }))
+          .concat(
+            chains.map((chain) => models.OffchainTopic.create({
+              name: 'Random',
+              description: 'Non-work banter and water cooler conversation',
+              chain_id: chain.id,
+            }))
+          )
+          .concat(
+            communities.map((community) => models.OffchainTopic.create({
+              name: 'General',
+              description: 'General discussion',
+              community_id: community.id,
+            }))
+          )
+          .concat(
+            communities.map((community) => models.OffchainTopic.create({
+              name: 'Random',
+              description: 'Non-work banter and water cooler conversation',
+              community_id: community.id,
+            }))
+          )
+      );
 
-    // OffchainTopics
-    await Promise.all(
-      chains.map((chain) => models.OffchainTopic.create({
-        name: 'General',
-        description: 'General discussion about this blockchain\'s chain development and governance',
-        chain_id: chain.id,
-      }))
-        .concat(
-          chains.map((chain) => models.OffchainTopic.create({
-            name: 'Random',
-            description: 'Non-work banter and water cooler conversation',
-            chain_id: chain.id,
-          }))
-        )
-        .concat(
-          communities.map((community) => models.OffchainTopic.create({
-            name: 'General',
-            description: 'General discussion',
-            community_id: community.id,
-          }))
-        )
-        .concat(
-          communities.map((community) => models.OffchainTopic.create({
-            name: 'Random',
-            description: 'Non-work banter and water cooler conversation',
-            community_id: community.id,
-          }))
-        )
-    );
+      await Promise.all([
+        models.Role.create({
+          address_id: 3,
+          chain_id: 'edgeware',
+          permission: 'admin',
+        }),
+        models.Role.create({
+          address_id: 4,
+          chain_id: 'edgeware',
+          permission: 'admin',
+        }),
+        models.Role.create({
+          address_id: 3,
+          offchain_community_id: 'staking',
+          permission: 'admin',
+        }),
+        models.Role.create({
+          address_id: 4,
+          offchain_community_id: 'staking',
+          permission: 'admin',
+        }),
+      ]);
 
-    await Promise.all([
-      models.Role.create({
-        address_id: 3,
-        chain_id: 'edgeware',
-        permission: 'admin',
-      }),
-      models.Role.create({
-        address_id: 4,
-        chain_id: 'edgeware',
-        permission: 'admin',
-      }),
-      models.Role.create({
-        address_id: 3,
-        offchain_community_id: 'staking',
-        permission: 'admin',
-      }),
-      models.Role.create({
-        address_id: 4,
-        offchain_community_id: 'staking',
-        permission: 'admin',
-      }),
-    ]);
+      await Promise.all(nodes.map(([ url, chain, address ]) => (models.ChainNode.create({ chain, url, address }))));
 
-    await Promise.all(nodes.map(([ url, chain, address ]) => (models.ChainNode.create({ chain, url, address }))));
+      // initialize chain event types
+      const initChainEventTypes = (chain: string) => {
+        if (chainSupportedBy(chain, SubstrateTypes.EventChains)) {
+          return Promise.all(
+            SubstrateTypes.EventKinds.map((event_name) => {
+              return models.ChainEventType.create({
+                id: `${chain}-${event_name}`,
+                chain,
+                event_name,
+              });
+            })
+          );
+        } else if (chainSupportedBy(chain, MolochTypes.EventChains)) {
+          return Promise.all(
+            MolochTypes.EventKinds.map((event_name) => {
+              return models.ChainEventType.create({
+                id: `${chain}-${event_name}`,
+                chain,
+                event_name,
+              });
+            })
+          );
+        } else {
+          log.error(`Unknown event chain at reset: ${chain}.`);
+        }
+      };
 
-    // initialize chain event types
-    const initChainEventTypes = (chain: string) => {
-      if (chainSupportedBy(chain, SubstrateTypes.EventChains)) {
-        return Promise.all(
-          SubstrateTypes.EventKinds.map((event_name) => {
-            return models.ChainEventType.create({
-              id: `${chain}-${event_name}`,
-              chain,
-              event_name,
-            });
-          })
-        );
-      } else if (chainSupportedBy(chain, MolochTypes.EventChains)) {
-        return Promise.all(
-          MolochTypes.EventKinds.map((event_name) => {
-            return models.ChainEventType.create({
-              id: `${chain}-${event_name}`,
-              chain,
-              event_name,
-            });
-          })
-        );
-      } else {
-        log.error(`Unknown event chain at reset: ${chain}.`);
-      }
-    };
+      await Promise.all(EventSupportingChains.map((chain) => initChainEventTypes(chain)));
 
-    await Promise.all(EventSupportingChains.map((chain) => initChainEventTypes(chain)));
-
-    closeMiddleware().then(() => {
       log.debug('Reset database and initialized default models');
-      process.exit(0);
-    });
-  }).catch((error) => {
-    closeMiddleware().then(() => {
+      resolve(0);
+    }).catch((error) => {
       log.error(error.message);
       log.error('Error syncing db and initializing default models');
-      process.exit(1);
+      resolve(1);
     });
   });
 };

--- a/test/unit/events/entityArchivalHandler.spec.ts
+++ b/test/unit/events/entityArchivalHandler.spec.ts
@@ -164,7 +164,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
       blockNumber: 10,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
-        referendumIndex: 3,
+        referendumIndex: 6,
         endBlock: 100,
         proposalHash: 'hash',
         voteThreshold: 'Supermajorityapproval',
@@ -180,7 +180,12 @@ describe('Edgeware Archival Event Handler Tests', () => {
 
     // verify outputs
     assert.deepEqual(handledDbEvent, duplicateEvent);
-    const chainEntities = await models['ChainEntity'].findAll();
+    const chainEntities = await models['ChainEntity'].findAll({
+      where: {
+        chain: 'edgeware',
+        type_id: '6',
+      }
+    });
     assert.lengthOf(chainEntities, 1);
     const entity = await handledDbEvent.getChainEntity();
     assert.deepEqual(entity.toJSON(), chainEntities[0].toJSON());


### PR DESCRIPTION
## Description
* Adds a `yarn listen` command to run just chain events with a connection to the db.
* Changes default behavior of `yarn start` to no longer launch chain events. The `CHAIN_EVENTS=...` variable can still be provided for the older method of initialization.
* Removes `NO_EVENTS` flag as it is now default behavior.

## Motivation and Context
The intent is to separate chain event listening code from the rest of the application code, as it was causing slowdowns and preventing the server from starting.

## How has this been tested?
Ran both sides and confirmed they did not crash. Did not QA.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no