### PR TITLE
Un-starring causes weird cascade of un-starring

### DIFF
--- a/client/scripts/controllers/server/communities.ts
+++ b/client/scripts/controllers/server/communities.ts
@@ -47,6 +47,7 @@ class CommunitiesController {
           app.user.removeStarredCommunity(star);
         }
         resolve();
+        m.redraw();
       }).catch((err) => {
         reject();
       });

--- a/client/scripts/controllers/server/communities.ts
+++ b/client/scripts/controllers/server/communities.ts
@@ -46,7 +46,6 @@ class CommunitiesController {
           });
           app.user.removeStarredCommunity(star);
         }
-        m.redraw();
         resolve();
       }).catch((err) => {
         reject();

--- a/client/scripts/controllers/server/user/base.ts
+++ b/client/scripts/controllers/server/user/base.ts
@@ -154,11 +154,12 @@ export default class {
   public setStarredCommunities(star: StarredCommunity[]): void { this._setStarredCommunities(star); }
   public addStarredCommunity(star: StarredCommunity): void { this._starredCommunities.push(star); }
   public removeStarredCommunity(star: StarredCommunity): void {
-    this._starredCommunities.splice(this._starredCommunities.findIndex((s) => (
-      s.user_id === star.user_id
-      && s.chain === star.chain
-      && s.community === star.community
-    ), 1));
+    const index = this._starredCommunities.findIndex((s) => (
+      s.chain
+        ? (s.user_id === star.user_id && s.chain === star.chain)
+        : (s.user_id === star.user_id && s.community === star.community)
+    ));
+    this._starredCommunities.splice(index, 1);
   }
 
 

--- a/client/scripts/views/components/sidebar/community_selector.ts
+++ b/client/scripts/views/components/sidebar/community_selector.ts
@@ -139,10 +139,11 @@ const CommunitySelector = {
           contentRight: app.isLoggedIn()
             && roles.length > 0
             && m('.community-star-toggle', {
-              onclick: (e) => {
+              onclick: async (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                app.communities.setStarred(item.id, null, !app.communities.isStarred(item.id, null));
+                await app.communities.setStarred(item.id, null, !app.communities.isStarred(item.id, null));
+                m.redraw();
               }
             }, [
               roles.map((role) => {
@@ -153,7 +154,7 @@ const CommunitySelector = {
                 });
               }),
               m('.star-icon', [
-                m(Icon, { name: Icons.STAR }),
+                m(Icon, { name: Icons.STAR, key: item.id, }),
               ]),
             ]),
         })
@@ -168,10 +169,11 @@ const CommunitySelector = {
             contentRight: app.isLoggedIn()
               && roles.length > 0
               && m('.community-star-toggle', {
-                onclick: (e) => {
+                onclick: async (e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  app.communities.setStarred(null, item.id, !app.communities.isStarred(null, item.id));
+                  await app.communities.setStarred(null, item.id, !app.communities.isStarred(null, item.id));
+                  m.redraw();
                 },
               }, [
                 roles.map((role) => {
@@ -182,7 +184,7 @@ const CommunitySelector = {
                   });
                 }),
                 m('.star-icon', [
-                  m(Icon, { name: Icons.STAR }),
+                  m(Icon, { name: Icons.STAR, key: item.id, }),
                 ]),
               ]),
           })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Un-starring can on occasion, because of how the `removeStarredCommunity` method worked, remove more than 1 starred community from the local store. Which would in-turn create another star in the db when clicked again, rather than destroy the old one, resulting in multiple stars for a single community.

Closes #881.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tried with db dump from August, simulated the bug and fixed it. Works perfectly from a clean db, no issues should arise for new users ~, only users that may have used the star/un-star feature and experienced the bug, will have lasting bugginess.~ **Update: Just checked against the latest.dump and it seems as though our db is good.** 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no