### PR TITLE
Support arbitrary cosmos chain login via Keplr.

### DIFF
--- a/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
+++ b/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
@@ -72,7 +72,6 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
     try {
       // enabling without version (i.e. cosmoshub instead of cosmoshub-4) should work
       this._chainId = app.chain.meta.chain.id;
-      console.log(app.chain.meta);
       try {
         await window.keplr.enable(this._chainId);
       } catch (err) {

--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -34,6 +34,7 @@ class ChainInfo {
   public members: RoleInfo[];
   public type: string;
   public readonly ss58Prefix: string;
+  public readonly bech32Prefix: string;
   public decimals: number;
   public substrateSpec: RegisteredTypes;
 
@@ -62,6 +63,7 @@ class ChainInfo {
     adminsAndMods,
     base,
     ss58_prefix,
+    bech32_prefix,
     type,
     decimals,
     substrateSpec,
@@ -92,6 +94,7 @@ class ChainInfo {
     this.adminsAndMods = adminsAndMods || [];
     this.type = type;
     this.ss58Prefix = ss58_prefix;
+    this.bech32Prefix = bech32_prefix;
     this.decimals = decimals;
     this.substrateSpec = substrateSpec;
   }
@@ -121,6 +124,7 @@ class ChainInfo {
     adminsAndMods,
     base,
     ss58_prefix,
+    bech32_prefix,
     type,
     decimals,
     substrate_spec,
@@ -157,6 +161,7 @@ class ChainInfo {
       adminsAndMods,
       base,
       ss58_prefix,
+      bech32_prefix,
       type,
       decimals: parseInt(decimals, 10),
       substrateSpec: substrate_spec,

--- a/client/scripts/views/pages/create_community/cosmos_form.ts
+++ b/client/scripts/views/pages/create_community/cosmos_form.ts
@@ -27,6 +27,7 @@ interface CosmosFormState extends ChainFormState {
   name: string;
   symbol: string;
   bech32_prefix: string;
+  decimals: string;
   saving: boolean;
   testing: boolean;
   height: number;
@@ -58,7 +59,7 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
           },
           [
             m(InputPropertyRow, {
-              title: 'Tendermint URL',
+              title: 'RPC URL',
               defaultValue: vnode.state.url,
               placeholder: 'http://my-rpc.cosmos-chain.com:26657/',
               onChangeHandler: async (v) => {
@@ -109,7 +110,6 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
             m(InputPropertyRow, {
               title: 'ID',
               defaultValue: vnode.state.id,
-              disabled: true,
               value: vnode.state.id,
               onChangeHandler: (v) => {
                 vnode.state.id = v;
@@ -131,6 +131,15 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
                 vnode.state.bech32_prefix = v;
               }
             }),
+            // TODO: validate this as number
+            m(InputPropertyRow, {
+              title: 'Decimals',
+              defaultValue: vnode.state.decimals,
+              placeholder: '6',
+              onChangeHandler: async (v) => {
+                vnode.state.decimals = v;
+              }
+            }),
             ...defaultChainRows(vnode.state),
           ]
         ),
@@ -147,6 +156,7 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
               description,
               symbol,
               bech32_prefix,
+              decimals,
               icon_url,
               website,
               discord,
@@ -163,6 +173,7 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
                 description,
                 symbol,
                 bech32_prefix,
+                decimals,
                 icon_url,
                 website,
                 discord,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for `experimentalSuggestChain` at Keplr enable time. This requires providing a significant amount of metadata, which we mostly synthesize from our existing data. Some notes:
- Chains using this feature must have a `decimal` field, which this PR also adds to the `cosmos_form` on the /createCommunity page. Another note regarding currency is that we expect the minimal token denom to be "u<tokenSymbol>" (e.g. "ucosmos").
- We hack around only requiring an RPC and not a REST url by using the former to populate the latter field. Keplr does not test for this, and likely only uses it to send transactions, which we never do using Keplr alone. Instead, we use Keplr as a signer, and send the signed transaction ourselves via the Stargate API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This permits us to onboard arbitrary Cosmos chains that lack native Keplr support, opening up a huge number of possible supported chains.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran it against Juno (url: https://rpc-juno.itastakers.com, decimals: 6, "juno" for prefix, symbol, etc) and verified login worked as expected. Did not attempt any transactions (ideally we would do this before pushing to production).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no