### PR TITLE
Ensure notification cache is cleared on initApi call

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -30,6 +30,8 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
       app.config.chains.clear();
       app.config.nodes.clear();
       app.config.communities.clear();
+      app.user.notifications.store.clear();
+      app.user.notifications.clearSubscriptions();
       data.chains.filter((chain) => chain.active).map((chain) => app.config.chains.add(ChainInfo.fromJSON(chain)));
       data.nodes.map((node) => {
         return app.config.nodes.add(NodeInfo.fromJSON({

--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -133,6 +133,10 @@ class NotificationsController {
     }
   }
 
+  public clearSubscriptions() {
+    this._subscriptions = [];
+  }
+
   public refresh() {
     if (!app.user || !app.user.jwt) {
       throw new Error('must be logged in to refresh notifications');


### PR DESCRIPTION
Closes #1069.

## Description

When switching between accounts, the first account's notifications would persevere in the second account's store. This ensures all subscriptions and notifications are cleared whenever the initApi fn is invoked.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no