### PR TITLE
Revert textbox border, make button order uniform

### DIFF
--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -508,6 +508,7 @@ const ProposalComment: m.Component<{
           !vnode.state.editing
             && !comment.deleted
             && m('.comment-response-row', [
+              m(ProposalBodyReaction, { item: comment }),
               m(InlineReplyButton, {
                 commentReplyCount,
                 onclick: (e) => {
@@ -520,7 +521,6 @@ const ProposalComment: m.Component<{
                   }
                 }
               }),
-              m(ProposalBodyReaction, { item: comment }),
             ]),
         ]),
       ]),

--- a/client/styles/components/quill_editor.scss
+++ b/client/styles/components/quill_editor.scss
@@ -110,7 +110,7 @@
 
     // 3. ql-snow form input styles, ql-bubble styles
     .ql-container.ql-snow {
-        border: 1px solid #B37DBA;
+        // border: 1px solid #B37DBA;
         border-radius: 0 0 3px 3px;
         // construct-ui input styles
         color: $text-color-darker;
@@ -128,7 +128,7 @@
 
     // 4. toolbar
     .ql-toolbar.ql-snow {
-        border: 1px solid #B37DBA;
+        // border: 1px solid #B37DBA;
         border-radius: 4px 4px 0 0;
         box-sizing: border-box;
         padding: 5px 8px;
@@ -137,10 +137,10 @@
         min-height: 39px;
     }
     .ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-label {
-        border-color: #B37DBA;
+        // border-color: #B37DBA;
     }
     .ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options {
-        border-color: #B37DBA;
+        // border-color: #B37DBA;
     }
     // link popup
     .ql-tooltip {


### PR DESCRIPTION
This branch reverts the purple borders on the Quill CreateComment component. 

It also ensures that the button order (of InlineReply and Reaction buttons) is uniform across proposals and comments.