### PR TITLE
Ensure thread readOnly state updates globally

### DIFF
--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -24,6 +24,7 @@ import User from 'views/components/widgets/user';
 import { getStatusClass, getStatusText, getSupportText } from 'views/components/proposal_row';
 import VersionHistoryModal from 'views/modals/version_history_modal';
 import jumpHighlightComment from 'views/pages/view_proposal/jump_to_comment';
+import { GlobalStatus } from './body';
 
 export const ProposalHeaderExternalLink: m.Component<{ proposal: AnyProposal | OffchainThread }> = {
   view: (vnode) => {
@@ -162,9 +163,12 @@ export const ProposalTitleEditor: m.Component<{ item: OffchainThread | AnyPropos
   }
 };
 
-export const ProposalHeaderPrivacyButtons: m.Component<{ proposal: AnyProposal | OffchainThread }> = {
+export const ProposalHeaderPrivacyButtons: m.Component<{
+  proposal: AnyProposal | OffchainThread,
+  getSetGlobalEditingStatus: CallableFunction
+}> = {
   view: (vnode) => {
-    const { proposal } = vnode.attrs;
+    const { proposal, getSetGlobalEditingStatus } = vnode.attrs;
     if (!proposal) return;
     if (!(proposal instanceof OffchainThread)) return;
 
@@ -176,7 +180,10 @@ export const ProposalHeaderPrivacyButtons: m.Component<{ proposal: AnyProposal |
           app.threads.setPrivacy({
             threadId: proposal.id,
             readOnly: !proposal.readOnly,
-          }).then(() => m.redraw());
+          }).then(() => {
+            getSetGlobalEditingStatus(GlobalStatus.Set, false);
+            m.redraw();
+          });
         },
         label: proposal.readOnly ? 'Unlock thread' : 'Lock thread',
       }),

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -129,7 +129,7 @@ const ProposalHeader: m.Component<{
                   }
                 }),
                 (isAuthor || isAdmin)
-                  && m(ProposalHeaderPrivacyButtons, { proposal }),
+                  && m(ProposalHeaderPrivacyButtons, { proposal, getSetGlobalEditingStatus }),
                 (isAuthor || isAdmin)
                   && m(MenuDivider),
                 m(ThreadSubscriptionButton, { proposal: proposal as OffchainThread }),


### PR DESCRIPTION
Closes #1077.

## Description

Previously, users had to refresh to see their threads locked or unlocked on the frontend. This branch ensures state updates at the wrapping ProposalHeader level.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no