### PR TITLE
Add user flags for councillor and validator.

### DIFF
--- a/client/scripts/controllers/server/profiles.ts
+++ b/client/scripts/controllers/server/profiles.ts
@@ -88,13 +88,16 @@ class ProfilesController {
             name, headline, bio, avatarUrl,
           } = JSON.parse(profileData.data);
           const lastActive = profileData.Address.last_active;
+          const isCouncillor = profileData.Address.is_councillor;
+          const isValidator = profileData.Address.is_validator;
           // ignore off-chain name if substrate id exists
           if (profileData.identity) {
             profile.initializeWithChain(
-              profileData.identity, headline, bio, avatarUrl, profileData.judgements, lastActive
+              profileData.identity, headline, bio, avatarUrl,
+              profileData.judgements, lastActive, isCouncillor, isValidator
             );
           } else {
-            profile.initialize(name, headline, bio, avatarUrl, lastActive);
+            profile.initialize(name, headline, bio, avatarUrl, lastActive, isCouncillor, isValidator);
           }
           return profile;
         }).filter((p) => p !== null);

--- a/client/scripts/models/Profile.ts
+++ b/client/scripts/models/Profile.ts
@@ -12,6 +12,8 @@ class Profile {
   private _judgements: { [registrar: string]: string } = {};
   private _isOnchain: boolean = false;
   private _lastActive: Date;
+  private _isCouncillor: boolean = false;
+  private _isValidator: boolean = false;
   get name() { return this._name; }
   get headline() { return this._headline; }
   get bio() { return this._bio; }
@@ -20,6 +22,8 @@ class Profile {
   get judgements() { return this._judgements; }
   get isOnchain() { return this._isOnchain; }
   get lastActive() { return this._lastActive; }
+  get isCouncillor() { return this._isCouncillor; }
+  get isValidator() { return this._isValidator; }
 
   public readonly chain: string;
   public readonly address: string;
@@ -33,7 +37,7 @@ class Profile {
     this._initialized = true;
   }
 
-  public initializeWithChain(name, headline, bio, avatarUrl, judgements, lastActive) {
+  public initializeWithChain(name, headline, bio, avatarUrl, judgements, lastActive, isCouncillor = false, isValidator = false) {
     this._initialized = true;
     this._isOnchain = true;
     this._name = name;
@@ -42,15 +46,19 @@ class Profile {
     this._avatarUrl = avatarUrl;
     this._judgements = judgements;
     this._lastActive = lastActive;
+    this._isCouncillor = isCouncillor;
+    this._isValidator = isValidator;
   }
 
-  public initialize(name, headline, bio, avatarUrl, lastActive) {
+  public initialize(name, headline, bio, avatarUrl, lastActive, isCouncillor = false, isValidator = false) {
     this._initialized = true;
     this._name = name;
     this._headline = headline;
     this._bio = bio;
     this._avatarUrl = avatarUrl;
     this._lastActive = lastActive;
+    this._isCouncillor = isCouncillor;
+    this._isValidator = isValidator;
   }
 
   get displayName() : string {

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -19,13 +19,14 @@ const User: m.Component<{
   onclick?: any;
   popover?: boolean;
   showRole?: boolean;
+  hideOnchainRole?: boolean;
 }, {
   identityWidgetLoading: boolean;
   IdentityWidget: any;
 }> = {
   view: (vnode) => {
     // TODO: Fix showRole logic to fetch the role from chain
-    const { avatarOnly, hideAvatar, hideIdentityIcon, user, linkify, popover, showRole } = vnode.attrs;
+    const { avatarOnly, hideAvatar, hideIdentityIcon, user, linkify, popover, showRole, hideOnchainRole } = vnode.attrs;
     const avatarSize = vnode.attrs.avatarSize || 16;
     const showAvatar = !hideAvatar;
     if (!user) return;
@@ -111,6 +112,9 @@ const User: m.Component<{
               : m('a.user-display-name.username', profile ? profile.name : addrShort)
           ],
         showRole && roleTag,
+        !hideOnchainRole
+          && (profile.isCouncillor || profile.isValidator)
+          && m('span.user-flag', `${profile.isCouncillor ? 'C' : 'V'}`),
       ]);
 
     const userPopover = m('.UserPopover', {
@@ -157,11 +161,12 @@ export const UserBlock: m.Component<{
   hideIdentityIcon?: boolean,
   popover?: boolean,
   showRole?: boolean,
+  hideOnchainRole?: boolean,
   selected?: boolean,
   compact?: boolean,
 }> = {
   view: (vnode) => {
-    const { user, hideIdentityIcon, popover, showRole, selected, compact } = vnode.attrs;
+    const { user, hideIdentityIcon, popover, showRole, hideOnchainRole, selected, compact } = vnode.attrs;
 
     let profile;
     if (user instanceof AddressInfo) {
@@ -192,6 +197,7 @@ export const UserBlock: m.Component<{
             hideIdentityIcon,
             popover,
             showRole,
+            hideOnchainRole,
           }),
         ]),
         m('.user-block-address', {

--- a/client/scripts/views/pages/discussions/sidebar.ts
+++ b/client/scripts/views/pages/discussions/sidebar.ts
@@ -18,7 +18,7 @@ export const MostActiveUser: m.Component<{ user: AddressInfo, activityCount: num
         avatarSize: 24,
         linkify: true,
         popover: true,
-        showRole: true
+        showRole: true,
       }),
       m('.activity-count', activityCount)
     ]);

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -198,10 +198,20 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
                 profileData.bio,
                 profileData.avatarUrl,
                 a.OffchainProfile.judgements,
-                a.last_active
+                a.last_active,
+                a.is_councillor,
+                a.is_validator,
               );
             } else {
-              profile.initialize(profileData.name, profileData.headline, profileData.bio, profileData.avatarUrl, a.last_active);
+              profile.initialize(
+                profileData.name,
+                profileData.headline,
+                profileData.bio,
+                profileData.avatarUrl,
+                a.last_active,
+                a.is_councillor,
+                a.is_validator
+              );
             }
           } else {
             profile.initializeEmpty();

--- a/client/styles/components/widgets/user.scss
+++ b/client/styles/components/widgets/user.scss
@@ -84,6 +84,15 @@
         background: $background-color-light;
         border-color: $background-color-border;
     }
+    .user-flag {
+        margin-left: 2px;
+        margin-right: 2px;
+        margin-top: -5px;
+        margin-bottom: -5px;
+        padding: 0 2px;
+        background: $background-color-light;
+        border-color: $background-color-border;
+    }
 }
 
 .UserPopover {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.3.8",
+    "@commonwealth/chain-events": "0.3.12",
     "@edgeware/node-types": "3.0.10",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "migrate-events": "NO_CLIENT=true NO_PRERENDER=true ENTITY_MIGRATION=all ts-node --project tsconfig.node.json server.ts",
     "migrate-server": "heroku run npx sequelize db:migrate --debug",
     "migrate-identities": "NO_CLIENT=true NO_PRERENDER=true IDENTITY_MIGRATION=true ts-node --project tsconfig.node.json server.ts",
+    "migrate-flags": "NO_CLIENT=true NO_PRERENDER=true FLAG_MIGRATION=true ts-node --project tsconfig.node.json server.ts",
     "reset-server": "NO_CLIENT=true NO_PRERENDER=true RESET_DB=true ts-node --project tsconfig.node.json server.ts",
     "start-ci": "FETCH_INTERVAL_MS=500 ts-node --project tsconfig.node.json server.ts",
     "psql": "psql -h localhost commonwealth -U commonwealth"

--- a/server-test.ts
+++ b/server-test.ts
@@ -121,15 +121,42 @@ const resetServer = (debug=false): Promise<void> => {
         type: 'chain',
       });
 
-      await models['Address'].create({
-        user_id: 1,
-        address: '0x34C3A5ea06a3A67229fb21a7043243B0eB3e853f',
-        chain: 'ethereum',
-        selected: true,
-        verification_token: 'PLACEHOLDER',
-        verification_token_expires: null,
-        verified: new Date(),
-      });
+      // Admin roles for specific communities
+      await Promise.all([
+        models['Address'].create({
+          user_id: 1,
+          address: '0x34C3A5ea06a3A67229fb21a7043243B0eB3e853f',
+          chain: 'ethereum',
+          selected: true,
+          verification_token: 'PLACEHOLDER',
+          verification_token_expires: null,
+          verified: new Date(),
+        }),
+        models['Address'].create({
+          address: '5DJA5ZCobDS3GVn8D2E5YRiotDqGkR2FN1bg6LtfNUmuadwX',
+          chain: 'edgeware',
+          verification_token: 'PLACEHOLDER',
+          verification_token_expires: null,
+          verified: true,
+          keytype: 'sr25519',
+        }),
+        models['Address'].create({
+          address: 'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+          chain: 'edgeware',
+          verification_token: 'PLACEHOLDER',
+          verification_token_expires: null,
+          verified: true,
+          keytype: 'sr25519',
+        }),
+        models['Address'].create({
+          address: 'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+          chain: 'edgeware',
+          verification_token: 'PLACEHOLDER',
+          verification_token_expires: null,
+          verified: true,
+          keytype: 'sr25519',
+        }),
+      ]);
 
       // Notification Categories
       await models['NotificationCategory'].create({

--- a/server.ts
+++ b/server.ts
@@ -38,6 +38,7 @@ import setupChainEventListeners from './server/scripts/setupChainEventListeners'
 import { fetchStats } from './server/routes/getEdgewareLockdropStats';
 import migrateChainEntities from './server/scripts/migrateChainEntities';
 import migrateIdentities from './server/scripts/migrateIdentities';
+import migrateCouncillorValidatorFlags from './server/scripts/migrateCouncillorValidatorFlags';
 
 // set up express async error handling hack
 require('express-async-errors');
@@ -64,6 +65,7 @@ async function main() {
   const SKIP_EVENT_CATCHUP = process.env.SKIP_EVENT_CATCHUP === 'true';
   const ENTITY_MIGRATION = process.env.ENTITY_MIGRATION;
   const IDENTITY_MIGRATION = process.env.IDENTITY_MIGRATION;
+  const FLAG_MIGRATION = process.env.FLAG_MIGRATION;
   const CHAIN_EVENTS = process.env.CHAIN_EVENTS;
   const RUN_AS_LISTENER = process.env.RUN_AS_LISTENER === 'true';
 
@@ -149,6 +151,16 @@ async function main() {
       rc = 0;
     } catch (e) {
       log.error('Failed migrating chain identities into the DB: ', e.message);
+      rc = 1;
+    }
+  } else if (FLAG_MIGRATION) {
+    log.info('Started migrating councillor and validator flags into the DB');
+    try {
+      await migrateCouncillorValidatorFlags(models);
+      log.info('Finished migrating councillor and validator flags into the DB');
+      rc = 0;
+    } catch (e) {
+      log.error('Failed migrating councillor and validator flags into the DB: ', e.message);
       rc = 1;
     }
   }

--- a/server/eventHandlers/userFlags.ts
+++ b/server/eventHandlers/userFlags.ts
@@ -1,0 +1,66 @@
+/**
+ * Event handler that processes changes in validator and councillor sets
+ * and updates user-related flags in the database accordingly.
+ */
+import { IEventHandler, CWEvent, IChainEventKind, SubstrateTypes } from '@commonwealth/chain-events';
+import Sequelize from 'sequelize';
+const Op = Sequelize.Op;
+
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+export default class extends IEventHandler {
+  constructor(
+    private readonly _models,
+    private readonly _chain: string,
+  ) {
+    super();
+  }
+
+  private async syncAddressFlags(flag: string, newList: string[]) {
+    // clear existing flags
+    const oldInstances = await this._models.Address.findAll({
+      where: {
+        chain: this._chain,
+        [flag]: true,
+      }
+    });
+    await Promise.all(oldInstances.map((c) => {
+      c[flag] = false;
+      return c.save();
+    }));
+
+    // add new councillor flags
+    const newInstances = await this._models.Address.findAll({
+      where: {
+        chain: this._chain,
+        address: {
+          [Op.in]: newList,
+        }
+      }
+    });
+    await Promise.all(newInstances.map((c) => {
+      c[flag] = true;
+      return c.save();
+    }));
+    log.info(`Cleared ${flag} on ${oldInstances.length} addresses and set on ${newInstances.length} addresses.`);
+  }
+
+  public async handle(event: CWEvent, dbEvent) {
+    // handle new councillors
+    if (event.data.kind === SubstrateTypes.EventKind.ElectionNewTerm
+        || event.data.kind === SubstrateTypes.EventKind.ElectionEmptyTerm) {
+      const councillors = event.data.kind === SubstrateTypes.EventKind.ElectionNewTerm
+        ? event.data.allMembers : event.data.members;
+      await this.syncAddressFlags('is_councillor', councillors);
+      return dbEvent;
+    }
+
+    // handle new validators
+    if (event.data.kind === SubstrateTypes.EventKind.StakingElection) {
+      const validators = event.data.validators;
+      await this.syncAddressFlags('is_validator', validators);
+      return dbEvent;
+    }
+  }
+}

--- a/server/eventHandlers/userFlags.ts
+++ b/server/eventHandlers/userFlags.ts
@@ -46,6 +46,15 @@ export default class extends IEventHandler {
     log.info(`Cleared ${flag} on ${oldInstances.length} addresses and set on ${newInstances.length} addresses.`);
   }
 
+  public async forceSync(councillors?: string[], validators?: string[]) {
+    if (councillors instanceof Array) {
+      await this.syncAddressFlags('is_councillor', councillors);
+    }
+    if (validators instanceof Array) {
+      await this.syncAddressFlags('is_validator', validators);
+    }
+  }
+
   public async handle(event: CWEvent, dbEvent) {
     // handle new councillors
     if (event.data.kind === SubstrateTypes.EventKind.ElectionNewTerm

--- a/server/migrations/20201202211421-add-councillor-validator-flags.js
+++ b/server/migrations/20201202211421-add-councillor-validator-flags.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn('Addresses', 'is_councillor', {
+          type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false,
+        }, { transaction: t }),
+        queryInterface.addColumn('Addresses', 'is_validator', {
+          type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false,
+        }, { transaction: t }),
+      ]);
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('Addresses', 'is_councillor', { transaction: t }),
+        queryInterface.removeColumn('Addresses', 'is_validator', { transaction: t }),
+      ]);
+    });
+  }
+};

