### PR TITLE
Fix discussion subheader alignment

### DIFF
--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -53,7 +53,8 @@
                 font-weight: 600;
             }
             .row-subheader {
-                margin-top: 3px;
+                margin-top: 5px;
+                display: flex;
                 > * {
                     display: inline;
                 }


### PR DESCRIPTION
For whatever reason, proposal tags got thrown out of alignment in discussion row subheaders.

This fixes.