### PR TITLE
Ensure New Proposal Form dropdowns render

### DIFF
--- a/client/styles/pages/new_proposal_page.scss
+++ b/client/styles/pages/new_proposal_page.scss
@@ -21,4 +21,7 @@
         margin-bottom: 22px;
         color: $text-color-light;
     }
+    .cui-overlay-inline {
+        display: block;
+    }
 }


### PR DESCRIPTION
Per report in #bugs, the New Proposal Form module, motion, & system dropdowns were not rendering on account of a global Construct `display: inline` style. This overwrites that style for all proposal forms.