### PR TITLE
Fix Discussion Drafts copy & button functionality 

### DIFF
--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -84,6 +84,7 @@ export const checkForModifications = async (state, modalMsg) => {
 };
 
 export const loadDraft = async (dom, state, draft) => {
+  debugger
   const titleInput = $(dom).find('div.new-thread-form-body input[name=\'new-thread-title\']');
 
   // First we check if the form has been updated, to avoid losing any unsaved form data
@@ -603,6 +604,10 @@ export const NewThreadForm: m.Component<{
                       try {
                         await app.user.discussionDrafts.delete(draft.id);
                         vnode.state.recentlyDeletedDrafts.push(draft.id);
+                        if (vnode.state.fromDraft === draft.id) {
+                          delete vnode.state.fromDraft;
+                          m.redraw();
+                        }
                       } catch (err) {
                         notifyError(err.message);
                       }

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -84,7 +84,6 @@ export const checkForModifications = async (state, modalMsg) => {
 };
 
 export const loadDraft = async (dom, state, draft) => {
-  debugger
   const titleInput = $(dom).find('div.new-thread-form-body input[name=\'new-thread-title\']');
 
   // First we check if the form has been updated, to avoid losing any unsaved form data


### PR DESCRIPTION
## Description
In investigating issue #907 (unable to replicate) I came across an issue with a state property, fromDraft. fromDraft references the id of the draft which the New Thread Form has loaded, so that users can update to that draft rather than saving anew. However, there was no logic to delete the fromDraft id if the originating draft was deleted (after being loaded into the editor). This caused issues with copy and button functionality.

## How has this been tested?
I've run a set of draft creations/deletions/loadings to ensure button functionality works as desired.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no