### PR TITLE
Fix notifications bug

### DIFF
--- a/client/scripts/views/components/header/notifications_menu.ts
+++ b/client/scripts/views/components/header/notifications_menu.ts
@@ -87,7 +87,8 @@ const NotificationsMenu: m.Component<{ small?: boolean }> = {
       }),
       position: 'bottom-end',
       inline: true,
-      closeOnContentClick: false,
+      closeOnContentClick: true,
+      closeOnOutsideClick: true,
       menuAttrs: {
         align: 'left',
       },

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -278,8 +278,6 @@ const NotificationRow: m.Component<{
           notificationArray.push(notification);
           await app.user.notifications.markAsRead(notificationArray).then(() => { console.log('279'); return m.redraw(); });
           await m.route.set(`/${app.activeId() || 'edgeware'}/notificationsList?id=${notification.id}`);
-          console.log(m.route.get());
-          console.log('281');
           m.redraw.sync();
         },
       }, [
@@ -317,16 +315,9 @@ const NotificationRow: m.Component<{
         key: notification.id,
         id: notification.id,
         onclick: async () => {
-          const notificationArray: Notification[] = [];
-          // await app.user.notifications.markAsRead(notifications).then(() => { console.log('321'); return m.redraw(); });
-          // console.log('322'); console.log(path);
-          m.route.set(path);
-          // await m.route.set('/edgeware/proposal/discussion/:identifier', { identifier: 634 });
-          console.log('323');
-          console.log(m.route.get());
-          m.redraw.sync();
-          // TODO: ensure notifs close
-          // if (pageJump) setTimeout(() => pageJump(), 1);
+          await app.user.notifications.markAsRead(notifications);
+          m.route.set(path)
+          if (pageJump) setTimeout(() => pageJump(), 1);
         },
       }, [
         authorInfo.length === 1

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -276,8 +276,10 @@ const NotificationRow: m.Component<{
           if (vnode.state.scrollOrStop) { vnode.state.scrollOrStop = false; return; }
           const notificationArray: Notification[] = [];
           notificationArray.push(notification);
-          app.user.notifications.markAsRead(notificationArray).then(() => m.redraw());
+          await app.user.notifications.markAsRead(notificationArray).then(() => { console.log('279'); return m.redraw(); });
           await m.route.set(`/${app.activeId() || 'edgeware'}/notificationsList?id=${notification.id}`);
+          console.log(m.route.get());
+          console.log('281');
           m.redraw.sync();
         },
       }, [
@@ -316,10 +318,15 @@ const NotificationRow: m.Component<{
         id: notification.id,
         onclick: async () => {
           const notificationArray: Notification[] = [];
-          app.user.notifications.markAsRead(notifications).then(() => m.redraw());
-          await m.route.set(path);
+          // await app.user.notifications.markAsRead(notifications).then(() => { console.log('321'); return m.redraw(); });
+          // console.log('322'); console.log(path);
+          m.route.set(path);
+          // await m.route.set('/edgeware/proposal/discussion/:identifier', { identifier: 634 });
+          console.log('323');
+          console.log(m.route.get());
           m.redraw.sync();
-          if (pageJump) setTimeout(() => pageJump(), 1);
+          // TODO: ensure notifs close
+          // if (pageJump) setTimeout(() => pageJump(), 1);
         },
       }, [
         authorInfo.length === 1

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -276,7 +276,7 @@ const NotificationRow: m.Component<{
           if (vnode.state.scrollOrStop) { vnode.state.scrollOrStop = false; return; }
           const notificationArray: Notification[] = [];
           notificationArray.push(notification);
-          await app.user.notifications.markAsRead(notificationArray).then(() => { console.log('279'); return m.redraw(); });
+          app.user.notifications.markAsRead(notificationArray).then(() => m.redraw());
           await m.route.set(`/${app.activeId() || 'edgeware'}/notificationsList?id=${notification.id}`);
           m.redraw.sync();
         },
@@ -315,8 +315,8 @@ const NotificationRow: m.Component<{
         key: notification.id,
         id: notification.id,
         onclick: async () => {
-          await app.user.notifications.markAsRead(notifications);
-          m.route.set(path)
+          app.user.notifications.markAsRead(notifications);
+          await m.route.set(path);
           if (pageJump) setTimeout(() => pageJump(), 1);
         },
       }, [

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -488,7 +488,6 @@ const ViewProposalPage: m.Component<{
   },
   view: (vnode) => {
     const { identifier, type } = vnode.attrs;
-    console.log({ identifier, type });
     if (typeof identifier !== 'string') return m(PageNotFound);
     if (!vnode.state.prefetch || !vnode.state.prefetch[identifier]) {
       vnode.state.prefetch = {};

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -509,6 +509,7 @@ const ViewProposalPage: m.Component<{
 
     // load proposal
     if (!vnode.state.proposal || Number(vnode.state.proposal.identifier) !== Number(proposalId)) {
+      debugger
       try {
         vnode.state.proposal = idToProposal(proposalType, proposalId);
       } catch (e) {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -488,6 +488,7 @@ const ViewProposalPage: m.Component<{
   },
   view: (vnode) => {
     const { identifier, type } = vnode.attrs;
+    console.log({ identifier, type });
     if (typeof identifier !== 'string') return m(PageNotFound);
     if (!vnode.state.prefetch || !vnode.state.prefetch[identifier]) {
       vnode.state.prefetch = {};
@@ -507,7 +508,7 @@ const ViewProposalPage: m.Component<{
     }
 
     // load proposal
-    if (!vnode.state.proposal) {
+    if (!vnode.state.proposal || Number(vnode.state.proposal.identifier) !== Number(proposalId)) {
       try {
         vnode.state.proposal = idToProposal(proposalType, proposalId);
       } catch (e) {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -509,7 +509,6 @@ const ViewProposalPage: m.Component<{
 
     // load proposal
     if (!vnode.state.proposal || Number(vnode.state.proposal.identifier) !== Number(proposalId)) {
-      debugger
       try {
         vnode.state.proposal = idToProposal(proposalType, proposalId);
       } catch (e) {


### PR DESCRIPTION
Closes #945.

## Description

This fix ensures that, when on an existing proposal page, navigating to a different proposal via the notifications menu will properly update the proposal component. 

## How has this been tested?

I drafted up several threads and toggled between them via the notifications menu, ensuring the URIs and component content dynamically updated.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no