### PR TITLE
Ensure mentioned users are not doubly notified

### DIFF
--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -231,6 +231,11 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
     mentionedAddresses = mentionedAddresses.filter((addr) => !!addr);
   }
 
+  console.log(mentionedAddresses);
+  const excludedAddrs = mentionedAddresses.map((addr) => addr.address);
+  excludedAddrs.push(finalComment.Address.address);
+  console.log(excludedAddrs);
+
   // dispatch notifications to root thread
   await models.Subscription.emitNotifications(
     models,
@@ -258,7 +263,7 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
       body: finalComment.text,
     },
     req.wss,
-    [ finalComment.Address.address ],
+    excludedAddrs
   );
 
   // if child comment, dispatch notification to parent author
@@ -291,7 +296,7 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
         body: finalComment.text,
       },
       req.wss,
-      [ finalComment.Address.address ],
+      excludedAddrs
     );
   }
 

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -231,10 +231,8 @@ const createComment = async (models, req: Request, res: Response, next: NextFunc
     mentionedAddresses = mentionedAddresses.filter((addr) => !!addr);
   }
 
-  console.log(mentionedAddresses);
   const excludedAddrs = mentionedAddresses.map((addr) => addr.address);
   excludedAddrs.push(finalComment.Address.address);
-  console.log(excludedAddrs);
 
   // dispatch notifications to root thread
   await models.Subscription.emitNotifications(

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -228,11 +228,10 @@ const createThread = async (models, req: Request, res: Response, next: NextFunct
     mentionedAddresses = mentionedAddresses.filter((addr) => !!addr);
   }
 
-  console.log(mentionedAddresses);
-  // dispatch notifications to subscribers of the given chain/community
   const excludedAddrs = mentionedAddresses.map((addr) => addr.address);
   excludedAddrs.push(finalThread.Address.address);
-  console.log(excludedAddrs);
+
+  // dispatch notifications to subscribers of the given chain/community
   await models.Subscription.emitNotifications(
     models,
     NotificationCategories.NewThread,


### PR DESCRIPTION
Closes #1039.
 
## Description

This branch adds the addresses of mentioned users, in the createThread and createComment endpoints, to the list of addresses excluded from notifications. This ensures they are notified only of their mention—and not, in addition, the creation of the thread/comment the tag originates in.

## How has this been tested?

Tagged a variety of users in comments and threads, ensuring that their corresponding userIds were excluded from receiving notifications.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no