### PR TITLE
fetch reactions when hovering react button

### DIFF
--- a/client/scripts/controllers/chain/community/main.ts
+++ b/client/scripts/controllers/chain/community/main.ts
@@ -35,7 +35,6 @@ class Community extends ICommunityAdapter<Coin, OffchainAccount> {
     } = response.result;
     this.app.threads.initialize(threads, numVotingThreads, true);
     this.app.comments.initialize(comments, true);
-    this.app.reactions.initialize(reactions, true);
     this.app.topics.initialize(topics, true);
     this.meta.setAdmins(admins);
     this.app.recentActivity.setMostActiveUsers(activeUsers);

--- a/client/scripts/controllers/server/reactionCounts.ts
+++ b/client/scripts/controllers/server/reactionCounts.ts
@@ -1,0 +1,37 @@
+/* eslint-disable dot-notation */
+/* eslint-disable no-restricted-syntax */
+import $ from 'jquery';
+import _ from 'lodash';
+
+import app from 'state';
+
+import { ReactionCountsStore } from 'stores';
+import ReactionCount from 'models/ReactionCount';
+import {AbridgedThread, AnyProposal, OffchainComment, OffchainThread} from "models";
+
+export const modelFromServer = (reactionCount) => {
+    return new ReactionCount(
+        reactionCount.thread_id,
+        reactionCount.comment_id,
+        reactionCount.proposal_id,
+        reactionCount.has_reacted,
+        parseInt(reactionCount.like),
+    );
+};
+
+class ReactionCountController {
+    private _store: ReactionCountsStore = new ReactionCountsStore();
+    public get store() {
+        return this._store;
+    }
+
+    public getByPost(post: OffchainThread | AbridgedThread | AnyProposal | OffchainComment<any>) {
+        return this._store.getReactionCountByPost(post);
+    }
+
+    public deinit() {
+        this.store.clear();
+    }
+}
+
+export default ReactionCountController

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -21,6 +21,7 @@ import { notifyError } from 'controllers/app/notifications';
 import { updateLastVisited } from 'controllers/app/login';
 import { modelFromServer as modelCommentFromServer } from 'controllers/server/comments';
 import { modelFromServer as modelReactionFromServer } from 'controllers/server/reactions';
+import { modelFromServer as modelReactionCountFromServer }  from 'controllers/server/reactionCounts';
 
 export const INITIAL_PAGE_SIZE = 10;
 export const DEFAULT_PAGE_SIZE = 20;
