### PR TITLE
Fixed README.md to properly display instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nvm install
 ```
 
 - if for some reason, nvm still doesnt work, try using
-````
+```
     source ~/.nvm/nvm.sh
 ```
 

--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -534,7 +534,7 @@ const LinkNewAddressModal: m.Component<ILinkNewAddressModalAttrs, ILinkNewAddres
               m('p', 'Use the secret phrase to sign this message:'),
               m(CodeBlock, { clickToSelect: true }, [
                 // eslint-disable-next-line max-len
-                `echo "${vnode.state.newAddress.validationToken}" | subkey sign ${vnode.state.isEd25519 ? '--scheme ed25519 ' : ''} "`,
+                `echo "${vnode.state.newAddress.validationToken}" | subkey sign ${vnode.state.isEd25519 ? '--scheme ed25519 ' : '--suri'} "`,
                 m('span.no-select', 'secret phrase'),
                 '"',
               ]),


### PR DESCRIPTION
## Description
Deleted a single backtick from the README which prevented proper rendering of instructions and added "-suri" to the link new address modal instructions.

## Motivation and Context
It's much easier to follow the README with the proper formatting and "-suri" flag is necessary cmd line arg for subkey.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [x] no