--- a/server/migrations/20201202211421-add-councillor-validator-flags.js
+++ b/server/migrations/20201202211421-add-councillor-validator-flags.js
@@ -5,10 +5,10 @@ module.exports = {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.addColumn('Addresses', 'is_councillor', {
-          type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false,
+          type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false,
         }, { transaction: t }),
         queryInterface.addColumn('Addresses', 'is_validator', {
-          type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false,
+          type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false,
         }, { transaction: t }),
       ]);
     });

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -40,6 +40,8 @@ export interface AddressAttributes {
   created_at?: Date;
   updated_at?: Date;
   user_id?: number;
+  is_councillor?: boolean;
+  is_validator?: boolean;
 
   // associations
   Chain?: ChainAttributes;
@@ -94,6 +96,8 @@ export default (
     created_at:                 { type: dataTypes.DATE, allowNull: false },
     updated_at:                 { type: dataTypes.DATE, allowNull: false },
     user_id:                    { type: dataTypes.INTEGER, allowNull: true },
+    is_councillor:              { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    is_validator:               { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   }, {
     underscored: true,
     indexes: [

--- a/server/scripts/migrateCouncillorValidatorFlags.ts
+++ b/server/scripts/migrateCouncillorValidatorFlags.ts
@@ -1,0 +1,56 @@
+/**
+ * This script "migrates" chain entities (proposals) from the chain into the database, by first
+ * querying events, and then attempting to fetch corresponding entities
+ * from the chain, writing the results back into the database.
+ */
+
+import _ from 'underscore';
+import { SubstrateTypes, SubstrateEvents, chainSupportedBy } from '@commonwealth/chain-events';
+import { Mainnet } from '@edgeware/node-types';
+import { AccountId, Balance } from '@polkadot/types/interfaces';
+import { Vec } from '@polkadot/types';
+import { Codec } from '@polkadot/types/types';
+
+import UserFlagsHandler from '../eventHandlers/userFlags';
+
+import { factory, formatFilename } from '../../shared/logging';
+import { constructSubstrateUrl } from '../../shared/substrate';
+const log = factory.getLogger(formatFilename(__filename));
+
+export default async function (models, chain?: string): Promise<void> {
+  // 1. fetch the node and url of supported/selected chains
+  log.info('Fetching node info for chain entity migrations...');
+  if (chain && !chainSupportedBy(chain, SubstrateTypes.EventChains)) {
+    throw new Error('unsupported chain');
+  }
+  const chains = !chain ? SubstrateTypes.EventChains.concat() : [ chain ];
+
+  // query one node for each supported chain
+  const nodes = (await Promise.all(chains.map((c) => {
+    return models.ChainNode.findOne({ where: { chain: c } });
+  }))).filter((n) => !!n);
+  if (!nodes) {
+    throw new Error('no nodes found for chain entity migration');
+  }
+
+  // 2. for each node, fetch and migrate chain entities
+  for (const node of nodes) {
+    console.log('Fetching and migrating councillor/validator flags for', node.chain);
+    const flagsHandler = new UserFlagsHandler(models, node.chain);
+
+    const nodeUrl = constructSubstrateUrl(node.url);
+    const api = await SubstrateEvents.createApi(
+      nodeUrl,
+      node.chain.includes('edgeware') ? Mainnet : {},
+    );
+
+    log.info('Fetching councillor and validator lists...');
+    const validators = await api.derive.staking.validators();
+    const section = api.query.electionsPhragmen ? 'electionsPhragmen' : 'elections';
+    const councillors = await api.query[section].members<Vec<[ AccountId, Balance ] & Codec>>();
+    await flagsHandler.forceSync(
+      councillors.map(([ who ]) => who.toString()),
+      validators.validators.map((v) => v.toString()),
+    );
+  }
+}

--- a/server/scripts/migrateCouncillorValidatorFlags.ts
+++ b/server/scripts/migrateCouncillorValidatorFlags.ts
@@ -1,7 +1,5 @@
 /**
- * This script "migrates" chain entities (proposals) from the chain into the database, by first
- * querying events, and then attempting to fetch corresponding entities
- * from the chain, writing the results back into the database.
+ * This script "migrates" councillors and validators into the database.
  */
 
 import _ from 'underscore';
@@ -33,7 +31,7 @@ export default async function (models, chain?: string): Promise<void> {
     throw new Error('no nodes found for chain entity migration');
   }
 
-  // 2. for each node, fetch and migrate chain entities
+  // 2. for each node, fetch councillors and validators
   for (const node of nodes) {
     log.info(`Fetching and migrating councillor/validator flags for ${node.chain}.`);
     const flagsHandler = new UserFlagsHandler(models, node.chain);

--- a/server/scripts/migrateCouncillorValidatorFlags.ts
+++ b/server/scripts/migrateCouncillorValidatorFlags.ts
@@ -46,12 +46,12 @@ export default async function (models, chain?: string): Promise<void> {
 
     log.info('Fetching councillor and validator lists...');
     try {
-      const validators = await api.derive.staking.validators();
+      const validators = await api.derive.staking?.validators();
       const section = api.query.electionsPhragmen ? 'electionsPhragmen' : 'elections';
       const councillors = await api.query[section].members<Vec<[ AccountId, Balance ] & Codec>>();
       await flagsHandler.forceSync(
         councillors.map(([ who ]) => who.toString()),
-        validators.validators.map((v) => v.toString()),
+        validators ? validators.validators.map((v) => v.toString()) : [],
       );
     } catch (e) {
       log.error(`Failed to sync flags: ${e.message}.`);

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -10,6 +10,7 @@ import EventStorageHandler from '../eventHandlers/storage';
 import EventNotificationHandler from '../eventHandlers/notifications';
 import EntityArchivalHandler from '../eventHandlers/entityArchival';
 import IdentityHandler from '../eventHandlers/identity';
+import UserFlagsHandler from '../eventHandlers/userFlags';
 import { sequelize } from '../database';
 import { constructSubstrateUrl } from '../../shared/substrate';
 import { factory, formatFilename } from '../../shared/logging';
@@ -77,11 +78,12 @@ const setupChainEventListeners = async (
     const notificationHandler = new EventNotificationHandler(models, wss);
     const entityArchivalHandler = new EntityArchivalHandler(models, node.chain, wss);
     const identityHandler = new IdentityHandler(models, node.chain);
+    const userFlagsHandler = new UserFlagsHandler(models, node.chain);
     const handlers: IEventHandler[] = [ storageHandler, notificationHandler, entityArchivalHandler ];
     let subscriber: IEventSubscriber<any, any>;
     if (chainSupportedBy(node.chain, SubstrateTypes.EventChains)) {
-      // only handle identities on substrate chains
-      handlers.push(identityHandler);
+      // only handle identities and user flags on substrate chains
+      handlers.push(identityHandler, userFlagsHandler);
 
       const nodeUrl = constructSubstrateUrl(node.url);
       const api = await SubstrateEvents.createApi(

--- a/test/unit/events/userFlagsHandler.spec.ts
+++ b/test/unit/events/userFlagsHandler.spec.ts
@@ -1,0 +1,174 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable dot-notation */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import 'chai/register-should';
+import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+
+import { resetDatabase } from '../../../server-test';
+import models from '../../../server/database';
+import StorageHandler from '../../../server/eventHandlers/storage';
+import UserFlagsHandler from '../../../server/eventHandlers/userFlags';
+
+chai.use(chaiHttp);
+const { assert } = chai;
+
+const setupDbEvent = async (event: CWEvent) => {
+  const storageHandler = new StorageHandler(models, 'edgeware');
+  return storageHandler.handle(event);
+};
+
+// add several addresses with some flags set and some unset
+const addresses = [
+  '5DJA5ZCobDS3GVn8D2E5YRiotDqGkR2FN1bg6LtfNUmuadwX',
+  'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+  'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+];
+
+describe('Edgeware Archival Event Handler Tests', () => {
+  before('reset database', async () => {
+    await resetDatabase();
+  });
+
+  beforeEach('reset address flags', async () => {
+    const addressModel = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    }});
+    addressModel.is_councillor = true;
+    addressModel.is_validator = true;
+    await addressModel.save();
+  });
+
+  it('should sync councillors from NewTerm event', async () => {
+    const event: CWEvent<SubstrateTypes.IEventData> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.ElectionNewTerm,
+        round: 5,
+        allMembers: [
+          'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+          'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+        ],
+        newMembers: [ ],
+      }
+    };
+
+    const dbEvent = await setupDbEvent(event);
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+
+    // process event
+    await eventHandler.handle(event, dbEvent);
+
+    // verify outputs
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    }});
+    assert.equal(address1Model.is_councillor, false);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    }});
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    }});
+    assert.equal(address2Model.is_councillor, true);
+    assert.equal(address3Model.is_councillor, true);
+  });
+
+  it('should sync councillors from EmptyTerm event', async () => {
+    const event: CWEvent<SubstrateTypes.IEventData> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.ElectionEmptyTerm,
+        round: 5,
+        members: [
+          'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+          'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+        ],
+      }
+    };
+
+    const dbEvent = await setupDbEvent(event);
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+
+    // process event
+    await eventHandler.handle(event, dbEvent);
+
+    // verify outputs
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    }});
+    assert.equal(address1Model.is_councillor, false);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    }});
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    }});
+    assert.equal(address2Model.is_councillor, true);
+    assert.equal(address3Model.is_councillor, true);
+  });
+
+  it('should sync validators from StakingElection event', async () => {
+    const event: CWEvent<SubstrateTypes.IEventData> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.StakingElection,
+        era: 5,
+        validators: [
+          'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
+          'js4NB7G3bqEsSYq4ruj9Lq24QHcoKaqauw6YDPD7hMr1Roj',
+        ],
+      }
+    };
+
+    const dbEvent = await setupDbEvent(event);
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+
+    // process event
+    await eventHandler.handle(event, dbEvent);
+
+    // verify outputs
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    }});
+    assert.equal(address1Model.is_validator, false);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    }});
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    }});
+    assert.equal(address2Model.is_validator, true);
+    assert.equal(address3Model.is_validator, true);
+  });
+
+  it('should ignore unrelated event', async () => {
+    const event: CWEvent<SubstrateTypes.IEventData> = {
+      blockNumber: 10,
+      data: {
+        kind: SubstrateTypes.EventKind.Reward,
+        amount: '500',
+      }
+    };
+
+    const dbEvent = await setupDbEvent(event);
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+
+    // process event
+    await eventHandler.handle(event, dbEvent);
+
+    // verify outputs (unchanged)
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    }});
+    assert.equal(address1Model.is_validator, true);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    }});
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    }});
+    assert.equal(address2Model.is_validator, false);
+    assert.equal(address3Model.is_validator, false);
+  });
+});

