### PR TITLE
Ensure search SVG always renders

### DIFF
--- a/client/scripts/helpers/search.ts
+++ b/client/scripts/helpers/search.ts
@@ -69,7 +69,7 @@ export const searchChainsAndCommunities = async (
   }
 };
 
-export const SearchIcon = {
+export const SearchIcon: m.Component<{ isMobile?: boolean }, {}> = {
   view: (vnode) => {
     return m('svg.SearchIcon', {
       width: '15px',
@@ -81,7 +81,10 @@ export const SearchIcon = {
         'fill-rule': 'evenodd',
         'clip-rule': 'evenodd',
         'd': 'M12.9816 7.64497C12.9816 10.9536 10.2994 13.6358 6.9908 13.6358C3.68217 13.6358 1 10.9536 1 7.64497C1 4.33635 3.68217 1.65417 6.9908 1.65417C10.2994 1.65417 12.9816 4.33635 12.9816 7.64497ZM11.5679 12.9292C10.3415 13.9924 8.74129 14.6358 6.9908 14.6358C3.12989 14.6358 0 11.5059 0 7.64497C0 3.78406 3.12989 0.654175 6.9908 0.654175C10.8517 0.654175 13.9816 3.78406 13.9816 7.64497C13.9816 9.39547 13.3382 10.9957 12.275 12.2221L14.5447 14.4917C14.7399 14.687 14.7399 15.0036 14.5447 15.1988C14.3494 15.3941 14.0328 15.3941 13.8376 15.1988L11.5679 12.9292Z',
-        'fill': 'url(#paint0_linear)',
+        // 'fill': 'url(#paint0_linear)',
+        'fill': vnode.attrs.isMobile ? 'url(#paint0_linear)' : 'black'
+        // Long-term, gradient URL fill should be used on desktop as well as mobile;
+        // for unclear reasons, currently failing to display on browsers >767.98px
       }),
       m('defs', [
         m('linearGradient', {

--- a/client/scripts/views/components/proposal_card.ts
+++ b/client/scripts/views/components/proposal_card.ts
@@ -150,7 +150,7 @@ const ProposalCard: m.Component<{ proposal: AnyProposal, injectedContent? }> = {
             return m(Tag, {
               label: (originatingProposalOrMotion instanceof SubstrateDemocracyProposal)
                 ? `PROP #${originatingProposalOrMotion.identifier}`
-                  : (originatingProposalOrMotion instanceof SubstrateCollectiveProposal)
+                : (originatingProposalOrMotion instanceof SubstrateCollectiveProposal)
                   ? `MOT #${originatingProposalOrMotion.identifier}` : 'MISSING PROP',
               intent: 'primary',
               rounded: true,

--- a/client/scripts/views/components/search_bar.ts
+++ b/client/scripts/views/components/search_bar.ts
@@ -449,10 +449,10 @@ export const SearchBar : m.Component<{}, {
       m(Input, {
         name: 'search',
         placeholder: 'Type to search...',
-        autofocus: !isMobile,
+        autofocus: false, // !isMobile,
         fluid: true,
         tabIndex: -10,
-        contentLeft: m(SearchIcon),
+        contentLeft: m(SearchIcon, { isMobile }),
         contentRight: cancelInputIcon || chainOrCommIcon,
         defaultValue: m.route.param('q') || vnode.state.searchTerm,
         value: vnode.state.searchTerm,

--- a/client/scripts/views/pages/landing/index.ts
+++ b/client/scripts/views/pages/landing/index.ts
@@ -318,7 +318,7 @@ const LandingPage: m.Component<{}, IState> = {
             { text:  'Terms', redirectTo:  '/terms' },
             { text:  'Privacy', redirectTo: '/privacy' },
             { text: 'Why Commonwealth?', redirectTo: '/whyCommonwealth' },
-            { text: 'Discord', externalLink: 'https://discord.gg/ZFQCKUMP' },
+            { text: 'Discord', externalLink: 'https://discord.gg/yK3x5HcsXG' },
             { text: 'Telegram', externalLink: 'https://t.me/HiCommonwealth' }
           ],
         }),

--- a/client/scripts/views/pages/landing/tokens_community_hero.ts
+++ b/client/scripts/views/pages/landing/tokens_community_hero.ts
@@ -167,7 +167,7 @@ const TokensCommunityComponent: m.Component<IAttrs, IState> = {
                         'a',
                         {
                           class: 'lg:ml-12',
-                          href: 'https://discord.gg/ZFQCKUMP',
+                          href: 'https://discord.gg/yK3x5HcsXG',
                           target: '_blank'
                         },
                         [


### PR DESCRIPTION
A mysterious issue with the gradient url fill, on the SearchIcon component, prevents the icon from rendering on desktop (even as it renders just fine on mobile). 

Several possible solutions were explored:
* It was considered that this may have been a browser support issue, but testing showed that the same behavior persevered when resizing browsers, i.e. narrow windows correctly displayed while wide windows did not, agnostic to browser
* It was considered that the padding change, between mobile-width and desktop-width browsers, on the input ele, might have been responsible. It was not.
* It was considered that a duplicate url (employing the generic '#paint0_linear' id) may have been conflicting in the desktop layout, but an alternate id/reference failed to resolve.
* It was considered that z-indexes and/or absolute vs. relative positioning was responsible for the failure to render, but this avenue proved unproductive

Until an explanation for this behavior is found, it is far better to display the search icon in a neutral black (at least on desktop) than not at all. Rendering it with a proper fill will make the component function clearer for users, while also avoiding strange left-padding on the input bar.

This PR adds a simple `isMobile` switch to the SearchIcon component, using the URL fill on mobile and the all-black fill on desktop.

Before:
![image](https://user-images.githubusercontent.com/22281010/125516004-03a75214-dc41-4e6f-ae9f-5fbaa0598afa.png)

After:
![image](https://user-images.githubusercontent.com/22281010/125515955-400417bf-a707-4ac6-862f-de66eed73935.png)

Mobile:
![image](https://user-images.githubusercontent.com/22281010/125516052-fde0524d-19c5-45e2-bb4d-f690423d0471.png)
