### PR TITLE
Add Payout to Sputnik Proposals page.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -260,7 +260,7 @@ export async function selectNode(n?: NodeInfo, deferred = false): Promise<boolea
       './controllers/chain/ethereum/main'
     )).default;
     newChain = new Ethereum(n, app);
-  } else if (n.chain.network === ChainNetwork.NEAR || n.chain.network == ChainNetwork.NEARTestnet) {
+  } else if (n.chain.network === ChainNetwork.NEAR || n.chain.network === ChainNetwork.NEARTestnet) {
     const Near = (await import(
       /* webpackMode: "lazy" */
       /* webpackChunkName: "near-main" */

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -159,7 +159,7 @@ export const OffchainNavigationModule: m.Component<{}, { dragulaInitialized: tru
           navigateToSubpage('/members');
         },
       }),
-      (app.activeId() == 'near'
+      (app.activeId() === 'near' || app.activeId() === 'near-testnet'
       ? m(Button, {
         rounded: true,
         fluid: true,

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -1128,11 +1128,11 @@ const NewProposalForm = {
                 name: 'member',
                 defaultValue: 'tokenfactory.testnet',
                 oncreate: (vvnode) => {
-                  vnode.state.target = 'tokenfactory.testnet';
+                  vnode.state.member = 'tokenfactory.testnet';
                 },
                 oninput: (e) => {
                   const result = (e.target as any).value;
-                  vnode.state.target = result;
+                  vnode.state.member = result;
                   m.redraw();
                 },
               }),

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -43,6 +43,13 @@ import { AaveProposalArgs } from 'controllers/chain/ethereum/aave/governance';
 import Aave from 'controllers/chain/ethereum/aave/adapter';
 import NearSputnik from 'controllers/chain/near/sputnik/adapter';
 import { navigateToSubpage } from 'app';
+import { NearSputnikProposalKind } from 'client/scripts/controllers/chain/near/sputnik/types';
+
+enum SupportedSputnikProposalTypes {
+  AddMemberToRole = 'Add Member',
+  RemoveMemberFromRole = 'Remove Member',
+  Transfer = 'Payout',
+}
 
 // this should be titled the Substrate/Edgeware new proposal form
 const NewProposalForm = {
@@ -420,9 +427,27 @@ const NewProposalForm = {
         // @TODO: Create Proposal via WebTx
       } else if (proposalTypeEnum === ProposalType.SputnikProposal) {
         // TODO: make type of proposal switchable
-        const account = vnode.state.addMember;
+        const member = vnode.state.member;
         const description = vnode.state.description;
-        const propArgs = { AddMemberToRole: { role: 'council', member_id: account } };
+        let propArgs: NearSputnikProposalKind;
+        if (vnode.state.sputnikProposalType === SupportedSputnikProposalTypes.AddMemberToRole) {
+          propArgs = { AddMemberToRole: { role: 'council', member_id: member } };
+        } else if (vnode.state.sputnikProposalType === SupportedSputnikProposalTypes.RemoveMemberFromRole) {
+          propArgs = { RemoveMemberFromRole: { role: 'council', member_id: member }};
+        } else if (vnode.state.sputnikProposalType === SupportedSputnikProposalTypes.Transfer) {
+          // TODO: validate amount / token id
+          const token_id = vnode.state.tokenId || '';
+          let amount: string;
+          // treat NEAR as in dollars but tokens as whole #s
+          if (!token_id) {
+            amount = app.chain.chain.coins(+vnode.state.payoutAmount, true).asBN.toString();
+          } else {
+            amount = `${+vnode.state.payoutAmount}`;
+          }
+          propArgs = { Transfer: { receiver_id: member, token_id, amount } }
+        } else {
+          throw new Error('unsupported sputnik proposal type');
+        }
         (app.chain as NearSputnik).dao.proposeTx(description, propArgs)
           .then((result) => done(result))
           .then(() => m.redraw())
@@ -1082,19 +1107,32 @@ const NewProposalForm = {
             ]),
           ]),
           hasSputnikFields && [
-            // TODO: add switcher for kinds that modifies fields
             // TODO: add deposit copy
+            m(DropdownFormField, {
+              title: 'Proposal Type',
+              value: vnode.state.sputnikProposalType,
+              defaultValue: SupportedSputnikProposalTypes.AddMemberToRole,
+              choices: Object.values(SupportedSputnikProposalTypes).map((v) => ({
+                name: 'proposalType',
+                label: v,
+                value: v,
+              })),
+              callback: (result) => {
+                vnode.state.sputnikProposalType = result;
+                m.redraw();
+              },
+            }),
             m(FormGroup, [
               m(FormLabel, 'Member'),
               m(Input, {
-                name: 'addMember',
+                name: 'member',
                 defaultValue: 'tokenfactory.testnet',
                 oncreate: (vvnode) => {
-                  vnode.state.addMember = 'tokenfactory.testnet';
+                  vnode.state.target = 'tokenfactory.testnet';
                 },
                 oninput: (e) => {
                   const result = (e.target as any).value;
-                  vnode.state.addMember = result;
+                  vnode.state.target = result;
                   m.redraw();
                 },
               }),
@@ -1110,6 +1148,36 @@ const NewProposalForm = {
                 oninput: (e) => {
                   const result = (e.target as any).value;
                   vnode.state.description = result;
+                  m.redraw();
+                },
+              }),
+            ]),
+            vnode.state.sputnikProposalType === SupportedSputnikProposalTypes.Transfer && m(FormGroup, [
+              m(FormLabel, 'Token ID (leave blank for Ⓝ)'),
+              m(Input, {
+                name: 'token_id',
+                defaultValue: '',
+                oncreate: (vvnode) => {
+                  vnode.state.tokenId = '';
+                },
+                oninput: (e) => {
+                  const result = (e.target as any).value;
+                  vnode.state.tokenId = result;
+                  m.redraw();
+                },
+              }),
+            ]),
+            vnode.state.sputnikProposalType === SupportedSputnikProposalTypes.Transfer && m(FormGroup, [
+              m(FormLabel, 'Amount'),
+              m(Input, {
+                name: 'amount',
+                defaultValue: '',
+                oncreate: (vvnode) => {
+                  vnode.state.payoutAmount = '';
+                },
+                oninput: (e) => {
+                  const result = (e.target as any).value;
+                  vnode.state.payoutAmount = result;
                   m.redraw();
                 },
               }),

--- a/client/scripts/views/pages/sputnikdaos.ts
+++ b/client/scripts/views/pages/sputnikdaos.ts
@@ -15,7 +15,7 @@ import { IDaoInfo } from 'controllers/chain/near/chain';
 
 const SputnikDAOsPage : m.Component<{}, { daosRequested: boolean, daosList: IDaoInfo[] }> = {
   view: (vnode) => {
-    if (app.activeId() && app.activeId() !== 'near')
+    if (app.activeId() && app.activeId() !== 'near' && app.activeId() !== 'near-testnet')
       m.route.set(`/${app.activeId()}`);
 
     const activeEntity = app.community ? app.community : app.chain;
@@ -35,13 +35,18 @@ const SputnikDAOsPage : m.Component<{}, { daosRequested: boolean, daosList: IDao
       showNewProposalButton: true,
     });
 
-    if(app.activeId() === 'near' && !vnode.state.daosRequested){
+    if ((app.activeId() === 'near' || app.activeId() === 'near-testnet') && !vnode.state.daosRequested) {
       vnode.state.daosRequested = true;
       (app.chain as Near).chain.viewDaoList().then((daos) => {
+        const isMainnet = app.activeId() === 'near';
         vnode.state.daosList = daos;
         vnode.state.daosList.sort((d1, d2) => {
-          const d1Exist = allCommunities.filter(c => c.id === `${d1.name}.sputnik-dao.near`).length;
-          const d2Exist = allCommunities.filter(c => c.id === `${d2.name}.sputnik-dao.near`).length;
+          const d1Exist = allCommunities.filter(c => isMainnet
+            ? c.id === `${d1.name}.sputnik-dao.near`
+            : c.id === `${d1.name}.sputnikv2.testnet`).length;
+          const d2Exist = allCommunities.filter(c => isMainnet
+            ? c.id === `${d2.name}.sputnik-dao.near`
+            : c.id === `${d1.name}.sputnikv2.testnet`).length;
           if(d1Exist !== d2Exist)
             return d2Exist - d1Exist;
           else
@@ -52,7 +57,7 @@ const SputnikDAOsPage : m.Component<{}, { daosRequested: boolean, daosList: IDao
     }
 
     if (!vnode.state.daosList) {
-      if (app.activeId() === 'near') {
+      if (app.activeId() === 'near' || app.activeId() === 'near-testnet') {
         return m(PageLoading, {
           message: 'Loading Sputnik DAOs',
           title: [

--- a/server/migrations/20211214183946-add-near-testnet.js
+++ b/server/migrations/20211214183946-add-near-testnet.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkInsert('Chains', [{
+        id: 'near-testnet',
+        symbol: 'NEAR',
+        name: 'NEAR Testnet',
+        icon_url: '/static/img/protocols/near.png',
+        type: 'chain',
+        network: 'near-testnet',
+        base: 'near',
+        active: true,
+        description: '',
+        website: '',
+        discord: '',
+        github: '',
+      }], { transaction: t });
+
+      await queryInterface.bulkInsert('ChainNodes', [{
+        chain: 'near-testnet',
+        url: 'https://rpc.testnet.near.org',
+      }], { transaction: t });
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.bulkDelete('ChainNodes', { chain: 'near-testnet' }, { transaction: t });
+      await queryInterface.bulkDelete('Chains', { id: ['near-testnet'] }, { transaction: t });
+    });
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds a dropdown allowing the proposal creator to select a payout proposal in addition to add/remove member.
- Adds NEAR testnet via migration, to permit easy testing (use https://testnet-v2.sputnik.fund/#/ with a testnet NEAR account to create a DAO and then you should be able to use Commonwealth to create proposals).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Feature request from NEAR team.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Created a payout proposal through CW UI (although voting did not work!).

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no