### PR TITLE
Always generate both an eth and substrate address on magic login.

### DIFF
--- a/client/scripts/controllers/app/login.ts
+++ b/client/scripts/controllers/app/login.ts
@@ -240,16 +240,13 @@ export async function unlinkLogin(account) {
 }
 
 export async function loginWithMagicLink(email: string) {
-  const polkadotUrl = app.chain?.base === ChainBase.Substrate && app.chain.meta.url;
-  const magic = new Magic(MAGIC_PUBLISHABLE_KEY, polkadotUrl
-    ? {
-      extensions: [
-        new PolkadotExtension({
-          rpcUrl: polkadotUrl,
-        })
-      ]
-    }
-    : {});
+  const magic = new Magic(MAGIC_PUBLISHABLE_KEY, { extensions: [
+    new PolkadotExtension({
+      // we don't need a real node URL because we're only generating an address,
+      // not doing anything requiring chain connection
+      rpcUrl: '',
+    })
+  ] });
   const didToken = await magic.auth.loginWithMagicLink({ email });
   const response = await $.post({
     url: `${app.serverUrl()}/auth/magic`,

--- a/client/scripts/controllers/app/login.ts
+++ b/client/scripts/controllers/app/login.ts
@@ -244,7 +244,7 @@ export async function loginWithMagicLink(email: string) {
     new PolkadotExtension({
       // we don't need a real node URL because we're only generating an address,
       // not doing anything requiring chain connection
-      rpcUrl: '',
+      rpcUrl: 'ws://localhost:9944',
     })
   ] });
   const didToken = await magic.auth.loginWithMagicLink({ email });

--- a/server/passport.ts
+++ b/server/passport.ts
@@ -190,7 +190,7 @@ function setupPassport(models) {
               address_id: edgewareAddressInstance.id,
               chain_id: 'edgeware',
               permission: 'member',
-            });
+            }, { transaction: t });
           }
 
           if (req.body.chain || req.body.community) await models.Role.create(req.body.community ? {


### PR DESCRIPTION
## Description
Now we will always generate an edgeware (or other substrate) and an ethereum address for users who create their accounts with magic link. Automatically adds each to the corresponding roles.

## How has this been tested?
Ran and verified both cases (substrate and non substrate chain/community).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no