### PR TITLE
Remove wsToHttp and support custom URL in createCommunity.

### DIFF
--- a/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -4,7 +4,6 @@ import app from 'state';
 import Web3 from 'web3';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { setActiveAccount } from 'controllers/app/login';
-import { wsToHttp } from 'utils';
 
 class WalletConnectWebWalletController implements IWebWallet<string> {
   private _enabled: boolean;
@@ -53,7 +52,7 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
       if (!app.chain?.meta.ethChainId) {
         throw new Error(`No chain id found!`);
       }
-      const rpc = { [app.chain.meta.ethChainId]: wsToHttp(app.chain.meta.url) };
+      const rpc = { [app.chain.meta.ethChainId]: app.chain.meta.url };
       this._provider = new WalletConnectProvider({ rpc, chainId: app.chain.meta.ethChainId });
 
       //  Enable session (triggers QR Code modal)

--- a/client/scripts/views/modals/create_community_modal.ts
+++ b/client/scripts/views/modals/create_community_modal.ts
@@ -558,7 +558,7 @@ interface ERC20FormState {
 const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
   oninit: (vnode) => {
     vnode.state.chain_id = '1';
-    vnode.state.url = 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr';
+    vnode.state.url = '';
     vnode.state.address = '';
     vnode.state.id = '';
     vnode.state.name = '';
@@ -580,12 +580,16 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
 
     const updateTokenForum = async () => {
       if (!vnode.state.address || !vnode.state.chain_id) return;
+      const args = {
+        address: vnode.state.address,
+        chain_id: vnode.state.chain_id,
+        allowUncached: true,
+      };
+      if (vnode.state.url) {
+        args['url'] = vnode.state.url;
+      }
       try {
-        const res = await $.get(`${app.serverUrl()}/getTokenForum`, {
-          address: vnode.state.address,
-          chain_id: vnode.state.chain_id,
-          allowUncached: true,
-        });
+        const res = await $.get(`${app.serverUrl()}/getTokenForum`, args);
         if (res.status === 'Success') {
           vnode.state.name = res?.result?.chain?.name || '';
           vnode.state.id = slugify(vnode.state.name);
@@ -630,9 +634,15 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
               onChangeHandler: async (v) => {
                 vnode.state.chain_id = v;
                 vnode.state.loaded = false;
-                if (+v) {
-                  updateTokenForum();
-                }
+              }
+            }),
+            m(InputPropertyRow, {
+              title: 'Websocket URL',
+              defaultValue: vnode.state.url,
+              placeholder: 'wss://... (leave empty for default)',
+              onChangeHandler: async (v) => {
+                vnode.state.url = v;
+                vnode.state.loaded = false;
               }
             }),
             m(InputPropertyRow, {
@@ -642,9 +652,6 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
               onChangeHandler: (v) => {
                 vnode.state.address = v;
                 vnode.state.loaded = false;
-                if (isAddress(v)) {
-                  updateTokenForum();
-                }
               },
             }),
             m(InputPropertyRow, {
@@ -739,6 +746,14 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
             }),
           ]
         ),
+        m(Button, {
+          label: 'Test fields',
+          intent: 'primary',
+          disabled: vnode.state.saving || !validAddress || !vnode.state.chain_id,
+          onclick: async (e) => {
+            await updateTokenForum();
+          },
+        }),
         m(Button, {
           label: 'Save changes',
           intent: 'primary',

--- a/server/routes/createChain.ts
+++ b/server/routes/createChain.ts
@@ -68,7 +68,6 @@ const createChain = async (
   if (!existingBaseChain) {
     return next(new Error(Errors.InvalidBase));
   }
-  let url: string = req.body.node_url;
   let eth_chain_id: number = null;
   if (req.body.base === ChainBase.Ethereum) {
     if (!Web3.utils.isAddress(req.body.address)) {
@@ -79,9 +78,10 @@ const createChain = async (
     }
     eth_chain_id = +req.body.eth_chain_id;
 
-    // ignore the provided URL for eth chains (typically ERC20) and used stored
+    // ignore the provided URL for eth chains (typically ERC20) and used stored, unless none found
+    let url = await getUrlForEthChainId(models, eth_chain_id);
     if (!url) {
-      url = await getUrlForEthChainId(models, eth_chain_id);
+      url = req.body.node_url;
       if (!url) {
         return next(new Error(Errors.InvalidChainIdOrUrl));
       }

--- a/server/routes/getTokenForum.ts
+++ b/server/routes/getTokenForum.ts
@@ -26,9 +26,9 @@ const getTokenForum = async (
       chain_id,
     }
   });
-  let url = req.query.url;
+  let url = await getUrlForEthChainId(models, chain_id);
   if (!url) {
-    url = await getUrlForEthChainId(models, chain_id);
+    url = req.query.url;
     if (!url) {
       return res.json({ status: 'Failure', message: 'Unsupported chain' });
     }

--- a/server/routes/getTokenForum.ts
+++ b/server/routes/getTokenForum.ts
@@ -3,7 +3,6 @@ import Sequelize, { Op } from 'sequelize';
 import Web3 from 'web3';
 import { sequelize, DB } from '../database';
 import { ChainBase, ChainNetwork, ChainType } from '../../shared/types';
-import { wsToHttp } from '../../shared/utils';
 import { getUrlForEthChainId } from '../util/supportedEthChains';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
@@ -27,9 +26,12 @@ const getTokenForum = async (
       chain_id,
     }
   });
-  const url = await getUrlForEthChainId(models, chain_id);
+  let url = req.query.url;
   if (!url) {
-    return res.json({ status: 'Failure', message: 'Unsupported chain' });
+    url = await getUrlForEthChainId(models, chain_id);
+    if (!url) {
+      return res.json({ status: 'Failure', message: 'Unsupported chain' });
+    }
   }
 
   if (!token) {
@@ -40,8 +42,10 @@ const getTokenForum = async (
   }
 
   try {
-    const web3 = new Web3(new Web3.providers.HttpProvider(wsToHttp(url)));
+    const provider = new Web3.providers.WebsocketProvider(url);
+    const web3 = new Web3(provider);
     const code = await web3.eth.getCode(address);
+    provider.disconnect(1000, 'finished');
     if (code === '0x') {
       // Account returns 0x, Smart contract returns bytecode
       return res.json({ status: 'Failure', message: 'Must provide contract address' });

--- a/server/util/tokenBalanceCache.ts
+++ b/server/util/tokenBalanceCache.ts
@@ -9,7 +9,6 @@ import JobRunner from './cacheJobRunner';
 
 import { factory, formatFilename } from '../../shared/logging';
 import { DB } from '../database';
-import { wsToHttp } from '../../shared/utils';
 import { getUrlForEthChainId } from './supportedEthChains';
 
 const log = factory.getLogger(formatFilename(__filename));
@@ -29,10 +28,11 @@ interface CacheT {
 // Uses a tiny class so it's mockable for testing
 export class TokenBalanceProvider {
   public async getBalance(url: string, tokenAddress: string, userAddress: string): Promise<BN> {
-    const provider = new Web3.providers.HttpProvider(url);
+    const provider = new Web3.providers.WebsocketProvider(url);
     const api = ERC20__factory.connect(tokenAddress, new providers.Web3Provider(provider));
     await api.deployed();
     const balanceBigNum = await api.balanceOf(userAddress);
+    provider.disconnect(1000, 'finished');
     return new BN(balanceBigNum.toString());
   }
 }
@@ -143,11 +143,10 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     if (!url) {
       throw new Error(`unsupported eth chain id ${chainId}`);
     }
-    const tokenUrlHttp = wsToHttp(url);
 
     let balance: BN;
     try {
-      balance = await this._balanceProvider.getBalance(tokenUrlHttp, contractAddress, address);
+      balance = await this._balanceProvider.getBalance(url, contractAddress, address);
     } catch (e) {
       throw new Error(`Could not fetch token balance: ${e.message}`);
     }

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -163,8 +163,3 @@ export function formatAddressShort(
     return `${address.slice(0, maxCharLength || 5)}${includeEllipsis ? '…' : ''}`;
   }
 }
-
-// Converts a ws or wss url to the corresponding http/https
-export function wsToHttp(url: string): string {
-  return url.replace(/^ws/, 'http');
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Removes ws -> http autoconversion (as it wont work in the case of e.g. Fantom, which uses separately named ws and http endpoints), by using wss throughout backend calls.
- Adds an optional URL field in create_community_modal, for adding the first entry of any chain id.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows BD team to add communities on new ETH endpoints without dev intervention.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ensured I could add Fantom.

## Open Bugs
Users will need to add the chain to Metamask manually; we cannot create it for them without some additional information (mainly we need an HTTP endpoint for Metamask, but also we need native currency info).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no