### PR TITLE
Complete passed referenda if chain height beyond dispatch block. (#1006)

### DIFF
--- a/client/scripts/controllers/chain/substrate/democracy_referendum.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_referendum.ts
@@ -252,6 +252,11 @@ export class SubstrateDemocracyReferendum
         this._passed.next(true);
         this._executionBlock = e.data.dispatchBlock;
         this._endBlock = e.data.dispatchBlock; // fix timer if in dispatch queue
+
+        // hack to complete proposals that didn't get an execution event for some reason
+        if (this._executionBlock < this._Democracy.app.chain.block.height) {
+          this.complete();
+        }
         break;
       }
       case SubstrateTypes.EventKind.DemocracyExecuted: {


### PR DESCRIPTION
## Description
Fixes #1006. We still don't know why certain DemocracyExecuted events aren't being captured by chain events, but as long as we get the Passed event, this fix will permit us to mark those referenda completed.

Re the description for #1006, I could not find other instances of proposals not being marked completed except wrt referenda.

## How has this been tested?
Ran it and verified fix on the UI.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no