### PR TITLE
Ensure pinned discussion rows feature a full user gallery

### DIFF
--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -129,7 +129,10 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
     return data;
   });
 
-  const allThreads = pinnedThreads.map((t) => t.toJSON()).concat(threads);
+  const allThreads = pinnedThreads.map((t) => {
+    root_ids.push(`discussion_${t.id}`);
+    return t.toJSON();
+  }).concat(threads);
 
   // Comments
   const comments = await models.OffchainComment.findAll({


### PR DESCRIPTION
Closes #937.

## Description

Previously, commenters on pinned threads were not being displayed in discussion_rows' user galleries. This branch ensures they are.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no