@@ -467,7 +468,7 @@ class ThreadsController {
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful refresh status: ${response.status}`);
     }
-    const { threads, comments, reactions } = response.result;
+    const { threads, comments } = response.result;
     for (const thread of threads) {
       const modeledThread = modelFromServer(thread);
       if (!thread.Address) {
@@ -495,13 +496,17 @@ class ThreadsController {
         console.error(e.message);
       }
     }
-    for (const reaction of reactions) {
-      const existing = app.reactions.store.getById(reaction.id);
+    const { result: reactionCounts } = await $.post(`${app.serverUrl()}/reactionsCounts`, {
+      thread_ids: threads.map((thread) => thread.id),
+      active_address: app.user.activeAccount?.address
+    });
+    for (const rc of reactionCounts) {
+      const existing = app.reactionCounts.store.getById(reactionCounts.id);
       if (existing) {
-        app.reactions.store.remove(existing);
+        app.reactionCounts.store.remove(existing);
       }
       try {
-        app.reactions.store.add(modelReactionFromServer(reaction));
+        app.reactionCounts.store.add(modelReactionCountFromServer(rc));
       } catch (e) {
         console.error(e.message);
       }

--- a/client/scripts/models/IChainAdapter.ts
+++ b/client/scripts/models/IChainAdapter.ts
@@ -78,7 +78,6 @@ abstract class IChainAdapter<C extends Coin, A extends Account<C>> {
     } = response.result;
     this.app.threads.initialize(threads, numVotingThreads, true);
     this.app.comments.initialize(comments, false);
-    this.app.reactions.initialize(reactions, true);
     this.app.topics.initialize(topics, true);
     this.meta.chain.setAdmins(admins);
     this.app.recentActivity.setMostActiveUsers(activeUsers);

--- a/client/scripts/models/ReactionCount.ts
+++ b/client/scripts/models/ReactionCount.ts
@@ -1,0 +1,24 @@
+import { IUniqueId } from './interfaces';
+
+class ReactionCount<T extends IUniqueId> {
+    public readonly id: number;
+    public readonly threadId: number;
+    public readonly commentId: number | string;
+    public readonly proposalId: number | string;
+    public readonly hasReacted: boolean;
+    public readonly likes: number;
+    public readonly dislikes: number;
+
+    constructor(threadId, commentId, proposalId, hasReacted, likes, dislikes = 0) {
+    this.id = threadId || commentId || proposalId;
+    this.threadId = threadId;
+    this.commentId = commentId;
+    this.proposalId = proposalId;
+    this.proposalId = proposalId;
+    this.hasReacted = hasReacted;
+    this.likes = likes;
+    this.dislikes = dislikes;
+    }
+}
+
+export default ReactionCount;

--- a/client/scripts/state.ts
+++ b/client/scripts/state.ts
@@ -14,6 +14,7 @@ import CommentsController from './controllers/server/comments';
 import ThreadsController from './controllers/server/threads';
 import SnapshotController from './controllers/chain/snapshot';
 import ReactionsController from './controllers/server/reactions';
+import ReactionCountsController from './controllers/server/reactionCounts';
 import WebsocketController from './controllers/server/socket';
 import TopicsController from './controllers/server/topics';
 import CommunitiesController from './controllers/server/communities';
@@ -49,6 +50,7 @@ export interface IApp {
   threads: ThreadsController;
   snapshot: SnapshotController;
   reactions: ReactionsController;
+  reactionCounts: ReactionCountsController;
   topics: TopicsController;
   communities: CommunitiesController;
   user: UserController;
@@ -115,6 +117,7 @@ const app: IApp = {
   threads: new ThreadsController(),
   snapshot: new SnapshotController(),
   reactions: new ReactionsController(),
+  reactionCounts: new ReactionCountsController(),
   topics: new TopicsController(),
   communities: new CommunitiesController(),
   user: new UserController(),

--- a/client/scripts/stores/ReactionCountsStore.ts
+++ b/client/scripts/stores/ReactionCountsStore.ts
@@ -1,0 +1,63 @@
+import IdStore from 'stores/IdStore';
+import ReactionCount from 'models/ReactionCount';
+import {AbridgedThread, AnyProposal, OffchainComment, OffchainReaction, OffchainThread, Proposal} from "models";
+
+
+class ReactionCountsStore  extends IdStore<ReactionCount<any>>  {
+    private _storePost: { [identifier: string]: ReactionCount<any> } = {};
+
+    public add(reactionCount: ReactionCount<any>) {
+        const identifier = this.getIdentifier(reactionCount);
+        const reactionAlreadyInStore = (this._storePost[identifier] || null);
+        if (!reactionAlreadyInStore) {
+            super.add(reactionCount);
+            if (!this._storePost[identifier]) {
+                this._storePost[identifier] = null;
+            }
+            this._storePost[identifier] = reactionCount;
+        }
+        return this;
+    }
+
+    public remove(reactionCount: ReactionCount<any>) {
+        super.remove(reactionCount);
+        const identifier = this.getIdentifier(reactionCount);
+        const proposal = this._storePost[identifier];
+        if (!proposal) {
+            throw new Error('Reaction count not in proposals store');
+        }
+        delete this._storePost[identifier];
+        return this;
+    }
+
+    public clear() {
+        super.clear();
+        this._storePost = {};
+    }
+
+    public getReactionCountByPost(post: OffchainThread | AbridgedThread | AnyProposal | OffchainComment<any>): ReactionCount<any> {
+        const identifier = this.getPostIdentifier(post);
+        return this._storePost[identifier] || null;
+    }
+
+    public getIdentifier(reactionCount: ReactionCount<any>) {
+        const { threadId, commentId, proposalId } = reactionCount;
+        return threadId
+            ? `discussion-${threadId}`
+            : proposalId
+                ? `${proposalId}`
+                : `comment-${commentId}`;
+    }
+
+    public getPostIdentifier(rxnOrPost: OffchainReaction<any> | OffchainThread | AbridgedThread | AnyProposal | OffchainComment<any>) {
+        if (rxnOrPost instanceof OffchainThread || rxnOrPost instanceof AbridgedThread) {
+            return `discussion-${rxnOrPost.id}`;
+        } else if (rxnOrPost instanceof Proposal) {
+            return `${(rxnOrPost as AnyProposal).slug}_${(rxnOrPost as AnyProposal).identifier}`;
+        } else if (rxnOrPost instanceof OffchainComment) {
+            return `comment-${rxnOrPost.id}`;
+        }
+    }
+}
+
+export default ReactionCountsStore;

--- a/client/scripts/stores/index.ts
+++ b/client/scripts/stores/index.ts
@@ -8,6 +8,7 @@ export { default as OffchainCommunitiesStore } from './OffchainCommunitiesStore'
 export { default as ProfileStore } from './ProfileStore';
 export { default as ProposalStore } from './ProposalStore';
 export { default as ReactionStore } from './ReactionStore';
+export { default as ReactionCountsStore } from './ReactionCountsStore';
 export { default as Store } from './Store';
 export { default as TopicStore } from './TopicStore';
 export { default as FilterScopedThreadStore } from './FilterScopedThreadStore';

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -258,7 +258,7 @@ const DiscussionsPage: m.Component<
     vnode.state.lookback = {};
     vnode.state.postsDepleted = {};
     vnode.state.topicInitialized = {};
-    vnode.state.topicInitialized[ALL_PROPOSALS_KEY] = true;
+    vnode.state.topicInitialized[ALL_PROPOSALS_KEY] = false;
     const topic = vnode.attrs.topic;
     const stage = m.route.param('stage');
     const subpage = topic || stage ? `${topic || ''}#${stage || ''}` : ALL_PROPOSALS_KEY;

--- a/server/router.ts
+++ b/server/router.ts
@@ -33,6 +33,7 @@ import createReaction from './routes/createReaction';
 import deleteReaction from './routes/deleteReaction';
 import viewReactions from './routes/viewReactions';
 import bulkReactions from './routes/bulkReactions';
+import reactionsCounts from './routes/reactionsCounts';
 import starCommunity from './routes/starCommunity';
 import createCommunity from './routes/createCommunity';
 import deleteCommunity from './routes/deleteCommunity';
@@ -307,6 +308,7 @@ function setupRouter(
   router.get('/viewReactions', viewReactions.bind(this, models));
   // TODO: Change to GET /reactions
   router.get('/bulkReactions', bulkReactions.bind(this, models));
+  router.post('/reactionsCounts', reactionsCounts.bind(this, models));
 
   // generic invite link
   // TODO: Change to POST /inviteLink

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -179,7 +179,8 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
         const allThreads = pinnedThreads.map((t) => {
           root_ids.push(`discussion_${t.id}`);
           return t.toJSON();
-        }).concat(threads);
+        })
+            // .concat(threads);
 
         // Comments
         const offchainComments = await models.OffchainComment.findAll({
@@ -196,21 +197,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
           return row;
         });
 
