### PR TITLE
Notification Pip

### DIFF
--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -349,7 +349,10 @@ const NotificationRow: m.Component<{
           notificationBody
             && category !== `${NotificationCategories.NewReaction}`
             && m('.comment-body-excerpt', notificationBody),
-          m('.comment-body-created', createdAt.twitterShort()),
+          m('.comment-body-bottom-wrap', [
+            m('.comment-body-created', createdAt.twitterShort()),
+            m('.comment-body-pip')
+          ])
         ]),
       ]);
     }

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -1,6 +1,6 @@
 import 'components/sidebar/notification_row.scss';
 
-import { Icon, Icons } from 'construct-ui';
+import { Icon, Icons, Tooltip } from 'construct-ui';
 import _ from 'lodash';
 import m from 'mithril';
 import moment from 'moment-twitter';
@@ -320,7 +320,7 @@ const NotificationRow: m.Component<{
         pageJump
       } = getBatchNotificationFields(category, notificationData);
       return m('li.NotificationRow', {
-        class: notifications[0].isRead ? '' : 'unread',
+        class: notification.isRead ? '' : 'unread',
         key: notification.id,
         id: notification.id,
         onclick: async () => {
@@ -351,7 +351,16 @@ const NotificationRow: m.Component<{
             && m('.comment-body-excerpt', notificationBody),
           m('.comment-body-bottom-wrap', [
             m('.comment-body-created', createdAt.twitterShort()),
-            m('.comment-body-pip')
+            !notification.isRead && m(Tooltip, {
+              content: m('', 'Mark as read'),
+              trigger: m('.comment-body-pip', {
+                onclick: (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  app.user.notifications.markAsRead(notifications);
+                }
+              })
+            })
           ])
         ]),
       ]);

--- a/client/styles/components/sidebar/notification_row.scss
+++ b/client/styles/components/sidebar/notification_row.scss
@@ -68,14 +68,14 @@
     }
     .comment-body-pip {
         border-radius: 50%;
-        background: #434d5a;
+        background: $background-color-dark-monochrome;
         border: none;
         height: 10px;
         width: 10px;
         margin-top: 8px;
     }
     .comment-body-pip:hover {
-        border: 1px solid #434d5a;
+        border: 1px solid $background-color-dark-monochrome;
         background: white;
     }
 }

--- a/client/styles/components/sidebar/notification_row.scss
+++ b/client/styles/components/sidebar/notification_row.scss
@@ -57,9 +57,25 @@
             text-overflow: ellipsis;
         }
     }
+    .comment-body-bottom-wrap {
+        display: flex;
+        justify-content: space-between;
+    }
     .comment-body-created {
         color: $text-color-medium;
         font-size: 15px;
         margin-top: 8px; // needed because .comment-body-excerpt may not be present
+    }
+    .comment-body-pip {
+        border-radius: 50%;
+        background: #434d5a;
+        border: none;
+        height: 10px;
+        width: 10px;
+        margin-top: 8px;
+    }
+    .comment-body-pip:hover {
+        border: 1px solid #434d5a;
+        background: white;
     }
 }


### PR DESCRIPTION
Closes #1076.

## Description

Adds a mark-as-read pip to notifications—specifically, to discussions notifications. Chain events currently have a 'X' structure where they are not just marked as read but cleared from notifications entirely. At some point, we may want consistency between these notification types for the sake of user clarity.

## How has this been tested?

I've successfully marked notifications as read, ensuring that live re-rendering and batch breaking-out happens (ie when a new thread notif is unread, it will be on its own notification row, but when marked as read, it will collapse into a larger batch notification eg '8 new threads in Edgeware'). 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no