### PR TITLE
Fix threshold check and only support token forum balance.

### DIFF
--- a/server/util/tokenBalanceCache.ts
+++ b/server/util/tokenBalanceCache.ts
@@ -2,14 +2,17 @@ import moment from 'moment';
 import Web3 from 'web3';
 import BN from 'bn.js';
 import { providers } from 'ethers';
+import { WhereOptions } from 'sequelize/types';
 
 import { ERC20__factory } from '../../shared/eth/types';
 
 import JobRunner from './cacheJobRunner';
 
+import { ChainAttributes } from '../models/chain';
 import { factory, formatFilename } from '../../shared/logging';
 import { DB } from '../database';
 import { wsToHttp } from '../../shared/utils';
+import { ChainType } from '../../shared/types';
 import { getUrlForEthChainId } from './supportedEthChains';
 
 const log = factory.getLogger(formatFilename(__filename));
@@ -76,15 +79,20 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
             model: this.models.Chain,
             required: true,
             as: 'chain',
+            where: {
+              // only support thresholds on token forums
+              // TODO: can we support for token-backed DAOs as well?
+              type: ChainType.Token,
+            } as WhereOptions<ChainAttributes>
           },
         ]
       });
       if (!topic?.chain) {
-        // if associated with an offchain community, always allow
+        // if associated with an offchain community, or if not token forum, always allow
         return true;
       }
       const threshold = topic.token_threshold;
-      if (threshold) {
+      if (threshold && threshold > 0) {
         const nodes = await this.models.ChainNode.findAll({ where: { chain: topic.chain.id } });
         if (!nodes || !nodes[0].eth_chain_id) {
           throw new Error('Could not find chain node.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- TokenBalanceCache was only checking balance threshold for nullability, and now it checks gt 0 as well.
- TokenBalanceCache was permitting any chain to have a token check, now it is restricted to Token type Chains only (i.e. not DAOs or base chains).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves issues with voting on Chain forum polls (that are not tokens).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran and verified. Please QA independently.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no