--- a/test/unit/events/userFlagsHandler.spec.ts
+++ b/test/unit/events/userFlagsHandler.spec.ts
@@ -31,12 +31,26 @@ describe('Edgeware Archival Event Handler Tests', () => {
   });
 
   beforeEach('reset address flags', async () => {
-    const addressModel = await models['Address'].findOne({ where: {
+    const address1Model = await models['Address'].findOne({ where: {
       address: addresses[0],
-    }});
-    addressModel.is_councillor = true;
-    addressModel.is_validator = true;
-    await addressModel.save();
+    } });
+    address1Model.is_councillor = true;
+    address1Model.is_validator = true;
+    await address1Model.save();
+
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    } });
+    address2Model.is_councillor = false;
+    address2Model.is_validator = false;
+    await address2Model.save();
+
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    } });
+    address3Model.is_councillor = false;
+    address3Model.is_validator = false;
+    await address3Model.save();
   });
 
   it('should sync councillors from NewTerm event', async () => {
@@ -62,14 +76,14 @@ describe('Edgeware Archival Event Handler Tests', () => {
     // verify outputs
     const address1Model = await models['Address'].findOne({ where: {
       address: addresses[0],
-    }});
+    } });
     assert.equal(address1Model.is_councillor, false);
     const address2Model = await models['Address'].findOne({ where: {
       address: addresses[1],
-    }});
+    } });
     const address3Model = await models['Address'].findOne({ where: {
       address: addresses[2],
-    }});
+    } });
     assert.equal(address2Model.is_councillor, true);
     assert.equal(address3Model.is_councillor, true);
   });
