### PR TITLE
add if defined and default values for ghost address column

### DIFF
--- a/client/scripts/views/components/widgets/user.ts
+++ b/client/scripts/views/components/widgets/user.ts
@@ -116,9 +116,9 @@ const User: m.Component<{
         size: 'xs',
       }),
     ];
-    const ghostAddress = app.user.addresses.some(({ address, ghostAddress }) => (
-        account.address === address && ghostAddress
-    ))
+    const ghostAddress = app.user.addresses.some(({ address, ghostAddress }) => {
+      if (this !== undefined) account.address === address && ghostAddress
+    })
     const userFinal = avatarOnly
       ? m('.User.avatar-only', {
         key: profile?.address || '-',

--- a/server/migrations/20210916060457-add-false-to-ghost-address.js
+++ b/server/migrations/20210916060457-add-false-to-ghost-address.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkUpdate('Addresses', { ghost_address: false }, { ghost_address: null }, { transaction: t });
+    });
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkUpdate('Addresses', {ghost_address: null }, { ghost_address: false }, { transaction: t });
+    });
+  }
+};


### PR DESCRIPTION
Hotfix for loading on member page when `this` returns undefined, as well as other issues tagged.

```
    const ghostAddress = app.user.addresses.some(({ address, ghostAddress }) => {
      account.address === address && ghostAddress
    })
```
would originally cause Mithril to bug out, now becomes


```
    const ghostAddress = app.user.addresses.some(({ address, ghostAddress }) => {
      **if (this !== undefined)** account.address === address && ghostAddress
    })
```

Fixes issues noted in bugs channel (https://hicommonwealth.slack.com/archives/CT2302L7L/p1631742264421600 + https://hicommonwealth.slack.com/archives/CT2302L7L/p1631678318405500?thread_ts=1631656467.403400&cid=CT2302L7L + https://hicommonwealth.slack.com/archives/CT2302L7L/p1631656467403400)