### PR TITLE
Allow sitewide admins to be community admins

### DIFF
--- a/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
+++ b/client/scripts/views/modals/manage_community_modal/admin_panel_tabs.ts
@@ -38,7 +38,6 @@ const WebhooksForm: m.Component<IWebhooksFormAttrs, IWebhooksFormState> = {
       $.post(`${app.serverUrl()}/createWebhook`, {
         ...chainOrCommObj,
         webhookUrl,
-        address: app.user.activeAccount.address,
         auth: true,
         jwt: app.user.jwt,
       }).then((result) => {

--- a/client/scripts/views/modals/new_topic_modal.ts
+++ b/client/scripts/views/modals/new_topic_modal.ts
@@ -24,7 +24,7 @@ const NewTopicModal: m.Component<{
   saving: boolean,
 }> = {
   view: (vnode) => {
-    if (!app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() })) return null;
+    if (!app.user.isSiteAdmin && !app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() })) return null;
     const { id, name, description } = vnode.attrs;
     if (!vnode.state.form) {
       vnode.state.form = { id, name, description };

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -473,7 +473,7 @@ const DiscussionsPage: m.Component<{ topic?: string }, {
     const emptyTopic = (allThreads.length === 0 && vnode.state.postsDepleted[subpage] === true && !stage);
     const emptyStage = (allThreads.length === 0 && vnode.state.postsDepleted[subpage] === true && !!stage);
 
-    const isAdmin = app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() });
+    const isAdmin = app.user.isSiteAdmin || app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() });
     const isMod = app.user.isRoleOfCommunity({
       role: 'moderator', chain: app.activeChainId(), community: app.activeCommunityId()
     });

--- a/client/scripts/views/pages/members.ts
+++ b/client/scripts/views/pages/members.ts
@@ -65,7 +65,7 @@ const MembersPage : m.Component<{}, { membersRequested: boolean, membersLoaded: 
       });
     }
 
-    const isAdmin = app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() });
+    const isAdmin = app.user.isSiteAdmin || app.user.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() });
     const isMod = app.user.isRoleOfCommunity({
       role: 'moderator', chain: app.activeChainId(), community: app.activeCommunityId()
     });

--- a/server/routes/createTopic.ts
+++ b/server/routes/createTopic.ts
@@ -23,7 +23,7 @@ const createTopic = async (models, req, res: Response, next: NextFunction) => {
       ...chainOrCommObj,
     },
   });
-  if (adminRoles.length === 0) {
+  if (!req.user.isAdmin && adminRoles.length === 0) {
     return next(new Error(Errors.MustBeAdmin));
   }
 

--- a/server/routes/updateChain.ts
+++ b/server/routes/updateChain.ts
@@ -35,7 +35,7 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
         permission: 'admin',
       },
     });
-    if (!userMembership) {
+    if (!req.user.isAdmin && !userMembership) {
       return next(new Error(Errors.NotAdmin));
     }
   }

--- a/server/routes/webhooks/createWebhook.ts
+++ b/server/routes/webhooks/createWebhook.ts
@@ -21,7 +21,7 @@ const createWebhook = async (models, req: Request, res: Response, next: NextFunc
       permission: ['admin']
     },
   });
-  if (adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
+  if (!req.user.isAdmin && adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
   // check if webhook url exists already in the community
   if (!req.body.webhookUrl) return next(new Error(Errors.MissingWebhook));
   const existingWebhook = await models.Webhook.findOne({

--- a/server/routes/webhooks/deleteWebhook.ts
+++ b/server/routes/webhooks/deleteWebhook.ts
@@ -21,7 +21,7 @@ const deleteWebhook = async (models, req: Request, res: Response, next: NextFunc
       permission: ['admin']
     },
   });
-  if (adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
+  if (!req.user.isAdmin && adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
   // delete webhook
   if (!req.body.webhookUrl) return next(new Error(Errors.MissingWebhook));
   const webhook = await models.Webhook.findOne({

--- a/server/routes/webhooks/getWebhooks.ts
+++ b/server/routes/webhooks/getWebhooks.ts
@@ -21,7 +21,7 @@ const getWebhooks = async (models, req: Request, res: Response, next: NextFuncti
       permission: ['admin']
     },
   });
-  if (adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
+  if (!req.user.isAdmin && adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
   // fetch webhooks
   const webhooks = await models.Webhook.findAll({ where: chainOrCommObj });
   return res.json({ status: 'Success', result: webhooks.map((w) => w.toJSON()) });

--- a/server/routes/webhooks/updateWebhook.ts
+++ b/server/routes/webhooks/updateWebhook.ts
@@ -20,7 +20,7 @@ const updateWebhook = async (models, req: Request, res: Response, next: NextFunc
       permission: ['admin']
     },
   });
-  if (adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
+  if (!req.user.isAdmin && adminRoles.length === 0) return next(new Error(Errors.NotAdmin));
   // check if webhook url exists already in the community
   if (!req.body.webhookId) return next(new Error(Errors.MissingWebhook));
   const existingWebhook = await models.Webhook.findOne({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Site wide admins can now access the same admin tools community admins can. 

## Motivation and Context
It was proposed to add an extra panel to allow site-wide admins to create and remove community admins, but this is an easier way to do it, since community admins already have that power