-        // Reactions
-        const matchThreadsOrComments = [
-          // @ts-ignore
-          { thread_id: allThreads.map((thread) => thread.id) },
-          // @ts-ignore
-          { comment_id: comments.map((comment) => comment.id) },
-        ];
-        const reactions = await models.OffchainReaction.findAll({
-          where: community
-            ? { community: community.id, [Op.or]: matchThreadsOrComments }
-            : { chain: chain.id, [Op.or]: matchThreadsOrComments },
-          include: [ models.Address ],
-          order: [['created_at', 'DESC']],
-        });
-        resolve([allThreads, comments, reactions]);
+        resolve([allThreads, comments]);
       } catch (e) {
         console.log(e);
         reject(new Error('Could not fetch threads, comments, or reactions'));
@@ -270,7 +257,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
     }),
   ]);
 
-  const [threads, comments, reactions] = threadsCommentsReactions as any;
+  const [threads, comments] = threadsCommentsReactions as any;
 
   const numVotingThreads = threadsInVoting.filter((t) => t.stage === 'voting').length;
 
@@ -282,7 +269,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
       numVotingThreads,
       threads, // already converted to JSON earlier
       comments, // already converted to JSON earlier
-      reactions: reactions.map((r) => r.toJSON()),
+      // reactions: reactions.map((r) => r.toJSON()),
       //
       admins: admins.map((a) => a.toJSON()),
       activeUsers: mostActiveUsers,

