### PR TITLE
Store Last Active Date on Address Model, add to view

### DIFF
--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -61,7 +61,7 @@ class RecentActivityController {
       const { count } = user;
       const { chain, address, name, headline, bio, avatarUrl } = user.info;
       const info = new Profile(chain, address);
-      info.initialize(name, headline, bio, avatarUrl);
+      info.initialize(name, headline, bio, avatarUrl, null);
       return ({ info, count });
     });
   }

--- a/client/scripts/controllers/server/profiles.ts
+++ b/client/scripts/controllers/server/profiles.ts
@@ -88,10 +88,11 @@ class ProfilesController {
             name, headline, bio, avatarUrl,
           } = JSON.parse(profileData.data);
           const lastActive = profileData.Address.last_active;
-          if (lastActive) console.log('has last Active', profile);
           // ignore off-chain name if substrate id exists
           if (profileData.identity) {
-            profile.initializeWithChain(profileData.identity, headline, bio, avatarUrl, profileData.judgements, lastActive);
+            profile.initializeWithChain(
+              profileData.identity, headline, bio, avatarUrl, profileData.judgements, lastActive
+            );
           } else {
             profile.initialize(name, headline, bio, avatarUrl, lastActive);
           }

--- a/client/scripts/controllers/server/profiles.ts
+++ b/client/scripts/controllers/server/profiles.ts
@@ -87,11 +87,13 @@ class ProfilesController {
           const {
             name, headline, bio, avatarUrl,
           } = JSON.parse(profileData.data);
+          const lastActive = profileData.Address.last_active;
+          if (lastActive) console.log('has last Active', profile);
           // ignore off-chain name if substrate id exists
           if (profileData.identity) {
-            profile.initializeWithChain(profileData.identity, headline, bio, avatarUrl, profileData.judgements);
+            profile.initializeWithChain(profileData.identity, headline, bio, avatarUrl, profileData.judgements, lastActive);
           } else {
-            profile.initialize(name, headline, bio, avatarUrl);
+            profile.initialize(name, headline, bio, avatarUrl, lastActive);
           }
           return profile;
         }).filter((p) => p !== null);

