### PR TITLE
CE no longer determines list of valid event chains.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -14,7 +14,6 @@ import moment from 'moment';
 import mixpanel from 'mixpanel-browser';
 import _ from 'underscore';
 
-import { AaveTypes, CompoundTypes, MolochTypes } from '@commonwealth/chain-events';
 import app, { ApiStatus, LoginState } from 'state';
 import {
   ChainInfo,
@@ -276,28 +275,28 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolea
     )).default;
     newChain = new Sputnik(n, app);
     initApi = true;
-  } else if (MolochTypes.EventChains.find((c) => c === n.chain.network)) {
+  } else if (n.chain.network === ChainNetwork.Moloch) {
     const Moloch = (await import(
       /* webpackMode: "lazy" */
       /* webpackChunkName: "moloch-main" */
       './controllers/chain/ethereum/moloch/adapter'
     )).default;
     newChain = new Moloch(n, app);
-  } else if (CompoundTypes.EventChains.find((c) => c === n.chain.network || c === n.chain.id)) {
+  } else if (n.chain.network === ChainNetwork.Compound) {
     const Compound = (await import(
       /* webpackMode: "lazy" */
       /* webpackChunkName: "compound-main" */
       './controllers/chain/ethereum/compound/adapter'
     )).default;
     newChain = new Compound(n, app);
-  } else if (AaveTypes.EventChains.find((c) => c === n.chain.network)) {
+  } else if (n.chain.network === ChainNetwork.Aave) {
     const Aave = (await import(
       /* webpackMode: "lazy" */
       /* webpackChunkName: "aave-main" */
       './controllers/chain/ethereum/aave/adapter'
     )).default;
     newChain = new Aave(n, app);
-  } else if (n.chain.type === 'token') {
+  } else if (n.chain.network === ChainNetwork.ERC20) {
     const Token = (await import(
     //   /* webpackMode: "lazy" */
     //   /* webpackChunkName: "token-main" */

--- a/client/scripts/controllers/chain/ethereum/aave/governance.ts
+++ b/client/scripts/controllers/chain/ethereum/aave/governance.ts
@@ -3,7 +3,7 @@ import { IApp } from 'state';
 import { IAaveProposalResponse } from 'adapters/chain/aave/types';
 import { AaveEvents, AaveTypes } from '@commonwealth/chain-events';
 import { Executor } from 'eth/types';
-import { EntityRefreshOption } from 'controllers/server/chain_entities';
+import { chainToEventNetwork, EntityRefreshOption } from 'controllers/server/chain_entities';
 
 import AaveProposal from './proposal';
 import AaveChain from './chain';
@@ -131,6 +131,7 @@ export default class AaveGovernance extends ProposalModule<
     // await this.app.chain.chainEntities.fetchEntities(this.app.chain.id, () => fetcher.fetch());
     await this.app.chain.chainEntities.subscribeEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       subscriber,
       processor,
     );

--- a/client/scripts/controllers/chain/ethereum/compound/governance.ts
+++ b/client/scripts/controllers/chain/ethereum/compound/governance.ts
@@ -3,7 +3,7 @@ import { ProposalModule, ITXModalData } from 'models';
 import { ICompoundProposalResponse } from 'adapters/chain/compound/types';
 import { CompoundEvents, CompoundTypes } from '@commonwealth/chain-events';
 import { IApp } from 'state';
-import { EntityRefreshOption } from 'controllers/server/chain_entities';
+import { chainToEventNetwork, EntityRefreshOption } from 'controllers/server/chain_entities';
 import { BigNumberish } from 'ethers';
 import CompoundAPI from './api';
 import CompoundProposal from './proposal';
@@ -125,6 +125,7 @@ export default class CompoundGovernance extends ProposalModule<
     // await this.app.chain.chainEntities.fetchEntities(this.app.chain.id, () => fetcher.fetch());
     await this.app.chain.chainEntities.subscribeEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       subscriber,
       processor,
     );

--- a/client/scripts/controllers/chain/ethereum/moloch/governance.ts
+++ b/client/scripts/controllers/chain/ethereum/moloch/governance.ts
@@ -5,7 +5,7 @@ import { ProposalModule, ITXModalData, ChainEntity, IChainModule } from 'models'
 
 import { ERC20Token, EthereumCoin } from 'adapters/chain/ethereum/types';
 import { IMolochProposalResponse } from 'adapters/chain/moloch/types';
-import { EntityRefreshOption } from 'controllers/server/chain_entities';
+import { chainToEventNetwork, EntityRefreshOption } from 'controllers/server/chain_entities';
 
 import { MolochEvents } from '@commonwealth/chain-events';
 
@@ -92,9 +92,14 @@ export default class MolochGovernance extends ProposalModule<
       );
       const subscriber = new MolochEvents.Subscriber(api.Contract as any, this.app.chain.id);
       const processor = new MolochEvents.Processor(api.Contract as any, 1);
-      await this.app.chain.chainEntities.fetchEntities(this.app.chain.id, () => fetcher.fetch());
+      await this.app.chain.chainEntities.fetchEntities(
+        this.app.chain.id,
+        chainToEventNetwork(this.app.chain.meta.chain),
+        () => fetcher.fetch()
+      );
       await this.app.chain.chainEntities.subscribeEntities(
         this.app.chain.id,
+        chainToEventNetwork(this.app.chain.meta.chain),
         subscriber,
         processor,
       );

--- a/client/scripts/controllers/chain/substrate/bountyTreasury.ts
+++ b/client/scripts/controllers/chain/substrate/bountyTreasury.ts
@@ -10,6 +10,7 @@ import { SubstrateTypes } from '@commonwealth/chain-events';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateBounty } from './bounty';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateBountyTreasury extends ProposalModule<
   ApiPromise,
@@ -70,6 +71,7 @@ class SubstrateBountyTreasury extends ProposalModule<
     // fetch proposals from chain
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchBounties(this.app.chain.block.height),
     );
 

--- a/client/scripts/controllers/chain/substrate/collective.ts
+++ b/client/scripts/controllers/chain/substrate/collective.ts
@@ -8,6 +8,7 @@ import { IApp } from 'state';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateCollectiveProposal } from './collective_proposal';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateCollective extends ProposalModule<
   ApiPromise,
@@ -56,6 +57,7 @@ class SubstrateCollective extends ProposalModule<
     // fetch proposals from chain
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchCollectiveProposals(this.moduleName, this.app.chain.block.height)
     );
 

--- a/client/scripts/controllers/chain/substrate/democracy.ts
+++ b/client/scripts/controllers/chain/substrate/democracy.ts
@@ -7,6 +7,7 @@ import { IApp } from 'state';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateDemocracyReferendum } from './democracy_referendum';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateDemocracy extends ProposalModule<
   ApiPromise,
@@ -72,11 +73,13 @@ class SubstrateDemocracy extends ProposalModule<
     // fetch referenda from chain
     const events = await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchDemocracyReferenda(this.app.chain.block.height)
     );
     const hashes = events.filter((e) => (e.data as any).proposalHash).map((e) => (e.data as any).proposalHash);
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchDemocracyPreimages(hashes)
     );
 

--- a/client/scripts/controllers/chain/substrate/democracy_proposals.ts
+++ b/client/scripts/controllers/chain/substrate/democracy_proposals.ts
@@ -7,6 +7,7 @@ import { IApp } from 'state';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import SubstrateDemocracyProposal from './democracy_proposal';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateDemocracyProposals extends ProposalModule<
   ApiPromise,
