### PR TITLE
Add stub treasury embed

### DIFF
--- a/client/scripts/controllers/chain/substrate/collective_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/collective_proposal.ts
@@ -43,12 +43,14 @@ export class SubstrateCollectiveProposal
   public get title() { return this._title; }
   public get description() { return null; }
   public get author() { return null; }
+  public get call() { return this._call; }
 
   // MEMBERS
   public canVoteFrom(account: SubstrateAccount) {
     return this._Collective.isMember(account);
   }
   private readonly _title: string;
+  private readonly _call;
   private _approved: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   private _Chain: SubstrateChain;
@@ -104,6 +106,7 @@ export class SubstrateCollectiveProposal
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
     this._Collective = Collective;
+    this._call = eventData.call;
     this._title = formatCall(eventData.call);
     this.createdAt = entity.createdAt;
 

--- a/client/scripts/controllers/chain/substrate/democracy_proposal.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposal.ts
@@ -50,6 +50,9 @@ class SubstrateDemocracyProposal extends Proposal<
   private readonly _author: SubstrateAccount;
   public get author() { return this._author; }
 
+  private _preimage;
+  public get preimage() { return this._preimage; }
+
   public readonly hash: string;
 
   public get votingType() {
@@ -143,6 +146,7 @@ class SubstrateDemocracyProposal extends Proposal<
     if (preimage) {
       this._method = preimage.method;
       this._section = preimage.section;
+      this._preimage = preimage;
       this._title = formatCall(preimage);
     } else {
       this._title = `Proposal ${formatProposalHashShort(eventData.proposalHash)}`;
@@ -182,6 +186,7 @@ class SubstrateDemocracyProposal extends Proposal<
         if (preimage) {
           this._method = preimage.method;
           this._section = preimage.section;
+          this._preimage = preimage;
           this._title = formatCall(preimage);
         }
         break;

--- a/client/scripts/controllers/chain/substrate/democracy_referendum.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_referendum.ts
@@ -127,6 +127,7 @@ export class SubstrateDemocracyReferendum
   public get title() { return this._title; }
   public get description() { return null; }
   public get author() { return null; }
+  public get preimage() { return this._preimage; }
 
   public get votingType() {
     return VotingType.ConvictionYesNoVoting;
@@ -138,6 +139,7 @@ export class SubstrateDemocracyReferendum
     return account.chainBase === ChainBase.Substrate;
   }
   private _title: string;
+  private _preimage;
   private _endBlock: number;
   public readonly hash: string;
 
@@ -205,6 +207,7 @@ export class SubstrateDemocracyReferendum
     // see if preimage exists and populate data if it does
     const preimage = this._Democracy.app.chain.chainEntities.getPreimage(eventData.proposalHash);
     if (preimage) {
+      this._preimage = preimage;
       this._title = formatCall(preimage);
     } else {
       this._title = `Referendum #${this.data.index}`;
@@ -269,6 +272,7 @@ export class SubstrateDemocracyReferendum
       case SubstrateTypes.EventKind.PreimageNoted: {
         const preimage = this._Democracy.app.chain.chainEntities.getPreimage(this.hash);
         if (preimage) {
+          this._preimage = preimage;
           this._title = formatCall(preimage);
         }
         break;

--- a/client/scripts/views/components/proposals/treasury_embed.ts
+++ b/client/scripts/views/components/proposals/treasury_embed.ts
@@ -1,0 +1,51 @@
+import 'components/proposals/treasury_embed.scss';
+
+import $ from 'jquery';
+import m from 'mithril';
+
+import { formatCoin } from 'adapters/currency';
+import { idToProposal } from 'identifiers';
+import { SubstrateDemocracyReferendum } from 'controllers/chain/substrate/democracy_referendum';
+import SubstrateDemocracyProposal from 'controllers/chain/substrate/democracy_proposal';
+import { SubstrateCollectiveProposal } from 'controllers/chain/substrate/collective_proposal';
+import { SubstrateTreasuryProposal } from 'controllers/chain/substrate/treasury_proposal';
+
+const TreasuryEmbed: m.Component<{ proposal }> = {
+  view: (vnode) => {
+    const { proposal } = vnode.attrs;
+    if (!(proposal instanceof SubstrateDemocracyProposal
+          || proposal instanceof SubstrateDemocracyReferendum
+          || proposal instanceof SubstrateCollectiveProposal)) return;
+
+    // only show TreasuryEmbed if this is a proposal that passes a treasury spend
+    let treasuryProposalIndex;
+    const call = proposal instanceof SubstrateDemocracyProposal ? proposal.preimage
+      : proposal instanceof SubstrateDemocracyReferendum ? proposal.preimage
+        : proposal instanceof SubstrateCollectiveProposal ? proposal.call : null;
+
+    if (call?.section === 'treasury' && (call.method === 'approveProposal' || call.method === 'rejectProposal')) {
+      treasuryProposalIndex = call.args[0];
+    } else {
+      return;
+    }
+
+    try {
+      const treasuryProposal = idToProposal('treasuryproposal', +treasuryProposalIndex);
+      return m('.TreasuryEmbed', [
+        m('p', [
+          m('strong', `Treasury Proposal ${treasuryProposalIndex}`),
+        ]),
+        m('p', [
+          'Awards ',
+          formatCoin(treasuryProposal.value),
+          ' to ',
+          treasuryProposal.beneficiaryAddress,
+        ]),
+      ]);
+    } catch (e) {
+      // TODO: catch error
+    }
+  }
+};
+
+export default TreasuryEmbed;

--- a/client/scripts/views/components/proposals/voting_actions.ts
+++ b/client/scripts/views/components/proposals/voting_actions.ts
@@ -135,7 +135,7 @@ const ProposalExtensions: m.Component<{ proposal, callback?, setDemocracyVoteCon
   }
 };
 
-const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, {
+const VotingActions: m.Component<{ proposal: AnyProposal }, {
   conviction: number,
   amount: number,
   votingModalOpen: boolean
@@ -616,4 +616,4 @@ const ProposalVotingActions: m.Component<{ proposal: AnyProposal }, {
   },
 };
 
-export default ProposalVotingActions;
+export default VotingActions;

--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -15,6 +15,8 @@ import { MolochProposalVote, MolochVote } from 'controllers/chain/ethereum/moloc
 import { SubstrateCollectiveVote } from 'controllers/chain/substrate/collective_proposal';
 import { SubstrateDemocracyVote } from 'controllers/chain/substrate/democracy_referendum';
 
+const COLLAPSE_VOTERS_AFTER = 6; // if there are >6 voters, collapse remaining under "Show more"
+
 const signalingVoteToString = (v: VoteOutcome): string => {
   const outcomeArray = v.toU8a();
   // cut off trailing 0s
@@ -38,7 +40,7 @@ const VoteListing: m.Component<{
       || proposal.votingUnit === VotingUnit.ConvictionCoinVote;
     const displayedVotes = vnode.state.expanded
       ? votes
-      : votes.slice(0, 3);
+      : votes.slice(0, COLLAPSE_VOTERS_AFTER);
 
     if (!vnode.state.balancesCache) vnode.state.balancesCache = {};
     if (!vnode.state.balancesCacheInitialized) vnode.state.balancesCacheInitialized = {};
@@ -119,14 +121,14 @@ const VoteListing: m.Component<{
           }
         ),
       !vnode.state.expanded
-      && votes.length > 3
+      && votes.length > COLLAPSE_VOTERS_AFTER
       && m('a.expand-listing-button', {
         href: '#',
         onclick: (e) => {
           e.preventDefault();
           vnode.state.expanded = true;
         }
-      }, `${votes.length - 3} more`)
+      }, `${votes.length - COLLAPSE_VOTERS_AFTER} more`)
     ]);
   }
 };
