### PR TITLE
Custom stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We also use certain environment variables to configure the application itself:
 To download and restore the production database, and run migrations:
 
 ```
-pg_dump $(heroku config:get DATABASE_URL --app commonwealthapp) --verbose --exclude-table-data="public.\"Sessions\"" --exclude-table-data="public.\"DiscussionDrafts\"" --exclude-table-data="public.\"LoginTokens\"" --exclude-table-data="public.\"Notifications\"" --exclude-table-data="public.\"SocialAccounts\"" --exclude-table-data="public.\"Webhooks\"" --exclude-table-data="public.\"ChainEvents\"" --no-privileges --no-owner -f latest.dump
+pg_dump $(heroku config:get DATABASE_URL --app commonwealthapp) --verbose --exclude-table-data="public.\"Sessions\"" --exclude-table-data="public.\"DiscussionDrafts\"" --exclude-table-data="public.\"LoginTokens\"" --exclude-table-data="public.\"Notifications\"" --exclude-table-data="public.\"EdgewareLockdropEverythings\"" --exclude-table-data="public.\"EdgewareLockdropBalances\"" --exclude-table-data="public.\"EdgewareLockdropEvents\"" --exclude-table-data="public.\"SocialAccounts\"" --exclude-table-data="public.\"Webhooks\"" --exclude-table-data="public.\"ChainEvents\"" --no-privileges --no-owner -f latest.dump
 
 npx sequelize db:drop
 npx sequelize db:create

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -82,6 +82,8 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
           privacyEnabled: community.privacyEnabled,
           featuredTopics: community.featured_topics,
           topics: community.topics,
+          stagesEnabled: community.stagesEnabled,
+          additionalStages: community.additionalStages,
           customDomain: community.customDomain,
           adminsAndMods: [],
         }));

--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -31,9 +31,9 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
     }
 
     const {
-      threads, comments, reactions, topics, admins, activeUsers, numPrevotingThreads, numVotingThreads
+      threads, comments, reactions, topics, admins, activeUsers, numVotingThreads
     } = response.result;
-    this.app.threads.initialize(threads, numPrevotingThreads, numVotingThreads, true);
+    this.app.threads.initialize(threads, numVotingThreads, true);
     this.app.comments.initialize(comments, true);
     this.app.reactions.initialize(reactions, true);
     this.app.topics.initialize(topics, true);

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -156,7 +156,6 @@ class ThreadsController {
 
   public get initialized() { return this._initialized; }
 
-  public numPrevotingThreads: number;
   public numVotingThreads: number;
 
   public getType(primary: string, secondary?: string, tertiary?: string) {
@@ -207,7 +206,6 @@ class ThreadsController {
       this._store.add(result);
 
       // Update stage counts
-      if (result.stage === OffchainThreadStage.ProposalInReview) this.numPrevotingThreads++;
       if (result.stage === OffchainThreadStage.Voting) this.numVotingThreads++;
 
       // New posts are added to both the topic and allProposals sub-store
@@ -253,9 +251,7 @@ class ThreadsController {
       success: (response) => {
         const result = modelFromServer(response.result);
         // Update counters
-        if (proposal.stage === OffchainThreadStage.ProposalInReview) this.numPrevotingThreads--;
         if (proposal.stage === OffchainThreadStage.Voting) this.numVotingThreads--;
-        if (result.stage === OffchainThreadStage.ProposalInReview) this.numPrevotingThreads++;
         if (result.stage === OffchainThreadStage.Voting) this.numVotingThreads++;
         // Post edits propagate to all thread stores
         this._store.update(result);
@@ -338,9 +334,7 @@ class ThreadsController {
       success: (response) => {
         const result = modelFromServer(response.result);
         // Update counters
-        if (args.stage === OffchainThreadStage.ProposalInReview) this.numPrevotingThreads--;
         if (args.stage === OffchainThreadStage.Voting) this.numVotingThreads--;
-        if (result.stage === OffchainThreadStage.ProposalInReview) this.numPrevotingThreads++;
         if (result.stage === OffchainThreadStage.Voting) this.numVotingThreads++;
         // Post edits propagate to all thread stores
         this._store.update(result);
@@ -535,7 +529,7 @@ class ThreadsController {
         }
         // Threads that are posted in an offchain community are still linked to a chain / author address,
         // so when we want just chain threads, then we have to filter away those that have a community
-        const { threads, numPrevotingThreads, numVotingThreads } = response.result;
+        const { threads, numVotingThreads } = response.result;
         for (const thread of threads) {
           // TODO: OffchainThreads should always have a linked Address
           if (!thread.Address) {
@@ -552,7 +546,6 @@ class ThreadsController {
             console.error(e.message);
           }
         }
-        this.numPrevotingThreads = numPrevotingThreads;
         this.numVotingThreads = numVotingThreads;
         this._initialized = true;
       }, (err) => {
@@ -563,7 +556,7 @@ class ThreadsController {
       });
   }
 
-  public initialize(initialThreads: any[], numPrevotingThreads, numVotingThreads, reset) {
+  public initialize(initialThreads: any[], numVotingThreads, reset) {
     if (reset) {
       this._store.clear();
       this._listingStore.clear();
@@ -582,7 +575,6 @@ class ThreadsController {
         console.error(e.message);
       }
     }
-    this.numPrevotingThreads = numPrevotingThreads;
     this.numVotingThreads = numVotingThreads;
     this._initialized = true;
   }

--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -21,23 +21,7 @@ export function offchainThreadStageToLabel(stage: OffchainThreadStage) {
   } else if (stage === OffchainThreadStage.Failed) {
     return 'Not Passed';
   } else {
-    return 'Other';
-  }
-}
-
-export function offchainThreadStageToIndex(stage: OffchainThreadStage) {
-  if (stage === OffchainThreadStage.Discussion) {
-    return 1;
-  } else if (stage === OffchainThreadStage.ProposalInReview) {
-    return 2;
-  } else if (stage === OffchainThreadStage.Voting) {
-    return 3;
-  } else if (stage === OffchainThreadStage.Passed) {
-    return 4;
-  } else if (stage === OffchainThreadStage.Failed) {
-    return 5;
-  } else {
-    return 6;
+    return stage;
   }
 }
 

--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -25,6 +25,18 @@ export function offchainThreadStageToLabel(stage: OffchainThreadStage) {
   }
 }
 
+export function parseCustomStages(str) {
+  // Parse additionalStages into a `string[]` and then cast to OffchainThreadStage[]
+  // If parsing fails, return an empty array.
+  let arr;
+  try {
+    arr = Array.from(JSON.parse(str));
+  } catch (e) {
+    return [];
+  }
+  return arr.map((s) => s?.toString()).filter(s => s) as unknown as OffchainThreadStage[];
+}
+
 /*
  * mithril link helper
  */

--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -18,6 +18,8 @@ class ChainInfo {
   public element: string;
   public telegram: string;
   public github: string;
+  public stagesEnabled: boolean;
+  public additionalStages: string;
   public customDomain: string;
   public readonly blockExplorerIds: { [id: string]: string };
   public readonly collapsedOnHomepage: boolean;
@@ -32,6 +34,7 @@ class ChainInfo {
 
   constructor({
     id, network, symbol, name, iconUrl, description, website, discord, element, telegram, github,
+    stagesEnabled, additionalStages,
     customDomain, blockExplorerIds, collapsedOnHomepage, featuredTopics, topics, adminsAndMods,
     base, ss58_prefix, type, substrateSpec
   }) {
@@ -47,6 +50,8 @@ class ChainInfo {
     this.element = element;
     this.telegram = telegram;
     this.github = github;
+    this.stagesEnabled = stagesEnabled;
+    this.additionalStages = additionalStages;
     this.customDomain = customDomain;
     this.blockExplorerIds = blockExplorerIds;
     this.collapsedOnHomepage = collapsedOnHomepage;
@@ -70,6 +75,8 @@ class ChainInfo {
     element,
     telegram,
     github,
+    stagesEnabled,
+    additionalStages,
     customDomain,
     blockExplorerIds,
     collapsed_on_homepage,
@@ -100,6 +107,8 @@ class ChainInfo {
       element,
       telegram,
       github,
+      stagesEnabled,
+      additionalStages,
       customDomain,
       blockExplorerIds: blockExplorerIdsParsed,
       collapsedOnHomepage: collapsed_on_homepage,
@@ -161,10 +170,10 @@ class ChainInfo {
   }
 
   // TODO: change to accept an object
-  public async updateChainData(
-    name: string, description: string, website: string, discord: string, element: string, telegram: string,
-    github: string, customDomain: string
-  ) {
+  public async updateChainData({
+    name, description, website, discord, element, telegram,
+    github, stagesEnabled, additionalStages, customDomain
+  }) {
     // TODO: Change to PUT /chain
     const r = await $.post(`${app.serverUrl()}/updateChain`, {
       'id': app.activeChainId(),
@@ -175,6 +184,8 @@ class ChainInfo {
       'element': element,
       'telegram': telegram,
       'github': github,
+      'stagesEnabled': stagesEnabled,
+      'additionalStages': additionalStages,
       'customDomain': customDomain,
       'jwt': app.user.jwt,
     });
@@ -186,6 +197,8 @@ class ChainInfo {
     this.element = updatedChain.element;
     this.telegram = updatedChain.telegram;
     this.github = updatedChain.github;
+    this.stagesEnabled = updatedChain.stagesEnabled;
+    this.additionalStages = updatedChain.additionalStages;
     this.customDomain = updatedChain.customDomain;
   }
 

--- a/client/scripts/models/CommunityInfo.ts
+++ b/client/scripts/models/CommunityInfo.ts
@@ -14,6 +14,8 @@ interface CommunityData {
   telegram: string;
   github: string;
   visible: boolean;
+  stagesEnabled: boolean,
+  additionalStages: string,
   customDomain: string;
   invitesEnabled: boolean,
   privacyEnabled: boolean,
@@ -33,6 +35,8 @@ class CommunityInfo {
   public readonly visible: boolean;
   public invitesEnabled: boolean;
   public privacyEnabled: boolean;
+  public stagesEnabled: boolean;
+  public additionalStages: string;
   public customDomain: string;
   public readonly collapsedOnHomepage: boolean;
   public readonly featuredTopics: string[];
@@ -43,6 +47,7 @@ class CommunityInfo {
   // TODO: convert this to accept opject with params instead
   constructor({
     id, name, description, iconUrl, website, discord, element, telegram, github, defaultChain, visible,
+    stagesEnabled, additionalStages,
     customDomain, invitesEnabled, privacyEnabled, collapsedOnHomepage, featuredTopics, topics, adminsAndMods
   }) {
     this.id = id;
@@ -56,6 +61,8 @@ class CommunityInfo {
     this.github = github;
     this.defaultChain = defaultChain;
     this.visible = visible;
+    this.stagesEnabled = stagesEnabled;
+    this.additionalStages = additionalStages;
     this.customDomain = customDomain;
     this.invitesEnabled = invitesEnabled;
     this.privacyEnabled = privacyEnabled;
@@ -77,6 +84,8 @@ class CommunityInfo {
     github,
     defaultChain: default_chain,
     visible,
+    stagesEnabled,
+    additionalStages,
     customDomain,
     invitesEnabled,
     privacyEnabled,
@@ -97,6 +106,8 @@ class CommunityInfo {
       github,
       defaultChain: default_chain,
       visible,
+      stagesEnabled,
+      additionalStages,
       customDomain,
       invitesEnabled,
       privacyEnabled,
@@ -160,6 +171,8 @@ class CommunityInfo {
     name,
     iconUrl,
     privacyEnabled,
+    stagesEnabled,
+    additionalStages,
     customDomain,
     website,
     discord,
@@ -178,6 +191,8 @@ class CommunityInfo {
       'element': element,
       'telegram': telegram,
       'github': github,
+      'stagesEnabled': stagesEnabled,
+      'additionalStages': additionalStages,
       'customDomain': customDomain,
       'privacy': privacyEnabled,
       'invites': invitesEnabled,
@@ -192,6 +207,8 @@ class CommunityInfo {
     this.element = updatedCommunity.element;
     this.telegram = updatedCommunity.telegram;
     this.github = updatedCommunity.github;
+    this.stagesEnabled = stagesEnabled;
+    this.additionalStages = additionalStages;
     this.customDomain = updatedCommunity.customDomain;
     this.privacyEnabled = updatedCommunity.privacyEnabled;
     this.invitesEnabled = updatedCommunity.invitesEnabled;

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -74,9 +74,9 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     }
 
     const {
-      threads, comments, reactions, topics, admins, activeUsers, numPrevotingThreads, numVotingThreads
+      threads, comments, reactions, topics, admins, activeUsers, numVotingThreads
     } = response.result;
-    this.app.threads.initialize(threads, numPrevotingThreads, numVotingThreads, true);
+    this.app.threads.initialize(threads, numVotingThreads, true);
     this.app.comments.initialize(comments, false);
     this.app.reactions.initialize(reactions, true);
     this.app.topics.initialize(topics, true);

--- a/client/scripts/models/types.ts
+++ b/client/scripts/models/types.ts
@@ -64,6 +64,7 @@ export enum OffchainThreadKind {
   Request = 'request',
 }
 
+// TODO: this list should be shared with the server
 export enum OffchainThreadStage {
   Discussion = 'discussion',
   ProposalInReview = 'proposal_in_review',

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -6,7 +6,7 @@ import { uuidv4 } from 'lib/util';
 import { QueryList, ListItem, Button, Classes, Dialog, InputSelect, Icon, Icons, MenuItem } from 'construct-ui';
 
 import app from 'state';
-import { offchainThreadStageToLabel } from 'helpers';
+import { offchainThreadStageToLabel, parseCustomStages } from 'helpers';
 import { ChainEntity, OffchainThread, OffchainThreadStage } from 'models';
 import { chainEntityTypeToProposalName } from 'identifiers';
 import ChainEntityController, { EntityRefreshOption } from 'controllers/server/chain_entities';
@@ -104,6 +104,9 @@ const StageEditor: m.Component<{
     vnode.attrs.thread.chainEntities.forEach((ce) => vnode.state.chainEntitiesToSet.push(ce));
   },
   view: (vnode) => {
+    if (!app.chain?.meta?.chain && !app.community?.meta) return;
+    const { additionalStages } = app.chain?.meta?.chain || app.community?.meta;
+
     return m('.StageEditor', [
       !vnode.attrs.popoverMenu && m('a', {
         href: '#',
@@ -119,6 +122,7 @@ const StageEditor: m.Component<{
             [
               OffchainThreadStage.Discussion,
               OffchainThreadStage.ProposalInReview,
+              ...parseCustomStages(additionalStages),
               OffchainThreadStage.Voting,
               OffchainThreadStage.Passed,
               OffchainThreadStage.Failed,

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -35,8 +35,8 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
     vnode.state.element = vnode.attrs.chain.element;
     vnode.state.telegram = vnode.attrs.chain.telegram;
     vnode.state.github = vnode.attrs.chain.github;
-    vnode.state.stagesEnabled = vnode.attrs.community.stagesEnabled;
-    vnode.state.additionalStages = vnode.attrs.community.additionalStages;
+    vnode.state.stagesEnabled = vnode.attrs.chain.stagesEnabled;
+    vnode.state.additionalStages = vnode.attrs.chain.additionalStages;
     vnode.state.customDomain = vnode.attrs.chain.customDomain;
     vnode.state.iconUrl = vnode.attrs.chain.iconUrl;
     vnode.state.network = vnode.attrs.chain.network;
@@ -95,14 +95,12 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
           title: 'Stages',
           defaultValue: vnode.attrs.chain.stagesEnabled,
           onToggle: (checked) => { vnode.state.stagesEnabled = checked; },
-          caption: (checked) => checked
-            ? 'Allow tagging threads with the progress of a governance proposal'
-            : 'Stages disabled',
+          caption: () => 'Tag threads with proposal progress',
         }),
         m(InputPropertyRow, {
-          title: 'Additional Stages',
+          title: 'Add Stages',
           defaultValue: vnode.state.additionalStages,
-          placeholder: '["Temperature Check", "Consensus Check"]',
+          placeholder: 'Optional: ["Temperature Check", "Consensus Check"]',
           onChangeHandler: (v) => { vnode.state.additionalStages = v; },
         }),
         m(InputPropertyRow, {

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -95,12 +95,14 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
           title: 'Stages',
           defaultValue: vnode.attrs.chain.stagesEnabled,
           onToggle: (checked) => { vnode.state.stagesEnabled = checked; },
-          caption: () => 'Tag threads with proposal progress',
+          caption: (checked) => checked
+            ? 'Show proposal progress on threads'
+            : 'Don\'t show progress on threads',
         }),
         m(InputPropertyRow, {
-          title: 'Add Stages',
+          title: 'Custom Stages',
           defaultValue: vnode.state.additionalStages,
-          placeholder: 'Optional: ["Temperature Check", "Consensus Check"]',
+          placeholder: '["Temperature Check", "Consensus Check"]',
           onChangeHandler: (v) => { vnode.state.additionalStages = v; },
         }),
         m(InputPropertyRow, {

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -5,7 +5,7 @@ import { Button, Table } from 'construct-ui';
 import { ChainNetwork } from 'models';
 import { notifyError } from 'controllers/app/notifications';
 import { IChainOrCommMetadataManagementAttrs } from './community_metadata_management_table';
-import { InputPropertyRow, ManageRolesRow } from './metadata_rows';
+import { TogglePropertyRow, InputPropertyRow, ManageRolesRow } from './metadata_rows';
 
 interface IChainMetadataManagementState {
   name: string;
@@ -19,6 +19,8 @@ interface IChainMetadataManagementState {
   loadingFinished: boolean;
   loadingStarted: boolean;
   iconUrl: string;
+  stagesEnabled: boolean;
+  additionalStages: string;
   customDomain: string;
   network: ChainNetwork;
   symbol: string;
@@ -33,6 +35,8 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
     vnode.state.element = vnode.attrs.chain.element;
     vnode.state.telegram = vnode.attrs.chain.telegram;
     vnode.state.github = vnode.attrs.chain.github;
+    vnode.state.stagesEnabled = vnode.attrs.community.stagesEnabled;
+    vnode.state.additionalStages = vnode.attrs.community.additionalStages;
     vnode.state.customDomain = vnode.attrs.chain.customDomain;
     vnode.state.iconUrl = vnode.attrs.chain.iconUrl;
     vnode.state.network = vnode.attrs.chain.network;
@@ -87,6 +91,20 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
           placeholder: 'https://github.com',
           onChangeHandler: (v) => { vnode.state.github = v; },
         }),
+        m(TogglePropertyRow, {
+          title: 'Stages',
+          defaultValue: vnode.attrs.chain.stagesEnabled,
+          onToggle: (checked) => { vnode.state.stagesEnabled = checked; },
+          caption: (checked) => checked
+            ? 'Allow tagging threads with the progress of a governance proposal'
+            : 'Stages disabled',
+        }),
+        m(InputPropertyRow, {
+          title: 'Additional Stages',
+          defaultValue: vnode.state.additionalStages,
+          placeholder: '["Temperature Check", "Consensus Check"]',
+          onChangeHandler: (v) => { vnode.state.additionalStages = v; },
+        }),
         m(InputPropertyRow, {
           title: 'Domain',
           defaultValue: vnode.state.customDomain,
@@ -114,9 +132,31 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
         label: 'Save changes',
         intent: 'primary',
         onclick: async (e) => {
-          const { name, description, website, discord, element, telegram, github, customDomain } = vnode.state;
+          const {
+            name,
+            description,
+            website,
+            discord,
+            element,
+            telegram,
+            github,
+            stagesEnabled,
+            additionalStages,
+            customDomain
+          } = vnode.state;
           try {
-            await vnode.attrs.chain.updateChainData(name, description, website, discord, element, telegram, github, customDomain);
+            await vnode.attrs.chain.updateChainData({
+              name,
+              description,
+              website,
+              discord,
+              element,
+              telegram,
+              github,
+              stagesEnabled,
+              additionalStages,
+              customDomain
+            });
             $(e.target).trigger('modalexit');
           } catch (err) {
             notifyError(err.responseJSON?.error || 'Chain update failed');

--- a/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
@@ -104,7 +104,7 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
       m(InputPropertyRow, {
         title: 'Additional Stages',
         defaultValue: vnode.state.additionalStages,
-        placeholder: '["Temperature Check", "Consensus Check"]',
+        placeholder: 'Optional: ["Temperature Check", "Consensus Check"]',
         onChangeHandler: (v) => { vnode.state.additionalStages = v; },
       }),
       m(InputPropertyRow, {

--- a/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
@@ -17,6 +17,8 @@ interface ICommunityMetadataManagementState {
   element: string;
   telegram: string;
   github: string;
+  stagesEnabled: boolean;
+  additionalStages: string;
   customDomain: string;
 }
 
@@ -39,6 +41,8 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
     vnode.state.element = vnode.attrs.community.element;
     vnode.state.telegram = vnode.attrs.community.telegram;
     vnode.state.github = vnode.attrs.community.github;
+    vnode.state.stagesEnabled = vnode.attrs.community.stagesEnabled;
+    vnode.state.additionalStages = vnode.attrs.community.additionalStages;
     vnode.state.customDomain = vnode.attrs.community.customDomain;
   },
   view: (vnode) => {
@@ -89,6 +93,20 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
         placeholder: 'https://github.com',
         onChangeHandler: (v) => { vnode.state.github = v; },
       }),
+      m(TogglePropertyRow, {
+        title: 'Stages',
+        defaultValue: vnode.attrs.community.stagesEnabled,
+        onToggle: (checked) => { vnode.state.stagesEnabled = checked; },
+        caption: (checked) => checked
+          ? 'Allow tagging threads with the progress of a governance proposal'
+          : 'Stages disabled',
+      }),
+      m(InputPropertyRow, {
+        title: 'Additional Stages',
+        defaultValue: vnode.state.additionalStages,
+        placeholder: '["Temperature Check", "Consensus Check"]',
+        onChangeHandler: (v) => { vnode.state.additionalStages = v; },
+      }),
       m(InputPropertyRow, {
         title: 'Domain',
         defaultValue: vnode.state.customDomain,
@@ -137,6 +155,8 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
           element,
           telegram,
           github,
+          stagesEnabled,
+          additionalStages,
           customDomain,
           invitesEnabled,
           privacyEnabled,
@@ -151,6 +171,8 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
             element,
             telegram,
             github,
+            stagesEnabled,
+            additionalStages,
             customDomain,
             privacyEnabled,
             invitesEnabled,

--- a/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
@@ -98,13 +98,13 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
         defaultValue: vnode.attrs.community.stagesEnabled,
         onToggle: (checked) => { vnode.state.stagesEnabled = checked; },
         caption: (checked) => checked
-          ? 'Allow tagging threads with the progress of a governance proposal'
-          : 'Stages disabled',
+          ? 'Show proposal progress on threads'
+          : 'Don\'t show progress on threads',
       }),
       m(InputPropertyRow, {
-        title: 'Additional Stages',
+        title: 'Custom Stages',
         defaultValue: vnode.state.additionalStages,
-        placeholder: 'Optional: ["Temperature Check", "Consensus Check"]',
+        placeholder: '["Temperature Check", "Consensus Check"]',
         onChangeHandler: (v) => { vnode.state.additionalStages = v; },
       }),
       m(InputPropertyRow, {

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -88,10 +88,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
           m('p', [
-            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `,
-          ]),
-          m('p', [
-            'Select a wallet below to continue:',
+            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community: `,
           ]),
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -88,7 +88,7 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread, showExcerpt?: boole
           intent: proposal.stage === OffchainThreadStage.ProposalInReview ? 'positive'
             : proposal.stage === OffchainThreadStage.Voting ? 'positive'
               : proposal.stage === OffchainThreadStage.Passed ? 'positive'
-                : proposal.stage === OffchainThreadStage.Failed ? 'negative' : null,
+                : proposal.stage === OffchainThreadStage.Failed ? 'negative' : 'positive',
           size: 'xs',
           compact: true,
           label: offchainThreadStageToLabel(proposal.stage),

--- a/client/scripts/views/pages/discussions/discussion_row_menu.ts
+++ b/client/scripts/views/pages/discussions/discussion_row_menu.ts
@@ -85,6 +85,11 @@ export const TopicEditorMenuItem: m.Component<{ openTopicEditor: Function }, { i
 export const StageEditorMenuItem: m.Component<{ openStageEditor: Function }, { isOpen: boolean }> = {
   view: (vnode) => {
     const { openStageEditor } = vnode.attrs;
+
+    if (!app.chain?.meta?.chain && !app.community?.meta) return;
+    const { stagesEnabled } = app.chain?.meta?.chain || app.community?.meta;
+    if (!stagesEnabled) return;
+
     return m('.StageEditorMenuItem', [
       m(MenuItem, {
         fluid: true,

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -97,6 +97,9 @@ export const CommunityOptionsPopover: m.Component<{ isAdmin: boolean, isMod: boo
 const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
   view: (vnode) => {
     const { topic, stage } = vnode.attrs;
+    if (!app.chain?.meta?.chain && !app.community?.meta) return;
+
+    const { stagesEnabled } = app.chain?.meta?.chain || app.community?.meta;
 
     const featuredTopicIds = app.community?.meta?.featuredTopics || app.chain?.meta?.chain?.featuredTopics;
     const topics = app.topics.getByCommunity(app.activeId()).map(({ id, name, description, telegram }) => {
@@ -170,7 +173,7 @@ const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
           })),
         ]),
       }),
-      m(PopoverMenu, {
+      stagesEnabled && m(PopoverMenu, {
         trigger: m(Button, {
           rounded: true,
           compact: true,

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -214,8 +214,6 @@ const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
             },
             label: [
               `${offchainThreadStageToLabel(targetStage)}`,
-              targetStage === OffchainThreadStage.ProposalInReview
-                && [ ' ', m('.discussions-stage-count', `${app.threads.numPrevotingThreads}`) ],
               targetStage === OffchainThreadStage.Voting
                 && [ ' ', m('.discussions-stage-count', `${app.threads.numVotingThreads}`) ],
             ],

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -8,7 +8,7 @@ import moment from 'moment';
 import app from 'state';
 
 import { Spinner, Button, ButtonGroup, Icons, Icon, PopoverMenu, MenuItem, MenuDivider } from 'construct-ui';
-import { pluralize, offchainThreadStageToLabel } from 'helpers';
+import { pluralize, offchainThreadStageToLabel, parseCustomStages } from 'helpers';
 import { NodeInfo, CommunityInfo, OffchainThreadStage, OffchainThread } from 'models';
 
 import { updateLastVisited } from 'controllers/app/login';
@@ -97,9 +97,9 @@ export const CommunityOptionsPopover: m.Component<{ isAdmin: boolean, isMod: boo
 const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
   view: (vnode) => {
     const { topic, stage } = vnode.attrs;
-    if (!app.chain?.meta?.chain && !app.community?.meta) return;
 
-    const { stagesEnabled } = app.chain?.meta?.chain || app.community?.meta;
+    if (!app.chain?.meta?.chain && !app.community?.meta) return;
+    const { stagesEnabled, additionalStages } = app.chain?.meta?.chain || app.community?.meta;
 
     const featuredTopicIds = app.community?.meta?.featuredTopics || app.chain?.meta?.chain?.featuredTopics;
     const topics = app.topics.getByCommunity(app.activeId()).map(({ id, name, description, telegram }) => {
@@ -201,6 +201,7 @@ const DiscussionStagesBar: m.Component<{ topic: string, stage: string }, {}> = {
           [
             // OffchainThreadStage.Discussion,
             OffchainThreadStage.ProposalInReview,
+            ...parseCustomStages(additionalStages),
             OffchainThreadStage.Voting,
             OffchainThreadStage.Passed,
             OffchainThreadStage.Failed,

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -262,7 +262,7 @@ export const ProposalHeaderStage: m.Component<{ proposal: OffchainThread }> = {
       class: proposal.stage === OffchainThreadStage.ProposalInReview ? 'positive'
         : proposal.stage === OffchainThreadStage.Voting ? 'positive'
           : proposal.stage === OffchainThreadStage.Passed ? 'positive'
-            : proposal.stage === OffchainThreadStage.Failed ? 'negative' : 'none',
+            : proposal.stage === OffchainThreadStage.Failed ? 'negative' : 'positive',
     }, offchainThreadStageToLabel(proposal.stage));
   }
 };

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -473,10 +473,14 @@ export const ProposalSidebarStageEditorModule: m.Component<{
   view: (vnode) => {
     const { proposal, openStageEditor } = vnode.attrs;
 
+    if (!app.chain?.meta?.chain && !app.community?.meta) return;
+    const { stagesEnabled } = app.chain?.meta?.chain || app.community?.meta;
+    if (!stagesEnabled) return;
+
     return m('.ProposalSidebarStageEditorModule', [
       proposal.chainEntities.length > 0
         ? m('.placeholder-copy', 'Proposals for this thread:')
-        : m('.placeholder-copy', app.chain ? 'Connect an on-chain proposal?' : 'Set a voting stage for this thread?'),
+        : m('.placeholder-copy', app.chain ? 'Connect an on-chain proposal?' : 'Track the progress of this thread?'),
       proposal.chainEntities.length > 0 && m('.proposal-chain-entities', [
         proposal.chainEntities.map((chainEntity) => {
           return m(ProposalHeaderThreadLinkedChainEntity, { proposal, chainEntity });

--- a/client/styles/components/stage_editor.scss
+++ b/client/styles/components/stage_editor.scss
@@ -31,13 +31,25 @@
 }
 
 .ChainEntitiesSelector {
-    padding: 22px 22px 0;
+    padding: 0;
     border: 1px solid #ddd;
     margin: 10px 8px 20px;
     border-radius: 5px;
+    .cui-control-group {
+        margin-bottom: 0;
+    }
+    .cui-input input {
+        border-top: none;
+        border-right: none;
+        border-left: none;
+        border-bottom-color: $border-color-light;
+        height: 44px;
+        border-radius: 0;
+    }
     .cui-list {
-        min-height: 200px;
-        max-height: 200px;
+        min-height: 150px;
+        max-height: 150px;
+        border-radius: 5px;
         .cui-active {
             background: initial;
         }

--- a/client/styles/mobile/mobile_sidebar.scss
+++ b/client/styles/mobile/mobile_sidebar.scss
@@ -8,18 +8,19 @@
     min-height: calc(100vh - 60px);
     width: 100vw;
     * {
-        -webkit-tap-highlight-color:  rgba(255, 255, 255, 0); 
+        -webkit-tap-highlight-color:  rgba(255, 255, 255, 0);
     }
     .cui-tabs {
         @include gradientTabs();
         .cui-tabs-item.cui-active {
-            border-image: linear-gradient(to right, #79E0E8, 
+            border-image: linear-gradient(to right, #79E0E8,
             #BF8E60, #D69FCC, #6086D1, #B37DBA) 1 !important;
         }
         margin-bottom: 20px;
         .cui-tabs-item {
-            padding: 13px 3% 7px;
+            padding: 13px 4% 7px;
             font-size: $text-size-mobile-header;
+            width: initial;
         }
     }
     > .cui-menu {

--- a/client/styles/modals/manage_community_modal.scss
+++ b/client/styles/modals/manage_community_modal.scss
@@ -16,7 +16,8 @@
 
     .cui-table.metadata-management-table {
         td {
-            padding: 5px 28px 0 !important;
+            line-height: 1.1;
+            padding: 5px 0 0 28px !important;
             border-bottom: none !important;
         }
         tr:first-child td {
@@ -72,12 +73,18 @@
             }
         }
         .TogglePropertyRow {
+            td:first-child {
+                padding-top: 7px !important;
+            }
             td {
-                padding-top: 12px !important;
+                padding-top: 14px !important;
+                padding-bottom: 4px !important;
             }
             .cui-switch {
                 display: inline-block;
                 margin-right: 5px;
+                position: relative;
+                top: -2px;
             }
             .switch-caption {
                 display: inline-block;
@@ -85,6 +92,11 @@
                 font-size: 94%;
                 position: relative;
                 top: 1px;
+            }
+        }
+        .TogglePropertyRow + .TogglePropertyRow {
+            td {
+                padding-bottom: 0 !important;
             }
         }
     }

--- a/server/migrations/20210712233629-add-custom-stages.js
+++ b/server/migrations/20210712233629-add-custom-stages.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn('OffchainCommunities', 'additionalStages', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }, { transaction: t });
+      await queryInterface.addColumn('OffchainCommunities', 'stagesEnabled', {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: true,
+      }, { transaction: t });
+      await queryInterface.addColumn('Chains', 'additionalStages', {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: true,
+      }, { transaction: t });
+      await queryInterface.addColumn('Chains', 'stagesEnabled', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }, { transaction: t });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('OffchainCommunities', 'additionalStages', { transaction: t });
+      await queryInterface.removeColumn('OffchainCommunities', 'stagesEnabled', { transaction: t });
+      await queryInterface.removeColumn('Chains', 'additionalStages', { transaction: t });
+      await queryInterface.removeColumn('Chains', 'stagesEnabled', { transaction: t });
+    });
+  }
+};

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -27,6 +27,8 @@ export interface ChainAttributes {
   blockExplorerIds: string;
   collapsed_on_homepage: boolean;
   active: boolean;
+  stagesEnabled: boolean;
+  additionalStages: string;
   customDomain: string;
   type: string;
   substrate_spec: RegisteredTypes;
@@ -71,6 +73,8 @@ export default (
     ss58_prefix: { type: dataTypes.INTEGER, allowNull: true },
     icon_url: { type: dataTypes.STRING },
     active: { type: dataTypes.BOOLEAN },
+    stagesEnabled: { type: dataTypes.BOOLEAN, allowNull: true, defaultValue: true },
+    additionalStages: { type: dataTypes.STRING, allowNull: true },
     customDomain: { type: dataTypes.STRING, allowNull: true, },
     blockExplorerIds: { type: dataTypes.STRING, allowNull: true, },
     collapsed_on_homepage: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -21,6 +21,8 @@ export interface OffchainCommunityAttributes {
   featured_topics?: string[];
   privacyEnabled?: boolean;
   invitesEnabled?: boolean;
+  stagesEnabled: boolean;
+  additionalStages: string;
   customDomain?: string;
   collapsed_on_homepage: boolean;
   created_at?: Date;
@@ -70,6 +72,8 @@ export default (
       // XXX: mixing camelCase and underscore_case is bad practice
       privacyEnabled: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
       invitesEnabled: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+      stagesEnabled: { type: dataTypes.BOOLEAN, allowNull: true, defaultValue: true },
+      additionalStages: { type: dataTypes.STRING, allowNull: true },
       customDomain: { type: dataTypes.STRING, allowNull: true, },
       collapsed_on_homepage: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
     }, {

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -266,7 +266,6 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
 
   const [threads, comments, reactions] = threadsCommentsReactions as any;
 
-  const numPrevotingThreads = threadsInVoting.filter((t) => t.stage === 'proposal_in_review').length;
   const numVotingThreads = threadsInVoting.filter((t) => t.stage === 'voting').length;
 
   return res.json({
@@ -274,7 +273,6 @@ const bulkOffchain = async (models, req: Request, res: Response, next: NextFunct
     result: {
       topics: topics.map((t) => t.toJSON()),
       //
-      numPrevotingThreads,
       numVotingThreads,
       threads, // already converted to JSON earlier
       comments, // already converted to JSON earlier

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -231,13 +231,11 @@ const bulkThreads = async (models, req: Request, res: Response, next: NextFuncti
     replacements,
     type: QueryTypes.SELECT
   });
-  const numPrevotingThreads = threadsInVoting.filter((t) => t.stage === 'proposal_in_review').length;
   const numVotingThreads = threadsInVoting.filter((t) => t.stage === 'voting').length;
 
   return res.json({
     status: 'Success',
     result: {
-      numPrevotingThreads,
       numVotingThreads,
       threads,
       comments, // already converted to JSON earlier

--- a/server/routes/updateChain.ts
+++ b/server/routes/updateChain.ts
@@ -40,7 +40,7 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
     }
   }
 
-  const { active, icon_url, symbol, type, name, description, website, discord, element, telegram, github, customDomain } = req.body;
+  const { active, icon_url, symbol, type, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain } = req.body;
 
   if (website && !urlHasValidHTTPPrefix(website)) {
     return next(new Error(Errors.InvalidWebsite));
@@ -67,6 +67,8 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
   chain.element = element;
   chain.telegram = telegram;
   chain.github = github;
+  chain.stagesEnabled = stagesEnabled;
+  chain.additionalStages = additionalStages;
   chain.customDomain = customDomain;
   if (req.body['featured_topics[]']) chain.featured_topics = req.body['featured_topics[]'];
 

--- a/server/routes/updateCommunity.ts
+++ b/server/routes/updateCommunity.ts
@@ -40,7 +40,7 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
     }
   }
 
-  const { iconUrl, name, description, website, discord, element, telegram, github, customDomain, invites, privacy } = req.body;
+  const { iconUrl, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain, invites, privacy } = req.body;
 
   if (website && !urlHasValidHTTPPrefix(website)) {
     return next(new Error(Errors.InvalidWebsite));
@@ -65,6 +65,8 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
   community.element = element;
   community.telegram = telegram;
   community.github = github;
+  community.stagesEnabled = stagesEnabled;
+  community.additionalStages = additionalStages;
   community.customDomain = customDomain;
   community.invitesEnabled = invites || false;
   community.privacyEnabled = privacy || false;


### PR DESCRIPTION
This PR allows custom stages to be set on threads in chains and communities.

Handled:
- Admins can now turn stages on/off for their chain/community.
- Admins can set a list of pre-voting stages. Anyone who can set the stage for a thread can use those stages.
- Threads are unaffected if admins change the set of available custom stages.
- Adds server-side validation of stages.