@@ -96,14 +110,14 @@ describe('Edgeware Archival Event Handler Tests', () => {
     // verify outputs
     const address1Model = await models['Address'].findOne({ where: {
       address: addresses[0],
-    }});
+    } });
     assert.equal(address1Model.is_councillor, false);
     const address2Model = await models['Address'].findOne({ where: {
       address: addresses[1],
-    }});
+    } });
     const address3Model = await models['Address'].findOne({ where: {
       address: addresses[2],
-    }});
+    } });
     assert.equal(address2Model.is_councillor, true);
     assert.equal(address3Model.is_councillor, true);
   });
@@ -130,14 +144,14 @@ describe('Edgeware Archival Event Handler Tests', () => {
     // verify outputs
     const address1Model = await models['Address'].findOne({ where: {
       address: addresses[0],
-    }});
+    } });
     assert.equal(address1Model.is_validator, false);
     const address2Model = await models['Address'].findOne({ where: {
       address: addresses[1],
-    }});
+    } });
     const address3Model = await models['Address'].findOne({ where: {
       address: addresses[2],
-    }});
+    } });
     assert.equal(address2Model.is_validator, true);
     assert.equal(address3Model.is_validator, true);
   });
@@ -160,15 +174,62 @@ describe('Edgeware Archival Event Handler Tests', () => {
     // verify outputs (unchanged)
     const address1Model = await models['Address'].findOne({ where: {
       address: addresses[0],
-    }});
+    } });
     assert.equal(address1Model.is_validator, true);
     const address2Model = await models['Address'].findOne({ where: {
       address: addresses[1],
-    }});
+    } });
     const address3Model = await models['Address'].findOne({ where: {
       address: addresses[2],
-    }});
+    } });
     assert.equal(address2Model.is_validator, false);
     assert.equal(address3Model.is_validator, false);
