### PR TITLE
Ensure batch threads notifications render properly

### DIFF
--- a/client/scripts/helpers/notifications.ts
+++ b/client/scripts/helpers/notifications.ts
@@ -10,7 +10,10 @@ export const batchNotifications = (n: Notification[], prop: string, prop2: strin
   }, {}));
 };
 
-export const sortNotifications = (n: Notification[]) => {
+export const sortNotifications = (unsortedNotifications: Notification[]) => {
+  // The .sort method here is crucial; the sortNotifications fn only works when
+  // notifications are sorted in advance by createdAt
+  const n = unsortedNotifications.sort((a, b) => b.createdAt.unix() - a.createdAt.unix());
   const batched =  batchNotifications(n, 'subscription', 'objectId');
   const unbatchChainEvents = [];
   batched.forEach((a: Notification[]) => {

--- a/client/scripts/views/components/header/notifications_menu.ts
+++ b/client/scripts/views/components/header/notifications_menu.ts
@@ -55,12 +55,11 @@ const NotificationsMenu: m.Component<{ small?: boolean }, { selectedChainEvents:
   view: (vnode) => {
     // TODO: Add helper directly on controller
     const { small } = vnode.attrs;
-    const notifications = app.user.notifications ? app.user.notifications.notifications : [];
+    const notifications = app.user.notifications?.notifications || [];
     const filteredNotifications = vnode.state.selectedChainEvents
       ? notifications.filter((n) => n.chainEvent)
       : notifications.filter((n) => !n.chainEvent);
     const sortedFilteredNotifications = sortNotifications(filteredNotifications).reverse();
-
     const unreadNotifications = notifications.filter((n) => !n.isRead);
     const unreadNotificationsCount = unreadNotifications.length;
     const unreadFilteredNotificationsCount = filteredNotifications.filter((n) => !n.isRead).length;

--- a/client/scripts/views/pages/notificationsList.ts
+++ b/client/scripts/views/pages/notificationsList.ts
@@ -5,7 +5,6 @@ import Infinite from 'mithril-infinite';
 import { Button, ButtonGroup, Popover, Tag } from 'construct-ui';
 
 import app from 'state';
-import { pluralize } from 'helpers';
 import { sortNotifications } from 'helpers/notifications';
 import NotificationRow from 'views/components/notification_row';
 import Sublayout from 'views/sublayout';
@@ -16,7 +15,7 @@ const NotificationsPage: m.Component<{}> = {
       return m('div', 'Must be logged in to view notifications.');
     }
 
-    const notifications = app.user.notifications.notifications.sort((a, b) => b.createdAt.unix() - a.createdAt.unix());
+    const notifications = app.user.notifications?.notifications || [];
     const sortedNotifications = sortNotifications(notifications).reverse();
 
     return m(Sublayout, {


### PR DESCRIPTION
Closes #1057.

## Description

Notifications were not being sorted by createdAt, in the NotificationsMenu, prior to being sent to sortNotifications. They were, however, being properly handled in the NotificationsList. This branch ensures that the .sort by createdAt happens inside the sortNotifications fn, so that in the future, this crucial step won't be left off or forgotten.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no