### PR TITLE
Jake.snapshot linking

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -462,7 +462,7 @@ class ThreadsController {
       type: 'GET',
       data: {
         snapshot: args.snapshot,
-        chain: app.activeChainId(),
+        chain: app.activeId(),
       },
     });
     if (response.status !== 'Success') {

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -456,6 +456,26 @@ class ThreadsController {
     });
   }
 
+  public async fetchThreadForSnapshot(args: { snapshot: string }) {
+    const response = await $.ajax({
+      url: `${app.serverUrl()}/fetchThreadForSnapshot`,
+      type: 'GET',
+      data: {
+        snapshot: args.snapshot,
+        chain: app.activeChainId(),
+      },
+    });
+    if (response.status !== 'Success') {
+      throw new Error(`Cannot fetch thread: ${response.status}`);
+    }
+
+    const thread = modelFromServer(response.result);
+    const existing = this._store.getByIdentifier(thread.id);
+    if (existing) this._store.remove(existing);
+    this._store.update(thread);
+    return thread;
+  }
+
   public async fetchThread(id) {
     const params = {
       chain: app.activeChainId(),

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -33,6 +33,7 @@ export const modelFromServer = (thread) => {
     body,
     last_edited,
     version_history,
+    snapshot_proposal,
     OffchainAttachments,
     created_at,
     topic,
@@ -94,6 +95,7 @@ export const modelFromServer = (thread) => {
     body: decodeURIComponent(body),
     createdAt: moment(created_at),
     attachments,
+    snapshotProposal: snapshot_proposal,
     topic,
     kind,
     stage,
@@ -396,6 +398,30 @@ class ThreadsController {
       error: (err) => {
         notifyError('Could not update pinned state');
         console.error(err);
+      }
+    });
+  }
+
+  public async setLinkedSnapshotProposal(args: { threadId: number, snapshotProposal: string }) {
+    await $.ajax({
+      url: `${app.serverUrl()}/updateThreadLinkedSnapshotProposal`,
+      type: 'POST',
+      data: {
+        'chain': app.activeChainId(),
+        'thread_id': args.threadId,
+        'snapshot_proposal': args.snapshotProposal,
+        'jwt': app.user.jwt
+      },
+      success: (response) => {
+        const thread = this._store.getByIdentifier(args.threadId);
+        if (!thread) return;
+        thread.snapshotProposal = args.snapshotProposal;
+        return thread;
+      },
+      error: (err) => {
+        console.log('Failed to update linked snapshot proposal');
+        throw new Error((err.responseJSON && err.responseJSON.error) ? err.responseJSON.error
+          : 'Failed to update linked proposals');
       }
     });
   }

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -456,7 +456,7 @@ class ThreadsController {
     });
   }
 
