### PR TITLE
Lint-Branch Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "stylelint": "stylelint client/styles/*",
     "lint": "./scripts/lint-new-work.sh",
     "lint-all": "eslint client/\\**/*.ts server/\\**/*.ts",
+    "lint-branch": "./scripts/lint-branch.sh",
     "listen": "RUN_AS_LISTENER=true ts-node --project tsconfig.node.json server.ts",
     "load-tokens": "ts-node --project tsconfig.node.json server/scripts/loadDatabaseFromTokenLists.ts",
     "emit-events": "ts-node --project tsconfig.node.json server/scripts/emitChainEvents.ts",

--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -1,0 +1,9 @@
+LINES=$(git diff master... --name-only --diff-filter=d | grep \\.ts)
+
+if [ -z "$LINES" ]
+then
+    echo "There is nothing to lint"
+else
+    echo $LINES
+    eslint $LINES
+fi


### PR DESCRIPTION
I wrote a quick lint script to run eslint only on the new/updated files in the branch you're currently on. This means you'll only lint the code you've been working on. Based on Ray's original `lint-all` script. Found it useful for myself, not sure it's necessary to make available to everyone, but thought I'd put it out here.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no