### PR TITLE
Ensure User popover is hoverable

### DIFF
--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -295,12 +295,12 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
             ),
             avatarOnly: true,
             avatarSize: 26,
-            tooltip: true,
+            popover true,
           })
           : m(UserGallery, {
             users: authorInfo.map((auth) => new AddressInfo(null, auth[1], auth[0], null)),
             avatarSize: 26,
-            tooltip: true,
+            popover true,
           }),
         m('.comment-body', [
           m('.comment-body-title', notificationHeader),

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -295,12 +295,12 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
             ),
             avatarOnly: true,
             avatarSize: 26,
-            popover true,
+            popover: true,
           })
           : m(UserGallery, {
             users: authorInfo.map((auth) => new AddressInfo(null, auth[1], auth[0], null)),
             avatarSize: 26,
-            popover true,
+            popover: true,
           }),
         m('.comment-body', [
           m('.comment-body-title', notificationHeader),

--- a/client/scripts/views/components/proposal_row.ts
+++ b/client/scripts/views/components/proposal_row.ts
@@ -288,7 +288,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
 
     const rowMetadata = [
       m(UserGallery, {
-        tooltip: true,
+        popover: true,
         avatarSize: 24,
         users: app.comments.uniqueCommenters(proposal)
       }),
@@ -352,7 +352,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
                   null
                 ),
                 hideAvatar: true,
-                tooltip: true,
+                popover: true,
               }),
             ]),
             m('.treasury-row-metadata .treasury-user-mobile', [
@@ -364,7 +364,7 @@ const ProposalRow: m.Component<IRowAttrs> = {
                   null
                 ),
                 hideAvatar: true,
-                tooltip: true,
+                popover: true,
               }),
             ]),
           ])

--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -42,20 +42,20 @@ const ProposalVotingResults = {
             });
           }
           return vote instanceof SignalingVote ? m('.vote', [
-            m('.vote-voter', m(User, { user: vote.account, linkify: true, tooltip: true })),
+            m('.vote-voter', m(User, { user: vote.account, linkify: true, popover: true })),
             m('.vote-choice', signalingVoteToString(vote.choices[0])),
             balanceWeighted && balance && m('.vote-balance', balanceStr),
           ]) : vote instanceof BinaryVote ? m('.vote', [
-            m('.vote-voter', m(User, { user: vote.account, linkify: true, tooltip: true })),
+            m('.vote-voter', m(User, { user: vote.account, linkify: true, popover: true })),
             m('.vote-choice', vote.choice ? 'yes' : 'no'),
             balanceWeighted && balance && m('.vote-balance', balanceStr),
             m('.vote-weight', vote.weight && `${vote.weight}x`),
           ]) : vote instanceof DepositVote ? m('.vote', [
-            m('.vote-voter', m(User, { user: vote.account, linkify: true, tooltip: true })),
+            m('.vote-voter', m(User, { user: vote.account, linkify: true, popover: true })),
             m('.vote-deposit', formatCoin(vote.deposit, true)),
           ])
             : vote instanceof CosmosVote ? m('.vote', [
-              m('.vote-voter', m(User, { user: vote.account, linkify: true, tooltip: true })),
+              m('.vote-voter', m(User, { user: vote.account, linkify: true, popover: true })),
               m('.vote-choice', vote.choice.toString()),
               // balanceWeighted && balance && m('.vote-balance', balanceStr),
             ])
