### PR TITLE
Switch from Sequelize replacements to binding params, where desirable

### DIFF
--- a/server/routes/deleteTopic.ts
+++ b/server/routes/deleteTopic.ts
@@ -30,15 +30,15 @@ const deleteTopic = async (models: DB, req, res: Response, next: NextFunction) =
   if (!topic) return next(new Error(Errors.TopicNotFound));
 
   const chainOrCommunity = community
-    ? 'community = :community'
-    : 'chain = :chain';
-  const replacements = community
+    ? 'community = $community'
+    : 'chain = $chain';
+  const bind = community
     ? { community: community.id }
     : { chain: chain.id };
-  replacements['id'] = id;
-  const query = `UPDATE "OffchainThreads" SET topic_id=null WHERE topic_id = :id AND ${chainOrCommunity};`;
+  bind['id'] = id;
+  const query = `UPDATE "OffchainThreads" SET topic_id=null WHERE topic_id = $id AND ${chainOrCommunity};`;
   await models.sequelize.query(query, {
-    replacements,
+    bind,
     type: QueryTypes.UPDATE,
   });
 

--- a/server/routes/threadsUsersCountAndAvatars.ts
+++ b/server/routes/threadsUsersCountAndAvatars.ts
@@ -23,14 +23,14 @@ const fetchUniqueAddressesByRootIds = async (
     SELECT distinct cts.address_id, address, root_id, cts.chain
     FROM "OffchainComments" cts INNER JOIN "Addresses" adr
     ON adr.id = cts.address_id
-    WHERE root_id IN (:root_ids)
-    AND cts.chain = :chain
+    WHERE root_id IN ($root_ids)
+    AND cts.chain = $chain
     AND deleted_at IS NULL
     ORDER BY root_id
   `,
     {
       type: QueryTypes.SELECT,
-      replacements: {
+      bind: {
         root_ids: formattedIds,
         chain,
       }
@@ -42,6 +42,9 @@ const fetchUniqueAddressesByRootIds = async (
 1) Get the number of distinct users for list of threads(root_id)
 2) Get first 2 avatars for each group of users
 3) Get latest comment
+
+TODO: The naming system here, and in the threadUniqueAddressesCount controller,
+is wildly unclear and wildly inconsistent. We should standardize + clarify.
  */
 const threadsUsersCountAndAvatar = async (
   models: DB,


### PR DESCRIPTION
While researching Sequelize w/r/t injection attacks, it was learned that Sequelize's `replacements` functionality dynamically parametrizes ahead of passing the query to SQL, which is less secure than parametrizing SQL-side. ([Documentation](https://sequelize.org/master/manual/raw-queries.html#bind-parameter).)

This branch switches several routes' use of `replacements` to `bind` params. It leaves `replacements` in place only on routes where the raw SQL query does not receive any user input.

Each route that has been altered has been queried, to ensure functionality is maintained.