### PR TITLE
Create empty profiles on important events.

### DIFF
--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -195,9 +195,9 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
             if (a.OffchainProfile.identity) {
               profile.initializeWithChain(
                 a.OffchainProfile.identity,
-                profileData.headline,
-                profileData.bio,
-                profileData.avatarUrl,
+                profileData?.headline,
+                profileData?.bio,
+                profileData?.avatarUrl,
                 a.OffchainProfile.judgements,
                 a.last_active,
                 a.is_councillor,
@@ -205,10 +205,10 @@ const ProfilePage: m.Component<{ address: string, setIdentity?: boolean }, IProf
               );
             } else {
               profile.initialize(
-                profileData.name,
-                profileData.headline,
-                profileData.bio,
-                profileData.avatarUrl,
+                profileData?.name,
+                profileData?.headline,
+                profileData?.bio,
+                profileData?.avatarUrl,
                 a.last_active,
                 a.is_councillor,
                 a.is_validator

--- a/server/eventHandlers/profileCreation.ts
+++ b/server/eventHandlers/profileCreation.ts
@@ -1,0 +1,73 @@
+/**
+ * Event handler that processes changes in validator and councillor sets
+ * and updates user-related flags in the database accordingly.
+ */
+import { IEventHandler, CWEvent, IChainEventKind, SubstrateTypes } from '@commonwealth/chain-events';
+import Sequelize from 'sequelize';
+const Op = Sequelize.Op;
+
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+// A mapping of supported Event Kinds to create empty profiles for, along with
+// the specific field to use in fetching the address.
+const SUPPORTED_KIND_FIELDS = {
+  [SubstrateTypes.EventKind.DemocracyProposed]: 'proposer',
+  [SubstrateTypes.EventKind.DemocracySeconded]: 'who',
+  [SubstrateTypes.EventKind.DemocracyVoted]: 'who',
+  [SubstrateTypes.EventKind.VoteDelegated]: [ 'who', 'target' ],
+  [SubstrateTypes.EventKind.TreasuryProposed]: 'proposer',
+  [SubstrateTypes.EventKind.ElectionCandidacySubmitted]: 'candidate',
+  [SubstrateTypes.EventKind.CollectiveProposed]: 'proposer',
+  [SubstrateTypes.EventKind.CollectiveVoted]: 'voter',
+  [SubstrateTypes.EventKind.SignalingNewProposal]: 'proposer',
+  [SubstrateTypes.EventKind.IdentitySet]: 'who',
+};
+
+export default class extends IEventHandler {
+  constructor(
+    private readonly _models,
+    private readonly _chain: string,
+  ) {
+    super();
+  }
+
+  public async handle(event: CWEvent, dbEvent) {
+    const fields = SUPPORTED_KIND_FIELDS[event.data.kind];
+    if (!fields) {
+      log.trace('Unsupported profile-related event.');
+      return dbEvent;
+    }
+
+    // fetch all addresses that we want to check for
+    const addresses = [];
+    if (fields instanceof Array) {
+      for (const field of fields) {
+        addresses.push(event.data[field]);
+      }
+    } else {
+      addresses.push(event.data[fields]);
+    }
+
+    // query for the addresses -- we skip them if they already exist
+    for (const address of addresses) {
+      let addressInstance = await this._models.Address.findOne({ where: {
+        address, chain: this._chain,
+      } });
+      if (addressInstance) {
+        log.trace('Address model already exists.');
+        return;
+      }
+
+      // create a new address and profile
+      addressInstance = await this._models.Address.createEmpty(this._chain, address);
+      const profileInstance = await this._models.OffchainProfile.create({
+        address_id: addressInstance.id,
+      });
+      // NOTE: if creating from identity, then identity info will be set on profile
+      //   in the "IdentityHandler", which must come after this handler in the order
+      //   of events
+    }
+    return dbEvent;
+  }
+}

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -56,6 +56,11 @@ export interface AddressInstance extends Sequelize.Instance<AddressAttributes>, 
 
 export interface AddressModel extends Sequelize.Model<AddressInstance, AddressAttributes> {
   // static methods
+  createEmpty?: (
+    chain: string,
+    address: string,
+  ) => Promise<AddressInstance>;
+
   createWithToken?: (
     user_id: number,
     chain: string,
@@ -106,6 +111,15 @@ export default (
       { fields: ['name'] }
     ]
   });
+
+  Address.createEmpty = (
+    chain: string,
+    address: string,
+  ): Promise<AddressInstance> => {
+    const verification_token = 'NO_USER';
+    const verification_token_expires = new Date(); // expired immediately
+    return Address.create({ chain, address, verification_token, verification_token_expires });
+  };
 
   Address.createWithToken = (
     user_id: number,

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -11,6 +11,7 @@ import EventNotificationHandler from '../eventHandlers/notifications';
 import EntityArchivalHandler from '../eventHandlers/entityArchival';
 import IdentityHandler from '../eventHandlers/identity';
 import UserFlagsHandler from '../eventHandlers/userFlags';
+import ProfileCreationHandler from '../eventHandlers/profileCreation';
 import { sequelize } from '../database';
 import { constructSubstrateUrl } from '../../shared/substrate';
 import { factory, formatFilename } from '../../shared/logging';
@@ -74,12 +75,35 @@ const setupChainEventListeners = async (
       SubstrateTypes.EventKind.TreasuryRewardMinting,
       SubstrateTypes.EventKind.TreasuryRewardMintingV2,
     ];
+
+    // writes events into the db as ChainEvents rows
     const storageHandler = new EventStorageHandler(models, node.chain, excludedEvents);
+
+    // emits notifications by writing into the db's Notifications table, and also optionally
+    // sending a notification to the client via websocket
     const notificationHandler = new EventNotificationHandler(models, wss);
+
+    // creates and updates ChainEntity rows corresponding with entity-related events
     const entityArchivalHandler = new EntityArchivalHandler(models, node.chain, wss);
+
+    // creates empty Address and OffchainProfile models for users who perform certain
+    // actions, like voting on proposals or registering an identity
+    const profileCreationHandler = new ProfileCreationHandler(models, node.chain);
+
+    // populates identity information in OffchainProfiles when received (Substrate only)
     const identityHandler = new IdentityHandler(models, node.chain);
+
+    // populates is_validator and is_councillor flags on Addresses when validator and
+    // councillor sets are updated (Substrate only)
     const userFlagsHandler = new UserFlagsHandler(models, node.chain);
-    const handlers: IEventHandler[] = [ storageHandler, notificationHandler, entityArchivalHandler ];
+
+    // the set of handlers, run sequentially on all incoming chain events
+    const handlers: IEventHandler[] = [
+      storageHandler,
+      notificationHandler,
+      entityArchivalHandler,
+      profileCreationHandler,
+    ];
     let subscriber: IEventSubscriber<any, any>;
     if (chainSupportedBy(node.chain, SubstrateTypes.EventChains)) {
       // only handle identities and user flags on substrate chains


### PR DESCRIPTION
## Description
Fixes #657. Creates empty profile pages for addresses involved in certain important events.

## How has this been tested?
Built and ran it on a test chain. Created a user identity via polkadot-apps, and verified the profile was created and accessible on CW.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no