### PR TITLE
Ensure app.chain exists before querying decimals.

### DIFF
--- a/client/scripts/views/modals/edit_topic_thresholds_modal.ts
+++ b/client/scripts/views/modals/edit_topic_thresholds_modal.ts
@@ -26,7 +26,7 @@ const EditTopicThresholdsRow: m.Component<{
 }> = {
   oninit: (vnode) => {
     const { topic } = vnode.attrs;
-    const decimals = app.chain.meta.chain.decimals ? app.chain.meta.chain.decimals : 18;
+    const decimals = app.chain?.meta.chain?.decimals ? app.chain.meta.chain.decimals : 18;
     if (vnode.state.newTokenThreshold === null || vnode.state.newTokenThreshold === undefined) {
       vnode.state.newTokenThreshold = topic.tokenThreshold
         ? tokenBaseUnitsToTokens(topic.tokenThreshold.toString(), decimals) : '0';
@@ -36,7 +36,7 @@ const EditTopicThresholdsRow: m.Component<{
   },
   view: (vnode) => {
     const { topic } = vnode.attrs;
-    const decimals = app.chain.meta.chain.decimals ? app.chain.meta.chain.decimals : 18;
+    const decimals = app.chain?.meta.chain?.decimals ? app.chain.meta.chain.decimals : 18;
 
     return m(Form, [
       m('.topic-name', [topic.name]),

--- a/client/scripts/views/pages/view_proposal/create_comment.ts
+++ b/client/scripts/views/pages/view_proposal/create_comment.ts
@@ -162,7 +162,7 @@ const CreateComment: m.Component<{
         || (!isAdmin && tokenPostingThreshold && tokenPostingThreshold.gt(tokenBalance));
     }
 
-    const decimals = app.chain.meta.chain.decimals ? app.chain.meta.chain.decimals : 18;
+    const decimals = app.chain?.meta.chain?.decimals ? app.chain.meta.chain.decimals : 18;
     return m('.CreateComment', {
       class: parentScopedClass
     }, [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A ternary operator on `app.chain.meta.chain.decimals` was throwing because we did not check for undefined objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes display of offchain voting results in communities.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran and ensured fix.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no