### PR TITLE
Update email copy to show address of unnamed profiles

### DIFF
--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -46,7 +46,7 @@ import { InterfaceTypes, CallFunction } from '@polkadot/types/types';
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
 import { u128, TypeRegistry } from '@polkadot/types';
 import { constructSubstrateUrl } from 'substrate';
-import { formatAddressShort } from '../../../../../../shared/utils';
+import { formatAddressShort } from '../../../../../shared/utils';
 import { SubstrateAccount } from './account';
 
 export interface ISubstrateTXData extends ITXData {

--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -27,7 +27,7 @@ import { Vec, Compact } from '@polkadot/types/codec';
 import { ApiOptions, Signer, SubmittableExtrinsic } from '@polkadot/api/types';
 
 import { formatCoin } from 'adapters/currency';
-import { formatAddressShort, BlocktimeHelper } from 'helpers';
+import { BlocktimeHelper } from 'helpers';
 import {
   NodeInfo,
   ITXModalData,
@@ -46,6 +46,7 @@ import { InterfaceTypes, CallFunction } from '@polkadot/types/types';
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
 import { u128, TypeRegistry } from '@polkadot/types';
 import { constructSubstrateUrl } from 'substrate';
+import { formatAddressShort } from '../../../../../../shared/utils';
 import { SubstrateAccount } from './account';
 
 export interface ISubstrateTXData extends ITXData {

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -5,7 +5,6 @@ import { BalanceOf, Permill, BlockNumber } from '@polkadot/types/interfaces';
 import { DeriveBalancesAccount } from '@polkadot/api-derive/types';
 import { stringToU8a, u8aToHex } from '@polkadot/util';
 import { IApp } from 'state';
-import { formatAddressShort } from 'helpers';
 import {
   ISubstrateTreasuryProposal,
   SubstrateCoin
@@ -14,6 +13,7 @@ import { ProposalModule } from 'models';
 import { SubstrateTypes } from '@commonwealth/chain-events';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
+import { formatAddressShort } from '../../../../../shared/utils';
 import { SubstrateTreasuryProposal } from './treasury_proposal';
 
 class SubstrateTreasury extends ProposalModule<

--- a/client/scripts/controllers/chain/substrate/treasury_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/treasury_proposal.ts
@@ -2,7 +2,6 @@ import { BehaviorSubject } from 'rxjs';
 import { ApiRx } from '@polkadot/api';
 
 import { formatCoin } from 'adapters/currency';
-import { formatAddressShort } from 'helpers';
 import { ISubstrateTreasuryProposal, SubstrateCoin } from 'adapters/chain/substrate/types';
 import {
   Proposal, ProposalStatus, ProposalEndTime, ITXModalData, BinaryVote,
@@ -12,6 +11,7 @@ import { SubstrateTypes } from '@commonwealth/chain-events';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import SubstrateTreasury from './treasury';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 const backportEventToAdapter = (
   ChainInfo: SubstrateChain,

--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -206,15 +206,6 @@ export function formatDuration(duration: moment.Duration, includeSeconds = true)
   ].join('');
 }
 
-export function formatAddressShort(address: string, chain: string) {
-  if (!address) return;
-  if (chain === 'near') {
-    return `@${address}`;
-  } else {
-    return `${address.slice(0, 5)}…`;
-  }
-}
-
 export function formatProposalHashShort(hash: string) {
   if (!hash) return;
   return `${hash.slice(0, 8)}…`;

--- a/client/scripts/models/Profile.ts
+++ b/client/scripts/models/Profile.ts
@@ -1,7 +1,7 @@
 import m from 'mithril';
 import jdenticon from 'jdenticon';
 
-import { formatAddressShort } from 'helpers';
+import { formatAddressShort } from '../../../shared/utils';
 
 class Profile {
   private _name: string;

--- a/client/scripts/views/components/widgets/substrate_identity.ts
+++ b/client/scripts/views/components/widgets/substrate_identity.ts
@@ -3,7 +3,8 @@ import 'components/widgets/user.scss';
 
 import m from 'mithril';
 import _ from 'lodash';
-import { formatAddressShort, link } from 'helpers';
+import { link } from 'helpers';
+import { formatAddressShort } from 'shared/utils';
 
 import app from 'state';
 import { Account, Profile } from 'models';

--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -3,11 +3,12 @@ import 'components/widgets/user.scss';
 
 import m from 'mithril';
 import _ from 'lodash';
-import { formatAddressShort, link } from 'helpers';
+import { link } from 'helpers';
 import { Tooltip, Tag, Icon, Icons, Popover } from 'construct-ui';
 
 import app from 'state';
 import { Account, AddressInfo, ChainInfo, ChainBase, Profile } from 'models';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 const User: m.Component<{
   user: Account<any> | AddressInfo | Profile;

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -10,7 +10,7 @@ import { SignerPayloadRaw } from '@polkadot/types/types/extrinsic';
 import { Button, Callout, Input, TextArea, Icon, Icons, Spinner, Checkbox } from 'construct-ui';
 
 import { initAppState } from 'app';
-import { formatAddressShort, isSameAccount, link } from 'helpers';
+import { isSameAccount, link } from 'helpers';
 import { AddressInfo, Account, ChainBase, ChainNetwork } from 'models';
 import app, { ApiStatus } from 'state';
 import { keyToMsgSend, VALIDATION_CHAIN_DATA } from 'adapters/chain/cosmos/keys';
@@ -27,6 +27,7 @@ import { ChainIcon } from 'views/components/chain_icon';
 import CodeBlock from 'views/components/widgets/code_block';
 import User, { UserBlock } from 'views/components/widgets/user';
 import AvatarUpload from 'views/components/avatar_upload';
+import { formatAddressShort } from '../../../../shared/utils';
 import AddressSwapper from '../components/addresses/address_swapper';
 
 enum LinkNewAddressSteps {

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -7,11 +7,12 @@ import { Tag, Button, Icon, Icons } from 'construct-ui';
 import app from 'state';
 import { Account, RoleInfo, RolePermission } from 'models';
 import { UserBlock } from 'views/components/widgets/user';
-import { isSameAccount, formatAsTitleCase, formatAddressShort } from 'helpers';
+import { isSameAccount, formatAsTitleCase } from 'helpers';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { setActiveAccount } from 'controllers/app/login';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import LoginWithWalletDropdown from 'views/components/login_with_wallet_dropdown';
+import { formatAddressShort } from '../../../../shared/utils';
 
 const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: boolean }> = {
   view: (vnode) => {

--- a/client/scripts/views/modals/view_voters_modal.ts
+++ b/client/scripts/views/modals/view_voters_modal.ts
@@ -6,7 +6,7 @@ import { SubstrateAccount } from 'controllers/chain/substrate/account';
 import { CompactModalExitButton } from 'views/modal';
 import app from 'state';
 import { PhragmenElectionVote } from 'controllers/chain/substrate/phragmen_election';
-import { formatAddressShort } from 'helpers';
+import { formatAddressShort } from '../../../../shared/utils';
 import User from '../components/widgets/user';
 
 interface IVoterRowAttrs {

--- a/client/scripts/views/pages/profile/profile_banner.ts
+++ b/client/scripts/views/pages/profile/profile_banner.ts
@@ -5,8 +5,8 @@ import { Button } from 'construct-ui';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { setActiveAccount } from 'controllers/app/login';
-import { formatAddressShort } from 'helpers';
 import { Account, AddressInfo } from 'models';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 const ProfileBanner: m.Component<{ account: Account<any>, addressInfo: AddressInfo }, { loading: boolean }> = {
   view: (vnode) => {

--- a/client/scripts/views/pages/profile/profile_header.ts
+++ b/client/scripts/views/pages/profile/profile_header.ts
@@ -8,7 +8,6 @@ import { Unsubscribable } from 'rxjs';
 import { initChain } from 'app';
 import app from 'state';
 
-import { formatAddressShort, isSameAccount } from 'helpers';
 import SubstrateIdentity from 'controllers/chain/substrate/identity';
 import User from 'views/components/widgets/user';
 import EditProfileModal from 'views/modals/edit_profile_modal';
@@ -17,6 +16,7 @@ import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { setActiveAccount } from 'controllers/app/login';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import PageLoading from 'views/pages/loading';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/client/scripts/views/pages/validators/cosmos.ts
+++ b/client/scripts/views/pages/validators/cosmos.ts
@@ -2,7 +2,7 @@ import m from 'mithril';
 
 import app from 'state';
 import { formatCoin } from 'adapters/currency';
-import { formatAddressShort, pluralize } from 'helpers';
+import { pluralize } from 'helpers';
 import { FormGroup, FormLabel, Input, Button } from 'construct-ui';
 
 import { Account } from 'models';
@@ -12,6 +12,7 @@ import { ICosmosValidator, CosmosAccount, CosmosValidatorState } from 'controlle
 import { createTXModal } from 'views/modals/tx_signing_modal';
 import User from 'views/components/widgets/user';
 import Tabs from 'views/components/widgets/tabs';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 import { IValidatorAttrs } from '.';
 

--- a/client/scripts/views/pages/validators/index.ts
+++ b/client/scripts/views/pages/validators/index.ts
@@ -5,7 +5,6 @@ import _ from 'lodash';
 import mixpanel from 'mixpanel-browser';
 
 import app, { ApiStatus } from 'state';
-import { formatAddressShort } from 'helpers';
 import { Coin, formatCoin } from 'adapters/currency';
 import { makeDynamicComponent } from 'models/mithril';
 import { IValidators, SubstrateAccount } from 'controllers/chain/substrate/account';
@@ -21,6 +20,7 @@ import Sublayout from 'views/sublayout';
 
 import * as CosmosValidationViews from './cosmos';
 import { SubstratePreHeader, SubstratePresentationComponent } from './substrate';
+import { formatAddressShort } from '../../../../../shared/utils';
 
 export interface IValidatorAttrs {
   stash: string;

--- a/client/scripts/views/pages/validators/substrate/claim_payout.ts
+++ b/client/scripts/views/pages/validators/substrate/claim_payout.ts
@@ -1,11 +1,11 @@
 import m from 'mithril';
 import app from 'state';
-import { formatAddressShort } from 'helpers';
-import { makeDynamicComponent } from 'models/mithril';
 import User from 'views/components/widgets/user';
+import { makeDynamicComponent } from 'models/mithril';
 import { StakingLedger } from '@polkadot/types/interfaces';
 import { SubstrateAccount } from 'controllers/chain/substrate/account';
 import Substrate from 'controllers/chain/substrate/main';
+import { formatAddressShort } from '../../../../../../shared/utils';
 import ActionForm from './action_form';
 
 

--- a/client/scripts/views/pages/validators/substrate/manage_staking.ts
+++ b/client/scripts/views/pages/validators/substrate/manage_staking.ts
@@ -1,12 +1,12 @@
 import m from 'mithril';
 import app from 'state';
-import { formatAddressShort } from 'helpers';
 import Substrate from 'controllers/chain/substrate/main';
 import { makeDynamicComponent } from 'models/mithril';
 import User from 'views/components/widgets/user';
 import { IValidators, SubstrateAccount } from 'controllers/chain/substrate/account';
 import { ICosmosValidator } from 'controllers/chain/cosmos/account';
 import { StakingLedger } from '@polkadot/types/interfaces';
+import { formatAddressShort } from '../../../../../../shared/utils';
 import StashAccountForm from './stash_form';
 import ControllerAccountForm from './controller_form';
 import NewStashForm from './new_stash_form';

--- a/server/webhookNotifier.ts
+++ b/server/webhookNotifier.ts
@@ -170,7 +170,6 @@ const send = async (models, content: WebhookContent) => {
           await request.post(url).send(webhookData);
         } else {
           console.log('Suppressed webhook notification to', url);
-          console.log(webhookData);
         }
       } catch (err) {
         console.error(err);

--- a/shared/notificationFormatter.ts
+++ b/shared/notificationFormatter.ts
@@ -73,7 +73,6 @@ export const getForumNotificationCopy = async (models, notification_data: IPostN
   };
   const proposalUrlArgs = comment_id ? [root_type, pseudoProposal, { id: comment_id }] : [root_type, pseudoProposal];
   const proposalPath = (getProposalUrl as any)(...proposalUrlArgs);
-
   return [emailSubjectLine, authorName, actionCopy, objectCopy, communityCopy, excerpt, proposalPath, authorPath];
 };
 

--- a/shared/notificationFormatter.ts
+++ b/shared/notificationFormatter.ts
@@ -1,5 +1,5 @@
 import { IPostNotificationData, IChainEventNotificationData, NotificationCategories } from './types';
-import { getProposalUrl, renderQuillDeltaToText, smartTrim } from './utils';
+import { getProposalUrl, renderQuillDeltaToText, smartTrim, formatAddressShort } from './utils';
 
 import { SERVER_URL } from '../server/config';
 
@@ -31,10 +31,11 @@ export const getForumNotificationCopy = async (models, notification_data: IPostN
     }]
   });
   let authorName;
+  const author_addr_short = formatAddressShort(author_address, author_chain);
   try {
-    authorName = authorProfile.Address.name || JSON.parse(authorProfile.data).name || 'Someone';
+    authorName = authorProfile.Address.name || JSON.parse(authorProfile.data).name || author_addr_short;
   } catch (e) {
-    authorName = 'Someone';
+    authorName = author_addr_short;
   }
 
   // author profile link

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -111,3 +111,12 @@ export const renderQuillDeltaToText = (delta, paragraphSeparator = '\n\n') => {
     }).filter((child) => !!child).join(' ').replace(/  +/g, ' '); // remove multiple spaces
   }).filter((parent) => !!parent).join(paragraphSeparator);
 };
+
+export function formatAddressShort(address: string, chain: string) {
+  if (!address) return;
+  if (chain === 'near') {
+    return `@${address}`;
+  } else {
+    return `${address.slice(0, 5)}…`;
+  }
+}


### PR DESCRIPTION
Closes #982.

## Description

Previously, if a username was unavailable for a given profile, that profile was displayed as "Someone" in the email notification copy (e.g. "Someone has left a comment on..."). This branch uses formatAddressShort() fn to instead display the truncated address of the user.

## How has this been tested?

I've logged the email message copy, and also sent test emails confirming proper copy.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no