### PR TITLE
Summary row updates

### DIFF
--- a/client/scripts/controllers/server/comments.ts
+++ b/client/scripts/controllers/server/comments.ts
@@ -207,7 +207,6 @@ class CommentsController {
   }
 
   public async delete(comment) {
-    const _this = this;
     return new Promise((resolve, reject) => {
       // TODO: Change to DELETE /comment
       $.post(`${app.serverUrl()}/deleteComment`, {

--- a/client/styles/pages/discussions/summary_listing.scss
+++ b/client/styles/pages/discussions/summary_listing.scss
@@ -4,7 +4,7 @@
     .topic {
         flex: 3;
     }
-    .thread-count {
+    .last-updated {
         flex: 1;
     }
     .recent-threads {
@@ -29,12 +29,6 @@
     padding: 20px 0;
     border-bottom: 1px solid #DDDDDD;
     max-width: 100%;
-    > div {
-        padding-right: 15px;
-        &:last-child {
-            padding-right: 0;
-        }
-    }
     &:last-child {
         border-bottom: none;
     }
@@ -55,8 +49,13 @@
             }
         }
     }
-    .thread-count {
-        font-weight: 500;
+    .last-updated {
+        .time {
+            font-weight: 500;
+        }
+        .date {
+            font-weight: 400;
+        }
     }
     .topic {
         h3 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22281010/147139604-0af3f828-9111-4ccc-9f14-5fcf90926d19.png)

This fixes several requests for a Summary Page cleanup, notably: displaying latest reply timestamp instead of threads/month; ensuring recent threads are always sorted by last update; displaying exact dates rather than "X months ago"; fixing column alignment problems.

It does not address (because too vague as requests):
- "make aggregate view more like discourse"
- "summary page UX flow: either i jump into something that already exists, or i'm lost"