### PR TITLE
Ensure thread and comment authors are always up-to-date

### DIFF
--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -213,7 +213,7 @@ export const NewThreadForm: m.Component<{
   },
   view: (vnode) => {
     if (!app.community && !app.chain) return;
-    const author = app.user.activeAccount;
+    let author = app.user.activeAccount;
     const activeEntityInfo = app.community ? app.community.meta : app.chain.meta.chain;
     const { isModal, hasTopics } = vnode.attrs;
     if (vnode.state.quillEditorState?.container) {
@@ -415,6 +415,7 @@ export const NewThreadForm: m.Component<{
                   return;
                 }
                 vnode.state.saving = true;
+                author = app.user.activeAccount;
                 if (!vnode.state.form.linkTitle) {
                   vnode.state.form.linkTitle = (
                     $(e.target).closest('.NewThreadForm').find('input[name=\'new-link-title\'').val() as string
@@ -500,6 +501,7 @@ export const NewThreadForm: m.Component<{
               onclick: async (e) => {
                 vnode.state.saving = true;
                 const { form, quillEditorState } = vnode.state;
+                author = app.user.activeAccount;
                 if (!vnode.state.form.threadTitle) {
                   vnode.state.form.threadTitle = (
                     $(e.target).closest('.NewThreadForm').find('input[name=\'new-thread-title\'').val() as string
@@ -537,6 +539,7 @@ export const NewThreadForm: m.Component<{
               onclick: async (e) => {
                 const { form, quillEditorState } = vnode.state;
                 vnode.state.saving = true;
+                author = app.user.activeAccount;
                 const title = $(e.target).closest('.NewThreadForm').find('input[name=\'new-thread-title\']');
                 if (!vnode.state.form.threadTitle) {
                   vnode.state.form.threadTitle = (title.val() as string);

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -38,7 +38,7 @@ const NewProposalForm = {
   },
   view: (vnode) => {
     const callback = vnode.attrs.callback;
-    const author = app.user.activeAccount;
+    let author = app.user.activeAccount;
     const proposalTypeEnum = vnode.attrs.typeEnum;
     const activeEntity = app.community || app.chain;
 
@@ -122,6 +122,7 @@ const NewProposalForm = {
       let createFunc: (...args) => ITXModalData | Promise<ITXModalData> = (a) => {
         return (proposalSlugToClass().get(proposalTypeEnum) as ProposalModule<any, any, any>).createTx(...a);
       };
+      author = app.user.activeAccount;
       let args = [];
       if (proposalTypeEnum === ProposalType.OffchainThread) {
         app.threads.create(

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -39,13 +39,12 @@ const CreateComment: m.Component<{
       rootProposal
     } = vnode.attrs;
     let { parentComment } = vnode.attrs;
-    const author = app.user.activeAccount;
+    let author = app.user.activeAccount;
     const parentType = parentComment ? CommentParent.Comment : CommentParent.Proposal;
     if (!parentComment) parentComment = null;
     if (vnode.state.uploadsInProgress === undefined) {
       vnode.state.uploadsInProgress = 0;
     }
-
     const submitComment = async (e?) => {
       if (!vnode.state.quillEditorState || !vnode.state.quillEditorState.editor) {
         if (e) e.preventDefault();
@@ -59,6 +58,7 @@ const CreateComment: m.Component<{
       }
 
       const { quillEditorState } = vnode.state;
+      author = app.user.activeAccount;
 
       const mentionsEle = document.getElementsByClassName('ql-mention-list-container')[0];
       if (mentionsEle) (mentionsEle as HTMLElement).style.visibility = 'hidden';


### PR DESCRIPTION
Closes #1010.

## Description

Previously, posts could originate from the incorrect address on account of a stale `author` value in various comment and thread creation fns. This branch ensures that the user.activeAccount is updated _on function call_, rather than being left over from the component's last redraw.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no