### PR TITLE
Token community bug fixes

### DIFF
--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -34,10 +34,7 @@ const ReactionButton: m.Component<{
     if (type === ReactionType.Like) likes = reactions.filter((r) => r.reaction === 'like');
     if (type === ReactionType.Dislike) dislikes = reactions.filter((r) => r.reaction === 'dislike');
 
-    const isCommunity = !!app.activeCommunityId();
-
-    const disabled = vnode.state.loading
-      || (!isCommunity && (app.chain as Token).isToken && !(app.chain as Token).hasToken);
+    const disabled = vnode.state.loading;
     const activeAddress = app.user.activeAccount?.address;
     const rxn = reactions.find((r) => r.reaction && r.author === activeAddress);
     const hasReacted : boolean = !!rxn;

--- a/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
+++ b/client/scripts/views/modals/manage_community_modal/chain_metadata_management_table.ts
@@ -118,23 +118,18 @@ const ChainMetadataManagementTable: m.Component<IChainOrCommMetadataManagementAt
           onChangeHandler: (v) => { vnode.state.customDomain = v; },
           disabled: true, // Custom domains should be admin configurable only
         }),
-        app.chain?.meta.chain.base === 'ethereum' ? m(InputPropertyRow, {
+        app.chain?.meta.chain.base === 'ethereum'
+        && m(InputPropertyRow, {
           title: 'Snapshot',
           defaultValue: vnode.state.snapshot,
           placeholder: vnode.state.network,
           onChangeHandler: (v) => { vnode.state.snapshot = v; },
-        }) : null,
+        }),
         m(InputPropertyRow, {
           title: 'Terms of Service',
           defaultValue: vnode.state.terms,
           placeholder: 'Url that new users see',
           onChangeHandler: (v) => { vnode.state.terms = v; },
-        }),
-        m(InputPropertyRow, {
-          title: 'Snapshot',
-          defaultValue: vnode.state.snapshot,
-          placeholder: vnode.state.network,
-          onChangeHandler: (v) => { vnode.state.snapshot = v; },
         }),
         m('tr', [
           m('td', 'Admins'),

--- a/client/scripts/views/sublayout.ts
+++ b/client/scripts/views/sublayout.ts
@@ -50,7 +50,7 @@ const Sublayout: m.Component<{
     const chain = app.chain ? app.chain.meta.chain : null;
     const community = app.community ? app.community.meta : null;
     const narrowBrowserWidth = (window.innerWidth > 767.98) && (window.innerWidth < 850);
-    const terms = app.chain ? app.chain.meta.chain.terms : null;
+    const terms = app.chain ? chain.terms : null;
 
     const ICON_SIZE = 22;
     const sublayoutHeaderLeft = m('.sublayout-header-left', [
@@ -133,7 +133,7 @@ const Sublayout: m.Component<{
             ? m('.sublayout-hero', hero)
             : (app.isLoggedIn() && (app.chain as Token)?.isToken && !(app.chain as Token)?.hasToken)
               ? m('.sublayout-hero.token-banner', [
-                m('.token-banner-content', `Link ${app.chain.meta.chain.symbol} address to participate in this community`),
+                m('.token-banner-content', `Link an address that holds ${chain.symbol} to participate in governance.`),
               ]) : '',
           terms && tosStatus !== 'off'
             ? m('.token-banner-terms', [


### PR DESCRIPTION
- Remove an undesired check for user tokens before enabling the reaction button in token communities
- Remove a redundant, non-Ethereum scoped Snapshot form field (was showing up erroneously on even e.g. Substrate communities)
- Copy update to token community token-holding requirements