### PR TITLE
Separate and share community options popover, first pass

### DIFF
--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -44,13 +44,63 @@ const getLastSeenDivider = (hasText = true) => {
   ]);
 };
 
+export const CommunityOptionsPopover: m.Component<{ isAdmin: boolean, isMod: boolean }, {}> = {
+  view: (vnode) => {
+    const { isAdmin, isMod } = vnode.attrs;
+    if (!isAdmin && !isMod && !app.community?.meta.invitesEnabled) return;
+    return m(PopoverMenu, {
+      class: 'community-options-popover',
+      position: 'bottom',
+      transitionDuration: 0,
+      hoverCloseDelay: 0,
+      closeOnContentClick: true,
+      trigger: m(Icon, {
+        name: Icons.CHEVRON_DOWN,
+        style: 'margin-left: 6px;',
+      }),
+      content: [
+        isAdmin && m(MenuItem, {
+          label: 'New topic',
+          onclick: (e) => {
+            e.preventDefault();
+            app.modals.create({ modal: NewTopicModal });
+          }
+        }),
+        (app.community?.meta.invitesEnabled || isAdmin) && m(MenuItem, {
+          label: 'Invite members',
+          onclick: (e) => {
+            e.preventDefault();
+            const data = app.activeCommunityId()
+              ? { communityInfo: app.community.meta } : { chainInfo: app.chain.meta.chain };
+            app.modals.create({
+              modal: CreateInviteModal,
+              data,
+            });
+          },
+        }),
+        isAdmin && m(MenuItem, {
+          label: 'Manage community',
+          onclick: (e) => {
+            e.preventDefault();
+            app.modals.lazyCreate('manage_community_modal');
+          }
+        }),
+        (isAdmin || isMod) && app.activeId() && m(MenuItem, {
+          label: 'Analytics',
+          onclick: (e) => m.route.set(`/${app.activeId()}/analytics`),
+        }),
+      ],
+    }),
+  }
+}
+
 const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
   view: (vnode) => {
     const { topic, stage } = vnode.attrs;
 
     const featuredTopicIds = app.community?.meta?.featuredTopics || app.chain?.meta?.chain?.featuredTopics;
     const topics = app.topics.getByCommunity(app.activeId()).map(({ id, name, description, telegram }) => {
-        return { id, name, description, telegram, featured_order: featuredTopicIds.indexOf(`${id}`) };
+      return { id, name, description, telegram, featured_order: featuredTopicIds.indexOf(`${id}`) };
     });
     const featuredTopics = topics.filter((t) => t.featured_order !== -1)
       .sort((a, b) => Number(a.featured_order) - Number(b.featured_order));
@@ -431,49 +481,7 @@ const DiscussionsPage: m.Component<{ topic?: string }, {
       title: [
         'Discussions',
         (isAdmin || isMod || app.community?.meta.invitesEnabled)
-          && m(PopoverMenu, {
-            class: 'sidebar-edit-topic',
-            position: 'bottom',
-            transitionDuration: 0,
-            hoverCloseDelay: 0,
-            closeOnContentClick: true,
-            trigger: m(Icon, {
-              name: Icons.CHEVRON_DOWN,
-              style: 'margin-left: 6px;',
-            }),
-            content: [
-              isAdmin && m(MenuItem, {
-                label: 'New topic',
-                onclick: (e) => {
-                  e.preventDefault();
-                  app.modals.create({ modal: NewTopicModal });
-                }
-              }),
-              (app.community?.meta.invitesEnabled || isAdmin) && m(MenuItem, {
-                label: 'Invite members',
-                onclick: (e) => {
-                  e.preventDefault();
-                  const data = app.activeCommunityId()
-                    ? { communityInfo: app.community.meta } : { chainInfo: app.chain.meta.chain };
-                  app.modals.create({
-                    modal: CreateInviteModal,
-                    data,
-                  });
-                },
-              }),
-              isAdmin && m(MenuItem, {
-                label: 'Manage community',
-                onclick: (e) => {
-                  e.preventDefault();
-                  app.modals.lazyCreate('manage_community_modal');
-                }
-              }),
-              (isAdmin || isMod) && app.activeId() && m(MenuItem, {
-                label: 'Analytics',
-                onclick: (e) => m.route.set(`/${app.activeId()}/analytics`),
-              }),
-            ],
-          }),
+        && m(CommunityOptionsPopover, { isAdmin, isMod })
       ],
       description: topicDescription,
       showNewProposalButton: true,

--- a/client/scripts/views/pages/members.ts
+++ b/client/scripts/views/pages/members.ts
@@ -15,6 +15,7 @@ import User, { UserBlock } from 'views/components/widgets/user';
 import Sublayout from 'views/sublayout';
 import ManageCommunityModal from 'views/modals/manage_community_modal';
 import { formatAddressShort } from '../../../../shared/utils';
+import { CommunityOptionsPopover } from './discussions';
 
 interface MemberInfo {
   chain: string;
@@ -63,10 +64,17 @@ const MembersPage : m.Component<{}, { membersRequested: boolean, membersLoaded: 
         }
       });
     }
+
+    const isAdmin = app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() });
+    const isMod = app.user.isRoleOfCommunity({
+      role: 'moderator', chain: app.activeChainId(), community: app.activeCommunityId()
+    });
+
     if (!vnode.state.membersLoaded) return m(PageLoading, {
       message: 'Loading members',
       title: [
         'Members',
+        m(CommunityOptionsPopover, { isAdmin, isMod }),
         m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
       ],
       showNewProposalButton: true,
@@ -76,6 +84,7 @@ const MembersPage : m.Component<{}, { membersRequested: boolean, membersLoaded: 
       class: 'MembersPage',
       title: [
         'Members',
+        m(CommunityOptionsPopover, { isAdmin, isMod }),
         m(Tag, { size: 'xs', label: 'Beta', style: 'position: relative; top: -2px; margin-left: 6px' })
       ],
       showNewProposalButton: true,

--- a/client/styles/components/sidebar/index.scss
+++ b/client/styles/components/sidebar/index.scss
@@ -269,7 +269,7 @@
     @include sidebar();
 }
 
-.cui-popover.sidebar-edit-topic .cui-menu,
-.cui-popover.sidebar-add-topic .cui-menu {
+.cui-popover.community-options-popover .cui-menu,
+.cui-popover.community-options-popover .cui-menu {
     padding: 4px 0;
 }


### PR DESCRIPTION
Currently, admins can't access member management options (invites, admin promotion, etc) from the Members page. This branch breaks off the community options popover into its own component, updates a legacy class name, and adds it to the Members sublayout. 