--- a/server/routes/bulkReactions.ts
+++ b/server/routes/bulkReactions.ts
@@ -1,28 +1,34 @@
 import { Request, Response, NextFunction } from 'express';
+import { Sequelize } from 'sequelize';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { factory, formatFilename } from '../../shared/logging';
 import { DB } from '../database';
+import { uniqBy } from 'lodash'
 
 const log = factory.getLogger(formatFilename(__filename));
 
 const bulkReactions = async (models: DB, req: Request, res: Response, next: NextFunction) => {
-  const [chain, community, error] = await lookupCommunityIsVisibleToUser(models, req.query, req.user);
-  if (error) return next(new Error(error));
-
-  let reactions;
+  // const [chain, community, error] = await lookupCommunityIsVisibleToUser(models, req.query, req.user);
+  // if (error) return next(new Error(error));
+  const { thread_id, proposal_id, comment_id } = req.query
+  let reactions = [];
   try {
-    reactions = await models.OffchainReaction.findAll({
-      where: community
-        ? { community: community.id }
-        : { chain: chain.id },
-      include: [ models.Address ],
-      order: [['created_at', 'DESC']],
-    });
+    if (thread_id || proposal_id || comment_id) {
+      reactions = await models.OffchainReaction.findAll({
+        where: {
+          thread_id: thread_id || null,
+          proposal_id: proposal_id || null,
+          comment_id: comment_id || null
+        },
+        include: [ models.Address ],
+        order: [['created_at', 'DESC']],
+      });
+    }
   } catch (err) {
     return next(new Error(err));
   }
 
-  return res.json({ status: 'Success', result: reactions.map((c) => c.toJSON()) });
+  return res.json({ status: 'Success', result: uniqBy(reactions.map((c) => c.toJSON()), 'id') });
 };
 
 export default bulkReactions;

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -211,16 +211,16 @@ const bulkThreads = async (models: DB, req: Request, res: Response, next: NextFu
     });
   }
 
