### PR TITLE
Bug: Sidebars disappear when on new & empty topic discussion page

### DIFF
--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -202,10 +202,17 @@ const DiscussionsPage: m.Component<{ topic?: string }, IDiscussionPageState> = {
       if (topic) {
         topicId = app.topics.getByName(topic, app.activeId())?.id;
         if (!topicId) {
-          return m(EmptyTopicPlaceholder, {
-            communityName: app.activeId(),
-            topicName: topic
-          });
+          return m(Sublayout, {
+            class: 'DiscussionsPage',
+            title: topic || 'Discussions',
+            showNewProposalButton: true,
+            rightSidebar: m(ListingSidebar, { entity: app.activeId() })
+          }, [
+            m(EmptyTopicPlaceholder, {
+              communityName: app.activeId(),
+              topicName: topic,
+            }),
+          ]);
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- The original ticket for this stated "Going to #updates-BuilDAO directly causes the sidebar and toolbars to disappear".
- There is no #updates-builDAO, just #builDAO, so traced back what happens when there isn't a valid tag and it just returned the `m(EmptyTopicPlaceholder...)`, without the Sublayout component wrapping.

- I added the `Sublayout` wrapper to `EmptyTopicPlaceholder` going directly to any new, unused topics discussion page directly now works.

#### FYI
- If the capitalization on the topic in the URL does **not** match the topic string itself, it will suggest to create a thread under the new, mis-capitalized topic.

Closes #958.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug 🐛 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no