### PR TITLE
Ensure activeAccount is updated on profile editing

### DIFF
--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -4,11 +4,11 @@ import $ from 'jquery';
 import m from 'mithril';
 import mixpanel from 'mixpanel-browser';
 
-import { Button, ButtonGroup, Icon, Icons, List, Menu, MenuItem, MenuDivider,
+import { Button, ButtonGroup, Icon, Icons, Menu, MenuItem, MenuDivider,
   Popover } from 'construct-ui';
 
 import app from 'state';
-import { ChainInfo, CommunityInfo, Profile } from 'models';
+import { ChainInfo, CommunityInfo } from 'models';
 import { isSameAccount, pluralize } from 'helpers';
 import { initAppState } from 'app';
 import { notifySuccess } from 'controllers/app/notifications';

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -8,7 +8,7 @@ import { Button, ButtonGroup, Icon, Icons, List, Menu, MenuItem, MenuDivider,
   Popover } from 'construct-ui';
 
 import app from 'state';
-import { ChainInfo, CommunityInfo } from 'models';
+import { ChainInfo, CommunityInfo, Profile } from 'models';
 import { isSameAccount, pluralize } from 'helpers';
 import { initAppState } from 'app';
 import { notifySuccess } from 'controllers/app/notifications';
@@ -93,7 +93,9 @@ export const CurrentCommunityLabel: m.Component<{}> = {
   }
 };
 
-const LoginSelector: m.Component<{ small?: boolean }, {
+const LoginSelector: m.Component<{
+  small?: boolean
+}, {
   profileLoadComplete: boolean
 }> = {
   view: (vnode) => {

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -7,7 +7,7 @@ import mixpanel from 'mixpanel-browser';
 import $ from 'jquery';
 
 import app from 'state';
-import { OffchainThread, OffchainComment, OffchainAttachment, Profile } from 'models';
+import { OffchainThread, OffchainComment, OffchainAttachment, Profile, Account } from 'models';
 
 import Sublayout from 'views/sublayout';
 import PageNotFound from 'views/pages/404';
@@ -15,6 +15,7 @@ import PageLoading from 'views/pages/loading';
 import Tabs from 'views/components/widgets/tabs';
 
 import { decodeAddress } from '@polkadot/keyring';
+import { setActiveAccount } from 'controllers/app/login';
 import ProfileHeader from './profile_header';
 import ProfileContent from './profile_content';
 import ProfileBio from './profile_bio';
@@ -261,10 +262,19 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
     if (!account) {
       return m(PageNotFound, { message: 'Invalid address provided' });
     }
+
+    const { onOwnProfile, onLinkedProfile, displayBanner, currentAddressInfo } = getProfileStatus(account);
+
     if (refreshProfile) {
       loadProfile();
       vnode.state.refreshProfile = false;
-      m.redraw();
+      if (onOwnProfile) {
+        setActiveAccount(account).then(() => {
+          m.redraw();
+        });
+      } else {
+        m.redraw();
+      }
     }
 
     // TODO: search for cosmos proposals, if ChainClass is Cosmos
@@ -284,8 +294,6 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
     const allTabTitle = (proposals && comments) ? `All (${proposals.length + comments.length})` : 'All';
     const threadsTabTitle = (proposals) ? `Threads (${proposals.length})` : 'Threads';
     const commentsTabTitle = (comments) ? `Comments (${comments.length})` : 'Comments';
-
-    const { onOwnProfile, onLinkedProfile, displayBanner, currentAddressInfo } = getProfileStatus(account);
 
     return m(Sublayout, {
       class: 'ProfilePage',

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -7,7 +7,7 @@ import mixpanel from 'mixpanel-browser';
 import $ from 'jquery';
 
 import app from 'state';
-import { OffchainThread, OffchainComment, OffchainAttachment, Profile, Account } from 'models';
+import { OffchainThread, OffchainComment, OffchainAttachment, Profile } from 'models';
 
 import Sublayout from 'views/sublayout';
 import PageNotFound from 'views/pages/404';

--- a/client/scripts/views/sublayout.ts
+++ b/client/scripts/views/sublayout.ts
@@ -8,12 +8,10 @@ import NewProposalButton from 'views/components/new_proposal_button';
 import ConfirmInviteModal from 'views/modals/confirm_invite_modal';
 import NotificationsMenu from 'views/components/header/notifications_menu';
 import LoginSelector from 'views/components/header/login_selector';
-import { CollectiveVotingButton, CandidacyButton, getCouncilCandidates } from './pages/council/index';
-import { SubstrateAccount } from '../controllers/chain/substrate/account';
-import Substrate from '../controllers/chain/substrate/main';
-
 import Sidebar from 'views/components/sidebar';
 import RightSidebar from 'views/components/right_sidebar';
+import { getCouncilCandidates } from './pages/council/index';
+import { SubstrateAccount } from '../controllers/chain/substrate/account';
 
 const Sublayout: m.Component<{
   // overrides


### PR DESCRIPTION
Closes #967.

## Description

Previously, when a user edited their display name, it would not update in the LoginSelector button & menus. This branch ensures the activeAccount is updated, so the new information propagates app-wide.

## How has this been tested?

Have successfully updated display name from different accounts. Will do a more rigorous QA this evening, but since it just uses the default setActiveAccount fn, it should be relatively robust.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no