### PR TITLE
Add polkadot magic support.

### DIFF
--- a/client/scripts/controllers/app/login.ts
+++ b/client/scripts/controllers/app/login.ts
@@ -7,6 +7,7 @@ import { isSameAccount } from 'helpers';
 
 import { initAppState } from 'app';
 import { Magic } from 'magic-sdk';
+import { PolkadotExtension } from '@magic-ext/polkadot';
 
 import {
   ChainInfo,
@@ -240,7 +241,16 @@ export async function unlinkLogin(account) {
 const MAGIC_PUBLISHABLE_KEY = 'pk_test_436D33AFC319E080';
 
 export async function loginWithMagicLink(email: string) {
-  const magic = new Magic(MAGIC_PUBLISHABLE_KEY);
+  const polkadotUrl = app.chain?.base === ChainBase.Substrate && app.chain.meta.url;
+  const magic = new Magic(MAGIC_PUBLISHABLE_KEY, polkadotUrl
+    ? {
+      extensions: [
+        new PolkadotExtension({
+          rpcUrl: polkadotUrl,
+        })
+      ]
+    }
+    : {});
   const didToken = await magic.auth.loginWithMagicLink({ email });
   const response = await $.post({
     url: `${app.serverUrl()}/auth/magic`,

--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -27,11 +27,11 @@ class ChainInfo {
 
   constructor(
     id, network, symbol, name, iconUrl, description, website, discord, element, telegram, github,
-    blockExplorerIds, collapsedOnHomepage, featuredTopics, topics, adminsAndMods?
+    blockExplorerIds, collapsedOnHomepage, featuredTopics, topics, adminsAndMods?, base?
   ) {
     this.id = id;
     this.network = network;
-    this.base = networkToBase(network);
+    this.base = base || networkToBase(network);
     this.symbol = symbol;
     this.name = name;
     this.iconUrl = iconUrl;
@@ -72,6 +72,7 @@ class ChainInfo {
       json.featured_topics,
       json.topics,
       json.adminsAndMods,
+      json.base,
     );
   }
 

--- a/client/scripts/views/pages/admin.ts
+++ b/client/scripts/views/pages/admin.ts
@@ -34,7 +34,7 @@ interface IChainManagerState {
 
 const ChainManager: m.Component<IChainManagerAttrs, IChainManagerState> = {
   view: (vnode) => {
-    const nodeRows = (chain) => (app.config.nodes.getByChain(chain.id) || [])
+    const nodeRows = (chain: ChainInfo) => (app.config.nodes.getByChain(chain.id) || [])
       .map((node, nodeIndex) => {
         return m('li.chain-node', [
           m('span', node.url),
@@ -70,7 +70,7 @@ const ChainManager: m.Component<IChainManagerAttrs, IChainManagerState> = {
         ]);
       });
 
-    const addNodeRow = (chain) => m('li', [
+    const addNodeRow = (chain: ChainInfo) => m('li', [
       m('a', {
         href: '#',
         onclick: (e) => {
@@ -81,11 +81,13 @@ const ChainManager: m.Component<IChainManagerAttrs, IChainManagerState> = {
           vnode.attrs.error = null;
           const url = prompt('Enter the node url:');
           // TODO: Change to POST /chainNode
+          // TODO: add ss58_prefix for substrate chains
           $.post(`${app.serverUrl()}/addChainNode`, {
             id: chain.id,
             name: chain.name,
             symbol: chain.symbol,
             network: chain.network,
+            base: chain.base,
             node_url: url,
             auth: true,
             jwt: app.user.jwt,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@edgeware/node-types": "3.3.1-newyork.0",
     "@lunie/cosmos-api": "git+https://git@github.com/hicommonwealth/cosmos-api.git#develop",
     "@lunie/cosmos-keys": "^0.3.2",
+    "@magic-ext/polkadot": "^0.1.2",
     "@magic-sdk/admin": "^1.3.0",
     "@openzeppelin/contracts": "^2.4.0",
     "@plasm/types": "^1.3.0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,5 +54,5 @@ export const MIXPANEL_TOKEN = process.env.MIXPANEL_TOKEN;
 export const INFURA_API_KEY = process.env.INFURA_API_KEY;
 
 export const MAGIC_API_KEY = process.env.MAGIC_API_KEY;
-export const MAGIC_SUPPORTED_CHAINS = process.env.MAGIC_SUPPORTED_CHAINS?.split(',') || ['ethereum'];
+export const MAGIC_SUPPORTED_CHAINS = process.env.MAGIC_SUPPORTED_CHAINS?.split(',') || ['edgeware', 'ethereum'];
 export const MAGIC_DEFAULT_CHAIN = MAGIC_SUPPORTED_CHAINS[0];

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,5 +54,5 @@ export const MIXPANEL_TOKEN = process.env.MIXPANEL_TOKEN;
 export const INFURA_API_KEY = process.env.INFURA_API_KEY;
 
 export const MAGIC_API_KEY = process.env.MAGIC_API_KEY;
-export const MAGIC_SUPPORTED_CHAINS = process.env.MAGIC_SUPPORTED_CHAINS?.split(',') || ['edgeware', 'ethereum'];
-export const MAGIC_DEFAULT_CHAIN = MAGIC_SUPPORTED_CHAINS[0];
+export const MAGIC_SUPPORTED_BASES = process.env.MAGIC_SUPPORTED_BASES?.split(',') || ['ethereum', 'substrate'];
+export const MAGIC_DEFAULT_CHAIN = process.env.MAGIC_DEFAULT_CHAIN || 'ethereum';

--- a/server/migrations/20210217161948-add-chain-base-and-ss58-prefix.js
+++ b/server/migrations/20210217161948-add-chain-base-and-ss58-prefix.js
@@ -1,0 +1,83 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'Chains', 'base',
+        { type: Sequelize.STRING, allowNull: false, defaultValue: '', },
+        { transaction: t },
+      );
+      await queryInterface.addColumn(
+        'Chains', 'ss58_prefix',
+        { type: Sequelize.INTEGER, allowNull: true, },
+        { transaction: t },
+      );
+
+      // populate columns for all extant chains
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'ethereum' },
+        { id: 'ethereum', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 7 },
+        { id: 'edgeware-testnet', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 36 },
+        { id: 'centrifuge', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 16 },
+        { id: 'kulupu', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 2 },
+        { id: 'kusama', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 5 },
+        { id: 'plasm', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'ethereum' },
+        { id: 'metacartel', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 30 },
+        { id: 'phala', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 0 },
+        { id: 'polkadot', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'near' },
+        { id: 'near', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'cosmos' },
+        { id: 'straightedge', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 7 },
+        { id: 'edgeware', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 18 },
+        { id: 'darwinia', },
+        { transaction: t, });
+      await queryInterface.bulkUpdate('Chains',
+        { base: 'substrate', ss58_prefix: 20 },
+        { id: 'stafi', },
+        { transaction: t, });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('Chains', 'base', { transaction: t });
+      await queryInterface.removeColumn('Chains', 'ss58_prefix', { transaction: t });
+    });
+  }
+};

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -20,6 +20,8 @@ export interface ChainAttributes {
   featured_topics: string[];
   symbol: string;
   network: string;
+  base: string;
+  ss58_prefix?: number;
   icon_url: string;
   blockExplorerIds: string;
   collapsed_on_homepage: boolean;
@@ -62,6 +64,8 @@ export default (
     featured_topics: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
     symbol: { type: dataTypes.STRING, allowNull: false },
     network: { type: dataTypes.STRING, allowNull: false },
+    base: { type: dataTypes.STRING, allowNull: false, defaultValue: '' },
+    ss58_prefix: { type: dataTypes.INTEGER, allowNull: true },
     icon_url: { type: dataTypes.STRING },
     active: { type: dataTypes.BOOLEAN },
     blockExplorerIds: { type: dataTypes.STRING, allowNull: true, },

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -1,7 +1,7 @@
 import * as Sequelize from 'sequelize';
 
 import { AddressAttributes } from './address';
-import { ChainAttributes } from './chain';
+import { ChainAttributes, ChainInstance } from './chain';
 import { StarredCommunityAttributes } from './starred_community';
 import { OffchainTopicAttributes } from './offchain_topic';
 import { OffchainThreadAttributes } from './offchain_thread';

--- a/server/passport.ts
+++ b/server/passport.ts
@@ -4,6 +4,8 @@ import passportJWT from 'passport-jwt';
 import { Request } from 'express';
 import request from 'superagent';
 
+import { encodeAddress } from '@polkadot/util-crypto';
+
 import { Magic, MagicUserMetadata } from '@magic-sdk/admin';
 import { Strategy as MagicStrategy } from 'passport-magic';
 
@@ -13,7 +15,7 @@ const log = factory.getLogger(formatFilename(__filename));
 
 
 import {
-  JWT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_CALLBACK, MAGIC_API_KEY, MAGIC_SUPPORTED_CHAINS,
+  JWT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_CALLBACK, MAGIC_API_KEY, MAGIC_SUPPORTED_BASES,
   MAGIC_DEFAULT_CHAIN
 } from './config';
 import { NotificationCategories } from '../shared/types';
@@ -56,8 +58,13 @@ function setupPassport(models) {
       if (req.body.chain || req.body.community) {
         [ chain, community ] = await lookupCommunityIsVisibleToUser(models, req.body, req.user, cb);
       }
-      const registrationChain: string = chain ? chain.id : community?.default_chain
-        ? community?.default_chain : MAGIC_DEFAULT_CHAIN;
+      let registrationChain;
+      if (chain?.id) {
+        registrationChain = chain;
+      } else {
+        const chainId = community?.default_chain || MAGIC_DEFAULT_CHAIN;
+        registrationChain = await models.Chain.findOne({ where: { id: chainId } });
+      }
 
       // fetch user data from magic backend
       let userMetadata: MagicUserMetadata;
@@ -80,33 +87,38 @@ function setupPassport(models) {
       });
 
       // unsupported chain -- client should send through old email flow
-      if (!existingUser && (!registrationChain || !MAGIC_SUPPORTED_CHAINS.includes(registrationChain))) {
+      if (!existingUser && (!registrationChain?.base || !MAGIC_SUPPORTED_BASES.includes(registrationChain.base))) {
         return cb(new Error('Unsupported magic chain.'));
       }
 
-      // ensure all eth addresses are lowercase
-      let address = userMetadata.publicAddress.toLowerCase();
-
-      // if on polkadot chain, retrieve the address for the user
-      console.log(userMetadata.publicAddress);
-      if (registrationChain === 'edgeware') {
-        try {
-          const polkadotResp = await request
-            // eslint-disable-next-line max-len
-            .get(`https://api.magic.link/v1/admin/auth/user/public/address/get?issuer=did:ethr:${userMetadata.publicAddress}`)
-            .set('X-Magic-Secret-key', MAGIC_API_KEY)
-            .accept('json');
-          if (polkadotResp.body?.status !== 'ok') {
-            throw new Error(polkadotResp.body?.message || 'Failed to fetch polkadot address');
-          }
-          // TODO: convert this to different SS58 format?
-          address = polkadotResp.body?.data?.public_address;
-        } catch (err) {
-          return cb(new Error(err.message));
-        }
-      }
-      console.log(`Received magic address: ${address}.`);
       if (!existingUser) {
+        // ensure all eth addresses are lowercase
+        let address = userMetadata.publicAddress.toLowerCase();
+
+        // if on polkadot chain, retrieve the address for the user
+        if (registrationChain.base === 'substrate') {
+          try {
+            const polkadotResp = await request
+              // eslint-disable-next-line max-len
+              .get(`https://api.magic.link/v1/admin/auth/user/public/address/get?issuer=did:ethr:${userMetadata.publicAddress}`)
+              .set('X-Magic-Secret-key', MAGIC_API_KEY)
+              .accept('json');
+            if (polkadotResp.body?.status !== 'ok') {
+              throw new Error(polkadotResp.body?.message || 'Failed to fetch polkadot address');
+            }
+            const polkadotAddress = polkadotResp.body?.data?.public_address;
+
+            // convert to chain-specific address based on ss58 prefix
+            if (registrationChain.ss58_prefix) {
+              address = encodeAddress(polkadotAddress, registrationChain.ss58_prefix);
+            } else {
+              address = polkadotAddress;
+            }
+          } catch (err) {
+            return cb(new Error(err.message));
+          }
+        }
+
         const result = await sequelize.transaction(async (t) => {
           // create new user and unverified address if doesn't exist
           const newUser = await models.User.create({
@@ -119,7 +131,7 @@ function setupPassport(models) {
           // TODO: use non-default chain in certain cases?
           const newAddress = await models.Address.create({
             address,
-            chain: registrationChain,
+            chain: registrationChain.id,
             verification_token: 'MAGIC',
             verification_token_expires: null,
             verified: new Date(), // trust addresses from magic
@@ -156,7 +168,6 @@ function setupPassport(models) {
 
           return newUser;
         });
-        console.log(`Created user: ${JSON.stringify(result)}`);
 
         // re-fetch user to include address object
         // TODO: simplify this without doing a refetch

--- a/server/routes/addChainNode.ts
+++ b/server/routes/addChainNode.ts
@@ -20,7 +20,7 @@ const addChainNode = async (models, req: Request, res: Response, next: NextFunct
   if (!req.user.isAdmin) {
     return next(new Error(Errors.MustBeAdmin));
   }
-  if (!req.body.id || !req.body.name || !req.body.symbol || !req.body.network || !req.body.node_url) {
+  if (!req.body.id || !req.body.name || !req.body.symbol || !req.body.network || !req.body.node_url || !req.body.base) {
     return next(new Error(Errors.MissingParams));
   }
 
@@ -47,6 +47,7 @@ const addChainNode = async (models, req: Request, res: Response, next: NextFunct
       network: req.body.network,
       icon_url: req.body.icon_url,
       active: true,
+      base: req.body.base,
     });
   }
 

--- a/server/routes/startEmailLogin.ts
+++ b/server/routes/startEmailLogin.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Request, Response, NextFunction } from 'express';
 import {
-  SERVER_URL, SENDGRID_API_KEY, LOGIN_RATE_LIMIT_MINS, LOGIN_RATE_LIMIT_TRIES, MAGIC_SUPPORTED_CHAINS,
+  SERVER_URL, SENDGRID_API_KEY, LOGIN_RATE_LIMIT_MINS, LOGIN_RATE_LIMIT_TRIES, MAGIC_SUPPORTED_BASES,
   MAGIC_DEFAULT_CHAIN
 } from '../config';
 import { factory, formatFilename } from '../../shared/logging';
@@ -45,11 +45,18 @@ const startEmailLogin = async (models, req: Request, res: Response, next: NextFu
     log.warn(`Could not look up chain/community for login email ${email}: ${err.message}`);
     return [ null, null ];
   });
-  const magicChain: string = chain ? chain.id : community ? community.default_chain : MAGIC_DEFAULT_CHAIN;
+  let magicChain;
+  if (chain?.id) {
+    magicChain = chain;
+  } else {
+    const chainId = community?.default_chain || MAGIC_DEFAULT_CHAIN;
+    magicChain = await models.Chain.findOne({ where: { id: chainId } });
+  }
+
   const isNewRegistration = !previousUser;
   const isExistingMagicUser = previousUser && !!previousUser.lastMagicLoginAt;
   if (isExistingMagicUser // existing magic users should always use magic login, even if they're in the wrong community
-      || (isNewRegistration && magicChain && MAGIC_SUPPORTED_CHAINS.includes(magicChain)
+      || (isNewRegistration && magicChain?.base && MAGIC_SUPPORTED_BASES.includes(magicChain.base)
           && !req.body.forceEmailLogin)) {
     return res.json({
       status: 'Success',

--- a/server/routes/startEmailLogin.ts
+++ b/server/routes/startEmailLogin.ts
@@ -41,8 +41,10 @@ const startEmailLogin = async (models, req: Request, res: Response, next: NextFu
   // check whether to recommend magic.link registration instead
   // 1. user should not already exist
   // 2. chain or community default chain should be "supported"
+  //
+  // ignore error because someone might try to log in from the homepage, or another page without
+  // chain or community
   const [ chain, community, error ] = await lookupCommunityIsVisibleToUser(models, req.body, req.user);
-  if (error) return next(new Error(error));
 
   let magicChain;
   if (chain?.id) {

--- a/server/scripts/resetServer.ts
+++ b/server/scripts/resetServer.ts
@@ -88,6 +88,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/edg.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 7,
         }),
         models.Chain.create({
           id: 'edgeware-testnet',
@@ -97,6 +99,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/edg.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 7,
         }),
         models.Chain.create({
           id: 'edgeware',
@@ -106,6 +110,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/edg.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 7,
         }),
         models.Chain.create({
           id: 'kusama-local',
@@ -115,6 +121,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/ksm.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 42,
         }),
         models.Chain.create({
           id: 'kusama',
@@ -124,6 +132,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/ksm.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 2,
         }),
         models.Chain.create({
           id: 'polkadot-local',
@@ -133,6 +143,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/dot.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 42,
         }),
         models.Chain.create({
           id: 'polkadot',
@@ -142,6 +154,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/dot.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 0,
         }),
         models.Chain.create({
           id: 'kulupu',
@@ -151,6 +165,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/klp.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 16,
         }),
         models.Chain.create({
           id: 'plasm',
@@ -160,6 +176,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/plm.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 5,
         }),
         models.Chain.create({
           id: 'stafi',
@@ -169,6 +187,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/fis.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 20,
         }),
         models.Chain.create({
           id: 'darwinia',
@@ -178,6 +198,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/ring.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 18,
         }),
         models.Chain.create({
           id: 'phala',
@@ -187,6 +209,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/pha.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 30,
         }),
         models.Chain.create({
           id: 'centrifuge',
@@ -196,6 +220,8 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/cennz.png',
           active: true,
           type: 'chain',
+          base: 'substrate',
+          ss58_prefix: 36,
         }),
         models.Chain.create({
           id: 'cosmos-local',
@@ -205,6 +231,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/atom.png',
           active: true,
           type: 'chain',
+          base: 'cosmos',
         }),
         models.Chain.create({
           id: 'cosmos-testnet',
@@ -214,6 +241,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/atom.png',
           active: true,
           type: 'chain',
+          base: 'cosmos',
         }),
         models.Chain.create({
           id: 'cosmos',
@@ -223,6 +251,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/atom.png',
           active: true,
           type: 'chain',
+          base: 'cosmos',
         }),
         // models.Chain.create({
         //   id: 'ethereum-ropsten',
@@ -232,6 +261,7 @@ const resetServer = (models): Promise<number> => {
         //   icon_url: '/static/img/protocols/eth.png',
         //   active: false,
         //   type: 'chain',
+        //   base: 'ethereum',
         // }),
         models.Chain.create({
           id: 'ethereum-local',
@@ -241,6 +271,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/eth.png',
           active: true,
           type: 'chain',
+          base: 'ethereum',
         }),
         models.Chain.create({
           id: 'ethereum',
@@ -250,6 +281,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/eth.png',
           active: true,
           type: 'chain',
+          base: 'ethereum',
         }),
         models.Chain.create({
           id: 'near-local',
@@ -259,6 +291,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/near.png',
           active: true,
           type: 'chain',
+          base: 'near',
         }),
         models.Chain.create({
           id: 'near',
@@ -268,6 +301,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/near.png',
           active: true,
           type: 'chain',
+          base: 'near',
         }),
         models.Chain.create({
           id: 'moloch',
@@ -277,6 +311,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/molochdao.png',
           active: true,
           type: 'dao',
+          base: 'ethereum',
         }),
         // This is the same exact as Moloch, but I want to show the picture on the front end
         models.Chain.create({
@@ -287,6 +322,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/metacartel.png',
           active: true,
           type: 'dao',
+          base: 'ethereum',
         }),
         models.Chain.create({
           id: 'moloch-local',
@@ -296,6 +332,7 @@ const resetServer = (models): Promise<number> => {
           icon_url: '/static/img/protocols/molochdao.png',
           active: true,
           type: 'dao',
+          base: 'ethereum',
         }),
       ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,11 @@
     bip39 "^3.0.2"
     crypto-js "^4.0.0"
 
+"@magic-ext/polkadot@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@magic-ext/polkadot/-/polkadot-0.1.2.tgz#e59653bdbeb9660519b64f84e36b7ce23df0ee0f"
+  integrity sha512-YrZ9uDCY+UtUBs4T9hxjDm9przDqIGIutqlZUFEclFihi1x/h5ZWSz4h++oVicKRWRmP0nzsFeXkUlTCD5+SjQ==
+
 "@magic-sdk/admin@^0.1.0-beta.8":
   version "0.1.0-beta.10"
   resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-0.1.0-beta.10.tgz#06986660303721cd69933193098152ddea424f05"


### PR DESCRIPTION
## Description
- Adds support for the polkadot magic extension on the client.
- Adds support on the backend for polkadot magic registration, using the HTTP route provided by the magic team.
- Adds the `base` and `ss58_prefix` columns to the `Users` table and corresponding migration.
- Changed `MAGIC_SUPPORTED_CHAINS` to `MAGIC_SUPPORTED_BASES`.

## Open Questions
- Why were we ignoring errors from chain/community lookup in `startEmailLogin`?
- Is it essential for the admin page to have an ss58 input field when adding a new chain, before we deploy this?

## How has this been tested?
Ran a bunch and tested on client.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run tests