### PR TITLE
Ensure chain initialization does not occur more than once

### DIFF
--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -357,6 +357,7 @@ const LinkNewAddressModal: m.Component<{
                 || vnode.state.initializingWallet !== false, // disable if loading, or loading state hasn't been set
               oninit: async (vvnode) => {
                 // initialize API if needed before starting webwallet
+                if (vnode.state.initializingWallet) return;
                 vnode.state.initializingWallet = true;
                 await app.chain.initApi();
                 await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();
@@ -365,6 +366,7 @@ const LinkNewAddressModal: m.Component<{
               },
               onclick: async (vvnode) => {
                 // initialize API if needed before starting webwallet
+                if (vnode.state.initializingWallet) return;
                 vnode.state.initializingWallet = true;
                 await app.chain.initApi();
                 await (app.chain as Substrate || app.chain as Ethereum).webWallet.enable();


### PR DESCRIPTION
Closes #1000; partial close on #1003. We could also implement a boolean switch on app.chain (e.g. "initializing") if we wanted to solve the multiple initializations more broadly. As is, this fix is component-scoped.

## Description

Previously, the webwallet login component was being (asynchronously) initialized multiple times. We may want to remove async oninit code entirely—the Mithril lifecycle docs advise against it. Regardless, this adds a simple boolean check to ensure that, if the wallet is already initializing, it will not be reinitialized (leading to an onslaught of Polkadotjs popups).

## How has this been tested?

I've been able to consistently bring up only a single Polkadot JS authorization popup when logging in via webwallet from Firefox and Chrome alike, and to then login via that popup. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no