### PR TITLE
Sticky sidebar, sticky header

### DIFF
--- a/client/styles/components/sidebar/index.scss
+++ b/client/styles/components/sidebar/index.scss
@@ -219,7 +219,9 @@
 }
 
 .Sidebar {
-    position: relative;
+    max-height: 100%;
+    position: sticky;
+    top: 83px;
     z-index: 2;
     padding-top: 36px;
     padding-bottom: 36px;

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -6,6 +6,10 @@
     .sublayout-main-col {
         padding: 0 5%;
     }
+    .sublayout-sidebar-col {
+        max-width: 0px;
+        padding-right: 0;
+    }
 
     .search-page-input {
         margin-top: 30px;

--- a/client/styles/pages/search.scss
+++ b/client/styles/pages/search.scss
@@ -182,7 +182,7 @@
     }
     .search-results-list, .cui-list {
         position: absolute;
-        z-index: 10;
+        z-index: 11;
         top: 40px;
         left: 4%;
         border-radius: 0 0 8px 8px;

--- a/client/styles/sublayout.scss
+++ b/client/styles/sublayout.scss
@@ -111,6 +111,10 @@
     }
 
     .sublayout-header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: white;
         @include sm-max {
             display: none;
         }


### PR DESCRIPTION
This branch makes the community Sidebar component and header component sticky, so that they stay on-screen while e.g. discussion listings or members are scrolled.

To test, I have:
- [x] Ensured mobile view is unaffected
- [x] Tested Member/Discussion views
- [x] Tested on communities with many pgs of posts vs. <1pg worth
- [x] Ensured that z-indexes of various other components don't clash with new header z-index
- [x] Ensured that profile pages, home page, search page all affected as intended (in addition, obviously, to disc listing)  

Additionally, this branch re-centers search results on the Search Page, after they had been de-centered by sidebar column styling.