### PR TITLE
Ensure Markdown handling is Safari-friendly

### DIFF
--- a/client/scripts/lib/markdownShortcuts.js
+++ b/client/scripts/lib/markdownShortcuts.js
@@ -90,7 +90,15 @@
               const openingDelimiter = match[1]
               const matchedText = match[2]
               const closingDelimiter = match[3]
-              const startIndex = lineStart + match.index + indexOffset;
+              const startIndex = lineStart + match.index - indexOffset;
+              console.log({
+                '0': match[0],
+                '1': match[1],
+                '2': match[2],
+                '3': match[3],
+              })
+              console.log({ indexOffset });
+              console.log(startIndex);
 
               // bolditalic must be prefixed with whitespace
               if (startIndex > 0 && this.quill.getText()[startIndex]
@@ -101,17 +109,16 @@
               if (openingDelimiter !== closingDelimiter) continue;
               if (openingDelimiter !== closingDelimiter.split('').reverse().join('')) continue;
               indexOffset += openingDelimiter.length * 2;
-              setTimeout(() => {
-                const formatting =
-                      (openingDelimiter === '*' || openingDelimiter === '_') ? {italic: true} :
-                      (openingDelimiter === '**' || openingDelimiter === '__') ? {bold: true} :
-                      {bold: true, italic: true};
-                this.quill.deleteText(startIndex + whitespaceStartOffset,
-                  annotatedText.length - whitespaceStartOffset - whitespaceEndOffset)
-                this.quill.insertText(startIndex + whitespaceStartOffset, matchedText, formatting)
-                this.quill.format('bold', false)
-                this.quill.format('italic', false)
-              }, 0)
+
+              const formatting =
+                    (openingDelimiter === '*' || openingDelimiter === '_') ? {italic: true} :
+                    (openingDelimiter === '**' || openingDelimiter === '__') ? {bold: true} :
+                    {bold: true, italic: true};
+              this.quill.deleteText(startIndex + whitespaceStartOffset,
+                annotatedText.length - whitespaceStartOffset - whitespaceEndOffset)
+              this.quill.insertText(startIndex + whitespaceStartOffset, matchedText, formatting)
+              this.quill.format('bold', false)
+              this.quill.format('italic', false)
            }
          }
        },

--- a/client/scripts/lib/markdownShortcuts.js
+++ b/client/scripts/lib/markdownShortcuts.js
@@ -79,34 +79,37 @@
        {
          // bolditalic now handles bold, italic, and bold italic
          name: 'bolditalic',
-         pattern: /(?<!\S)((?:\*|_){1,3})([^\s*_]{1,2}|[^\s_*][^_*]+?[^\s_*])((?:\*|_){1,3})(?!\S)/g,
+         pattern: /[^\S]?((?:\*|_){1,3})([^\s*_]{1,2}|[^\s_*][^_*]+?[^\s_*])((?:\*|_){1,3})[^\S]?/g,
          action: (text, selection, pattern, lineStart) => {
            const allMatches = text.matchAll(pattern);
-
            let indexOffset = 0;
            for (const match of allMatches) {
-              const annotatedText = match[0]
+              const annotatedText = match[0];
+              const whitespaceStartOffset = annotatedText[0] === ' ' ? 1 : 0;
+              const whitespaceEndOffset = annotatedText[annotatedText.length - 1] === ' ' ? 1 : 0;
               const openingDelimiter = match[1]
               const matchedText = match[2]
               const closingDelimiter = match[3]
               const startIndex = lineStart + match.index + indexOffset;
 
               // bolditalic must be prefixed with whitespace
-              if (startIndex > 0 && this.quill.getText()[startIndex - 1]
-                && this.quill.getText()[startIndex - 1].match(/[*_ \n]/) === null) continue;
+              if (startIndex > 0 && this.quill.getText()[startIndex]
+                && this.quill.getText()[startIndex].match(/[*_ \n]/) === null) continue;
               if (text.match(/^([*_ \n]+)$/g)) continue;
               if (matchedText[0] === ' ' || matchedText[matchedText.length - 1] === ' ') continue;
               if (matchedText[0] === '*' || matchedText[0] === '_') continue;
               if (openingDelimiter !== closingDelimiter) continue;
               if (openingDelimiter !== closingDelimiter.split('').reverse().join('')) continue;
               indexOffset += openingDelimiter.length * 2;
+              console.log('timeout');
               setTimeout(() => {
                 const formatting =
                       (openingDelimiter === '*' || openingDelimiter === '_') ? {italic: true} :
                       (openingDelimiter === '**' || openingDelimiter === '__') ? {bold: true} :
                       {bold: true, italic: true};
-                this.quill.deleteText(startIndex, annotatedText.length)
-                this.quill.insertText(startIndex, matchedText, formatting)
+                this.quill.deleteText(startIndex + whitespaceStartOffset,
+                  annotatedText.length - whitespaceStartOffset - whitespaceEndOffset)
+                this.quill.insertText(startIndex + whitespaceStartOffset, matchedText, formatting)
                 this.quill.format('bold', false)
                 this.quill.format('italic', false)
               }, 0)

--- a/client/scripts/lib/markdownShortcuts.js
+++ b/client/scripts/lib/markdownShortcuts.js
@@ -101,7 +101,6 @@
               if (openingDelimiter !== closingDelimiter) continue;
               if (openingDelimiter !== closingDelimiter.split('').reverse().join('')) continue;
               indexOffset += openingDelimiter.length * 2;
-              console.log('timeout');
               setTimeout(() => {
                 const formatting =
                       (openingDelimiter === '*' || openingDelimiter === '_') ? {italic: true} :

--- a/client/scripts/lib/markdownShortcuts.js
+++ b/client/scripts/lib/markdownShortcuts.js
@@ -91,14 +91,6 @@
               const matchedText = match[2]
               const closingDelimiter = match[3]
               const startIndex = lineStart + match.index - indexOffset;
-              console.log({
-                '0': match[0],
-                '1': match[1],
-                '2': match[2],
-                '3': match[3],
-              })
-              console.log({ indexOffset });
-              console.log(startIndex);
 
               // bolditalic must be prefixed with whitespace
               if (startIndex > 0 && this.quill.getText()[startIndex]


### PR DESCRIPTION
The previous Markdown RegEx handler used lookahead/lookbehind features, which are not supported by Safari.

This changes the programmatic handling so that lookahead/lookbehind RegEx functionality is no longer necessary.

It also theoretically adds support (currently missing) for full-document copy-paste Markdown to RichText conversion.

The big things to test here:
- That Markdown formatting, while inside the RichText setting of the QuillJS editor, works in both asterisk and underscore delimiter form for all of: italic (single delimiter), bold (double delimiter), and bold-italic (triple delimiter) styling
- That all the above formatting works correctly in-line while typing out a new text body ("as you go")
- That all the above formatting works correctly when being inserted mid-body text ("going back to add/edit")
- That all the above formatting works correctly when Markdown text is copy-pasted into the text editor