### PR TITLE
Do not display voters for completed cosmos proposals.

### DIFF
--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -316,7 +316,7 @@ const VotingResults: m.Component<{ proposal: AnyProposal }> = {
         }
         const voteTotal = yes.add(no).add(abstain).add(noWithVeto);
         const getPct = (n: BN) => {
-          return (n.muln(10_000).div(voteTotal).toNumber() / 10_000).toFixed(3);
+          return (n.muln(10_000).div(voteTotal).toNumber() / 100).toFixed(2);
         }
         return m('.VotingResults', [
           m('.results-column', [

--- a/client/scripts/views/components/proposals/voting_results.ts
+++ b/client/scripts/views/components/proposals/voting_results.ts
@@ -314,18 +314,26 @@ const VotingResults: m.Component<{ proposal: AnyProposal }> = {
           const coin = new Coin(denom, n, false, decimals);
           return coin.format();
         }
+        const voteTotal = yes.add(no).add(abstain).add(noWithVeto);
+        const getPct = (n: BN) => {
+          return (n.muln(10_000).div(voteTotal).toNumber() / 10_000).toFixed(3);
+        }
         return m('.VotingResults', [
           m('.results-column', [
-            m('.results-header', `Voted yes (${formatCurrency(yes)})`),
+            m('.results-header', `${getPct(yes)}% voted Yes`),
+            m('.results-cell', `(${formatCurrency(yes)})`),
           ]),
           m('.results-column', [
-            m('.results-header', `Voted no (${formatCurrency(no)})`),
+            m('.results-header', `${getPct(no)}% voted No`),
+            m('.results-cell', `(${formatCurrency(no)})`),
           ]),
           m('.results-column', [
-            m('.results-header', `Voted abstain (${formatCurrency(abstain)})`),
+            m('.results-header', `${getPct(abstain)}% voted Abstain`),
+            m('.results-cell', `(${formatCurrency(abstain)})`),
           ]),
           m('.results-column', [
-            m('.results-header', `Voted veto (${formatCurrency(noWithVeto)})`),
+            m('.results-header', `${getPct(noWithVeto)}% voted Veto`),
+            m('.results-cell', `(${formatCurrency(noWithVeto)})`),
           ])
         ]);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**NEEDS BETTER STYLING**

Changes completed cosmos proposal vote results to look like:
![2021-12-28-162500_1122x479_scrot](https://user-images.githubusercontent.com/1860629/147608191-65873dec-53c9-4969-b435-667479363669.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes confusion about "why are there no voters?" on completed cosmos proposals.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran it and verified output.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no