### PR TITLE
Ensure submission button tracks Quill comment state

### DIFF
--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -845,8 +845,20 @@ const instantiateEditor = (
   state.unsavedChanges = new Delta();
   quill.on('text-change', (delta, oldDelta, source) => {
     state.unsavedChanges = state.unsavedChanges.compose(delta);
+    // Log that the quill doc has been altered, so that
+    // newThread draft system prompts w/ save confirmation modal
     if (source === 'user' && !state.alteredText) {
+      console.log('redrawing for alteration');
       state.alteredText = true;
+      m.redraw();
+    }
+    // Log that the editor isBlank status has changed, to change
+    // enabled/disabled state of submission button
+    if (state.enableSubmission && quill.editor.isBlank()) {
+      state.enableSubmission = false;
+      m.redraw();
+    } else if (!state.enableSubmission && !quill.editor.isBlank()) {
+      state.enableSubmission = true;
       m.redraw();
     }
   });
@@ -882,7 +894,8 @@ interface IQuillEditorState {
   uploading?: boolean;
   // for localStorage drafts:
   beforeunloadHandler;
-  alteredText;
+  alteredText: boolean;
+  enableSubmission: boolean;
   unsavedChanges;
   clearUnsavedChanges;
 }


### PR DESCRIPTION
What previously appeared to be an issue with max char length was in fact an issue with the Submission button failing to check whether it ought to be enabled or disabled.

This adds a redraw whenever the status of quill.editor.isBlank() changes, so that the submission button's disabled state stays up to date with the isBlank status.