### PR TITLE
Reorganize discussion rows

### DIFF
--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -17,7 +17,7 @@ export function externalLink(selector, target, children) {
     rel: 'noopener noreferrer',
     onclick: (e) => {
       if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) return;
-      if (target.startsWith(document.location.origin + '/')) {
+      if (target.startsWith(`${document.location.origin}/`)) {
         // don't open a new window if the link is on Commonwealth
         e.preventDefault();
         e.stopPropagation();
@@ -128,11 +128,11 @@ export function byAscendingCreationDate(a, b) {
 }
 
 export function byDescendingUpdatedDate(a, b) {
-  return (+b.updatedAt || +b.createdAt) - (+a.updatedAt || +a.createdAt)
+  return (+b.updatedAt || +b.createdAt) - (+a.updatedAt || +a.createdAt);
 }
 
 export function byAscendingUpdatedDate(a, b) {
-  return (+a.updatedAt || +a.createdAt) - (+b.updatedAt || +b.createdAt)
+  return (+a.updatedAt || +a.createdAt) - (+b.updatedAt || +b.createdAt);
 }
 
 export function orderAccountsByAddress(a, b) {
@@ -184,13 +184,13 @@ export function formatLastUpdated(timestamp) {
   if (formatted.indexOf(' month') !== -1) {
     return timestamp.format('MMM D');
   } else {
-    return formatted
+    return `${formatted
       .replace(' days', 'd')
       .replace(' day', 'd')
       .replace(' hours', 'h')
-      .replace(' hour', 'h');
+      .replace(' hour', 'h')} ago`;
   }
-};
+}
 
 // duplicated in adapters/currency.ts
 export function formatNumberLong(num: number) {

--- a/client/scripts/views/components/listing_row.ts
+++ b/client/scripts/views/components/listing_row.ts
@@ -10,8 +10,8 @@ import { Grid, Col, Icon, Icons } from 'construct-ui';
 interface IContentLeft {
   header: Vnode | Vnode[];
   subheader: Vnode | Vnode[];
-  subheader2?: Vnode | Vnode[];
   pinned?: boolean;
+  reaction?: Vnode | Vnode[];
 }
 
 const ListingRow: m.Component<{
@@ -31,13 +31,11 @@ const ListingRow: m.Component<{
     const initialOffset = 12 - rightColSpacing.reduce((t, n) => t + n);
     return m('.ListingRow', attrs, [
       m('.row-left', [
-        contentLeft.pinned && m('.pinned', [
-          m('span.icon-pin-outline'),
-        ]),
+        contentLeft.pinned ? m('.pinned', m('span.icon-pin-outline'))
+          : contentLeft.reaction ? m('.reaction', contentLeft.reaction) : '',
         m('.title-container', [
           m('.row-header', contentLeft.header),
           m('.row-subheader', contentLeft.subheader),
-          contentLeft.subheader2 && m('.row-subheader', contentLeft.subheader2),
         ]),
       ]),
       m('.row-right', [

--- a/client/scripts/views/components/proposal_row.ts
+++ b/client/scripts/views/components/proposal_row.ts
@@ -286,16 +286,18 @@ const ProposalRow: m.Component<IRowAttrs> = {
       })(),
     ]);
 
+    const reaction = m(ReactionButton, {
+      post: proposal,
+      type: ReactionType.Like,
+      tooltip: true,
+      large: true,
+    });
+
     const rowMetadata = [
       m(UserGallery, {
         popover: true,
         avatarSize: 24,
         users: app.comments.uniqueCommenters(proposal)
-      }),
-      m(ReactionButton, {
-        post: proposal,
-        type: ReactionType.Like,
-        tooltip: true
       }),
       !proposal.completed
         ? m('.last-updated', 'Active')
@@ -310,9 +312,10 @@ const ProposalRow: m.Component<IRowAttrs> = {
         contentLeft: {
           header: rowHeader,
           subheader: m('.proposal-row-sub', [rowSubheader, rowComments]),
+          reaction,
         },
         contentRight: rowMetadata,
-        rightColSpacing: [4, 4, 4],
+        rightColSpacing: [6, 6],
         onclick: (e) => {
           e.stopPropagation();
           e.preventDefault();

--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -17,20 +17,15 @@ export enum ReactionType {
   Dislike = 'dislike'
 }
 
-interface IAttrs {
+const ReactionButton: m.Component<{
   post: OffchainThread | AnyProposal | OffchainComment<any>;
   type: ReactionType;
   displayAsLink?: boolean;
   tooltip?: boolean;
-}
-
-interface IState {
-  loading: boolean;
-}
-
-const ReactionButton: m.Component<IAttrs, IState> = {
-  view: (vnode: m.VnodeDOM<IAttrs, IState>) => {
-    const { post, type, displayAsLink, tooltip } = vnode.attrs;
+  large?: boolean;
+}, { loading: boolean }> = {
+  view: (vnode) => {
+    const { post, type, displayAsLink, tooltip, large } = vnode.attrs;
     const reactions = app.reactions.getByPost(post);
     let dislikes;
     let likes;
@@ -58,7 +53,10 @@ const ReactionButton: m.Component<IAttrs, IState> = {
 
     const rxnButton = m('.ReactionButton', {
       class: `${(disabled ? 'disabled' : type === hasReactedType ? 'active' : '')
-        + (displayAsLink ? ' as-link' : '')}`,
+        + (displayAsLink ? ' as-link' : '')
+        + (large ? ' large' : '')
+        + (type === ReactionType.Like ? ' like' : '')
+        + (type === ReactionType.Dislike ? ' dislike' : '')}`,
       onclick: (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -111,10 +109,10 @@ const ReactionButton: m.Component<IAttrs, IState> = {
         }
       },
     }, (type === ReactionType.Dislike) && [
-      m('.upvote-icon', '👎'),
+      m('.upvote-icon', large ? '▾' : '👎'),
       m('.upvote-count', dislikes.length),
     ], (type === ReactionType.Like) && [
-      m('.reactions-icon', '👍'),
+      m('.reactions-icon', large ? '▾' : '👍'),
       m('.reactions-count', likes.length),
     ]);
 

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -102,9 +102,9 @@ const ProposalHeader: m.Component<{
             && m(ProposalTitleEditor, { item: proposal, parentState: vnode.state }),
           m('.proposal-body-meta', proposal instanceof OffchainThread ? [
             m(ProposalHeaderTopics, { proposal }),
-            m(ProposalBodyAuthor, { item: proposal }),
             m(ProposalBodyCreated, { item: proposal, link: proposalLink }),
             m(ProposalBodyLastEdited, { item: proposal }),
+            m(ProposalBodyAuthor, { item: proposal }),
             m(ProposalHeaderViewCount, { viewCount }),
             app.isLoggedIn() && !getSetGlobalEditingStatus(GlobalStatus.Get) && m(PopoverMenu, {
               transitionDuration: 0,

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -3,13 +3,6 @@
 .ListingRow {
     @include listing-row-base;
 
-    .UserGallery {
-        .User {
-            margin-top: 3px;
-            margin-right: -16px;
-        }
-    }
-
     .row-left {
         line-height: 1.1;
         flex: $listing-left-flex;
@@ -17,8 +10,21 @@
         flex-direction: row;
         align-items: center;
         position: relative;
+        .reaction {
+            margin-right: 22px;
+            position: relative;
+            top: -2px;
+        }
         .pinned {
-            width: 34px;
+            position: relative;
+            top: -2px;
+            margin-right: 22px;
+            height: 43px;
+            width: 45px;
+            border: 1px solid #ddd;
+            border-radius: 12px;
+            padding-top: 15px;
+            text-align: center;
             .icon-pin-outline {
                 display: block;
                 font-size: 15px;
@@ -47,9 +53,14 @@
             }
             .row-subheader > a,
             .row-subheader > .User > a,
+            .row-subheader > .created-at > a,
+            .row-subheader > .mobile-comment-count,
             > span {
                 color: $text-color-light;
                 font-size: $text-size-item-meta;
+                &:hover {
+                    color: darken($text-color-light, 8%);
+                }
             }
         }
     }
@@ -63,10 +74,13 @@
             > div {
                 display: flex;
                 justify-content: flex-end;
-                .UserGallery {
-                    margin-right: 8px;
+                > .UserGallery {
+                    margin-right: 10px;
                     text-align: right;
                     white-space: nowrap;
+                    > .User, > .overflow-users-wrap {
+                        margin-right: -10px;
+                    }
                     .overflow-users {
                         font-size: 13.5px;
                     }
@@ -74,22 +88,6 @@
                 .ReactionButton {
                     width: min-content;
                     height: min-content;
-                }
-                .last-updated {
-                    text-align: right;
-                    font-size: $text-size-item-meta;
-                    color: $text-color-light;
-                    padding-top: 6px;
-                    &.older {
-                        min-width: 116px;
-                    }
-                    a {
-                        font-size: inherit;
-                        color: inherit;
-                        &:hover {
-                            color: darken($text-color-light, 8%);
-                        }
-                    }
                 }
             }
         }

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -28,7 +28,7 @@
             .icon-pin-outline {
                 display: block;
                 font-size: 15px;
-                color: $text-color-light;
+                color: $text-color-medium-dark;
                 position: relative;
                 top: -2px;
             }

--- a/client/styles/components/reaction_button.scss
+++ b/client/styles/components/reaction_button.scss
@@ -35,6 +35,30 @@
         font-weight: 500;
         text-align: center;
     }
+    &.large {
+        display: block;
+        min-height: 43px !important;
+        min-width: 45px !important;
+        text-align: center;
+        border-radius: 12px;
+        .reactions-icon {
+            font-size: 85%;
+            padding: 0;
+            margin: 0;
+            margin-bottom: 4px;
+        }
+        &.like .reactions-icon {
+            -webkit-transform: rotate(180deg);
+            -moz-transform: rotate(180deg);
+            -o-transform: rotate(180deg);
+            -ms-transform: rotate(180deg);
+            transform: rotate(180deg);
+        }
+        .reactions-count {
+            top: 0;
+            padding: 0;
+        }
+    }
 }
 
 .cui-popover.cui-tooltip.ReactionButtonTooltip {

--- a/client/styles/components/widgets/user_gallery.scss
+++ b/client/styles/components/widgets/user_gallery.scss
@@ -6,7 +6,7 @@
         @include circledAvatar();
         display: inline-block;
         margin-right: -16px;
-        margin-top: 5px;
+        margin-top: -3px;
         white-space: nowrap;
         background-color: $background-color-medium-accent;
         .overflow-users {

--- a/client/styles/pages/discussions/discussion_row.scss
+++ b/client/styles/pages/discussions/discussion_row.scss
@@ -1,7 +1,5 @@
 @import 'client/styles/shared';
 
-$discussion-meta-padding: 18px;
-
 .DiscussionRow {
     .row-left {
         .row-header {
@@ -27,7 +25,7 @@ $discussion-meta-padding: 18px;
             }
             a.proposal-topic {
                 @include proposal-topic-inline;
-                margin-right: $discussion-meta-padding;
+                margin-right: 16px;
                 color: $text-color-light;
                 span.proposal-topic-icon {
                     display: inline-block;
@@ -42,9 +40,9 @@ $discussion-meta-padding: 18px;
             .mobile-comment-count {
                 display: none;
                 color: $text-color-light;
-                margin-left: 12px;
+                margin-right: 14px;
                 @include xs-max {
-                    display: block;
+                    display: flex;
                 }
                 .cui-icon svg {
                     position: relative;
@@ -87,22 +85,21 @@ $discussion-meta-padding: 18px;
                     color: $primary-bg-color;
                 }
             }
-            .row-excerpt {
-                color: $text-color-light;
-                max-width: calc(44vw - 220px);
-                @include sm-max {
-                    max-width: calc(44vw);
-                }
-                @include xs-max {
-                    max-width: calc(100vw - 120px);
-                }
+            > .created-at {
+                display: flex;
+                margin-right: 14px;
             }
         }
     }
     .row-right {
         .discussion-row-menu {
             width: 28px;
-            padding-top: 3px;
+            position: relative;
+            top: -2px;
+            svg {
+                position: relative;
+                top: 1px;
+            }
         }
     }
 }

--- a/client/styles/shared.scss
+++ b/client/styles/shared.scss
@@ -79,12 +79,12 @@ $border-color-focus: mix($border-color, $primary-bg-color, 50%);
 
 $text-size-item-header: 19px;
 $text-size-item-meta: 17px;
-$listing-left-flex: 4;
-$listing-right-flex: 3;
+$listing-left-flex: 6;
+$listing-right-flex: 1;
 
 @mixin listing-row-base {
     display: flex;
-    padding: 15px 20px 10px;
+    padding: 16px 20px 9px;
     margin: 0 -20px;
     cursor: pointer;
     &:hover {


### PR DESCRIPTION
Moves the "upvote" to the left of the discussion row, and cleans up discussion rows in general.

This is inconsistent with how upvotes work within the thread view (where they still show as 👍 ) and it also doesn't really take into account how governance rows work, but the latter need a full design pass anyway so PR'ing this now to move faster.