### PR TITLE
Add support for cosmos decimals and tally view.

### DIFF
--- a/client/scripts/controllers/chain/cosmos/account.ts
+++ b/client/scripts/controllers/chain/cosmos/account.ts
@@ -49,7 +49,7 @@ export default class CosmosAccount extends Account<CosmosToken> {
 
   public updateBalance = _.throttle(async () => {
     try {
-      const bal = await this._Chain.api.bank.balance(this.address, this._Chain.denom);
+      const bal = await this._Chain.api.bank.balance(this.address, this._Chain.stakingDenom);
       this._balance = this._Chain.coins(new BN(bal.amount));
     } catch (e) {
       // if coins is null, they have a zero balance

--- a/client/scripts/controllers/chain/cosmos/account.ts
+++ b/client/scripts/controllers/chain/cosmos/account.ts
@@ -47,6 +47,8 @@ export default class CosmosAccount extends Account<CosmosToken> {
     throw new Error('unsupported');
   }
 
+  // for now, we are betting that staking denom === governance denom,
+  // but if this not true in the future then we should separate the balances somehow
   public updateBalance = _.throttle(async () => {
     try {
       const bal = await this._Chain.api.bank.balance(this.address, this._Chain.stakingDenom);

--- a/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/client/scripts/controllers/chain/cosmos/chain.ts
@@ -55,6 +55,13 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
     return this._denom;
   }
 
+  private _stakingDenom: string;
+  public get stakingDenom() { return this._stakingDenom; }
+
+  // only applies to governance tokens
+  private _decimals: BN;
+  public get decimals() { return this._decimals; }
+
   private _staked: CosmosToken;
   public get staked(): CosmosToken {
     return this._staked;
@@ -67,9 +74,8 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
     this._app = app;
   }
 
-  public coins(n: number | BN, inDollars?: boolean) {
-    // never interpret a CosmosToken in dollars
-    return new CosmosToken(this.denom, n);
+  public coins(n: number | BN, inDollars = false, overrideDenom?: string) {
+    return new CosmosToken(overrideDenom || this.denom, n, inDollars, this.decimals);
   }
 
   private _blocktimeHelper: BlocktimeHelper = new BlocktimeHelper();
@@ -81,6 +87,11 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
     // that forwards the requests to it, and adds the header 'Access-Control-Allow-Origin: *'
     /* eslint-disable prefer-template */
     this._url = node.url;
+
+    // do not fetch symbol from chain -- use stored version + decimals
+    // denom here should be the standard denomination of governance token (i.e. OSMO not uosmo)
+    this._denom = node.chain.symbol;
+    this._decimals = new BN(10).pow(new BN(node.chain.decimals || 1));
 
     console.log(`Starting Tendermint RPC API at ${this._url}...`);
     // TODO: configure broadcast mode
@@ -109,11 +120,11 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
     await fetchBlockJob();
     this._blockSubscription = setInterval(fetchBlockJob, 6000);
 
-    const { pool: { bondedTokens } } = await this._api.staking.pool();
-    this._staked = this.coins(new BN(bondedTokens));
-
     const { params: { bondDenom } } = await this._api.staking.params();
-    this._denom = bondDenom;
+    const { pool: { bondedTokens } } = await this._api.staking.pool();
+    this._stakingDenom = bondDenom;
+    this._staked = this.coins(new BN(bondedTokens), false, bondDenom);
+
     this.app.chain.networkStatus = ApiStatus.Connected;
     m.redraw();
   }

--- a/client/scripts/controllers/chain/cosmos/proposal.ts
+++ b/client/scripts/controllers/chain/cosmos/proposal.ts
@@ -24,7 +24,7 @@ import { ProposalType } from 'types';
 import CosmosAccount from './account';
 import CosmosAccounts from './accounts';
 import CosmosChain, { CosmosApiType } from './chain';
-import CosmosGovernance, { marshalTally } from './governance';
+import CosmosGovernance from './governance';
 
 export const voteToEnum = (voteOption: number | string): CosmosVoteChoice => {
   if (typeof voteOption === 'number') {
@@ -92,7 +92,7 @@ export class CosmosProposal extends Proposal<
   public get depositorsAsVotes(): Array<DepositVote<CosmosToken>> {
     return this.data.state.depositors.map(([a, n]) => new DepositVote(
       this._Accounts.fromAddress(a),
-      this._Chain.coins(n)
+      this._Chain.coins(n, false, this._Governance.govDenom)
     ));
   }
 
@@ -149,7 +149,7 @@ export class CosmosProposal extends Proposal<
           }
         }
         if (tallyResp?.tally) {
-          this.data.state.tally = marshalTally(tallyResp?.tally);
+          this.data.state.tally = this._Governance.marshalTally(tallyResp?.tally);
         }
       } catch (err) {
         console.error(`Cosmos query failed: ${err.message}`);
@@ -167,7 +167,7 @@ export class CosmosProposal extends Proposal<
   // see: https://blog.chorus.one/an-overview-of-cosmos-hub-governance/
   get support() {
     if (this.status === 'DepositPeriod') {
-      return this._Chain.coins(this.data.state.totalDeposit);
+      return this._Chain.coins(this.data.state.totalDeposit, false, this._Governance.govDenom);
     }
     if (!this.data.state.tally) return 0;
     const nonAbstainingPower = this.data.state.tally.no

--- a/client/scripts/controllers/chain/cosmos/types.ts
+++ b/client/scripts/controllers/chain/cosmos/types.ts
@@ -4,24 +4,10 @@ import { Coin } from 'adapters/currency';
 import { IIdentifiable, ICompletable } from 'adapters/shared';
 
 export class CosmosToken extends Coin {
-  constructor(denom: string, n: number | string | BN, inDollars: boolean = false) {
-    if (typeof n === 'string') {
-      n = parseInt(n, 10);
-    }
-    if (inDollars) {
-      throw new Error('cannot create cosmos token in dollars!');
-    }
-    super(denom, n, inDollars);
-  }
-
-  get inDollars(): number {
-    return +this;
-  }
-
   public toCoinObject() {
     return {
       denom: this.denom,
-      amount: this.toString(),
+      amount: this.asBN.toString(),
     };
   }
 }
@@ -30,10 +16,10 @@ export type CosmosProposalType = 'text' | 'upgrade' | 'parameter';
 export type CosmosVoteChoice = 'Yes' | 'No' | 'NoWithVeto' | 'Abstain';
 export type CosmosProposalState = 'DepositPeriod' | 'VotingPeriod' | 'Passed' | 'Rejected' | 'Failed';
 export interface ICosmosProposalTally {
-  yes: BN;
-  abstain: BN;
-  no: BN;
-  noWithVeto: BN;
+  yes: CosmosToken;
+  abstain: CosmosToken;
+  no: CosmosToken;
+  noWithVeto: CosmosToken;
 }
 
 // TODO: note that these vote number values are in terms of _stake_

--- a/client/scripts/views/components/proposals/voting_actions.ts
+++ b/client/scripts/views/components/proposals/voting_actions.ts
@@ -311,7 +311,11 @@ const VotingActions: m.Component<{ proposal: AnyProposal }, {
       } else if (proposal instanceof CosmosProposal) {
         if (proposal.status === 'DepositPeriod') {
           // TODO: configure deposit amount
-          proposal.submitDepositTx(user, (app.chain as Cosmos).chain.coins(vnode.state.amount))
+          proposal.submitDepositTx(user, (app.chain as Cosmos).chain.coins(
+            vnode.state.amount,
+            false,
+            (app.chain as Cosmos).governance.govDenom)
+          )
             .then(() => m.redraw())
             .catch((err) => notifyError(err.toString()));
         } else {

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -15,7 +15,7 @@ import app from 'state';
 import { ProposalType, ChainBase, ChainNetwork } from 'types';
 import { ITXModalData, ProposalModule, OffchainThreadKind, OffchainThreadStage } from 'models';
 import { proposalSlugToClass } from 'identifiers';
-import { formatCoin } from 'adapters/currency';
+import { formatCoin, formatNumberLong } from 'adapters/currency';
 import { CosmosToken } from 'controllers/chain/cosmos/types';
 import CosmosAccount from 'controllers/chain/cosmos/account';
 
@@ -304,7 +304,11 @@ const NewProposalForm = {
         });
       } else if (proposalTypeEnum === ProposalType.CosmosProposal) {
         const deposit = vnode.state.deposit
-          ? new CosmosToken((app.chain as Cosmos).governance.minDeposit.denom, vnode.state.deposit, false)
+          ? (app.chain as Cosmos).chain.coins(
+            new BN(vnode.state.deposit),
+            true,
+            (app.chain as Cosmos).governance.govDenom
+          )
           : (app.chain as Cosmos).governance.minDeposit;
         // TODO: add disabled / loading
         (app.chain as Cosmos).governance.submitProposalTx(
@@ -648,15 +652,15 @@ const NewProposalForm = {
             m(FormGroup, [
               m(FormLabel, `Deposit (${app.chain.base === ChainBase.Substrate
                 ? app.chain.currency
-                : (app.chain as Cosmos).governance.minDeposit.denom})`),
+                : (app.chain as Cosmos).chain.denom})`),
               m(Input, {
                 name: 'deposit',
                 placeholder: `Min: ${app.chain.base === ChainBase.Substrate
                   ? (app.chain as Substrate).democracyProposals.minimumDeposit.inDollars
-                  : +(app.chain as Cosmos).governance.minDeposit}`,
+                  : formatNumberLong((app.chain as Cosmos).governance.minDeposit.inDollars)}`,
                 oncreate: (vvnode) => $(vvnode.dom).val(app.chain.base === ChainBase.Substrate
                   ? (app.chain as Substrate).democracyProposals.minimumDeposit.inDollars
-                  : +(app.chain as Cosmos).governance.minDeposit),
+                  : formatNumberLong((app.chain as Cosmos).governance.minDeposit.inDollars)),
                 oninput: (e) => {
                   const result = (e.target as any).value;
                   vnode.state.deposit = parseFloat(result);

--- a/server/migrations/20211118184310-add-cosmos-decimals.js
+++ b/server/migrations/20211118184310-add-cosmos-decimals.js
@@ -1,0 +1,61 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: 6
+    }, {
+      id: 'osmosis'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: 6,
+      symbol: 'BLD'
+    }, {
+      id: 'agoric'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: 9
+    }, {
+      id: 'terra'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: 18
+    }, {
+      id: 'injective'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: 18
+    }, {
+      id: 'injective-testnet'
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: null
+    }, {
+      id: 'osmosis'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: null,
+      symbol: 'RUN'
+    }, {
+      id: 'agoric'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: null
+    }, {
+      id: 'terra'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: null
+    }, {
+      id: 'injective'
+    });
+    await queryInterface.bulkUpdate('Chains', {
+      decimals: null
+    }, {
+      id: 'injective-testnet'
+    });
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- CosmosToken type now supports denominations and decimals, the latter of which is fetched from the Chains table and used to properly display the chain's symbols.
- Includes a migration to populate decimal values for Cosmos chains and also correct Agoric's token symbol (RUN = defi token, BLD = gov/staking token).
- The token decimals are used to format the display of final vote tallies on completed Cosmos proposals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves view of Cosmos proposals.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran it against injective/osmosis/agoric. Did not test tx sending, but should still work as expected.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no