### PR TITLE
Add exclude parameter to NotificationHandler. (#1040)

### DIFF
--- a/server/eventHandlers/notifications.ts
+++ b/server/eventHandlers/notifications.ts
@@ -2,7 +2,7 @@
  * Generic handler that transforms events into notifications.
  */
 import WebSocket from 'ws';
-import { IEventHandler, CWEvent } from '@commonwealth/chain-events';
+import { IEventHandler, CWEvent, IChainEventKind } from '@commonwealth/chain-events';
 import { NotificationCategories } from '../../shared/types';
 
 import { factory, formatFilename } from '../../shared/logging';
@@ -12,6 +12,7 @@ export default class extends IEventHandler {
   constructor(
     private readonly _models,
     private readonly _wss?: WebSocket.Server,
+    private readonly _excludedEvents: IChainEventKind[] = [],
   ) {
     super();
   }
@@ -24,6 +25,10 @@ export default class extends IEventHandler {
     if (!dbEvent) {
       log.trace('No db event received! Ignoring.');
       return;
+    }
+    if (this._excludedEvents.includes(event.data.kind)) {
+      log.trace('Skipping event!');
+      return dbEvent;
     }
     const dbEventType = await dbEvent.getChainEventType();
     if (!dbEventType) {

--- a/server/scripts/setupChainEventListeners.ts
+++ b/server/scripts/setupChainEventListeners.ts
@@ -81,7 +81,10 @@ const setupChainEventListeners = async (
 
     // emits notifications by writing into the db's Notifications table, and also optionally
     // sending a notification to the client via websocket
-    const notificationHandler = new EventNotificationHandler(models, wss);
+    const excludedNotificationEvents = [
+      SubstrateTypes.EventKind.DemocracyTabled,
+    ];
+    const notificationHandler = new EventNotificationHandler(models, wss, excludedNotificationEvents);
 
     // creates and updates ChainEntity rows corresponding with entity-related events
     const entityArchivalHandler = new EntityArchivalHandler(models, node.chain, wss);


### PR DESCRIPTION
## Description
Fixes #1040.

My only concern is making sure we somehow synchronize this list on the client side, so we don't display the option to enable this particular notification. We can discuss that prior to merging if you think it's significant.

## How has this been tested?
Unit test case passes.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no