### PR TITLE
Clearable Chain Event Notifications

### DIFF
--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -118,6 +118,17 @@ class NotificationsController {
     });
   }
 
+  public clear(notifications: Notification[]) {
+    // TODO: Decide REST API handling
+    return post('/clearNotifications', {
+      'notification_ids[]': notifications.map((n) => n.id),
+    }, (result) => {
+      for (const n of notifications) {
+        this._store.remove(n);
+      }
+    });
+  }
+
   public update(n: Notification) {
     if (!this._store.getById(n.id)) {
       this._store.add(n);

--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -122,9 +122,9 @@ class NotificationsController {
     // TODO: Decide REST API handling
     return post('/clearNotifications', {
       'notification_ids[]': notifications.map((n) => n.id),
-    }, (result) => {
+    }, async (result) => {
       for (const n of notifications) {
-        this._store.remove(n);
+        await this._store.remove(n);
       }
     });
   }

--- a/client/scripts/views/components/header/notifications_menu.ts
+++ b/client/scripts/views/components/header/notifications_menu.ts
@@ -59,7 +59,7 @@ const NotificationsMenu: m.Component<{ small?: boolean }> = {
       }),
       position: 'bottom-end',
       inline: true,
-      closeOnContentClick: true,
+      closeOnContentClick: false,
       menuAttrs: {
         align: 'left',
       },
@@ -70,6 +70,7 @@ const NotificationsMenu: m.Component<{ small?: boolean }> = {
             ? m(Infinite, {
               maxPages: 1, // prevents rollover/repeat
               pageData: () => sortedNotifications,
+              key: notifications.length,
               item: (data, opts, index) => {
                 return m(NotificationRow, { notifications: data });
               },

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -20,6 +20,7 @@ import {
 } from '@commonwealth/chain-events';
 import { getProposalUrl, getCommunityUrl } from '../../../../shared/utils';
 import UserGallery from './widgets/user_gallery';
+import { Icon, Icons } from 'construct-ui';
 
 const getCommentPreview = (comment_text) => {
   let decoded_comment_text;
@@ -261,7 +262,16 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
         },
       }, [
         m('.comment-body', [
-          m('.comment-body-top', `${label.heading} on ${chainName}`),
+          m('.comment-body-top.chain-event-notification-top', [
+            `${label.heading} on ${chainName}`,
+            m(Icon, {
+              name: Icons.X,
+              onclick: (e) => {
+                e.preventDefault();
+                app.user.notifications.clear([notification]);
+              },
+            })
+          ]),
           m('.comment-body-bottom', `Block ${notification.chainEvent.blockNumber}`),
           m('.comment-body-excerpt', label.label),
         ]),

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -212,13 +212,13 @@ const NotificationRow: m.Component<{
   Labeler: any,
   MolochTypes: any,
   SubstrateTypes: any,
-  scroll: boolean;
+  scrollOrStop: boolean;
 }> = {
   oncreate: (vnode) => {
     if (m.route.param('id') && vnode.attrs.onListPage
       && m.route.param('id') === vnode.attrs.notifications[0].id.toString()
     ) {
-      vnode.state.scroll = true;
+      vnode.state.scrollOrStop = true;
     }
   },
   view: (vnode) => {
@@ -249,11 +249,11 @@ const NotificationRow: m.Component<{
       }
       m.redraw();
 
-      if (vnode.state.scroll) {
+      if (vnode.state.scrollOrStop) {
         setTimeout(() => {
           document.getElementById(m.route.param('id')).scrollIntoView();
         }, 1);
-        vnode.state.scroll = false;
+        vnode.state.scrollOrStop = false;
       }
 
       if (!label) {
@@ -272,10 +272,11 @@ const NotificationRow: m.Component<{
         key: notification.id,
         id: notification.id,
         onclick: async () => {
+          if (vnode.state.scrollOrStop) { vnode.state.scrollOrStop = false; return; }
           const notificationArray: Notification[] = [];
           notificationArray.push(notification);
           app.user.notifications.markAsRead(notificationArray).then(() => m.redraw());
-          await m.route.set(`/${app.activeId()}/notificationsList?id=${notification.id}`);
+          await m.route.set(`/${app.activeId() || 'edgeware'}/notificationsList?id=${notification.id}`);
           m.redraw.sync();
         },
       }, [
@@ -286,7 +287,9 @@ const NotificationRow: m.Component<{
               name: Icons.X,
               onclick: (e) => {
                 e.preventDefault();
+                vnode.state.scrollOrStop = true;
                 app.user.notifications.clear([notification]);
+                m.redraw();
               },
             })
           ]),

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -241,6 +241,7 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
       if (!label) {
         return m('li.NotificationRow', {
           class: notification.isRead ? '' : 'unread',
+          key: notification.id,
         }, [
           m('.comment-body', [
             m('.comment-body-top', 'Loading...'),
@@ -249,6 +250,7 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
       }
       return m('li.NotificationRow', {
         class: notification.isRead ? '' : 'unread',
+        key: notification.id,
         onclick: async () => {
           const notificationArray: Notification[] = [];
           notificationArray.push(notification);
@@ -278,6 +280,7 @@ const NotificationRow: m.Component<{ notifications: Notification[] }, {
       } = getBatchNotificationFields(category, notificationData);
       return m('li.NotificationRow', {
         class: notifications[0].isRead ? '' : 'unread',
+        key: notification.id,
         onclick: async () => {
           const notificationArray: Notification[] = [];
           app.user.notifications.markAsRead(notifications).then(() => m.redraw());

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -283,7 +283,7 @@ const NotificationRow: m.Component<{
         m('.comment-body', [
           m('.comment-body-top.chain-event-notification-top', [
             `${label.heading} on ${chainName}`,
-            m(Icon, {
+            !vnode.attrs.onListPage && m(Icon, {
               name: Icons.X,
               onclick: (e) => {
                 e.preventDefault();

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -282,7 +282,7 @@ const NotificationRow: m.Component<{
         m('.comment-body', [
           m('.comment-body-top.chain-event-notification-top', [
             `${label.heading} on ${chainName}`,
-            m(Icon, {
+            !vnode.attrs.onListPage && m(Icon, {
               name: Icons.X,
               onclick: (e) => {
                 e.preventDefault();

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -283,7 +283,7 @@ const NotificationRow: m.Component<{
         m('.comment-body', [
           m('.comment-body-top.chain-event-notification-top', [
             `${label.heading} on ${chainName}`,
-            !vnode.attrs.onListPage && m(Icon, {
+            m(Icon, {
               name: Icons.X,
               onclick: (e) => {
                 e.preventDefault();

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -50,7 +50,7 @@ const NotificationsPage: m.Component<{}> = {
                   e.preventDefault();
                   const chainEventNotifications = app.user.notifications.notifications.filter((n) => n.chainEvent);
                   if (chainEventNotifications.length === 0) return;
-                  app.user.notifications.clear(chainEventNotifications).then(() => m.redraw());
+                  app.user.notifications.clear(chainEventNotifications).then(() => m.redraw.sync());
                 }
               })
             ],
@@ -66,6 +66,7 @@ const NotificationsPage: m.Component<{}> = {
           sortedNotifications.length > 0
             ? m(Infinite, {
               maxPages: 1, // prevents rollover/repeat
+              key: sortedNotifications.length,
               pageData: () => sortedNotifications,
               item: (data, opts, index) => {
                 return m(NotificationRow, { notifications: data, });

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -50,7 +50,7 @@ const NotificationsPage: m.Component<{}> = {
                   e.preventDefault();
                   const chainEventNotifications = app.user.notifications.notifications.filter((n) => n.chainEvent);
                   if (chainEventNotifications.length === 0) return;
-                  app.user.notifications.clear(chainEventNotifications).then(() => m.redraw.sync());
+                  app.user.notifications.clear(chainEventNotifications).then(() => m.redraw());
                 }
               })
             ],
@@ -69,7 +69,7 @@ const NotificationsPage: m.Component<{}> = {
               key: sortedNotifications.length,
               pageData: () => sortedNotifications,
               item: (data, opts, index) => {
-                return m(NotificationRow, { notifications: data, });
+                return m(NotificationRow, { notifications: data });
               },
             })
             : m('.no-notifications', 'No Notifications'),

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -69,7 +69,7 @@ const NotificationsPage: m.Component<{}> = {
               key: sortedNotifications.length,
               pageData: () => sortedNotifications,
               item: (data, opts, index) => {
-                return m(NotificationRow, { notifications: data });
+                return m(NotificationRow, { notifications: data, onListPage: true, });
               },
             })
             : m('.no-notifications', 'No Notifications'),

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -28,6 +28,10 @@ const NotificationsPage: m.Component<{}> = {
           outlined: true,
         }, [
           m(Button, {
+            label: 'Redraw',
+            onclick: (e) => m.redraw(),
+          }),
+          m(Button, {
             label: 'Refresh',
             onclick: (e) => {
               e.preventDefault();
@@ -46,9 +50,11 @@ const NotificationsPage: m.Component<{}> = {
               m('p', 'Are you sure?'),
               m(Button, {
                 label: 'Confirm',
-                onclick: (e) => {
+                onclick: async (e) => {
                   e.preventDefault();
-                  const chainEvents = app.user.notifications.subscriptions.filter((s) => s.ChainEventType !== null);
+                  const chainEventNotifications = app.user.notifications.notifications.filter((n) => n.chainEvent);
+                  if (chainEventNotifications.length === 0) return;
+                  app.user.notifications.clear(chainEventNotifications).then(() => m.redraw());
                 }
               })
             ],
@@ -57,6 +63,7 @@ const NotificationsPage: m.Component<{}> = {
             }),
             closeOnContentClick: true,
             closeOnEscapeKey: true,
+            onClosed: () => { console.log(app.user.notifications.notifications.length); m.redraw(); },
           }),
         ]),
         m('.NotificationsList', [
@@ -65,7 +72,7 @@ const NotificationsPage: m.Component<{}> = {
               maxPages: 1, // prevents rollover/repeat
               pageData: () => sortedNotifications,
               item: (data, opts, index) => {
-                return m(NotificationRow, { notifications: data });
+                return m(NotificationRow, { notifications: data, key: data[0].id });
               },
             })
             : m('.no-notifications', 'No Notifications'),

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -28,10 +28,6 @@ const NotificationsPage: m.Component<{}> = {
           outlined: true,
         }, [
           m(Button, {
-            label: 'Redraw',
-            onclick: (e) => m.redraw(),
-          }),
-          m(Button, {
             label: 'Refresh',
             onclick: (e) => {
               e.preventDefault();
@@ -72,7 +68,7 @@ const NotificationsPage: m.Component<{}> = {
               maxPages: 1, // prevents rollover/repeat
               pageData: () => sortedNotifications,
               item: (data, opts, index) => {
-                return m(NotificationRow, { notifications: data, key: data[0].id });
+                return m(NotificationRow, { notifications: data, });
               },
             })
             : m('.no-notifications', 'No Notifications'),

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -2,7 +2,7 @@ import 'pages/notificationsList.scss';
 
 import m from 'mithril';
 import Infinite from 'mithril-infinite';
-import { Button, ButtonGroup } from 'construct-ui';
+import { Button, ButtonGroup, Popover } from 'construct-ui';
 
 import app from 'state';
 import { sortNotifications } from 'helpers/notifications';
@@ -40,6 +40,23 @@ const NotificationsPage: m.Component<{}> = {
               e.preventDefault();
               app.user.notifications.markAsRead(notifications).then(() => m.redraw());
             }
+          }),
+          m(Popover, {
+            content: [
+              m('p', 'Are you sure?'),
+              m(Button, {
+                label: 'Confirm',
+                onclick: (e) => {
+                  e.preventDefault();
+                  const chainEvents = app.user.notifications.subscriptions.filter((s) => s.ChainEventType !== null);
+                }
+              })
+            ],
+            trigger: m(Button, {
+              label: 'Remove all chain events',
+            }),
+            closeOnContentClick: true,
+            closeOnEscapeKey: true,
           }),
         ]),
         m('.NotificationsList', [

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -59,7 +59,7 @@ const NotificationsPage: m.Component<{}> = {
             }),
             closeOnContentClick: true,
             closeOnEscapeKey: true,
-            onClosed: () => { console.log(app.user.notifications.notifications.length); m.redraw(); },
+            onClosed: () => { m.redraw(); },
           }),
         ]),
         m('.NotificationsList', [

--- a/client/styles/components/sidebar/notification_row.scss
+++ b/client/styles/components/sidebar/notification_row.scss
@@ -26,6 +26,10 @@
     }
     .comment-body {
         flex: 1;
+        .chain-event-notification-top {
+            display: flex;
+            justify-content: space-between;
+        }
     }
     .comment-body-title {
         .User .user-display-name,

--- a/client/styles/components/sidebar/notification_row.scss
+++ b/client/styles/components/sidebar/notification_row.scss
@@ -29,6 +29,9 @@
         .chain-event-notification-top {
             display: flex;
             justify-content: space-between;
+            .cui-icon-action svg:hover {
+                color: $negative-bg-color;
+            }
         }
     }
     .comment-body-title {

--- a/server/router.ts
+++ b/server/router.ts
@@ -44,6 +44,7 @@ import disableImmediateEmails from './routes/subscription/disableImmediateEmails
 import viewNotifications from './routes/viewNotifications';
 import markNotificationsRead from './routes/markNotificationsRead';
 import clearReadNotifications from './routes/clearReadNotifications';
+import clearNotifications from './routes/clearNotifications';
 import bulkMembers from './routes/bulkMembers';
 import bulkAddresses from './routes/bulkAddresses';
 import createInvite from './routes/createInvite';
@@ -282,6 +283,8 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   // TODO: Change to DELETE /notificationsRead
   router.post('/clearReadNotifications', passport.authenticate('jwt', { session: false }),
     clearReadNotifications.bind(this, models));
+  router.post('/clearNotifications', passport.authenticate('jwt', { session: false }),
+    clearNotifications.bind(this, models));
   // TODO: Change to PUT /immediateEmails
   router.post('/enableImmediateEmails', passport.authenticate('jwt', { session: false }),
     enableImmediateEmails.bind(this, models));

--- a/server/routes/clearNotifications.ts
+++ b/server/routes/clearNotifications.ts
@@ -1,0 +1,43 @@
+import Sequelize from 'sequelize';
+import { Request, Response, NextFunction } from 'express';
+import { factory, formatFilename } from '../../shared/logging';
+
+const Op = Sequelize.Op;
+const log = factory.getLogger(formatFilename(__filename));
+
+export const Errors = {
+  NotLoggedIn: 'Not logged in',
+  NoNotificationIds: 'Must specify notification IDs',
+  WrongOwner: 'Notification not owned by user',
+};
+
+export default async (models, req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    return next(new Error(Errors.NotLoggedIn));
+  }
+  if (!req.body['notification_ids[]']) {
+    return next(new Error(Errors.NoNotificationIds));
+  }
+
+  let idOptions;
+  if (typeof req.body['notification_ids[]'] === 'string') {
+    idOptions = { [Op.eq]: +req.body['notification_ids[]'] };
+  } else {
+    idOptions = { [Op.in]: req.body['notification_ids[]'].map((n) => +n) };
+  }
+
+  const notifications = await models.Notification.findAll({
+    where: { id: idOptions },
+    include: [ models.Subscription ]
+  });
+
+  if (notifications.find((n) => n.Subscription.subscriber_id !== req.user.id)) {
+    return next(new Error(Errors.WrongOwner));
+  }
+
+  await Promise.all(notifications.map((n) => {
+    return n.destroy();
+  }));
+
+  return res.json({ status: 'Success', result: 'Cleared notifications' });
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Created `/clearNotifications` route that takes an array of notification ids and clears them from the database. This is used to clear the chain event notifications. 
  - Added a `clear` method to the notifications controller that posts to the route.
- Added an X Icon to Chain Event Notification Rows, shows up in the dropdown menu and NotificationList. Uses controller method. 
- Added a Button with Popover confirmation to Remove all chain events to NotificationList page. Uses controller method.
- Changed link url for chain event notifications to direct to NotificationsList page and autoscroll to location.

Closes #873, closes #872.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
"Chain events are often noisy and it's hard to know how noisy they will be before turning them on, which means we should make it possible to users to clean them up."

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
~Known issue: When clicking the 'Remove all chain events' button on the NotificationList page, it successfully deletes from the store but doesn't refresh the page. I followed the same flow as the 'mark read' button in terms of when to refresh, but it doesn't seem to impact the Infinite load. I also tried adding `keys` to the notification rows, but that didn't impact the refresh bug. If anything comes to mind, please suggest.~ 
~Also clicking the clear X on the notification in the dropdown reroutes the page. Bad behavior.~

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not write tests