--- a/client/scripts/models/Profile.ts
+++ b/client/scripts/models/Profile.ts
@@ -11,6 +11,7 @@ class Profile {
   private _initialized: boolean;
   private _judgements: { [registrar: string]: string } = {};
   private _isOnchain: boolean = false;
+  private _lastActive: Date;
   get name() { return this._name; }
   get headline() { return this._headline; }
   get bio() { return this._bio; }
@@ -18,6 +19,7 @@ class Profile {
   get initialized() { return this._initialized; }
   get judgements() { return this._judgements; }
   get isOnchain() { return this._isOnchain; }
+  get lastActive() { return this._lastActive; }
 
   public readonly chain: string;
   public readonly address: string;
@@ -31,7 +33,7 @@ class Profile {
     this._initialized = true;
   }
 
-  public initializeWithChain(name, headline, bio, avatarUrl, judgements) {
+  public initializeWithChain(name, headline, bio, avatarUrl, judgements, lastActive) {
     this._initialized = true;
     this._isOnchain = true;
     this._name = name;
@@ -39,14 +41,16 @@ class Profile {
     this._bio = bio;
     this._avatarUrl = avatarUrl;
     this._judgements = judgements;
+    this._lastActive = lastActive;
   }
 
-  public initialize(name, headline, bio, avatarUrl) {
+  public initialize(name, headline, bio, avatarUrl, lastActive) {
     this._initialized = true;
     this._name = name;
     this._headline = headline;
     this._bio = bio;
     this._avatarUrl = avatarUrl;
+    this._lastActive = lastActive;
   }
 
   get displayName() : string {

--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -293,12 +293,16 @@ const instantiateEditor = (
         addrSpan.innerText = addr.chain === 'near' ? addr.address : `${addr.address.slice(0, 6)}...`;
         addrSpan.className = 'ql-mention-addr';
 
+        const lastActiveSpan = document.createElement('span');
+        lastActiveSpan.innerText = profile.lastActive?.toString() || null;
+
         const textWrap = document.createElement('div');
         textWrap.className = 'ql-mention-text-wrap';
 
         node.appendChild(avatar);
         textWrap.appendChild(nameSpan);
         textWrap.appendChild(addrSpan);
+        textWrap.appendChild(lastActiveSpan);
         node.appendChild(textWrap);
 
         return ({

--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -2,6 +2,7 @@ import 'components/quill_editor.scss';
 
 import m, { VnodeDOM } from 'mithril';
 import $ from 'jquery';
+import moment from 'moment-twitter';
 import Quill from 'quill-2.0-dev/quill';
 import { Tag, Tooltip } from 'construct-ui';
 import ImageUploader from 'quill-image-uploader';
@@ -282,7 +283,7 @@ const instantiateEditor = (
         } else {
           avatar = document.createElement('div');
           avatar.className = 'ql-mention-avatar';
-          avatar.innerHTML = Profile.getSVGAvatar(addr.address, 16);
+          avatar.innerHTML = Profile.getSVGAvatar(addr.address, 20);
         }
 
         const nameSpan = document.createElement('span');
@@ -294,7 +295,7 @@ const instantiateEditor = (
         addrSpan.className = 'ql-mention-addr';
 
         const lastActiveSpan = document.createElement('span');
-        lastActiveSpan.innerText = profile.lastActive?.toString() || null;
+        lastActiveSpan.innerText = profile.lastActive ? `Last active ${moment(profile.lastActive).fromNow()}` : null;
         lastActiveSpan.className = 'ql-mention-la';
 
         const textWrap = document.createElement('div');

--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -295,6 +295,7 @@ const instantiateEditor = (
 
         const lastActiveSpan = document.createElement('span');
         lastActiveSpan.innerText = profile.lastActive?.toString() || null;
+        lastActiveSpan.className = 'ql-mention-la';
 
         const textWrap = document.createElement('div');
         textWrap.className = 'ql-mention-text-wrap';

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -149,10 +149,11 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
                 profileData.headline,
                 profileData.bio,
                 profileData.avatarUrl,
-                a.OffchainProfile.judgements
+                a.OffchainProfile.judgements,
+                a.last_active
               );
             } else {
-              profile.initialize(profileData.name, profileData.headline, profileData.bio, profileData.avatarUrl);
+              profile.initialize(profileData.name, profileData.headline, profileData.bio, profileData.avatarUrl, a.last_active);
             }
           } else {
             profile.initializeEmpty();

--- a/client/styles/components/quill_editor.scss
+++ b/client/styles/components/quill_editor.scss
@@ -266,27 +266,29 @@
             cursor: pointer;
         }
         .ql-mention-text-wrap {
-            display: flex;
-            justify-content: space-between;
             width: 100%;
-        }
-        .ql-mention-name {
-            display: block;
-            min-width: 50px;
-            margin-right: 12px;
-        }
-        .ql-mention-addr {
-            color: #999;
-        }
-        .ql-mention-la {
-            color: #999;
+            .ql-mention-name {
+                margin-right: 15px;
+            }
+            .ql-mention-addr {
+                float: right;
+                color: #999;
+                font-size: 90%;
+                line-height: 1.6;
+            }
+            .ql-mention-la {
+                display: block;
+                color: #999;
+                font-size: 90%;
+                white-space: nowrap;
+            }
         }
         .ql-mention-avatar {
             height: 20px;
             width: 20px;
             min-height: 20px;
             min-width: 20px;
-            margin-right: 8px;
+            margin-right: 12px;
             border-radius: 9999px;
             &.missing {
                 background-color: $background-color-light;

--- a/client/styles/components/quill_editor.scss
+++ b/client/styles/components/quill_editor.scss
@@ -278,6 +278,9 @@
         .ql-mention-addr {
             color: #999;
         }
+        .ql-mention-la {
+            color: #999;
+        }
         .ql-mention-avatar {
             height: 20px;
             width: 20px;

--- a/server/migrations/20201124224946-add-last-active-to-address.js
+++ b/server/migrations/20201124224946-add-last-active-to-address.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};

--- a/server/migrations/20201124224946-add-last-active-to-address.js
+++ b/server/migrations/20201124224946-add-last-active-to-address.js
@@ -1,23 +1,16 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    /*
-      Add altering commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
-    */
+  up: (queryInterface, DataTypes) => {
+    return queryInterface.addColumn(
+      'Addresses', 'last_active', {
+        type: DataTypes.DATE,
+        allowNull: true
+      }
+    );
   },
 
-  down: (queryInterface, Sequelize) => {
-    /*
-      Add reverting commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.dropTable('users');
-    */
+  down: (queryInterface, DataTypes) => {
+    return queryInterface.removeColumn('Addresses', 'last_active');
   }
 };

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -111,7 +111,8 @@ export default (
   ): Promise<AddressInstance> => {
     const verification_token = crypto.randomBytes(18).toString('hex');
     const verification_token_expires = new Date(+(new Date()) + ADDRESS_TOKEN_EXPIRES_IN * 60 * 1000);
-    return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype });
+    const last_active = new Date();
+    return Address.create({ user_id, chain, address, verification_token, verification_token_expires, keytype, last_active });
   };
 
   // Update an existing address' verification token
@@ -128,6 +129,8 @@ export default (
     address.keytype = keytype;
     address.verification_token = verification_token;
     address.verification_token_expires = verification_token_expires;
+    address.last_active = new Date();
+
     return address.save();
   };
 
@@ -245,6 +248,8 @@ export default (
       log.error(`invalid network: ${chain.network}`);
       isValid = false;
     }
+
+    addressModel.last_active = new Date();
 
     if (isValid && user_id === null) {
       // mark the address as verified, and if it doesn't have an associated user, create a new user

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -36,6 +36,7 @@ export interface AddressAttributes {
   verified?: Date;
   keytype?: string;
   name?: string;
+  last_active?: Date;
   created_at?: Date;
   updated_at?: Date;
   user_id?: number;
@@ -89,6 +90,7 @@ export default (
     verified:                   { type: dataTypes.DATE, allowNull: true },
     keytype:                    { type: dataTypes.STRING, allowNull: true },
     name:                       { type: dataTypes.STRING, allowNull: true },
+    last_active:                 { type: dataTypes.DATE, allowNull: true },
     created_at:                 { type: dataTypes.DATE, allowNull: false },
     updated_at:                 { type: dataTypes.DATE, allowNull: false },
     user_id:                    { type: dataTypes.INTEGER, allowNull: true },

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -90,7 +90,7 @@ export default (
     verified:                   { type: dataTypes.DATE, allowNull: true },
     keytype:                    { type: dataTypes.STRING, allowNull: true },
     name:                       { type: dataTypes.STRING, allowNull: true },
-    last_active:                 { type: dataTypes.DATE, allowNull: true },
+    last_active:                { type: dataTypes.DATE, allowNull: true },
     created_at:                 { type: dataTypes.DATE, allowNull: false },
     updated_at:                 { type: dataTypes.DATE, allowNull: false },
     user_id:                    { type: dataTypes.INTEGER, allowNull: true },
@@ -265,14 +265,13 @@ export default (
         });
         addressModel.user_id = user.id;
       }
-      await addressModel.save();
     } else if (isValid) {
       // mark the address as verified
       addressModel.verification_token_expires = null;
       addressModel.verified = new Date();
       addressModel.user_id = user_id;
-      await addressModel.save();
     }
+    await addressModel.save();
     return isValid;
   };
 

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -333,6 +333,10 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
     }));
   }
 
+  // update author.last_active (no await)
+  author.last_active = new Date();
+  author.save();
+
   return res.json({ status: 'Success', result: finalComment.toJSON() });
 };
 

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -133,6 +133,10 @@ const createReaction = async (models, req: Request, res: Response, next: NextFun
     [ finalReaction.Address.address ],
   );
 
+  // update author.last_active (no await)
+  author.last_active = new Date();
+  author.save();
+
   return res.json({ status: 'Success', result: finalReaction.toJSON() });
 };
 

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -291,6 +291,10 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     );
   }));
 
