### PR TITLE
Add timeout flag to Substrate chain.

### DIFF
--- a/client/scripts/controllers/chain/substrate/main.ts
+++ b/client/scripts/controllers/chain/substrate/main.ts
@@ -28,10 +28,15 @@ class Substrate extends IChainAdapter<SubstrateCoin, SubstrateAccount> {
   public readonly base = ChainBase.Substrate;
   public readonly class: ChainClass;
 
+  public get timedOut() {
+    console.log(this.chain);
+    return !!this.chain?.timedOut;
+  }
+
   constructor(meta: NodeInfo, app: IApp, _class: ChainClass, private _enableModules: boolean = true) {
     super(meta, app);
     this.class = _class;
-    this.chain = new SubstrateChain(this.app); // kusama chain id
+    this.chain = new SubstrateChain(this.app);
     this.accounts = new SubstrateAccounts(this.app);
     if (this._enableModules) {
       this.phragmenElections = new SubstratePhragmenElections(this.app);

--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -57,19 +57,6 @@ import { EdgewareSignalingProposal } from '../edgeware/signaling_proposal';
 
 export type HandlerId = number;
 
-// creates a substrate API provider and waits for it to emit a connected event
-async function createApiProvider(node: NodeInfo): Promise<WsProvider> {
-  const nodeUrl = constructSubstrateUrl(node.url);
-  const provider = new WsProvider(nodeUrl, 10 * 1000);
-  let unsubscribe: () => void;
-  await new Promise((resolve) => {
-    unsubscribe = provider.on('connected', () => resolve());
-  });
-  if (unsubscribe) unsubscribe();
-  window['wsProvider'] = provider;
-  return provider;
-}
-
 // dispatches an entity update to the appropriate module
 export function handleSubstrateEntityUpdate(chain, entity: ChainEntity, event: ChainEvent): void {
   switch (entity.type) {
@@ -218,42 +205,78 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
   }
   public get registry() { return this._api.registry; }
 
-  public async resetApi(selectedNode: NodeInfo, additionalOptions?): Promise<ApiRx> {
+  private _connectTime = 0;
+  private _timedOut: boolean = false;
+  public get timedOut() {
+    return this._timedOut;
+  }
+
+  // creates a substrate API provider and waits for it to emit a connected event
+  public async createApiProvider(node: NodeInfo): Promise<WsProvider> {
+    this._suppressAPIDisconnectErrors = false;
+    const INTERVAL = 1000;
+    const CONNECT_TIMEOUT = 10000;
+
+    const nodeUrl = constructSubstrateUrl(node.url);
+    const provider = new WsProvider(nodeUrl, INTERVAL);
+
     const connectedCb = () => {
       this.app.chain.networkStatus = ApiStatus.Connected;
       this.app.chain.networkError = null;
       this._suppressAPIDisconnectErrors = false;
+      this._connectTime = 0;
       m.redraw();
     };
     const disconnectedCb = () => {
-      if (!this._suppressAPIDisconnectErrors && this.app.chain && selectedNode === this.app.chain.meta) {
+      if (!this._suppressAPIDisconnectErrors && this.app.chain && node === this.app.chain.meta) {
         this.app.chain.networkStatus = ApiStatus.Disconnected;
         this.app.chain.networkError = null;
         this._suppressAPIDisconnectErrors = true;
         setTimeout(() => {
           this._suppressAPIDisconnectErrors = false;
-        }, 5000);
+        }, CONNECT_TIMEOUT);
         m.redraw();
       }
     };
     const errorCb = (err) => {
-      if (!this._suppressAPIDisconnectErrors && this.app.chain && selectedNode === this.app.chain.meta) {
-        console.log('api error');
+      console.log(`api error; waited ${this._connectTime}ms`);
+      this._connectTime += INTERVAL;
+      if (!this._suppressAPIDisconnectErrors && this.app.chain && node === this.app.chain.meta) {
+        if (this.app.chain.networkStatus === ApiStatus.Connected) {
+          notifyInfo('Reconnecting to chain...');
+        } else {
+          notifyInfo('Connecting to chain...');
+        }
         this.app.chain.networkStatus = ApiStatus.Disconnected;
         this.app.chain.networkError = err.message;
-        notifyInfo('Reconnecting to chain...');
         this._suppressAPIDisconnectErrors = true;
         setTimeout(() => {
-          this._suppressAPIDisconnectErrors = false;
-        }, 5000);
+          // this._suppressAPIDisconnectErrors = false;
+          console.log('chain connection timed out!');
+          provider.disconnect();
+          this._timedOut = true;
+          m.redraw();
+        }, CONNECT_TIMEOUT);
         m.redraw();
       }
     };
-    const provider = await createApiProvider(selectedNode);
-    if (provider.isConnected) connectedCb();
+
     this._removeConnectedCb = provider.on('connected', connectedCb);
     this._removeDisconnectedCb = provider.on('disconnected', disconnectedCb);
     this._removeErrorCb = provider.on('error', errorCb);
+
+    let unsubscribe: () => void;
+    await new Promise((resolve) => {
+      unsubscribe = provider.on('connected', () => resolve());
+    });
+    if (unsubscribe) unsubscribe();
+    window['wsProvider'] = provider;
+    if (provider.isConnected) connectedCb();
+    return provider;
+  }
+
+  public async resetApi(selectedNode: NodeInfo, additionalOptions?): Promise<ApiRx> {
+    const provider = await this.createApiProvider(selectedNode);
 
     // note that we reuse the same provider and type registry to create both an rxjs
     // and a promise-based API -- this avoids creating multiple connections to the node

--- a/client/scripts/views/pages/council/index.ts
+++ b/client/scripts/views/pages/council/index.ts
@@ -26,6 +26,7 @@ import { Grid, Col, Button, MenuItem } from 'construct-ui';
 import CouncilRow from './council_row';
 import ListingHeader from '../../components/listing_header';
 import Listing from '../listing';
+import ErrorPage from '../error';
 
 interface ICouncilElectionVoterAttrs {
   vote: PhragmenElectionVote;
@@ -205,7 +206,13 @@ const CouncilPage: m.Component<{}> = {
     });
   },
   view: (vnode) => {
-    if (!app.chain) {
+    if (!app.chain || !app.chain.loaded) {
+      if (app.chain?.base === ChainBase.Substrate && (app.chain as Substrate).chain?.timedOut) {
+        return m(ErrorPage, {
+          message: 'Chain connection timed out.',
+          title: 'Proposals',
+        });
+      }
       return m(PageLoading, {
         message: 'Connecting to chain (may take up to 30s)...',
         title: 'Council',

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -28,6 +28,7 @@ import {
 import EdgewareFunctionPicker from 'views/components/edgeware_function_picker';
 import { createTXModal } from 'views/modals/tx_signing_modal';
 import TopicSelector from 'views/components/topic_selector';
+import ErrorPage from 'views/pages/error';
 
 // this should be titled the Substrate/Edgeware new proposal form
 const NewProposalForm = {
@@ -296,6 +297,12 @@ const NewProposalForm = {
     const asCosmos = (app.chain as Cosmos);
 
     if (!dataLoaded) {
+      if (app.chain?.base === ChainBase.Substrate && (app.chain as Substrate).chain?.timedOut) {
+        return m(ErrorPage, {
+          message: 'Chain connection timed out.',
+          title: 'Proposals',
+        });
+      }
       return m(Spinner, {
         fill: true,
         message: 'Connecting to chain...',

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -24,6 +24,7 @@ import NewProposalPage from 'views/pages/new_proposal/index';
 import { Grid, Col, List } from 'construct-ui';
 import moment from 'moment';
 import Listing from './listing';
+import ErrorPage from './error';
 
 const SubstrateProposalStats: m.Component<{}, {}> = {
   view: (vnode) => {
@@ -94,6 +95,12 @@ const ProposalsPage: m.Component<{}> = {
   },
   view: (vnode) => {
     if (!app.chain || !app.chain.loaded) {
+      if (app.chain?.base === ChainBase.Substrate && (app.chain as Substrate).chain?.timedOut) {
+        return m(ErrorPage, {
+          message: 'Chain connection timed out.',
+          title: 'Proposals',
+        });
+      }
       return m(PageLoading, {
         message: 'Connecting to chain (may take up to 30s)...',
         title: 'Proposals',

--- a/client/scripts/views/pages/referenda.ts
+++ b/client/scripts/views/pages/referenda.ts
@@ -24,6 +24,7 @@ import NewProposalPage from 'views/pages/new_proposal/index';
 import { Grid, Col, List } from 'construct-ui';
 import moment from 'moment';
 import Listing from './listing';
+import ErrorPage from './error';
 
 const SubstrateProposalStats: m.Component<{}, {}> = {
   view: (vnode) => {
@@ -76,6 +77,12 @@ const ReferendaPage: m.Component<{}> = {
   },
   view: (vnode) => {
     if (!app.chain || !app.chain.loaded) {
+      if (app.chain?.base === ChainBase.Substrate && (app.chain as Substrate).chain?.timedOut) {
+        return m(ErrorPage, {
+          message: 'Chain connection timed out.',
+          title: 'Proposals',
+        });
+      }
       return m(PageLoading, {
         message: 'Connecting to chain (may take up to 30s)...',
         title: 'Referenda',

--- a/client/scripts/views/pages/treasury.ts
+++ b/client/scripts/views/pages/treasury.ts
@@ -24,6 +24,7 @@ import NewProposalPage from 'views/pages/new_proposal/index';
 import { Grid, Col, List } from 'construct-ui';
 import moment from 'moment';
 import Listing from './listing';
+import ErrorPage from './error';
 
 const SubstrateProposalStats: m.Component<{}, {}> = {
   view: (vnode) => {
@@ -92,6 +93,12 @@ const TreasuryPage: m.Component<{}> = {
   },
   view: (vnode) => {
     if (!app.chain || !app.chain.loaded) {
+      if (app.chain?.base === ChainBase.Substrate && (app.chain as Substrate).chain?.timedOut) {
+        return m(ErrorPage, {
+          message: 'Chain connection timed out.',
+          title: 'Proposals',
+        });
+      }
       return m(PageLoading, {
         message: 'Connecting to chain (may take up to 30s)...',
         title: 'Treasury',


### PR DESCRIPTION
## Description
Fixes #858. This PR currently only works on Substrate, but could easily be extended to other chains in the future, if we're facing similar connection-related concerns. Note the configurable `INTERVAL` and `CONNECTION_TIMEOUT` flags in the substrate shared.ts file. 

## Motivation and Context
We didn't want to sit on the chain loader forever if the connection fails, so this PR adds a flag which says we gave up, and displays the following screen:

![2020-10-07-125538_1835x810_scrot](https://user-images.githubusercontent.com/1860629/95366900-0c5bd080-08a2-11eb-8692-9812979e4207.png)

## How has this been tested?
Tested various working connections to ensure they still worked, tested against a non-running edgeware node to verify that the screen displays as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes
- [x] no