### PR TITLE
Fix snapshot redirect bug

### DIFF
--- a/client/scripts/views/components/new_proposal_button.ts
+++ b/client/scripts/views/components/new_proposal_button.ts
@@ -120,8 +120,7 @@ export const getNewProposalMenu = (candidates?: Array<[SubstrateAccount, number]
     }),
     showSnapshotOptions && m(MenuItem, {
       onclick: (e) => {
-        e.preventDefault();
-        navigateToSubpage(`/new/snapshot-proposal/${app.chain.meta.chain.snapshot}`);
+        navigateToSubpage(`/new/snapshot/${app.chain.meta.chain.snapshot}`);
       },
       label: 'New Snapshot Proposal',
       iconLeft: mobile ? Icons.PLUS : undefined,


### PR DESCRIPTION
Test on local custom domain. Snapshot proposal button redirect was to `/snapshot-proposal` rather than `/snapshot`. There's probably something fishy in our redirect-old-url-tree in `app.ts` but I chose just to change button redirect to be accurate. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no