@@ -262,7 +264,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
       // special case for cosmos proposals in deposit stage
       return m('.ProposalVotingResults', [
         m('.results-column', [
-          m('.results-header', `Voted to approve ${proposal.depositorsAsVotes.length}`),
+          m('.results-header', `Approved ${proposal.depositorsAsVotes.length}`),
           m('.results-cell', [
             m(VoteListing, {
               proposal,
@@ -274,7 +276,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
     } else if (proposal.votingType === VotingType.SimpleYesApprovalVoting) {
       return m('.ProposalVotingResults', [
         m('.results-column', [
-          m('.results-header', `Voted to approve ${votes.length}`),
+          m('.results-header', `Approved ${votes.length}`),
           m('.results-cell', [
             m(VoteListing, {
               proposal,

--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -133,14 +133,14 @@ const VoteListing: m.Component<{
   }
 };
 
-const ProposalVotingResults: m.Component<{ proposal }> = {
+const VotingResults: m.Component<{ proposal }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
     const votes = proposal.getVotes();
 
     // TODO: fix up this function for cosmos votes
     if (proposal instanceof EdgewareSignalingProposal) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         proposal.data.choices.map((outcome) => {
           return m('.results-column', [
             m('.results-header', signalingVoteToString(outcome)),
@@ -154,7 +154,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
         }),
       ]);
     } else if (proposal.votingType === VotingType.SimpleYesNoVoting) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Voted yes (${votes.filter((v) => v.choice === true).length})`),
           m('.results-cell', [
@@ -175,7 +175,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
         ])
       ]);
     } else if (proposal.votingType === VotingType.MolochYesNo) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Voted yes (${votes.filter((v) => v.choice === MolochVote.YES).length})`),
           m('.results-cell', [
@@ -196,7 +196,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
         ])
       ]);
     } else if (proposal.votingType === VotingType.ConvictionYesNoVoting) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Voted yes (${votes.filter((v) => v.choice === true).length})`),
           m('.results-cell', [
@@ -221,7 +221,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
         ])
       ]);
     } else if (proposal.votingType === VotingType.YesNoAbstainVeto) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Voted yes (${votes.filter((v) => v.choice === CosmosVoteChoice.YES).length})`),
           m('.results-cell', [
@@ -262,7 +262,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
     } else if (proposal.votingType === VotingType.SimpleYesApprovalVoting
                && proposal instanceof CosmosProposal) {
       // special case for cosmos proposals in deposit stage
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Approved ${proposal.depositorsAsVotes.length}`),
           m('.results-cell', [
@@ -274,7 +274,7 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
         ]),
       ]);
     } else if (proposal.votingType === VotingType.SimpleYesApprovalVoting) {
-      return m('.ProposalVotingResults', [
+      return m('.VotingResults', [
         m('.results-column', [
           m('.results-header', `Approved ${votes.length}`),
           m('.results-cell', [
@@ -293,4 +293,4 @@ const ProposalVotingResults: m.Component<{ proposal }> = {
   }
 };
 
-export default ProposalVotingResults;
+export default VotingResults;

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -89,6 +89,7 @@ async function loadCmd() {
     await Promise.all([
       chain.council.init(chain.chain, chain.accounts),
       chain.signaling.init(chain.chain, chain.accounts),
+      chain.treasury.init(chain.chain, chain.accounts),
       chain.democracyProposals.init(chain.chain, chain.accounts),
       chain.democracy.init(chain.chain, chain.accounts),
     ]);

--- a/client/scripts/views/pages/referenda.ts
+++ b/client/scripts/views/pages/referenda.ts
@@ -69,6 +69,7 @@ async function loadCmd() {
   }
   const chain = (app.chain as Substrate);
   await Promise.all([
+    chain.treasury.init(chain.chain, chain.accounts),
     chain.democracy.init(chain.chain, chain.accounts),
     chain.democracyProposals.init(chain.chain, chain.accounts),
   ]);

--- a/client/scripts/views/pages/treasury.ts
+++ b/client/scripts/views/pages/treasury.ts
@@ -86,7 +86,12 @@ async function loadCmd() {
     return;
   }
   const chain = (app.chain as Substrate);
-  await chain.treasury.init(chain.chain, chain.accounts);
+  await Promise.all([
+    chain.council.init(chain.chain, chain.accounts),
+    chain.treasury.init(chain.chain, chain.accounts),
+    chain.democracyProposals.init(chain.chain, chain.accounts),
+    chain.democracy.init(chain.chain, chain.accounts),
+  ]);
 }
 
 const TreasuryPage: m.Component<{}> = {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -32,6 +32,7 @@ import {
 } from 'views/pages/discussions/discussion_row_menu';
 import ProposalVotingActions from 'views/components/proposals/voting_actions';
 import ProposalVotingResults from 'views/components/proposals/voting_results';
+import ProposalVotingTreasuryEmbed from 'views/components/proposals/treasury_embed';
 import PageLoading from 'views/pages/loading';
 import PageNotFound from 'views/pages/404';
 
@@ -724,6 +725,8 @@ const ViewProposalPage: m.Component<{
         getSetGlobalEditingStatus,
         getSetGlobalReplyStatus
       }),
+      !(proposal instanceof OffchainThread)
+        && m(ProposalVotingTreasuryEmbed, { proposal }),
       !(proposal instanceof OffchainThread)
         && m(ProposalVotingResults, { proposal }),
       !(proposal instanceof OffchainThread)

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -10,6 +10,7 @@ import Sublayout from 'views/sublayout';
 import { idToProposal, ProposalType, proposalSlugToClass } from 'identifiers';
 import { slugify, isSameAccount } from 'helpers';
 
+import Substrate from 'controllers/chain/substrate/main';
 import { notifyError } from 'controllers/app/notifications';
 import { CommentParent } from 'controllers/server/comments';
 import {
@@ -462,10 +463,14 @@ async function loadCmd(type: string) {
   if (app.chain.base !== ChainBase.Substrate) {
     return;
   }
-  const c = proposalSlugToClass().get(type);
-  if (c && c instanceof ProposalModule && !c.disabled) {
-    await c.init(app.chain.chain, app.chain.accounts);
-  }
+  const chain = app.chain as Substrate;
+  await Promise.all([
+    chain.council.init(chain.chain, chain.accounts),
+    chain.signaling.init(chain.chain, chain.accounts),
+    chain.treasury.init(chain.chain, chain.accounts),
+    chain.democracyProposals.init(chain.chain, chain.accounts),
+    chain.democracy.init(chain.chain, chain.accounts),
+  ]);
 }
 
 const ViewProposalPage: m.Component<{

--- a/client/styles/components/proposals/treasury_embed.scss
+++ b/client/styles/components/proposals/treasury_embed.scss
@@ -1,0 +1,9 @@
+@import 'client/styles/shared';
+
+.TreasuryEmbed {
+    display: flex;
+    background-color: $background-color-light;
+    margin-top: 25px;
+    padding: 20px;
+    border-radius: 3px;
+}

--- a/client/styles/components/proposals/treasury_embed.scss
+++ b/client/styles/components/proposals/treasury_embed.scss
@@ -1,9 +1,11 @@
 @import 'client/styles/shared';
 
 .TreasuryEmbed {
-    display: flex;
     background-color: $background-color-light;
     margin-top: 25px;
-    padding: 20px;
+    padding: 12px 20px 6px;
     border-radius: 3px;
+    p {
+        margin: 10px 0;
+    }
 }

--- a/client/styles/components/proposals/voting_results.scss
+++ b/client/styles/components/proposals/voting_results.scss
@@ -1,6 +1,6 @@
 @import 'client/styles/shared';
 
-.ProposalVotingResults {
+.VotingResults {
     display: flex;
     background-color: $background-color-light;
     margin-top: 25px;


### PR DESCRIPTION
Adds a component that shows treasury proposals on approving council motions & democracy proposals/referenda.

Needs more work to fully communicate that this is a child unit inside a parent unit, and to show the treasury proposal's associated title / comments.