### PR TITLE
Prevent Quill from saving to LocalStorage if disabled

### DIFF
--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -775,10 +775,12 @@ const instantiateEditor = (
 
   setInterval(() => {
     if (state.unsavedChanges.length() > 0) {
-      // Save the entire updated text to localStorage
-      const data = JSON.stringify(quill.getContents());
-      localStorage.setItem(`${app.activeId()}-${editorNamespace}-storedText`, data);
-      state.unsavedChanges = new Delta();
+      if (quill.isEnabled()) {
+        // Save the entire updated text to localStorage
+        const data = JSON.stringify(quill.getContents());
+        localStorage.setItem(`${app.activeId()}-${editorNamespace}-storedText`, data);
+        state.unsavedChanges = new Delta();
+      }
     }
   }, 2500);
 


### PR DESCRIPTION
Closes #986. 

## Description

Previously, users visiting the NewProposalForm were being inappropriately prompted to restore "unsaved changes" from localStorage, even when their recent edits or threads had already been submitted/saved to the backend. This was being caused by an intervalic save to localStorage stemming from within the quillEditor code, that caused already submitted/saved (and thus, already cleared from localStorage) threads to be _again re-saved_ in localStorage. A simple check that quill is enabled ensures that, once an editor is closed, and a thread or edit submitted, its contents will not be re-propagated to localStorage, preventing the false prompting.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no