### PR TITLE
Thread decoding falls back on error.

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -118,12 +118,28 @@ export const modelFromServer = (thread) => {
     topicFromStore = app.topics.store.getById(topic.id);
   }
 
+  let decodedTitle;
+  try {
+    decodedTitle = decodeURIComponent(title);
+  } catch (err) {
+    console.error(`Could not decode title: "${title}"`);
+    decodedTitle = title;
+  }
+
+  let decodedBody;
+  try {
+    decodedBody = decodeURIComponent(body);
+  } catch (err) {
+    console.error(`Could not decode body: "${body}"`);
+    decodedBody = body;
+  }
+
   return new OffchainThread({
     id,
     author: thread.Address.address,
     authorChain: thread.Address.chain,
-    title: decodeURIComponent(title),
-    body: decodeURIComponent(body),
+    title: decodedTitle,
+    body: decodedBody,
     createdAt: moment(created_at),
     attachments,
     snapshotProposal: snapshot_proposal,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes `Uncaught (in promise) URIError: URI malformed` error -- does not isolate cause of why the thread was created with an improperly escaped title.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves error of thread not appearing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran against broken thread and ensured it works.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no