@@ -65,7 +65,7 @@ const ProposalVotingResults = {
                 balance && m('.vote-balance', balanceStr),
               ])
                 : m('.vote', [
-                  m('.vote-voter', m(User, { user: vote.account, linkify: true, tooltip: true })),
+                  m('.vote-voter', m(User, { user: vote.account, linkify: true, popover: true })),
                 ]);
         }
       );

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -17,7 +17,7 @@ const User: m.Component<{
   hideIdentityIcon?: boolean; // only applies to substrate identities
   linkify?: boolean;
   onclick?: any;
-  tooltip?: boolean;
+  popover?: boolean;
   showRole?: boolean;
 }, {
   identityWidgetLoading: boolean;
@@ -25,7 +25,7 @@ const User: m.Component<{
 }> = {
   view: (vnode) => {
     // TODO: Fix showRole logic to fetch the role from chain
-    const { avatarOnly, hideAvatar, hideIdentityIcon, user, linkify, tooltip, showRole } = vnode.attrs;
+    const { avatarOnly, hideAvatar, hideIdentityIcon, user, linkify, popover, showRole } = vnode.attrs;
     const avatarSize = vnode.attrs.avatarSize || 16;
     const showAvatar = !hideAvatar;
     if (!user) return;
@@ -110,7 +110,7 @@ const User: m.Component<{
         showRole && roleTag,
       ]);
 
-    const tooltipPopover = m('.UserTooltip', {
+    const userPopover = m('.UserPopover', {
       onclick: (e) => {
         e.stopPropagation();
       }
@@ -135,10 +135,10 @@ const User: m.Component<{
       showRole && roleTag,
     ]);
 
-    return tooltip
+    return popover
       ? m(Popover, {
         interactionType: 'hover',
-        content: tooltipPopover,
+        content: userPopover,
         trigger: userFinal,
         key: profile?.address || '-'
       })
@@ -149,13 +149,13 @@ const User: m.Component<{
 export const UserBlock: m.Component<{
   user: Account<any> | AddressInfo,
   hideIdentityIcon?: boolean,
-  tooltip?: boolean,
+  popover?: boolean,
   showRole?: boolean,
   selected?: boolean,
   compact?: boolean,
 }> = {
   view: (vnode) => {
-    const { user, hideIdentityIcon, tooltip, showRole, selected, compact } = vnode.attrs;
+    const { user, hideIdentityIcon, popover, showRole, selected, compact } = vnode.attrs;
 
     let profile;
     if (user instanceof AddressInfo) {
@@ -173,7 +173,7 @@ export const UserBlock: m.Component<{
           user,
           avatarOnly: true,
           avatarSize: 28,
-          tooltip,
+          popover,
         }),
         // TODO: this is weird...symbol display should not depend on user being an Account
         user.chain instanceof ChainInfo && m('.user-block-symbol', user.chain.symbol),
@@ -184,7 +184,7 @@ export const UserBlock: m.Component<{
             user,
             hideAvatar: true,
             hideIdentityIcon,
-            tooltip,
+            popover,
             showRole,
           }),
         ]),

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -4,7 +4,7 @@ import 'components/widgets/user.scss';
 import m from 'mithril';
 import _ from 'lodash';
 import { formatAddressShort, link } from 'helpers';
-import { Tooltip, Tag, Icon, Icons } from 'construct-ui';
+import { Tooltip, Tag, Icon, Icons, Popover } from 'construct-ui';
 
 import app from 'state';
 import { Account, AddressInfo, ChainInfo, ChainBase } from 'models';
@@ -136,7 +136,12 @@ const User: m.Component<{
     ]);
 
     return tooltip
-      ? m(Tooltip, { content: tooltipPopover, hoverOpenDelay: 1000, trigger: userFinal, key: profile?.address || '-' })
+      ? m(Popover, {
+        interactionType: 'hover',
+        content: tooltipPopover,
+        trigger: userFinal,
+        key: profile?.address || '-'
+      })
       : userFinal;
   }
 };

--- a/client/scripts/views/components/widgets/user_gallery.ts
+++ b/client/scripts/views/components/widgets/user_gallery.ts
@@ -15,11 +15,11 @@ const UserGallery: m.Component<{
   users: Account<any>[] | AddressInfo[];
   class?: string;
   avatarSize: number;
-  tooltip?: boolean;
+  popover?: boolean;
   maxUsers?: number;
 }, {}> = {
   view: (vnode) => {
-    const { users, avatarSize, tooltip } = vnode.attrs;
+    const { users, avatarSize, popover } = vnode.attrs;
     const userCount = users.length;
     const maxUsers = vnode.attrs.maxUsers || 10;
     const displayedUsers = (users as any)
@@ -28,7 +28,7 @@ const UserGallery: m.Component<{
         return m(User, {
           user,
           avatarOnly: true,
-          tooltip,
+          popover,
           avatarSize,
         });
       });

--- a/client/scripts/views/modals/manage_community_modal/metadata_rows.ts
+++ b/client/scripts/views/modals/manage_community_modal/metadata_rows.ts
@@ -21,7 +21,7 @@ export const ManageRolesRow: m.Component<{ roledata?, onRoleUpdate?: Function }>
         return m('.RoleChild', [
           m(User, {
             user: new AddressInfo(addr.id, addr.address, addr.chain, null), //role.Address, // make AddressInfo?
-            tooltip: true,
+            popover: true,
             linkify: false,
             hideAvatar: false,
           }),

--- a/client/scripts/views/modals/view_voters_modal.ts
+++ b/client/scripts/views/modals/view_voters_modal.ts
@@ -30,7 +30,7 @@ const VoterRow: m.Component<IVoterRowAttrs> = {
             user: account,
             avatarOnly: true,
             avatarSize: 36,
-            tooltip: true,
+            popover: true,
           }),
         ]),
         m('.proposal-pre-mobile', [
@@ -38,7 +38,7 @@ const VoterRow: m.Component<IVoterRowAttrs> = {
             user: account,
             avatarOnly: true,
             avatarSize: 16,
-            tooltip: true,
+            popover: true,
           }),
         ]),
       ]),
@@ -50,14 +50,14 @@ const VoterRow: m.Component<IVoterRowAttrs> = {
               m(User, {
                 user: account,
                 hideAvatar: true,
-                tooltip: true,
+                popover: true,
               }),
             ]),
             m('.proposal-user-mobile', [
               m(User, {
                 user: account,
                 hideAvatar: true,
-                tooltip: true,
+                popover: true,
               }),
             ]),
           ]),

