### PR TITLE
Remove console log from search

### DIFF
--- a/client/scripts/views/components/quill_formatted_text.ts
+++ b/client/scripts/views/components/quill_formatted_text.ts
@@ -297,7 +297,6 @@ const QuillFormattedText : m.Component<{
             chunks.length <= 1 ? {} : index === 0 ? { position: 0 } : index === chunks.length - 1
               ? {} : { position: middle }
           );
-          console.log(text);
           return highlight ? m('mark', text) : m('span', text);
         });
       }


### PR DESCRIPTION
Right now, cached search results on the livesite are being printed to console. Possible they're meant to be, but pulling assuming they're not.

![image](https://user-images.githubusercontent.com/22281010/112078584-af509000-8b4c-11eb-8325-ef9e1b88f0a3.png)
