### PR TITLE
Exclude deleted comments from comment counts

### DIFF
--- a/client/scripts/stores/CommentsStore.ts
+++ b/client/scripts/stores/CommentsStore.ts
@@ -73,7 +73,8 @@ class CommentsStore extends IdStore<OffchainComment<any>> {
 
   public nComments<T extends IUniqueId>(proposal: T): number {
     if (this._storeProposal[proposal.uniqueIdentifier]) {
-      return this._storeProposal[proposal.uniqueIdentifier].length;
+      return this._storeProposal[proposal.uniqueIdentifier]
+        .filter((c) => !c.deleted).length;
     } else {
       return 0;
     }

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -437,7 +437,7 @@ const ProposalComment: m.Component<{
       + `${proposal.identifier}-${slugify(proposal.title)}?comment=${comment.id}`;
 
     const commentReplyCount = app.comments.getByProposal(proposal)
-      .filter((c) => c.parentComment === comment.id)
+      .filter((c) => c.parentComment === comment.id && !c.deleted)
       .length;
     return m('.ProposalComment', {
       class: `${parentType}-child comment-${comment.id}`,


### PR DESCRIPTION
Bug fix. Previously, comment counts did not filter out soft-deleted comments, in light of our new soft-deletion threading system.