+  });
+
+  it('should force sync with valid data', async () => {
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+    await eventHandler.forceSync(
+      [ addresses[1], addresses[2] ],
+      [ addresses[1], addresses[2] ]
+    );
+
+    // verify outputs
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    } });
+    assert.equal(address1Model.is_validator, false);
+    assert.equal(address1Model.is_councillor, false);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    } });
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    } });
+    assert.equal(address2Model.is_validator, true);
+    assert.equal(address3Model.is_validator, true);
+    assert.equal(address2Model.is_councillor, true);
+    assert.equal(address3Model.is_councillor, true);
+  });
+
+  it('should ignore force sync without data', async () => {
+    const eventHandler = new UserFlagsHandler(models, 'edgeware');
+    await eventHandler.forceSync();
+
+    // verify outputs (unchanged)
+    const address1Model = await models['Address'].findOne({ where: {
+      address: addresses[0],
+    } });
+    assert.equal(address1Model.is_validator, true);
+    assert.equal(address1Model.is_councillor, true);
+    const address2Model = await models['Address'].findOne({ where: {
+      address: addresses[1],
+    } });
+    const address3Model = await models['Address'].findOne({ where: {
+      address: addresses[2],
+    } });
+    assert.equal(address2Model.is_validator, false);
+    assert.equal(address3Model.is_validator, false);
+    assert.equal(address2Model.is_councillor, false);
+    assert.equal(address3Model.is_councillor, false);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.3.8":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.3.8.tgz#1c97c4fb5f58683d102636502bbc42060c3684c4"
-  integrity sha512-efhIpO2SV4bq1jIj/BoEyGe0YW3pSsAIdkKQAvE/wFAUCN9Clbd9rXITc2LWE9KY4wRyw6XLQNBHJmT24UO8ww==
+"@commonwealth/chain-events@0.3.12":
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.3.12.tgz#115bf23fd36b1599699f39285e6c7e226a7ff555"
+  integrity sha512-bLmzml8bBto9UWyAel/pTy9DDNRRUlar5/zJQTQYS5n5KAI7jr+osKP8LoqOEUp6zM6A1g9tH978PSjLczeYBg==
   dependencies:
     "@edgeware/node-types" "3.0.10"
     "@polkadot/api" "2.5.1"


### PR DESCRIPTION
## Description
Fixes #892. Adds a chain event listener for NewTerm/EmptyTerm and StakingElection events, which fire on changes to the councillor and validator sets. Writes the results to the db on `is_councillor` and `is_validator` fields of Address respectively (plus a db migration to add these fields). Propagates these changes down to client models, where it's used to display a `C` or `V` tag for users with these fields set.

Also adds a command `yarn migrate-flags` to immediately sync these flags for existing users.

Note that newly registered users will not be given these flags until the next event arrives, or until the migration is run. We may want to implement an additional feature to handle this.

## How has this been tested?
- Wrote a unit test for the event handler.
- Ran everything using a manual flag sync and verified the tags display in the UI.
- **Did not verify chain event handling against real chain conditions -- we may need additional QA to confirm that the specified chain events are handled as expected.**

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no