### PR TITLE
fix unit test  'should fail when not the owner of the notification'

### DIFF
--- a/test/unit/api/subscriptions.spec.ts
+++ b/test/unit/api/subscriptions.spec.ts
@@ -685,9 +685,12 @@ describe('Subscriptions Tests', () => {
       });
       it('should fail when not the owner of the notification', async () => {
         expect(notifications).to.not.be.null;
-        const notification_ids = notifications.map((n) => { return n.id; });
+        // create fake user who doesn't have any notifications
+        const user = await models['User'].create({ email: 'test@dummy.com' });
+        // get existing notif in the DB
+        const notification_ids = (await models.Notification.findAll()).map((n) => { return n.id; });
         const result = await modelUtils.createAndVerifyAddress({ chain });
-        const newJwt = jwt.sign({ id: result.user_id, email: result.email }, JWT_SECRET);
+        const newJwt = jwt.sign({ id: user.id, email: user.email }, JWT_SECRET);
         const res = await chai.request(app)
           .post('/api/markNotificationsRead')
           .set('Accept', 'application/json')


### PR DESCRIPTION
The unit test `should fail when not the owner of the notification` aims at flaggingwrong owner of notifications.
It is currently failing fail because of the notifications array, using populated array from previous unit tests, which are not in synced with the DB.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've added a query to fetch the current notifications in the DB and created a fake user that do not have notifications.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Making sure there's no regression in the notifications


## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no