-  const reactions = await models.OffchainReaction.findAll({
-    where: {
-      [Op.or]: [
-        { thread_id: threads.map((thread) => thread.id) },
-        { comment_id: comments.map((comment) => comment.id) },
-      ],
-    },
-    include: [ models.Address ],
-    order: [['created_at', 'DESC']],
-  });
+  // const reactions = await models.OffchainReaction.findAll({
+  //   where: {
+  //     [Op.or]: [
+  //       { thread_id: threads.map((thread) => thread.id) },
+  //       { comment_id: comments.map((comment) => comment.id) },
+  //     ],
+  //   },
+  //   include: [ models.Address ],
+  //   order: [['created_at', 'DESC']],
+  // });
 
   const countsQuery = `
      SELECT id, title, stage FROM "OffchainThreads"
@@ -238,7 +238,7 @@ const bulkThreads = async (models: DB, req: Request, res: Response, next: NextFu
       numVotingThreads,
       threads,
       comments, // already converted to JSON earlier
-      reactions: reactions.map((r) => r.toJSON()),
+      // reactions: reactions.map((r) => r.toJSON()),
     }
   });
 };

--- a/server/routes/reactionsCounts.ts
+++ b/server/routes/reactionsCounts.ts
@@ -1,0 +1,72 @@
+import { Request, Response, NextFunction } from 'express';
+import { Sequelize } from 'sequelize'
+import { factory, formatFilename } from '../../shared/logging';
+import { DB } from '../database';
+import {OffchainReactionInstance} from "../models/offchain_reaction";
+
+const log = factory.getLogger(formatFilename(__filename));
+
+// fetch reaction counts and whether user has reacted
+const reactionsCounts = async (models: DB, req: Request, res: Response, next: NextFunction) => {
+    const { active_address } = req.body
+    const thread_ids = req.body['thread_ids[]'];
+    const comment_ids = req.body['comment_ids[]'];
+    const proposal_ids = req.body['proposal_ids[]'];
+    try {
+        if (thread_ids || comment_ids || proposal_ids) {
+            let countField = 'thread_id';
+            if (comment_ids) {
+                countField = 'comment_id';
+            } else if (proposal_ids) {
+                countField = 'proposal_id';
+            }
+            const [reactionsCounts = [], myReactions = []] = await <Promise<[OffchainReactionInstance[], OffchainReactionInstance[]]>>Promise.all([
+                models.OffchainReaction.findAll({
+                    group: ['thread_id', 'comment_id', 'proposal_id', 'reaction'],
+                    attributes: ['thread_id', 'comment_id', 'proposal_id', 'reaction',
+                        [Sequelize.fn('COUNT', countField), 'count']],
+                    where: {
+                        thread_id: thread_ids || null,
+                        proposal_id: proposal_ids || null,
+                        comment_id: comment_ids || null
+                    },
+                }),
+                models.OffchainReaction.findAll({
+                    attributes: ['thread_id', 'comment_id', 'proposal_id'],
+                    where: {
+                        thread_id: thread_ids || null,
+                        proposal_id: proposal_ids || null,
+                        comment_id: comment_ids || null
+                    },
+                    include: [{
+                        model: models.Address,
+                        where: { address: active_address }
+                    }]
+                })
+            ])
+            return res.json({
+                status: 'Success',
+                result: reactionsCounts.reduce((acc, rc) => {
+                    const rcJSon: any = rc.toJSON()
+                    const id = rcJSon.thread_id || rcJSon.comment_id || rcJSon.proposal_id
+                    const index = acc.findIndex(({ thread_id, comment_id, proposal_id }) => (id === thread_id || id === comment_id
+                        || id === proposal_id))
+                    const has_reacted = myReactions.some(({ thread_id, comment_id, proposal_id }) => {
+                        return (id === thread_id || id === comment_id || id === proposal_id)
+                    })
+                    if (index > 0) {
+                        acc[index][rcJSon.reaction] = rcJSon.count;
+                    } else {
+                        acc.push({ ...rcJSon, [rcJSon.reaction]: rcJSon.count, has_reacted })
+                    }
+                    return acc
+                }, [])
+            });
+        }
+    } catch (err) {
+        return next(new Error(err));
+    }
+
+};
+
+export default reactionsCounts;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Performance issue in the loading of threads since we are fetching a lot of stuff we don't need like comments and reactions
The first goal is to load user's reactions when hovering the reaction button.
In addition to that, a new endpoint responsible for fetching the number of reaction has been created. 
That endpoint only counts reactions based on the thread_ids or comment_ids currently loaded on the page.


## Description
<!--- Describe your changes in detail -->
- Lazy load reactions count as part of a new endpoint
- Lazy load active users when hovering react button
- Remove fetching of threads in /offchain endpoint as it's already done in /bulkThreads

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no