### PR TITLE
Fix "Thread Not Found" Issue from TG

### DIFF
--- a/server/routes/getThread.ts
+++ b/server/routes/getThread.ts
@@ -34,7 +34,8 @@ const getThread = async (models: DB, req: Request, res: Response, next: NextFunc
           as: 'reactions',
           include: [{
             model: models.Address,
-            as: 'Address'
+            as: 'Address',
+            required: true
           }]
         }
       ],

--- a/server/routes/viewComments.ts
+++ b/server/routes/viewComments.ts
@@ -29,7 +29,8 @@ const viewComments = async (models: DB, req: Request, res: Response, next: NextF
         as: 'reactions',
         include: [{
           model: models.Address,
-          as: 'Address'
+          as: 'Address',
+          required: true
         }]
       }
     ],


### PR DESCRIPTION
Mr. Bulb found that while [going directly to this thread](https://commonwealth.im/edgeware/proposal/discussion/1127-newfutures-web3-media-dao-and-nft-launchpad-on-edgeware-based-on-rmrk) that commonwealth fails to render the thread, and that when navigated to directly from the discussions page, fails to the render the comments.

~This PR currently only addresses the first issue~ (and doesn't address any issue of speed... it takes forever to load). 

- [x] Thread loads directly? YES
- [x] Comments load? YES