### PR TITLE
Add synopsis view to offchain polling

### DIFF
--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -58,9 +58,11 @@ class OffchainThread implements IUniqueId {
   public offchainVotingNumVotes: number;
   public offchainVotingEndsAt: moment.Moment | null;
   public offchainVotes: OffchainVote[]; // lazy loaded
+  
   public getOffchainVoteFor(chain: string, address: string) {
     return this.offchainVotes?.find((vote) => vote.address === address && vote.author_chain === chain);
   }
+
   public setOffchainVotes(voteData) {
     const votes = voteData.map((data) => {
       const { address, author_chain, thread_id, option } = data;
@@ -68,6 +70,7 @@ class OffchainThread implements IUniqueId {
     });
     this.offchainVotes = votes;
   }
+
   public async submitOffchainVote(chain: string, community: string, authorChain: string, address: string, option: string) {
     const thread_id = this.id;
     return $.post(`${app.serverUrl()}/updateOffchainVote`, {

--- a/client/scripts/views/modals/offchain_voting_modal.ts
+++ b/client/scripts/views/modals/offchain_voting_modal.ts
@@ -1,0 +1,35 @@
+import 'modals/offchain_voting_modal.scss';
+
+import m from 'mithril';
+import { OffchainVote, AddressInfo } from 'models';
+import { CompactModalExitButton } from 'views/modal';
+import User from 'views/components/widgets/user';
+
+const OffchainVotingModal : m.Component<{ votes: OffchainVote[] }, {}> = {
+  view: (vnode) => {
+    const { votes } = vnode.attrs;
+    if (!votes || votes.length === 0) return;
+
+    return m('.OffchainVotingModal', [
+      m('.compact-modal-title', [
+        m('h3', 'Votes'),
+        m(CompactModalExitButton),
+      ]),
+      m('.compact-modal-body', votes.map((vote) => m('.offchain-poll-voter', [
+        m('.offchain-poll-voter-user', [
+          m(User, {
+            avatarSize: 16,
+            popover: true,
+            linkify: true,
+            user: new AddressInfo(null, vote.address, vote.author_chain, null, null),
+            hideIdentityIcon: true,
+          }),
+        ]),
+        m('.offchain-poll-voter-choice', vote.option),
+      ])),
+      )
+    ]);
+  }
+};
+
+export default OffchainVotingModal;

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -24,6 +24,7 @@ import {
   OffchainThreadStage,
   AnyProposal,
   AddressInfo,
+  OffchainVote,
 } from 'models';
 
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
@@ -36,6 +37,7 @@ import { alertModalWithText } from 'views/modals/alert_modal';
 import { activeQuillEditorHasText, GlobalStatus } from './body';
 import { IProposalPageState } from '.';
 import { SnapshotProposal } from 'client/scripts/helpers/snapshot_utils';
+import OffchainVotingModal from '../../modals/offchain_voting_modal';
 
 export const ProposalHeaderExternalLink: m.Component<{ proposal: AnyProposal | OffchainThread }> = {
   view: (vnode) => {
@@ -52,7 +54,11 @@ export const ProposalHeaderExternalLink: m.Component<{ proposal: AnyProposal | O
   }
 };
 
-export const ProposalHeaderOffchainPoll: m.Component<{ proposal: OffchainThread }, { offchainVotes }> = {
+interface IProposalScopedVotes {
+  proposalId?: boolean;
+}
+
+export const ProposalHeaderOffchainPoll: m.Component<{ proposal: OffchainThread }, { offchainVotes: IProposalScopedVotes }> = {
   view: (vnode) => {
     const { proposal } = vnode.attrs;
     if (!proposal.offchainVotingEndsAt) return;
@@ -60,7 +66,7 @@ export const ProposalHeaderOffchainPoll: m.Component<{ proposal: OffchainThread 
     if (vnode.state.offchainVotes === undefined || vnode.state.offchainVotes[proposal.id] === undefined) {
       // initialize or reset offchain votes
       vnode.state.offchainVotes = {};
-      vnode.state.offchainVotes[proposal.id] = [];
+      vnode.state.offchainVotes[proposal.id] = true;
       // fetch from backend, and then set
       $.get(`/api/viewOffchainVotes?thread_id=${proposal.id}${
         app.activeChainId() ? `&chain=${app.activeChainId()}`
@@ -98,6 +104,38 @@ export const ProposalHeaderOffchainPoll: m.Component<{ proposal: OffchainThread 
       });
     };
 
+    const optionScopedVotes = proposal.offchainVotingOptions.choices.map((option) => {
+      return ({
+        option,
+        votes: proposal.offchainVotes.filter((v) => v.option === option)
+      });
+    });
+
+    const totalVoteCount = proposal.offchainVotes.length;
+    const voteSynopsis = m('.vote-synopsis', [
+      optionScopedVotes.map((optionWithVotes) => {
+        const optionVoteCount = optionWithVotes.votes.length;
+        const optionVotePercentage = (optionVoteCount / totalVoteCount);
+        return m('.option-with-votes', [
+          m('.option-results-label', [
+            m('div', { style: 'font-weight: 500; margin-right: 5px;' }, `${optionWithVotes.option}`),
+            m('div', `(${optionVoteCount})`),
+          ]),
+          m('.poll-bar', { style: `width: ${Math.round(optionVotePercentage * 10000) / 100}%` }),
+        ])
+      }),
+      m('a', {
+        href: '#',
+        onclick: (e) => {
+          e.preventDefault();
+          app.modals.create({
+            modal: OffchainVotingModal,
+            data: { votes: proposal.offchainVotes }
+          });
+        }
+      }, 'See all votes')
+    ]);
+
     return m('.ProposalHeaderOffchainPoll', [
       m('.offchain-poll-header', [
         proposal.offchainVotingOptions?.name || (pollingEnded ? 'Poll closed' : 'Poll open')
@@ -134,19 +172,9 @@ export const ProposalHeaderOffchainPoll: m.Component<{ proposal: OffchainThread 
       ]),
       m('.offchain-poll-header', 'Voters'),
       m('.offchain-poll-voters', [
-        proposal.offchainVotes.length === 0 && m('.offchain-poll-no-voters', 'Nobody has voted'),
-        proposal.offchainVotes.map((vote_) => m('.offchain-poll-voter', [
-          m('.offchain-poll-voter-user', [
-            m(User, {
-              avatarSize: 16,
-              popover: true,
-              linkify: true,
-              user: new AddressInfo(null, vote_.address, vote_.author_chain, null, null),
-              hideIdentityIcon: true,
-            }),
-          ]),
-          m('.offchain-poll-voter-choice', vote_.option),
-        ])),
+        proposal.offchainVotes.length === 0
+          ? m('.offchain-poll-no-voters', 'Nobody has voted')
+          : voteSynopsis,
       ]),
     ]);
   }

--- a/client/styles/modals/offchain_voting_modal.scss
+++ b/client/styles/modals/offchain_voting_modal.scss
@@ -1,0 +1,27 @@
+@import 'client/styles/shared';
+
+.OffchainVotingModal {
+    .compact-modal-body {
+        width: 640px;
+        @include xs-max {
+            width: initial;
+        }
+        .offchain-poll-voter {
+            display: flex;
+            .User {
+                display: inline;
+            }
+            .offchain-poll-voter-user {
+                flex: 1;
+                padding-right: 5px;
+            }
+            .offchain-poll-voter-choice {
+                display: inline;
+                font-weight: 600;
+                flex: 2;
+                text-align: right;
+                margin-bottom: 5px;
+            }
+        }
+    }
+}

--- a/client/styles/modals/offchain_voting_modal.scss
+++ b/client/styles/modals/offchain_voting_modal.scss
@@ -3,6 +3,7 @@
 .OffchainVotingModal {
     .compact-modal-body {
         width: 640px;
+        overflow-y: scroll;
         @include xs-max {
             width: initial;
         }

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -448,19 +448,22 @@ $discussion-title-font-size: 1.45rem;
         }
         .offchain-poll-voters {
             margin-top: 10px;
-            .offchain-poll-voter {
-                display: flex;
-                .User {
-                    display: inline;
-                }
-                .offchain-poll-voter-user {
-                    flex: 1;
-                    padding-right: 5px;
-                }
-                .offchain-poll-voter-choice {
-                    display: inline;
-                    font-weight: 600;
-                    margin-right: 5px;
+            .vote-synopsis {
+                margin-top: 10px;
+                .option-with-votes {
+                    margin: 10px 0;
+                    .poll-bar {
+                        height: 5px;
+                        border-radius: 5px;
+                        background-color: $primary-bg-color;
+                    }
+                    .option-results-label {
+                        display: flex;
+                    }
+                    a {
+                        margin-top: 10px;
+                        display: inline-block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, poll results were displayed as individual rows. This meant that getting an overview of voter response was difficult. Additionally, the cramped sidebar meant that lengthy poll responses were hard to read and visually problematic.

This branch moves individual voting results to a modal, and instead provides an overview bar graph.

QA'd with a few existing Ethereum polls, everything worked fine. But never touched polling before, so hard to predict which parts of the codebase are brittle—could be nice to get QA guidance here, as to possible different polling states/edge cases of the polling data.

Recent database dump should have poll at `/ethereum/proposal/discussion/1157`.

![image](https://user-images.githubusercontent.com/22281010/133314213-31b49d7f-a33e-4218-860c-8f1d6616859c.png)
