### PR TITLE
Fix types and factor substrate module loading.

### DIFF
--- a/client/scripts/controllers/chain/substrate/account.ts
+++ b/client/scripts/controllers/chain/substrate/account.ts
@@ -465,7 +465,8 @@ class SubstrateAccounts implements IAccountsModule<SubstrateCoin, SubstrateAccou
 
   public get validators(): Promise<IValidators> {
     return new Promise(async (resolve) => {
-      const { nextElected, validators: currentSet } = await this._Chain.api.derive.staking.validators();
+      const res = await this._Chain.api.derive.staking.validators();
+      const { nextElected, validators: currentSet } = res;
       const era = await this._Chain.api.query.staking.currentEra<EraIndex>();
 
       // set of not yet but future validators

--- a/client/scripts/controllers/chain/substrate/phragmen_election.ts
+++ b/client/scripts/controllers/chain/substrate/phragmen_election.ts
@@ -123,7 +123,9 @@ export class SubstratePhragmenElection extends Proposal<
     const votingData: { [voter: string]: PhragmenElectionVote } = {};
     if (this._Chain.api.query[this.moduleName].voting) {
       const voting = await this._Chain.api.query[this.moduleName].voting.entries();
-      for (const [ key, [ stake, votes ]] of voting as Array<[StorageKey, [ BalanceOf, Vec<AccountId> ] & Codec ]>) {
+      for (const [ key, data ] of voting as Array<[StorageKey, any]>) {
+        const votes = data.votes !== undefined ? data.votes : data[1];
+        const stake = data.stake !== undefined ? data.stake : data[0];
         const voter = key.args[0].toString();
         const vote = new PhragmenElectionVote(
           this._Accounts.get(voter),

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -125,6 +125,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     if (modules.some((mod) => !mod.initializing && !mod.ready)) {
       await Promise.all(modules.map((mod) => mod.init(this.chain, this.accounts)));
     }
+    m.redraw();
   }
 
   public abstract base: ChainBase;

--- a/client/scripts/models/ProposalModule.ts
+++ b/client/scripts/models/ProposalModule.ts
@@ -26,6 +26,9 @@ export abstract class ProposalModule<
   public get initialized() { return this._initialized; }
   public get ready() { return this._initialized || this._disabled; }
 
+  protected _error?: string;
+  public get error() { return this._error; }
+
   private _app: IApp;
   public get app() { return this._app; }
 
@@ -55,6 +58,7 @@ export abstract class ProposalModule<
     - set `this._initializing` to true while in progress, false before returning
     - set `this._initialized` to true before returning
     - set itself to disabled if the functionality is unavailable on the active chain
+    - set an error if functionality throws an error on the active chain
     - guard against multiple calls by returning immediately if initializing/initialized/ready
     - an example:
         (note that it's safe for multiple calls because JS threads will not yield until `return`)
@@ -78,6 +82,7 @@ export abstract class ProposalModule<
 
   public deinit() {
     this._initialized = false;
+    this._error = undefined;
     this.store.getAll().map((p) => p.deinit());
     this.store.clear();
   }

--- a/client/scripts/views/components/load_substrate_modules.ts
+++ b/client/scripts/views/components/load_substrate_modules.ts
@@ -1,0 +1,39 @@
+import m from 'mithril';
+import app from 'state';
+import { ChainBase, ProposalModule } from 'models';
+import { Tag } from 'construct-ui';
+import PageLoading from 'views/pages/loading';
+import ErrorPage from 'views/pages/error';
+
+const loadSubstrateModules = (
+  name: string,
+  getModules: () => ProposalModule<any, any, any>[]
+): m.Vnode | undefined => {
+  const onSubstrate = app.chain?.base === ChainBase.Substrate;
+  if (onSubstrate) {
+    const modules = getModules();
+    if (modules.some((mod) => !mod.ready)) {
+      if (modules.some((mod) => mod.error)) {
+        const errors = modules.map((mod) => mod.error).filter((e) => !!e);
+        return m(ErrorPage, {
+          message: `Failed to initialize chain modules: ${errors.join(', ')}.`,
+          title: [
+            name,
+            m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
+          ],
+        });
+      }
+      app.chain.loadModules(modules);
+      return m(PageLoading, {
+        message: `Loading ${name.toLowerCase()}`,
+        title: [
+          name,
+          m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
+        ],
+        showNewProposalButton: true
+      });
+    }
+  }
+};
+
+export default loadSubstrateModules;

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -258,6 +258,7 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
         }),
       // validators (substrate only)
       !app.community && app.chain?.base === ChainBase.Substrate
+        && app.chain?.class !== ChainClass.Kulupu && app.chain?.class !== ChainClass.Darwinia
         && m(Button, {
           fluid: true,
           rounded: true,

--- a/client/scripts/views/pages/bounties.ts
+++ b/client/scripts/views/pages/bounties.ts
@@ -15,6 +15,7 @@ import ProposalCard from 'views/components/proposal_card';
 import Substrate from 'controllers/chain/substrate/main';
 import Listing from './listing';
 import ErrorPage from './error';
+import loadSubstrateModules from '../components/load_substrate_modules';
 
 function getModules() {
   if (!app || !app.chain || !app.chain.loaded) {
@@ -50,21 +51,8 @@ const BountiesPage: m.Component<{}> = {
       });
     }
 
-    const onSubstrate = app.chain?.base === ChainBase.Substrate;
-    if (onSubstrate) {
-      const modules = getModules();
-      if (modules.some((mod) => !mod.ready)) {
-        app.chain.loadModules(modules);
-        return m(PageLoading, {
-          message: 'Loading bounties',
-          title: [
-            'Bounties',
-            m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
-          ],
-          showNewProposalButton: true,
-        });
-      }
-    }
+    const modLoading = loadSubstrateModules('Bounties', getModules);
+    if (modLoading) return modLoading;
 
     const activeBounties = (app.chain as Substrate).bounties.store.getAll().filter((p) => !p.completed);
     const inactiveBounties = (app.chain as Substrate).bounties.store.getAll().filter((p) => p.completed);

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -26,6 +26,7 @@ import PageLoading from 'views/pages/loading';
 import LoadingRow from 'views/components/loading_row';
 import ProposalCard from 'views/components/proposal_card';
 import { CountdownUntilBlock } from 'views/components/countdown';
+import loadSubstrateModules from 'views/components/load_substrate_modules';
 
 import NewProposalPage from 'views/pages/new_proposal/index';
 import PageNotFound from 'views/pages/404';
@@ -163,22 +164,13 @@ const ProposalsPage: m.Component<{}> = {
 
     const onSubstrate = app.chain && app.chain.base === ChainBase.Substrate;
     const onMoloch = app.chain && app.chain.class === ChainClass.Moloch;
-    const onMarlin = app.chain && (app.chain.network === ChainNetwork.Marlin || app.chain.network === ChainNetwork.MarlinTestnet);
+    const onMarlin = app.chain && (
+      app.chain.network === ChainNetwork.Marlin || app.chain.network === ChainNetwork.MarlinTestnet
+    );
 
-    if (onSubstrate) {
-      const modules = getModules();
-      if (modules.some((mod) => !mod.ready)) {
-        app.chain.loadModules(modules);
-        return m(PageLoading, {
-          message: 'Loading proposals',
-          title: [
-            'Proposals',
-            m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
-          ],
-          showNewProposalButton: true,
-        });
-      }
-    }
+    const modLoading = loadSubstrateModules('Proposals', getModules);
+    if (modLoading) return modLoading;
+
     // active proposals
     const activeDemocracyProposals = onSubstrate
       && (app.chain as Substrate).democracyProposals.store.getAll().filter((p) => !p.completed);

--- a/client/scripts/views/pages/referenda.ts
+++ b/client/scripts/views/pages/referenda.ts
@@ -24,6 +24,7 @@ import LoadingRow from 'views/components/loading_row';
 import ProposalCard from 'views/components/proposal_card';
 import { CountdownUntilBlock } from 'views/components/countdown';
 import NewProposalPage from 'views/pages/new_proposal/index';
+import loadSubstrateModules from 'views/components/load_substrate_modules';
 
 import Listing from './listing';
 import ErrorPage from './error';
@@ -111,21 +112,10 @@ const ReferendaPage: m.Component<{}> = {
         showNewProposalButton: true,
       });
     }
-    const onSubstrate = app.chain && app.chain.base === ChainBase.Substrate;
-    if (onSubstrate) {
-      const modules = getModules();
-      if (modules.some((mod) => !mod.ready)) {
-        app.chain.loadModules(modules);
-        return m(PageLoading, {
-          message: 'Loading referenda',
-          title: [
-            'Referenda',
-            m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
-          ],
-          showNewProposalButton: true,
-        });
-      }
-    }
+
+    const onSubstrate = app.chain?.base === ChainBase.Substrate;
+    const modLoading = loadSubstrateModules('Referenda', getModules);
+    if (modLoading) return modLoading;
 
     // active proposals
     const activeDemocracyReferenda = onSubstrate

--- a/client/scripts/views/pages/treasury.ts
+++ b/client/scripts/views/pages/treasury.ts
@@ -27,6 +27,7 @@ import { CountdownUntilBlock } from 'views/components/countdown';
 import NewProposalPage from 'views/pages/new_proposal/index';
 import Listing from 'views/pages/listing';
 import ErrorPage from 'views/pages/error';
+import loadSubstrateModules from 'views/components/load_substrate_modules';
 
 const SubstrateProposalStats: m.Component<{}, {}> = {
   view: (vnode) => {
@@ -126,20 +127,9 @@ const TreasuryPage: m.Component<{}> = {
       });
     }
     const onSubstrate = app.chain && app.chain.base === ChainBase.Substrate;
-    if (onSubstrate) {
-      const modules = getModules();
-      if (modules.some((mod) => !mod.ready)) {
-        app.chain.loadModules(modules);
-        return m(PageLoading, {
-          message: 'Loading treasury',
-          title: [
-            'Treasury',
-            m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
-          ],
-          showNewProposalButton: true,
-        });
-      }
-    }
+
+    const modLoading = loadSubstrateModules('Treasury', getModules);
+    if (modLoading) return modLoading;
 
     const activeTreasuryProposals = onSubstrate
       && (app.chain as Substrate).treasury.store.getAll().filter((p) => !p.completed);

--- a/client/scripts/views/pages/validators.ts
+++ b/client/scripts/views/pages/validators.ts
@@ -86,6 +86,7 @@ const ValidatorsPage: m.Component<{}, { validators, totalStaked, validatorsIniti
       });
       // TODO: handle error fetching vals
       vnode.state.validatorsInitialized = true;
+      m.redraw();
     }
     const validators = vnode.state.validators;
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.6.0",
+    "@commonwealth/chain-events": "0.6.1",
     "@cosmjs/launchpad": "^0.24.0-alpha.13",
     "@edgeware/node-types": "3.3.3",
     "@keplr-wallet/types": "^0.9.0-alpha.1",

--- a/shared/adapters/chain/clover/spec.ts
+++ b/shared/adapters/chain/clover/spec.ts
@@ -14,6 +14,7 @@ const CloverSpec: RegisteredTypes = {
     BridgeNetworks: {
       _enum: ['BSC', 'Ethereum'],
     },
+    AccountInfo: 'AccountInfoWithDualRefCount',
   }
 };
 

--- a/shared/adapters/chain/darwinia/spec.ts
+++ b/shared/adapters/chain/darwinia/spec.ts
@@ -44,9 +44,7 @@ export default {
     'free': 'Balance',
     'reserved': 'Balance',
     'freeKton': 'Balance',
-    'reservedKton': 'Balance',
-    'miscFrozen': 'Balance',
-    'feeFrozen': 'Balance'
+    'reservedKton': 'Balance'
   },
   'RingBalance': 'Balance',
   'KtonBalance': 'Balance',

--- a/shared/substrate.ts
+++ b/shared/substrate.ts
@@ -1,9 +1,9 @@
-import * as CloverSpecTypes from '@clover-network/node-types';
 import { spec as EdgewareSpec } from '@edgeware/node-types';
 import { RegisteredTypes } from '@polkadot/types/types';
 import StafiSpec from './adapters/chain/stafi/spec';
 import HydraSpec from './adapters/chain/hydradx/spec';
 import KulupuSpec from './adapters/chain/kulupu/spec';
+import CloverSpec from './adapters/chain/clover/spec';
 
 export function selectSpec(chain: string): RegisteredTypes {
   if (chain.includes('edgeware')) {
@@ -11,7 +11,7 @@ export function selectSpec(chain: string): RegisteredTypes {
   } else if (chain === 'stafi') {
     return StafiSpec;
   } else if (chain === 'clover') {
-    return { types: CloverSpecTypes };
+    return CloverSpec;
   } else if (chain === 'hydradx') {
     return { types: HydraSpec };
   } else if (chain === 'kulupu') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,17 +1194,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@clover-network/node-types@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@clover-network/node-types/-/node-types-1.0.3.tgz#0a83b850918ddf75b517b1f81784a398b94dc314"
-  integrity sha512-7zNm68KaRxyZWVOrDFWOWyG6h/khgkXpVKw6mByJnrzG6MajDkdctTFeu2RrXeYFl5fH9gm2sv0UDFvMuk3m5Q==
-
-"@commonwealth/chain-events@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.6.0.tgz#4b2a1ef4cf2c72f62d648839db5f02e1b4eeaebd"
-  integrity sha512-VMxfsku4lmPKvo8mghjPMDt9vEFnxcLCNI82HIoI34PSxVQ+LU9MKF11J2q+VwlDCFzTPrSlRC56TviUpuNvfA==
+"@commonwealth/chain-events@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.6.1.tgz#677134cf9ac9c80f3cc5228b45f12879f37260a2"
+  integrity sha512-iTNy7aMFchUWNxmydWcgySlbWw5HC5le1FloGukbdZshb2fvQWP1APTwLILzR3ulQRlIFYTP8hoMagfYvrFO0w==
   dependencies:
-    "@clover-network/node-types" "1.0.3"
     "@edgeware/node-types" "^3.3.3"
     bn.js "^5.1.3"
     ethereum-block-by-date "^1.2.2"


### PR DESCRIPTION
## Description
* Fixes the council page on certain chains.
* Updates clover and darwinia types.
* Refactors the substrate module loading block into a separate page.
* Adds an unused `error` field to ChainModules which can be populated if necessary to display an error page on a module page.
* Disables the validators page on certain chains which support different schemes.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] no