### PR TITLE
Auto-disable Substrate modules and cleanup view module loading.

### DIFF
--- a/client/scripts/controllers/chain/centrifuge/main.ts
+++ b/client/scripts/controllers/chain/centrifuge/main.ts
@@ -6,9 +6,6 @@ import Substrate from '../substrate/main';
 class Centrifuge extends Substrate {
   constructor(n: NodeInfo, app: IApp) {
     super(n, app, ChainClass.Centrifuge);
-
-    this.treasury.disable();
-    this.technicalCommittee.disable();
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/darwinia/main.ts
+++ b/client/scripts/controllers/chain/darwinia/main.ts
@@ -7,10 +7,6 @@ import Substrate from '../substrate/main';
 class Darwinia extends Substrate {
   constructor(n: NodeInfo, app: IApp) {
     super(n, app, ChainClass.Darwinia);
-
-    this.phragmenElections.disable();
-    this.democracyProposals.disable();
-    this.democracy.disable();
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/edgeware/main.ts
+++ b/client/scripts/controllers/chain/edgeware/main.ts
@@ -6,8 +6,6 @@ import Substrate from '../substrate/main';
 class Edgeware extends Substrate {
   constructor(n: NodeInfo, app: IApp) {
     super(n, app, ChainClass.Edgeware);
-
-    this.technicalCommittee.disable();
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/plasm/main.ts
+++ b/client/scripts/controllers/chain/plasm/main.ts
@@ -7,15 +7,6 @@ import Substrate from '../substrate/main';
 class Plasm extends Substrate {
   constructor(n: NodeInfo, app: IApp) {
     super(n, app, ChainClass.Plasm);
-
-    // disable all governance modules
-    this.phragmenElections.disable();
-    this.council.disable();
-    this.technicalCommittee.disable();
-    this.democracyProposals.disable();
-    this.democracy.disable();
-    this.treasury.disable();
-    this.identities.disable();
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/stafi/main.ts
+++ b/client/scripts/controllers/chain/stafi/main.ts
@@ -5,7 +5,7 @@ import Substrate from '../substrate/main';
 
 class Stafi extends Substrate {
   constructor(n: NodeInfo, app: IApp) {
-    super(n, app, ChainClass.Polkadot);
+    super(n, app, ChainClass.Stafi);
   }
 
   public async initApi() {

--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -29,6 +29,7 @@ class SubstrateCollective extends ProposalModule<
 
   // TODO: we may want to track membership here as well as in elections
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query[this.moduleName];
     if (this._initializing || this._initialized || this.disabled) return;
     this._initializing = true;
     this._Chain = ChainInfo;

--- a/client/scripts/controllers/chain/substrate/democracy.ts
+++ b/client/scripts/controllers/chain/substrate/democracy.ts
@@ -37,6 +37,7 @@ class SubstrateDemocracy extends ProposalModule<
 
   // Loads all proposals and referendums currently present in the democracy module
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query.democracy;
     if (this._initializing || this._initialized || this.disabled) return;
     this._initializing = true;
     this._Chain = ChainInfo;

--- a/client/scripts/controllers/chain/substrate/democracy_proposals.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposals.ts
@@ -49,6 +49,7 @@ class SubstrateDemocracyProposals extends ProposalModule<
 
   // Loads all proposals and referendums currently present in the democracy module
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query.democracy;
     if (this._initializing || this._initialized || this.disabled) return;
     this._initializing = true;
     this._Chain = ChainInfo;

--- a/client/scripts/controllers/chain/substrate/identities.ts
+++ b/client/scripts/controllers/chain/substrate/identities.ts
@@ -95,6 +95,7 @@ class SubstrateIdentities implements StorageModule {
   }
 
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query.identity;
     if (this._initializing || this._initialized || this.disabled) return;
     this._initializing = true;
 

--- a/client/scripts/controllers/chain/substrate/phragmen_elections.ts
+++ b/client/scripts/controllers/chain/substrate/phragmen_elections.ts
@@ -49,6 +49,7 @@ class SubstratePhragmenElections extends ProposalModule<
   private _Accounts: SubstrateAccounts;
 
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query.elections;
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
 

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -55,6 +55,7 @@ class SubstrateTreasury extends ProposalModule<
   }
 
   public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+    this._disabled = !ChainInfo.api.query.treasury;
     if (this._initializing || this._initialized || this.disabled) return;
     this._initializing = true;
     this._Chain = ChainInfo;

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -1,7 +1,6 @@
 import moment from 'moment-twitter';
 import { ApiStatus, IApp } from 'state';
 import { Coin } from 'adapters/currency';
-import { WebsocketMessageType, IWebsocketsPayload } from 'types';
 import { clearLocalStorage } from 'stores/PersistentStore';
 import $ from 'jquery';
 import m from 'mithril';
@@ -10,7 +9,7 @@ import { CommentRefreshOption } from 'controllers/server/comments';
 import ChainEntityController, { EntityRefreshOption } from 'controllers/server/chain_entities';
 import { IChainModule, IAccountsModule, IBlockInfo } from './interfaces';
 import { ChainBase, ChainClass } from './types';
-import { Account, NodeInfo, ChainEntity, ChainEvent } from '.';
+import { Account, NodeInfo, ProposalModule } from '.';
 
 // Extended by a chain's main implementation. Responsible for module
 // initialization. Saved as `app.chain` in the global object store.
@@ -114,6 +113,16 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     this.app.isModuleReady = false;
     this._loaded = false;
     console.log(`Stopping ${this.meta.chain.id}...`);
+  }
+
+  public async loadModules(modules: ProposalModule<any, any, any>[]) {
+    if (!this.loaded) {
+      throw new Error('secondary loading cmd called before chain load');
+    }
+    // TODO: does this need debouncing?
+    if (modules.some((mod) => !mod.initializing && !mod.ready)) {
+      await Promise.all(modules.map((mod) => mod.init(this.chain, this.accounts)));
+    }
   }
 
   public abstract base: ChainBase;

--- a/client/scripts/models/ProposalModule.ts
+++ b/client/scripts/models/ProposalModule.ts
@@ -51,7 +51,30 @@ export abstract class ProposalModule<
     this._app = app;
   }
 
-  public abstract init(chain: IChainModule<any, any>, accounts: IAccountsModule<any, any>): Promise<void>;
+  /* `init()` MUST do the following:
+    - set `this._initializing` to true while in progress, false before returning
+    - set `this._initialized` to true before returning
+    - set itself to disabled if the functionality is unavailable on the active chain
+    - guard against multiple calls by returning immediately if initializing/initialized/ready
+    - an example:
+        (note that it's safe for multiple calls because JS threads will not yield until `return`)
+    ```
+      public async init(ChainInfo: SubstrateChain, Accounts: SubstrateAccounts): Promise<void> {
+        this._disabled = !ChainInfo.api.query.democracy;
+        if (this._initializing || this._initialized || this.disabled) return;
+        this._initializing = true;
+        this._Chain = ChainInfo;
+        this._Accounts = Accounts;
+
+        .....perform initialization.....
+
+        this._initialized = true;
+        this._initializing = false;
+      }
+    ```
+    TODO: create a helper function that encapsulates this boilerplate
+  */
+  public abstract init(ChainInfo: IChainModule<any, any>, Accounts: IAccountsModule<any, any>): Promise<void>;
 
   public deinit() {
     this._initialized = false;

--- a/client/scripts/models/ProposalModule.ts
+++ b/client/scripts/models/ProposalModule.ts
@@ -24,6 +24,7 @@ export abstract class ProposalModule<
   public get initializing() { return this._initializing; }
   protected _initialized: boolean = false;
   public get initialized() { return this._initialized; }
+  public get ready() { return this._initialized || this._disabled; }
 
   private _app: IApp;
   public get app() { return this._app; }

--- a/client/scripts/views/pages/new_proposal/index.ts
+++ b/client/scripts/views/pages/new_proposal/index.ts
@@ -10,19 +10,6 @@ import { ProposalType, proposalSlugToClass, proposalSlugToFriendlyName } from 'i
 import { ChainBase, ProposalModule } from 'models';
 import NewProposalForm from 'views/pages/new_proposal/new_proposal_form';
 
-async function loadCmd(type: string) {
-  if (!app || !app.chain || !app.chain.loaded) {
-    throw new Error('secondary loading cmd called before chain load');
-  }
-  if (app.chain.base !== ChainBase.Substrate) {
-    return;
-  }
-  const c = proposalSlugToClass().get(type);
-  if (c && c instanceof ProposalModule && !c.disabled) {
-    await c.init(app.chain.chain, app.chain.accounts);
-  }
-}
-
 const NewProposalPage: m.Component<{ type }, { typeEnum, titlePre }> = {
   view: (vnode) => {
     vnode.state.typeEnum = vnode.attrs.type;
@@ -35,8 +22,8 @@ const NewProposalPage: m.Component<{ type }, { typeEnum, titlePre }> = {
 
       // check if module is still initializing
       const c = proposalSlugToClass().get(vnode.state.typeEnum) as ProposalModule<any, any, any>;
-      if (!c.disabled && !c.initialized) {
-        if (!c.initializing) loadCmd(vnode.state.typeEnum);
+      if (!c.ready) {
+        app.chain.loadModules([ c ]);
         return m(PageLoading, { narrow: true, showNewProposalButton: true });
       }
     }

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -88,6 +88,7 @@ async function loadCmd() {
     const chain = (app.chain as Substrate);
     await Promise.all([
       chain.council.init(chain.chain, chain.accounts),
+      chain.technicalCommittee.init(chain.chain, chain.accounts),
       chain.treasury.init(chain.chain, chain.accounts),
       chain.democracyProposals.init(chain.chain, chain.accounts),
       chain.democracy.init(chain.chain, chain.accounts),
@@ -97,9 +98,6 @@ async function loadCmd() {
     await Promise.all([
       chain.governance.init(chain.chain, chain.accounts),
     ]);
-    return;
-  } else {
-    return;
   }
 }
 
@@ -145,7 +143,7 @@ const ProposalsPage: m.Component<{}> = {
       // Democracy, Council must be loaded to proceed
       const chain = app.chain as Substrate;
       if (!chain.democracy.initialized || !chain.council.initialized || !chain.democracyProposals.initialized) {
-        if (!chain.democracy.initializing) loadCmd();
+        if (!chain.democracy.initializing && !chain.council.initializing) loadCmd();
         return m(PageLoading, {
           message: 'Connecting to chain',
           title: [

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -468,24 +468,6 @@ interface IPrefetch {
   }
 }
 
-function getModules() {
-  if (!app || !app.chain || !app.chain.loaded) {
-    throw new Error('secondary loading cmd called before chain load');
-  }
-  if (app.chain.base === ChainBase.Substrate) {
-    const chain = (app.chain as Substrate);
-    return [
-      chain.treasury,
-      chain.council,
-      chain.technicalCommittee,
-      chain.democracy,
-      chain.democracyProposals
-    ];
-  } else {
-    throw new Error('invalid chain');
-  }
-}
-
 const ViewProposalPage: m.Component<{
   identifier: string,
   type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Substrate `main.ts` files no longer declare `module.disable()` -- instead, the modules disable themselves if needed when `init()` is called.
- Pages now declare a list of modules that they wait to load, rather than each page having a unique `loadCmd`. This could possible be generalized further into a separate component (pass in a list of modules, display waiting screen until ready).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplifies adding new chains, as you no longer need to investigate which modules to manually disable, and simplifies adding new Substrate controllers, as you no longer need to explicitly disable them on each existing chain.

Also cleans up how pages check whether they are loaded or not, which should avoid "endless loading" bugs.

## How has this been tested?
Ran against several Substrate chains and verified all module-using pages loaded as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no