### PR TITLE
Add chain event types underneath each chain event category

### DIFF
--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -388,6 +388,9 @@ const ChainEventSubscriptionRow: m.Component<{
       m('td.subscription-label', [
         title,
         recommended && m(Tag, { size: 'xs', label: 'Recommended' }),
+        m('.ChainEventDetails', [
+          notificationTypeArray.map((s) => `${s}, `)
+        ]),
       ]),
       m('td.subscription-setting', [
         m(SelectList, {

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -361,9 +361,10 @@ const ChainEventSubscriptionRow: m.Component<{
   title: string;
   notificationTypeArray: string[];
   recommended?: boolean;
+  noisy?: boolean;
 }, { option: string, }> = {
   view: (vnode) => {
-    const { title, notificationTypeArray, recommended } = vnode.attrs;
+    const { title, notificationTypeArray, recommended, noisy } = vnode.attrs;
     const subscriptions = app.user.notifications.subscriptions.filter((s) => {
       return (
         s.category === NotificationCategories.ChainEvent
@@ -388,8 +389,12 @@ const ChainEventSubscriptionRow: m.Component<{
       m('td.subscription-label', [
         title,
         recommended && m(Tag, { size: 'xs', label: 'Recommended' }),
+        noisy && m(Tag, { size: 'xs', label: 'Noisy', intent: 'negative' }),
         m('.ChainEventDetails', [
-          notificationTypeArray.map((s) => `${s}, `)
+          notificationTypeArray
+            .filter((s) => s.indexOf('reward') === -1) // filter out treasury-reward and reward events (they are silent)
+            .map((s) => `${s.replace(/^[a-z]+-/, '')}, `)
+            .join('').replace(/, $/, '')
         ]),
       ]),
       m('td.subscription-setting', [
@@ -469,8 +474,8 @@ const EdgewareChainEventNotifications: m.Component = {
       m(ChainEventSubscriptionRow, { title: 'Council events', notificationTypeArray: EdgewareChainNotificationTypes.Council, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Democracy events', notificationTypeArray: EdgewareChainNotificationTypes.Democracy, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Signaling events', notificationTypeArray: EdgewareChainNotificationTypes.Signaling, recommended: true }),
-      m(ChainEventSubscriptionRow, { title: 'Treasury events', notificationTypeArray: EdgewareChainNotificationTypes.Treasury, }),
-      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: EdgewareChainNotificationTypes.Validator, }),
+      m(ChainEventSubscriptionRow, { title: 'Treasury events', notificationTypeArray: EdgewareChainNotificationTypes.Treasury, recommended: true }),
+      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: EdgewareChainNotificationTypes.Validator, noisy: true }),
       m(ChainEventSubscriptionRow, { title: 'Preimage events', notificationTypeArray: EdgewareChainNotificationTypes.Preimage, }),
       m(ChainEventSubscriptionRow, { title: 'Voting delegation events', notificationTypeArray: EdgewareChainNotificationTypes.VotingDelegation, }),
     ];
@@ -483,7 +488,7 @@ const KusamaChainEventNotifications: m.Component = {
       m(ChainEventSubscriptionRow, { title: 'Council events', notificationTypeArray: KusamaChainNotificationTypes.Council, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Democracy events', notificationTypeArray: KusamaChainNotificationTypes.Democracy, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Treasury events', notificationTypeArray: KusamaChainNotificationTypes.Treasury, recommended: true }),
-      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: KusamaChainNotificationTypes.Validator, }),
+      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: KusamaChainNotificationTypes.Validator, noisy: true }),
       m(ChainEventSubscriptionRow, { title: 'Preimage events', notificationTypeArray: KusamaChainNotificationTypes.Preimage, }),
       m(ChainEventSubscriptionRow, { title: 'Voting delegation events', notificationTypeArray: KusamaChainNotificationTypes.VotingDelegation, }),
     ];
@@ -496,7 +501,7 @@ const PolkadotChainEventNotifications: m.Component = {
       m(ChainEventSubscriptionRow, { title: 'Council events', notificationTypeArray: PolkadotChainNotificationTypes.Council, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Democracy events', notificationTypeArray: PolkadotChainNotificationTypes.Democracy, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Treasury events', notificationTypeArray: PolkadotChainNotificationTypes.Treasury, recommended: true }),
-      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: PolkadotChainNotificationTypes.Validator, }),
+      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: PolkadotChainNotificationTypes.Validator, noisy: true }),
       m(ChainEventSubscriptionRow, { title: 'Preimage events', notificationTypeArray: PolkadotChainNotificationTypes.Preimage, }),
       m(ChainEventSubscriptionRow, { title: 'Voting delegation events', notificationTypeArray: PolkadotChainNotificationTypes.VotingDelegation, }),
     ];
@@ -509,7 +514,7 @@ const KulupuChainEventNotifications: m.Component = {
       m(ChainEventSubscriptionRow, { title: 'Council events', notificationTypeArray: KulupuChainNotificationTypes.Council, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Democracy events', notificationTypeArray: KulupuChainNotificationTypes.Democracy, recommended: true }),
       m(ChainEventSubscriptionRow, { title: 'Treasury events', notificationTypeArray: KulupuChainNotificationTypes.Treasury, recommended: true }),
-      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: KulupuChainNotificationTypes.Validator, }),
+      m(ChainEventSubscriptionRow, { title: 'Validator events', notificationTypeArray: KulupuChainNotificationTypes.Validator, noisy: true }),
       m(ChainEventSubscriptionRow, { title: 'Preimage events', notificationTypeArray: KulupuChainNotificationTypes.Preimage, }),
       m(ChainEventSubscriptionRow, { title: 'Voting delegation events', notificationTypeArray: KulupuChainNotificationTypes.VotingDelegation, }),
     ];

--- a/client/styles/pages/notifications.scss
+++ b/client/styles/pages/notifications.scss
@@ -44,6 +44,10 @@
                 .cui-tag {
                     margin-left: 8px;
                 }
+                .ChainEventDetails {
+                    color: $text-color-light;
+                    font-size: .8em;
+                }
             }
             .item-metadata {
                 font-size: 90%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added a few lines to iterate through each of the notification types and return their string into a div classed 'ChainEventDetails'. I added some styling to it to look like image in the github issue.
Closes #875.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Give more details to the user about chain event notifications. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no