### PR TITLE
Change Threshold check server-side to not check balances if 0

### DIFF
--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -41,7 +41,7 @@ export interface OffchainThreadAttributes {
   OffchainAttachments?: OffchainAttachmentAttributes[] | OffchainAttachmentAttributes['id'][];
   ChainEntity?: ChainEntityAttributes;
   collaborators?: AddressAttributes[];
-  OffchainTopic?: OffchainTopicAttributes;
+  topic?: OffchainTopicAttributes;
 }
 
 export interface OffchainThreadInstance extends Model<OffchainThreadAttributes>, OffchainThreadAttributes {

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -6,7 +6,6 @@ import { ChainAttributes } from './chain';
 import { OffchainCommunityAttributes } from './offchain_community';
 import { OffchainAttachmentAttributes } from './offchain_attachment';
 import { ChainEntityAttributes } from './chain_entity';
-import { OffchainTopicAttributes } from './offchain_topic';
 
 export interface OffchainThreadAttributes {
   address_id: number;
@@ -40,8 +39,7 @@ export interface OffchainThreadAttributes {
   Address?: AddressAttributes;
   OffchainAttachments?: OffchainAttachmentAttributes[] | OffchainAttachmentAttributes['id'][];
   ChainEntity?: ChainEntityAttributes;
-  collaborators?: AddressAttributes[];
-  topic?: OffchainTopicAttributes;
+  collaborators?: AddressAttributes[]
 }
 
 export interface OffchainThreadInstance extends Model<OffchainThreadAttributes>, OffchainThreadAttributes {

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -6,6 +6,7 @@ import { ChainAttributes } from './chain';
 import { OffchainCommunityAttributes } from './offchain_community';
 import { OffchainAttachmentAttributes } from './offchain_attachment';
 import { ChainEntityAttributes } from './chain_entity';
+import { OffchainTopicAttributes } from './offchain_topic';
 
 export interface OffchainThreadAttributes {
   address_id: number;
@@ -39,7 +40,8 @@ export interface OffchainThreadAttributes {
   Address?: AddressAttributes;
   OffchainAttachments?: OffchainAttachmentAttributes[] | OffchainAttachmentAttributes['id'][];
   ChainEntity?: ChainEntityAttributes;
-  collaborators?: AddressAttributes[]
+  collaborators?: AddressAttributes[];
+  OffchainTopic?: OffchainTopicAttributes;
 }
 
 export interface OffchainThreadInstance extends Model<OffchainThreadAttributes>, OffchainThreadAttributes {

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -58,9 +58,10 @@ const createComment = async (
         const thread_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({
           where: { id: thread_id },
-          include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
+          include: [{ model: models.OffchainTopic, as: 'topic' }],
         });
-        const threshold = thread.OffchainTopic.token_threshold;
+        console.log(thread);
+        const threshold = thread.topic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -58,10 +58,12 @@ const createComment = async (
         const thread_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({
           where: { id: thread_id },
-          include: [{ model: models.OffchainTopic, as: 'topic' }],
+          // include: [{ model: models.OffchainTopic, as: 'topic' }],
         });
-        console.log(thread);
-        const threshold = thread.topic.token_threshold;
+        const topic = await models.OffchainTopic.findOne({
+          where: { id: thread.topic_id },
+        });
+        const threshold = topic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -59,8 +59,10 @@ const createComment = async (
         const topic_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({ where:{ stage, id: topic_id } });
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
-        const tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
-
+        let tokenBalance = new BN(0);
+        if (threshold) {
+          tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
+        }
         if (threshold && tokenBalance.lt(new BN(threshold))) return next(new Error(Errors.InsufficientTokenBalance));
       } catch (e) {
         log.error(`hasToken failed: ${e.message}`);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -58,7 +58,9 @@ const createComment = async (
         console.log(root_id);
         const stage = root_id.substring(0, root_id.indexOf('_'));
         const topic_id = root_id.substring(root_id.indexOf('_') + 1);
-        const thread = await models.OffchainThread.findOne({ where:{ stage, id: topic_id } });
+        console.log(stage);
+        console.log(topic_id);
+        const thread = await models.OffchainThread.findOne({ where:{ id: topic_id } });
         console.log('thread', thread);
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -58,7 +58,6 @@ const createComment = async (
         const thread_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({
           where: { id: thread_id },
-          // include: [{ model: models.OffchainTopic, as: 'topic' }],
         });
         const topic = await models.OffchainTopic.findOne({
           where: { id: thread.topic_id },

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -58,7 +58,7 @@ const createComment = async (
         const thread_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({
           where: { id: thread_id },
-          include: [models.OffchainTopic],
+          include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
         });
         const threshold = thread.OffchainTopic.token_threshold;
         let tokenBalance = new BN(0);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -55,11 +55,14 @@ const createComment = async (
     });
     if (!req.user.isAdmin && isAdmin.length === 0) {
       try {
+        console.log(root_id);
         const stage = root_id.substring(0, root_id.indexOf('_'));
         const topic_id = root_id.substring(root_id.indexOf('_') + 1);
         const thread = await models.OffchainThread.findOne({ where:{ stage, id: topic_id } });
+        console.log('thread', thread);
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);
+        console.log(threshold);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
         }

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -55,10 +55,12 @@ const createComment = async (
     });
     if (!req.user.isAdmin && isAdmin.length === 0) {
       try {
-        const stage = root_id.substring(0, root_id.indexOf('_'));
         const thread_id = root_id.substring(root_id.indexOf('_') + 1);
-        const thread = await models.OffchainThread.findOne({ where:{ id: thread_id } });
-        const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
+        const thread = await models.OffchainThread.findOne({
+          where: { id: thread_id },
+          include: [models.OffchainTopic],
+        });
+        const threshold = thread.OffchainTopic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -55,16 +55,11 @@ const createComment = async (
     });
     if (!req.user.isAdmin && isAdmin.length === 0) {
       try {
-        console.log(root_id);
         const stage = root_id.substring(0, root_id.indexOf('_'));
-        const topic_id = root_id.substring(root_id.indexOf('_') + 1);
-        console.log(stage);
-        console.log(topic_id);
-        const thread = await models.OffchainThread.findOne({ where:{ id: topic_id } });
-        console.log('thread', thread);
+        const thread_id = root_id.substring(root_id.indexOf('_') + 1);
+        const thread = await models.OffchainThread.findOne({ where:{ id: thread_id } });
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);
-        console.log(threshold);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
         }

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -50,7 +50,6 @@ const createReaction = async (
         if (thread_id) {
           thread = await models.OffchainThread.findOne({
             where: { id: thread_id },
-            // include: [{ model: models.OffchainTopic, as: 'topic' }],
           });
         } else if (comment_id) {
           const root_id = (
@@ -59,14 +58,12 @@ const createReaction = async (
           const comment_thread_id = root_id.substring(root_id.indexOf('_') + 1);
           thread = await models.OffchainThread.findOne({
             where: { id: comment_thread_id },
-            // include: [{ model: models.OffchainTopic, as: 'topic' }],
           });
         }
         const topic = await models.OffchainTopic.findOne({
           where: { id: thread.topic_id },
         });
         const threshold = topic.token_threshold;
-        // const threshold = thread.topic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -56,8 +56,12 @@ const createReaction = async (
           thread = await models.OffchainThread.findOne({ where:{ stage, id: topic_id } });
         }
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
-        const tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
-        if (threshold && tokenBalance.lt(new BN(threshold))) return next(new Error(Errors.InsufficientTokenBalance));
+        let tokenBalance = new BN(0);
+        if (threshold) {
+          tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
+        }
+        if (threshold && tokenBalance.lt(new BN(threshold)))
+          return next(new Error(Errors.InsufficientTokenBalance));
       } catch (e) {
         log.error(`hasToken failed: ${e.message}`);
         return next(new Error(Errors.CouldNotFetchTokenBalance));

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -51,9 +51,8 @@ const createReaction = async (
           thread = await models.OffchainThread.findOne({ where: { id: thread_id } });
         } else if (comment_id) {
           const root_id = (await models.OffchainComment.findOne({ where: { id: comment_id } })).root_id;
-          const stage = root_id.substring(0, root_id.indexOf('_'));
           const topic_id = root_id.substring(root_id.indexOf('_') + 1);
-          thread = await models.OffchainThread.findOne({ where:{ stage, id: topic_id } });
+          thread = await models.OffchainThread.findOne({ where:{ id: topic_id } });
         }
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -49,7 +49,6 @@ const createReaction = async (
         let thread;
         if (thread_id) {
           thread = await models.OffchainThread.findOne({ where: { id: thread_id } });
-          console.log('thread', thread);
         } else if (comment_id) {
           const root_id = (await models.OffchainComment.findOne({ where: { id: comment_id } })).root_id;
           const stage = root_id.substring(0, root_id.indexOf('_'));
@@ -58,7 +57,6 @@ const createReaction = async (
         }
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);
-        console.log(threshold);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
         }

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -50,7 +50,7 @@ const createReaction = async (
         if (thread_id) {
           thread = await models.OffchainThread.findOne({
             where: { id: thread_id },
-            include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
+            include: [{ model: models.OffchainTopic, as: 'topic' }],
           });
         } else if (comment_id) {
           const root_id = (
@@ -59,10 +59,11 @@ const createReaction = async (
           const comment_thread_id = root_id.substring(root_id.indexOf('_') + 1);
           thread = await models.OffchainThread.findOne({
             where: { id: comment_thread_id },
-            include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
+            include: [{ model: models.OffchainTopic, as: 'topic' }],
           });
         }
-        const threshold = thread.OffchainTopic.token_threshold;
+        console.log(thread);
+        const threshold = thread.topic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -49,6 +49,7 @@ const createReaction = async (
         let thread;
         if (thread_id) {
           thread = await models.OffchainThread.findOne({ where: { id: thread_id } });
+          console.log('thread', thread);
         } else if (comment_id) {
           const root_id = (await models.OffchainComment.findOne({ where: { id: comment_id } })).root_id;
           const stage = root_id.substring(0, root_id.indexOf('_'));
@@ -57,6 +58,7 @@ const createReaction = async (
         }
         const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
         let tokenBalance = new BN(0);
+        console.log(threshold);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
         }

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -48,13 +48,21 @@ const createReaction = async (
       try {
         let thread;
         if (thread_id) {
-          thread = await models.OffchainThread.findOne({ where: { id: thread_id } });
+          thread = await models.OffchainThread.findOne({
+            where: { id: thread_id },
+            include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
+          });
         } else if (comment_id) {
-          const root_id = (await models.OffchainComment.findOne({ where: { id: comment_id } })).root_id;
-          const topic_id = root_id.substring(root_id.indexOf('_') + 1);
-          thread = await models.OffchainThread.findOne({ where:{ id: topic_id } });
+          const root_id = (
+            await models.OffchainComment.findOne({ where: { id: comment_id } })
+          ).root_id;
+          const comment_thread_id = root_id.substring(root_id.indexOf('_') + 1);
+          thread = await models.OffchainThread.findOne({
+            where: { id: comment_thread_id },
+            include: [{ model: models.OffchainTopic, as: 'OffchainTopic' }],
+          });
         }
-        const threshold = (await models.OffchainTopic.findOne({ where: { id: thread.topic_id } })).token_threshold;
+        const threshold = thread.OffchainTopic.token_threshold;
         let tokenBalance = new BN(0);
         if (threshold) {
           tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -151,8 +151,10 @@ const createThread = async (
     if (!req.user.isAdmin && isAdmin.length === 0) {
       try {
         const threshold = (await models.OffchainTopic.findOne({ where: { id: topic_id } })).token_threshold;
-        const tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
-
+        let tokenBalance = new BN(0);
+        if (threshold) {
+          tokenBalance = await tokenBalanceCache.getBalance(chain.id, req.body.address);
+        }
         if (threshold && tokenBalance.lt(new BN(threshold))) return next(new Error(Errors.InsufficientTokenBalance));
       } catch (e) {
         log.error(`hasToken failed: ${e.message}`);


### PR DESCRIPTION
We currently always check the balance of a user's wallet for the token forum even if the threshold is set to 0. That's inefficient but also is causing problems with the HashesDAO community (ERC721) being able to comment and post threads and react. Only their admins can post right now.