### PR TITLE
Disallow non-alphanum chars in new topics

### DIFF
--- a/client/scripts/helpers/index.ts
+++ b/client/scripts/helpers/index.ts
@@ -169,6 +169,7 @@ export function isSameAccount(a, b) {
 /*
  * formatters
  */
+
 export function pluralize(num: number, str: string) {
   if (str.endsWith('y')) {
     return `${num} ${str.slice(0, str.length - 1)}${(num === 1) ? 'y' : 'ies'}`;
@@ -176,6 +177,16 @@ export function pluralize(num: number, str: string) {
     return `${num} ${str}${num === 1 ? '' : 'es'}`;
   } else {
     return `${num} ${str}${(num === 1 || str.endsWith('s')) ? '' : 's'}`;
+  }
+}
+
+export function pluralizeWithoutNumberPrefix(num: number, str: string) {
+  if (str.endsWith('y')) {
+    return `${str.slice(0, str.length - 1)}${(num === 1) ? 'y' : 'ies'}`;
+  } else if (str.endsWith('ss')) {
+    return `${str}${num === 1 ? '' : 'es'}`;
+  } else {
+    return `${str}${(num === 1 || str.endsWith('s')) ? '' : 's'}`;
   }
 }
 

--- a/client/scripts/views/components/component_kit/forms.ts
+++ b/client/scripts/views/components/component_kit/forms.ts
@@ -10,12 +10,13 @@ export enum TextInputStatus {
 export const TextInput: m.Component<
   {
     name: string;
-    oninput?: (e) => null;
+    oninput?: (e) => void | null;
     inputValidationFn?: (value: string) => [TextInputStatus, string];
     label?: string;
     className?: string;
     placeholder?: string;
     defaultValue?: string;
+    otherAttrs?: any;
   },
   {
     statusMessage: string;
@@ -33,9 +34,10 @@ export const TextInput: m.Component<
       className,
       placeholder,
       defaultValue,
+      otherAttrs
     } = vnode.attrs;
     const { statusMessage, statusType } = vnode.state;
-    return m('.TextInput', [
+    return m('.TextInput', otherAttrs, [
       label && m('label', label),
       m(Input, {
         class: `${className || ''} ${statusType || ''}`,

--- a/client/scripts/views/modals/new_topic_modal.ts
+++ b/client/scripts/views/modals/new_topic_modal.ts
@@ -7,7 +7,7 @@ import { Button, Input, Form, FormGroup, FormLabel, Checkbox } from 'construct-u
 
 import QuillEditor from 'views/components/quill_editor';
 import { CompactModalExitButton } from 'views/modal';
-import { tokensToWei } from 'helpers';
+import { pluralizeWithoutNumberPrefix, tokensToWei } from 'helpers';
 import TokenDecimalInput from '../components/token_decimal_input';
 import { TextInput, TextInputStatus } from '../components/component_kit/forms';
 interface INewTopicModalForm {
@@ -69,8 +69,13 @@ const NewTopicModal: m.Component<{
               vnode.state.form.name = (e.target as any).value;
             },
             inputValidationFn: (text) => {
-              if (text.match(/["<>%{}|\\/^`]/g)) {
-                return [TextInputStatus.Error, 'Only alphanumeric input allowed'];
+              const disallowedCharMatches = text.match(/["<>%{}|\\/^`]/g);
+              if (disallowedCharMatches) {
+                return [
+                  TextInputStatus.Error,
+                  `The ${pluralizeWithoutNumberPrefix(disallowedCharMatches.length, 'char')} 
+                  ${disallowedCharMatches.join(', ')} are not permitted`
+                ];
               } else {
                 return [TextInputStatus.Validate, 'Valid topic name'];
               }

--- a/client/scripts/views/modals/new_topic_modal.ts
+++ b/client/scripts/views/modals/new_topic_modal.ts
@@ -69,7 +69,7 @@ const NewTopicModal: m.Component<{
               vnode.state.form.name = (e.target as any).value;
             },
             inputValidationFn: (text) => {
-              if (text.match(/[^\w\s]/g)) {
+              if (text.match(/["<>%{}|\\/^`]/g)) {
                 return [TextInputStatus.Error, 'Only alphanumeric input allowed'];
               } else {
                 return [TextInputStatus.Validate, 'Valid topic name'];

--- a/client/scripts/views/modals/new_topic_modal.ts
+++ b/client/scripts/views/modals/new_topic_modal.ts
@@ -4,13 +4,12 @@ import m from 'mithril';
 import app from 'state';
 import $ from 'jquery';
 import { Button, Input, Form, FormGroup, FormLabel, Checkbox } from 'construct-ui';
-import BN from 'bn.js';
 
 import QuillEditor from 'views/components/quill_editor';
 import { CompactModalExitButton } from 'views/modal';
 import { tokensToWei } from 'helpers';
-import { stubFalse } from 'lodash';
 import TokenDecimalInput from '../components/token_decimal_input';
+import { TextInput, TextInputStatus } from '../components/component_kit/forms';
 interface INewTopicModalForm {
   id: number,
   name: string,
@@ -61,24 +60,31 @@ const NewTopicModal: m.Component<{
       ]),
       m('.compact-modal-body', [
         m(Form, [
-          m(FormGroup, [
-            m(FormLabel, { for: 'name' }, 'Name'),
-            m(Input, {
-              title: 'Name',
-              name: 'name',
-              class: 'topic-form-name',
-              tabindex: 1,
-              defaultValue: vnode.state.form.name,
+          m(TextInput, {
+            name: 'name',
+            label: 'Name',
+            className: 'topic-form-name',
+            defaultValue: vnode.state.form.name,
+            oninput: (e) => {
+              vnode.state.form.name = (e.target as any).value;
+            },
+            inputValidationFn: (text) => {
+              if (text.match(/[^\w\s]/g)) {
+                return [TextInputStatus.Error, 'Only alphanumeric input allowed'];
+              } else {
+                return [TextInputStatus.Validate, 'Valid topic name'];
+              }
+            },
+            otherAttrs: {
               autocomplete: 'off',
+              tabindex: 1,
               oncreate: (vvnode) => {
                 // use oncreate to focus because autofocus: true fails when component is recycled in a modal
                 setTimeout(() => $(vvnode.dom).find('input').focus(), 0);
               },
-              oninput: (e) => {
-                vnode.state.form.name = (e.target as any).value;
-              },
-            }),
-          ]),
+              style: 'margin-bottom: 10px;'
+            }
+          }),
           m(FormGroup, [
             m(FormLabel, { for: 'description' }, 'Description'),
             m(Input, {
@@ -92,7 +98,9 @@ const NewTopicModal: m.Component<{
             }),
           ]),
           app.activeChainId() && m(FormGroup, [
-            m(FormLabel, { for: 'tokenThreshold' }, `Number of tokens needed to post (${app.chain?.meta.chain.symbol})`),
+            m(FormLabel, {
+              for: 'tokenThreshold'
+            }, `Number of tokens needed to post (${app.chain?.meta.chain.symbol})`),
             m(TokenDecimalInput, {
               decimals,
               defaultValueInWei: '0',

--- a/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
+++ b/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    const prohibitedChars = '["<>%{}|\\/^/`]';
+    const prohibitedChars = '["<>%{}|\\/^`]';
     const query = `UPDATE "OffchainTopics" SET name=REGEXP_REPLACE(name, '${prohibitedChars}', '', 'g');`;
     queryInterface.sequelize.query(query);
   },

--- a/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
+++ b/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
@@ -2,7 +2,8 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    const query = `UPDATE "OffchainTopics" SET name=REGEXP_REPLACE(name, '[^[:alpha:][:digit:][:space:]]', '', 'g');`;
+    const prohibitedChars = '["<>%{}|\\/^/`]';
+    const query = `UPDATE "OffchainTopics" SET name=REGEXP_REPLACE(name, '${prohibitedChars}', '', 'g');`;
     queryInterface.sequelize.query(query);
   },
 

--- a/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
+++ b/server/migrations/20211222191316-remove-non-alphanumeric-chars-from-topic-names.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const query = `UPDATE "OffchainTopics" SET name=REGEXP_REPLACE(name, '[^[:alpha:][:digit:][:space:]]', '', 'g');`;
+    queryInterface.sequelize.query(query);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // Down not possible
+  }
+};

--- a/server/routes/createTopic.ts
+++ b/server/routes/createTopic.ts
@@ -8,7 +8,8 @@ export const Errors = {
   TopicRequired: 'Topic name required',
   MustBeAdmin: 'Must be an admin',
   InvalidTokenThreshold: 'Invalid token threshold',
-  DefaultTemplateRequired: 'Default Template required'
+  DefaultTemplateRequired: 'Default Template required',
+  InvalidTopicName: 'Only alphanumeric chars allowed'
 };
 
 const createTopic = async (models: DB, req, res: Response, next: NextFunction) => {
@@ -16,6 +17,7 @@ const createTopic = async (models: DB, req, res: Response, next: NextFunction) =
   if (error) return next(new Error(error));
   if (!req.user) return next(new Error(Errors.NotLoggedIn));
   if (!req.body.name) return next(new Error(Errors.TopicRequired));
+  if (req.body.name.match(/[^\w\s]/g)) return next(new Error(Errors.InvalidTopicName))
   if (req.body.featured_in_new_post === 'true'
     && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
     return next(new Error(Errors.DefaultTemplateRequired));

--- a/server/routes/createTopic.ts
+++ b/server/routes/createTopic.ts
@@ -17,7 +17,7 @@ const createTopic = async (models: DB, req, res: Response, next: NextFunction) =
   if (error) return next(new Error(error));
   if (!req.user) return next(new Error(Errors.NotLoggedIn));
   if (!req.body.name) return next(new Error(Errors.TopicRequired));
-  if (req.body.name.match(/[^\w\s]/g)) return next(new Error(Errors.InvalidTopicName))
+  if (req.body.name.match(/["<>%{}|\\/^`]/g)) return next(new Error(Errors.InvalidTopicName))
   if (req.body.featured_in_new_post === 'true'
     && (!req.body.default_offchain_template || !req.body.default_offchain_template.trim())) {
     return next(new Error(Errors.DefaultTemplateRequired));


### PR DESCRIPTION
Previously, use of slash chars in topic names was causing URL issues.

This branch uses the new component kit TextInput's inputValidationFn with a regexp match method to identify and disallow non-alphanumeric chars in newly created offchain topics. 

It also includes a migration that removes punctuation and special chars/symbols from existing topic names.

![image](https://user-images.githubusercontent.com/22281010/147145748-3d39f9ff-4d75-4e8f-bead-77a5a15a9250.png)
