### PR TITLE
Auto-create ChainEventTypes.

### DIFF
--- a/server/eventHandlers/storage.ts
+++ b/server/eventHandlers/storage.ts
@@ -40,16 +40,23 @@ export default class extends IEventHandler {
       return;
     }
 
-    // locate event type and add event to database
-    const dbEventType = await this._models.ChainEventType.findOne({ where: {
-      chain: this._chain,
-      event_name: event.data.kind.toString(),
-    } });
+    // locate event type and add event (and event type if needed) to database
+    const [ dbEventType, created ] = await this._models.ChainEventType.findOrCreate({
+      where: {
+        id: `${this._chain}-${event.data.kind.toString()}`,
+        chain: this._chain,
+        event_name: event.data.kind.toString(),
+      }
+    });
     if (!dbEventType) {
       log.error(`unknown event type: ${event.data.kind}`);
       return;
     } else {
-      log.trace(`found chain event type: ${dbEventType.id}`);
+      if (created) {
+        log.info(`Created new ChainEventType: ${dbEventType.id}`);
+      } else {
+        log.trace(`found chain event type: ${dbEventType.id}`);
+      }
     }
 
     // create event in db


### PR DESCRIPTION
## Description
Storage event handler auto-creates ChainEventTypes which we have not yet seen.

## Motivation and Context
Currently, if we add new chains or events to the ChainEvents project, we require a manual migration in order to start saving them to the database. This PR should remove any need for that migration, only new risk being that "invalid" chain events will also trigger the creation of new database objects. However this should never be a concern since we manage the entire list of events emitted by ChainEvents.

## How has this been tested?
Modified a unit test to ensure the new case works properly.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no