### PR TITLE
Proxy cosmos requests through server to fix CORS issues.

### DIFF
--- a/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/client/scripts/controllers/chain/cosmos/chain.ts
@@ -42,8 +42,6 @@ export type CosmosApiType = QueryClient
   & BankExtension;
 
 class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
-  private _url: string;
-  public get url() { return this._url; }
   private _api: CosmosApiType;
   public get api() { return this._api; }
 
@@ -75,16 +73,10 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
   private _blocktimeHelper: BlocktimeHelper = new BlocktimeHelper();
   private _tmClient: Tendermint34Client;
   public async init(node: NodeInfo, reset = false) {
-    // A note on REST RPC: gaiacli exposes a command line option "rest-server" which
-    // creates the endpoint necessary. However, it doesn't send headers correctly
-    // on its own, so you need to configure a reverse-proxy server (I did it with nginx)
-    // that forwards the requests to it, and adds the header 'Access-Control-Allow-Origin: *'
-    /* eslint-disable prefer-template */
-    this._url = node.url;
-
-    console.log(`Starting Tendermint RPC API at ${this._url}...`);
+    const url = `${window.location.origin}/cosmosAPI/${node.chain.id}`;
+    console.log(`Starting Tendermint RPC API at ${url}...`);
     // TODO: configure broadcast mode
-    this._tmClient = await Tendermint34Client.connect(this._url);
+    this._tmClient = await Tendermint34Client.connect(url);
     this._api = QueryClient.withExtensions(
       this._tmClient,
       setupGovExtension,

--- a/client/scripts/views/pages/create_community/cosmos_form.ts
+++ b/client/scripts/views/pages/create_community/cosmos_form.ts
@@ -69,7 +69,7 @@ const CosmosForm: m.Component<CosmosFormAttrs, CosmosFormState> = {
               m('td', { class: 'title-column', }, ''),
               m(Button, {
                 label: 'Test Connection',
-                disabled: vnode.state.testing,
+                disabled: true, // vnode.state.testing,
                 onclick: async (e) => {
                   vnode.state.endpointError = null;
                   vnode.state.testing = true;

--- a/client/scripts/views/pages/create_community/cosmos_form.ts
+++ b/client/scripts/views/pages/create_community/cosmos_form.ts
@@ -7,8 +7,6 @@ import $ from 'jquery';
 import { initAppState } from 'app';
 import { slugify } from 'utils';
 import { ChainBase, ChainType } from 'types';
-import { notifyError } from 'controllers/app/notifications';
-import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
 import {
   InputPropertyRow
 } from 'views/components/metadata_rows';

--- a/server.ts
+++ b/server.ts
@@ -36,6 +36,7 @@ import setupErrorHandlers from './server/scripts/setupErrorHandlers';
 import setupPrerenderServer from './server/scripts/setupPrerenderService';
 import { sendBatchedNotificationEmails } from './server/scripts/emails';
 import setupAPI from './server/router';
+import setupCosmosProxy from './server/util/cosmosProxy';
 import setupPassport from './server/passport';
 import setupChainEventListeners from './server/scripts/setupChainEventListeners';
 import { fetchStats } from './server/routes/getEdgewareLockdropStats';
@@ -309,6 +310,7 @@ async function main() {
     <any>identityFetchCache,
     tokenBalanceCache
   );
+  setupCosmosProxy(app, models);
   setupAppRoutes(app, models, devMiddleware, templateFile, sendFile);
   setupErrorHandlers(app);
 

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import passport from 'passport';
+import type { Express } from 'express';
 
 import domain from './routes/domain';
 import status from './routes/status';
@@ -131,7 +132,7 @@ import { DB } from './database';
 import { sendMessage } from './routes/snapshotAPI';
 
 function setupRouter(
-  app,
+  app: Express,
   models: DB,
   viewCountCache: ViewCountCache,
   identityFetchCache: IdentityFetchCache,
@@ -652,4 +653,5 @@ function setupRouter(
 
   app.use('/api', router);
 }
+
 export default setupRouter;

--- a/server/util/cosmosProxy.ts
+++ b/server/util/cosmosProxy.ts
@@ -21,7 +21,11 @@ function setupCosmosProxy(app: Express, models: DB) {
         throw new Error('Invalid chain');
       }
       log.trace(`Found cosmos endpoint: ${chainNode.url}`);
-      const response = await axios.post(chainNode.url, req.body);
+      const response = await axios.post(chainNode.url, req.body, {
+        headers: {
+          origin: 'https://commonwealth.im'
+        }
+      });
       log.trace(`Got response from endpoint: ${JSON.stringify(response.data, null, 2)}`);
       return res.send(response.data);
     } catch (err) {

--- a/server/util/cosmosProxy.ts
+++ b/server/util/cosmosProxy.ts
@@ -1,0 +1,33 @@
+import type { Express } from 'express';
+import axios from 'axios';
+import bodyParser from 'body-parser';
+
+import { DB } from '../database';
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+
+function setupCosmosProxy(app: Express, models: DB) {
+  // using bodyParser here because cosmjs generates text/plain type headers
+  app.post('/cosmosAPI/:chain', bodyParser.text(), async function cosmosProxy(req, res, next) {
+    log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`)
+    try {
+      log.trace(`Querying cosmos endpoint for chain: ${req.params.chain}`);
+      const chainNode = await models.ChainNode.findOne({
+        where: {
+          chain: req.params.chain,
+        }
+      });
+      if (!chainNode) {
+        throw new Error('Invalid chain');
+      }
+      log.trace(`Found cosmos endpoint: ${chainNode.url}`);
+      const response = await axios.post(chainNode.url, req.body);
+      log.trace(`Got response from endpoint: ${JSON.stringify(response.data, null, 2)}`);
+      return res.send(response.data);
+    } catch (err) {
+      res.status(500).json({ message: err.message });
+    }
+  });
+}
+
+export default setupCosmosProxy;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a cosmos proxy as an express `.post` handler, that queries our DB for the endpoint URL and forwards traffic. Also adds an origin header to abide by our current cloudflare worker proxy whitelists.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures we can communicate with Cosmos endpoints from the frontend regardless of whether they use HTTPS or not, or whether they use a custom port. Makes life a lot easier for BD to integrate Cosmos chains.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran against multiple existing cosmos chains. Tested adding gravity-bridge to ensure the /createCommunity page support still works.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no