### PR TITLE
Remove old mobile logo styling

### DIFF
--- a/client/styles/mobile/mobile_header.scss
+++ b/client/styles/mobile/mobile_header.scss
@@ -13,8 +13,6 @@
         height: 36px;
         top: 1px;
         position: relative;
-        background: black;
-        border-radius: 50%;
     }
     .mobile-header-center {
         flex: 1;


### PR DESCRIPTION
This should've been included in my Favicons/Logo PR. Not sure why it wasn't.

Removes black background + border radius from CW logo, so that it matches design specs.