### PR TITLE
Fix Reaction Button Bug

### DIFF
--- a/client/scripts/views/components/reaction_button.ts
+++ b/client/scripts/views/components/reaction_button.ts
@@ -113,12 +113,7 @@ const ReactionButton: m.Component<ReactionButtonAttrs, ReactionButtonState> = {
     let hasReactedType;
     if (hasReacted) hasReactedType = ReactionType.Like;
 
-    const rxnButton = m('.ReactionButton', {
-      class: `${(disabled ? 'disabled' : type === hasReactedType ? 'active' : '')
-        + (displayAsLink ? ' as-link' : '')
-        + (large ? ' large' : '')
-        + (type === ReactionType.Like ? ' like' : '')
-        + (type === ReactionType.Dislike ? ' dislike' : '')}`,
+    const rxnButton = m('.ProposalBodyReaction', {
       onmouseenter:  async (e) => {
         vnode.state.reactors = await fetchReactionsByPost(post);
       },
@@ -185,6 +180,12 @@ const ReactionButton: m.Component<ReactionButtonAttrs, ReactionButtonState> = {
           });
         }
       },
+    }, [ m('.ReactionButton', {
+      class: `${(disabled ? 'disabled' : type === hasReactedType ? 'active' : '')
+        + (displayAsLink ? ' as-link' : '')
+        + (large ? ' large' : '')
+        + (type === ReactionType.Like ? ' like' : '')
+        + (type === ReactionType.Dislike ? ' dislike' : '')}`,
     }, (type === ReactionType.Dislike) && [
       large
         ? m('.reactions-icon', '▾')
@@ -203,7 +204,7 @@ const ReactionButton: m.Component<ReactionButtonAttrs, ReactionButtonState> = {
           size: Size.XL,
         }),
       m('.reactions-count', vnode.state.likes),
-    ]);
+    ])]);
 
     return (tooltip && (vnode.state.likes || vnode.state.dislikes))
       ? m(Popover, {

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -708,8 +708,6 @@ export const ProposalBodyReaction: m.Component<{ item: OffchainThread | AnyPropo
     const { item } = vnode.attrs;
     if (!item) return;
 
-    return m('.ProposalBodyReaction', [
-      m(ReactionButton, { post: item, type: ReactionType.Like, tooltip: true })
-    ]);
+    return m(ReactionButton, { post: item, type: ReactionType.Like, tooltip: true });
   }
 };


### PR DESCRIPTION
If a user wasn't clicking on the center of the reaction button, their click wouldn't be added so it would seem like the reaction button didn't work "some of the times". 

There is another race condition about reactions loading on the button popover making clicking difficult, but I do not believe the user who commented on the bad button was encountering that issue.