### PR TITLE
Add disabled state to Notification settings dropdowns 

### DIFF
--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -102,6 +102,7 @@ const BatchedSubscriptionRow: m.Component<{
   label?: string;
 }, {
   option: string;
+  loading: boolean;
 }> = {
   view: (vnode) => {
     const { label, subscriptions } = vnode.attrs;
@@ -220,6 +221,7 @@ const BatchedSubscriptionRow: m.Component<{
           trigger: m(Button, {
             align: 'left',
             compact: true,
+            disabled: !app.user.emailVerified || vnode.state.loading,
             iconRight: Icons.CHEVRON_DOWN,
             label: vnode.state.option,
             size: 'sm',
@@ -227,6 +229,7 @@ const BatchedSubscriptionRow: m.Component<{
           }),
           onSelect: async (option: string) => {
             vnode.state.option = option;
+            vnode.state.loading = true;
             try {
               if (subscriptions.length < 1) return;
               if (option === NOTIFICATION_OFF_OPTION) {
@@ -239,10 +242,11 @@ const BatchedSubscriptionRow: m.Component<{
                 if (!everyActive) await app.user.notifications.enableSubscriptions(subscriptions);
                 await app.user.notifications.enableImmediateEmails(subscriptions);
               }
-              m.redraw();
             } catch (err) {
               notifyError(err.toString());
             }
+            vnode.state.loading = false;
+            m.redraw();
           }
         })
       ]),
@@ -361,7 +365,7 @@ const ChainEventSubscriptionRow: m.Component<{
   title: string;
   notificationTypeArray: string[];
   recommended?: boolean;
-}, { option: string, }> = {
+}, { option: string; loading: boolean, }> = {
   view: (vnode) => {
     const { title, notificationTypeArray, recommended } = vnode.attrs;
     const subscriptions = app.user.notifications.subscriptions.filter((s) => {
@@ -411,12 +415,14 @@ const ChainEventSubscriptionRow: m.Component<{
           trigger: m(Button, {
             align: 'left',
             compact: true,
+            disabled: !app.user.emailVerified || vnode.state.loading,
             iconRight: Icons.CHEVRON_DOWN,
             label: vnode.state.option,
             size: 'sm',
           }),
           onSelect: async (option: string) => {
             vnode.state.option = option;
+            vnode.state.loading = true;
             if (option === NOTIFICATION_OFF_OPTION) {
               await app.user.notifications.disableImmediateEmails(subscriptions);
               await app.user.notifications.disableSubscriptions(subscriptions);
@@ -452,6 +458,7 @@ const ChainEventSubscriptionRow: m.Component<{
                 if (!everySubscriptionEmail) await app.user.notifications.enableImmediateEmails(subscriptions);
               }
             }
+            vnode.state.loading = false;
             m.redraw();
           }
         }),
@@ -675,7 +682,7 @@ const NotificationsPage: m.Component<{}, {
       message: 'This page requires you to be logged in.'
     });
     if (subscriptions.length < 1) return m(PageLoading);
-
+    console.log(app.user.emailVerified);
     return m(Sublayout, {
       class: 'NotificationsPage',
       title: 'Notification Settings',
@@ -702,6 +709,7 @@ const NotificationsPage: m.Component<{}, {
               trigger: m(Button, {
                 align: 'left',
                 compact: true,
+                disabled: !app.user.emailVerified,
                 iconRight: Icons.CHEVRON_DOWN,
                 label: vnode.state.selectedCommunity
                   ? vnode.state.selectedCommunityId

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -682,7 +682,6 @@ const NotificationsPage: m.Component<{}, {
       message: 'This page requires you to be logged in.'
     });
     if (subscriptions.length < 1) return m(PageLoading);
-    console.log(app.user.emailVerified);
     return m(Sublayout, {
       class: 'NotificationsPage',
       title: 'Notification Settings',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While you can't add a disabled state to the SelectList, I discovered after reading a bunch of docs that you can disable the trigger to the SelectList, the Button component. So I added a disabled state to the notification row and the chain event rows if either the user doesn't have a verified email or they have recently selected something new and are await server response. 
Closes #868.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
🐛 
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tried with unverified email and in debug mode you can see the quick blip of a disabled state while awaiting the server to respond.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no