### PR TITLE
Search for offchain threads and comments

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -479,6 +479,7 @@ $(() => {
 
     '/:scope':                   importRoute('views/pages/discussions', { scoped: true, deferChain: true }),
     '/:scope/discussions/:topic': importRoute('views/pages/discussions', { scoped: true, deferChain: true }),
+    '/:scope/search':            importRoute('views/pages/search', { scoped: true, deferChain: true }),
     '/:scope/chat':              importRoute('views/pages/chat', { scoped: true }),
     '/:scope/referenda':         importRoute('views/pages/referenda', { scoped: true }),
     '/:scope/proposals':         importRoute('views/pages/proposals', { scoped: true }),

--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -37,6 +37,7 @@ export const modelFromServer = (comment) => {
     comment.chain,
     comment?.Address?.address || comment.author,
     decodeURIComponent(comment.text),
+    comment.plaintext,
     comment.version_history,
     attachments,
     proposal,

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -32,6 +32,7 @@ export const modelFromServer = (thread) => {
     thread.chain,
     thread.read_only,
     decodeURIComponent(thread.body),
+    thread.plaintext,
     thread.url,
     thread.Address.chain,
     thread.pinned,

--- a/client/scripts/models/OffchainComment.ts
+++ b/client/scripts/models/OffchainComment.ts
@@ -7,6 +7,7 @@ class OffchainComment<T extends IUniqueId> {
   public readonly chain: string;
   public readonly author: string;
   public readonly text: string;
+  public readonly plaintext: string;
   public readonly attachments: OffchainAttachment[];
   public readonly proposal: T; // this may not be populated if the comment was loaded before the proposal!
   public readonly id: number;
@@ -22,6 +23,7 @@ class OffchainComment<T extends IUniqueId> {
     chain,
     author,
     text,
+    plaintext,
     versionHistory,
     attachments,
     proposal,
@@ -36,6 +38,7 @@ class OffchainComment<T extends IUniqueId> {
     this.chain = chain;
     this.author = author;
     this.text = text;
+    this.plaintext = plaintext;
     this.versionHistory = versionHistory;
     this.attachments = attachments;
     this.proposal = proposal;

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -9,6 +9,7 @@ class OffchainThread implements IUniqueId {
   public readonly authorChain: string;
   public readonly title: string;
   public readonly body: string;
+  public readonly plaintext: string;
   public readonly pinned: boolean;
   public readonly kind: OffchainThreadKind;
   public readonly attachments: OffchainAttachment[];
@@ -43,6 +44,7 @@ class OffchainThread implements IUniqueId {
     chain: string,
     readOnly: boolean,
     body?: string,
+    plaintext?: string,
     url?: string,
     authorChain?: string,
     pinned?: boolean,
@@ -50,6 +52,7 @@ class OffchainThread implements IUniqueId {
     this.author = author;
     this.title = title;
     this.body = body;
+    this.plaintext = plaintext;
     this.attachments = attachments;
     this.id = id;
     this.identifier = `${id}`;

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -93,6 +93,7 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
 
     const onDiscussionsPage = (p) => p === `/${app.activeId()}` || p === `/${app.activeId()}/`
       || p.startsWith(`/${app.activeId()}/proposal/discussion/`);
+    const onSearchPage = (p) => p.startsWith(`/${app.activeId()}/search`);
     const onChatPage = (p) => p === `/${app.activeId()}/chat`;
 
     const featuredTopics = {};
@@ -182,6 +183,16 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
             m.route.set(`/${app.activeId()}`);
           },
           contentLeft: m(Icon, { name: Icons.MESSAGE_CIRCLE }),
+        }),
+        m(ListItem, {
+          active: onSearchPage(m.route.get())
+            && (app.chain ? app.chain.serverLoaded : app.community ? app.community.serverLoaded : true),
+          label: 'Search',
+          onclick: (e) => {
+            e.preventDefault();
+            m.route.set(`/${app.activeId()}/search`);
+          },
+          contentLeft: m(Icon, { name: Icons.SEARCH }),
         }),
         // m(ListItem, {
         //   active: onChatPage(m.route.get()),

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -184,6 +184,16 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
           },
           contentLeft: m(Icon, { name: Icons.MESSAGE_CIRCLE }),
         }),
+        m(ListItem, {
+          active: onSearchPage(m.route.get())
+            && (app.chain ? app.chain.serverLoaded : app.community ? app.community.serverLoaded : true),
+          label: 'Search',
+          onclick: (e) => {
+            e.preventDefault();
+            m.route.set(`/${app.activeId()}/search`);
+          },
+          contentLeft: m(Icon, { name: Icons.SEARCH }),
+        }),
         // m(ListItem, {
         //   active: onChatPage(m.route.get()),
         //   label: 'Chat',
@@ -216,18 +226,6 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
         }
       }, featuredTopicListItems),
       m(List, { class: 'more-topics-list' }, otherTopicListItems),
-      m(List, { class: 'search-list' }, [
-        m(ListItem, {
-          active: onSearchPage(m.route.get())
-            && (app.chain ? app.chain.serverLoaded : app.community ? app.community.serverLoaded : true),
-          label: 'Search',
-          onclick: (e) => {
-            e.preventDefault();
-            m.route.set(`/${app.activeId()}/search`);
-          },
-          contentLeft: m(Icon, { name: Icons.SEARCH }),
-        }),
-      ]),
     ]);
   }
 };

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -184,16 +184,6 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
           },
           contentLeft: m(Icon, { name: Icons.MESSAGE_CIRCLE }),
         }),
