### PR TITLE
Privacy & terms pages improvements

### DIFF
--- a/client/scripts/views/pages/commonwealth/index.ts
+++ b/client/scripts/views/pages/commonwealth/index.ts
@@ -13,6 +13,7 @@ const WhyCommonWealthView: m.Component<{}, {}> = {
         'div',
         { class: 'absolute w-screen z-20' },
         m(HeaderLandingPage, {
+          scrollHeader: true,
           navs: [
             { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
             // { text: 'Use Cases' },
@@ -202,12 +203,14 @@ const WhyCommonWealthView: m.Component<{}, {}> = {
       ]),
       m(FooterLandingPage, {
         list: [
-          { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
-          // { text:  'Use Cases' },
+          { text:  'Privacy', redirectTo: '/privacy' },
+          { text:  'Terms', redirectTo:  '/terms' },
+          { text: 'Jobs', externalLink: 'https://angel.co/company/commonwealth-labs/jobs' },
+          { text: 'Blog', externalLink: 'https://commonwealth.im/' }          // { text:  'Use Cases' },
           // { text:  'Crowdfunding' },
           // { text:  'Developers' },
           // { text:  'About us' },
-          // { text:  'Carrers' }
+          // { text:  'Careers' }
         ],
       }),
     ]);

--- a/client/scripts/views/pages/landing/index.ts
+++ b/client/scripts/views/pages/landing/index.ts
@@ -116,6 +116,7 @@ const LandingPage: m.Component<{}, IState> = {
           'div',
           { class: 'absolute w-screen z-20' },
           m(HeaderLandingPage, {
+            scrollHeader: true,
             navs: [
               { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
             // { text: 'Use Cases', redirectTo: '/whyCommonwealth' },

--- a/client/scripts/views/pages/landing/landing_page_header.ts
+++ b/client/scripts/views/pages/landing/landing_page_header.ts
@@ -5,11 +5,12 @@ import LoginModal from 'views/modals/login_modal';
 
 interface IAttrs {
   navs: { text: string; redirectTo: string }[];
+  scrollHeader: boolean;
 }
 
 interface IState {
   headerMinimized: boolean;
-  hideHeader: boolean;
+  hideHeader?: boolean;
 }
 
 // eslint-disable-next-line max-len
@@ -37,10 +38,14 @@ const scrollingHeader = () => {
 
 const HeaderLandingPage: m.Component<IAttrs, IState> = {
   oninit: (vnode) => {
-    window.addEventListener('scroll', scrollingHeader);
+    if (vnode.attrs.scrollHeader) {
+      window.addEventListener('scroll', scrollingHeader);
+    }
   },
   onremove: (vnode) => {
-    window.removeEventListener('scroll', scrollingHeader);
+    if (vnode.attrs.scrollHeader) {
+      window.removeEventListener('scroll', scrollingHeader);
+    }
   },
   view: (vnode) => {
     const redirectClick = (route) => {
@@ -61,6 +66,7 @@ const HeaderLandingPage: m.Component<IAttrs, IState> = {
             class: 'w-32 md:w-48 lg:w-60',
             src: 'static/img/logo.svg',
             alt: 'Commonwealth',
+            style: m.route.get() === '/' ? '' : 'cursor:pointer',
             onclick: () => redirectClick('/'),
           }),
           m(

--- a/client/scripts/views/pages/landing/privacy.ts
+++ b/client/scripts/views/pages/landing/privacy.ts
@@ -1,8 +1,11 @@
 /* eslint-disable max-len */
 
+import 'pages/landing/privacyAndTerms.scss';
+
 import m from 'mithril';
 import mixpanel from 'mixpanel-browser';
 import { renderMultilineText } from 'helpers';
+import HeaderLandingPage from './landing_page_header';
 
 const PrivacyPolicy = `
 Last updated: January 14, 2019
@@ -117,6 +120,12 @@ const PrivacyPage: m.Component<{}> = {
   },
   view: (vnode) => {
     return m('.PrivacyPage', [
+      m(HeaderLandingPage, {
+        scrollHeader: false,
+        navs: [
+          { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
+        ],
+      }),
       m('.forum-container', [
         m('h1.page-title', 'Privacy Policy'),
         renderMultilineText(PrivacyPolicy),

--- a/client/scripts/views/pages/landing/terms.ts
+++ b/client/scripts/views/pages/landing/terms.ts
@@ -1,8 +1,11 @@
 /* eslint-disable max-len */
 
+import 'pages/landing/privacyAndTerms.scss';
+
 import m from 'mithril';
 import mixpanel from 'mixpanel-browser';
 import { renderMultilineText } from 'helpers';
+import HeaderLandingPage from './landing_page_header';
 
 const TermsOfService = `
 PLEASE READ THE BELOW GOVERNANCE PLATFORM SERVICES AGREEMENT VERY CAREFULLY. THE BELOW GOVERNANCE PLATFORM SERVICES AGREEMENT IS A LEGALLY BINDING CONTRACT BETWEEN YOU AND COMMONWEALTH LABS THAT SETS FORTH AND DETERMINES, AMONG OTHER THINGS:
@@ -123,6 +126,12 @@ const TermsPage: m.Component<{}> = {
   },
   view: (vnode) => {
     return m('.TermsPage', [
+      m(HeaderLandingPage, {
+        scrollHeader: false,
+        navs: [
+          { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
+        ],
+      }),
       m('.forum-container', [
         m('h1.page-title', 'Terms of Service'),
         renderMultilineText(TermsOfService),

--- a/client/styles/pages/landing/privacyAndTerms.scss
+++ b/client/styles/pages/landing/privacyAndTerms.scss
@@ -1,0 +1,8 @@
+.PrivacyPage, .TermsPage {
+    .forum-container {
+        padding: 10vh 20vw;
+    }
+    p {
+        margin: 7px 0;
+    }
+}


### PR DESCRIPTION
These changes add header navigation, so the user can return to the CW landing page, as well as line and text body padding to make the terms more readable.

Before: 

![image](https://user-images.githubusercontent.com/22281010/118684607-fb742580-b7c7-11eb-86f7-11a920078466.png)

After:

![image](https://user-images.githubusercontent.com/22281010/118684655-04fd8d80-b7c8-11eb-9a84-95e3e8964f58.png)
