### PR TITLE
Support > 2 voting options on Snapshot Proposals

### DIFF
--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -199,7 +199,7 @@ export function formatLastUpdated(timestamp) {
     .replace(' days', 'd')
     .replace(' day', 'd')
     .replace(' hours', 'h')
-    .replace(' hour', 'h')} ago`;
+    .replace(' hour', 'h')} ${formatted !== 'now' ? 'ago' : ''}`;
 }
 
 export function formatTimestamp(timestamp) {

--- a/client/scripts/views/modals/confirm_snapshot_vote_modal.ts
+++ b/client/scripts/views/modals/confirm_snapshot_vote_modal.ts
@@ -26,14 +26,13 @@ const ConfirmSnapshotVoteModal: m.Component<{
   totalScore: number,
   scores: any
   snapshot: any,
-  state: any,
 }, {
   error: any,
   saving: boolean,
 }> = {
   view: (vnode) => {
     const author = app.user.activeAccount;
-    const { proposal, space, id, selectedChoice, totalScore, scores, snapshot, state } = vnode.attrs;
+    const { proposal, space, id, selectedChoice, totalScore, scores, snapshot } = vnode.attrs;
     return m('.ConfirmSnapshotVoteModal', [
       m('.compact-modal-title', [
         m('h3', 'Confirm vote'),
@@ -112,7 +111,6 @@ const ConfirmSnapshotVoteModal: m.Component<{
                     : NewVoteErrors.SomethingWentWrong;
                   notifyError(errorMessage);
                 } else if (result.status === 'Success') {
-                  state.hasVoted = selectedChoice;
                   $(e.target).trigger('modalexit');
                   m.route.set(`/${app.activeId()}/snapshot-proposals/${space.id}`);
                 }

--- a/client/scripts/views/modals/confirm_snapshot_vote_modal.ts
+++ b/client/scripts/views/modals/confirm_snapshot_vote_modal.ts
@@ -24,13 +24,16 @@ const ConfirmSnapshotVoteModal: m.Component<{
   id: string,
   selectedChoice: string,
   totalScore: number,
+  scores: any
+  snapshot: any,
+  state: any,
 }, {
   error: any,
   saving: boolean,
 }> = {
   view: (vnode) => {
     const author = app.user.activeAccount;
-    const { proposal, space, id, selectedChoice, totalScore } = vnode.attrs;
+    const { proposal, space, id, selectedChoice, totalScore, scores, snapshot, state } = vnode.attrs;
     return m('.ConfirmSnapshotVoteModal', [
       m('.compact-modal-title', [
         m('h3', 'Confirm vote'),
@@ -109,6 +112,7 @@ const ConfirmSnapshotVoteModal: m.Component<{
                     : NewVoteErrors.SomethingWentWrong;
                   notifyError(errorMessage);
                 } else if (result.status === 'Success') {
+                  state.hasVoted = selectedChoice;
                   $(e.target).trigger('modalexit');
                   m.route.set(`/${app.activeId()}/snapshot-proposals/${space.id}`);
                 }

--- a/client/scripts/views/pages/new_snapshot_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_snapshot_proposal/new_proposal_form.ts
@@ -2,7 +2,7 @@ import 'pages/new_proposal_page.scss';
 
 import $ from 'jquery';
 import m from 'mithril';
-import { Input, Form, FormLabel, FormGroup, Button, Callout, Spinner, RadioGroup } from 'construct-ui';
+import { Input, Form, FormLabel, FormGroup, Button, Callout, Spinner, RadioGroup, Icon, Icons } from 'construct-ui';
 
 import moment from 'moment';
 import app from 'state';
@@ -271,31 +271,48 @@ const NewProposalForm: m.Component<{snapshotId: string}, {
                 defaultValue: vnode.state.form.name,
               }),
             ]),
-            m(FormGroup, [
-              m(FormGroup, [
-                m(FormLabel, 'Choice 1'),
+            m(FormGroup, vnode.state.form.choices.map((choice, idx) => {
+              const placeholder = idx === 0
+                ? 'Yes'
+                : idx === 1
+                  ? 'No'
+                  : `Option ${idx + 1}`;
+              return m(FormGroup, [
+                m(FormLabel, `Choice ${idx + 1}`),
                 m(Input, {
                   name: 'targets',
-                  placeholder: 'Yes',
+                  placeholder,
                   oninput: (e) => {
                     const result = (e.target as any).value;
-                    vnode.state.form.choices[0] = result;
+                    vnode.state.form.choices[idx] = result;
                     m.redraw();
                   },
+                  contentRight: (idx > 1 && idx === vnode.state.form.choices.length - 1)
+                    && m(Icon, {
+                      name: Icons.TRASH,
+                      size: 'xl',
+                      style: 'cursor: pointer;',
+                      onclick: () => {
+                        vnode.state.form.choices.pop();
+                        m.redraw();
+                      }
+                    })
                 }),
-              ]),
-              m(FormGroup, [
-                m(FormLabel, 'Choice 2'),
-                m(Input, {
-                  name: 'targets',
-                  placeholder: 'No',
-                  oninput: (e) => {
-                    const result = (e.target as any).value;
-                    vnode.state.form.choices[1] = result;
-                    m.redraw();
-                  },
-                }),
-              ]),
+              ]);
+            })),
+            m('.add-vote-choice', {
+              style: 'cursor: pointer;',
+              onclick: () => {
+                const choiceLength = vnode.state.form.choices.length;
+                vnode.state.form.choices.push(`Option ${choiceLength + 1}`);
+                m.redraw();
+              }
+            }, [
+              m('span', 'Add voting choice'),
+              m(Icon, {
+                name: Icons.PLUS,
+                size: 'xl',
+              }),
             ]),
             m(FormGroup, [
               m(FormLabel, { for: 'period' }, 'Date Range:'),

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -260,6 +260,7 @@ const ViewProposalPage: m.Component<{
       }),
       m('.PinnedDivider', m('hr')),
       vnode.state.votes
+      && vnode.state.proposal
       && m(VoteView, {
         choices: vnode.state.proposal.choices,
         votes: vnode.state.votes

--- a/client/styles/components/new_thread_form.scss
+++ b/client/styles/components/new_thread_form.scss
@@ -44,7 +44,20 @@
         max-width: 100%;
         .new-snapshot-proposal-form {
             display: flex;
-
+            .add-vote-choice {
+                color: #4f6dbd;
+                font-weight: 500;
+                margin: 10px 0 20px;
+                display: flex;
+                justify-content: flex-end;
+                span {
+                    padding-top: 1px;
+                }
+                .cui-icon {
+                    color: #4f6dbd;
+                    margin-left: 12px;
+                }
+            }
             form:last-child {
                 display: block;
             }

--- a/client/styles/components/proposals/voting_actions.scss
+++ b/client/styles/components/proposals/voting_actions.scss
@@ -36,6 +36,25 @@
     }
 }
 
+.VotingActions.Snapshot {
+    .button-row {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        .voting-option {
+            min-width: 48%;
+            max-width: 48%;
+            button {
+                width: 100%;
+                margin: 5px 0;
+                span {
+                    overflow: clip;
+                }
+            }
+        }
+    }
+}
+
 .VotingActions.AaveProposal {
     padding: 0;
     background: none;

--- a/client/styles/components/proposals/voting_results.scss
+++ b/client/styles/components/proposals/voting_results.scss
@@ -14,7 +14,7 @@
         background-color: $background-color-light;
         padding: 18px 0 12px;
         flex: 1;
-        width: 48%;
+        min-width: 48%;
         max-width: 48%;
         border-radius: 10px;
         .results-cell, .results-header,

--- a/client/styles/components/proposals/voting_results.scss
+++ b/client/styles/components/proposals/voting_results.scss
@@ -23,7 +23,7 @@
         }
         .results-header {
             font-weight: 500;
-            margin-bottom: 28px;
+            margin-bottom: 14px;
         }
         .results-subheader {
             display: flex;


### PR DESCRIPTION
This branch provides support for both creating and voting on Snapshot proposals that have >2 choices. 

Previously, we only allowed two voting options, and hardcoded them to a "Yes" / "No" vote.

This branch makes available proposal vote choice from the API and then maps them dynamically to a set of voting options.

![image](https://user-images.githubusercontent.com/22281010/132911119-0d7e5542-39ee-41d2-8d32-bf9be62a11db.png)

To test:
- Draw up a new proposal on e.g. $ALEX
- Test adding and removing new voting options with the PLUS and TRASH icons
- Submit and navigate to the proposal, test voting
- The vote chosen should be disabled, and your name should show up in the Voters column, with the correct option name 
