### PR TITLE
Topic & Template Fixes

### DIFF
--- a/client/scripts/views/modals/edit_topic_modal.ts
+++ b/client/scripts/views/modals/edit_topic_modal.ts
@@ -42,7 +42,8 @@ const EditTopicModal : m.Component<{
     const updateTopic = async (form) => {
       const { quillEditorState } = vnode.state;
       if (form.featuredInNewPost && quillEditorState.editor.editor.isBlank()) {
-        return;
+        vnode.state.error = 'Must provide template.';
+        throw new Error('Must provide template.');
       }
 
       if (quillEditorState) {
@@ -68,6 +69,7 @@ const EditTopicModal : m.Component<{
       };
       await app.topics.edit(topicInfo);
       navigateToSubpage(`/discussions/${encodeURI(form.name.toString().trim())}`);
+      return true;
     };
 
     const deleteTopic = async (form) => {

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -170,17 +170,18 @@ const DiscussionStagesBar: m.Component<{ topic: string; stage: string }, {}> = {
                 featuredInNewPost,
                 defaultOffchainTemplate
               }, idx) => {
+                const active = m.route.get() === `/${app.activeId()}/discussions/${encodeURI(name.toString().trim())}`
+                  || (topic && topic === name);
                 return m(MenuItem, {
                   key: name,
-                  active: m.route.get() === `/${app.activeId()}/discussions/${encodeURI(name.toString().trim())}`
-                    || (topic && topic === name),
-                  iconLeft: m.route.get() === `/${app.activeId()}/discussions/${encodeURI(name.toString().trim())}`
-                    || (topic && topic === name) ? Icons.CHECK : null,
+                  active,
+                  // iconLeft: active ? Icons.CHECK : null,
                   onclick: (e) => {
                     e.preventDefault();
                     navigateToSubpage(`/discussions/${name}`);
                   },
                   label: m('.topic-menu-item', [
+                    active && m(Icon, { name: Icons.CHECK }),
                     m('.topic-menu-item-name', name),
                     app.user?.isAdminOfEntity({ chain: app.activeChainId(), community: app.activeCommunityId() })
                       && m(Button, {

--- a/client/styles/components/sidebar/index.scss
+++ b/client/styles/components/sidebar/index.scss
@@ -1,6 +1,13 @@
 @import 'client/styles/shared';
 
 @mixin sidebar {
+    .OffchainNavigationModule {
+        button > span {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+    }
     .cui-button.cui-active {
         background: linear-gradient(268.91deg, #91BFFF -61.91%, #91FFA0 2.69%, #FBFF91 60.22%, #FF9191 131.89%);
         border: 1px solid transparent;

--- a/client/styles/modals/edit_topic_modal.scss
+++ b/client/styles/modals/edit_topic_modal.scss
@@ -2,4 +2,8 @@
 
 .EditTopicModal {
     max-width: 680px;
+    .error-message {
+        @include error-text();
+        margin-top: 20px;
+    }
 }

--- a/client/styles/pages/discussions/index.scss
+++ b/client/styles/pages/discussions/index.scss
@@ -41,8 +41,14 @@
         max-width: 300px;
         .topic-menu-item {
             display: flex;
-            .topic-menu-item-name {
+            .cui-icon {
                 flex: 1;
+            }
+            .topic-menu-item-name {
+                flex: 7;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
                 position: relative;
                 top: 1px;
             }

--- a/client/styles/pages/discussions/index.scss
+++ b/client/styles/pages/discussions/index.scss
@@ -51,6 +51,7 @@
             display: flex;
             .cui-icon {
                 flex: 1;
+                margin-right: 0;
             }
             .topic-menu-item-name {
                 flex: 7;

--- a/client/styles/pages/discussions/index.scss
+++ b/client/styles/pages/discussions/index.scss
@@ -19,13 +19,21 @@
         }
     }
 
-    .discussions-topics,
-    .discussions-stages {
-        margin-bottom: 20px;
-        font-size: 17px;
-        line-height: 1.25;
-        .cui-button-group {
-            flex-wrap: wrap;
+    .DiscussionStagesBar {
+        > button {
+            max-width: 200px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .discussions-topics,
+        .discussions-stages {
+            margin-bottom: 20px;
+            font-size: 17px;
+            line-height: 1.25;
+            .cui-button-group {
+                flex-wrap: wrap;
+            }
         }
     }
     @include xs-max {

--- a/server/routes/createTopic.ts
+++ b/server/routes/createTopic.ts
@@ -15,7 +15,8 @@ const createTopic = async (models: DB, req, res: Response, next: NextFunction) =
   if (error) return next(new Error(error));
   if (!req.user) return next(new Error(Errors.NotLoggedIn));
   if (!req.body.name) return next(new Error(Errors.TopicRequired));
-  if (req.body.featured_in_new_post && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
+  if (req.body.featured_in_new_post === 'true'
+    && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
     return next(new Error(Errors.DefaultTemplateRequired));
   }
 
@@ -37,8 +38,8 @@ const createTopic = async (models: DB, req, res: Response, next: NextFunction) =
   const options = {
     name: req.body.name,
     description: req.body.description || '',
-    featured_in_sidebar: req.body.featured_in_sidebar || false,
-    featured_in_new_post: req.body.featured_in_new_post || false,
+    featured_in_sidebar: !!(req.body.featured_in_sidebar === 'true'),
+    featured_in_new_post: !!(req.body.featured_in_new_post === 'true'),
     default_offchain_template: req.body.default_offchain_template || '',
     ...chainOrCommObj2,
   };

--- a/server/routes/editTopic.ts
+++ b/server/routes/editTopic.ts
@@ -23,7 +23,8 @@ const editTopic = async (models: DB, req: Request, res: Response, next: NextFunc
     return next(new Error(Errors.NoTopicId));
   }
   if (!req.body.name) return next(new Error(Errors.TopicRequired));
-  if (req.body.featured_in_new_post && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
+  if (req.body.featured_in_new_post === 'true'
+    && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
     return next(new Error(Errors.DefaultTemplateRequired));
   }
 
@@ -53,15 +54,24 @@ const editTopic = async (models: DB, req: Request, res: Response, next: NextFunc
     return next(new Error(Errors.NotAdmin));
   }
 
-  const { id, name, description, telegram, featured_order, featured_in_sidebar, featured_in_new_post, default_offchain_template } = req.body;
+  const {
+    id,
+    name,
+    description,
+    telegram,
+    featured_order,
+    featured_in_sidebar,
+    featured_in_new_post,
+    default_offchain_template
+  } = req.body;
   try {
     const topic = await models.OffchainTopic.findOne({ where: { id } });
     if (!topic) return next(new Error(Errors.TopicNotFound));
     if (name) topic.name = name;
     if (name || description) topic.description = description || '';
     if (name || telegram) topic.telegram = telegram || '';
-    topic.featured_in_sidebar = featured_in_sidebar || false;
-    topic.featured_in_new_post = featured_in_new_post || false;
+    topic.featured_in_sidebar = !!(featured_in_sidebar === 'true');
+    topic.featured_in_new_post = !!(featured_in_new_post === 'true');
     topic.default_offchain_template = default_offchain_template || '';
     await topic.save();
 


### PR DESCRIPTION
Currently, long topic names overflow the left menu. This introduces a CSS fix.

Currently, the backend route checks for template presence erroneously check strings as if they were booleans. This introduces a fix.