### PR TITLE
add ghost address column for discourse user

### DIFF
--- a/server/migrations/20210830103157-add-ghost-address-column.js
+++ b/server/migrations/20210830103157-add-ghost-address-column.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+        'Addresses',
+        'ghost_address',
+        Sequelize.BOOLEAN
+    );
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.removeColumn(
+        'Addresses',
+        'ghost_address'
+    );
+  }
+};


### PR DESCRIPTION
As part of the import of discourse users, we need to create fake addresses that those users will have to change later.

## Description
Add migration file to add `ghost_address` column

## Motivation and Context
Discourse import
