### PR TITLE
Change unnamed to named SQL replacements

### DIFF
--- a/server/routes/threadsUsersCountAndAvatars.ts
+++ b/server/routes/threadsUsersCountAndAvatars.ts
@@ -23,14 +23,17 @@ const fetchUniqueAddressesByRootIds = async (
     select distinct cts.address_id, address, root_id, cts.chain
     from "OffchainComments" cts inner join "Addresses" adr
     on adr.id = cts.address_id
-    where root_id in (?)
-    and cts.chain = '?'
+    where root_id in (:root_ids)
+    and cts.chain = ':chain'
     and deleted_at is null
     order by root_id
   `,
     {
       type: QueryTypes.SELECT,
-      replacements: [formattedIds, chain]
+      replacements: {
+        root_ids: formattedIds,
+        chain,
+      }
     }
   );
 };

--- a/server/routes/threadsUsersCountAndAvatars.ts
+++ b/server/routes/threadsUsersCountAndAvatars.ts
@@ -17,16 +17,16 @@ const fetchUniqueAddressesByRootIds = async (
   models: DB,
   { chain, root_ids }
 ) => {
-  const formattedIds = root_ids.map((root_id) => `'${root_id}'`);
+  const formattedIds = root_ids.map((root_id) => `${root_id}`);
   return sequelize.query<UniqueAddresses>(
     `
-    select distinct cts.address_id, address, root_id, cts.chain
-    from "OffchainComments" cts inner join "Addresses" adr
-    on adr.id = cts.address_id
-    where root_id in (:root_ids)
-    and cts.chain = ':chain'
-    and deleted_at is null
-    order by root_id
+    SELECT distinct cts.address_id, address, root_id, cts.chain
+    FROM "OffchainComments" cts INNER JOIN "Addresses" adr
+    ON adr.id = cts.address_id
+    WHERE root_id IN (:root_ids)
+    AND cts.chain = :chain
+    AND deleted_at IS NULL
+    ORDER BY root_id
   `,
     {
       type: QueryTypes.SELECT,


### PR DESCRIPTION
The codebase features several instances of unnamed SQL replacements. This pull changed them to named replacements.