### PR TITLE
Fix non-persisting selection in Create Invite Modal

### DIFF
--- a/client/scripts/views/modals/create_invite_modal.ts
+++ b/client/scripts/views/modals/create_invite_modal.ts
@@ -37,7 +37,6 @@ const InviteButton: m.Component<IInviteButtonAttrs, { disabled: boolean, }> = {
         ? 'Invite Commonwealth user' : selection === 'email' ? 'Invite email' : 'Add',
       onclick: (e) => {
         e.preventDefault();
-        console.log(vnode.attrs);
         const address = invitedAddress;
         const emailAddress = invitedEmail;
         const selectedChain = invitedAddressChain;
@@ -198,7 +197,7 @@ const CreateInviteModal: m.Component<{
   invitedEmail: string;
 }> = {
   oncreate: (vnode) => {
-    vnode.state.invitedAddressChain = 'none';
+    vnode.state.invitedAddressChain = '';
     mixpanel.track('New Invite', {
       'Step No': 1,
       'Step': 'Modal Opened'
@@ -221,7 +220,8 @@ const CreateInviteModal: m.Component<{
             m(FormLabel, { class: 'chainSelectLabel' }, 'Chain'),
             m(Select, {
               name: 'invitedAddressChain',
-              defaultValue: chainInfo ? chainInfo.id : app.config.chains.getAll()[0].id,
+              defaultValue: vnode.state.invitedAddressChain
+                || (chainInfo ? chainInfo.id : app.config.chains.getAll()[0].id),
               options: chainInfo
                 ? [{ label: chainInfo.name, value: chainInfo.id, }]
                 : app.config.chains.getAll().map((chain) => ({


### PR DESCRIPTION
# Description

When inviting an address to a community, the construct Selector component for picking an address chain continually reverted to its defaultValue, either from a construct bug or use failure. This pull ensures that selected options are properly displayed as selected in the UI.

## How has this been tested?

Messed around this Selector component in a couple different states/communities. Sent a successful invite to a private community post-fix. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no