### PR TITLE
Hotfix for referenda loading.

### DIFF
--- a/client/scripts/views/pages/referenda.ts
+++ b/client/scripts/views/pages/referenda.ts
@@ -70,7 +70,7 @@ function getModules() {
   }
   if (app.chain.base === ChainBase.Substrate) {
     const chain = (app.chain as Substrate);
-    return [ chain.treasury, chain.democracy, chain.democracyProposals, chain.council ];
+    return [ chain.democracy, chain.democracyProposals ];
   } else {
     throw new Error('invalid chain');
   }


### PR DESCRIPTION
Removes dependency on council and treasury to load referenda page. Tested and it seems working. Unsure about other pages.