-  public async fetchThreadForSnapshot(args: { snapshot: string }) {
+  public async fetchThreadIdForSnapshot(args: { snapshot: string }) {
     const response = await $.ajax({
       url: `${app.serverUrl()}/fetchThreadForSnapshot`,
       type: 'GET',
@@ -466,14 +466,9 @@ class ThreadsController {
       },
     });
     if (response.status !== 'Success') {
-      throw new Error(`Cannot fetch thread: ${response.status}`);
+      return 'false';
     }
-
-    const thread = modelFromServer(response.result);
-    const existing = this._store.getByIdentifier(thread.id);
-    if (existing) this._store.remove(existing);
-    this._store.update(thread);
-    return thread;
+    return response.result;
   }
 
   public async fetchThread(id) {

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -42,6 +42,7 @@ class OffchainThread implements IUniqueId {
   public readonly community: string;
   public readonly chain: string;
   public readonly lastEdited: moment.Moment;
+  public snapshotProposal: string;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -115,6 +116,7 @@ class OffchainThread implements IUniqueId {
     collaborators,
     chainEntities,
     lastEdited,
+    snapshotProposal,
     offchainVotingOptions,
     offchainVotingEndsAt,
     offchainVotingNumVotes,
@@ -140,6 +142,7 @@ class OffchainThread implements IUniqueId {
     collaborators?: any[],
     chainEntities?: any[],
     lastEdited?: moment.Moment,
+    snapshotProposal: string,
     offchainVotingOptions?: string,
     offchainVotingEndsAt?: string | moment.Moment | null,
     offchainVotingNumVotes?: number,
@@ -175,6 +178,7 @@ class OffchainThread implements IUniqueId {
     try {
       this.offchainVotingOptions = JSON.parse(offchainVotingOptions);
     } catch (e) {}
+    this.snapshotProposal = snapshotProposal;
     this.offchainVotingEndsAt = offchainVotingEndsAt ? moment(offchainVotingEndsAt) : null;
     this.offchainVotingNumVotes = offchainVotingNumVotes;
     this.offchainVotes = offchainVotes || [];

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -100,7 +100,7 @@ const ChainEntitiesSelector: m.Component<{
     if (!app.chain || !app.activeChainId()) return;
     if (!vnode.state.initialized) {
       vnode.state.initialized = true;
-      app.chain.chainEntities.refresh(app.chain.id, EntityRefreshOption.AllEntities).then((entities) => {
+      app.chain.chainEntities?.refresh(app.chain.id, EntityRefreshOption.AllEntities).then((entities) => {
         // refreshing loads the latest chain entities into app.chain.chainEntities store
         vnode.state.chainEntitiesLoaded = true;
         m.redraw();
@@ -226,7 +226,7 @@ const StageEditor: m.Component<{
             },
             snapshotProposalsToSet: vnode.state.snapshotProposalsToSet,
           }),
-          m(ChainEntitiesSelector, {
+          app.chain.chainEntities && m(ChainEntitiesSelector, {
             thread: vnode.attrs.thread,
             onSelect: (result) => {
               if (vnode.state.stage === OffchainThreadStage.Discussion

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -1,15 +1,76 @@
 import 'components/stage_editor.scss';
 
 import m from 'mithril';
-import $ from 'jquery';
 import { uuidv4 } from 'lib/util';
-import { QueryList, ListItem, Button, Classes, Dialog, InputSelect, Icon, Icons, MenuItem } from 'construct-ui';
+import { QueryList, ListItem, Button, Classes, Dialog, Icons } from 'construct-ui';
 
 import app from 'state';
 import { offchainThreadStageToLabel, parseCustomStages } from 'helpers';
 import { ChainEntity, OffchainThread, OffchainThreadStage } from 'models';
 import { chainEntityTypeToProposalName } from 'identifiers';
-import ChainEntityController, { EntityRefreshOption } from 'controllers/server/chain_entities';
+import { EntityRefreshOption } from 'controllers/server/chain_entities';
+import { SnapshotProposal } from 'helpers/snapshot_utils';
+
+/*
+const SnapshotProposalSelector: m.Component<{
+  thread: OffchainThread;
+  onSelect,
+}, {
+  initialized: boolean;
+  snapshotProposalsLoaded: boolean;
+}> = {
+  view: (vnode) => {
+    const { thread, onSelect } = vnode.attrs;
+    if (!app.chain || !app.activeChainId()) return;
+    if (!vnode.state.initialized) {
+      vnode.state.initialized = true;
+      if (app.chain.meta.chain.snapshot) {
+        app.snapshot.init(app.chain.meta.chain.snapshot).then(() => {
+          // refreshing loads the latest snapshot proposals into app.snapshot.proposals array
+          vnode.state.snapshotProposalsLoaded = true;
+          m.redraw();
+        });
+      }
+    }
+
+    return m('.ChainEntitiesSelector', [
+      vnode.state.snapshotProposalsLoaded ? m(QueryList, {
+        checkmark: true,
+        items: app.snapshot.proposals.sort((a, b) => {
+          return b.created - a.created;
+        }),
+        inputAttrs: {
+          placeholder: 'Search for an existing snapshot proposal...',
+        },
+        itemRender: (sn: SnapshotProposal, idx: number) => {
+          const selected = vnode.attrs.chainEntitiesToSet.map((ce_) => ce_.id).indexOf(ce.id) !== -1;
+          // TODO: show additional info on the ListItem, like any set proposal title, the creator, or other metadata
+          return m(ListItem, {
+            label: m('.chain-entity-info', [
+              m('.chain-entity-top', `Snapshot Proposal ${sn.id}`),
+              m('.chain-entity-bottom', sn.title),
+            ]),
+            selected,
+            key: sn.id,
+          });
+        },
+        itemPredicate: (query, ce: ChainEntity, idx) => {
+          // TODO
+        },
+        onSelect: (ce: ChainEntity) => {
+          // TODO
+        },
+      }) : m('.chain-entities-selector-placeholder', [
+        m('.chain-entities-selector-placeholder-text', [
+          vnode.state.snapshotProposalsLoaded
+            ? 'TODO: how to begin?'
+            : 'Loading snapshot proposals...'
+        ]),
+      ]),
+    ]);
+  }
+};
+*/
 
 const ChainEntitiesSelector: m.Component<{
   thread: OffchainThread;

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -294,8 +294,7 @@ const StageEditor: m.Component<{
               }
 
               // TODO: add set linked snapshot proposals
-
-              vnode.attrs.onChangeHandler(vnode.state.stage, vnode.state.chainEntitiesToSet);
+              vnode.attrs.onChangeHandler(vnode.state.stage, vnode.state.chainEntitiesToSet, vnode.state.snapshotProposalsToSet);
 
               if (vnode.attrs.popoverMenu) {
                 vnode.attrs.openStateHandler(false);

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -70,10 +70,8 @@ const SnapshotProposalSelector: m.Component<{
           if (vnode.attrs.snapshotProposalsToSet.map((sn_) => sn_.created).indexOf(sn.created) !== -1) {
             const index = vnode.attrs.snapshotProposalsToSet.findIndex((sn_) => sn_.id === sn.id);
             vnode.attrs.snapshotProposalsToSet.splice(index, 1);
-            console.log(sn);
           } else {
             vnode.attrs.snapshotProposalsToSet.push(sn);
-            console.log(sn);
           }
           onSelect(sn);
         },
@@ -277,8 +275,8 @@ const StageEditor: m.Component<{
               } catch (err) {
                 console.log('Failed to update stage');
                 throw new Error((err.responseJSON && err.responseJSON.error)
-                  ? err.responseJSON.error
-                  : 'Failed to update stage');
+                  ?  `${err.responseJSON.error}. Make sure one is selected.`
+                  : 'Failed to update stage, make sure one is selected');
               }
 
               // set linked chain entities

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -216,7 +216,7 @@ const StageEditor: m.Component<{
               }
             })),
           ]),
-          app.chain.meta.chain.snapshot && m(SnapshotProposalSelector, {
+          app.chain?.meta?.chain.snapshot && m(SnapshotProposalSelector, {
             thread: vnode.attrs.thread,
             onSelect: (result) => {
               if (vnode.state.stage === OffchainThreadStage.Discussion

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -263,6 +263,8 @@ const StageEditor: m.Component<{
                   : 'Failed to update linked proposals');
               }
 
+              // TODO: add set linked snapshot proposals
+
               vnode.attrs.onChangeHandler(vnode.state.stage, vnode.state.chainEntitiesToSet);
 
               if (vnode.attrs.popoverMenu) {

--- a/client/scripts/views/components/stage_editor.ts
+++ b/client/scripts/views/components/stage_editor.ts
@@ -282,10 +282,8 @@ const StageEditor: m.Component<{
               // set linked chain entities
               try {
                 await app.threads.setLinkedChainEntities({ threadId: thread.id, entities: vnode.state.chainEntitiesToSet });
-                for (let i = 0; i < vnode.state.snapshotProposalsToSet.length; i++) {
-                  await app.threads.setLinkedSnapshotProposal({ threadId: thread.id, 
-                    snapshotProposal: vnode.state.snapshotProposalsToSet[i].id })
-                }
+                await app.threads.setLinkedSnapshotProposal({ threadId: thread.id, 
+                  snapshotProposal: vnode.state.snapshotProposalsToSet[0]?.id })
               } catch (err) {
                 console.log('Failed to update linked proposals');
                 throw new Error((err.responseJSON && err.responseJSON.error)

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -81,6 +81,16 @@ const DiscussionRow: m.Component<{ proposal: OffchainThread, showExcerpt?: boole
           });
         }),
       ],
+      proposal.snapshotProposal && m(Button, {
+        class: 'discussion-row-linked-chain-entity',
+        label: [
+          'Snap ',
+          `${proposal.snapshotProposal.slice(0, 4)}…`,
+        ],
+        intent: 'primary',
+        size: 'xs',
+        compact: true,
+      }),
       proposal instanceof OffchainThread
         && proposal.stage !== OffchainThreadStage.Discussion
         && m(Button, {

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -35,6 +35,7 @@ import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import { alertModalWithText } from 'views/modals/alert_modal';
 import { activeQuillEditorHasText, GlobalStatus } from './body';
 import { IProposalPageState } from '.';
+import { SnapshotProposal } from 'client/scripts/helpers/snapshot_utils';
 
 export const ProposalHeaderExternalLink: m.Component<{ proposal: AnyProposal | OffchainThread }> = {
   view: (vnode) => {
@@ -164,6 +165,20 @@ export const ProposalHeaderBlockExplorerLink: m.Component<{ proposal: AnyProposa
   }
 };
 
+export const ProposalHeaderExternalSnapshotLink: m.Component<{ proposal: SnapshotProposal, spaceId: string }> = {
+  view: (vnode) => {
+    const { proposal, spaceId } = vnode.attrs;
+    if (!proposal || !proposal.id || !spaceId) return;
+
+    return m('.ProposalHeaderBlockExplorerLink', [
+      externalLink('a.voting-link', `https://snapshot.org/#/proposal/${spaceId}/${proposal.id}`, [
+        `View on Snapshot`,
+        m(Icon, { name: Icons.EXTERNAL_LINK }),
+      ]),
+    ]);
+  }
+};
+
 export const ProposalHeaderVotingInterfaceLink: m.Component<{ proposal: AnyProposal }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
@@ -237,7 +252,7 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
   view: (vnode) => {
     const { proposal } = vnode.attrs;
     if (!proposal.snapshotProposal) return;
-    if (!app.chain.meta.chain.snapshot) return;
+    if (!app.chain?.meta.chain.snapshot) return;
     
     if (!vnode.state.initialized) {
       vnode.state.initialized = true;

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -205,11 +205,11 @@ export const ProposalHeaderThreadLink: m.Component<{ proposal: AnyProposal }> = 
   }
 };
 
-export const ProposalHeaderSnapshotThreadLink: m.Component<{ thread: OffchainThread }> = {
+export const ProposalHeaderSnapshotThreadLink: m.Component<{ threadId: string }> = {
   view: (vnode) => {
-    const { thread } = vnode.attrs;
-    if (!thread || !thread.id) return;
-    const proposalLink = `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/discussion/${thread.id}`;
+    const { threadId } = vnode.attrs;
+    if (!threadId) return;
+    const proposalLink = `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/discussion/${threadId}`;
 
     return m('.ProposalHeaderThreadLink', [
       link('a.thread-link', proposalLink, [

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -247,7 +247,7 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
 }, { 
   initialized,
   snapshotProposalsLoaded
-  currentSnapshot
+  snapshot
 }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
@@ -258,14 +258,14 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
       vnode.state.initialized = true;
       app.snapshot.init(app.chain.meta.chain.snapshot).then(() => {
           // refreshing loads the latest snapshot proposals into app.snapshot.proposals array
-        vnode.state.currentSnapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
+        vnode.state.snapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
         vnode.state.snapshotProposalsLoaded = true;
         m.redraw();
       })
     }
 
-    if (vnode.state.snapshotProposalsLoaded && proposal.snapshotProposal !== vnode.state.currentSnapshot) {
-      vnode.state.currentSnapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
+    if (vnode.state.snapshotProposalsLoaded && proposal.snapshotProposal !== vnode.state.snapshot) {
+      vnode.state.snapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
       m.redraw();
     }
 
@@ -273,21 +273,10 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
       }/snapshot-proposal/${(app.chain?.meta.chain.snapshot)}/${proposal.snapshotProposal}`;
 
     return m('.ProposalHeaderThreadLinkedChainEntity', 
-    !vnode.state.snapshotProposalsLoaded ?   
-    [
-      link(
-        'a', proposalLink,
-        [
-          `Snapshot: ${proposal.snapshotProposal.slice(0,10)} ...`,
-        ],
-      ),
+    !vnode.state.snapshotProposalsLoaded ? [
+      link('a', proposalLink, [`Snapshot: ${proposal.snapshotProposal.slice(0,10)} ...`,]),
     ] : [
-      link(
-        'a', proposalLink,
-        [
-          `Snapshot: ${vnode.state.currentSnapshot.title.slice(0,20)} ...`,
-        ],
-      ),
+      link('a', proposalLink, [`Snapshot: ${vnode.state.snapshot.title.slice(0,20)} ...`,]),
     ]);
   }
 };

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -549,6 +549,26 @@ export const ProposalSidebarPollEditorModule: m.Component<{
   }
 };
 
+export const ProposalSidebarLinkedViewer: m.Component<{
+  proposal: OffchainThread
+}> = {
+  view: (vnode) => {
+    const { proposal } = vnode.attrs;
+
+    return m('.ProposalSidebarLinkedViewer', [
+      (proposal.chainEntities.length > 0 || proposal.snapshotProposal?.length > 0) 
+        ? m('.placeholder-copy', 'Proposals for this thread:')
+        : m('.placeholder-copy', app.chain ? 'Connect an on-chain proposal?' : 'Track the progress of this thread?'),
+      proposal.chainEntities.length > 0 && m('.proposal-chain-entities', [
+        proposal.chainEntities.map((chainEntity) => {
+          return m(ProposalHeaderThreadLinkedChainEntity, { proposal, chainEntity });
+        }),
+      ]),
+      proposal.snapshotProposal?.length > 0 && m(ProposalHeaderThreadLinkedSnapshot, { proposal }),
+    ])
+  }
+}
+
 export const ProposalSidebarStageEditorModule: m.Component<{
   proposal: OffchainThread,
   openStageEditor: Function
@@ -563,16 +583,6 @@ export const ProposalSidebarStageEditorModule: m.Component<{
     if (!stagesEnabled) return;
 
     return m('.ProposalSidebarStageEditorModule', [
-      (proposal.chainEntities.length > 0 || proposal.snapshotProposal?.length >0) 
-        ? m('.placeholder-copy', 'Proposals for this thread:')
-        : m('.placeholder-copy', app.chain ? 'Connect an on-chain proposal?' : 'Track the progress of this thread?'),
-      proposal.chainEntities.length > 0 && m('.proposal-chain-entities', [
-        proposal.chainEntities.map((chainEntity) => {
-          return m(ProposalHeaderThreadLinkedChainEntity, { proposal, chainEntity });
-        }),
-      ]),
-      proposal.snapshotProposal?.length > 0 && m(ProposalHeaderThreadLinkedSnapshot, { proposal }),
-      m('br'),
       m(Button, {
         rounded: true,
         compact: true,

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -245,9 +245,9 @@ export const ProposalHeaderThreadLinkedChainEntity: m.Component<{ proposal: Offc
 export const ProposalHeaderThreadLinkedSnapshot: m.Component<{ 
   proposal: OffchainThread, 
 }, { 
-  initialized, 
+  initialized,
   snapshotProposalsLoaded
-  snapshot
+  currentSnapshot
 }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
@@ -258,11 +258,17 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
       vnode.state.initialized = true;
       app.snapshot.init(app.chain.meta.chain.snapshot).then(() => {
           // refreshing loads the latest snapshot proposals into app.snapshot.proposals array
-        vnode.state.snapshot = app.snapshot.proposals.find((sn) => sn.id = proposal.snapshotProposal);
+        vnode.state.currentSnapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
         vnode.state.snapshotProposalsLoaded = true;
         m.redraw();
       })
     }
+
+    if (vnode.state.snapshotProposalsLoaded && proposal.snapshotProposal !== vnode.state.currentSnapshot) {
+      vnode.state.currentSnapshot = app.snapshot.proposals.find((sn) => sn.id === proposal.snapshotProposal);
+      m.redraw();
+    }
+
     const proposalLink = `${app.isCustomDomain() ? '' : `/${proposal.chain}`
       }/snapshot-proposal/${(app.chain?.meta.chain.snapshot)}/${proposal.snapshotProposal}`;
 
@@ -279,7 +285,7 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
       link(
         'a', proposalLink,
         [
-          `Snapshot: ${vnode.state.snapshot.title.slice(0,20)} ...`,
+          `Snapshot: ${vnode.state.currentSnapshot.title.slice(0,20)} ...`,
         ],
       ),
     ]);

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -190,6 +190,19 @@ export const ProposalHeaderThreadLink: m.Component<{ proposal: AnyProposal }> = 
   }
 };
 
+export const ProposalHeaderSnapshotThreadLink: m.Component<{ thread: OffchainThread }> = {
+  view: (vnode) => {
+    const { thread } = vnode.attrs;
+    if (!thread || !thread.id) return;
+    return m('.ProposalHeaderThreadLink', [
+      link('a.thread-link', `/${thread['chain'] || app.activeId()}/proposal/discussion/${thread.id}`, [
+        'Go to discussion',
+        m(Icon, { name: Icons.EXTERNAL_LINK }),
+      ]),
+    ]);
+  }
+};
+
 export const ProposalHeaderThreadLinkedChainEntity: m.Component<{ proposal: OffchainThread, chainEntity }> = {
   view: (vnode) => {
     const { proposal, chainEntity } = vnode.attrs;

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -194,8 +194,10 @@ export const ProposalHeaderSnapshotThreadLink: m.Component<{ thread: OffchainThr
   view: (vnode) => {
     const { thread } = vnode.attrs;
     if (!thread || !thread.id) return;
+    const proposalLink = `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/discussion/${thread.id}`;
+
     return m('.ProposalHeaderThreadLink', [
-      link('a.thread-link', `/${thread['chain'] || app.activeId()}/proposal/discussion/${thread.id}`, [
+      link('a.thread-link', proposalLink, [
         'Go to discussion',
         m(Icon, { name: Icons.EXTERNAL_LINK }),
       ]),
@@ -209,10 +211,13 @@ export const ProposalHeaderThreadLinkedChainEntity: m.Component<{ proposal: Offc
     const slug = chainEntityTypeToProposalSlug(chainEntity.type);
     if (!slug) return;
 
+    const proposalLink = `${app.isCustomDomain() ? '' : `/${proposal.chain}`
+      }/proposal/${slug}/${chainEntity.typeId}`
+
     return m('.ProposalHeaderThreadLinkedChainEntity', [
       link(
         'a',
-        `/${proposal.chain}/proposal/${slug}/${chainEntity.typeId}`,
+          proposalLink,
         [
           `${chainEntityTypeToProposalName(chainEntity.type)} #${chainEntity.typeId}`,
           chainEntity.completed === 't' ? ' (Completed) ' : ' ',
@@ -243,20 +248,21 @@ export const ProposalHeaderThreadLinkedSnapshot: m.Component<{
         m.redraw();
       })
     }
+    const proposalLink = `${app.isCustomDomain() ? '' : `/${proposal.chain}`
+      }/snapshot-proposal/${(app.chain?.meta.chain.snapshot)}/${proposal.snapshotProposal}`;
+
     return m('.ProposalHeaderThreadLinkedChainEntity', 
     !vnode.state.snapshotProposalsLoaded ?   
     [
       link(
-        'a',
-        `/${proposal.chain}/snapshot-proposal/${(app.chain?.meta.chain.snapshot)}/${proposal.snapshotProposal}`,
+        'a', proposalLink,
         [
           `Snapshot: ${proposal.snapshotProposal.slice(0,10)} ...`,
         ],
       ),
     ] : [
       link(
-        'a',
-        `/${proposal.chain}/snapshot-proposal/${(app.chain?.meta.chain.snapshot)}/${proposal.snapshotProposal}`,
+        'a', proposalLink,
         [
           `Snapshot: ${vnode.state.snapshot.title.slice(0,20)} ...`,
         ],

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -299,7 +299,9 @@ const ProposalHeader: m.Component<{
                   onChangeHandler: (stage: OffchainThreadStage, chainEntities: ChainEntity[], snapshotProposal: SnapshotProposal) => {
                     proposal.stage = stage;
                     proposal.chainEntities = chainEntities;
-                    proposal.snapshotProposal = snapshotProposal[0].id;
+                    if (app.chain?.meta.chain.snapshot) {
+                      proposal.snapshotProposal = snapshotProposal[0]?.id;
+                    }
                     app.threads.fetchThread(proposal.identifier);
                     m.redraw();
                   },

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -78,6 +78,7 @@ import User from '../../components/widgets/user';
 import MarkdownFormattedText from '../../components/markdown_formatted_text';
 import { createTXModal } from '../../modals/tx_signing_modal';
 import { SubstrateAccount } from '../../../controllers/chain/substrate/account';
+import { SnapshotProposal } from 'client/scripts/helpers/snapshot_utils';
 
 const MAX_THREAD_LEVEL = 2;
 
@@ -295,9 +296,11 @@ const ProposalHeader: m.Component<{
                 && m(StageEditor, {
                   thread: vnode.attrs.proposal as OffchainThread,
                   popoverMenu: true,
-                  onChangeHandler: (stage: OffchainThreadStage, chainEntities: ChainEntity[]) => {
+                  onChangeHandler: (stage: OffchainThreadStage, chainEntities: ChainEntity[], snapshotProposal: SnapshotProposal) => {
                     proposal.stage = stage;
                     proposal.chainEntities = chainEntities;
+                    proposal.snapshotProposal = snapshotProposal[0].id;
+                    app.threads.fetchThread(proposal.identifier);
                     m.redraw();
                   },
                   openStateHandler: (v) => {
@@ -1044,8 +1047,11 @@ const ViewProposalPage: m.Component<{
         isAdmin,
         stageEditorIsOpen: vnode.state.stageEditorIsOpen,
         pollEditorIsOpen: vnode.state.pollEditorIsOpen,
-        closeStageEditor: () => { vnode.state.stageEditorIsOpen = false; m.redraw(); },
-        closePollEditor: () => { vnode.state.pollEditorIsOpen = false; m.redraw(); },
+        closeStageEditor: () => { vnode.state.stageEditorIsOpen = false; 
+          m.redraw(); },
+        closePollEditor: () => { 
+          vnode.state.pollEditorIsOpen = false; 
+          m.redraw(); },
       }),
       !(proposal instanceof OffchainThread)
         && m(LinkedProposalsEmbed, { proposal }),

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -1016,7 +1016,7 @@ const ViewProposalPage: m.Component<{
               vnode.state.pollEditorIsOpen = true;
             }
           }),
-        (isAuthor || isAdmin) && proposal instanceof OffchainThread
+        proposal instanceof OffchainThread
           && m(ProposalSidebarStageEditorModule, {
             proposal,
             openStageEditor: () => {

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -62,6 +62,7 @@ import {
   ProposalSidebarStageEditorModule,
   ProposalSidebarPollEditorModule,
   ProposalLinkEditor,
+  ProposalSidebarLinkedViewer,
 } from './header';
 import { AaveViewProposalDetail, AaveViewProposalSummary } from './aave_view_proposal_detail';
 import {
@@ -1008,7 +1009,7 @@ const ViewProposalPage: m.Component<{
           && proposal.hasOffchainPoll
           && m(ProposalHeaderOffchainPoll, { proposal }),
         proposal instanceof OffchainThread
-          && isAuthor
+          && (isAuthor || isAdmin)
           && !proposal.offchainVotingEndsAt
           && m(ProposalSidebarPollEditorModule, {
             proposal,
@@ -1016,8 +1017,15 @@ const ViewProposalPage: m.Component<{
               vnode.state.pollEditorIsOpen = true;
             }
           }),
-        proposal instanceof OffchainThread
-          && m(ProposalSidebarStageEditorModule, {
+          proposal instanceof OffchainThread 
+            && ((proposal as OffchainThread).chainEntities.length > 0 
+              || (proposal as OffchainThread).snapshotProposal?.length > 0)
+            && m(ProposalSidebarLinkedViewer, {
+            proposal
+          }),
+          proposal instanceof OffchainThread 
+            && (isAuthor || isAdmin) 
+            && m(ProposalSidebarStageEditorModule, {
             proposal,
             openStageEditor: () => {
               vnode.state.stageEditorIsOpen = true;

--- a/client/scripts/views/pages/view_snapshot_proposal/body.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/body.ts
@@ -2,7 +2,7 @@ import 'pages/view_proposal/editor_permissions.scss';
 
 import m from 'mithril';
 
-import { formatLastUpdated } from 'helpers';
+import { formatLastUpdated, formatTimestamp } from 'helpers';
 import { AddressInfo } from 'models';
 
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
@@ -49,10 +49,14 @@ export const ProposalBodyEnded: m.Component<{ item: SnapshotProposal }> = {
     if (!item.end) {
       return;
     }
+
+    const now = moment();
     const time = moment(+item.end * 1000);
 
     return m('.ProposalBodyLastEnded', [
-      m('', `Ended ${formatLastUpdated(time)}`)
+      m('', (now > time)
+      ? `Ended ${formatLastUpdated(time)}`
+      : `Ending in ${formatTimestamp(time)}`)
     ]);
   }
 };

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -161,7 +161,6 @@ const VoteAction: m.Component<{
     };
 
     const vote = async (selectedChoice: number) => {
-      console.log(`vnode.attrs.proposal ${vnode.attrs.proposal}`);
       try {
         app.modals.create({
           modal: ConfirmSnapshotVoteModal,

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -43,8 +43,8 @@ const ProposalHeader: m.Component<{
 
     if (!vnode.state.loaded) {
       try {
+        vnode.state.loaded = true;
         app.threads.fetchThreadIdForSnapshot({snapshot: proposal.id}).then((res) => { 
-          vnode.state.loaded = true;
           vnode.state.thread = res;
         })
         m.redraw();

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -253,7 +253,10 @@ const ViewProposalPage: m.Component<{
     && moment(+vnode.state.proposal.start * 1000) <= moment()
     && moment(+vnode.state.proposal.end * 1000) > moment();
 
-    return m(Sublayout, { class: 'ViewProposalPage', title: 'Snapshot Proposal' }, [
+    return m(Sublayout, { 
+      class: 'ViewProposalPage', 
+      title: 'Snapshot Proposal',
+    }, [
       m(ProposalHeader, {
         snapshotId: vnode.attrs.snapshotId,
         proposal: vnode.state.proposal,

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 
 import app from 'state';
 import Sublayout from 'views/sublayout';
-import { AddressInfo, OffchainThread } from 'models';
+import { AddressInfo } from 'models';
 import ConfirmSnapshotVoteModal from 'views/modals/confirm_snapshot_vote_modal';
 import { getPower, SnapshotSpace, SnapshotProposal, getVotes, SnapshotProposalVote } from 'helpers/snapshot_utils';
 
@@ -28,7 +28,7 @@ const ProposalHeader: m.Component<{
   proposal: SnapshotProposal
 }, {
   loaded: boolean, 
-  thread: OffchainThread
+  thread: string,
 }> = {
   view: (vnode) => {
     const { proposal, snapshotId } = vnode.attrs;
@@ -43,7 +43,7 @@ const ProposalHeader: m.Component<{
 
     if (!vnode.state.loaded) {
       try {
-        app.threads.fetchThreadForSnapshot({snapshot: proposal.id}).then((res) => { 
+        app.threads.fetchThreadIdForSnapshot({snapshot: proposal.id}).then((res) => { 
           vnode.state.loaded = true;
           vnode.state.thread = res;
         })
@@ -68,7 +68,7 @@ const ProposalHeader: m.Component<{
             m('.CommentSocialHeader', [ m(SocialSharingCarat) ]),
           ]),
           m('.proposal-body-link', [
-            vnode.state.loaded && m(ProposalHeaderSnapshotThreadLink, { thread: vnode.state.thread }),
+            (vnode.state.thread !== 'false') && vnode.state.loaded && m(ProposalHeaderSnapshotThreadLink, { threadId: vnode.state.thread }),
             vnode.state.loaded && m(ProposalHeaderExternalSnapshotLink, { proposal: proposal, spaceId: snapshotId }),
           ]),
           m('br')

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -19,7 +19,7 @@ import {
   ProposalBodyAuthor, ProposalBodyCreated,
   ProposalBodyEnded, ProposalBodyText,
 } from './body';
-import { ProposalHeaderSnapshotThreadLink } from '../view_proposal/header';
+import { ProposalHeaderExternalSnapshotLink, ProposalHeaderSnapshotThreadLink } from '../view_proposal/header';
 import User from '../../components/widgets/user';
 import { SocialSharingCarat } from '../../components/social_sharing_carat';
 
@@ -31,7 +31,7 @@ const ProposalHeader: m.Component<{
   thread: OffchainThread
 }> = {
   view: (vnode) => {
-    const { proposal } = vnode.attrs;
+    const { proposal, snapshotId } = vnode.attrs;
     if (!proposal) {
       return m('.topic-loading-spinner-wrap', [ m(Spinner, { active: true, size: 'lg' }) ]);
     }
@@ -39,7 +39,7 @@ const ProposalHeader: m.Component<{
     // Original posters have full editorial control, while added collaborators
     // merely have access to the body and title
 
-    const proposalLink = `/${app.activeId()}/snapshot-proposal/${vnode.attrs.snapshotId}/${proposal.ipfs}`;
+    const proposalLink = `/${app.activeId()}/snapshot-proposal/${snapshotId}/${proposal.ipfs}`;
 
     if (!vnode.state.loaded) {
       try {
@@ -68,7 +68,8 @@ const ProposalHeader: m.Component<{
             m('.CommentSocialHeader', [ m(SocialSharingCarat) ]),
           ]),
           m('.proposal-body-link', [
-            vnode.state.loaded && m(ProposalHeaderSnapshotThreadLink, { thread: vnode.state.thread })
+            vnode.state.loaded && m(ProposalHeaderSnapshotThreadLink, { thread: vnode.state.thread }),
+            vnode.state.loaded && m(ProposalHeaderExternalSnapshotLink, { proposal: proposal, spaceId: snapshotId }),
           ]),
           m('br')
         ]),

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -401,6 +401,7 @@ $discussion-title-font-size: 1.45rem;
     }
 
     .ProposalHeaderOffchainPoll,
+    .ProposalSidebarLinkedViewer,
     .ProposalSidebarStageEditorModule,
     .ProposalSidebarPollEditorModule {
         border-radius: 10px;

--- a/server/migrations/20210910195947-add-snapshot-proposal-column.js
+++ b/server/migrations/20210910195947-add-snapshot-proposal-column.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn('OffchainThreads', 'snapshot_proposal', {
+        type: Sequelize.STRING(48),
+        allowNull: true,
+      }, { transaction });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'OffchainThreads',
+      'snapshot_proposal'
+    );
+  }
+};

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -23,6 +23,7 @@ export interface OffchainThreadAttributes {
 
   read_only?: boolean;
   version_history?: string[];
+  snapshot_proposal?: string;
 
   offchain_voting_options?: string;
   offchain_voting_ends_at?: Date;
@@ -66,6 +67,7 @@ export default (
     community: { type: dataTypes.STRING, allowNull: true },
     read_only: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
     version_history: { type: dataTypes.ARRAY(dataTypes.TEXT), defaultValue: [], allowNull: false },
+    snapshot_proposal: { type: dataTypes.STRING(48), allowNull: true },
 
     offchain_voting_options: { type: dataTypes.STRING },
     offchain_voting_ends_at: { type: dataTypes.DATE, allowNull: true },

--- a/server/router.ts
+++ b/server/router.ts
@@ -80,6 +80,7 @@ import updateThreadStage from './routes/updateThreadStage';
 import updateThreadPrivacy from './routes/updateThreadPrivacy';
 import updateThreadPinned from './routes/updateThreadPinned';
 import updateThreadLinkedChainEntities from './routes/updateThreadLinkedChainEntities';
+import updateThreadLinkedSnapshotProposal from './routes/updateThreadLinkedSnapshotProposal';
 import updateOffchainVote from './routes/updateOffchainVote';
 import viewOffchainVotes from './routes/viewOffchainVotes';
 import fetchEntityTitle from './routes/fetchEntityTitle';
@@ -239,6 +240,11 @@ function setupRouter(
     passport.authenticate('jwt', { session: false }),
     updateThreadLinkedChainEntities.bind(this, models),
   );
+  router.post(
+    '/updateThreadLinkedSnapshotProposal',
+    passport.authenticate('jwt', { session: false }),
+    updateThreadLinkedSnapshotProposal.bind(this, models),
+  );
 
   router.post(
     '/updateOffchainVote',
@@ -298,7 +304,11 @@ function setupRouter(
   router.post('/deleteTopic', passport.authenticate('jwt', { session: false }), deleteTopic.bind(this, models));
   // TODO: Change to GET /topics
   router.get('/bulkTopics', bulkTopics.bind(this, models));
-  router.post('/setTopicThreshold', passport.authenticate('jwt', { session: false }), setTopicThreshold.bind(this, models));
+  router.post(
+    '/setTopicThreshold',
+    passport.authenticate('jwt', { session: false }),
+    setTopicThreshold.bind(this, models),
+  );
 
   // offchain reactions
   // TODO: Change to POST /reaction

--- a/server/router.ts
+++ b/server/router.ts
@@ -84,6 +84,7 @@ import updateThreadLinkedSnapshotProposal from './routes/updateThreadLinkedSnaps
 import updateOffchainVote from './routes/updateOffchainVote';
 import viewOffchainVotes from './routes/viewOffchainVotes';
 import fetchEntityTitle from './routes/fetchEntityTitle';
+import fetchThreadForSnapshot from './routes/fetchThreadForSnapshot';
 import updateChainEntityTitle from './routes/updateChainEntityTitle';
 import deleteThread from './routes/deleteThread';
 import addEditors from './routes/addEditors';
@@ -254,6 +255,8 @@ function setupRouter(
   router.get('/viewOffchainVotes', viewOffchainVotes.bind(this, models));
 
   router.get('/fetchEntityTitle', fetchEntityTitle.bind(this, models));
+  router.get('/fetchThreadForSnapshot', fetchThreadForSnapshot.bind(this, models));
+
   router.post(
     '/updateChainEntityTitle',
     passport.authenticate('jwt', { session: false }),

--- a/server/routes/bulkOffchain.ts
+++ b/server/routes/bulkOffchain.ts
@@ -65,7 +65,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
         const query = `
           SELECT addr.id AS addr_id, addr.address AS addr_address,
             addr.chain AS addr_chain, thread_id, thread_title,
-            thread_community, thread_chain, thread_created, threads.kind, threads.stage,
+            thread_community, thread_chain, thread_created, threads.kind, threads.stage, threads.snapshot_proposal,
             threads.read_only, threads.body, threads.offchain_voting_options,
             threads.offchain_voting_votes, threads.offchain_voting_ends_at,
             threads.url, threads.pinned, topics.id AS topic_id, topics.name AS topic_name,
@@ -78,7 +78,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
               t.created_at AS thread_created, t.community AS thread_community,
               t.chain AS thread_chain, t.read_only, t.body,
               t.offchain_voting_options, t.offchain_voting_votes, t.offchain_voting_ends_at,
-              t.stage, t.url, t.pinned, t.topic_id, t.kind, ARRAY_AGG(DISTINCT
+              t.stage, t.snapshot_proposal, t.url, t.pinned, t.topic_id, t.kind, ARRAY_AGG(DISTINCT
                 CONCAT(
                   '{ "address": "', editors.address, '", "chain": "', editors.chain, '" }'
                   )
@@ -154,6 +154,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response, next: NextF
             created_at: t.thread_created,
             collaborators,
             chain_entities,
+            snapshot_proposal: t.snapshot_proposal,
             offchain_voting_options: t.offchain_voting_options,
             offchain_voting_votes: t.offchain_voting_votes,
             offchain_voting_ends_at: t.offchain_voting_ends_at,

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -42,7 +42,7 @@ const bulkThreads = async (models: DB, req: Request, res: Response, next: NextFu
       SELECT addr.id AS addr_id, addr.address AS addr_address,
         addr.chain AS addr_chain, thread_id, thread_title,
         thread_community, thread_chain, thread_created, threads.kind,
-        threads.read_only, threads.body, threads.stage,
+        threads.read_only, threads.body, threads.stage, threads.snapshot_proposal,
         threads.offchain_voting_options, threads.offchain_voting_votes, threads.offchain_voting_ends_at,
         threads.url, threads.pinned, topics.id AS topic_id, topics.name AS topic_name,
         topics.description AS topic_description, topics.chain_id AS topic_chain,
@@ -54,7 +54,7 @@ const bulkThreads = async (models: DB, req: Request, res: Response, next: NextFu
           t.created_at AS thread_created, t.community AS thread_community,
           t.chain AS thread_chain, t.read_only, t.body,
           t.offchain_voting_options, t.offchain_voting_votes, t.offchain_voting_ends_at,
-          t.stage, t.url, t.pinned, t.topic_id, t.kind, ARRAY_AGG(DISTINCT
+          t.stage, t.snapshot_proposal, t.url, t.pinned, t.topic_id, t.kind, ARRAY_AGG(DISTINCT
             CONCAT(
               '{ "address": "', editors.address, '", "chain": "', editors.chain, '" }'
               )
@@ -134,6 +134,7 @@ const bulkThreads = async (models: DB, req: Request, res: Response, next: NextFu
         created_at: t.thread_created,
         collaborators,
         chain_entities,
+        snapshot_proposal: t.snapshot_proposal,
         offchain_voting_options: t.offchain_voting_options,
         offchain_voting_votes: t.offchain_voting_votes,
         offchain_voting_ends_at: t.offchain_voting_ends_at,

--- a/server/routes/fetchThreadForSnapshot.ts
+++ b/server/routes/fetchThreadForSnapshot.ts
@@ -16,37 +16,11 @@ const fetchThreadForSnapshot = async (models: DB, req: Request, res: Response, n
     where: { 
       chain: chain,
       snapshot_proposal: snapshot,
-    },
-    include: [
-      {
-        model: models.Address,
-        as: 'Address'
-      },
-      {
-        model: models.Address,
-        // through: models.Collaboration,
-        as: 'collaborators'
-      },
-      {
-        model: models.OffchainTopic,
-        as: 'topic'
-      },
-      {
-        model: models.ChainEntity,
-      },
-      {
-        model: models.OffchainReaction,
-        as: 'reactions',
-        include: [{
-          model: models.Address,
-          as: 'Address'
-        }]
-      }
-    ],
+    }
   });
-  if (!thread) return res.json({ status: 'Failure', message: Errors.NoThread });
+  if (!thread) return res.json({ status: 'Failure', message: '' });
 
-  return res.json({ status: 'Success', result: thread.toJSON() });
+  return res.json({ status: 'Success', result: thread.id });
 };
 
 export default fetchThreadForSnapshot;

--- a/server/routes/fetchThreadForSnapshot.ts
+++ b/server/routes/fetchThreadForSnapshot.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express';
+import { DB } from '../database';
+
+export const Errors = {
+  NoThread: 'Cannot find thread',
+  InvalidSnapshot: 'InvalidSnapshot ID',
+  InvalidChain: 'No chain', 
+};
+
+const fetchThreadForSnapshot = async (models: DB, req: Request, res: Response, next: NextFunction) => {
+  const { snapshot, chain } = req.query;
+  if (!snapshot) return next(new Error(Errors.InvalidSnapshot));
+  if (!chain) return next(new Error(Errors.InvalidChain));
+
+  const thread = await models.OffchainThread.findOne({
+    where: { 
+      chain: chain,
+      snapshot_proposal: snapshot,
+    },
+    include: [
+      {
+        model: models.Address,
+        as: 'Address'
+      },
+      {
+        model: models.Address,
+        // through: models.Collaboration,
+        as: 'collaborators'
+      },
+      {
+        model: models.OffchainTopic,
+        as: 'topic'
+      },
+      {
+        model: models.ChainEntity,
+      },
+      {
+        model: models.OffchainReaction,
+        as: 'reactions',
+        include: [{
+          model: models.Address,
+          as: 'Address'
+        }]
+      }
+    ],
+  });
+  if (!thread) return res.json({ status: 'Failure', message: Errors.NoThread });
+
+  return res.json({ status: 'Success', result: thread.toJSON() });
+};
+
+export default fetchThreadForSnapshot;

--- a/server/routes/updateThreadLinkedSnapshotProposal.ts
+++ b/server/routes/updateThreadLinkedSnapshotProposal.ts
@@ -17,10 +17,9 @@ const updateThreadLinkedSnapshotProposal = async (models: DB, req: Request, res:
   if (!chain?.snapshot) {
     return next(new Error(Errors.MustBeSnapshotChain));
   }
-
   // ensure snapshot proposal is a bs58-encoded sha256 hash
-  const decodedHash = bs58.decodeUnsafe(req.body.snapshot_proposal);
-  if (!decodedHash || decodedHash.length !== 256) {
+  // const decodedHash = bs58.decodeUnsafe(req.body.snapshot_proposal);
+  if (!req.body.snapshot_proposal) { //  || decodedHash.toString().length !== 256
     return next(new Error(Errors.InvalidSnapshotProposal));
   }
 

--- a/server/routes/updateThreadLinkedSnapshotProposal.ts
+++ b/server/routes/updateThreadLinkedSnapshotProposal.ts
@@ -19,9 +19,10 @@ const updateThreadLinkedSnapshotProposal = async (models: DB, req: Request, res:
   }
   // ensure snapshot proposal is a bs58-encoded sha256 hash
   // const decodedHash = bs58.decodeUnsafe(req.body.snapshot_proposal);
-  if (!req.body.snapshot_proposal) { //  || decodedHash.toString().length !== 256
-    return next(new Error(Errors.InvalidSnapshotProposal));
-  }
+  //  || decodedHash.toString().length !== 256
+  // if (!req.body.snapshot_proposal) { 
+  //   return next(new Error(Errors.InvalidSnapshotProposal));
+  // }
 
   const { thread_id } = req.body;
 

--- a/server/routes/updateThreadLinkedSnapshotProposal.ts
+++ b/server/routes/updateThreadLinkedSnapshotProposal.ts
@@ -31,6 +31,7 @@ const updateThreadLinkedSnapshotProposal = async (models: DB, req: Request, res:
       id: thread_id,
     },
   });
+  
   if (!thread) return next(new Error(Errors.NoThread));
   const userOwnedAddressIds = (await req.user.getAddresses())
     .filter((addr) => !!addr.verified).map((addr) => addr.id);

--- a/server/routes/updateThreadLinkedSnapshotProposal.ts
+++ b/server/routes/updateThreadLinkedSnapshotProposal.ts
@@ -1,0 +1,78 @@
+import { Request, Response, NextFunction } from 'express';
+import bs58 from 'bs58';
+import { Op } from 'sequelize';
+import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
+import { DB } from '../database';
+
+export const Errors = {
+  NoThread: 'Cannot find thread',
+  NotAdminOrOwner: 'Not an admin or owner of this thread',
+  MustBeSnapshotChain: 'Thread chain must support snapshot',
+  InvalidSnapshotProposal: 'Invalid snapshot proposal hash',
+};
+
+const updateThreadLinkedSnapshotProposal = async (models: DB, req: Request, res: Response, next: NextFunction) => {
+  const [chain, community, error] = await lookupCommunityIsVisibleToUser(models, req.body, req.user);
+  if (error) return next(new Error(error));
+  if (!chain?.snapshot) {
+    return next(new Error(Errors.MustBeSnapshotChain));
+  }
+
+  // ensure snapshot proposal is a bs58-encoded sha256 hash
+  const decodedHash = bs58.decodeUnsafe(req.body.snapshot_proposal);
+  if (!decodedHash || decodedHash.length !== 256) {
+    return next(new Error(Errors.InvalidSnapshotProposal));
+  }
+
+  const { thread_id } = req.body;
+
+  const thread = await models.OffchainThread.findOne({
+    where: {
+      id: thread_id,
+    },
+  });
+  if (!thread) return next(new Error(Errors.NoThread));
+  const userOwnedAddressIds = (await req.user.getAddresses())
+    .filter((addr) => !!addr.verified).map((addr) => addr.id);
+  if (!userOwnedAddressIds.includes(thread.address_id)) { // is not author
+    const roles = await models.Role.findAll({
+      where: {
+        address_id: { [Op.in]: userOwnedAddressIds, },
+        permission: { [Op.in]: ['admin', 'moderator'] },
+      }
+    });
+    const role = roles.find((r) => {
+      return r.offchain_community_id === thread.community || r.chain_id === thread.chain;
+    });
+    if (!role) return next(new Error(Errors.NotAdminOrOwner));
+  }
+
+  // link snapshot proposal
+  // TODO: should we verify proposal exists here?
+  thread.snapshot_proposal = req.body.snapshot_proposal;
+  await thread.save();
+
+  const finalThread = await models.OffchainThread.findOne({
+    where: { id: thread_id, },
+    include: [
+      {
+        model: models.Address,
+        as: 'Address'
+      },
+      {
+        model: models.Address,
+        // through: models.Collaboration,
+        as: 'collaborators'
+      },
+      models.OffchainAttachment,
+      {
+        model: models.OffchainTopic,
+        as: 'topic'
+      }
+    ],
+  });
+
+  return res.json({ status: 'Success', result: finalThread.toJSON() });
+};
+
+export default updateThreadLinkedSnapshotProposal;


### PR DESCRIPTION
Allows you to link a snapshot proposal to thread, and also ensures that the link keeps you on the custom domain when you're already on the custom domain. Last, keeps the linked proposals / snapshots of a thread visible in the right hand sidebar at all times.

1. This was kind of a pain to do because Snapshot isn't well integrated into our codebase, I.e not added as a chain entity, not in our existing proposal stores, nor included in our existing views. 

The code could be much clear (including what I've written)

Tested by:
- creating and associating snapshot proposals to thread (and navigating back and forth on custom and non-custom domains)

Future Work to this will include:
- refactoring the proposal page and snapshot page sidebar to include "perma" right sidebars where you can see linked proposals / threads
- allowing snapshot proposals to be linked to multiple threads and showing this to users
- easily removing snapshot proposals