### PR TITLE
Fix Snapshot Linked Threads Bug

### DIFF
--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -614,7 +614,7 @@ class ThreadsController {
         chain: app.activeId(),
       },
     });
-    if (response.status === 'Failed') {
+    if (response.status === 'Failure') {
       return null;
     }
     return response.result;

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -614,8 +614,8 @@ class ThreadsController {
         chain: app.activeId(),
       },
     });
-    if (response.status !== 'Success') {
-      return 'false';
+    if (response.status === 'Failed') {
+      return null;
     }
     return response.result;
   }

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -444,7 +444,7 @@ const ViewProposalPage: m.Component<
                   threads !== null &&
                     m('.linked-discussion', [
                       m('.heading-2', 'Linked Discussions'),
-                      threads.length > 0 && threads.map((thread) => 
+                      threads.map((thread) => 
                         m(ProposalHeaderSnapshotThreadLink, {
                           thread
                         }),

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -444,7 +444,7 @@ const ViewProposalPage: m.Component<
                   threads !== null &&
                     m('.linked-discussion', [
                       m('.heading-2', 'Linked Discussions'),
-                      threads.map((thread) => 
+                      threads.length > 0 && threads.map((thread) => 
                         m(ProposalHeaderSnapshotThreadLink, {
                           thread
                         }),

--- a/server/routes/fetchThreadForSnapshot.ts
+++ b/server/routes/fetchThreadForSnapshot.ts
@@ -18,7 +18,7 @@ const fetchThreadForSnapshot = async (models: DB, req: Request, res: Response, n
       snapshot_proposal: snapshot,
     }
   });
-  if (threads.length < 1) return res.json({ status: 'Failed' });
+  if (threads.length < 1) return res.json({ status: 'Failure' });
   
   return res.json({ status: 'Success', result: threads.map((thread) => { return { id: thread.id, title: thread.title } }) });
 };

--- a/server/routes/fetchThreadForSnapshot.ts
+++ b/server/routes/fetchThreadForSnapshot.ts
@@ -18,9 +18,9 @@ const fetchThreadForSnapshot = async (models: DB, req: Request, res: Response, n
       snapshot_proposal: snapshot,
     }
   });
-  if (threads.length < 1) return res.json({ status: 'Failure', message: '' });
+  if (threads.length < 1) return res.json({ status: 'Failed' });
   
-  return res.json({ status: 'Success', result: threads.map((thread) => { return {id: thread.id, title: thread.title} }) });
+  return res.json({ status: 'Success', result: threads.map((thread) => { return { id: thread.id, title: thread.title } }) });
 };
 
 export default fetchThreadForSnapshot;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When you go to a snapshot proposal page that didn't have a linked thread, it would throw a console error.

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no