-        m(ListItem, {
-          active: onSearchPage(m.route.get())
-            && (app.chain ? app.chain.serverLoaded : app.community ? app.community.serverLoaded : true),
-          label: 'Search',
-          onclick: (e) => {
-            e.preventDefault();
-            m.route.set(`/${app.activeId()}/search`);
-          },
-          contentLeft: m(Icon, { name: Icons.SEARCH }),
-        }),
         // m(ListItem, {
         //   active: onChatPage(m.route.get()),
         //   label: 'Chat',
@@ -226,6 +216,18 @@ const OffchainNavigationModule: m.Component<{ sidebarTopic: number }, { dragulaI
         }
       }, featuredTopicListItems),
       m(List, { class: 'more-topics-list' }, otherTopicListItems),
+      m(List, { class: 'search-list' }, [
+        m(ListItem, {
+          active: onSearchPage(m.route.get())
+            && (app.chain ? app.chain.serverLoaded : app.community ? app.community.serverLoaded : true),
+          label: 'Search',
+          onclick: (e) => {
+            e.preventDefault();
+            m.route.set(`/${app.activeId()}/search`);
+          },
+          contentLeft: m(Icon, { name: Icons.SEARCH }),
+        }),
+      ]),
     ]);
   }
 };

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -692,7 +692,10 @@ const NotificationsPage: m.Component<{}, {
     if (subscriptions.length < 1) return m(PageLoading);
     return m(Sublayout, {
       class: 'NotificationsPage',
-      title: 'Notification Settings',
+      title: [
+        'Notification Settings ',
+        m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
+      ],
     }, [
       m('.forum-container', [
         m(EmailIntervalConfiguration),

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -2,7 +2,7 @@ import 'pages/notificationsList.scss';
 
 import m from 'mithril';
 import Infinite from 'mithril-infinite';
-import { Button, ButtonGroup, Popover } from 'construct-ui';
+import { Button, ButtonGroup, Popover, Tag } from 'construct-ui';
 
 import app from 'state';
 import { pluralize } from 'helpers';
@@ -21,7 +21,10 @@ const NotificationsPage: m.Component<{}> = {
 
     return m(Sublayout, {
       class: 'NotificationsListPage',
-      title: 'Notifications',
+      title: [
+        'Notifications ',
+        m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
+      ],
     }, [
       m('.forum-container', [
         m(ButtonGroup, {

--- a/client/scripts/views/pages/profile/index.ts
+++ b/client/scripts/views/pages/profile/index.ts
@@ -41,6 +41,7 @@ const commentModelFromServer = (comment) => {
         comment.community,
         comment.chain,
         null,
+        null,
         null
       );
     } else {
@@ -58,6 +59,7 @@ const commentModelFromServer = (comment) => {
     comment.chain,
     comment?.Address?.address || comment.author,
     decodeURIComponent(comment.text),
+    comment.plaintext,
     comment.version_history,
     attachments,
     proposal,
@@ -88,6 +90,7 @@ const threadModelFromServer = (thread) => {
     thread.chain,
     thread.read_only,
     decodeURIComponent(thread.body),
+    thread.plaintext,
     thread.url,
     thread.Address.chain,
     thread.pinned,

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -68,7 +68,7 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
         class: 'search-page-input',
         defaultValue: m.route.param('q'),
         oncreate: (vvnode) => {
-          const $input = $(vvnode.dom).find('input');
+          const $input = $(vvnode.dom).find('input').focus();
           // wait for defaultValue to be applied, then try to load the search request for ?q=
           setTimeout(() => {
             if ($input.val() !== '' && $input.val().toString().length >= 3) {

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -1,0 +1,76 @@
+import 'pages/search.scss';
+
+import $ from 'jquery';
+import m from 'mithril';
+import _ from 'lodash';
+import moment from 'moment-twitter';
+import { Input } from 'construct-ui';
+
+import { link, pluralize } from 'helpers';
+import app from 'state';
+
+import { modelFromServer as threadModelFromServer } from 'controllers/server/threads';
+import { modelFromServer as commentModelFromServer } from 'controllers/server/comments';
+import Sublayout from 'views/sublayout';
+
+const SEARCH_PAGE_SIZE = 20;
+const SEARCH_DELAY = 750;
+
+const SearchPage : m.Component<{}, { results }> = {
+  view: (vnode) => {
+    const onSearchInput = _.debounce(async (e) => {
+      const searchTerm = e.target.value;
+      if (!searchTerm || !searchTerm.toString().trim() || !searchTerm.match(/[A-Za-z]+/)) {
+        return;
+      }
+
+      const chainId = app.activeChainId();
+      const communityId = app.activeCommunityId();
+      const params = {
+        chain: chainId,
+        community: communityId,
+        cutoff_date: null, // cutoffDate.toISOString(),
+        search: searchTerm,
+        page_size: SEARCH_PAGE_SIZE,
+      };
+      const response = await $.get(`${app.serverUrl()}/search`, params);
+      if (response.status !== 'Success') return;
+      vnode.state.results = response.response;
+      m.redraw();
+    }, SEARCH_DELAY);
+
+    return m(Sublayout, {
+      class: 'ChatPage',
+      title: 'Search',
+      showNewProposalButton: true,
+    }, [
+      m(Input, {
+        placeholder: 'Type to search...',
+        autofocus: true,
+        fluid: true,
+        oninput: onSearchInput,
+      }),
+      vnode.state.results && m('.SearchResults', [
+        m('.search-results-caption', [
+          pluralize(vnode.state.results.length, 'result')
+        ]),
+        m('.search-results-list', [
+          vnode.state.results.map((result) => {
+            return result.title
+              ? m('.search-results-item', [
+                m('strong', 'Thread: '),
+                m('.search-results-thread-title', result.title),
+                m('.search-results-thread-body', result.body),
+              ])
+              : m('.search-results-item', [
+                m('strong', 'Comment: '),
+                m('.search-results-comment', result.text),
+              ]);
+          })
+        ]),
+      ]),
+    ]);
+  }
+};
+
+export default SearchPage;

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -97,19 +97,22 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
           m.route.set(`/${app.activeId()}/search?q=${encodeURIComponent(searchTerm.toString().trim())}`);
         }
       }),
-      vnode.state.searchLoading ? m('.SearchLoading', [
+      vnode.state.searchLoading ? m('.search-loading', [
         m(Spinner, {
           active: true,
           fill: true,
           size: 'xl',
         }),
-      ]) : vnode.state.errorText ? m('.SearchError', [
+      ]) : vnode.state.errorText ? m('.search-error', [
         m('.error-text', vnode.state.errorText),
-      ]) : vnode.state.results && m('.SearchResults', [
+      ]) : !vnode.state.results ? m('.search-loading', [
+        // TODO: prompt to start searching
+      ]) : m('.search-results', [
         m('.search-results-caption', [
           pluralize(vnode.state.results.length, 'result'),
-          ' for ',
+          ' for \'',
           vnode.state.searchTerm,
+          '\'',
           m('a.search-results-clear', {
             href: '#',
             onclick: (e) => {

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -49,19 +49,21 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
   view: (vnode) => {
     return m(Sublayout, {
       class: 'SearchPage',
-      title: [ 'Search ', m(Tag, { size: 'xs', label: 'Beta' }) ],
+      title: [
+        'Search ',
+        m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
+      ],
       showNewProposalButton: true,
     }, [
       m(Input, {
         placeholder: 'Type to search...',
         autofocus: true,
         fluid: true,
-        style: 'margin-top: 15px;',
         class: 'search-page-input',
         defaultValue: m.route.param('q'),
-        oncreate: (vnode) => {
-          const $input = $(vnode.dom).find('input');
-          if ($input.val() !== '') {
+        oncreate: (vvnode) => {
+          const $input = $(vvnode.dom).find('input');
+          if ($input.val() !== '' && $input.val().toString().length >= 3) {
             search($input.val(), vnode);
           }
         },
@@ -73,6 +75,9 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
             return;
           }
           vnode.state.errorText = null;
+          if (searchTerm.length < 3) {
+            return;
+          }
           vnode.state.searchLoading = true;
           search(e.target.value, vnode);
           m.route.set(`/${app.activeId()}/search?q=${encodeURIComponent(searchTerm.toString().trim())}`);
@@ -92,7 +97,6 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
           ' for ',
           vnode.state.searchTerm,
           m('a.search-results-clear', {
-            style: 'margin-left: 10px;',
             href: '#',
             onclick: (e) => {
               e.preventDefault();
@@ -123,7 +127,10 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
               }
             }, [
               result.type === 'thread' ? [
-                m('.search-results-thread-title', decodeURIComponent(result.title)),
+                m('.search-results-thread-title', [
+                  decodeURIComponent(result.title),
+                  m('span.created-at', moment(result.created_at).fromNow()),
+                ]),
                 m('.search-results-thread-body', [
                   (() => {
                     try {
@@ -135,17 +142,24 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
                     }
                   })(),
                 ])
-              ] : m('.search-results-comment', [
-                (() => {
-                  try {
-                    const doc = JSON.parse(decodeURIComponent(result.body));
-                    return m(QuillFormattedText, { doc, hideFormatting: true, collapse: true });
-                  } catch (e) {
-                    const doc = decodeURIComponent(result.body);
-                    return m(MarkdownFormattedText, { doc, hideFormatting: true, collapse: true });
-                  }
-                })(),
-              ])
+              ] : [
+                m('.search-results-thread-title', [
+                  'Comment on ',
+                  decodeURIComponent(result.title),
+                  m('span.created-at', moment(result.created_at).fromNow()),
+                ]),
+                m('.search-results-comment', [
+                  (() => {
+                    try {
+                      const doc = JSON.parse(decodeURIComponent(result.body));
+                      return m(QuillFormattedText, { doc, hideFormatting: true, collapse: true });
+                    } catch (e) {
+                      const doc = decodeURIComponent(result.body);
+                      return m(MarkdownFormattedText, { doc, hideFormatting: true, collapse: true });
+                    }
+                  })(),
+                ]),
+              ]
             ]);
           })
         ]),

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -151,7 +151,7 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
                 ]),
                 m('.search-results-thread-subtitle', [
                   m('span.created-at', moment(result.created_at).fromNow()),
-                  m(User, { user: new AddressInfo(result.address_id, result.address, result.chain, null) }),
+                  m(User, { user: new AddressInfo(result.address_id, result.address, result.address_chain, null) }),
                 ]),
                 m('.search-results-thread-body', [
                   (() => {
@@ -171,7 +171,7 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
                 ]),
                 m('.search-results-thread-subtitle', [
                   m('span.created-at', moment(result.created_at).fromNow()),
-                  m(User, { user: new AddressInfo(result.address_id, result.address, result.chain, null) }),
+                  m(User, { user: new AddressInfo(result.address_id, result.address, result.address_chain, null) }),
                 ]),
                 m('.search-results-comment', [
                   (() => {

--- a/client/scripts/views/pages/search.ts
+++ b/client/scripts/views/pages/search.ts
@@ -8,11 +8,13 @@ import { Input, Spinner, Tag } from 'construct-ui';
 
 import { link, pluralize } from 'helpers';
 import app from 'state';
+import { AddressInfo } from 'models';
 
 import { modelFromServer as threadModelFromServer } from 'controllers/server/threads';
 import { modelFromServer as commentModelFromServer } from 'controllers/server/comments';
 import QuillFormattedText from 'views/components/quill_formatted_text';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
+import User from 'views/components/widgets/user';
 import Sublayout from 'views/sublayout';
 
 const SEARCH_PAGE_SIZE = 20;
@@ -146,7 +148,10 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
               result.type === 'thread' ? [
                 m('.search-results-thread-title', [
                   decodeURIComponent(result.title),
+                ]),
+                m('.search-results-thread-subtitle', [
                   m('span.created-at', moment(result.created_at).fromNow()),
+                  m(User, { user: new AddressInfo(result.address_id, result.address, result.chain, null) }),
                 ]),
                 m('.search-results-thread-body', [
                   (() => {
@@ -163,7 +168,10 @@ const SearchPage : m.Component<{}, { results, searchLoading, searchTerm, errorTe
                 m('.search-results-thread-title', [
                   'Comment on ',
                   decodeURIComponent(result.title),
+                ]),
+                m('.search-results-thread-subtitle', [
                   m('span.created-at', moment(result.created_at).fromNow()),
+                  m(User, { user: new AddressInfo(result.address_id, result.address, result.chain, null) }),
                 ]),
                 m('.search-results-comment', [
                   (() => {

--- a/client/scripts/views/sublayout.ts
+++ b/client/scripts/views/sublayout.ts
@@ -20,7 +20,7 @@ const Sublayout: m.Component<{
 
   // content
   class?: string,
-  title?: string,                  // displayed at the top of the layout
+  title?,                          // displayed at the top of the layout
   description?: string,            // displayed at the top of the layout
   sidebarTopic?: number,           // used to override the sidebar
   showNewProposalButton?: boolean,

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -9,6 +9,7 @@
     .SearchLoading {
     }
     .SearchError {
+        margin: 21px 0 8px;
     }
     .SearchResults {
         .search-results-caption {

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -28,8 +28,15 @@
             }
             .search-results-thread-title {
                 font-weight: 500;
+            }
+            .search-results-thread-subtitle {
+                margin: 2px 0 3px;
                 .created-at {
-                    margin-left: 10px;
+                    font-weight: 400;
+                    color: $text-color-light;
+                }
+                .User {
+                    margin-left: 14px;
                     font-weight: 400;
                     color: $text-color-light;
                 }

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -1,4 +1,42 @@
 @import 'client/styles/shared';
 
 .SearchPage {
+    .cui-tag {
+        position: relative;
+        top: -2px;
+        margin-left: 6px;
+    }
+    .SearchLoading {
+    }
+    .SearchError {
+    }
+    .SearchResults {
+        .search-results-caption {
+            margin: 21px 0 8px;
+            color: $text-color-light;
+        }
+        .search-results-list {
+            a.search-results-item {
+                display: block;
+                padding: 9px 0;
+                color: $text-color-dark;
+                text-decoration: none;
+            }
+            .search-results-thread-title {
+                font-weight: 500;
+            }
+            .search-results-item:hover {
+                cursor: pointer;
+            }
+            .search-results-item:hover .search-results-thread-title {
+                text-decoration: underline;
+            }
+            .search-results-thread-body {
+                color: $text-color-light;
+            }
+            .search-results-comment {
+                color: $text-color-light;
+            }
+        }
+    }
 }

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -1,10 +1,10 @@
 @import 'client/styles/shared';
 
 .SearchPage {
-    .cui-tag {
-        position: relative;
-        top: -2px;
-        margin-left: 6px;
+    padding-bottom: 40px;
+
+    .search-page-input {
+        margin-top: 30px;
     }
     .SearchLoading {
     }
@@ -13,24 +13,29 @@
     }
     .SearchResults {
         .search-results-caption {
-            margin: 21px 0 8px;
+            margin: 20px 0;
             color: $text-color-light;
+            .search-results-clear {
+                margin-left: 10px;
+            }
         }
         .search-results-list {
             a.search-results-item {
                 display: block;
-                padding: 9px 0;
+                padding: 13px 0;
                 color: $text-color-dark;
                 text-decoration: none;
             }
             .search-results-thread-title {
                 font-weight: 500;
+                .created-at {
+                    margin-left: 10px;
+                    font-weight: 400;
+                    color: $text-color-light;
+                }
             }
             .search-results-item:hover {
                 cursor: pointer;
-            }
-            .search-results-item:hover .search-results-thread-title {
-                text-decoration: underline;
             }
             .search-results-thread-body {
                 color: $text-color-light;

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -6,12 +6,12 @@
     .search-page-input {
         margin-top: 30px;
     }
-    .SearchLoading {
+    .search-loading {
     }
-    .SearchError {
+    .search-error {
         margin: 21px 0 8px;
     }
-    .SearchResults {
+    .search-results {
         .search-results-caption {
             margin: 20px 0;
             color: $text-color-light;

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -1,0 +1,4 @@
+@import 'client/styles/shared';
+
+.SearchPage {
+}

--- a/server/migrations/20201214194224-add-search-indexes.js
+++ b/server/migrations/20201214194224-add-search-indexes.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // add threads index
+      await queryInterface.sequelize.query(
+        'ALTER TABLE "OffchainThreads" ADD COLUMN _search TSVECTOR',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'UPDATE "OffchainThreads" SET _search = to_tsvector(\'english\', title || \' \' || body)',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'CREATE INDEX "OffchainThreads_search" ON "OffchainThreads" USING gin(_search)',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'CREATE TRIGGER "OffchainThreads_vector_update" BEFORE INSERT OR UPDATE ON "OffchainThreads" '
+          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', title, body)',
+        { transaction: t }
+      );
+
+      // add comments index
+      await queryInterface.sequelize.query(
+        'ALTER TABLE "OffchainComments" ADD COLUMN _search TSVECTOR',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'UPDATE "OffchainComments" SET _search = to_tsvector(\'english\', text)',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'CREATE INDEX "OffchainComments_search" ON "OffchainComments" USING gin(_search)',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'CREATE TRIGGER "OffchainComments_vector_update" BEFORE INSERT OR UPDATE ON "OffchainComments" '
+          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', text)',
+        { transaction: t }
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // remove threads index
+      await queryInterface.sequelize.query(
+        'DROP TRIGGER "OffchainThreads_vector_update" ON "OffchainThreads";',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'DROP INDEX "OffchainThreads_search";',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'ALTER TABLE "OffchainThreads" DROP COLUMN _search;',
+        { transaction: t }
+      );
+
+      // remove comments index
+      await queryInterface.sequelize.query(
+        'DROP TRIGGER "OffchainComments_vector_update" ON "OffchainComments";',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'DROP INDEX "OffchainComments_search";',
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        'ALTER TABLE "OffchainComments" DROP COLUMN _search;',
+        { transaction: t }
+      );
+    });
+  }
+};

--- a/server/migrations/20201215074112-add-plaintext-columns-for-indexer.js
+++ b/server/migrations/20201215074112-add-plaintext-columns-for-indexer.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn('OffchainThreads', 'plaintext', { type: Sequelize.TEXT, allowNull: true, }, {
+        transaction: t
+      });
+      await queryInterface.addColumn('OffchainComments', 'plaintext', { type: Sequelize.TEXT, allowNull: true, }, {
+        transaction: t
+      });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('OffchainThreads', 'plaintext');
+      await queryInterface.removeColumn('OffchainComments', 'plaintext');
+    });
+  }
+};

--- a/server/migrations/20201215074113-add-search-indexes.js
+++ b/server/migrations/20201215074113-add-search-indexes.js
@@ -9,7 +9,7 @@ module.exports = {
         { transaction: t }
       );
       await queryInterface.sequelize.query(
-        'UPDATE "OffchainThreads" SET _search = to_tsvector(\'english\', title || \' \' || body)',
+        'UPDATE "OffchainThreads" SET _search = to_tsvector(\'english\', title || \' \' || plaintext)',
         { transaction: t }
       );
       await queryInterface.sequelize.query(
@@ -18,7 +18,7 @@ module.exports = {
       );
       await queryInterface.sequelize.query(
         'CREATE TRIGGER "OffchainThreads_vector_update" BEFORE INSERT OR UPDATE ON "OffchainThreads" '
-          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', title, body)',
+          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', title, plaintext)',
         { transaction: t }
       );
 
@@ -28,7 +28,7 @@ module.exports = {
         { transaction: t }
       );
       await queryInterface.sequelize.query(
-        'UPDATE "OffchainComments" SET _search = to_tsvector(\'english\', text)',
+        'UPDATE "OffchainComments" SET _search = to_tsvector(\'english\', plaintext)',
         { transaction: t }
       );
       await queryInterface.sequelize.query(
@@ -37,7 +37,7 @@ module.exports = {
       );
       await queryInterface.sequelize.query(
         'CREATE TRIGGER "OffchainComments_vector_update" BEFORE INSERT OR UPDATE ON "OffchainComments" '
-          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', text)',
+          + 'FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(_search, \'pg_catalog.english\', plaintext)',
         { transaction: t }
       );
     });

--- a/server/migrations/20201215091459-populate-plaintext-columns-for-indexer.js
+++ b/server/migrations/20201215091459-populate-plaintext-columns-for-indexer.js
@@ -1,0 +1,116 @@
+'use strict';
+
+// copied from shared/utils because sequelize migration import pipeline seems broken
+const preprocessQuillDeltaForRendering = (nodes) => {
+  // split up nodes at line boundaries
+  const lines = [];
+  for (const node of nodes) {
+    if (typeof node.insert === 'string') {
+      node.insert.match(/[^\n]+\n?|\n/g).forEach((line) => {
+        lines.push({ attributes: node.attributes, insert: line });
+      });
+    } else {
+      lines.push(node);
+    }
+  }
+  // group nodes under parents
+  const result = [];
+  let parent = { children: [], attributes: undefined };
+  for (const node of lines) {
+    if (typeof node.insert === 'string' && node.insert.endsWith('\n')) {
+      parent.attributes = node.attributes;
+      // concatenate code-block node parents together, keeping newlines
+      if (result.length > 0 && result[result.length - 1].attributes && parent.attributes
+          && parent.attributes['code-block'] && result[result.length - 1].attributes['code-block']) {
+        parent.children.push({ insert: node.insert });
+        result[result.length - 1].children = result[result.length - 1].children.concat(parent.children);
+      } else {
+        parent.children.push({ insert: node.insert });
+        result.push(parent);
+      }
+      parent = { children: [], attributes: undefined };
+    } else {
+      parent.children.push(node);
+    }
+  }
+  // If there was no \n at the end of the document, we need to push whatever remains in `parent`
+  // onto the result. This may happen if we are rendering a truncated Quill document
+  if (parent.children.length > 0) {
+    result.push(parent);
+  }
+
+  // trim empty newlines at end of document
+  while (result.length
+         && result[result.length - 1].children.length === 1
+         && typeof result[result.length - 1].children[0].insert === 'string'
+         && result[result.length - 1].children[0].insert === '\n'
+         && result[result.length - 1].children[0].attributes === undefined) {
+    result.pop();
+  }
+
+  return result;
+};
+
+const renderQuillDeltaToText = (delta, paragraphSeparator = '\n\n') => {
+  return preprocessQuillDeltaForRendering(delta.ops).map((parent) => {
+    return parent.children.map((child) => {
+      if (typeof child.insert === 'string') return child.insert.trimRight('\n');
+      if (child.insert && child.insert.image) return '(image)';
+      if (child.insert && child.insert.twitter) return '(tweet)';
+      if (child.insert && child.insert.video) return '(video)';
+      return '';
+    }).filter((child) => !!child).join(' ').replace(/  +/g, ' '); // remove multiple spaces
+  }).filter((parent) => !!parent).join(paragraphSeparator);
+};
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      console.log('Populating OffchainThreads plaintext');
+      const threads = await queryInterface.sequelize.query('SELECT id, body FROM "OffchainThreads";', {
+        transaction: t
+      });
+      console.log(threads[0].length);
+      await Promise.all(threads[0].map(async (thread) => {
+        const id = thread.id;
+        const plaintext = (() => {
+          try {
+            return renderQuillDeltaToText(JSON.parse(decodeURIComponent(thread.body)));
+          } catch (e) {
+            return decodeURIComponent(thread.body);
+          }
+        })();
+        console.log('Migrating OffchainThread id:', id);
+        await queryInterface.sequelize.query('UPDATE "OffchainThreads" SET plaintext=:plaintext WHERE id=:id;', {
+          replacements: { id, plaintext },
+          type: queryInterface.sequelize.QueryTypes.UPDATE,
+        }, { transaction: t });
+      }));
+
+      console.log('Populating OffchainComments plaintext');
+      const comments = await queryInterface.sequelize.query('SELECT id, text FROM "OffchainComments";',  {
+        transaction: t
+      });
+      console.log(comments[0].length);
+      await Promise.all(comments[0].map(async (comment) => {
+        const id = comment.id;
+        const plaintext = (() => {
+          try {
+            return renderQuillDeltaToText(JSON.parse(decodeURIComponent(comment.text)));
+          } catch (e) {
+            return decodeURIComponent(comment.text);
+          }
+        })();
+        console.log('Migrating OffchainComment id:', id);
+        await queryInterface.sequelize.query('UPDATE "OffchainComments" SET plaintext=:plaintext WHERE id=:id;', {
+          replacements: { id, plaintext },
+          type: queryInterface.sequelize.QueryTypes.UPDATE,
+        }, { transaction: t });
+      }));
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return new Promise((resolve) => resolve());
+  }
+};

--- a/server/models/offchain_comment.ts
+++ b/server/models/offchain_comment.ts
@@ -13,6 +13,7 @@ export interface OffchainCommentAttributes {
   child_comments?: number[];
   address_id: number;
   text: string;
+  plaintext: string;
   community?: string;
   version_history?: string[];
   created_at?: Date;
@@ -47,6 +48,7 @@ export default (
     child_comments: { type: dataTypes.ARRAY(dataTypes.INTEGER), allowNull: false, defaultValue: [] },
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     text: { type: dataTypes.TEXT, allowNull: false },
+    plaintext: { type: dataTypes.TEXT, allowNull: true },
     community: { type: dataTypes.STRING, allowNull: true },
     version_history: { type: dataTypes.ARRAY(dataTypes.TEXT), defaultValue: [], allowNull: false },
     created_at: { type: dataTypes.DATE, allowNull: false },

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -11,6 +11,7 @@ export interface OffchainThreadAttributes {
   address_id: number;
   title: string;
   body?: string;
+  plaintext?: string;
   kind: string;
   url?: string;
   topic_id?: number;
@@ -48,6 +49,7 @@ export default (
     address_id: { type: dataTypes.INTEGER, allowNull: false },
     title: { type: dataTypes.TEXT, allowNull: false },
     body: { type: dataTypes.TEXT, allowNull: true },
+    plaintext: { type: dataTypes.TEXT, allowNull: true },
     kind: { type: dataTypes.TEXT, allowNull: false },
     url: { type: dataTypes.TEXT, allowNull: true },
     topic_id: { type: dataTypes.INTEGER, allowNull: true },

--- a/server/router.ts
+++ b/server/router.ts
@@ -70,6 +70,7 @@ import editThread from './routes/editThread';
 import deleteThread from './routes/deleteThread';
 import bulkThreads from './routes/bulkThreads';
 import getThread from './routes/getThread';
+import search from './routes/search';
 import createDraft from './routes/drafts/createDraft';
 import deleteDraft from './routes/drafts/deleteDraft';
 import editDraft from './routes/drafts/editDraft';
@@ -150,6 +151,7 @@ function setupRouter(app, models, viewCountCache: ViewCountCache, identityFetchC
   // TODO: Change to GET /threads
   router.get('/bulkThreads', bulkThreads.bind(this, models));
   router.get('/getThread', getThread.bind(this, models));
+  router.get('/search', search.bind(this, models));
 
   router.get('/profile', getProfile.bind(this, models));
 

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -7,6 +7,13 @@ import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 // bulkThreads takes a date param and fetches the most recent 20 threads before that date
+
+// TODO: also support search here, using the form:
+//
+// SELECT *
+// FROM authors
+// WHERE _search @@ plainto_tsquery('english', 'John Doe');
+
 const bulkThreads = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
   const { cutoff_date, topic_id } = req.query;
@@ -35,7 +42,7 @@ const bulkThreads = async (models, req: Request, res: Response, next: NextFuncti
         addr.chain AS addr_chain, thread_id, thread_title,
         thread_community, thread_chain, thread_created, threads.kind,
         threads.version_history, threads.read_only, threads.body,
-        threads.url, threads.pinned, topics.id AS topic_id, topics.name AS topic_name, 
+        threads.url, threads.pinned, topics.id AS topic_id, topics.name AS topic_name,
         topics.description AS topic_description, topics.chain_id AS topic_chain,
         topics.community_id AS topic_community
       FROM "Addresses" AS addr

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -7,13 +7,6 @@ import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
 // bulkThreads takes a date param and fetches the most recent 20 threads before that date
-
-// TODO: also support search here, using the form:
-//
-// SELECT *
-// FROM authors
-// WHERE _search @@ plainto_tsquery('english', 'John Doe');
-
 const bulkThreads = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
   const { cutoff_date, topic_id } = req.query;

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -3,7 +3,7 @@ import { NotificationCategories } from '../../shared/types';
 
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
-import { getProposalUrl, getProposalUrlWithoutObject } from '../../shared/utils';
+import { getProposalUrl, getProposalUrlWithoutObject, renderQuillDeltaToText } from '../../shared/utils';
 import proposalIdToEntity from '../util/proposalIdToEntity';
 import { factory, formatFilename } from '../../shared/logging';
 
@@ -32,6 +32,14 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
     : typeof req.body['mentions[]'] === 'undefined'
       ? []
       : req.body['mentions[]'];
+
+  const plaintext = (() => {
+    try {
+      return renderQuillDeltaToText(JSON.parse(decodeURIComponent(text)));
+    } catch (e) {
+      return decodeURIComponent(text);
+    }
+  })();
 
   // TODO: 'let parentComment' here, saves one db query
   if (parent_id) {
@@ -73,6 +81,7 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
     root_id,
     child_comments: [],
     text,
+    plaintext,
     version_history: versionHistory,
     address_id: author.id,
     chain: null,

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -63,9 +63,9 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
   // Render a copy of the thread to plaintext for the search indexer
   const plaintext = (() => {
     try {
-      return renderQuillDeltaToText(JSON.parse(body));
+      return renderQuillDeltaToText(JSON.parse(decodeURIComponent(body)));
     } catch (e) {
-      return body;
+      return decodeURIComponent(body);
     }
   })();
 

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -3,7 +3,7 @@ import { NotificationCategories, ProposalType } from '../../shared/types';
 
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
-import { getProposalUrl } from '../../shared/utils';
+import { getProposalUrl, renderQuillDeltaToText } from '../../shared/utils';
 import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
@@ -60,6 +60,15 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     return next(new Error(Errors.UnsupportedKind));
   }
 
+  // Render a copy of the thread to plaintext for the search indexer
+  const plaintext = (() => {
+    try {
+      return renderQuillDeltaToText(JSON.parse(body));
+    } catch (e) {
+      return body;
+    }
+  })();
+
   // New threads get an empty version history initialized, which is passed
   // the thread's first version, formatted on the frontend with timestamps
   const versionHistory = [];
@@ -70,6 +79,7 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     address_id: author.id,
     title,
     body,
+    plaintext,
     version_history: versionHistory,
     kind,
     url,
@@ -79,6 +89,7 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     address_id: author.id,
     title,
     body,
+    plaintext,
     version_history: versionHistory,
     kind,
     url,

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -3,7 +3,7 @@ import { Op } from 'sequelize';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
 import { NotificationCategories } from '../../shared/types';
-import { getProposalUrl, getProposalUrlWithoutObject } from '../../shared/utils';
+import { getProposalUrl, getProposalUrlWithoutObject, renderQuillDeltaToText } from '../../shared/utils';
 import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
@@ -52,6 +52,13 @@ const editComment = async (models, req: Request, res: Response, next: NextFuncti
     arr.unshift(req.body.version_history);
     comment.version_history = arr;
     comment.text = req.body.body;
+    comment.plaintext = (() => {
+      try {
+        return renderQuillDeltaToText(JSON.parse(decodeURIComponent(req.body.body)));
+      } catch (e) {
+        return decodeURIComponent(req.body.body);
+      }
+    })();
     await comment.save();
     await attachFiles();
     const finalComment = await models.OffchainComment.findOne({

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -59,9 +59,9 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
     thread.body = body;
     thread.plaintext = (() => {
       try {
-        return renderQuillDeltaToText(JSON.parse(body));
+        return renderQuillDeltaToText(JSON.parse(decodeURIComponent(body)));
       } catch (e) {
-        return body;
+        return decodeURIComponent(body);
       }
     })();
     if (title) {

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { Op } from 'sequelize';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
+import { renderQuillDeltaToText } from '../../shared/utils';
 import { NotificationCategories, ProposalType } from '../../shared/types';
 import { factory, formatFilename } from '../../shared/logging';
 
@@ -56,6 +57,13 @@ const editThread = async (models, req: Request, res: Response, next: NextFunctio
     arr.unshift(version_history);
     thread.version_history = arr;
     thread.body = body;
+    thread.plaintext = (() => {
+      try {
+        return renderQuillDeltaToText(JSON.parse(body));
+      } catch (e) {
+        return body;
+      }
+    })();
     if (title) {
       thread.title = title;
     }

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -6,6 +6,11 @@ import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
+const Errors = {
+  UnexpectedError: 'Unexpected error',
+  QueryTooShort: 'Query must be at least 3 characters',
+};
+
 const search = async (models, req: Request, res: Response, next: NextFunction) => {
   const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
   const { cutoff_date } = req.query;
@@ -14,11 +19,18 @@ const search = async (models, req: Request, res: Response, next: NextFunction) =
   const communityOptions = community
     ? `community = :community `
     : `chain = :chain `;
+  const communityOptions2 = community
+    ? `"OffchainComments".community = :community `
+    : `"OffchainComments".chain = :chain `;
   const replacements = community
     ? { community: community.id }
     : { chain: chain.id };
   replacements['searchTerm'] = req.query.search;
   replacements['limit'] = 20;
+
+  if (req.query.search.length < 3) {
+    return next(new Error(Errors.QueryTooShort));
+  }
 
   // query for both threads and comments, and then execute a union and keep only the most recent :limit
   let threadsAndComments;
@@ -28,8 +40,10 @@ SELECT * FROM
 ((SELECT title, body, CAST(id as VARCHAR) as proposalId, 'thread' as type, created_at FROM "OffchainThreads"
 WHERE ${communityOptions} AND _search @@ plainto_tsquery('english', :searchTerm) ORDER BY created_at DESC LIMIT :limit)
 UNION ALL
-(SELECT '' as title, text, root_id as proposalId, 'comment' as type, created_at FROM "OffchainComments"
-WHERE ${communityOptions} AND _search @@ plainto_tsquery('english', :searchTerm) ORDER BY created_at DESC LIMIT :limit)) s
+(SELECT "OffchainThreads".title, text, root_id as proposalId, 'comment' as type, "OffchainComments".created_at FROM "OffchainComments"
+JOIN "OffchainThreads" ON "OffchainThreads".id = CAST(REPLACE(root_id, 'discussion_', '') AS int)
+WHERE ${communityOptions2} AND "OffchainComments"._search @@ plainto_tsquery('english', :searchTerm)
+ORDER BY created_at DESC LIMIT :limit)) s
 ORDER BY created_at DESC LIMIT :limit;
 `, {
       replacements,
@@ -37,7 +51,7 @@ ORDER BY created_at DESC LIMIT :limit;
     });
   } catch (e) {
     console.log(e);
-    return next(new Error('Invalid search term'));
+    return next(new Error(Errors.UnexpectedError));
   }
 
   return res.json({

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -44,7 +44,7 @@ SELECT * FROM (
       'thread' as type,
       "Addresses".id as address_id,
       "Addresses".address,
-      "Addresses".chain,
+      "Addresses".chain as address_chain,
       "OffchainThreads".created_at
     FROM "OffchainThreads"
     JOIN "Addresses" ON "OffchainThreads".address_id = "Addresses".id
@@ -58,10 +58,11 @@ SELECT * FROM (
       'comment' as type,
       "Addresses".id as address_id,
       "Addresses".address,
-      "Addresses".chain,
+      "Addresses".chain as address_chain,
       "OffchainComments".created_at
     FROM "OffchainComments"
-    JOIN "OffchainThreads" ON "OffchainThreads".id = CAST(REPLACE(root_id, 'discussion_', '') AS int)
+    JOIN "OffchainThreads" ON "OffchainThreads".id =
+        CASE WHEN root_id ~ '^discussion_[0-9\\.]+$' THEN CAST(REPLACE(root_id, 'discussion_', '') AS int) ELSE NULL END
     JOIN "Addresses" ON "OffchainComments".address_id = "Addresses".id
     WHERE ${communityOptions2} AND "OffchainComments"._search @@ plainto_tsquery('english', :searchTerm)
     ORDER BY "OffchainComments".created_at DESC LIMIT :limit)

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,0 +1,44 @@
+/* eslint-disable quotes */
+import { Request, Response, NextFunction } from 'express';
+import { QueryTypes } from 'sequelize';
+import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
+import { factory, formatFilename } from '../../shared/logging';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+const search = async (models, req: Request, res: Response, next: NextFunction) => {
+  const [chain, community] = await lookupCommunityIsVisibleToUser(models, req.query, req.user, next);
+  const { cutoff_date } = req.query;
+
+  // set up query parameters
+  const communityOptions = community
+    ? `community = :community `
+    : `chain = :chain `;
+  const replacements = community
+    ? { community: community.id }
+    : { chain: chain.id };
+  replacements['searchTerm'] = req.query.search;
+
+  // make search query
+  let threadsAndComments;
+  try {
+    threadsAndComments = await models.sequelize.query(`
+SELECT title, body FROM "OffchainThreads" WHERE ${communityOptions}
+AND _search @@ plainto_tsquery('english', :searchTerm)
+LIMIT 20;
+`, {
+      replacements,
+      type: QueryTypes.SELECT
+    });
+  } catch (e) {
+    console.log(e);
+    return next(new Error('Invalid search term'));
+  }
+
+  return res.json({
+    status: 'Success',
+    response: threadsAndComments,
+  });
+};
+
+export default search;


### PR DESCRIPTION
Adds plaintext indexes for OffchainThreads and OffchainComments.

Adds a search page and search endpoint, which fetches both threads and comments matching the search term.

Needs testing:
- Creating of indexes when a thread or comment is created or edited (all 4 combinations)
- Check that this works in all communities 
- Clarify visual design of search results
- Show the specific place where the match was found (ideally)