### PR TITLE
fetch all proposals using snapshot

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -380,6 +380,8 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolea
     return false;
   } else {
     app.chain = newChain;
+    const snapshotId = app.chain?.meta.chain.snapshot;
+    app.snapshot.fetchSnapshotProposals(snapshotId);
   }
   if (initApi) {
     app.chain.initApi(); // required for loading NearAccounts

--- a/client/scripts/controllers/server/snapshot.ts
+++ b/client/scripts/controllers/server/snapshot.ts
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import app from 'state';
 import m from 'mithril';
 import { SnapshotProposalStore } from 'stores';
+import { SnapshotProposal } from '../../models';
 
 class SnapshotController {
   private _proposalStore: SnapshotProposalStore = new SnapshotProposalStore();
@@ -9,11 +10,25 @@ class SnapshotController {
   public get proposalStore() { return this._proposalStore; }
 
   public async fetchSnapshotProposals(snapshot: string) {
-    return new Promise((resolve, reject) => {
-      this._proposalStore.clear();
-      resolve('');
-      m.redraw();
-    });
+    const response = await $.get(`https://hub.snapshot.page/api/${snapshot}/proposals`);
+    // if (response.status !== 'Success') {
+    //   throw new Error(`Cannot fetch snapshot proposals: ${response.status}`);
+    // }
+    this._proposalStore.clear();
+    for (const key in response) {
+      this._proposalStore.add(new SnapshotProposal(
+        key,
+        response[key].address,
+        +response[key].msg.timestamp,
+        response[key].msg.payload.start,
+        response[key].msg.payload.end,
+        response[key].msg.payload.name,
+        response[key].msg.payload.body,
+        response[key].sig,
+        response[key].authorIpfsHash,
+        response[key].relayerIpfsHash
+      ))
+    }
   }
 }
 

--- a/client/scripts/models/SnapshotProposal.ts
+++ b/client/scripts/models/SnapshotProposal.ts
@@ -1,5 +1,6 @@
 class SnapshotProposal {
-	public readonly address: string;
+	public readonly ipfsHash: string;
+	public readonly authorAddress: string;
 	public readonly timestamp: string;
 	public readonly start: string;
 	public readonly end: string;
@@ -9,8 +10,9 @@ class SnapshotProposal {
 	public readonly authorIpfsHash: string;
 	public readonly relayerIpfsHash: string;
 
-	constructor(address, timestamp, start, end, name, body, sig, authorIpfsHash, relayerIpfsHash) {
-		this.address = address;
+	constructor(ipfsHash, authorAddress, timestamp, start, end, name, body, sig, authorIpfsHash, relayerIpfsHash) {
+		this.ipfsHash = ipfsHash;
+		this.authorAddress = authorAddress;
 		this.timestamp = timestamp;
 		this.start = start;
 		this.end = end;

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -91,7 +91,6 @@ export const OffchainNavigationModule: m.Component<{}, { dragulaInitialized: tru
     const onSearchPage = (p) => p.startsWith(`/${app.activeId()}/search`);
     const onMembersPage = (p) => p.startsWith(`/${app.activeId()}/members`)
       || p.startsWith(`/${app.activeId()}/account/`);
-    const onSnapshotProposal = (p) => p.startsWith(`/${app.activeId()}/snapshot-proposals`);
     const onChatPage = (p) => p === `/${app.activeId()}/chat`;
 
     return m('.OffchainNavigationModule.SidebarModule', [
@@ -129,17 +128,6 @@ export const OffchainNavigationModule: m.Component<{}, { dragulaInitialized: tru
           m.route.set(`/${app.activeId()}/members`);
         },
       }),
-      app.chain?.meta.chain.snapshot !== null
-        && m(Button, {
-          rounded: true,
-          fluid: true,
-          active: onSnapshotProposal(m.route.get()),
-          label: 'Snapshot proposal',
-          onclick: (e) => {
-            e.preventDefault();
-            m.route.set(`/${app.activeId()}/snapshot-proposals`);
-          },
-        }),
       // m(Button, {
       //   rounded: true,
       //   fluid: true,
@@ -174,7 +162,8 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
         || app.chain.class === ChainClass.Moloch
         || app.chain.network === ChainNetwork.Marlin
         || app.chain.network === ChainNetwork.MarlinTestnet
-        || app.chain.class === ChainClass.Commonwealth);
+        || app.chain.class === ChainClass.Commonwealth
+        || app.chain?.meta.chain.snapshot)
     if (!hasProposals) return;
 
     const showMolochMenuOptions = app.user.activeAccount && app.chain?.class === ChainClass.Moloch;
@@ -183,6 +172,7 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
 
     const showMarlinOptions = app.user.activeAccount && app.chain?.network === ChainNetwork.Marlin;
 
+    const onSnapshotProposal = (p) => p.startsWith(`/${app.activeId()}/snapshot-proposals`);
     const onProposalPage = (p) => (
       p.startsWith(`/${app.activeChainId()}/proposals`)
         || p.startsWith(`/${app.activeChainId()}/proposal/councilmotion`)
@@ -343,6 +333,17 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
           });
         },
         label: 'Approve tokens',
+      }),
+      app.chain?.meta.chain.snapshot !== null
+      && m(Button, {
+        rounded: true,
+        fluid: true,
+        active: onSnapshotProposal(m.route.get()),
+        label: 'Snapshot Proposals',
+        onclick: (e) => {
+          e.preventDefault();
+          m.route.set(`/${app.activeId()}/snapshot-proposals`);
+        },
       }),
       showCommonwealthMenuOptions && m(Button, {
         fluid: true,

--- a/client/scripts/views/pages/snapshot_proposals/index.ts
+++ b/client/scripts/views/pages/snapshot_proposals/index.ts
@@ -104,6 +104,7 @@ const SnapshotProposalsPage: m.Component<{ topic?: string }, {
   lastSubpage: string;
   lastVisitedUpdated?: boolean;
   onscroll: any;
+  allProposals: any;
 }> = {
   oncreate: (vnode) => {
     mixpanel.track('PageVisit', {
@@ -113,27 +114,27 @@ const SnapshotProposalsPage: m.Component<{ topic?: string }, {
   },
 
   oninit: (vnode) => {
-    const snapshotId = app.chain?.meta.chain.snapshot;
-    app.snapshot.fetchSnapshotProposals(snapshotId);
   },
   
   view: (vnode) => {
     let listing = [];
-    const allProposals = app.snapshot.proposalStore.getAll();
     
-    listing.push(m('.discussion-group-wrap', allProposals
-        .map((proposal) => m(ProposalRow, { proposal }))));
+    listing.push(m('.discussion-group-wrap', app.snapshot.proposalStore.getAll()
+    .map((proposal) => m(ProposalRow, { proposal }))));
+    
 
     return m(Sublayout, {
-      class: 'SnapshotProposalsPage',
-      title: '',
+      class: 'DiscussionsPage',
+      title: 'Snapshot Proposals',
       description: '',
       showNewProposalButton: true,
     }, [
       (app.chain || app.community) && [
         m('.discussions-main', [
           m(SnapshotProposalStagesBar, {}),
-          m(Listing, { content: listing }),
+          listing.length === 0
+            ? m('.topic-loading-spinner-wrap', [ m(Spinner, { active: true, size: 'lg' }) ])
+            : m(Listing, { content: listing }),
         ])
       ]
     ]);

--- a/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
+++ b/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
@@ -17,6 +17,8 @@ const ProposalRow: m.Component<{ proposal: SnapshotProposal }, { expanded: boole
     if (!proposal) return;
     const proposalLink = `/${app.activeId()}/snapshot-proposals/${proposal.ipfsHash}`;
 
+    const time = moment(+proposal.end * 1000);
+    const now = moment();
     const rowHeader: any = [
       link('a', proposalLink, proposal.name),
     ];
@@ -24,7 +26,8 @@ const ProposalRow: m.Component<{ proposal: SnapshotProposal }, { expanded: boole
       proposal.ipfsHash && link('a.proposal-topic', proposalLink, [
         m('span.proposal-topic-name', `${proposal.ipfsHash}`),
       ]),
-      m('.created-at', link('a', proposalLink, `Ended ${formatLastUpdated(moment(+proposal.end))}`)),
+      m('.created-at', link('a', proposalLink, (now > time) ? `Ended ${formatLastUpdated(time)}` 
+        : `Ending ${formatLastUpdated(moment(+proposal.end * 1000))}`)),
     ];
 
     return m(ProposalListingRow, {

--- a/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
+++ b/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
@@ -1,6 +1,7 @@
 import 'pages/discussions/discussion_row.scss';
 
 import m from 'mithril';
+import moment from 'moment-twitter';
 import _ from 'lodash';
 
 import app from 'state';
@@ -12,17 +13,18 @@ import ProposalListingRow from 'views/components/proposal_listing_row';
 const ProposalRow: m.Component<{ proposal: SnapshotProposal }, { expanded: boolean }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
+
     if (!proposal) return;
-    const proposalLink = `/${app.activeId()}/snapshot-proposals/${proposal.address}`;
+    const proposalLink = `/${app.activeId()}/snapshot-proposals/${proposal.ipfsHash}`;
 
     const rowHeader: any = [
       link('a', proposalLink, proposal.name),
     ];
     const rowSubheader = [
-      proposal.address && link('a.proposal-topic', proposalLink, [
-        m('span.proposal-topic-name', `${proposal.address}`),
+      proposal.ipfsHash && link('a.proposal-topic', proposalLink, [
+        m('span.proposal-topic-name', `${proposal.ipfsHash}`),
       ]),
-      m('.created-at', link('a', proposalLink, `Ended ${formatLastUpdated(proposal.end)}`)),
+      m('.created-at', link('a', proposalLink, `Ended ${formatLastUpdated(moment(+proposal.end))}`)),
     ];
 
     return m(ProposalListingRow, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fetch all the Proposals from IPFS (PR5)
"UI Component to view each proposal (active/inactive)" Snapshot api result does not provide the proposal status like active/inactive. Can you check it? @zakhap 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no