### PR TITLE
Fix buggy batched email notifications

### DIFF
--- a/server/scripts/emails.ts
+++ b/server/scripts/emails.ts
@@ -122,12 +122,14 @@ const createNotificationDigestEmailObject = async (user, notifications, models) 
         label: label.heading,
         path: `https://commonwealth.im${label.linkUrl}`,
         createdAt,
-      }
+      };
     } else {
       const notification_data = JSON.parse(n.notification_data);
       const [
         emailSubjectLine, subjectCopy, actionCopy, objectCopy, communityCopy, excerpt, proposalPath, authorPath
       ] = await getForumNotificationCopy(models, notification_data as IPostNotificationData, category_id);
+
+      if (actionCopy === null) return; // don't return notification object if object no-longer exists
 
       let createdAt = moment(n.created_at).fromNow();
       if (createdAt === 'a day ago') createdAt = `${moment(Date.now()).diff(n.created_at, 'hours')} hours ago`;

--- a/shared/notificationFormatter.ts
+++ b/shared/notificationFormatter.ts
@@ -41,10 +41,10 @@ export const getForumNotificationCopy = async (models, notification_data: IPostN
   const authorPath = `https://commonwealth.im/${author_chain}/account/${author_address}?base=${author_chain}`;
 
   // action and community
-  const actionCopy = ((category_id === NotificationCategories.NewComment) ? 'commented on'
+  const actionCopy = (([NotificationCategories.NewComment, NotificationCategories.CommentEdit].includes(category_id)) ? 'commented on'
     : (category_id === NotificationCategories.NewMention) ? 'mentioned you in the thread'
-      : (category_id === NotificationCategories.NewThread) ? 'created a new thread'
-        : '');
+      : [NotificationCategories.ThreadEdit, NotificationCategories.NewThread].includes(category_id) ? 'created a new thread'
+        : null);
   const objectCopy = decodeURIComponent(root_title).trim();
   const communityObject = chain_id
     ? await models.Chain.findOne({ where: { id: chain_id } })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Action verbs missing on some notifications
  - Fixed by including editComment/editThread to the category types to assign the actionCopy
- Deleted threads/comments generate empty email notification
  - Fixed by not returning a notification object if there is no actionCopy returned from the formatter
Closes #915.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugs 🐛 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no