### PR TITLE
Load bulkOffchain in parallel with proposal comments and chain entities

### DIFF
--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -44,17 +44,20 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
         ? EntityRefreshOption.AllEntities
         : EntityRefreshOption.CompletedEntities;
 
-      await this.chainEntities.refresh(this.meta.chain.id, refresh);
-      await this.app.comments.refreshAll(
-        this.meta.chain.id,
-        null,
-        CommentRefreshOption.LoadProposalComments
-      );
-      response = await $.get(`${this.app.serverUrl()}/bulkOffchain`, {
-        chain: this.id,
-        community: null,
-        jwt: this.app.user.jwt,
-      });
+      let _unused1, _unused2;
+      [_unused1, _unused2, response] = await Promise.all([
+        this.chainEntities.refresh(this.meta.chain.id, refresh),
+        this.app.comments.refreshAll(
+          this.meta.chain.id,
+          null,
+          CommentRefreshOption.LoadProposalComments
+        ),
+        $.get(`${this.app.serverUrl()}/bulkOffchain`, {
+          chain: this.id,
+          community: null,
+          jwt: this.app.user.jwt,
+        }),
+      ]);
     } else {
       response = await $.get(`${this.app.serverUrl()}/bulkOffchain`, {
         chain: this.id,


### PR DESCRIPTION
This allows bulkOffchain to start loading about 1sec earlier when proposal comments and chain entities start loading, rather than waiting for them to finish.

Considering that bulkOffchain is the longest running request for most of our communities, this seems worth optimizing.

## How has this been tested?
Tested:
- Going to a community
- Switching between communities
- Leaving and returning to a community's homepage
- Leaving and returning to a community's homepage, while moving between different communities

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [X] no