@@ -82,12 +83,14 @@ class SubstrateDemocracyProposals extends ProposalModule<
     // fetch proposals from chain
     const events = await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchDemocracyProposals(this.app.chain.block.height)
     );
 
     const hashes = events.map((e) => e.data.proposalHash);
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchDemocracyPreimages(hashes)
     );
 

--- a/client/scripts/controllers/chain/substrate/shared.ts
+++ b/client/scripts/controllers/chain/substrate/shared.ts
@@ -39,6 +39,7 @@ import { u128 } from '@polkadot/types';
 import { constructSubstrateUrl } from 'substrate';
 import { formatAddressShort } from '../../../../../shared/utils';
 import { SubstrateAccount } from './account';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 export interface ISubstrateTXData extends ITXData {
   nonce: string;
@@ -229,6 +230,7 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
     const processor = new SubstrateEvents.Processor(this.api);
     return this._app.chain.chainEntities.subscribeEntities(
       this._app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       subscriber,
       processor,
     );

--- a/client/scripts/controllers/chain/substrate/treasury.ts
+++ b/client/scripts/controllers/chain/substrate/treasury.ts
@@ -12,6 +12,7 @@ import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { formatAddressShort } from '../../../../../shared/utils';
 import { SubstrateTreasuryProposal } from './treasury_proposal';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateTreasury extends ProposalModule<
   ApiPromise,
@@ -85,6 +86,7 @@ class SubstrateTreasury extends ProposalModule<
     // fetch proposals from chain
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchTreasuryProposals(this.app.chain.block.height),
     );
 

--- a/client/scripts/controllers/chain/substrate/treasury_tips.ts
+++ b/client/scripts/controllers/chain/substrate/treasury_tips.ts
@@ -9,6 +9,7 @@ import { formatAddressShort } from 'utils';
 import SubstrateChain from './shared';
 import SubstrateAccounts, { SubstrateAccount } from './account';
 import { SubstrateTreasuryTip } from './treasury_tip';
+import { chainToEventNetwork } from '../../server/chain_entities';
 
 class SubstrateTreasuryTips extends ProposalModule<
   ApiPromise,
@@ -49,6 +50,7 @@ class SubstrateTreasuryTips extends ProposalModule<
     // fetch proposals from chain
     await this.app.chain.chainEntities.fetchEntities(
       this.app.chain.id,
+      chainToEventNetwork(this.app.chain.meta.chain),
       () => this._Chain.fetcher.fetchTips(this.app.chain.block.height)
     );
 

--- a/client/scripts/controllers/server/chain_entities.ts
+++ b/client/scripts/controllers/server/chain_entities.ts
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 
 import { ChainEntityStore } from 'stores';
-import { ChainEntity, ChainEvent, ChainEventType } from 'models';
+import { ChainEntity, ChainEvent, ChainEventType, ChainInfo, ChainNetwork } from 'models';
 import app from 'state';
 import {
   CWEvent,
@@ -13,7 +13,7 @@ import {
   IEventSubscriber,
   SubstrateTypes,
   IChainEntityKind,
-  isSupportedChain,
+  SupportedNetwork,
 } from '@commonwealth/chain-events';
 import { notifyError } from '../app/notifications';
 
@@ -21,6 +21,15 @@ export enum EntityRefreshOption {
   AllEntities = 'all-entities',
   CompletedEntities = 'completed-entities',
   Nothing = 'nothing',
+}
+
+export function chainToEventNetwork(c: ChainInfo): SupportedNetwork {
+  if (c.base === 'substrate') return SupportedNetwork.Substrate;
+  if (c.network === ChainNetwork.ERC20) return SupportedNetwork.ERC20;
+  if (c.network === ChainNetwork.Compound) return SupportedNetwork.Compound;
+  if (c.network === ChainNetwork.Aave) return SupportedNetwork.Aave;
+  if (c.network === ChainNetwork.Moloch) return SupportedNetwork.Moloch;
+  throw new Error(`Invalid event chain: ${c.id}, on network ${c.network}, base ${c.base}`);
 }
 
 const get = (route, args, callback) => {
@@ -33,7 +42,7 @@ const get = (route, args, callback) => {
   }).catch((e) => console.error(e));
 };
 
-type EntityHandler = (entity: ChainEntity, event: ChainEvent) => void
+type EntityHandler = (entity: ChainEntity, event: ChainEvent) => void;
 
 class ChainEntityController {
   private _store: ChainEntityStore = new ChainEntityStore();
@@ -111,13 +120,10 @@ class ChainEntityController {
     }
   }
 
-  private _handleEvents(chain: string, events: CWEvent[]) {
-    if (!isSupportedChain(chain)) {
-      return;
-    }
+  private _handleEvents(chain: string, network: SupportedNetwork, events: CWEvent[]) {
     for (const cwEvent of events) {
       // immediately return if no entity involved, event unrelated to proposals/etc
-      const eventEntity = eventToEntity(chain, cwEvent.data.kind);
+      const eventEntity = eventToEntity(network, cwEvent.data.kind);
       // eslint-disable-next-line no-continue
       if (!eventEntity) continue;
       const [ entityKind ] = eventEntity;
@@ -125,6 +131,7 @@ class ChainEntityController {
       const eventType = new ChainEventType(
         `${chain}-${cwEvent.data.kind.toString()}`,
         chain,
+        network,
         cwEvent.data.kind.toString()
       );
 
@@ -132,7 +139,7 @@ class ChainEntityController {
       const event = new ChainEvent(cwEvent.blockNumber, cwEvent.data, eventType);
 
       // create entity
-      const fieldName = entityToFieldName(chain, entityKind);
+      const fieldName = entityToFieldName(network, entityKind);
       // eslint-disable-next-line no-continue
       if (!fieldName) continue;
       const fieldValue = event.data[fieldName];
@@ -197,6 +204,7 @@ class ChainEntityController {
 
   public async fetchEntities<T extends CWEvent>(
     chain: string,
+    network: SupportedNetwork,
     fetch: () => Promise<T[]>,
     eventSortFn?: (a: CWEvent, b: CWEvent) => number,
   ): Promise<T[]> {
@@ -209,12 +217,13 @@ class ChainEntityController {
       return;
     }
     if (eventSortFn) existingEvents.sort(eventSortFn);
-    this._handleEvents(chain, existingEvents);
+    this._handleEvents(chain, network, existingEvents);
     return existingEvents;
   }
 
   public async subscribeEntities<Api, RawEvent>(
     chain: string,
+    network: SupportedNetwork,
     subscriber: IEventSubscriber<Api, RawEvent>,
     processor: IEventProcessor<Api, RawEvent>,
   ): Promise<void> {
@@ -225,7 +234,7 @@ class ChainEntityController {
     console.log('Subscribing to chain events.');
     subscriber.subscribe(async (block) => {
       const incomingEvents = await processor.process(block);
-      this._handleEvents(chain, incomingEvents);
+      this._handleEvents(chain, network, incomingEvents);
     });
   }
 }

--- a/client/scripts/identifiers.ts
+++ b/client/scripts/identifiers.ts
@@ -1,6 +1,5 @@
 import { StorageModule, ChainBase, ProposalModule, ChainNetwork } from 'models';
 import { ProposalStore } from 'stores';
-import { AaveTypes, CompoundTypes, MolochTypes } from '@commonwealth/chain-events';
 import app from './state';
 import ThreadsController from './controllers/server/threads';
 
@@ -44,13 +43,13 @@ export const proposalSlugToClass = () => {
   if (app.chain.network === ChainNetwork.Kusama || app.chain.network === ChainNetwork.Polkadot) {
     mmap.set('technicalcommitteemotion', (app.chain as any).technicalCommittee);
   }
-  if (MolochTypes.EventChains.find((c) => c === app.chain.network)) {
+  if (app.chain.network === ChainNetwork.Moloch) {
     mmap.set('molochproposal', (app.chain as any).governance);
   }
-  if (CompoundTypes.EventChains.find((c) => c === app.chain.network)) {
+  if (app.chain.network === ChainNetwork.Compound) {
     mmap.set('compoundproposal', (app.chain as any).governance);
   }
-  if (AaveTypes.EventChains.find((c) => c === app.chain.network)) {
+  if (app.chain.network === ChainNetwork.Aave) {
     mmap.set('onchainproposal', (app.chain as any).governance);
   }
   if (app.chain.network === ChainNetwork.Sputnik) {
@@ -110,13 +109,13 @@ export const chainEntityTypeToProposalSlug = (t: string) => {
     if (app.chain.network === ChainNetwork.Sputnik) {
       return ProposalType.SputnikProposal;
     }
-    if (MolochTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Moloch) {
       return ProposalType.MolochProposal;
     }
-    if (CompoundTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Compound) {
       return ProposalType.CompoundProposal;
     }
-    if (AaveTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Aave) {
       return ProposalType.AaveProposal;
     }
   }
@@ -142,13 +141,13 @@ export const chainEntityTypeToProposalName = (t: string) => {
     if (app.chain.network === ChainNetwork.Sputnik) {
       return 'Sputnik Proposal';
     }
-    if (MolochTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Moloch) {
       return 'Moloch Proposal';
     }
-    if (CompoundTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Compound) {
       return 'Onchain Proposal';
     }
-    if (AaveTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Aave) {
       return 'Onchain Proposal';
     }
   }

--- a/client/scripts/models/ChainEventType.ts
+++ b/client/scripts/models/ChainEventType.ts
@@ -1,18 +1,20 @@
-import { SubstrateTypes } from '@commonwealth/chain-events';
+import { IChainEventKind, SupportedNetwork } from '@commonwealth/chain-events';
 
 class ChainEventType {
   public readonly id: string;
   public readonly chain: string;
-  public readonly eventName: SubstrateTypes.EventKind;
+  public readonly eventNetwork: SupportedNetwork;
+  public readonly eventName: IChainEventKind;
 
-  constructor(id, chain, eventName) {
+  constructor(id, chain, eventNetwork, eventName) {
     this.id = id;
     this.chain = chain;
+    this.eventNetwork = eventNetwork;
     this.eventName = eventName;
   }
 
   public static fromJSON(json) {
-    return new ChainEventType(json.id, json.chain, json.event_name);
+    return new ChainEventType(json.id, json.chain, json.event_network, json.event_name);
   }
 }
 

--- a/client/scripts/views/components/notification_row.ts
+++ b/client/scripts/views/components/notification_row.ts
@@ -4,10 +4,7 @@ import { Icon, Icons, Tooltip, Spinner } from 'construct-ui';
 import _ from 'lodash';
 import m from 'mithril';
 import moment from 'moment';
-import {
-  SubstrateTypes, MolochTypes, SubstrateEvents, MolochEvents, IEventLabel, chainSupportedBy, CompoundTypes, CompoundEvents, AaveTypes, AaveEvents,
-  // CompoundEvents
-} from '@commonwealth/chain-events';
+import { CWEvent, Label as ChainEventLabel } from '@commonwealth/chain-events';
 
 import app from 'state';
 import { navigateToSubpage } from 'app';
@@ -215,9 +212,6 @@ const NotificationRow: m.Component<{
   notifications: Notification[],
   onListPage?: boolean,
 }, {
-  Labeler: any,
-  MolochTypes: any,
-  SubstrateTypes: any,
   scrollOrStop: boolean;
   markingRead: boolean;
 }> = {
@@ -237,37 +231,17 @@ const NotificationRow: m.Component<{
         throw new Error('chain event notification does not have expected data');
       }
       const chainId = notification.chainEvent.type.chain;
+
+      // construct compatible CW event from DB by inserting network from type
+      const chainEvent: CWEvent = {
+        blockNumber: notification.chainEvent.blockNumber,
+        network: notification.chainEvent.type.eventNetwork,
+        data: notification.chainEvent.data,
+      };
       const chainName = app.config.chains.getById(chainId)?.name;
-      let label: IEventLabel;
 
       if (app.isCustomDomain() && chainId !== app.customDomainId()) return;
-      if (chainSupportedBy(chainId, SubstrateTypes.EventChains)) {
-        label = SubstrateEvents.Label(
-          notification.chainEvent.blockNumber,
-          chainId,
-          notification.chainEvent.data,
-        );
-      } else if (chainSupportedBy(chainId, MolochTypes.EventChains)) {
-        label = MolochEvents.Label(
-          notification.chainEvent.blockNumber,
-          chainId,
-          notification.chainEvent.data,
-        );
-      } else if (chainSupportedBy(chainId, CompoundTypes.EventChains)) {
-        label = CompoundEvents.Label(
-          notification.chainEvent.blockNumber,
-          chainId,
-          notification.chainEvent.data,
-        );
-      } else if (chainSupportedBy(chainId, AaveTypes.EventChains)) {
-        label = AaveEvents.Label(
-          notification.chainEvent.blockNumber,
-          chainId,
-          notification.chainEvent.data,
-        );
-      } else {
-        throw new Error(`invalid notification chain: ${chainId}`);
-      }
+      const label = ChainEventLabel(chainId, chainEvent);
       m.redraw();
 
       if (vnode.state.scrollOrStop) {

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -19,7 +19,6 @@ import { ChainIcon, CommunityIcon } from 'views/components/chain_icon';
 import CommunitySelector from 'views/components/sidebar/community_selector';
 import CreateCommunityModal from 'views/modals/create_community_modal';
 
-import { AaveTypes, CompoundTypes, MolochTypes } from '@commonwealth/chain-events';
 import { discordIcon, telegramIcon, elementIcon, githubIcon, websiteIcon } from './icons';
 
 const SidebarQuickSwitcherItem: m.Component<{ item, size }> = {
@@ -188,13 +187,13 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
 
     const hasProposals = app.chain && !app.community && (
       app.chain.base === ChainBase.CosmosSDK
-        || app.chain?.network === ChainNetwork.Sputnik
+        || app.chain.network === ChainNetwork.Sputnik
         || (app.chain.base === ChainBase.Substrate && app.chain.network !== ChainNetwork.Plasm)
-        || MolochTypes.EventChains.find((c) => c === app.chain.network)
-        || CompoundTypes.EventChains.find((c) => c === app.chain.network)
-        || AaveTypes.EventChains.find((c) => c === app.chain.network)
+        || app.chain.network === ChainNetwork.Moloch
+        || app.chain.network === ChainNetwork.Compound
+        || app.chain.network === ChainNetwork.Aave
         || app.chain.network === ChainNetwork.Commonwealth
-        || app.chain?.meta.chain.snapshot);
+        || app.chain.meta.chain.snapshot);
     if (!hasProposals) return;
 
     const showMolochMenuOptions = app.user.activeAccount && app.chain?.network === ChainNetwork.Moloch;
@@ -249,9 +248,9 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
       !app.community && ((app.chain?.base === ChainBase.Substrate && app.chain.network !== ChainNetwork.Darwinia)
                          || app.chain?.base === ChainBase.CosmosSDK
                          || app.chain?.network === ChainNetwork.Sputnik
-                         || MolochTypes.EventChains.find((c) => c === app.chain.network)
-                         || CompoundTypes.EventChains.find((c) => c === app.chain.network)
-                         || AaveTypes.EventChains.find((c) => c === app.chain.network))
+                         || app.chain?.network === ChainNetwork.Moloch
+                         || app.chain?.network === ChainNetwork.Compound
+                         || app.chain?.network === ChainNetwork.Aave)
         && m(Button, {
           fluid: true,
           rounded: true,

--- a/client/scripts/views/modals/create_community_modal.ts
+++ b/client/scripts/views/modals/create_community_modal.ts
@@ -554,7 +554,7 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
             jwt: app.user.jwt,
             type: 'token',
             base: 'ethereum',
-            network: slugify(name),
+            network: 'erc20',
             node_url: 'wss://mainnet.infura.io/ws',
           }).then(async (res) => {
             await initAppState(false);

--- a/client/scripts/views/pages/delegate.ts
+++ b/client/scripts/views/pages/delegate.ts
@@ -3,7 +3,6 @@ import 'pages/delegate.scss';
 import m from 'mithril';
 import app from 'state';
 import { ChainNetwork } from 'models';
-import { AaveTypes, CompoundTypes } from '@commonwealth/chain-events';
 
 import Sublayout from 'views/sublayout';
 import PageLoading from 'views/pages/loading';
@@ -61,9 +60,9 @@ interface IDelegateFormState {
 }
 
 const getDelegate = async (vnode: m.Vnode<{}, IDelegateFormState>) => {
-  if (CompoundTypes.EventChains.find((c) => c === app.chain.network)) {
+  if (app.chain.network === ChainNetwork.Compound) {
     vnode.state.currentDelegate = await (app.chain as Compound).chain.getDelegate();
-  } else if (AaveTypes.EventChains.find((c) => c === app.chain.network)) {
+  } else if (app.chain.network === ChainNetwork.Aave) {
     // TODO: switch on delegation type
     vnode.state.currentDelegate = await (app.chain as Aave).chain.getDelegate(app.user.activeAccount.address, 'voting');
   }
@@ -73,11 +72,11 @@ const getDelegate = async (vnode: m.Vnode<{}, IDelegateFormState>) => {
 const setDelegate = async (vnode: m.Vnode<{}, IDelegateFormState>) => {
   if (app.chain.apiInitialized) {
     let delegationPromise: Promise<any>;
-    if (CompoundTypes.EventChains.find((c) => c === app.chain.network)) {
+    if (app.chain.network === ChainNetwork.Compound) {
       delegationPromise = (app.chain as Compound).chain.setDelegate(
         vnode.state.form.address, vnode.state.form.amount
       );
-    } else if (AaveTypes.EventChains.find((c) => c === app.chain.network)) {
+    } else if (app.chain.network === ChainNetwork.Aave) {
       delegationPromise = (app.chain as Aave).chain.setDelegate(vnode.state.form.address);
     }
     if (delegationPromise) {
@@ -172,8 +171,8 @@ const DelegatePage: m.Component<{}> = {
       if (
         app.chain
         && app.chain.loaded
-        && !CompoundTypes.EventChains.find((c) => c === app.chain.network)
-        && !AaveTypes.EventChains.find((c) => c === app.chain.network)
+        && app.chain.network !== ChainNetwork.Compound
+        && app.chain.network !== ChainNetwork.Aave
       ) {
         return m(PageNotFound, {
           title: 'Delegate Page',

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -5,7 +5,6 @@ import $ from 'jquery';
 import _ from 'lodash';
 import moment from 'moment';
 import { Checkbox, Button, Icons, ListItem, Table, Tag, Grid, Col, SelectList, RadioGroup } from 'construct-ui';
-import { SubstrateEvents, SubstrateTypes, IChainEventKind, TitlerFilter } from '@commonwealth/chain-events';
 
 import app from 'state';
 import { NotificationSubscription, ChainInfo, CommunityInfo, ChainNetwork } from 'models';

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -28,7 +28,6 @@ import NewProposalPage from 'views/pages/new_proposal/index';
 import PageNotFound from 'views/pages/404';
 import Listing from 'views/pages/listing';
 import ErrorPage from 'views/pages/error';
-import { AaveTypes, CompoundTypes } from '@commonwealth/chain-events';
 import NearSputnik from 'controllers/chain/near/sputnik/adapter';
 import AaveProposalCardDetail from '../components/proposals/aave_proposal_card_detail';
 
@@ -173,8 +172,8 @@ const ProposalsPage: m.Component<{}> = {
 
     const onSubstrate = app.chain && app.chain.base === ChainBase.Substrate;
     const onMoloch = app.chain && app.chain.network === ChainNetwork.Moloch;
-    const onCompound = app.chain && CompoundTypes.EventChains.find((c) => c === app.chain.network);
-    const onAave = app.chain && AaveTypes.EventChains.find((c) => c === app.chain.network);
+    const onCompound = app.chain && app.chain.network === ChainNetwork.Compound;
+    const onAave = app.chain && app.chain.network === ChainNetwork.Aave;
     const onSputnik = app.chain && app.chain.network === ChainNetwork.Sputnik;
 
     const modLoading = loadSubstrateModules('Proposals', getModules);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.4.0",
-    "@commonwealth/chain-events": "0.9.3",
+    "@commonwealth/chain-events": "0.10.0",
     "@cosmjs/amino": "^0.26.1",
     "@cosmjs/proto-signing": "^0.26.1",
     "@cosmjs/stargate": "^0.26.1",

--- a/server-test.ts
+++ b/server-test.ts
@@ -10,8 +10,6 @@ import express from 'express';
 import SessionSequelizeStore from 'connect-session-sequelize';
 import WebSocket from 'ws';
 
-import { SubstrateTypes } from '@commonwealth/chain-events';
-
 import { SESSION_SECRET } from './server/config';
 import setupAPI from './server/router';
 import setupPassport from './server/passport';
@@ -269,24 +267,6 @@ const resetServer = (debug = false): Promise<void> => {
         [ 'wss://mainnet.infura.io/ws', 'sushi', '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2'],
       ];
       await Promise.all(nodes.map(([ url, chain, address ]) => (models['ChainNode'].create({ chain, url, address }))));
-
-      // initialize chain event types
-      // we don't need to do this on regular reset, because incoming
-      // chain events create their own types, but for testing purposes
-      // we should have these pre-populated.
-      const initChainEventTypes = (chain) => {
-        return Promise.all(
-          SubstrateTypes.EventKinds.map((event_name) => {
-            return models['ChainEventType'].create({
-              id: `${chain}-${event_name}`,
-              chain,
-              event_name,
-            });
-          })
-        );
-      };
-
-      await initChainEventTypes('edgeware');
 
       if (debug) console.log('Database reset!');
       resolve();

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { SubstrateEvents, SubstrateTypes, chainSupportedBy } from '@commonwealth/chain-events';
+import { SubstrateEvents, SubstrateTypes } from '@commonwealth/chain-events';
 import session from 'express-session';
 import Rollbar from 'rollbar';
 import express from 'express';
@@ -87,12 +87,18 @@ async function main() {
       } else if (CHAIN_EVENTS) {
         chains = CHAIN_EVENTS.split(',');
       }
-      const subscribers = await setupChainEventListeners(null, chains, SKIP_EVENT_CATCHUP);
+      const subscribers = await setupChainEventListeners(
+        null,
+        chains,
+        SKIP_EVENT_CATCHUP
+      );
       // construct storageFetchers needed for the identity cache
       const fetchers = {};
-      for (const [ chain, subscriber ] of Object.entries(subscribers)) {
-        if (chainSupportedBy(chain, SubstrateTypes.EventChains)) {
-          fetchers[chain] = new SubstrateEvents.StorageFetcher(subscriber.api);
+      for (const [node, subscriber] of subscribers) {
+        if (node.Chain.base === 'substrate') {
+          fetchers[node.chain] = new SubstrateEvents.StorageFetcher(
+            subscriber.api
+          );
         }
       }
       await (<IdentityFetchCache>identityFetchCache).start(models, fetchers);

--- a/server/eventHandlers/entityArchival.ts
+++ b/server/eventHandlers/entityArchival.ts
@@ -11,7 +11,6 @@ import {
   IChainEntityKind,
   IChainEventData,
   SubstrateTypes,
-  EventSupportingChainT
 } from '@commonwealth/chain-events';
 
 import { factory, formatFilename } from '../../shared/logging';
@@ -127,13 +126,13 @@ export default class extends IEventHandler {
       return dbEvent;
     };
 
-    const entity = eventToEntity(chain as EventSupportingChainT, event.data.kind);
+    const entity = eventToEntity(event.network, event.data.kind);
     if (!entity) {
       log.info(`no archival action needed for event of kind ${event.data.kind.toString()}`);
       return dbEvent;
     }
     const [ entityKind, updateType ] = entity;
-    const fieldName = entityToFieldName(chain as EventSupportingChainT, entityKind);
+    const fieldName = entityToFieldName(event.network, entityKind);
     const fieldValue = event.data[fieldName].toString();
     const author = event.data['proposer'];
     switch (updateType) {
@@ -148,7 +147,7 @@ export default class extends IEventHandler {
         return updateEntityFn(entityKind, fieldValue, true);
       }
       default: {
-        return null
+        return null;
       }
     }
   }

--- a/server/eventHandlers/storage.ts
+++ b/server/eventHandlers/storage.ts
@@ -82,7 +82,8 @@ export default class extends IEventHandler {
     const [ dbEventType, created ] = await this._models.ChainEventType.findOrCreate({
       where: {
         id: `${chain}-${event.data.kind.toString()}`,
-        chain: chain,
+        chain,
+        event_network: event.network,
         event_name: event.data.kind.toString(),
       }
     });

--- a/server/migrations/20211006161514-set-token-network-to-erc20.js
+++ b/server/migrations/20211006161514-set-token-network-to-erc20.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkUpdate(
+        'Chains',
+        { type: 'dao' },
+        { id: 'compound' },
+        { transaction: t }
+      );
+      await queryInterface.bulkUpdate(
+        'Chains',
+        { network: 'erc20' },
+        {
+          type: 'token',
+          base: 'ethereum',
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      const tokens = await queryInterface.sequelize.query(
+        "SELECT id FROM \"Chains\" WHERE type = 'token' AND base = 'ethereum';",
+        { transaction: t }
+      );
+      for (const { id } of tokens[0]) {
+        await queryInterface.bulkUpdate(
+          'Chains',
+          { network: id },
+          { id },
+          { transaction: t }
+        );
+      }
+      await queryInterface.bulkUpdate(
+        'Chains',
+        { type: 'token' },
+        { id: 'compound' },
+        { transaction: t }
+      );
+    });
+  },
+};

--- a/server/migrations/20211006172112-add-event-network.js
+++ b/server/migrations/20211006172112-add-event-network.js
@@ -1,0 +1,40 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // add the new column
+      await queryInterface.addColumn(
+        'ChainEventTypes',
+        'event_network',
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        { transaction: t }
+      );
+
+      // update all types
+      await queryInterface.sequelize.query(
+        'UPDATE "ChainEventTypes" SET event_network=\'substrate\' WHERE chain IN (SELECT id FROM "Chains" WHERE base = \'substrate\');',
+        {
+          type: queryInterface.sequelize.QueryTypes.UPDATE,
+          transaction: t,
+        }
+      );
+
+      for (const n of ['compound', 'aave', 'erc20', 'moloch']) {
+        await queryInterface.sequelize.query(
+          'UPDATE "ChainEventTypes" SET event_network=:n WHERE chain IN (SELECT id FROM "Chains" WHERE network = :n);',
+          {
+            replacements: { n },
+            type: queryInterface.sequelize.QueryTypes.UPDATE,
+            transaction: t,
+          }
+        );
+      }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('ChainEventTypes', 'event_network');
+  },
+};

--- a/server/models/chain_event.ts
+++ b/server/models/chain_event.ts
@@ -2,7 +2,7 @@ import * as Sequelize from 'sequelize';
 import { Model, DataTypes } from 'sequelize';
 import { ModelStatic } from './types';
 
-import { ChainEventTypeAttributes } from './chain_event_type';
+import { ChainEventTypeAttributes, ChainEventTypeInstance } from './chain_event_type';
 import { ChainEntityAttributes } from './chain_entity';
 
 export interface ChainEventAttributes {
@@ -10,7 +10,7 @@ export interface ChainEventAttributes {
   block_number: number;
   id?: number;
   entity_id?: number;
-  event_data: object;
+  event_data: any;
   created_at?: Date;
   updated_at?: Date;
 
@@ -19,7 +19,10 @@ export interface ChainEventAttributes {
 }
 
 export interface ChainEventInstance
-extends Model<ChainEventAttributes>, ChainEventAttributes {}
+  extends Model<ChainEventAttributes>,
+    ChainEventAttributes {
+  getChainEventType: Sequelize.HasOneGetAssociationMixin<ChainEventTypeInstance>;
+}
 
 export type ChainEventModelStatic = ModelStatic<ChainEventInstance>
 

--- a/server/models/chain_event_type.ts
+++ b/server/models/chain_event_type.ts
@@ -7,6 +7,7 @@ import { ModelStatic } from './types';
 export interface ChainEventTypeAttributes {
   id: string;
   chain: string;
+  event_network: string;
   event_name: string;
   ChainEvents?: ChainEventAttributes[];
   Chain?: ChainAttributes;
@@ -25,6 +26,8 @@ export default (
     // id = chain-event_name (event_name is value of string enum)
     id: { type: dataTypes.STRING, primaryKey: true },
     chain: { type: dataTypes.STRING, allowNull: false },
+    // should never be null, but added here for migration purposes
+    event_network: { type: dataTypes.STRING, allowNull: true },
     event_name: { type: dataTypes.STRING, allowNull: false },
   }, {
     tableName: 'ChainEventTypes',

--- a/server/routes/createChain.ts
+++ b/server/routes/createChain.ts
@@ -82,7 +82,7 @@ const createChain = async (
     }
   }
 
-  const { website, discord, element, telegram, github, icon_url, node_url } = req.body;
+  const { website, discord, element, telegram, github, icon_url, node_url, network } = req.body;
 
   if (!node_url || !node_url.trim()) {
     return next(new Error(Errors.NoNodeUrl));
@@ -123,7 +123,7 @@ const createChain = async (
     icon_url: req.body.icon_url,
     description: req.body.description,
     active: true,
-    network: req.body.id,
+    network: req.body.network,
     type: req.body.type,
     website: req.body.website,
     discord: req.body.discord,

--- a/server/routes/getTokenForum.ts
+++ b/server/routes/getTokenForum.ts
@@ -31,7 +31,7 @@ const getTokenForum = async (
           where: { id: token.id },
           defaults: {
             active: true,
-            network: token.id,
+            network: 'erc20',
             type: 'token',
             icon_url: token.icon_url,
             symbol: token.symbol,

--- a/server/scripts/chainEventsConsumer.ts
+++ b/server/scripts/chainEventsConsumer.ts
@@ -1,7 +1,4 @@
-import {
-  SubstrateTypes,
-  CWEvent,
-} from '@commonwealth/chain-events';
+import { SubstrateTypes, CWEvent } from '@commonwealth/chain-events';
 import * as WebSocket from 'ws';
 import RabbitMQConfig from '../util/rabbitmq/RabbitMQConfig';
 
@@ -19,20 +16,13 @@ import models from '../database';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-const setupChainEventListeners = async (
-  wss: WebSocket.Server,
-): Promise<{}> => {
+const setupChainEventListeners = async (wss: WebSocket.Server): Promise<{}> => {
   // writes events into the db as ChainEvents rows
-  const storageHandler = new EventStorageHandler(
-    models,
-    null
-  );
+  const storageHandler = new EventStorageHandler(models, null);
 
   // emits notifications by writing into the db's Notifications table, and also optionally
   // sending a notification to the client via websocket
-  const excludedNotificationEvents = [
-    SubstrateTypes.EventKind.DemocracyTabled
-  ];
+  const excludedNotificationEvents = [SubstrateTypes.EventKind.DemocracyTabled];
   const notificationHandler = new EventNotificationHandler(
     models,
     wss,
@@ -40,17 +30,18 @@ const setupChainEventListeners = async (
   );
 
   // creates and updates ChainEntity rows corresponding with entity-related events
-  const entityArchivalHandler = new EntityArchivalHandler(
-    models, null, wss
-  );
+  const entityArchivalHandler = new EntityArchivalHandler(models, null, wss);
 
   // creates empty Address and OffchainProfile models for users who perform certain
   // actions, like voting on proposals or registering an identity
-  const profileCreationHandler = new ProfileCreationHandler(
-    models, null
-  );
+  const profileCreationHandler = new ProfileCreationHandler(models, null);
 
-  const allChainEventHandlers = [storageHandler, notificationHandler, entityArchivalHandler, profileCreationHandler];
+  const allChainEventHandlers = [
+    storageHandler,
+    notificationHandler,
+    entityArchivalHandler,
+    profileCreationHandler,
+  ];
 
   // populates identity information in OffchainProfiles when received (Substrate only)
   const identityHandler = new IdentityHandler(models, null);
@@ -61,12 +52,14 @@ const setupChainEventListeners = async (
 
   const substrateEventHandlers = [identityHandler, userFlagsHandler];
 
-  const substrateChains = (await models.Chain.findAll({
-    attributes: ['id'],
-    where: {
-      'base': 'substrate'
-    }
-  })).map((o) => o.id);
+  const substrateChains = (
+    await models.Chain.findAll({
+      attributes: ['id'],
+      where: {
+        base: 'substrate',
+      },
+    })
+  ).map((o) => o.id);
 
   // feed the events into their respective handlers
   async function processClassicEvents(event: CWEvent): Promise<void> {
@@ -78,7 +71,14 @@ const setupChainEventListeners = async (
         // unknown chain event originates from the webhookNotifier which does not support erc20 events
         // and thus throws if an erc20 event is given
         if (err.message !== 'unknown chain event') {
-          log.error(`Classic event handle failure for the following event: ${JSON.stringify(event, null, 2)}`, err);
+          log.error(
+            `Classic event handle failure for the following event: ${JSON.stringify(
+              event,
+              null,
+              2
+            )}`,
+            err
+          );
           break;
         }
       }

--- a/server/scripts/migrateCouncillorValidatorFlags.ts
+++ b/server/scripts/migrateCouncillorValidatorFlags.ts
@@ -3,13 +3,12 @@
  */
 
 import _ from 'underscore';
-import { SubstrateTypes, SubstrateEvents, chainSupportedBy } from '@commonwealth/chain-events';
+import { SubstrateEvents } from '@commonwealth/chain-events';
 import { AccountId, Balance } from '@polkadot/types/interfaces';
 import { Vec } from '@polkadot/types';
 import { Codec } from '@polkadot/types/types';
 
 import UserFlagsHandler from '../eventHandlers/userFlags';
-import { ChainNodeInstance } from '../models/chain_node';
 
 import { factory, formatFilename } from '../../shared/logging';
 import { constructSubstrateUrl } from '../../shared/substrate';
@@ -18,21 +17,21 @@ const log = factory.getLogger(formatFilename(__filename));
 export default async function (models, chain?: string): Promise<void> {
   // 1. fetch the node and url of supported/selected chains
   log.info('Fetching node info for chain entity migrations...');
-  if (chain && !chainSupportedBy(chain, SubstrateTypes.EventChains)) {
-    throw new Error('unsupported chain');
-  }
-  const chains = !chain ? SubstrateTypes.EventChains.concat() : [ chain ];
-
-  // query one node for each supported chain
-  const nodes: ChainNodeInstance[] = (await Promise.all(chains.map((c) => {
-    return models.ChainNode.findOne({
-      where: { chain: c },
-      include: [{
+  const whereOption = chain ? { chain } : {};
+  const nodes = await models.ChainNode.findAll({
+    where: whereOption,
+    include: [
+      {
         model: models.Chain,
-        where: { active: true },
+        where: {
+          active: true,
+          has_chain_events_listener: true,
+          base: 'substrate',
+        },
         required: true,
-      }] });
-  }))).filter((n) => !!n);
+      },
+    ],
+  });
   if (!nodes) {
     throw new Error('no nodes found for chain entity migration');
   }

--- a/server/scripts/migrateIdentities.ts
+++ b/server/scripts/migrateIdentities.ts
@@ -6,10 +6,9 @@
  */
 
 import _ from 'underscore';
-import { SubstrateTypes, SubstrateEvents, chainSupportedBy } from '@commonwealth/chain-events';
+import { SubstrateEvents } from '@commonwealth/chain-events';
 import { OffchainProfileInstance } from '../models/offchain_profile';
 import IdentityEventHandler from '../eventHandlers/identity';
-import { ChainNodeInstance } from '../models/chain_node';
 import { constructSubstrateUrl } from '../../shared/substrate';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
@@ -17,23 +16,23 @@ const log = factory.getLogger(formatFilename(__filename));
 export default async function (models, chain?: string): Promise<void> {
   // 1. fetch the node and url of supported/selected chains
   log.info('Fetching node info for identity migrations...');
-  if (chain && !chainSupportedBy(chain, SubstrateTypes.EventChains)) {
-    throw new Error('unsupported chain');
-  }
-  const chains = !chain ? SubstrateTypes.EventChains.concat() : [ chain ];
-
-  // query one node for each supported chain
-  const nodes: ChainNodeInstance[] = (await Promise.all(chains.map((c) => {
-    return models.ChainNode.findOne({
-      where: { chain: c },
-      include: [{
+  const whereOption = chain ? { chain } : {};
+  const nodes = await models.ChainNode.findAll({
+    where: whereOption,
+    include: [
+      {
         model: models.Chain,
-        where: { active: true },
+        where: {
+          active: true,
+          has_chain_events_listener: true,
+          base: 'substrate',
+        },
         required: true,
-      }] });
-  }))).filter((n) => !!n);
+      },
+    ],
+  });
   if (!nodes) {
-    throw new Error('no nodes found for identity migration');
+    throw new Error('no nodes found for chain entity migration');
   }
 
   // 2. for each node, fetch and migrate identities

--- a/server/webhookNotifier.ts
+++ b/server/webhookNotifier.ts
@@ -1,7 +1,7 @@
 import request from 'superagent';
 import { Op } from 'sequelize';
 import { capitalize } from 'lodash';
-import { AaveEvents, chainSupportedBy, CompoundEvents, MolochEvents, SubstrateEvents } from '@commonwealth/chain-events';
+import { Label as ChainEventLabel } from '@commonwealth/chain-events';
 
 import { NotificationCategories } from '../shared/types';
 import { smartTrim, validURL, renderQuillDeltaToText } from '../shared/utils';
@@ -24,24 +24,8 @@ const REGEX_IMAGE = /\b(https?:\/\/\S*?\.(?:png|jpe?g|gif)(?:\?(?:(?:(?:[\w_-]+=
 const REGEX_EMOJI = /([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/g;
 
 const getFilteredContent = (content, address) => {
-  let event;
   if (content.chainEvent && content.chainEventType) {
-    let labelerFn;
-    if (chainSupportedBy(content.chainEventType.chain, SubstrateEvents.Types.EventChains)) {
-      labelerFn = SubstrateEvents.Label;
-    } else if (chainSupportedBy(content.chainEventType.chain, MolochEvents.Types.EventChains)) {
-      labelerFn = MolochEvents.Label;
-    } else if (chainSupportedBy(content.chainEventType.chain, CompoundEvents.Types.EventChains)) {
-      labelerFn = CompoundEvents.Label;
-    } else if (chainSupportedBy(content.chainEventType.chain, AaveEvents.Types.EventChains)) {
-      labelerFn = AaveEvents.Label;
-    }
-    if (!labelerFn) throw new Error('unknown chain event');
-    event = labelerFn(
-      content.chainEvent.block_number,
-      content.chainEventType.chain,
-      content.chainEvent.event_data
-    );
+    const event = ChainEventLabel(content.chainEventType.chain, content.chainEvent);
     const title = `${capitalize(content.chainEventType.chain)}`;
     const chainEventLink = `${SERVER_URL}/${content.chainEventType.chain}`;
     const fulltext = `${event.heading} on ${capitalize(content.chainEventType?.chain)} at block`

--- a/test/unit/events/entityArchivalHandler.spec.ts
+++ b/test/unit/events/entityArchivalHandler.spec.ts
@@ -4,7 +4,11 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
 import { EventEmitter } from 'events';
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import {
+  CWEvent,
+  SubstrateTypes,
+  SupportedNetwork,
+} from '@commonwealth/chain-events';
 
 import { resetDatabase } from '../../../server-test';
 import models from '../../../server/database';
@@ -28,6 +32,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should create chain entity from event', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 3,
@@ -67,6 +72,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should update chain entity from event', async () => {
     const createEvent: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 20,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.TreasuryProposed,
         proposalIndex: 5,
@@ -79,6 +85,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
 
     const updateEvent: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 25,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.TreasuryAwarded,
         proposalIndex: 5,
@@ -134,6 +141,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should ignore unrelated events', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 11,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Slash,
         validator: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
@@ -161,6 +169,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should ignore duplicate entities', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 6,

--- a/test/unit/events/identityHandler.spec.ts
+++ b/test/unit/events/identityHandler.spec.ts
@@ -8,7 +8,7 @@ import jwtLib from 'jsonwebtoken';
 import {
   CWEvent,
   SubstrateTypes,
-  SubstrateEvents
+  SupportedNetwork,
 } from '@commonwealth/chain-events';
 
 import * as modelUtils from '../../util/modelUtils';
@@ -133,6 +133,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should add identity to existing offchain profile', async () => {
     const event: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: address,
@@ -157,6 +158,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should add first judgement to existing offchain profile', async () => {
     const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: address,
@@ -166,6 +168,7 @@ describe('Identity Chain Event Handler Tests', () => {
     };
     const judgementEvent: CWEvent<SubstrateTypes.IJudgementGiven> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.JudgementGiven,
         who: address,
@@ -188,6 +191,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should add more judgements to existing offchain profile', async () => {
     const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: address,
@@ -200,6 +204,7 @@ describe('Identity Chain Event Handler Tests', () => {
     };
     const judgementEvent: CWEvent<SubstrateTypes.IJudgementGiven> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.JudgementGiven,
         who: address,
@@ -231,6 +236,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should remove identity on identity-cleared', async () => {
     const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: address,
@@ -243,6 +249,7 @@ describe('Identity Chain Event Handler Tests', () => {
     };
     const clearEvent: CWEvent<SubstrateTypes.IIdentityCleared> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentityCleared,
         who: address
@@ -261,6 +268,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should remove identity on identity-killed', async () => {
     const setEvent: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: address,
@@ -273,6 +281,7 @@ describe('Identity Chain Event Handler Tests', () => {
     };
     const killedEvent: CWEvent<SubstrateTypes.IIdentityKilled> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentityKilled,
         who: address
@@ -291,6 +300,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should do nothing if no corresponding profile found', async () => {
     const event: CWEvent<SubstrateTypes.IIdentitySet> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.IdentitySet,
         who: 'bob',
@@ -312,6 +322,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should not add judgement to offchain profile without identity', async () => {
     const judgementEvent: CWEvent<SubstrateTypes.IJudgementGiven> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.JudgementGiven,
         who: address,
@@ -331,6 +342,7 @@ describe('Identity Chain Event Handler Tests', () => {
   it('should do nothing on unrelated events', async () => {
     const event: CWEvent = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 0,

--- a/test/unit/events/migrationHandler.spec.ts
+++ b/test/unit/events/migrationHandler.spec.ts
@@ -4,7 +4,11 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
 
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import {
+  CWEvent,
+  SubstrateTypes,
+  SupportedNetwork,
+} from '@commonwealth/chain-events';
 
 import { resetDatabase } from '../../../server-test';
 import models from '../../../server/database';
@@ -28,6 +32,7 @@ describe('Edgeware Migration Event Handler Tests', () => {
     // setup
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 0,
@@ -63,6 +68,7 @@ describe('Edgeware Migration Event Handler Tests', () => {
   it('should upgrade existing event', async () => {
     const legacyEvent: any = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.PreimageNoted,
         proposalHash: 'hash',
@@ -71,6 +77,7 @@ describe('Edgeware Migration Event Handler Tests', () => {
     };
     const currentEvent: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.PreimageNoted,
         proposalHash: 'hash',
@@ -109,6 +116,7 @@ describe('Edgeware Migration Event Handler Tests', () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 11,
       includeAddresses: ['5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'],
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Slash,
         validator: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
@@ -126,7 +134,7 @@ describe('Edgeware Migration Event Handler Tests', () => {
   it('should ignore unknown events', async () => {
     const event = {
       blockNumber: 13,
-
+      network: SupportedNetwork.Substrate,
       data: {
         kind: 'democracy-exploded',
         whoops: true,

--- a/test/unit/events/notificationHandler.spec.ts
+++ b/test/unit/events/notificationHandler.spec.ts
@@ -4,7 +4,11 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
 
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import {
+  CWEvent,
+  SubstrateTypes,
+  SupportedNetwork,
+} from '@commonwealth/chain-events';
 
 import { resetDatabase } from '../../../server-test';
 import models from '../../../server/database';
@@ -78,6 +82,7 @@ describe('Event Handler Tests', () => {
     // setup
     const event: CWEvent = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 0,
@@ -115,6 +120,7 @@ describe('Event Handler Tests', () => {
     const event: CWEvent = {
       blockNumber: 11,
       includeAddresses: ['5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'],
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Slash,
         validator: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
@@ -152,6 +158,7 @@ describe('Event Handler Tests', () => {
     const event: CWEvent = {
       blockNumber: 12,
       excludeAddresses: ['5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'],
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 1,
@@ -190,6 +197,7 @@ describe('Event Handler Tests', () => {
     const event: CWEvent = {
       blockNumber: 12,
       excludeAddresses: ['5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'],
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 1,
@@ -215,6 +223,7 @@ describe('Event Handler Tests', () => {
     // setup
     const event: CWEvent = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 0,

--- a/test/unit/events/rabbitmqProducer.spec.ts
+++ b/test/unit/events/rabbitmqProducer.spec.ts
@@ -23,6 +23,7 @@ describe.skip('RabbitMQ producer integration tests', () => {
       assert.equal(content.blockNumber, 10);
       assert.equal(content.data, {});
       assert.equal(content.chain, 'polkadot');
+      assert.equal(content.network, 'substrate');
       assert.equal(content.received, 123);
     });
 
@@ -30,6 +31,7 @@ describe.skip('RabbitMQ producer integration tests', () => {
       blockNumber: 10,
       data: {},
       chain: 'polkadot',
+      network: 'substrate',
       received: 123,
     });
   });
@@ -40,6 +42,7 @@ describe.skip('RabbitMQ producer integration tests', () => {
       assert.equal(content.blockNumber, 10);
       assert.equal(content.data, {});
       assert.equal(content.chain, 'polkadot');
+      assert.equal(content.network, 'substrate');
       assert.equal(content.received, 123);
     });
 
@@ -48,6 +51,7 @@ describe.skip('RabbitMQ producer integration tests', () => {
       data: {
         kind: 'dont-skip',
       },
+      network: 'substrate',
       chain: 'polkadot',
       received: 123,
     });
@@ -57,6 +61,7 @@ describe.skip('RabbitMQ producer integration tests', () => {
       data: {
         kind: 'skip',
       },
+      network: 'substrate',
       chain: 'polkadot',
       received: 77,
     });

--- a/test/unit/events/storageHandler.spec.ts
+++ b/test/unit/events/storageHandler.spec.ts
@@ -3,9 +3,12 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
-import BN from 'bn.js';
 
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import {
+  CWEvent,
+  SubstrateTypes,
+  SupportedNetwork,
+} from '@commonwealth/chain-events';
 
 import { resetDatabase } from '../../../server-test';
 import models from '../../../server/database';
@@ -29,6 +32,7 @@ describe('Event Storage Handler Tests', () => {
     // setup
     const event: CWEvent = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.DemocracyStarted,
         referendumIndex: 0,
@@ -65,6 +69,7 @@ describe('Event Storage Handler Tests', () => {
     // setup
     const event: CWEvent<SubstrateTypes.IPreimageNoted> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.PreimageNoted,
         proposalHash: 'hash',
@@ -107,6 +112,7 @@ describe('Event Storage Handler Tests', () => {
   it('should create chain event and type for unknown event type', async () => {
     const event = {
       blockNumber: 13,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: 'democracy-exploded',
         whoops: true,
@@ -139,6 +145,7 @@ describe('Event Storage Handler Tests', () => {
   it('should not create chain event for excluded event type', async () => {
     const event: CWEvent = {
       blockNumber: 13,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Reward,
         amount: '10000',
@@ -163,6 +170,7 @@ describe('Event Storage Handler Tests', () => {
   it('should create chain event if included address exists in db', async () => {
     const event: CWEvent = {
       blockNumber: 14,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Bonded,
         stash: loggedInAddr,
@@ -191,6 +199,7 @@ describe('Event Storage Handler Tests', () => {
   it('should not create chain event if no included address exists in db', async () => {
     const event: CWEvent = {
       blockNumber: 15,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Bonded,
         stash: 'alice',

--- a/test/unit/events/userFlagsHandler.spec.ts
+++ b/test/unit/events/userFlagsHandler.spec.ts
@@ -3,7 +3,11 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
-import { CWEvent, SubstrateTypes } from '@commonwealth/chain-events';
+import {
+  CWEvent,
+  SubstrateTypes,
+  SupportedNetwork,
+} from '@commonwealth/chain-events';
 
 import { resetDatabase } from '../../../server-test';
 import models from '../../../server/database';
@@ -56,6 +60,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should sync councillors from NewTerm event', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.ElectionNewTerm,
         round: 5,
@@ -91,6 +96,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should sync councillors from EmptyTerm event', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.ElectionEmptyTerm,
         round: 5,
@@ -125,6 +131,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should sync validators from StakingElection event', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.StakingElection,
         era: 5,
@@ -159,6 +166,7 @@ describe('Edgeware Archival Event Handler Tests', () => {
   it('should ignore unrelated event', async () => {
     const event: CWEvent<SubstrateTypes.IEventData> = {
       blockNumber: 10,
+      network: SupportedNetwork.Substrate,
       data: {
         kind: SubstrateTypes.EventKind.Reward,
         amount: '500',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,10 +1243,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@commonwealth/chain-events@0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.9.3.tgz#a6dc7cd6b3a86ca8ebe93ac9f12e2dd5dab7f0ae"
-  integrity sha512-VQY8YQiiJUYYoLDQMbIly25lUhDqRBt4860Cpy0jkikaFw6ngeK4NJJhRZ/cMMDWN3RnKsjZ6lYHLYAtrm1OwQ==
+"@commonwealth/chain-events@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@commonwealth/chain-events/-/chain-events-0.10.0.tgz#5dd0232b552d3a3dfd7539e3a648de856de901ae"
+  integrity sha512-S7enuOMh3FeqlcHBDdOndaq1AktfjHbd8mJjHaNysegFMbwyEuZBsFUZMwLeJfiCEPFycxGGQSl3+Fu3wxNTWQ==
   dependencies:
     "@edgeware/node-types" "^3.3.3"
     "@ethersproject/abi" "^5.0.0"


### PR DESCRIPTION
- Depends on https://github.com/hicommonwealth/chain-events/pull/86
  - This upgrade required removing any logic which hardcoded chain _names_, and instead now only relies on chain _networks_. Most changes in CW reflect this changing dependency.
  - We now _explicitly_ identify a ChainEvent's network as being Substrate if on chain.base === 'substrate', or else Aave/Compound/Moloch/ERC20 based on the chain.network column (see migration below).
- Two migrations:
  - The first migration sets ERC20 chain networks to "erc20" rather than identical to their id.
  - The second migration adds an "event_network" column to the ChainEventTypes table, which identifies the source network of the provided event, as per the SupportedNetwork enum in ChainEvents.
