### PR TITLE
Correct param on Cosmos createChain call.

### DIFF
--- a/client/scripts/views/pages/create_community/cosmos_form.ts
+++ b/client/scripts/views/pages/create_community/cosmos_form.ts
@@ -157,7 +157,7 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
             vnode.state.saving = true;
             try {
               const res = await $.post(`${app.serverUrl()}/createChain`, {
-                url,
+                node_url: url,
                 id,
                 name,
                 description,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug where you couldn't create a new cosmos chain from the /createCommunity page, because the url param was provided incorrectly. Confirmed the fix locally.