+  // update author.last_active (no await)
+  author.last_active = new Date();
+  author.save();
+
   return res.json({ status: 'Success', result: finalThread.toJSON() });
 };
 

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -108,13 +108,16 @@ const editComment = async (models, req: Request, res: Response, next: NextFuncti
       req.wss,
       [ finalComment.Address.address ],
     );
+    // TODO: dispatch notifications for new mention(s)
+
+    // update author.last_active (no await)
+    author.last_active = new Date();
+    author.save();
 
     return res.json({ status: 'Success', result: finalComment.toJSON() });
   } catch (e) {
     return next(e);
   }
-
-  // Todo: dispatch notifications conditional on a new mention
 };
 
 export default editComment;

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -85,12 +85,13 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
       req.wss,
       [ finalThread.Address.address ],
     );
+    // TODO: dispatch notifications for new mention(s)
+    // TODO: update author.last_active
+
     return res.json({ status: 'Success', result: finalThread.toJSON() });
   } catch (e) {
     return next(new Error(e));
   }
-
-  // Todo: dispatch notifications conditional on a new mention
 };
 
 export default editThread;

--- a/server/routes/setDefaultRole.ts
+++ b/server/routes/setDefaultRole.ts
@@ -32,6 +32,9 @@ const setDefaultRole = async (models, req, res: Response, next: NextFunction) =>
   } });
   if (!existingRole) return next(new Error(Errors.RoleDNE));
 
+  validAddress.last_active = new Date();
+  await validAddress.save();
+
   const otherAddresses = await models.Address.findAll({
     where: {
       id: { [Sequelize.Op.ne]: validAddress.id },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `last_active` to Address Model as `Datatype.DATE`
- Added `last_active` to be set when creating new Address Model via all 3 methods.
- Wrote migration that adds/removes column on `Addresses` Table
- Modified `/setDefaultRole` to update `last_active` whenever it's called with an address
- Added `last_active` to client profile model when setting. 
- Added `span` view of `last_active` to Quill Editor mentions pop up (if applicable).

Closes #953.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Shows users an address's recent usage/login while mentioning.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Run Migration
- Log in with multiple linked addresses
- Switch between all your addresses to update their `last_active` from null to today.
- Start new thread/comment and `@mention` your addresses to see the date appear

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested.