### PR TITLE
Add compound expired check.

### DIFF
--- a/client/scripts/controllers/chain/ethereum/compound/governance.ts
+++ b/client/scripts/controllers/chain/ethereum/compound/governance.ts
@@ -107,9 +107,7 @@ export default class CompoundGovernance extends ProposalModule<
     const entities = this.app.chain.chainEntities.store.getByType(CompoundTypes.EntityKind.Proposal);
     console.log(`Found ${entities.length} proposals!`);
     entities.forEach((e) => this._entityConstructor(e));
-
-    // no init logic currently needed
-    // await Promise.all(this.store.getAll().map((p) => p.init()));
+    await Promise.all(this.store.getAll().map((p) => p.init()));
 
     // register new chain-event handlers
     this.app.chain.chainEntities.registerEntityHandler(
@@ -127,7 +125,7 @@ export default class CompoundGovernance extends ProposalModule<
       this.app.chain.id,
       chainToEventNetwork(this.app.chain.meta.chain),
       subscriber,
-      processor,
+      processor
     );
 
     this._initialized = true;

--- a/client/scripts/controllers/chain/ethereum/compound/proposal.ts
+++ b/client/scripts/controllers/chain/ethereum/compound/proposal.ts
@@ -1,11 +1,12 @@
 import moment from 'moment';
 import BN from 'bn.js';
+import { capitalize } from 'lodash';
+
+import { CompoundTypes } from '@commonwealth/chain-events';
+import { ProposalType } from 'types';
 
 import { EthereumCoin } from 'adapters/chain/ethereum/types';
 import { ICompoundProposalResponse } from 'adapters/chain/compound/types';
-import { capitalize } from 'lodash';
-import { ProposalType } from 'types';
-import { CompoundTypes } from '@commonwealth/chain-events';
 
 import {
   Proposal,
@@ -55,6 +56,7 @@ const backportEntityToAdapter = (
     executed: false,
     cancelled: false,
     completed: false,
+    expired: false,
     ...startData,
   };
 };
@@ -77,7 +79,9 @@ export default class CompoundProposal extends Proposal<
   private _Chain: CompoundChain;
   private _Gov: CompoundGovernance;
 
-  public get shortIdentifier() { return `${capitalize(this._Accounts?.app.activeChainId())}Proposal-${this.data.identifier}`; }
+  public get shortIdentifier() {
+    return `${capitalize(this._Accounts?.app.activeChainId())}Proposal-${this.data.identifier}`;
+  }
   public get title(): string {
     try {
       const parsed = JSON.parse(this.data.description);
@@ -154,9 +158,12 @@ export default class CompoundProposal extends Proposal<
     const blockNumber = this._Gov.app.chain.block.height;
     if (this.data.cancelled) return CompoundTypes.ProposalState.Canceled;
     if (this.data.executed) return CompoundTypes.ProposalState.Executed;
+    if (this.data.expired) return CompoundTypes.ProposalState.Expired;
     if (this.data.queued) return CompoundTypes.ProposalState.Queued;
-    if (blockNumber <= this.data.startBlock) return CompoundTypes.ProposalState.Pending;
-    if (blockNumber <= this.data.endBlock) return CompoundTypes.ProposalState.Active;
+    if (blockNumber <= this.data.startBlock)
+      return CompoundTypes.ProposalState.Pending;
+    if (blockNumber <= this.data.endBlock)
+      return CompoundTypes.ProposalState.Active;
 
     const votes = this.getVotes();
     const yesPower = sumVotes(votes.filter((v) => v.choice));
@@ -164,20 +171,24 @@ export default class CompoundProposal extends Proposal<
     if (yesPower <= noPower || yesPower <= this._Gov.quorumVotes)
       return CompoundTypes.ProposalState.Defeated;
     if (!this.data.eta) return CompoundTypes.ProposalState.Succeeded;
-    return CompoundTypes.ProposalState.Expired;
+    console.warn(`Invalid state for proposal: ${this}`);
+    return null;
   }
 
   public get endTime(): ProposalEndTime {
     const state = this.state;
 
     // waiting to start
-    if (state === CompoundTypes.ProposalState.Pending) return { kind: 'fixed_block', blocknum: this.data.startBlock };
+    if (state === CompoundTypes.ProposalState.Pending)
+      return { kind: 'fixed_block', blocknum: this.data.startBlock };
 
     // started
-    if (state === CompoundTypes.ProposalState.Active) return { kind: 'fixed_block', blocknum: this.data.endBlock };
+    if (state === CompoundTypes.ProposalState.Active)
+      return { kind: 'fixed_block', blocknum: this.data.endBlock };
 
     // queued but not ready for execution
-    if (state === CompoundTypes.ProposalState.Queued) return { kind: 'fixed', time: moment(this.data.eta) };
+    if (state === CompoundTypes.ProposalState.Queued)
+      return { kind: 'fixed', time: moment(this.data.eta) };
 
     // unavailable if: waiting to passed/failed but not in queue, or completed
     return { kind: 'unavailable' };
@@ -224,13 +235,25 @@ export default class CompoundProposal extends Proposal<
 
     entity.chainEvents.sort((e1, e2) => e1.blockNumber - e2.blockNumber).forEach((e) => this.update(e));
 
-    // special case for expiration because no event is emitted
-    if (this.state === CompoundTypes.ProposalState.Expired || this.state === CompoundTypes.ProposalState.Defeated) {
-      this.complete(this._Gov.store);
+    this._Gov.store.add(this);
+  }
+
+  public async init() {
+    // fetch state from chain to check for expired (no event emitted + no way to compute w/o timelock)
+    const queriedState = await this._Gov.api.Contract.state(this.data.id);
+    if (queriedState === CompoundTypes.ProposalState.Expired) {
+      this.data.expired = true;
     }
 
     this._initialized = true;
-    this._Gov.store.add(this);
+
+    // special case for expiration because no event is emitted
+    if (
+      this.state === CompoundTypes.ProposalState.Expired ||
+      this.state === CompoundTypes.ProposalState.Defeated
+    ) {
+      this.complete(this._Gov.store);
+    }
   }
 
   public update(e: ChainEvent) {
@@ -243,7 +266,7 @@ export default class CompoundProposal extends Proposal<
         const vote = new CompoundProposalVote(
           this._Accounts.get(e.data.voter),
           e.data.support ? CompoundVote.YES : CompoundVote.NO,
-          power,
+          power
         );
         this.addOrUpdateVote(vote);
         break;

--- a/shared/adapters/chain/compound/types.ts
+++ b/shared/adapters/chain/compound/types.ts
@@ -1,9 +1,14 @@
 import { CompoundTypes } from '@commonwealth/chain-events';
 import { ICompletable } from '../../shared';
 
-export type ICompoundProposalResponse = Omit<CompoundTypes.IProposalCreated, 'kind'> & ICompletable & {
-  eta?: number;
-  queued: boolean;
-  executed: boolean;
-  cancelled: boolean;
-};
+export type ICompoundProposalResponse = Omit<
+  CompoundTypes.IProposalCreated,
+  'kind'
+> &
+  ICompletable & {
+    eta?: number;
+    queued: boolean;
+    executed: boolean;
+    cancelled: boolean;
+    expired: boolean;
+  };


### PR DESCRIPTION
Had an issue where if a Compound proposal expired, we would not know, as Comp governance does not emit expired events. Expired status is instead based on the grace period that comes from Timelock, which we cannot query directly without adding much more serious initialization logic. However, the Compound `state()` call allows us to access the current state, so if that happens to be expired, we can now set that.

This will not actually fix the Queued countdown bug we saw earlier, though, as that was the result of the infura subscription issue missing `Executed` events.