### PR TITLE
bug fix for /reactionCount in proposal tab.

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -540,9 +540,16 @@ class ThreadsController {
         console.error(e.message);
       }
     }
-    const { result: reactionCounts } = await $.post(`${app.serverUrl()}/reactionsCounts`, {
-      thread_ids: threads.map((thread) => thread.id),
-      active_address: app.user.activeAccount?.address
+    const { result: reactionCounts } = await $.ajax({
+      type: 'POST',
+      url: `${app.serverUrl()}/reactionsCounts`,
+      headers: {
+        'content-type': 'application/json',
+      },
+      data: JSON.stringify({
+        thread_ids: threads.map((thread) => thread.id),
+        active_address: app.user.activeAccount?.address,
+      }),
     });
     for (const rc of reactionCounts) {
       const id = app.reactionCounts.store.getIdentifier(rc);
@@ -551,7 +558,9 @@ class ThreadsController {
         app.reactionCounts.store.remove(existing);
       }
       try {
-        app.reactionCounts.store.add(modelReactionCountFromServer({ ...rc, id }));
+        app.reactionCounts.store.add(
+          modelReactionCountFromServer({ ...rc, id })
+        );
       } catch (e) {
         console.error(e.message);
       }

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -777,15 +777,24 @@ const ViewProposalPage: m.Component<{
         .then(async (result) => {
           vnode.state.comments = app.comments.getByProposal(proposal).filter((c) => c.parentComment === null);
           // fetch reactions
-          const { result: reactionCounts } = await $.post(`${app.serverUrl()}/reactionsCounts`, {
-            thread_ids: [proposalId],
-            comment_ids: vnode.state.comments.map((comment) => comment.id),
-            active_address: app.user.activeAccount?.address
+          const { result: reactionCounts } = await $.ajax({
+            type: 'POST',
+            url: `${app.serverUrl()}/reactionsCounts`,
+            headers: {
+              'content-type': 'application/json',
+            },
+            data: JSON.stringify({
+              proposal_ids: [proposalId],
+              comment_ids: vnode.state.comments.map((comment) => comment.id),
+              active_address: app.user.activeAccount?.address,
+            }),
           });
           // app.reactionCounts.deinit()
           for (const rc of reactionCounts) {
             const id = app.reactionCounts.store.getIdentifier(rc);
-            app.reactionCounts.store.add(modelReactionCountFromServer({ ...rc, id }));
+            app.reactionCounts.store.add(
+              modelReactionCountFromServer({ ...rc, id })
+            );
           }
           m.redraw();
         }).catch((err) => {
@@ -1022,14 +1031,14 @@ const ViewProposalPage: m.Component<{
               vnode.state.pollEditorIsOpen = true;
             }
           }),
-          proposal instanceof OffchainThread 
-            && ((proposal as OffchainThread).chainEntities.length > 0 
+          proposal instanceof OffchainThread
+            && ((proposal as OffchainThread).chainEntities.length > 0
               || (proposal as OffchainThread).snapshotProposal?.length > 0)
             && m(ProposalSidebarLinkedViewer, {
             proposal
           }),
-          proposal instanceof OffchainThread 
-            && (isAuthor || isAdmin) 
+          proposal instanceof OffchainThread
+            && (isAuthor || isAdmin)
             && m(ProposalSidebarStageEditorModule, {
             proposal,
             openStageEditor: () => {
@@ -1049,10 +1058,10 @@ const ViewProposalPage: m.Component<{
         isAdmin,
         stageEditorIsOpen: vnode.state.stageEditorIsOpen,
         pollEditorIsOpen: vnode.state.pollEditorIsOpen,
-        closeStageEditor: () => { vnode.state.stageEditorIsOpen = false; 
+        closeStageEditor: () => { vnode.state.stageEditorIsOpen = false;
           m.redraw(); },
-        closePollEditor: () => { 
-          vnode.state.pollEditorIsOpen = false; 
+        closePollEditor: () => {
+          vnode.state.pollEditorIsOpen = false;
           m.redraw(); },
       }),
       !(proposal instanceof OffchainThread)

--- a/server/routes/reactionsCounts.ts
+++ b/server/routes/reactionsCounts.ts
@@ -14,11 +14,13 @@ const log = factory.getLogger(formatFilename(__filename));
 The reduce function goes through each result returned by query that counts
 and checks whether there's a match between thread/comment/proposal ids
  */
-const reactionsCounts = async (models: DB, req: Request, res: Response, next: NextFunction) => {
-  const { active_address } = req.body;
-  const thread_ids = req.body['thread_ids[]'];
-  const comment_ids = req.body['comment_ids[]'];
-  const proposal_ids = req.body['proposal_ids[]'];
+const reactionsCounts = async (
+  models: DB,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { active_address, thread_ids, comment_ids, proposal_ids } = req.body;
   try {
     if (thread_ids || comment_ids || proposal_ids) {
       let countField = 'thread_id';
@@ -27,48 +29,78 @@ const reactionsCounts = async (models: DB, req: Request, res: Response, next: Ne
       } else if (proposal_ids) {
         countField = 'proposal_id';
       }
-      const [reactionsCounts = [], myReactions = []] = await <Promise<[OffchainReactionInstance[], OffchainReactionInstance[]]>>Promise.all([
+      const [reacCounts = [], myReactions = []] = await (<
+        Promise<[OffchainReactionInstance[], OffchainReactionInstance[]]>
+      >Promise.all([
         models.OffchainReaction.findAll({
           group: ['thread_id', 'comment_id', 'proposal_id', 'reaction'],
-          attributes: ['thread_id', 'comment_id', 'proposal_id', 'reaction',
-            [Sequelize.fn('COUNT', countField), 'count']],
+          attributes: [
+            'thread_id',
+            'comment_id',
+            'proposal_id',
+            'reaction',
+            [Sequelize.fn('COUNT', countField), 'count'],
+          ],
           where: Sequelize.or(
             { thread_id: thread_ids || [] },
-            {  proposal_id: proposal_ids || [] },
+            { proposal_id: proposal_ids || [] },
             { comment_id: comment_ids || [] }
           ),
         }),
-        active_address ? models.OffchainReaction.findAll({
-          attributes: ['thread_id', 'comment_id', 'proposal_id'],
-          where: Sequelize.or(
-            { thread_id: thread_ids || [] },
-            {  proposal_id: proposal_ids || [] },
-            { comment_id: comment_ids || [] }
-          ),
-          include: [{
-            model: models.Address,
-            where: { address: active_address }
-          }]
-        }) : []
-      ]);
+        active_address
+          ? models.OffchainReaction.findAll({
+              attributes: ['thread_id', 'comment_id', 'proposal_id'],
+              where: Sequelize.or(
+                { thread_id: thread_ids || [] },
+                { proposal_id: proposal_ids || [] },
+                { comment_id: comment_ids || [] }
+              ),
+              include: [
+                {
+                  model: models.Address,
+                  where: { address: active_address },
+                },
+              ],
+            })
+          : [],
+      ]));
       return res.json({
         status: 'Success',
-        result: reactionsCounts.reduce((acc, rc) => {
+        result: reacCounts.reduce((acc, rc) => {
           const rcJSon: any = rc.toJSON();
-          const { thread_id: threadId, comment_id: commentId, proposal_id: proposalId, reaction, count } = rcJSon;
-          const id = rcJSon.thread_id || rcJSon.comment_id || rcJSon.proposal_id;
-          const index = acc.findIndex(({ thread_id, comment_id, proposal_id }) => (id === thread_id || id === comment_id
-                        || id === proposal_id));
-          const hasReacted = myReactions.some(({ thread_id, comment_id, proposal_id }) => {
-            return (id === thread_id || id === comment_id || id === proposal_id);
-          });
+          const {
+            thread_id: threadId,
+            comment_id: commentId,
+            proposal_id: proposalId,
+            reaction,
+            count,
+          } = rcJSon;
+          const id =
+            rcJSon.thread_id || rcJSon.comment_id || rcJSon.proposal_id;
+          const index = acc.findIndex(
+            ({ thread_id, comment_id, proposal_id }) =>
+              id === thread_id || id === comment_id || id === proposal_id
+          );
+          const hasReacted = myReactions.some(
+            ({ thread_id, comment_id, proposal_id }) => {
+              return (
+                id === thread_id || id === comment_id || id === proposal_id
+              );
+            }
+          );
           if (index > 0) {
             acc[index][reaction] = count;
           } else {
-            acc.push({ threadId, commentId, proposalId, [reaction]: count, hasReacted });
+            acc.push({
+              threadId,
+              commentId,
+              proposalId,
+              [reaction]: count,
+              hasReacted,
+            });
           }
           return acc;
-        }, [])
+        }, []),
       });
     } else {
       return res.json({ result: [] });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
/reactionCount endpoint fails in proposals view because incorrect parameter was passed.
it is expected `proposal_ids` which is a list of addresses (string), instead I was passing a list of threads which are integer.
https://rollbar.com/commonwealth/Commonwealth/items/843/occurrences/183170615570/?utm_campaign=item_velocity&utm_medium=email&utm_source=rollbar-notification&utm_content=view-item-button-1


## Description
<!--- Describe your changes in detail -->
Beside passing the right parameter `proposal_ids`, I also did some refactoring around the post requests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no