### PR TITLE
Fix Logging in (not via email)

### DIFF
--- a/client/scripts/views/modals/link_new_address_modal.ts
+++ b/client/scripts/views/modals/link_new_address_modal.ts
@@ -306,6 +306,9 @@ const LinkNewAddressModal: m.Component<ILinkNewAddressModalAttrs, ILinkNewAddres
             ? app.user.selectedNode.chain
             : app.config.nodes.getByChain(app.activeChainId())[0].chain;
           await updateActiveAddresses(chain);
+          if (app.user.activeAccounts.find((addr) => addr.ghost_address === true && addr.chainBase === chain.base)) {
+            await app.user.activeAccount.updateGhostAddress(vnode.state.userProvidedSignature)
+          }
         } else {
           notifyError('Signed in, but no chain or community found');
         }


### PR DESCRIPTION
If a user did not login via email, they were not able to login.

- Moves `updateAddress` out of the validate call and only calls after a user has a jwt from logging in and only if they are adding an address with same chainbase as a ghost address.
- fixes controller/models/Account where `ghost_address` was `ChainBase` instead of `boolean`
