### PR TITLE
remove slider scaling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,6 @@
 web: USE_NEW_IDENTITY_CACHE=true ts-node -P tsconfig.node.json -T server.ts
 ceConsumer: node build/server/scripts/chainEventsConsumer.js
-ceNode: WORKER_NUMBER=0 node build/server/scripts/dbNode.js
+ceNode0: WORKER_NUMBER=0 node build/server/scripts/dbNode.js
+ceNode1: WORKER_NUMBER=1 node build/server/scripts/dbNode.js
+ceNode2: WORKER_NUMBER=2 node build/server/scripts/dbNode.js
 release: npx sequelize-cli db:migrate --config server/sequelize.json

--- a/server/scripts/dbNode.ts
+++ b/server/scripts/dbNode.ts
@@ -451,7 +451,7 @@ async function initializer(): Promise<void> {
   });
 
   // these requests cannot work locally
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' && process.env.USE_SLIDER_SCALING) {
     // get all dyno's list
     const res = await fetch(
       `https://api.heroku.com/apps/${process.env.HEROKU_APP_NAME}/dynos`,
@@ -525,8 +525,8 @@ async function initializer(): Promise<void> {
       }
     }
   } else {
-    workerNumber = 0;
-    numWorkers = 1;
+    workerNumber = Number(process.env.WORKER_NUMBER) || 0;
+    numWorkers = Number(process.env.NUM_WORKERS) || 1;
   }
 
   log.info(`Worker Number: ${workerNumber}\nNumber of Workers: ${numWorkers}`);


### PR DESCRIPTION
Remove slider scaling to bring CE back online.

This is due to blocked permissions. Heroku API is inaccessible from the ceNodes (403 Forbidden) even with correct API keys. Removing slider scaling while debugging the issue.