### PR TITLE
Fix mobile and tablet voting results display

### DIFF
--- a/client/styles/components/proposals/voting_results.scss
+++ b/client/styles/components/proposals/voting_results.scss
@@ -52,9 +52,6 @@
             line-height: 2;
             margin-bottom: 20px;
         }
-        .results-header, .results-cell {
-            min-width: calc(50% - 15px);
-        }
         &.yes-votes {
             border: 2px solid #C5EEE9;
             .results-header {
@@ -73,8 +70,9 @@
     @include lg-max {
         display: block;
         width: 100%;
-        .results-header, .results-cell {
-            width: 100%;
+        .results-column, .results-header, .results-cell {
+            min-width: 100%;
+            max-width: 100%;
         }
     }
     .vote {

--- a/client/styles/sublayout.scss
+++ b/client/styles/sublayout.scss
@@ -104,8 +104,7 @@
     }
     @include md-max {
         .sublayout-main-col {
-            min-width: 100%;
-            max-width: 100%;
+            width: calc(100% - #{$sidebar-width});
             padding: 0;
         }
     }


### PR DESCRIPTION
AAVE/DYDX proposal results weren't styled for mobile and tablet yet. 

To test, check out DYDX proposal/snapshot votes in mobile and tablet view.

Before:
![image](https://user-images.githubusercontent.com/22281010/135914827-425a3ec0-68a0-4ae8-a7c2-599ae559ebed.png)
![image](https://user-images.githubusercontent.com/22281010/135914893-602e2132-5c97-49fc-aa71-8c634ba374ca.png)

After:
![image](https://user-images.githubusercontent.com/22281010/135914949-bf8ebb2e-6ea3-45f7-a60d-b3bf75c989ac.png)
![image](https://user-images.githubusercontent.com/22281010/135914996-c935b308-cd8e-4456-9fe4-a6357eaf0866.png)
