### PR TITLE
Factor out magic auth into separate route for mobile.

### DIFF
--- a/server/passport.ts
+++ b/server/passport.ts
@@ -2,21 +2,16 @@ import passport from 'passport';
 import passportGithub from 'passport-github';
 import passportJWT from 'passport-jwt';
 import { Request } from 'express';
-import request from 'superagent';
 
-import { encodeAddress } from '@polkadot/util-crypto';
-
-import { Magic, MagicUserMetadata } from '@magic-sdk/admin';
+import { Magic } from '@magic-sdk/admin';
 import { Strategy as MagicStrategy } from 'passport-magic';
 
-import { sequelize } from './database';
+import { authenticateMagicLink } from './util/magicLink';
 import { factory, formatFilename } from '../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
-
 import {
-  JWT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_CALLBACK, MAGIC_API_KEY, MAGIC_SUPPORTED_BASES,
-  MAGIC_DEFAULT_CHAIN
+  JWT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_CALLBACK, MAGIC_DEFAULT_CHAIN
 } from './config';
 import { NotificationCategories } from '../shared/types';
 import lookupCommunityIsVisibleToUser from './util/lookupCommunityIsVisibleToUser';
@@ -25,7 +20,7 @@ const GithubStrategy = passportGithub.Strategy;
 const JWTStrategy = passportJWT.Strategy;
 const ExtractJWT = passportJWT.ExtractJwt;
 
