### PR TITLE
Add community terms of service support

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -85,6 +85,7 @@ export async function initAppState(updateSelectedNode = true): Promise<void> {
           stagesEnabled: community.stagesEnabled,
           additionalStages: community.additionalStages,
           customDomain: community.customDomain,
+          terms: community.terms,
           adminsAndMods: [],
         }));
       });

--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -21,6 +21,7 @@ class ChainInfo {
   public stagesEnabled: boolean;
   public additionalStages: string;
   public customDomain: string;
+  public terms: string;
   public readonly blockExplorerIds: { [id: string]: string };
   public readonly collapsedOnHomepage: boolean;
   public readonly featuredTopics: string[];
@@ -35,7 +36,7 @@ class ChainInfo {
   constructor({
     id, network, symbol, name, iconUrl, description, website, discord, element, telegram, github,
     stagesEnabled, additionalStages,
-    customDomain, blockExplorerIds, collapsedOnHomepage, featuredTopics, topics, adminsAndMods,
+    customDomain, terms, blockExplorerIds, collapsedOnHomepage, featuredTopics, topics, adminsAndMods,
     base, ss58_prefix, type, substrateSpec
   }) {
     this.id = id;
@@ -53,6 +54,7 @@ class ChainInfo {
     this.stagesEnabled = stagesEnabled;
     this.additionalStages = additionalStages;
     this.customDomain = customDomain;
+    this.terms = terms;
     this.blockExplorerIds = blockExplorerIds;
     this.collapsedOnHomepage = collapsedOnHomepage;
     this.featuredTopics = featuredTopics || [];
@@ -78,6 +80,7 @@ class ChainInfo {
     stagesEnabled,
     additionalStages,
     customDomain,
+    terms,
     blockExplorerIds,
     collapsed_on_homepage,
     featured_topics,
@@ -110,6 +113,7 @@ class ChainInfo {
       stagesEnabled,
       additionalStages,
       customDomain,
+      terms,
       blockExplorerIds: blockExplorerIdsParsed,
       collapsedOnHomepage: collapsed_on_homepage,
       featuredTopics: featured_topics,
@@ -172,7 +176,7 @@ class ChainInfo {
   // TODO: change to accept an object
   public async updateChainData({
     name, description, website, discord, element, telegram,
-    github, stagesEnabled, additionalStages, customDomain
+    github, stagesEnabled, additionalStages, customDomain, terms
   }) {
     // TODO: Change to PUT /chain
     const r = await $.post(`${app.serverUrl()}/updateChain`, {
@@ -187,6 +191,7 @@ class ChainInfo {
       'stagesEnabled': stagesEnabled,
       'additionalStages': additionalStages,
       'customDomain': customDomain,
+      'terms': terms,
       'jwt': app.user.jwt,
     });
     const updatedChain: ChainInfo = r.result;

--- a/client/scripts/models/CommunityInfo.ts
+++ b/client/scripts/models/CommunityInfo.ts
@@ -17,6 +17,7 @@ interface CommunityData {
   stagesEnabled: boolean,
   additionalStages: string,
   customDomain: string;
+  terms: string;
   invitesEnabled: boolean,
   privacyEnabled: boolean,
 }
@@ -38,6 +39,7 @@ class CommunityInfo {
   public stagesEnabled: boolean;
   public additionalStages: string;
   public customDomain: string;
+  public terms: string;
   public readonly collapsedOnHomepage: boolean;
   public readonly featuredTopics: string[];
   public readonly topics: OffchainTopic[];
@@ -48,7 +50,7 @@ class CommunityInfo {
   constructor({
     id, name, description, iconUrl, website, discord, element, telegram, github, defaultChain, visible,
     stagesEnabled, additionalStages,
-    customDomain, invitesEnabled, privacyEnabled, collapsedOnHomepage, featuredTopics, topics, adminsAndMods
+    customDomain, terms, invitesEnabled, privacyEnabled, collapsedOnHomepage, featuredTopics, topics, adminsAndMods
   }) {
     this.id = id;
     this.name = name;
@@ -64,6 +66,7 @@ class CommunityInfo {
     this.stagesEnabled = stagesEnabled;
     this.additionalStages = additionalStages;
     this.customDomain = customDomain;
+    this.terms = terms;
     this.invitesEnabled = invitesEnabled;
     this.privacyEnabled = privacyEnabled;
     this.collapsedOnHomepage = collapsedOnHomepage;
@@ -87,6 +90,7 @@ class CommunityInfo {
     stagesEnabled,
     additionalStages,
     customDomain,
+    terms,
     invitesEnabled,
     privacyEnabled,
     collapsedOnHomepage: collapsed_on_homepage,
@@ -109,6 +113,7 @@ class CommunityInfo {
       stagesEnabled,
       additionalStages,
       customDomain,
+      terms,
       invitesEnabled,
       privacyEnabled,
       collapsedOnHomepage: collapsed_on_homepage,
@@ -174,6 +179,7 @@ class CommunityInfo {
     stagesEnabled,
     additionalStages,
     customDomain,
+    terms,
     website,
     discord,
     element,
@@ -194,6 +200,7 @@ class CommunityInfo {
       'stagesEnabled': stagesEnabled,
       'additionalStages': additionalStages,
       'customDomain': customDomain,
+      'terms': terms,
       'privacy': privacyEnabled,
       'invites': invitesEnabled,
       'jwt': app.user.jwt,
@@ -210,6 +217,7 @@ class CommunityInfo {
     this.stagesEnabled = stagesEnabled;
     this.additionalStages = additionalStages;
     this.customDomain = updatedCommunity.customDomain;
+    this.terms = updatedCommunity.terms;
     this.privacyEnabled = updatedCommunity.privacyEnabled;
     this.invitesEnabled = updatedCommunity.invitesEnabled;
   }

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -290,6 +290,8 @@ const LoginSelector: m.Component<{
       }
     }
 
+    const hasTermsOfServie = app.chain?.meta?.chain?.terms || app.community?.meta?.terms;
+
     return m(ButtonGroup, { class: 'LoginSelector' }, [
       (app.chain || app.community)
         && !app.chainPreloading
@@ -298,7 +300,7 @@ const LoginSelector: m.Component<{
         && m(Button, {
           class: 'login-selector-left',
           onclick: async (e) => {
-            if (samebaseAddresses.length === 1) {
+            if (samebaseAddresses.length === 1 && !hasTermsOfServie) {
               const originAddressInfo = samebaseAddresses[0];
 
               if (originAddressInfo) {

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -290,7 +290,8 @@ const LoginSelector: m.Component<{
       }
     }
 
-    const hasTermsOfService = app.chain ? app.chain.meta?.chain : app.community?.meta;
+    const activeCommunityMeta = app.chain ? app.chain.meta?.chain : app.community?.meta;
+    const hasTermsOfService = !!activeCommunityMeta.terms;
 
     return m(ButtonGroup, { class: 'LoginSelector' }, [
       (app.chain || app.community)

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -291,7 +291,7 @@ const LoginSelector: m.Component<{
     }
 
     const activeCommunityMeta = app.chain ? app.chain.meta?.chain : app.community?.meta;
-    const hasTermsOfService = !!activeCommunityMeta.terms;
+    const hasTermsOfService = !!activeCommunityMeta?.terms;
 
     return m(ButtonGroup, { class: 'LoginSelector' }, [
       (app.chain || app.community)

--- a/client/scripts/views/components/header/login_selector.ts
+++ b/client/scripts/views/components/header/login_selector.ts
@@ -290,7 +290,7 @@ const LoginSelector: m.Component<{
       }
     }
 
-    const hasTermsOfServie = app.chain?.meta?.chain?.terms || app.community?.meta?.terms;
+    const hasTermsOfService = app.chain ? app.chain.meta?.chain : app.community?.meta;
 
     return m(ButtonGroup, { class: 'LoginSelector' }, [
       (app.chain || app.community)
@@ -300,7 +300,7 @@ const LoginSelector: m.Component<{
         && m(Button, {
           class: 'login-selector-left',
           onclick: async (e) => {
-            if (samebaseAddresses.length === 1 && !hasTermsOfServie) {
+            if (samebaseAddresses.length === 1 && !hasTermsOfService) {
               const originAddressInfo = samebaseAddresses[0];
 
               if (originAddressInfo) {

--- a/client/scripts/views/modals/confirm_invite_modal.ts
+++ b/client/scripts/views/modals/confirm_invite_modal.ts
@@ -77,6 +77,12 @@ const ConfirmInviteModal: m.Component<{}, {
         .map((account) => SelectAddress(account));
     }
 
+    const activeInvite = invites[location].community_id
+      ? app.config.communities.getById(invites[location].community_id)
+      : app.config.chains.getById(invites[location].chain_id);
+
+    const hasTermsOfService = !!activeInvite.terms;
+
     return m('.ConfirmInviteModal', [
       m('.compact-modal-title', [
         !vnode.state.isComplete
@@ -96,6 +102,12 @@ const ConfirmInviteModal: m.Component<{}, {
             'You\'ve been invited to the ',
             m('strong', invites[location].community_name),
             ' community. Select an address to accept the invite:'
+          ]),
+          hasTermsOfService
+          && m('p', [
+            `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
+            m('a', { href: activeInvite.terms, target: '_blank' }, 'terms of service'),
+            '.'
           ]),
           vnode.state.accepted.includes(location) ? m('h4', 'You\'ve accepted this invite!')
             : vnode.state.rejected.includes(location) ? m('h4', 'You\'ve already deleted this invite!') : [
@@ -127,7 +139,8 @@ const ConfirmInviteModal: m.Component<{}, {
                           $(e.target).trigger('modalexit');
                         }
                         const communityId = invites[location].community_id;
-                        const chainId = invites[location].community_id;
+                        const chainId = invites[location].chain_id;
+                        console.log({ communityId, chainId });
                         // if private community, re-init app
                         if (communityId && !app.config.communities.getByCommunity(communityId)) {
                           initAppState().then(() => m.route.set(`/${communityId}`));

--- a/client/scripts/views/modals/confirm_invite_modal.ts
+++ b/client/scripts/views/modals/confirm_invite_modal.ts
@@ -80,7 +80,7 @@ const ConfirmInviteModal: m.Component<{}, {
     const activeInvite = invites[location].community_id
       ? app.config.communities.getById(invites[location].community_id)
       : app.config.chains.getById(invites[location].chain_id);
-    const hasTermsOfService = !!activeInvite.terms;
+    const hasTermsOfService = !!activeInvite?.terms;
 
     return m('.ConfirmInviteModal', [
       m('.compact-modal-title', [

--- a/client/scripts/views/modals/confirm_invite_modal.ts
+++ b/client/scripts/views/modals/confirm_invite_modal.ts
@@ -104,8 +104,8 @@ const ConfirmInviteModal: m.Component<{}, {
             ' community. Select an address to accept the invite:'
           ]),
           hasTermsOfService
-          && m('p', [
-            `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
+          && m('p.terms-of-service', [
+            `By linking an address, you agree to ${activeInvite.name}'s `,
             m('a', { href: activeInvite.terms, target: '_blank' }, 'terms of service'),
             '.'
           ]),

--- a/client/scripts/views/modals/confirm_invite_modal.ts
+++ b/client/scripts/views/modals/confirm_invite_modal.ts
@@ -80,7 +80,6 @@ const ConfirmInviteModal: m.Component<{}, {
     const activeInvite = invites[location].community_id
       ? app.config.communities.getById(invites[location].community_id)
       : app.config.chains.getById(invites[location].chain_id);
-
     const hasTermsOfService = !!activeInvite.terms;
 
     return m('.ConfirmInviteModal', [

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -116,7 +116,7 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
         m(InputPropertyRow, {
           title: 'Terms of Service',
           defaultValue: vnode.state.terms,
-          placeholder: 'Users upon entering forum with address will see this',
+          placeholder: 'Url that new users see',
           onChangeHandler: (v) => { vnode.state.terms = v; },
         }),
         m('tr', [

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -22,6 +22,7 @@ interface IChainMetadataManagementState {
   stagesEnabled: boolean;
   additionalStages: string;
   customDomain: string;
+  terms: string;
   network: ChainNetwork;
   symbol: string;
 }
@@ -38,6 +39,7 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
     vnode.state.stagesEnabled = vnode.attrs.chain.stagesEnabled;
     vnode.state.additionalStages = vnode.attrs.chain.additionalStages;
     vnode.state.customDomain = vnode.attrs.chain.customDomain;
+    vnode.state.terms = vnode.attrs.chain.terms;
     vnode.state.iconUrl = vnode.attrs.chain.iconUrl;
     vnode.state.network = vnode.attrs.chain.network;
     vnode.state.symbol = vnode.attrs.chain.symbol;
@@ -111,6 +113,12 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
           placeholder: 'gov.edgewa.re',
           onChangeHandler: (v) => { vnode.state.customDomain = v; },
         }),
+        m(InputPropertyRow, {
+          title: 'Terms of Service',
+          defaultValue: vnode.state.terms,
+          placeholder: 'Users upon entering forum with address will see this',
+          onChangeHandler: (v) => { vnode.state.terms = v; },
+        }),
         m('tr', [
           m('td', 'Admins'),
           m('td', [ m(ManageRolesRow, {
@@ -142,7 +150,8 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
             github,
             stagesEnabled,
             additionalStages,
-            customDomain
+            customDomain,
+            terms
           } = vnode.state;
           try {
             await vnode.attrs.chain.updateChainData({
@@ -155,7 +164,8 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
               github,
               stagesEnabled,
               additionalStages,
-              customDomain
+              customDomain,
+              terms
             });
             $(e.target).trigger('modalexit');
           } catch (err) {

--- a/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
@@ -20,6 +20,7 @@ interface ICommunityMetadataManagementState {
   stagesEnabled: boolean;
   additionalStages: string;
   customDomain: string;
+  terms: string;
 }
 
 export interface IChainOrCommMetadataManagementAttrs {
@@ -44,6 +45,7 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
     vnode.state.stagesEnabled = vnode.attrs.community.stagesEnabled;
     vnode.state.additionalStages = vnode.attrs.community.additionalStages;
     vnode.state.customDomain = vnode.attrs.community.customDomain;
+    vnode.state.terms = vnode.attrs.community.terms;
   },
   view: (vnode) => {
     return m('.CommunityMetadataManagementTable', [m(Table, {
@@ -113,6 +115,12 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
         placeholder: 'gov.edgewa.re',
         onChangeHandler: (v) => { vnode.state.customDomain = v; },
       }),
+      m(InputPropertyRow, {
+        title: 'Terms of Service',
+        defaultValue: vnode.state.terms,
+        placeholder: 'Users upon entering forum with address will see this',
+        onChangeHandler: (v) => { vnode.state.terms = v; },
+      }),
       m(TogglePropertyRow, {
         title: 'Privacy',
         defaultValue: vnode.attrs.community.privacyEnabled,
@@ -158,6 +166,7 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
           stagesEnabled,
           additionalStages,
           customDomain,
+          terms,
           invitesEnabled,
           privacyEnabled,
         } = vnode.state;
@@ -174,6 +183,7 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
             stagesEnabled,
             additionalStages,
             customDomain,
+            terms,
             privacyEnabled,
             invitesEnabled,
           });

--- a/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/community_metadata_management_table.ts
@@ -118,7 +118,7 @@ m.Component<IChainOrCommMetadataManagementAttrs, ICommunityMetadataManagementSta
       m(InputPropertyRow, {
         title: 'Terms of Service',
         defaultValue: vnode.state.terms,
-        placeholder: 'Users upon entering forum with address will see this',
+        placeholder: 'Url that new users see',
         onChangeHandler: (v) => { vnode.state.terms = v; },
       }),
       m(TogglePropertyRow, {

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -80,7 +80,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
 
-    const hasTermsOfService = app.chain ? app.chain.meta?.chain.terms : app.community?.meta.terms;
+    const meta = app.chain ? app.chain.meta?.chain : app.community?.meta;
 
     return m('.SelectAddressModal', [
       m('.compact-modal-title', [
@@ -121,9 +121,9 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
             ]),
           ])),
         ]),
-        meta.terms
-        && m('p', [
-          `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
+        !!meta.terms
+        && m('p.terms-of-service', [
+          `By linking an address, you agree to ${meta.name}'s `,
           m('a', { href: meta.terms, target: '_blank' }, 'terms of service'),
           '.'
         ]),

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -81,7 +81,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
 
     const activeCommunityMeta = app.chain ? app.chain.meta?.chain : app.community?.meta;
-    const hasTermsOfService = !!activeCommunityMeta.terms;
+    const hasTermsOfService = !!activeCommunityMeta?.terms;
 
     return m('.SelectAddressModal', [
       m('.compact-modal-title', [

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -80,6 +80,8 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
     };
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
+    
+    const meta = app.chain ? app.chain.meta.chain : app.community.meta;
 
     return m('.SelectAddressModal', [
       m('.compact-modal-title', [
@@ -88,7 +90,9 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
           m('p', [
-            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community: `,
+            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `,
+            meta.terms && `By linking an address, you agree to ${articlize(app.chain?.meta?.chain.name || 'Web3')}'s`,
+            { text: 'terms of service', externalLink: meta.terms }
           ]),
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -18,7 +18,6 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
   view: (vnode) => {
     const activeAccountsByRole: Array<[Account<any>, RoleInfo]> = app.user.getActiveAccountsByRole();
     const activeEntityInfo = app.community ? app.community.meta : app.chain?.meta?.chain;
-
     const createRole = (e) => {
       vnode.state.loading = true;
 

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -93,7 +93,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
           meta.terms
           && m('p', [
             `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
-            link('a', meta.terms, 'terms of service'),
+            m('a', { href: meta.terms, target: '_blank' }, 'terms of service'),
             '.'
           ])
         ]) : m('.select-address-options', [

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -14,7 +14,7 @@ import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import LoginWithWalletDropdown from 'views/components/login_with_wallet_dropdown';
 import { formatAddressShort } from '../../../../shared/utils';
 
-const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: boolean }> = {
+const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: boolean, termsOpen: boolean }> = {
   view: (vnode) => {
     const activeAccountsByRole: Array<[Account<any>, RoleInfo]> = app.user.getActiveAccountsByRole();
     const activeEntityInfo = app.community ? app.community.meta : app.chain?.meta?.chain;
@@ -80,7 +80,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
     };
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
-    
+
     const meta = app.chain ? app.chain.meta.chain : app.community.meta;
 
     return m('.SelectAddressModal', [
@@ -89,11 +89,18 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       ]),
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
-          m('p', [
-            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `,
-            meta.terms && `By linking an address, you agree to ${articlize(app.chain?.meta?.chain.name || 'Web3')}'s`,
-            { text: 'terms of service', externalLink: meta.terms }
+          m('p', `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `),
+          meta.terms
+          && m('p', [
+            `By linking an address, you agree to ${app.chain?.meta?.chain.name || app.community?.name}'s `,
+            m('a', {
+              href: '#',
+              onclick: () => { vnode.state.termsOpen = !vnode.state.termsOpen; },
+            }, 'terms of service'),
+            '.'
           ]),
+          vnode.state.termsOpen
+          && m('.community-terms-of-service', meta.terms)
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [
             m('.select-address-option-left', [

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -80,7 +80,8 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
 
-    const meta = app.chain ? app.chain.meta?.chain : app.community?.meta;
+    const activeCommunityMeta = app.chain ? app.chain.meta?.chain : app.community?.meta;
+    const hasTermsOfService = !!activeCommunityMeta.terms;
 
     return m('.SelectAddressModal', [
       m('.compact-modal-title', [
@@ -121,10 +122,10 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
             ]),
           ])),
         ]),
-        !!meta.terms
+        hasTermsOfService
         && m('p.terms-of-service', [
-          `By linking an address, you agree to ${meta.name}'s `,
-          m('a', { href: meta.terms, target: '_blank' }, 'terms of service'),
+          `By linking an address, you agree to ${activeCommunityMeta.name}'s `,
+          m('a', { href: activeCommunityMeta.terms, target: '_blank' }, 'terms of service'),
           '.'
         ]),
         activeAccountsByRole.length !== 0 && m(Button, {

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -14,7 +14,7 @@ import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import LoginWithWalletDropdown from 'views/components/login_with_wallet_dropdown';
 import { formatAddressShort } from '../../../../shared/utils';
 
-const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: boolean, termsOpen: boolean }> = {
+const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: boolean }> = {
   view: (vnode) => {
     const activeAccountsByRole: Array<[Account<any>, RoleInfo]> = app.user.getActiveAccountsByRole();
     const activeEntityInfo = app.community ? app.community.meta : app.chain?.meta?.chain;
@@ -80,7 +80,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
     };
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
-
+    
     const meta = app.chain ? app.chain.meta.chain : app.community.meta;
 
     return m('.SelectAddressModal', [
@@ -89,18 +89,11 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       ]),
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
-          m('p', `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `),
-          meta.terms
-          && m('p', [
-            `By linking an address, you agree to ${app.chain?.meta?.chain.name || app.community?.name}'s `,
-            m('a', {
-              href: '#',
-              onclick: () => { vnode.state.termsOpen = !vnode.state.termsOpen; },
-            }, 'terms of service'),
-            '.'
+          m('p', [
+            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `,
+            meta.terms && `By linking an address, you agree to ${articlize(app.chain?.meta?.chain.name || 'Web3')}'s`,
+            { text: 'terms of service', externalLink: meta.terms }
           ]),
-          vnode.state.termsOpen
-          && m('.community-terms-of-service', meta.terms)
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [
             m('.select-address-option-left', [

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -80,7 +80,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
 
-    const meta = app.chain ? app.chain.meta.chain : app.community.meta;
+    const hasTermsOfService = app.chain ? app.chain.meta?.chain.terms : app.community?.meta.terms;
 
     return m('.SelectAddressModal', [
       m('.compact-modal-title', [
@@ -89,12 +89,6 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
           m('p', `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `),
-          meta.terms
-          && m('p', [
-            `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
-            m('a', { href: meta.terms, target: '_blank' }, 'terms of service'),
-            '.'
-          ])
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [
             m('.select-address-option-left', [
@@ -126,6 +120,12 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
               role.is_user_default && m(Tag, { label: 'Last used', rounded: true, size: 'sm' }),
             ]),
           ])),
+        ]),
+        meta.terms
+        && m('p', [
+          `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
+          m('a', { href: meta.terms, target: '_blank' }, 'terms of service'),
+          '.'
         ]),
         activeAccountsByRole.length !== 0 && m(Button, {
           label: 'Join community with address',

--- a/client/scripts/views/modals/select_address_modal.ts
+++ b/client/scripts/views/modals/select_address_modal.ts
@@ -7,7 +7,7 @@ import { Tag, Button, Icon, Icons } from 'construct-ui';
 import app from 'state';
 import { Account, RoleInfo, ChainBase } from 'models';
 import { UserBlock } from 'views/components/widgets/user';
-import { articlize, isSameAccount, formatAsTitleCase } from 'helpers';
+import { articlize, isSameAccount, formatAsTitleCase, link } from 'helpers';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { setActiveAccount } from 'controllers/app/login';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
@@ -80,7 +80,7 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
     };
 
     // const chainbase = (app.chain?.meta?.chain?.base.length != 0) ? app.chain?.meta?.chain?.base : ChainBase.Ethereum;
-    
+
     const meta = app.chain ? app.chain.meta.chain : app.community.meta;
 
     return m('.SelectAddressModal', [
@@ -89,11 +89,13 @@ const SelectAddressModal: m.Component<{}, { selectedIndex: number, loading: bool
       ]),
       m('.compact-modal-body', [
         activeAccountsByRole.length === 0 ? m('.select-address-placeholder', [
-          m('p', [
-            `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `,
-            meta.terms && `By linking an address, you agree to ${articlize(app.chain?.meta?.chain.name || 'Web3')}'s`,
-            { text: 'terms of service', externalLink: meta.terms }
-          ]),
+          m('p', `Connect ${articlize(app.chain?.meta?.chain.name || 'Web3')} address to join this community. `),
+          meta.terms
+          && m('p', [
+            `By linking an address, you agree to ${app.chain?.meta?.chain?.name || app.community?.meta?.name}'s `,
+            link('a', meta.terms, 'terms of service'),
+            '.'
+          ])
         ]) : m('.select-address-options', [
           activeAccountsByRole.map(([account, role], index) => role && m('.select-address-option.existing', [
             m('.select-address-option-left', [

--- a/client/styles/modals/confirm_invite_modal.scss
+++ b/client/styles/modals/confirm_invite_modal.scss
@@ -25,6 +25,9 @@
         display: inline-block;
         height: initial;
     }
+    .terms-of-service {
+        padding: 7px 0;
+    }
 
     .invite-addresses {
         max-height: 209px;

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -17,8 +17,8 @@
         p:first-child {
             margin-top: 0;
         }
-        p:last-child {
-            margin-bottom: 0;
+        p {
+            padding-bottom: 5px;
         }
     }
 

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -16,9 +16,20 @@
         margin-bottom: 12px;
         p:first-child {
             margin-top: 0;
+            padding-top: 0;
         }
         p {
-            padding-bottom: 5px;
+            padding-top: 7px;
+        }
+        .community-terms-of-service {
+            max-height: 150px;
+            overflow-y: auto;
+            background: $background-color-light;
+            color: $text-color-medium-dark;
+            margin-top: 14px;
+            padding: 15px;
+            border-radius: 15px;
+            font-size: 14px;
         }
     }
 

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -16,9 +16,9 @@
         margin-bottom: 12px;
         p:first-child {
             margin-top: 0;
-            padding-top: 0;
         }
         p:last-child {
+            padding-top: 7px;
             margin-bottom: 0;
         }
     }

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -18,8 +18,10 @@
             margin-top: 0;
         }
         p:last-child {
-            padding-top: 7px;
             margin-bottom: 0;
+        }
+        .terms-of-service {
+            padding-top: 7px;
         }
     }
 

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -18,18 +18,8 @@
             margin-top: 0;
             padding-top: 0;
         }
-        p {
-            padding-top: 7px;
-        }
-        .community-terms-of-service {
-            max-height: 150px;
-            overflow-y: auto;
-            background: $background-color-light;
-            color: $text-color-medium-dark;
-            margin-top: 14px;
-            padding: 15px;
-            border-radius: 15px;
-            font-size: 14px;
+        p:last-child {
+            margin-bottom: 0;
         }
     }
 

--- a/client/styles/modals/select_address_modal.scss
+++ b/client/styles/modals/select_address_modal.scss
@@ -20,9 +20,9 @@
         p:last-child {
             margin-bottom: 0;
         }
-        .terms-of-service {
-            padding-top: 7px;
-        }
+    }
+    .terms-of-service {
+        padding: 7px;
     }
 
     .select-address-options {

--- a/server/migrations/20210715002927-add-terms-to-chains.js
+++ b/server/migrations/20210715002927-add-terms-to-chains.js
@@ -4,11 +4,11 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
       await queryInterface.addColumn('OffchainCommunities', 'terms', {
-        type: Sequelize.TEXT,
+        type: Sequelize.STRING,
         allowNull: true,
       }, { transaction: t });
       await queryInterface.addColumn('Chains', 'terms', {
-        type: Sequelize.TEXT,
+        type: Sequelize.STRING,
         allowNull: true,
       }, { transaction: t });
     });

--- a/server/migrations/20210715002927-add-terms-to-chains.js
+++ b/server/migrations/20210715002927-add-terms-to-chains.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn('OffchainCommunities', 'terms', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }, { transaction: t });
+      await queryInterface.addColumn('Chains', 'terms', {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: true,
+      }, { transaction: t });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('OffchainCommunities', 'terms', { transaction: t });
+      await queryInterface.removeColumn('Chains', 'terms', { transaction: t });
+    });
+  }
+};
+
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};

--- a/server/migrations/20210715002927-add-terms-to-chains.js
+++ b/server/migrations/20210715002927-add-terms-to-chains.js
@@ -4,11 +4,11 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
       await queryInterface.addColumn('OffchainCommunities', 'terms', {
-        type: Sequelize.STRING,
+        type: Sequelize.TEXT,
         allowNull: true,
       }, { transaction: t });
       await queryInterface.addColumn('Chains', 'terms', {
-        type: Sequelize.STRING,
+        type: Sequelize.TEXT,
         allowNull: true,
       }, { transaction: t });
     });

--- a/server/migrations/20210715002927-add-terms-to-chains.js
+++ b/server/migrations/20210715002927-add-terms-to-chains.js
@@ -10,7 +10,6 @@ module.exports = {
       await queryInterface.addColumn('Chains', 'terms', {
         type: Sequelize.STRING,
         allowNull: true,
-        defaultValue: true,
       }, { transaction: t });
     });
   },
@@ -20,29 +19,5 @@ module.exports = {
       await queryInterface.removeColumn('OffchainCommunities', 'terms', { transaction: t });
       await queryInterface.removeColumn('Chains', 'terms', { transaction: t });
     });
-  }
-};
-
-'use strict';
-
-module.exports = {
-  up: (queryInterface, Sequelize) => {
-    /*
-      Add altering commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
-    */
-  },
-
-  down: (queryInterface, Sequelize) => {
-    /*
-      Add reverting commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.dropTable('users');
-    */
   }
 };

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -32,6 +32,7 @@ export interface ChainAttributes {
   customDomain: string;
   type: string;
   substrate_spec: RegisteredTypes;
+  terms: string;
 
   // associations
   ChainNodes?: ChainNodeAttributes[] | ChainNodeAttributes['id'][];
@@ -80,6 +81,7 @@ export default (
     collapsed_on_homepage: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
     type: { type: dataTypes.STRING, allowNull: false },
     substrate_spec: { type: dataTypes.JSONB, allowNull: true },
+    terms: { type: dataTypes.STRING, allowNull: true },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -81,7 +81,7 @@ export default (
     collapsed_on_homepage: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
     type: { type: dataTypes.STRING, allowNull: false },
     substrate_spec: { type: dataTypes.JSONB, allowNull: true },
-    terms: { type: dataTypes.STRING, allowNull: true },
+    terms: { type: dataTypes.TEXT, allowNull: true },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -81,7 +81,7 @@ export default (
     collapsed_on_homepage: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
     type: { type: dataTypes.STRING, allowNull: false },
     substrate_spec: { type: dataTypes.JSONB, allowNull: true },
-    terms: { type: dataTypes.TEXT, allowNull: true },
+    terms: { type: dataTypes.STRING, allowNull: true },
   }, {
     timestamps: false,
     underscored: true,

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -66,7 +66,7 @@ export default (
       telegram: { type: dataTypes.STRING, allowNull: true },
       github: { type: dataTypes.STRING, allowNull: true },
       featured_topics: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
-      terms: { type: dataTypes.TEXT, allowNull: true },
+      terms: { type: dataTypes.STRING, allowNull: true },
       // auth_forum: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
       // auth_condition: { type: DataTypes.STRING, allowNull: true, defaultValue: null }, // For Auth Forum Checking
       // ^^^ other names: community_config, OffchainCommunityConfiguration, CommunityConditions

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -18,6 +18,7 @@ export interface OffchainCommunityAttributes {
   element?: string;
   telegram?: string;
   github?: string;
+  terms?: string;
   featured_topics?: string[];
   privacyEnabled?: boolean;
   invitesEnabled?: boolean;
@@ -65,6 +66,7 @@ export default (
       telegram: { type: dataTypes.STRING, allowNull: true },
       github: { type: dataTypes.STRING, allowNull: true },
       featured_topics: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
+      terms: { type: dataTypes.STRING, allowNull: true },
       // auth_forum: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
       // auth_condition: { type: DataTypes.STRING, allowNull: true, defaultValue: null }, // For Auth Forum Checking
       // ^^^ other names: community_config, OffchainCommunityConfiguration, CommunityConditions

--- a/server/models/offchain_community.ts
+++ b/server/models/offchain_community.ts
@@ -66,7 +66,7 @@ export default (
       telegram: { type: dataTypes.STRING, allowNull: true },
       github: { type: dataTypes.STRING, allowNull: true },
       featured_topics: { type: dataTypes.ARRAY(dataTypes.STRING), allowNull: false, defaultValue: [] },
-      terms: { type: dataTypes.STRING, allowNull: true },
+      terms: { type: dataTypes.TEXT, allowNull: true },
       // auth_forum: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
       // auth_condition: { type: DataTypes.STRING, allowNull: true, defaultValue: null }, // For Auth Forum Checking
       // ^^^ other names: community_config, OffchainCommunityConfiguration, CommunityConditions

--- a/server/routes/updateChain.ts
+++ b/server/routes/updateChain.ts
@@ -16,6 +16,7 @@ export const Errors = {
   InvalidTelegram: 'Telegram must begin with https://t.me/',
   InvalidGithub: 'Github must begin with https://github.com/',
   InvalidCustomDomain: 'Custom domain may not include "commonwealth"',
+  InvalidTerms: 'Terms of Service must begin with https://',
 };
 
 const updateChain = async (models, req: Request, res: Response, next: NextFunction) => {
@@ -40,7 +41,7 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
     }
   }
 
-  const { active, icon_url, symbol, type, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain } = req.body;
+  const { active, icon_url, symbol, type, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain, terms } = req.body;
 
   if (website && !urlHasValidHTTPPrefix(website)) {
     return next(new Error(Errors.InvalidWebsite));
@@ -54,6 +55,8 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
     return next(new Error(Errors.InvalidGithub));
   } else if (customDomain && customDomain.includes('commonwealth')) {
     return next(new Error(Errors.InvalidCustomDomain));
+  } else if (terms && !urlHasValidHTTPPrefix(terms)) {
+    return next(new Error(Errors.InvalidTerms));
   }
 
   if (name) chain.name = name;
@@ -70,6 +73,7 @@ const updateChain = async (models, req: Request, res: Response, next: NextFuncti
   chain.stagesEnabled = stagesEnabled;
   chain.additionalStages = additionalStages;
   chain.customDomain = customDomain;
+  chain.terms = terms;
   if (req.body['featured_topics[]']) chain.featured_topics = req.body['featured_topics[]'];
 
   await chain.save();

--- a/server/routes/updateCommunity.ts
+++ b/server/routes/updateCommunity.ts
@@ -16,6 +16,7 @@ export const Errors = {
   InvalidTelegram: 'Telegram must begin with https://t.me/',
   InvalidGithub: 'Github must begin with https://github.com/',
   InvalidCustomDomain: 'Custom domain may not include "commonwealth"',
+  InvalidTerms: 'Terms of Service must begin with https://',
 };
 
 const updateCommunity = async (models, req: Request, res: Response, next: NextFunction) => {
@@ -40,7 +41,7 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
     }
   }
 
-  const { iconUrl, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain, invites, privacy } = req.body;
+  const { iconUrl, name, description, website, discord, element, telegram, github, stagesEnabled, additionalStages, customDomain, invites, privacy, terms } = req.body;
 
   if (website && !urlHasValidHTTPPrefix(website)) {
     return next(new Error(Errors.InvalidWebsite));
@@ -54,6 +55,8 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
     return next(new Error(Errors.InvalidGithub));
   } else if (customDomain && customDomain.includes('commonwealth')) {
     return next(new Error(Errors.InvalidCustomDomain));
+  } else if (terms && !urlHasValidHTTPPrefix(terms)) {
+    return next(new Error(Errors.InvalidTerms));
   }
 
   if (req.body.name) community.name = req.body.name;
@@ -68,6 +71,7 @@ const updateCommunity = async (models, req: Request, res: Response, next: NextFu
   community.stagesEnabled = stagesEnabled;
   community.additionalStages = additionalStages;
   community.customDomain = customDomain;
+  community.terms = terms;
   community.invitesEnabled = invites || false;
   community.privacyEnabled = privacy || false;
   await community.save();


### PR DESCRIPTION
This pull adds community support for a TOS URI, which community admins can set in the community management modal.

This URI is then displayed whenever a user attempts to join a community with a new address, or accepts an email-based community invite.

It does not provide support for silent address-based invitations; see issue #1267. 

To test:
1. From an admin account, add a TOS link (should be valid http/s or will fail) to the community metadata form, in the "Manage Community" modal.
2. Add a new address to the community via the "Manage addresses"/SelectNewAddress modal
3. From an admin account, invite an email account (e.g. via mail.tm) to the community, then accept this invite by adding/connecting a new address to the community.

At each stage in which a user is connecting a new address to join the community, a link to the TOS should render. These steps should replicate on both on- and off-chain, and both public and private, communities. 