### PR TITLE
Ensure proper spinner behavior

### DIFF
--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -228,6 +228,8 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
           m.redraw();
         });
         vnode.state.topicInitialized[subpage] = true;
+      } else if (allThreads.length < 20 && subpage === ALL_PROPOSALS_KEY) {
+        vnode.state.postsDepleted[subpage] = true;
       }
 
       // Initialize infiniteScroll


### PR DESCRIPTION
Closes #969 

## Description

This branch ensures that communities with less than 20 posts properly hide the infinite scroll spinner on initialization.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no