### PR TITLE
Fixes reaction buttons in offchain communities

### DIFF
--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -90,7 +90,7 @@ const ReactionButton: m.Component<ReactionButtonAttrs, ReactionButtonState> = {
 
     let tokenPostingThreshold;
     if( post instanceof OffchainThread && post.topic && app.topics) {
-      tokenPostingThreshold = app.topics.getByName((post as OffchainThread).topic.name, app.activeId()).tokenThreshold
+      tokenPostingThreshold = (app.chain as Token) ? app.topics.getByName((post as OffchainThread).topic.name, app.activeId()).tokenThreshold : null;
     } else if (post instanceof OffchainComment) {
       // post.rootProposal has typescript typedef number but in practice seems to be a string
       const parentThread = app.threads.getById(parseInt(post.rootProposal.toString().split('_')[1], 10));


### PR DESCRIPTION
Mithril was flashing n-many reaction buttons and bricking the page. This fix things and retains same behavior on existing communities