### PR TITLE
Ensure chain notifications send a full label in the email

### DIFF
--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -173,6 +173,9 @@ export default (
             notification_data: JSON.stringify(notification_data)
           }
       );
+      if (msg && isChainEventData(notification_data)) {
+        msg.dynamic_template_data.notification.path = `https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
+      }
       if (msg && subscription.immediate_email) sendImmediateNotificationEmail(subscription, msg);
     }));
 

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import WebSocket from 'ws';
 import Sequelize from 'sequelize';
 import send, { WebhookContent } from '../webhookNotifier';
-import { SENDGRID_API_KEY } from '../config';
+import { SENDGRID_API_KEY, SERVER_URL } from '../config';
 import { UserAttributes } from './user';
 import { NotificationCategoryAttributes } from './notification_category';
 import { NotificationAttributes } from './notification';
@@ -174,7 +174,7 @@ export default (
           }
       );
       if (msg && isChainEventData(notification_data)) {
-        msg.dynamic_template_data.notification.path = `https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
+        msg.dynamic_template_data.notification.path = `${SERVER_URL}/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
       }
       if (msg && subscription.immediate_email) sendImmediateNotificationEmail(subscription, msg);
     }));

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -174,7 +174,7 @@ export default (
           }
       );
       if (msg && isChainEventData(notification_data)) {
-        msg.dynamic_template_data.notification.path = `https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
+        msg.dynamic_template_data.notification.label += ` https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
       }
       if (msg && subscription.immediate_email) sendImmediateNotificationEmail(subscription, msg);
     }));

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -174,7 +174,7 @@ export default (
           }
       );
       if (msg && isChainEventData(notification_data)) {
-        msg.dynamic_template_data.notification.label += ` https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
+        msg.dynamic_template_data.notification.path = `https://commonwealth.im/${notification_data.chainEventType.chain}/notificationsList?id=${notification.id}`;
       }
       if (msg && subscription.immediate_email) sendImmediateNotificationEmail(subscription, msg);
     }));

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -52,6 +52,7 @@ export const createImmediateNotificationEmailObject = async (notification_data, 
         notification: {
           chainId: notification_data.chainEventType?.chain,
           blockNumber: notification_data.chainEvent?.blockNumber,
+          subject,
           label: subject,
           path: null,
         }

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -51,8 +51,8 @@ export const createImmediateNotificationEmailObject = async (notification_data, 
         notification: {
           chainId: notification_data.chainEventType?.chain,
           blockNumber: notification_data.chainEvent?.blockNumber,
-          label: chainEventLabel.heading,
-          path: `https://commonwealth.im${chainEventLabel.linkUrl}`,
+          label: subject,
+          path: null,
         }
       }
     };

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -12,6 +12,7 @@ import {
   IPostNotificationData, NotificationCategories,
   DynamicTemplate, IChainEventNotificationData
 } from '../../shared/types';
+import { capitalize } from 'lodash';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -39,7 +40,7 @@ export const createImmediateNotificationEmailObject = async (notification_data, 
     }
     if (!chainEventLabel) return;
 
-    const subject = `${chainEventLabel.heading} event on ${notification_data.chainEventType?.chain}`;
+    const subject = `${chainEventLabel.heading} event on ${capitalize(notification_data.chainEventType?.chain)}`;
 
     return {
       from: 'Commonwealth <no-reply@commonwealth.im>',
@@ -161,8 +162,8 @@ export const sendImmediateNotificationEmail = async (subscription, emailObject) 
     console.log('attempted to send empty immediate notification email');
     return;
   }
-  emailObject.to = process.env.NODE_ENV === 'development' ? 'raymond@commonwealth.im' : user.email;
-  emailObject.bcc = 'raymond+bcc@commonwealth.im';
+  emailObject.to = process.env.NODE_ENV === 'development' ? 'zak@commonwealth.im' : user.email;
+  emailObject.bcc = 'zak@commonwealth.im';
 
   try {
     console.log('sending immediate notification email');
@@ -208,8 +209,8 @@ export const sendBatchedNotificationEmails = async (models): Promise<number> => 
       try {
         console.log(`producing digest for ${user.email}`);
         const emailObject = await createNotificationDigestEmailObject(user, notifications, models);
-        emailObject.to = process.env.NODE_ENV === 'development' ? 'raymond@commonwealth.im' : user.email;
-        emailObject.bcc = 'raymond+bcc@commonwealth.im';
+        emailObject.to = process.env.NODE_ENV === 'development' ? 'zak@commonwealth.im' : user.email;
+        emailObject.bcc = 'zak@commonwealth.im';
 
         console.log(`sending batch notification email to ${user.email}`);
         await sgMail.send(emailObject);

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -162,8 +162,8 @@ export const sendImmediateNotificationEmail = async (subscription, emailObject) 
     console.log('attempted to send empty immediate notification email');
     return;
   }
-  emailObject.to = process.env.NODE_ENV === 'development' ? 'zak@commonwealth.im' : user.email;
-  emailObject.bcc = 'zak@commonwealth.im';
+  emailObject.to = process.env.NODE_ENV === 'development' ? 'raymond@commonwealth.im' : user.email;
+  emailObject.bcc = 'raymond+bcc@commonwealth.im';
 
   try {
     console.log('sending immediate notification email');
@@ -209,8 +209,8 @@ export const sendBatchedNotificationEmails = async (models): Promise<number> => 
       try {
         console.log(`producing digest for ${user.email}`);
         const emailObject = await createNotificationDigestEmailObject(user, notifications, models);
-        emailObject.to = process.env.NODE_ENV === 'development' ? 'zak@commonwealth.im' : user.email;
-        emailObject.bcc = 'zak@commonwealth.im';
+        emailObject.to = process.env.NODE_ENV === 'development' ? 'raymond@commonwealth.im' : user.email;
+        emailObject.bcc = 'raymond+bcc@commonwealth.im';
 
         console.log(`sending batch notification email to ${user.email}`);
         await sgMail.send(emailObject);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add whole subject line to email body instead of just the "bonded"/event label. 
- Also create a new link for chain events to go to the notificationsList and scroll down to the specific notification.
Closes #895.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More info for the user and better UX for the link back to CW.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I only tested on a single chain event.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no