--- a/client/scripts/views/pages/council/council_row.ts
+++ b/client/scripts/views/pages/council/council_row.ts
@@ -28,7 +28,7 @@ const CouncilRow: m.Component<ICollectiveMemberAttrs> = {
     const rowHeader = m(User, {
       user: account,
       hideAvatar: true,
-      tooltip: true,
+      popover: true,
     });
 
     const rowSubheader = m('span.council-row-subheader', election.isMember(account)

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -56,7 +56,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread, showExcerpt?: boole
       m(User, {
         user: new AddressInfo(null, proposal.author, proposal.authorChain, null),
         linkify: true,
-        tooltip: true,
+        popover: true,
         hideAvatar: true,
       }),
     ];
@@ -79,7 +79,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread, showExcerpt?: boole
     const rowMetadata = [
       m(UserGallery, {
         avatarSize: 24,
-        tooltip: true,
+        popover: true,
         users: app.comments.uniqueCommenters(
           proposal,
           proposal.author,

--- a/client/scripts/views/pages/discussions/sidebar.ts
+++ b/client/scripts/views/pages/discussions/sidebar.ts
@@ -16,7 +16,7 @@ export const MostActiveUser: m.Component<{ user: AddressInfo, activityCount: num
         user,
         avatarSize: 24,
         linkify: true,
-        tooltip: true,
+        popover: true,
       }),
       m('.activity-count', activityCount)
     ]);

--- a/client/scripts/views/pages/profile/profile_comment_group.ts
+++ b/client/scripts/views/pages/profile/profile_comment_group.ts
@@ -28,7 +28,7 @@ const ProfileCommentGroup : m.Component<IProfileCommentGroupAttrs> = {
           user: new AddressInfo(null, account.address, account.chain, null),
           linkify: true,
           hideAvatar: true,
-          tooltip: true
+          popover: true
         }),
         ' commented',
         (proposal.chain || proposal.community) && [

--- a/client/scripts/views/pages/settings/linked_addresses_well.ts
+++ b/client/scripts/views/pages/settings/linked_addresses_well.ts
@@ -31,7 +31,7 @@ const AccountRow: m.Component<{ account: AddressInfo, onclick?: (e: Event) => an
           avatarOnly: true,
           avatarSize: 32,
           linkify: true,
-          tooltip: true
+          popover: true
         }),
       ]),
       m('.info-col', [
@@ -40,7 +40,7 @@ const AccountRow: m.Component<{ account: AddressInfo, onclick?: (e: Event) => an
             user: account,
             hideAvatar: true,
             linkify: true,
-            tooltip: true,
+            popover: true,
           }),
         ]),
         // checking for balance to guarantee that delegate key has loaded

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -59,7 +59,7 @@ export const ProposalBodyAvatar: m.Component<{ item: OffchainThread | OffchainCo
     return m('.ProposalBodyAvatar', [
       m(User, {
         user: author,
-        tooltip: true,
+        popover: true,
         avatarOnly: true,
         avatarSize: 40,
       }),
@@ -82,7 +82,7 @@ export const ProposalBodyAuthor: m.Component<{ item: AnyProposal | OffchainThrea
     return m('.ProposalBodyAuthor', [
       m(User, {
         user: author,
-        tooltip: true,
+        popover: true,
         linkify: true,
         hideAvatar: true,
       }),

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -124,10 +124,10 @@ const CreateComment: m.Component<{
       class: parentType === CommentParent.Comment ? 'new-comment-child' : 'new-thread-child'
     }, [
       m('.create-comment-avatar', [
-        m(User, { user: author, tooltip: true, avatarOnly: true, avatarSize: 36 }),
+        m(User, { user: author, popover: true, avatarOnly: true, avatarSize: 36 }),
       ]),
       m('.create-comment-body', [
-        m(User, { user: author, tooltip: true, hideAvatar: true }),
+        m(User, { user: author, popover: true, hideAvatar: true }),
         (rootProposal instanceof OffchainThread && rootProposal.readOnly)
           ? m(Callout, {
             intent: 'primary',

--- a/client/styles/components/sidebar/notification_row.scss
+++ b/client/styles/components/sidebar/notification_row.scss
@@ -14,6 +14,9 @@
     &.unread {
         background: #ffffe0;
     }
+    > .User {
+        width: min-content;
+    }
     > .User,
     > .UserGallery {
         margin-bottom: 10px;

--- a/client/styles/components/widgets/user.scss
+++ b/client/styles/components/widgets/user.scss
@@ -83,10 +83,8 @@
     }
 }
 
-.UserTooltip {
+.UserPopover {
     text-align: center;
-    padding: 6px;
-    padding-bottom: 4px;
 
     .user-avatar,
     .user-name {


### PR DESCRIPTION
Closes #869.

## Description

Previously, we used a tooltip to display address info when a User component was hovered over (provided it had been passed tooltip: true). This branch switches that tooltip functionality to a hover-triggered popover, allowing the address and profile to be clickable.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no