### PR TITLE
Add community/chain name to tab

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -141,6 +141,7 @@ export async function deinitChainOrCommunity() {
   app.user.setSelectedNode(null);
   app.user.setActiveAccounts([]);
   app.user.ephemerallySetActiveAccount(null);
+  document.title = 'Commonwealth';
 }
 
 export async function handleInviteLinkRedirect() {
@@ -183,6 +184,8 @@ export async function selectCommunity(c?: CommunityInfo): Promise<boolean> {
 
   // Shut down old chain if applicable
   await deinitChainOrCommunity();
+  document.title = `Commonwealth – ${c.name}`;
+
 
   // Begin initializing the community
   const newCommunity = new Community(c, app);
@@ -211,6 +214,7 @@ export async function selectCommunity(c?: CommunityInfo): Promise<boolean> {
 // initChain fn ought to proceed or abort
 export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolean> {
   // Select the default node, if one wasn't provided
+
   if (!n) {
     if (app.user.selectedNode) {
       n = app.user.selectedNode;
@@ -230,6 +234,7 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolea
   // Shut down old chain if applicable
   await deinitChainOrCommunity();
   app.chainPreloading = true;
+  document.title = `Commonwealth – ${n.chain.name}`;
   setTimeout(() => m.redraw()); // redraw to show API status indicator
 
   // Import top-level chain adapter lazily, to facilitate code split.
@@ -378,6 +383,7 @@ export async function initChain(): Promise<void> {
 
 export function initCommunity(communityId: string): Promise<boolean> {
   const community = app.config.communities.getByCommunity(communityId);
+
   if (community && community.length > 0) {
     return selectCommunity(community[0]);
   } else {

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -186,7 +186,6 @@ export async function selectCommunity(c?: CommunityInfo): Promise<boolean> {
   await deinitChainOrCommunity();
   document.title = `Commonwealth – ${c.name}`;
 
-
   // Begin initializing the community
   const newCommunity = new Community(c, app);
   const finalizeInitialization = await newCommunity.init();
@@ -214,7 +213,6 @@ export async function selectCommunity(c?: CommunityInfo): Promise<boolean> {
 // initChain fn ought to proceed or abort
 export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolean> {
   // Select the default node, if one wasn't provided
-
   if (!n) {
     if (app.user.selectedNode) {
       n = app.user.selectedNode;
@@ -383,7 +381,6 @@ export async function initChain(): Promise<void> {
 
 export function initCommunity(communityId: string): Promise<boolean> {
   const community = app.config.communities.getByCommunity(communityId);
-
   if (community && community.length > 0) {
     return selectCommunity(community[0]);
   } else {

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -147,7 +147,7 @@ const CreateComment: m.Component<{
       || vnode.state.quillEditorState?.editor?.editor?.isBlank()
       || sendingComment
       || uploadsInProgress
-      || !app.isLoggedIn();
+      || !app.user.activeAccount;
 
     // token balance check if needed
     let tokenPostingThreshold = null;

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -146,7 +146,8 @@ const CreateComment: m.Component<{
     disabled = getSetGlobalEditingStatus(GlobalStatus.Get)
       || vnode.state.quillEditorState?.editor?.editor?.isBlank()
       || sendingComment
-      || uploadsInProgress;
+      || uploadsInProgress
+      || !app.isLoggedIn();
 
     // token balance check if needed
     let tokenPostingThreshold = null;
@@ -202,6 +203,7 @@ const CreateComment: m.Component<{
             }),
             m(QuillEditor, {
               contentsDoc: '',
+              
               oncreateBind: (state) => {
                 vnode.state.quillEditorState = state;
               },

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -203,7 +203,6 @@ const CreateComment: m.Component<{
             }),
             m(QuillEditor, {
               contentsDoc: '',
-              
               oncreateBind: (state) => {
                 vnode.state.quillEditorState = state;
               },


### PR DESCRIPTION
One of our communities wanted their name next to `Commonwealth – ZakFinance` in the tab/document.title so I added it for all communities/chains. It is part of the initialization and deinitalization of the chain/community flow in `app.ts`. 