### PR TITLE
Bug: Chain event listener sends duplicate emails when running on dev

### DIFF
--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -106,6 +106,9 @@ export default (
       ],
     };
 
+    // stop all notification emission if running as listener
+    if (process.env.RUN_AS_LISTENER === 'true') return;
+
     // typeguard function to differentiate between chain event notifications as needed
     const isChainEventData = (
       n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData

--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -106,9 +106,6 @@ export default (
       ],
     };
 
-    // stop all notification emission if running as listener
-    if (process.env.RUN_AS_LISTENER === 'true') return;
-
     // typeguard function to differentiate between chain event notifications as needed
     const isChainEventData = (
       n: IPostNotificationData | ICommunityNotificationData | IChainEventNotificationData

--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -158,6 +158,9 @@ const createNotificationDigestEmailObject = async (user, notifications, models) 
 };
 
 export const sendImmediateNotificationEmail = async (subscription, emailObject) => {
+  // supress immediate emails if running as listener
+  if (process.env.RUN_AS_LISTENER === 'true') return;
+
   const user = await subscription.getUser();
   if (!emailObject) {
     console.log('attempted to send empty immediate notification email');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- [x] Chain event listeners shouldn't send emails when running on dev (yarn run listen). 
  - This was solved by adding a check prior to sending the email (line 162 in `emails.ts`).
- [x] Chain event listeners shouldn't trigger webhooks when running on dev (yarn run listen), unless the webhook is equal to the value of the environment variable SLACK_FEEDBACK_WEBHOOK (see line 168 of server/webhookNotifier.ts, where this is already implemented for app-generated notifications)
  - 168 seems to already be doing this? It only sends a webhook if running production or `SLACK_FEEDBACK_WEBHOOK && url === SLACK_FEEDBACK_WEBHOOK`. 
  - Unless I misunderstand, this is a non-issue? 

Closes #909.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugs 🐛 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no