### PR TITLE
Disable "name" field in Edit Profile modal if user has set an on-chain identity

### DIFF
--- a/client/scripts/views/modals/edit_profile_modal.ts
+++ b/client/scripts/views/modals/edit_profile_modal.ts
@@ -44,6 +44,7 @@ const EditProfileModal = {
             name: 'name',
             defaultValue: account.name,
             placeholder: 'Display name',
+            disabled: account.profile.isOnchain,
             fluid: true,
             autocomplete: 'off',
             oncreate: (vvnode) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a simple disabled property to the name input in `EditProfileModal` whose condition is `account.profile.isOnchain`.
Closes #874. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Un petit bug

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Switched between two addresses, one with an onchain identity and one without. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no