### PR TITLE
Send num candidates rather than candidate objects.

### DIFF
--- a/client/scripts/controllers/chain/substrate/phragmen_election.ts
+++ b/client/scripts/controllers/chain/substrate/phragmen_election.ts
@@ -210,7 +210,7 @@ export class SubstratePhragmenElection extends Proposal<
     // handle differing versions of Substrate API
     const txFunc = (api: ApiPromise) => {
       if (api.tx[this.moduleName].submitCandidacy.meta.args.length === 1) {
-        return api.tx[this.moduleName].submitCandidacy(this.candidates);
+        return api.tx[this.moduleName].submitCandidacy(this._exposedCandidates.length);
       } else {
         return api.tx[this.moduleName].submitCandidacy();
       }


### PR DESCRIPTION
NEEDS QA BEFORE MERGING, but should fix issue with submitCandidacy() call.