### PR TITLE
fix layout init for custom domain

### DIFF
--- a/client/scripts/views/layout.ts
+++ b/client/scripts/views/layout.ts
@@ -90,10 +90,14 @@ export const Layout: m.Component<{
     } else if (!scope && ((app.chain && app.chain.network) || app.community)) {
       // Handle the case where we unload the network or community, if we're
       // going to a page that doesn't have one
-      deinitChainOrCommunity().then(() => {
-        vnode.state.loadingScope = null;
-        m.redraw();
-      });
+      // Include this in if for isCustomDomain, scope gets unset on redirect
+      // We don't need this to happen
+      if (!app.isCustomDomain()) {
+        deinitChainOrCommunity().then(() => {
+          vnode.state.loadingScope = null;
+          m.redraw();
+        });
+      }
       return m(LoadingLayout, { hideSidebar });
     }
     return m('.Layout.mithril-app', {


### PR DESCRIPTION
Previously, Think I found out why custom domains are loading slowly as well as well as why the threads are loading incorrectly on custom domains.

For custom domains, we redirect away from `domain/:scope/discussions` to `domain/discissions` the scope gets unset (as we pull this directly from the url: ie :scope/discussions). As a result, in `layout.ts` this causes the chain (and stores associated) to become deinitialized. This had some noticeable side effects:

1. As we were moving into a `view proposal page` from the main discussions listing page. We deinitialized then reinitialized the chain, which caused noticeably slower loading on viewing a thread.

2. As we navigated back to the discussions page (via the back button), the threads didn't match.

The fix here was to include an `if (app.isCustomDomain())` check where we.

**QA / Testing**

1. Should navigate within two separate tabs the localhost/scope and custom domain version of all pages.
2. Should **directly** open in **new tabs** all relevant pages for each respective version. I.e directly navigate to:
     
- `localhost/scope/proposals`
- `localhost/scope/proposal/discussion/whatever-it-is`
- `customdomain/proposal/discussion/whatever-it-is`
- `customdomain/proposals`

