### PR TITLE
Truncate text overflow in discussions listing rows

### DIFF
--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -62,6 +62,11 @@
             .row-subheader + .row-subheader {
                 margin-top: 1px;
             }
+            .row-subheader > .created-at {
+                max-height: 17px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
             .row-subheader > a,
             .row-subheader > .User > a,
             .row-subheader > .created-at > a,
@@ -69,9 +74,15 @@
             > span {
                 color: $text-color-light;
                 font-size: $text-size-item-meta;
+                max-height: 17px;
+                overflow: hidden;
+                text-overflow: ellipsis;
                 &:hover {
                     color: darken($text-color-light, 8%);
                 }
+            }
+            .external-discussion-link {
+                word-break: break-all;
             }
         }
     }


### PR DESCRIPTION
Previously, text overflow in discussion rows caused problematic UI:
![image](https://user-images.githubusercontent.com/22281010/141009403-e86ecb2f-79d6-4554-a1cf-2c1547d86daa.png)

This branch adds text-overflow rules that prevent this behavior:
![image](https://user-images.githubusercontent.com/22281010/141009488-e280e751-d72d-4c94-ae1b-6ceaef268360.png)

In the long-term, we should probably handle row width dynamically in the Mithril component, choosing to hide certain pieces of subheader information depending on browser size. That way, we can clearly display critical info, rather than truncating several pieces of varyingly-important info. However, this fix should tide us over until such changes can be spec'd out. 