### PR TITLE
Ensure correct address is fetched for upgrading member.

### DIFF
--- a/server/routes/upgradeMember.ts
+++ b/server/routes/upgradeMember.ts
@@ -50,11 +50,10 @@ const upgradeMember = async (models: DB, req: Request, res: Response, next: Next
       }
     }]
   });
-  const roles = memberAddress.Roles;
+  const roles = memberAddress?.Roles;
   if (!memberAddress || !roles) return next(new Error(Errors.NoMember));
 
-  // TODO: use first role for now -- unclear if it's possible to have multiple roles on
-  //   same chain / community
+  // There should only be one role per address per chain/community
   const member = await models.Role.findOne({ where: { id: roles[0].id } });
   if (!member) return next(new Error(Errors.NoMember));
 

--- a/test/unit/api/roles.spec.ts
+++ b/test/unit/api/roles.spec.ts
@@ -156,7 +156,7 @@ describe('Roles Test', () => {
           new_role: role,
         });
       expect(res.body.error).to.not.be.null;
-      expect(res.body.error).to.be.equal(upgradeErrors.InvalidAddress);
+      expect(res.body.error).to.be.equal(upgradeErrors.NoMember);
     });
 
     it('should fail when admin upgrades without role', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use include route to query the role rather than a separate query.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a bug where if a user had two Addresses with the same "address" field (e.g. one on ethereum and one on an erc token), with only the latter having a role, then the `findOne` call would select the first one on ethereum and thus be unable to locate the role. Include required ensures we always find the right one.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran it and played around a bit with the route.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no