-function setupPassport(models) {
+function setupPassport(models, magic?: Magic) {
   passport.use(new JWTStrategy({
     jwtFromRequest: ExtractJWT.fromExtractors([
       ExtractJWT.fromBodyField('jwt'),
@@ -49,9 +44,8 @@ function setupPassport(models) {
   }));
 
   // allow magic login if configured with key
-  if (MAGIC_API_KEY) {
+  if (magic) {
     // TODO: verify we are in a community that supports magic login
-    const magic = new Magic(MAGIC_API_KEY);
     passport.use(new MagicStrategy({ passReqToCallback: true }, async (req, user, cb) => {
       // determine login location
       let chain, community, error;
@@ -67,188 +61,23 @@ function setupPassport(models) {
         registrationChain = await models.Chain.findOne({ where: { id: chainId } });
       }
 
-      // fetch user data from magic backend
-      let userMetadata: MagicUserMetadata;
-      try {
-        userMetadata = await magic.users.getMetadataByIssuer(user.issuer);
-      } catch (e) {
-        return cb(new Error('Magic fetch failed.'));
+      const result = await authenticateMagicLink(
+        models,
+        magic,
+        user,
+        registrationChain,
+        { chain: req.body.chain, community: req.body.community },
+      );
+      if (result.error) {
+        return cb(new Error(result.error));
       }
-
-      // check if this is a new signup or a login
-      const existingUser = await models.User.scope('withPrivateData').findOne({
-        where: {
-          email: userMetadata.email,
-        },
-        include: [{
-          model: models.Address,
-          where: { is_magic: true },
-          required: false,
-        }],
-      });
-
-      // unsupported chain -- client should send through old email flow
-      if (!existingUser && (!registrationChain?.base || !MAGIC_SUPPORTED_BASES.includes(registrationChain.base))) {
-        return cb(new Error('Unsupported magic chain.'));
+      if (result.user) {
+        return cb(null, result.user, { message: result.message });
       }
-
-      if (!existingUser) {
-        const ethAddress = userMetadata.publicAddress;
-        let polkadotAddress;
-
-        // always retrieve the polkadot address for the user regardless of chain
-        try {
-          const polkadotResp = await request
-            // eslint-disable-next-line max-len
-            .get(`https://api.magic.link/v1/admin/auth/user/public/address/get?issuer=did:ethr:${userMetadata.publicAddress}`)
-            .set('X-Magic-Secret-key', MAGIC_API_KEY)
-            .accept('json');
-          if (polkadotResp.body?.status !== 'ok') {
-            throw new Error(polkadotResp.body?.message || 'Failed to fetch polkadot address');
-          }
-          const polkadotRespAddress = polkadotResp.body?.data?.public_address;
-
-          // convert to chain-specific address based on ss58 prefix, if we are on a specific
-          // polkadot chain. otherwise, encode to edgeware.
-          if (registrationChain.ss58_prefix) {
-            polkadotAddress = encodeAddress(polkadotRespAddress, registrationChain.ss58_prefix);
-          } else {
-            polkadotAddress = encodeAddress(polkadotRespAddress, 7); // edgeware SS58 prefix
-          }
-        } catch (err) {
-          return cb(new Error(err.message));
-        }
-
-        const result = await sequelize.transaction(async (t) => {
-          // create new user and unverified address if doesn't exist
-          const newUser = await models.User.create({
-            email: userMetadata.email,
-            emailVerified: true,
-            magicIssuer: userMetadata.issuer,
-            lastMagicLoginAt: user.claim.iat,
-          }, { transaction: t });
-
-          // create an address on their selected chain
-          let newAddress;
-          if (registrationChain.base === 'substrate') {
-            newAddress = await models.Address.create({
-              address: polkadotAddress,
-              chain: registrationChain.id,
-              verification_token: 'MAGIC',
-              verification_token_expires: null,
-              verified: new Date(), // trust addresses from magic
-              last_active: new Date(),
-              user_id: newUser.id,
-              is_magic: true,
-            }, { transaction: t });
-
-            // if they selected a substrate chain, create an additional address on ethereum
-            // and auto-add them to the eth forum
-            const ethAddressInstance = await models.Address.create({
-              address: ethAddress,
-              chain: 'ethereum',
-              verification_token: 'MAGIC',
-              verification_token_expires: null,
-              verified: new Date(), // trust addresses from magic
-              last_active: new Date(),
-              user_id: newUser.id,
-              is_magic: true,
-            }, { transaction: t });
-
-            await models.Role.create({
-              address_id: ethAddressInstance.id,
-              chain_id: 'ethereum',
-              permission: 'member',
-            });
-          } else {
-            newAddress = await models.Address.create({
-              address: ethAddress,
-              chain: registrationChain.id,
-              verification_token: 'MAGIC',
-              verification_token_expires: null,
-              verified: new Date(), // trust addresses from magic
-              last_active: new Date(),
-              user_id: newUser.id,
-              is_magic: true,
-            }, { transaction: t });
-
-            // if they selected an eth chain, create an additional address on edgeware
-            // and auto-add them to the forum
-            const edgewareAddressInstance = await models.Address.create({
-              address: polkadotAddress,
-              chain: 'edgeware',
-              verification_token: 'MAGIC',
-              verification_token_expires: null,
-              verified: new Date(), // trust addresses from magic
-              last_active: new Date(),
-              user_id: newUser.id,
-              is_magic: true,
-            }, { transaction: t });
-
-            await models.Role.create({
-              address_id: edgewareAddressInstance.id,
-              chain_id: 'edgeware',
-              permission: 'member',
-            }, { transaction: t });
-          }
-
-          if (req.body.chain || req.body.community) await models.Role.create(req.body.community ? {
-            address_id: newAddress.id,
-            offchain_community_id: req.body.community,
-            permission: 'member',
-          } : {
-            address_id: newAddress.id,
-            chain_id: req.body.chain,
-            permission: 'member',
-          }, { transaction: t });
-
-          // Automatically create subscription to their own mentions
-          await models.Subscription.create({
-            subscriber_id: newUser.id,
-            category_id: NotificationCategories.NewMention,
-            object_id: `user-${newUser.id}`,
-            is_active: true,
-          }, { transaction: t });
-
-          // Automatically create a subscription to collaborations
-          await models.Subscription.create({
-            subscriber_id: newUser.id,
-            category_id: NotificationCategories.NewCollaboration,
-            object_id: `user-${newUser.id}`,
-            is_active: true,
-          }, { transaction: t });
-
-          return newUser;
-        });
-
-        // re-fetch user to include address object
-        // TODO: simplify this without doing a refetch
-        const newUser = await models.User.findOne({
-          where: {
-            id: result.id,
-          },
-          include: [ models.Address ],
-        });
-        return cb(null, newUser);
-      } else if (existingUser.Addresses) {
-        // login user if they registered via magic
-        if (user.claim.iat <= existingUser.lastMagicLoginAt) {
-          console.log('Replay attack detected.');
-          return cb(null, null, {
-            message: `Replay attack detected for user ${user.issuer}}.`,
-          });
-        }
-        existingUser.lastMagicLoginAt = user.claim.iat;
-        await existingUser.save();
-        console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
-        return cb(null, existingUser);
-      } else {
-        // error if email exists but not registered with magic
-        console.log('User already registered with old method.');
-        return cb(null, null, {
-          message: `Email for user ${user.issuer} already registered`
-        });
+      if (result.message) {
+        return cb(null, null, { message: result.message });
       }
+      return cb(new Error('Unknown magic link failure.'));
     }));
   }
 

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import webpack from 'webpack';
 import passport from 'passport';
+import { Magic } from '@magic-sdk/admin';
 
 import status from './routes/status';
 import createGist from './routes/createGist';
@@ -62,7 +63,6 @@ import getInviteLinks from './routes/getInviteLinks';
 import deleteGithubAccount from './routes/deleteGithubAccount';
 import getProfile from './routes/getProfile';
 
-
 import createRole from './routes/createRole';
 import deleteRole from './routes/deleteRole';
 import setDefaultRole from './routes/setDefaultRole';
@@ -104,6 +104,7 @@ import editTopic from './routes/editTopic';
 import deleteTopic from './routes/deleteTopic';
 import bulkTopics from './routes/bulkTopics';
 import bulkOffchain from './routes/bulkOffchain';
+import mobileLoginRedirect from './routes/mobileLoginRedirect';
 
 import edgewareLockdropLookup from './routes/getEdgewareLockdropLookup';
 import edgewareLockdropStats from './routes/getEdgewareLockdropStats';
@@ -124,7 +125,8 @@ function setupRouter(
   models,
   viewCountCache: ViewCountCache,
   identityFetchCache: IdentityFetchCache,
-  tokenBalanceCache: TokenBalanceCache
+  tokenBalanceCache: TokenBalanceCache,
+  magic?: Magic,
 ) {
   const router = express.Router();
   router.get('/status', status.bind(this, models));
@@ -207,7 +209,11 @@ function setupRouter(
     updateThreadLinkedChainEntities.bind(this, models),
   );
 
-  router.post('/updateOffchainVote', passport.authenticate('jwt', { session: false }), updateOffchainVote.bind(this, models));
+  router.post(
+    '/updateOffchainVote',
+    passport.authenticate('jwt', { session: false }),
+    updateOffchainVote.bind(this, models)
+  );
   router.get('/viewOffchainVotes', viewOffchainVotes.bind(this, models));
 
   router.get('/fetchEntityTitle', fetchEntityTitle.bind(this, models));
@@ -449,13 +455,14 @@ function setupRouter(
   router.post('/auth/magic', passport.authenticate('magic'), (req, res, next) => {
     return res.json({ status: 'Success', result: req.user.toJSON() });
   });
+  router.get('/mobileLoginRedirect', mobileLoginRedirect.bind(this, models, magic));
   router.get('/auth/github', passport.authenticate('github'));
   router.get(
     '/auth/github/callback',
     passport.authenticate('github', { successRedirect: '/', failureRedirect: '/#!/login' }),
   );
   // logout
-  router.get('/logout', logout.bind(this, models));
+  router.get('/logout', logout.bind(this, models, magic));
 
   router.get('/edgewareLockdropLookup', edgewareLockdropLookup.bind(this, models));
   router.get('/edgewareLockdropStats', edgewareLockdropStats.bind(this, models));

--- a/server/routes/logout.ts
+++ b/server/routes/logout.ts
@@ -1,9 +1,10 @@
+import { Magic } from '@magic-sdk/admin';
 import { Request, Response } from 'express';
 import { factory, formatFilename } from '../../shared/logging';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-const logout = async (models, req: Request, res: Response) => {
+const logout = async (models, magic: Magic, req: Request, res: Response) => {
   // Passport has a race condition where req.logout resolves too
   // early, so we also call req.session.destroy() and clear the
   // session cookie before returning
@@ -12,6 +13,11 @@ const logout = async (models, req: Request, res: Response) => {
     res.clearCookie('connect.sid');
     res.redirect('/');
   });
+
+  // support magic logout
+  if (magic && req.query.didToken) {
+    await magic.users.logoutByToken(req.query.didToken);
+  }
 };
 
 export default logout;

--- a/server/routes/mobileLoginRedirect.ts
+++ b/server/routes/mobileLoginRedirect.ts
@@ -1,0 +1,63 @@
+import { NextFunction, Request, Response } from 'express';
+import { Magic } from '@magic-sdk/admin';
+import { MagicUser } from 'passport-magic';
+import jwt from 'jsonwebtoken';
+
+import { MAGIC_DEFAULT_CHAIN, JWT_SECRET } from '../config';
+import { authenticateMagicLink } from '../util/magicLink';
+import { factory, formatFilename } from '../../shared/logging';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+/**
+ * Used as the redirect endpoint from a user's magic.link email on a mobile device.
+ * Should register the user, generate a jwt, and redirect them to the deeplink URL
+ * with appropriate arguments set.
+ */
+const mobileLoginRedirect = async (models, magic: Magic, req: Request, res: Response, next: NextFunction) => {
+  if (!magic) {
+    return next(new Error('Magic support not enabled.'));
+  }
+  const { didToken, redirectDeeplink } = req.query;
+  if (!didToken) {
+    return next(new Error('Must provide DID token'));
+  }
+  if (!redirectDeeplink) {
+    return next(new Error('Must provide redirectDeeplink'));
+  }
+
+  // parse user from DID
+  let magicUser: MagicUser;
+  try {
+    magic.token.validate(didToken);
+    magicUser = {
+      issuer: magic.token.getIssuer(didToken),
+      publicAddress: magic.token.getPublicAddress(didToken),
+      claim: magic.token.decode(didToken)[1],
+    };
+  } catch (err) {
+    return next(new Error('Could not validate DID token.'));
+  }
+
+  // fetch default chain (TODO: provide option to pass in chain)
+  const chain = await models.Chain.findOne({ where: { id: MAGIC_DEFAULT_CHAIN } });
+
+  // perform login (TODO: support additional roles)
+  const result = await authenticateMagicLink(models, magic, magicUser, chain);
+  if (result.error) {
+    return next(new Error(result.error));
+  }
+  if (!result.user) {
+    return next(new Error(result.message || 'Could not authenticate user.'));
+  }
+  const { user, isSignup } = result;
+  const jwtToken = jwt.sign({ id: user.id, email: user.email }, JWT_SECRET);
+
+  // TODO: validate deep link
+  const redirectUrl = `${
+    decodeURIComponent(redirectDeeplink)
+  }?screen=Validate&jwt=${jwtToken}&mode=${isSignup ? 'signup' : 'login'}`;
+  return res.redirect(303, redirectUrl);
+};
+
+export default mobileLoginRedirect;

--- a/server/util/magicLink.ts
+++ b/server/util/magicLink.ts
@@ -1,0 +1,208 @@
+import { Magic, MagicUserMetadata } from '@magic-sdk/admin';
+import { MagicUser } from 'passport-magic';
+
+import request from 'superagent';
+import { encodeAddress } from '@polkadot/util-crypto';
+
+import { ChainInstance } from '../models/chain';
+import { UserInstance } from '../models/user';
+import { MAGIC_API_KEY, MAGIC_SUPPORTED_BASES } from '../config';
+import { sequelize } from '../database';
+
+import { NotificationCategories } from '../../shared/types';
+
+export interface AuthenticateMagicLinkResults {
+  user?: UserInstance;
+  message?: string;
+  isSignup?: boolean;
+  error?: string;
+}
+
+export async function authenticateMagicLink(
+  models,
+  magic: Magic,
+  user: MagicUser,
+  chain: ChainInstance,
+  roleInfo?: { chain?: string, community: string },
+): Promise<AuthenticateMagicLinkResults> {
+  // fetch user data from magic backend
+  let userMetadata: MagicUserMetadata;
+  try {
+    userMetadata = await magic.users.getMetadataByIssuer(user.issuer);
+  } catch (e) {
+    return { error: 'Magic fetch failed.' };
+  }
+
+  // check if this is a new signup or a login
+  const existingUser: UserInstance | undefined = await models.User.scope('withPrivateData').findOne({
+    where: {
+      email: userMetadata.email,
+    },
+    include: [{
+      model: models.Address,
+      where: { is_magic: true },
+      required: false,
+    }],
+  });
+
+  if (!existingUser) {
+    // unsupported chain -- client should send through old email flow
+    if (!chain?.base || !MAGIC_SUPPORTED_BASES.includes(chain.base)) {
+      return { error: 'Unsupported magic chain.' };
+    }
+
+    const ethAddress = userMetadata.publicAddress;
+    let polkadotAddress;
+
+    // always retrieve the polkadot address for the user regardless of chain
+    try {
+      const polkadotResp = await request
+        // eslint-disable-next-line max-len
+        .get(`https://api.magic.link/v1/admin/auth/user/public/address/get?issuer=did:ethr:${userMetadata.publicAddress}`)
+        .set('X-Magic-Secret-key', MAGIC_API_KEY)
+        .accept('json');
+      if (polkadotResp.body?.status !== 'ok') {
+        return { error: polkadotResp.body?.message || 'Failed to fetch polkadot address' };
+      }
+      const polkadotRespAddress = polkadotResp.body?.data?.public_address;
+
+      // convert to chain-specific address based on ss58 prefix, if we are on a specific
+      // polkadot chain. otherwise, encode to edgeware.
+      if (chain.ss58_prefix) {
+        polkadotAddress = encodeAddress(polkadotRespAddress, chain.ss58_prefix);
+      } else {
+        polkadotAddress = encodeAddress(polkadotRespAddress, 7); // edgeware SS58 prefix
+      }
+    } catch (err) {
+      return { error: err.message };
+    }
+
+    const result = await sequelize.transaction(async (t) => {
+      // create new user and unverified address if doesn't exist
+      const newUser = await models.User.create({
+        email: userMetadata.email,
+        emailVerified: true,
+        magicIssuer: userMetadata.issuer,
+        lastMagicLoginAt: user.claim.iat,
+      }, { transaction: t });
+
+      // create an address on their selected chain
+      let newAddress;
+      if (chain.base === 'substrate') {
+        newAddress = await models.Address.create({
+          address: polkadotAddress,
+          chain: chain.id,
+          verification_token: 'MAGIC',
+          verification_token_expires: null,
+          verified: new Date(), // trust addresses from magic
+          last_active: new Date(),
+          user_id: newUser.id,
+          is_magic: true,
+        }, { transaction: t });
+
+        // if they selected a substrate chain, create an additional address on ethereum
+        // and auto-add them to the eth forum
+        const ethAddressInstance = await models.Address.create({
+          address: ethAddress,
+          chain: 'ethereum',
+          verification_token: 'MAGIC',
+          verification_token_expires: null,
+          verified: new Date(), // trust addresses from magic
+          last_active: new Date(),
+          user_id: newUser.id,
+          is_magic: true,
+        }, { transaction: t });
+
+        await models.Role.create({
+          address_id: ethAddressInstance.id,
+          chain_id: 'ethereum',
+          permission: 'member',
+        }, { transaction: t });
+      } else {
+        newAddress = await models.Address.create({
+          address: ethAddress,
+          chain: chain.id,
+          verification_token: 'MAGIC',
+          verification_token_expires: null,
+          verified: new Date(), // trust addresses from magic
+          last_active: new Date(),
+          user_id: newUser.id,
+          is_magic: true,
+        }, { transaction: t });
+
+        // if they selected an eth chain, create an additional address on edgeware
+        // and auto-add them to the forum
+        const edgewareAddressInstance = await models.Address.create({
+          address: polkadotAddress,
+          chain: 'edgeware',
+          verification_token: 'MAGIC',
+          verification_token_expires: null,
+          verified: new Date(), // trust addresses from magic
+          last_active: new Date(),
+          user_id: newUser.id,
+          is_magic: true,
+        }, { transaction: t });
+
+        await models.Role.create({
+          address_id: edgewareAddressInstance.id,
+          chain_id: 'edgeware',
+          permission: 'member',
+        }, { transaction: t });
+      }
+
+      if (roleInfo?.chain || roleInfo?.community) {
+        await models.Role.create(roleInfo?.community ? {
+          address_id: newAddress.id,
+          offchain_community_id: roleInfo?.community,
+          permission: 'member',
+        } : {
+          address_id: newAddress.id,
+          chain_id: roleInfo?.chain,
+          permission: 'member',
+        }, { transaction: t });
+      }
+
+      // Automatically create subscription to their own mentions
+      await models.Subscription.create({
+        subscriber_id: newUser.id,
+        category_id: NotificationCategories.NewMention,
+        object_id: `user-${newUser.id}`,
+        is_active: true,
+      }, { transaction: t });
+
+      // Automatically create a subscription to collaborations
+      await models.Subscription.create({
+        subscriber_id: newUser.id,
+        category_id: NotificationCategories.NewCollaboration,
+        object_id: `user-${newUser.id}`,
+        is_active: true,
+      }, { transaction: t });
+
+      return newUser;
+    });
+
+    // re-fetch user to include address object
+    // TODO: simplify this without doing a refetch
+    const newUser: UserInstance = await models.User.findOne({
+      where: {
+        id: result.id,
+      },
+      include: [ models.Address ],
+    });
+    return { user: newUser, isSignup: true };
+  } else if (existingUser.Addresses) {
+    // login user if they registered via magic
+    if (user.claim.iat <= existingUser.lastMagicLoginAt) {
+      console.log('Replay attack detected.');
+      return { message: `Replay attack detected for user ${user.issuer}}.` };
+    }
+    existingUser.lastMagicLoginAt = user.claim.iat;
+    await existingUser.save();
+    console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
+    return { user: existingUser, isSignup: false };
+  } else {
+    // error if email exists but not registered with magic
+    console.log('User already registered with old method.');
+    return { message: `Email for user ${user.issuer} already registered.` };
+  }
+}


### PR DESCRIPTION
## Description
- Adds a `/api/mobileLoginRedirect` route which accepts a redirect and a DID token and performs the same authorization as within the passport's `/auth/magic`, but followed by a 303 redirect to the requested URL. This is so the mobile app can have the magic email link perform a deeplink redirect once clicked.
- Added an optional JWT authorization inside the `/api/status` route, to support fetching site user data without supplying cookies.

## Motivation and Context
Required for mobile app.

## How has this been tested?
Manually ran through currently supported cases + created a small test infrastructure for testing the redirectURI feature.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [x] yes, but I did not run tests