### PR TITLE
Ungroup unread notifications

### DIFF
--- a/client/scripts/helpers/notifications.ts
+++ b/client/scripts/helpers/notifications.ts
@@ -21,11 +21,11 @@ export const sortNotifications = (n: Notification[]) => {
       a.forEach((n2) => unbatchChainEvents.push([n2]));
     } else if (!a[0].isRead) {
       const b: Notification[] = [];
-      a.forEach((n) => {
-        if (n.isRead) {
-          b.push(n);
+      a.forEach((n2) => {
+        if (n2.isRead) {
+          b.push(n2);
         } else {
-          unbatchChainEvents.push([n]);
+          unbatchChainEvents.push([n2]);
         }
       });
       unbatchChainEvents.push(b);

--- a/client/scripts/helpers/notifications.ts
+++ b/client/scripts/helpers/notifications.ts
@@ -15,11 +15,13 @@ export const sortNotifications = (n: Notification[]) => {
   const unbatchChainEvents = [];
   batched.forEach((a: Notification[]) => {
     if (a[0].chainEvent
+      // unbatch chain-events, comments, and mentions
       || a[0].subscription.category === NotificationCategories.NewComment
       || a[0].subscription.category === NotificationCategories.NewMention
     ) {
       a.forEach((n2) => unbatchChainEvents.push([n2]));
     } else if (!a[0].isRead) {
+      // unbatch unread notifications.
       const b: Notification[] = [];
       a.forEach((n2) => {
         if (n2.isRead) {
@@ -30,6 +32,7 @@ export const sortNotifications = (n: Notification[]) => {
       });
       unbatchChainEvents.push(b);
     } else {
+      // don't unbatch at all
       unbatchChainEvents.push(a);
     }
   });

--- a/client/scripts/helpers/notifications.ts
+++ b/client/scripts/helpers/notifications.ts
@@ -19,6 +19,16 @@ export const sortNotifications = (n: Notification[]) => {
       || a[0].subscription.category === NotificationCategories.NewMention
     ) {
       a.forEach((n2) => unbatchChainEvents.push([n2]));
+    } else if (!a[0].isRead) {
+      const b: Notification[] = [];
+      a.forEach((n) => {
+        if (n.isRead) {
+          b.push(n);
+        } else {
+          unbatchChainEvents.push([n]);
+        }
+      });
+      unbatchChainEvents.push(b);
     } else {
       unbatchChainEvents.push(a);
     }


### PR DESCRIPTION
 Description
<!--- Describe your changes in detail -->
Closes #857.
Ungroup unread notifications in the dropdown menu for clarity. Once read, the notifications are batched again, moving up the older batched row to the place of the newest read notification. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clarity's sake.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on my flashed notifications.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no