### PR TITLE
Bug fix: double roles on hot-reload

### DIFF
--- a/client/scripts/controllers/server/user/base.ts
+++ b/client/scripts/controllers/server/user/base.ts
@@ -94,11 +94,14 @@ export default class {
   public setJWT(JWT: string): void { this._setJWT(JWT); }
 
   public setRoles(roles = []): void {
+    const roleIds = this.roles.map((r) => r.id);
     roles.forEach((role) => {
-      role.address = role.Address.address;
-      role.address_chain = role.Address.chain;
-      delete role.Address;
-      this._roles.push(role);
+      if (!roleIds.includes(role.id)) {
+        role.address = role.Address.address;
+        role.address_chain = role.Address.chain;
+        delete role.Address;
+        this._roles.push(role);
+      }
     });
   }
   public addRole(role: RoleInfo): void {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Roles doubled in menu on hot-reload. Fixed this where they were doubling.
Closes #882.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Hot reloading no longer doubles roles in community selector. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no