### PR TITLE
Fix token forum tests and front-end token balance gating.

### DIFF
--- a/client/scripts/controllers/app/login.ts
+++ b/client/scripts/controllers/app/login.ts
@@ -2,12 +2,14 @@
  * @file Manages logged-in user accounts and local storage.
  */
 import $ from 'jquery';
+import m from 'mithril';
 import app from 'state';
 import { isSameAccount } from 'helpers';
 
 import { initAppState } from 'app';
 import { Magic } from 'magic-sdk';
 import { PolkadotExtension } from '@magic-ext/polkadot';
+import Token from 'controllers/chain/ethereum/token/adapter';
 
 import {
   ChainInfo,
@@ -51,9 +53,14 @@ export function linkExistingAddressToChainOrCommunity(
 }
 
 export async function setActiveAccount(account: Account<any>): Promise<void> {
+  console.log('set active account');
   const chain = app.activeChainId();
   const community = app.activeCommunityId();
   const role = app.user.getRoleInCommunity({ account, chain, community });
+
+  if (app.chain && (app.chain as Token).isToken) {
+    (app.chain as Token).activeAddressHasToken(account.address).then(() => m.redraw());
+  }
 
   if (!role || role.is_user_default) {
     app.user.ephemerallySetActiveAccount(account);

--- a/client/scripts/controllers/chain/ethereum/token/adapter.ts
+++ b/client/scripts/controllers/chain/ethereum/token/adapter.ts
@@ -5,7 +5,6 @@ import EthereumAccount from 'controllers/chain/ethereum/account';
 import EthereumAccounts from 'controllers/chain/ethereum/accounts';
 import { ChainBase, IChainAdapter, NodeInfo } from 'models';
 
-import ChainEntityController from 'controllers/server/chain_entities';
 import { IApp } from 'state';
 
 import EthereumTokenChain from './chain';
@@ -56,6 +55,7 @@ export default class Token extends IChainAdapter<EthereumCoin, EthereumAccount> 
 
   public async activeAddressHasToken(activeAddress?: string) {
     if (!activeAddress) return false;
+    this.hasToken = false;
     const account = this.accounts.get(activeAddress);
     const balance = await account.tokenBalance(this.contractAddress);
     this.hasToken = balance && !balance.isZero();

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -9,7 +9,7 @@ import { Button, Input, TextArea, Spinner, Checkbox } from 'construct-ui';
 
 import { initAppState } from 'app';
 import { isSameAccount, link } from 'helpers';
-import { AddressInfo, Account, ChainBase, ChainInfo, IWebWallet } from 'models';
+import { AddressInfo, Account, ChainBase, IWebWallet } from 'models';
 import app, { ApiStatus } from 'state';
 
 import { updateActiveAddresses, createUserWithAddress, setActiveAccount } from 'controllers/app/login';
@@ -21,8 +21,6 @@ import CodeBlock from 'views/components/widgets/code_block';
 import User from 'views/components/widgets/user';
 import AvatarUpload from 'views/components/avatar_upload';
 import AddressSwapper from 'views/components/addresses/address_swapper';
-import Token from 'controllers/chain/ethereum/token/adapter';
-import { slugify } from 'utils';
 
 enum LinkNewAddressSteps {
   Step1VerifyWithCLI,
@@ -271,10 +269,6 @@ const LinkNewAddressModal: m.Component<ILinkNewAddressModalAttrs, ILinkNewAddres
           await setActiveAccount(account);
           if (app.user.activeAccounts.filter((a) => isSameAccount(a, account)).length === 0) {
             app.user.setActiveAccounts(app.user.activeAccounts.concat([account]));
-          }
-
-          if (app.chain && (app.chain as Token).isToken) {
-            await (app.chain as Token).activeAddressHasToken(app.user.activeAccount.address);
           }
           // TODO: set the address as default
         } catch (e) {

--- a/client/scripts/views/sublayout.ts
+++ b/client/scripts/views/sublayout.ts
@@ -114,7 +114,7 @@ const Sublayout: m.Component<{
           ]),
           hero
             ? m('.sublayout-hero', hero)
-            : ((app.chain as Token)?.isToken && !(app.chain as Token)?.hasToken && app.isLoggedIn())
+            : (app.isLoggedIn() && (app.chain as Token)?.isToken && !(app.chain as Token)?.hasToken)
               ? m('.sublayout-hero.token-banner', [
                 m('.token-banner-content', `Link ${app.chain.meta.chain.symbol} address to participate in this community`),
               ]) : '',

--- a/server-test.ts
+++ b/server-test.ts
@@ -22,6 +22,7 @@ import ViewCountCache from './server/util/viewCountCache';
 import IdentityFetchCache from './server/util/identityFetchCache';
 import TokenBalanceCache from './server/util/tokenBalanceCache';
 import TokenListCache from './server/util/tokenListCache';
+import { MockTokenBalanceProvider } from './test/util/modelUtils';
 
 require('express-async-errors');
 
@@ -33,7 +34,8 @@ const identityFetchCache = new IdentityFetchCache(0);
 
 // always prune both token and non-token holders asap
 const tokenListCache = new TokenListCache();
-const tokenBalanceCache = new TokenBalanceCache(tokenListCache, 0, 0);
+const mockTokenBalanceProvider = new MockTokenBalanceProvider();
+const tokenBalanceCache = new TokenBalanceCache(tokenListCache, 0, 0, mockTokenBalanceProvider);
 const wss = new WebSocket.Server({ clientTracking: false, noServer: true });
 let server;
 
@@ -311,5 +313,6 @@ setupServer();
 export const resetDatabase = () => resetServer();
 export const getIdentityFetchCache = () => identityFetchCache;
 export const getTokenBalanceCache = () => tokenBalanceCache;
+export const getMockBalanceProvider = () => mockTokenBalanceProvider;
 
 export default app;

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -266,7 +266,7 @@ export default (
       || chain.network === 'alex'
       || chain.network === 'metacartel'
       || chain.network === 'commonwealth'
-      || chain.type === "token"
+      || chain.type === 'token'
     ) {
       //
       // ethereum address handling

--- a/server/util/tokenBalanceCache.ts
+++ b/server/util/tokenBalanceCache.ts
@@ -5,7 +5,6 @@ import { providers } from 'ethers';
 
 import { INFURA_API_KEY } from '../config';
 import { Erc20Factory } from '../../eth/types/Erc20Factory';
-import { Erc20 } from '../../eth/types/Erc20';
 import { TokenResponse } from '../../shared/types';
 
 import JobRunner from './cacheJobRunner';
@@ -14,7 +13,6 @@ import { slugify } from '../../shared/utils';
 
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
-const TEST_CONTRACT_ID = 'ABC';
 
 // map of addresses to balances
 interface CacheT {
@@ -35,6 +33,18 @@ export interface TokenForumMeta {
   balanceThreshold?: BN;
 }
 
+export class TokenBalanceProvider {
+  constructor(private _network = 'mainnet') { }
+
+  public async getBalance(tokenAddress: string, userAddress: string): Promise<BN> {
+    const web3Provider = new Web3.providers.HttpProvider(`https://${this._network}.infura.io/v3/${INFURA_API_KEY}`);
+    const provider = new providers.Web3Provider(web3Provider);
+    const api = Erc20Factory.connect(tokenAddress, provider);
+    const balanceBigNum = await api.balanceOf(userAddress);
+    return new BN(balanceBigNum.toString());
+  }
+}
+
 export default class TokenBalanceCache extends JobRunner<CacheT> {
   private _contracts: TokenForumMeta[];
 
@@ -42,12 +52,13 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     private readonly _listCache: TokenListCache,
     noBalancePruneTimeS: number = 5 * 60,
     private readonly _hasBalancePruneTimeS: number = 24 * 60 * 60,
+    private readonly _balanceProvider = new TokenBalanceProvider(),
   ) {
     super({}, noBalancePruneTimeS);
     this._listCache = new TokenListCache();
   }
 
-  private async _connectTokens(models, network = 'mainnet'): Promise<TokenForumMeta[]> {
+  private async _connectTokens(models): Promise<TokenForumMeta[]> {
     // initialize metadata from database
     const dbTokens = await models['Chain'].findAll({
       where: { type: 'token' },
@@ -91,9 +102,9 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     return this._contracts.find(({ address }) => address === searchAddress);
   }
 
-  public async start(models?, network = 'mainnet', prefetchedTokenMeta?: TokenForumMeta[]) {
+  public async start(models?, prefetchedTokenMeta?: TokenForumMeta[]) {
     if (!prefetchedTokenMeta) {
-      const tokenMeta = await this._connectTokens(models, network);
+      const tokenMeta = await this._connectTokens(models);
       this._contracts = tokenMeta;
     } else {
       this._contracts = prefetchedTokenMeta;
@@ -111,14 +122,14 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     log.info(`Started Token Balance Cache with ${this._contracts.length} tokens.`);
   }
 
-  public async reset(models?, network = 'mainnet', prefetchedTokenMeta?: TokenForumMeta[]) {
+  public async reset(models?, prefetchedTokenMeta?: TokenForumMeta[]) {
     super.close();
     await this.access(async (cache) => {
       for (const key of Object.keys(cache)) {
         delete cache[key];
       }
     });
-    return this.start(models, network, prefetchedTokenMeta);
+    return this.start(models, prefetchedTokenMeta);
   }
 
   public getTokens(): Promise<TokenResponse[]> {
@@ -127,9 +138,6 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
 
   // query a user's balance on a given token contract and save in cache
   public async hasToken(contractId: string, address: string, network = 'mainnet'): Promise<boolean> {
-    if (process.env.NODE_ENV === 'development' && contractId === TEST_CONTRACT_ID) {
-      return true;
-    }
     const tokenMeta = this._contracts.find(({ id }) => id === contractId);
     if (!tokenMeta) throw new Error('unsupported token');
     const threshold = tokenMeta.balanceThreshold || new BN(1);
@@ -143,12 +151,7 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     // fetch balance if not found in cache
     let balance: BN;
     try {
-      // init API against infura
-      const web3Provider = new Web3.providers.HttpProvider(`https://${network}.infura.io/v3/${INFURA_API_KEY}`);
-      const provider = new providers.Web3Provider(web3Provider);
-      const api = Erc20Factory.connect(tokenMeta.address, provider);
-      const balanceBigNum = await api.balanceOf(address);
-      balance = new BN(balanceBigNum.toString());
+      balance = await this._balanceProvider.getBalance(tokenMeta.address, address);
     } catch (e) {
       throw new Error(`Could not fetch token balance: ${e.message}`);
     }

--- a/test/unit/api/index.spec.ts
+++ b/test/unit/api/index.spec.ts
@@ -43,8 +43,7 @@ describe('API Tests', () => {
     });
 
     it('should verify an address', async () => {
-      const keypair = wallet.generate();
-      const address = `0x${keypair.getAddress().toString('hex')}`;
+      const { keypair, address } = modelUtils.generateEthAddress();
       const chain = 'ethereum';
       let res = await chai.request(app)
         .post('/api/createAddress')

--- a/test/unit/api/tokenForum.spec.ts
+++ b/test/unit/api/tokenForum.spec.ts
@@ -3,8 +3,10 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
+import BN from 'bn.js';
 import jwt from 'jsonwebtoken';
-import { resetDatabase, getTokenBalanceCache } from '../../../server-test';
+import TokenBalanceCache from 'server/util/tokenBalanceCache';
+import { resetDatabase, getTokenBalanceCache, getMockBalanceProvider } from '../../../server-test';
 import { JWT_SECRET } from '../../../server/config';
 import * as modelUtils from '../../util/modelUtils';
 
@@ -32,6 +34,8 @@ describe('Token Forum tests', () => {
   let userAddress;
   let userAddressId;
   let thread;
+  let tbc: TokenBalanceCache;
+  let tokenProvider: modelUtils.MockTokenBalanceProvider;
 
   before(async () => {
     await resetDatabase();
@@ -55,16 +59,18 @@ describe('Token Forum tests', () => {
     userJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     expect(userAddress).to.not.be.null;
     expect(userJWT).to.not.be.null;
+
+    tbc = getTokenBalanceCache();
+    tokenProvider = getMockBalanceProvider();
+  });
+
+  beforeEach(async () => {
+    await tbc.reset(null, modelUtils.createTokenMeta());
   });
 
   it('should permit token-holder to take actions on token forum', async () => {
-    // init cache
-    const tbc = getTokenBalanceCache();
-    const meta = modelUtils.createTokenMeta(async (a: string) => {
-      // everyone is a token holder
-      return 1;
-    });
-    await tbc.reset(null, null, [ meta ]);
+    // everyone is a token holder
+    tokenProvider.balanceFn = async () => new BN(1);
 
     // create a thread
     const res = await modelUtils.createThread({
@@ -104,13 +110,29 @@ describe('Token Forum tests', () => {
   });
 
   it('should not permit non-token-holder to take actions on token forum', async () => {
-    // init cache
-    const tbc = getTokenBalanceCache();
-    const meta = modelUtils.createTokenMeta(async (a: string) => {
-      // nobody is a token holder
-      return 0;
+    // nobody is a token holder
+    tokenProvider.balanceFn = async () => new BN(0);
+
+    // fail to create a thread
+    const res = await modelUtils.createThread({
+      address: userAddress,
+      kind,
+      stage,
+      chainId: chain,
+      communityId: undefined,
+      title,
+      topicName,
+      topicId,
+      body,
+      jwt: userJWT,
     });
-    await tbc.reset(null, null, [ meta ]);
+    expect(res).not.to.be.null;
+    expect(res.error).not.to.be.null;
+  });
+
+  it('should gracefully deny actions on token forum on balance fetch failure', async () => {
+    // nobody is a token holder
+    tokenProvider.balanceFn = null;
 
     // fail to create a thread
     const res = await modelUtils.createThread({
@@ -130,16 +152,13 @@ describe('Token Forum tests', () => {
   });
 
   it('should not permit former token-holder to take actions on token forum', async () => {
-    // init cache
-    const tbc = getTokenBalanceCache();
+    // first query is a token holder, then no longer
     let nQueries = 0;
-    const meta = modelUtils.createTokenMeta(async (a: string) => {
-      // first query is a token holder, then no longer
+    tokenProvider.balanceFn = async () => {
       nQueries++;
-      if (nQueries === 1) return 1;
-      else return 0;
-    });
-    await tbc.reset(null, null, [ meta ]);
+      if (nQueries === 1) return new BN(1);
+      else return new BN(0);
+    };
 
     // create a thread successfully
     const res = await modelUtils.createThread({
@@ -181,16 +200,13 @@ describe('Token Forum tests', () => {
   });
 
   it('should permit new token-holder to take actions on token forum', async () => {
-    // init cache
-    const tbc = getTokenBalanceCache();
+    // first query is not a token holder, then all further queries are
     let nQueries = 0;
-    const meta = modelUtils.createTokenMeta(async (a: string) => {
-      // first query is not a token holder, then all further queries are
+    tokenProvider.balanceFn = async () => {
       nQueries++;
-      if (nQueries === 1) return 0;
-      else return 1;
-    });
-    await tbc.reset(null, null, [ meta ]);
+      if (nQueries === 1) return new BN(0);
+      else return new BN(1);
+    };
 
     // create a thread successfully
     const errorRes = await modelUtils.createThread({
@@ -237,13 +253,8 @@ describe('Token Forum tests', () => {
   });
 
   it('should permit admin to act even without tokens', async () => {
-    // init cache
-    const tbc = getTokenBalanceCache();
-    const meta = modelUtils.createTokenMeta(async (a: string) => {
-      // nobody is a token holder
-      return 0;
-    });
-    await tbc.reset(null, null, [ meta ]);
+    // nobody is a token holder
+    tokenProvider.balanceFn = async () => new BN(0);
 
     // create a thread
     const res = await modelUtils.createThread({

--- a/test/util/modelUtils.ts
+++ b/test/util/modelUtils.ts
@@ -1,23 +1,22 @@
 /* eslint-disable no-unused-expressions */
 import chai from 'chai';
 import 'chai/register-should';
-import moment from 'moment';
+import Web3 from 'web3';
+import BN from 'bn.js';
 import wallet from 'ethereumjs-wallet';
-import { bigNumberify } from 'ethers/utils';
 import { Keyring } from '@polkadot/api';
 import { stringToU8a, u8aToHex } from '@polkadot/util';
-import { NotificationCategory } from 'models';
-import { Erc20 } from '../../eth/types/Erc20';
 import { factory, formatFilename } from '../../shared/logging';
 import app from '../../server-test';
 import models from '../../server/database';
-import { TokenForumMeta } from '../../server/util/tokenBalanceCache';
+import { TokenBalanceProvider, TokenForumMeta } from '../../server/util/tokenBalanceCache';
 const ethUtil = require('ethereumjs-util');
 const log = factory.getLogger(formatFilename(__filename));
 
 export const generateEthAddress = () => {
   const keypair = wallet.generate();
-  const address = `0x${keypair.getAddress().toString('hex')}`;
+  const lowercaseAddress = `0x${keypair.getAddress().toString('hex')}`;
+  const address = Web3.utils.toChecksumAddress(lowercaseAddress);
   return { keypair, address };
 };
 
@@ -37,6 +36,7 @@ export const createAndVerifyAddress = async ({ chain }, mnemonic = 'Alice') => {
       .post('/api/verifyAddress')
       .set('Accept', 'application/json')
       .send({ address, chain, signature });
+    console.log(JSON.stringify(res.body));
     const user_id = res.body.result.user.id;
     const email = res.body.result.user.email;
     return { address_id, address, user_id, email };
@@ -294,21 +294,26 @@ export const createInvite = async (args: InviteArgs) => {
   return invite;
 };
 
-export const createTokenMeta = (
-  balanceCb: (address: string) => Promise<number>
-): TokenForumMeta => {
-  return {
-    id: 'alex',
-    address: '0xFab46E002BbF0b4509813474841E0716E6730136',
-    symbol: 'alex',
-    name: 'Alex',
-    iconUrl: '',
-    // TODO: refactor this to succeed
-    // api: {
-    //   balanceOf: async (a: string) => {
-    //     const res = await balanceCb(a);
-    //     return bigNumberify(res);
-    //   }
-    // } as unknown as Erc20,
-  };
+export const createTokenMeta = (): TokenForumMeta[] => {
+  return [
+    {
+      id: 'alex',
+      address: '0xFab46E002BbF0b4509813474841E0716E6730136',
+      symbol: 'alex',
+      name: 'Alex',
+      iconUrl: '',
+    }
+  ];
 };
+
+export class MockTokenBalanceProvider extends TokenBalanceProvider {
+  public balanceFn: (tokenAddress: string, userAddress: string) => Promise<BN>;
+
+  public async getBalance(tokenAddress: string, userAddress: string): Promise<BN> {
+    if (this.balanceFn) {
+      return this.balanceFn(tokenAddress, userAddress);
+    } else {
+      throw new Error('unable to fetch token balance');
+    }
+  }
+}


### PR DESCRIPTION
## Description
* Adds a TokenBalanceProvider class that can be mocked for testing the TokenBalanceCache.
* Fixes an issue where switching addresses wouldn't update the token balance of the active account, leading to incorrect `disabled` states on e.g. the "New Thread" button. However, unfortunately, this fix requires a redraw inside the login code. Hacky.

## How has this been tested?
Ran and QA'd.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, and they are tested