### PR TITLE
Fix ambiguous confirmation modal

### DIFF
--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -716,7 +716,9 @@ const LinkNewAddressModal: m.Component<{
 
 // inject confirmExit property
 LinkNewAddressModal['confirmExit'] = confirmationModalWithText(
-  app.isLoggedIn() ? 'Cancel connecting new address?' : 'Cancel log in?'
+  app.isLoggedIn() ? 'Cancel connecting new address?' : 'Cancel log in?',
+  'Yes',
+  'No'
 );
 
 export default LinkNewAddressModal;


### PR DESCRIPTION
## Description

Previously, the confirmation modal for cancelling an address registration asked, "Cancel connecting new address?" and prompted a "Yes" and "Cancel" option. This branches removes the ambiguity by passing "No" to the second button, rather than "Cancel."