### PR TITLE
Ensure user mentions link to correct thread

### DIFF
--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -260,7 +260,7 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
       `comment-${parent_id}`,
       {
         created_at: new Date(),
-        root_id,
+        root_id: Number(id),
         root_title,
         root_type: prefix,
         comment_id: Number(finalComment.id),
@@ -308,7 +308,7 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
         `user-${mentionedAddress.User.id}`,
         {
           created_at: new Date(),
-          root_id,
+          root_id: Number(id),
           root_title,
           root_type: prefix,
           comment_id: Number(finalComment.id),


### PR DESCRIPTION
Closes #929 

## Description

A full root_id (e.g. 'discussions_624') was being erroneously passed up as a proposal id from the createComment route, on both nested comments and comment mentions. This broke the notification links.

This branch ensures only the id number is passed up.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no