### PR TITLE
Support scope/proposal/X and scope/discussion/X paths.

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -32,6 +32,7 @@ import { Layout } from 'views/layout';
 import ConfirmInviteModal from 'views/modals/confirm_invite_modal';
 import LoginModal from 'views/modals/login_modal';
 import { alertModalWithText } from 'views/modals/alert_modal';
+import { pathIsDiscussion } from './identifiers';
 
 // Prefetch commonly used pages
 import(/* webpackPrefetch: true */ 'views/pages/landing');
@@ -576,7 +577,8 @@ Promise.all([
       // a special case because OffchainThreads and on-chain proposals are all viewed through the
       // same "/:scope/proposal/:type/:id" route.
       let deferChain = attrs.deferChain;
-      if (path === 'views/pages/view_proposal/index' && vnode.attrs.type === 'discussion') {
+      const isDiscussion = vnode.attrs.type === 'discussion' || pathIsDiscussion(scope, window.location.pathname);
+      if (path === 'views/pages/view_proposal/index' && isDiscussion) {
         deferChain = true;
       }
       if (app.chain?.meta.chain.type === ChainType.Token) {
@@ -627,6 +629,8 @@ Promise.all([
       '/council':                importRoute('views/pages/council', { scoped: true }),
       '/delegate':               importRoute('views/pages/delegate', { scoped: true, }),
       '/proposal/:type/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
+      '/proposal/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
+      '/discussion/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
       '/new/proposal/:type':     importRoute('views/pages/new_proposal/index', { scoped: true }),
       // Treasury
       '/treasury':               importRoute('views/pages/treasury', { scoped: true }),
@@ -679,6 +683,8 @@ Promise.all([
       '/:scope/council':            redirectRoute(() => '/council'),
       '/:scope/delegate':           redirectRoute(() => '/delegate'),
       '/:scope/proposal/:type/:identifier': redirectRoute((attrs) => `/proposal/${attrs.type}/${attrs.identifier}/`),
+      '/:scope/proposal/:identifier': redirectRoute((attrs) => `/proposal/${attrs.identifier}/`),
+      '/:scope/discussion/:identifier': redirectRoute((attrs) => `/discussion/${attrs.identifier}/`),
       '/:scope/new/proposal/:type':  redirectRoute((attrs) => `/new/proposal/${attrs.type}/`),
       '/:scope/treasury':           redirectRoute(() => '/treasury'),
       '/:scope/bounties':           redirectRoute(() => '/bounties'),
@@ -751,6 +757,8 @@ Promise.all([
       '/:scope/council':           importRoute('views/pages/council', { scoped: true }),
       '/:scope/delegate':          importRoute('views/pages/delegate', { scoped: true, }),
       '/:scope/proposal/:type/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
+      '/:scope/proposal/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
+      '/:scope/discussion/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
       '/:scope/new/proposal/:type': importRoute('views/pages/new_proposal/index', { scoped: true }),
 
       // Treasury

--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -632,6 +632,7 @@ Promise.all([
       '/proposal/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
       '/discussion/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
       '/new/proposal/:type':     importRoute('views/pages/new_proposal/index', { scoped: true }),
+      '/new/proposal':           importRoute('views/pages/new_proposal/index', { scoped: true }),
       // Treasury
       '/treasury':               importRoute('views/pages/treasury', { scoped: true }),
       '/bounties':               importRoute('views/pages/bounties', { scoped: true }),
@@ -686,6 +687,7 @@ Promise.all([
       '/:scope/proposal/:identifier': redirectRoute((attrs) => `/proposal/${attrs.identifier}/`),
       '/:scope/discussion/:identifier': redirectRoute((attrs) => `/discussion/${attrs.identifier}/`),
       '/:scope/new/proposal/:type':  redirectRoute((attrs) => `/new/proposal/${attrs.type}/`),
+      '/:scope/new/proposal':        redirectRoute(() => '/new/proposal'),
       '/:scope/treasury':           redirectRoute(() => '/treasury'),
       '/:scope/bounties':           redirectRoute(() => '/bounties'),
       '/:scope/tips':               redirectRoute(() => '/tips'),
@@ -757,9 +759,10 @@ Promise.all([
       '/:scope/council':           importRoute('views/pages/council', { scoped: true }),
       '/:scope/delegate':          importRoute('views/pages/delegate', { scoped: true, }),
       '/:scope/proposal/:type/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
-      '/:scope/proposal/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
+      '/:scope/proposal/:identifier':   importRoute('views/pages/view_proposal/index', { scoped: true }),
       '/:scope/discussion/:identifier': importRoute('views/pages/view_proposal/index', { scoped: true }),
-      '/:scope/new/proposal/:type': importRoute('views/pages/new_proposal/index', { scoped: true }),
+      '/:scope/new/proposal/:type':     importRoute('views/pages/new_proposal/index', { scoped: true }),
+      '/:scope/new/proposal':           importRoute('views/pages/new_proposal/index', { scoped: true }),
 
       // Treasury
       '/:scope/treasury':          importRoute('views/pages/treasury', { scoped: true }),

--- a/client/scripts/controllers/chain/near/sputnik/dao.ts
+++ b/client/scripts/controllers/chain/near/sputnik/dao.ts
@@ -83,7 +83,7 @@ export default class NearSputnikDao extends ProposalModule<
     };
 
     const nextProposalId = this._nProposals;
-    const callbackUrl = `${window.location.origin}/${contractId}/proposal/${ProposalType.SputnikProposal}/${nextProposalId}`;
+    const callbackUrl = `${window.location.origin}/${contractId}/proposal/${nextProposalId}`;
     await this._Chain.redirectTx(
       contractId,
       methodName,

--- a/client/scripts/identifiers.ts
+++ b/client/scripts/identifiers.ts
@@ -2,11 +2,31 @@ import { StorageModule, ProposalModule, ChainInfo } from 'models';
 import { SubstrateTypes, IChainEntityKind } from '@commonwealth/chain-events';
 import { ProposalStore } from 'stores';
 import { ProposalType, ChainBase, ChainNetwork } from 'types';
+import { requiresTypeSlug } from 'utils';
 import app from './state';
 import ThreadsController from './controllers/server/threads';
 
 export const pathIsDiscussion = (scope: string | null, path: string): boolean => {
   return path.startsWith(`/${scope}/discussion`) || path.startsWith('/discussion');
+}
+
+// returns a URL path to a proposal based on its type and id, taking into account
+// custom domain prefixes as well.
+export const getProposalUrlPath = (type: ProposalType, id: string, omitActiveId = false): string => {
+  let basePath: string;
+  const useTypeSlug = requiresTypeSlug(type);
+  if (type === ProposalType.OffchainThread) {
+    basePath = `/discussion/${id}`;
+  } else if (useTypeSlug) {
+    basePath = `/proposal/${type}/${id}`;
+  } else {
+    basePath = `/proposal/${id}`;
+  }
+  if (!app.isCustomDomain() && !omitActiveId) {
+    return `/${app.activeId()}${basePath}`;
+  } else {
+    return basePath;
+  }
 }
 
 export const chainToProposalSlug = (c: ChainInfo): ProposalType => {

--- a/client/scripts/identifiers.ts
+++ b/client/scripts/identifiers.ts
@@ -1,9 +1,22 @@
-import { StorageModule, ProposalModule } from 'models';
+import { StorageModule, ProposalModule, ChainInfo } from 'models';
 import { SubstrateTypes, IChainEntityKind } from '@commonwealth/chain-events';
 import { ProposalStore } from 'stores';
 import { ProposalType, ChainBase, ChainNetwork } from 'types';
 import app from './state';
 import ThreadsController from './controllers/server/threads';
+
+export const pathIsDiscussion = (scope: string | null, path: string): boolean => {
+  return path.startsWith(`/${scope}/discussion`) || path.startsWith('/discussion');
+}
+
+export const chainToProposalSlug = (c: ChainInfo): ProposalType => {
+  if (c.base === ChainBase.CosmosSDK) return ProposalType.CosmosProposal;
+  if (c.network === ChainNetwork.Sputnik) return ProposalType.SputnikProposal;
+  if (c.network === ChainNetwork.Moloch) return ProposalType.MolochProposal;
+  if (c.network === ChainNetwork.Compound) return ProposalType.CompoundProposal;
+  if (c.network === ChainNetwork.Aave) return ProposalType.AaveProposal;
+  throw new Error(`Cannot determine proposal slug from chain ${c.id}.`);
+}
 
 export const proposalSlugToClass = () => {
   if (app.community) {

--- a/client/scripts/views/components/new_proposal_button.ts
+++ b/client/scripts/views/components/new_proposal_button.ts
@@ -52,24 +52,18 @@ export const getNewProposalMenu = (candidates?: Array<[SubstrateAccount, number]
       && !mobile
       && m(MenuDivider),
     app.chain?.base === ChainBase.CosmosSDK && m(MenuItem, {
-      onclick: (e) => navigateToSubpage('/new/proposal/:type', {
-        type: ProposalType.CosmosProposal
-      }),
+      onclick: (e) => navigateToSubpage('/new/proposal'),
       label: 'New text proposal',
       iconLeft: mobile ? Icons.PLUS : undefined,
     }),
     app.chain?.base === ChainBase.Ethereum && app.chain?.network === ChainNetwork.Aave
      && m(MenuItem, {
-       onclick: (e) => navigateToSubpage('/new/proposal/:type', {
-         type: ProposalType.AaveProposal
-       }),
-       label: 'New On-Chain Proposal',
-       iconLeft: mobile ? Icons.PLUS : undefined,
+      onclick: (e) => navigateToSubpage('/new/proposal'),
+      label: 'New On-Chain Proposal',
+      iconLeft: mobile ? Icons.PLUS : undefined,
      }),
     app.chain?.network === ChainNetwork.Compound && m(MenuItem, {
-      onclick: (e) => navigateToSubpage('/new/proposal/:type', {
-        type: ProposalType.CompoundProposal
-      }),
+      onclick: (e) => navigateToSubpage('/new/proposal'),
       label: 'New On-Chain Proposal',
       iconLeft: mobile ? Icons.PLUS : undefined,
     }),
@@ -112,9 +106,7 @@ export const getNewProposalMenu = (candidates?: Array<[SubstrateAccount, number]
       }),
     ],
     app.chain.network === ChainNetwork.Sputnik && m(MenuItem, {
-      onclick: (e) => navigateToSubpage('/new/proposal/:type', {
-        type: ProposalType.SputnikProposal
-      }),
+      onclick: (e) => navigateToSubpage('/new/proposal'),
       label: 'New Sputnik proposal',
       iconLeft: mobile ? Icons.PLUS : undefined,
     }),

--- a/client/scripts/views/components/new_thread_form.ts
+++ b/client/scripts/views/components/new_thread_form.ts
@@ -181,7 +181,7 @@ const newThread = async (
 
   await app.user.notifications.refresh();
 
-  navigateToSubpage(`/proposal/discussion/${result.id}`);
+  navigateToSubpage(`/discussion/${result.id}`);
 
   if (result.topic) {
     try {

--- a/client/scripts/views/components/proposal_card.ts
+++ b/client/scripts/views/components/proposal_card.ts
@@ -12,7 +12,7 @@ import { Coin } from 'adapters/currency';
 import { blocknumToDuration, formatNumberLong, formatPercentShort, link, pluralize } from 'helpers';
 import { ProposalStatus, VotingType, AnyProposal, AddressInfo } from 'models';
 import { ProposalType } from 'types';
-import { proposalSlugToChainEntityType, chainEntityTypeToProposalShortName } from 'identifiers';
+import { proposalSlugToChainEntityType, chainEntityTypeToProposalShortName, getProposalUrlPath } from 'identifiers';
 
 import Substrate from 'controllers/chain/substrate/main';
 import { SubstrateTreasuryProposal } from 'controllers/chain/substrate/treasury_proposal';
@@ -180,8 +180,8 @@ const ProposalCard: m.Component<{ proposal: AnyProposal, injectedContent? }> = {
           e.stopPropagation();
           e.preventDefault();
           localStorage[`${app.activeId()}-proposals-scrollY`] = window.scrollY;
-          navigateToSubpage(`/proposal/${proposal.slug}/${proposal.identifier}`
-                                   + `-${slugify(proposal.title)}`); // avoid resetting scroll point
+          const path = getProposalUrlPath(proposal.slug, `${proposal.identifier}-${slugify(proposal.title)}`, true);
+          navigateToSubpage(path); // avoid resetting scroll point
         },
       }, [
         m('.proposal-card-metadata', [
@@ -253,12 +253,12 @@ const ProposalCard: m.Component<{ proposal: AnyProposal, injectedContent? }> = {
         // thread link
         proposal.threadId && m('.proposal-thread-link', [
           m('a', {
-            href: `/${app.activeId()}/proposal/discussion/${proposal.threadId}`,
+            href: getProposalUrlPath(ProposalType.OffchainThread, `${proposal.threadId}`),
             onclick: (e) => {
               e.stopPropagation();
               e.preventDefault();
               localStorage[`${app.activeId()}-proposals-scrollY`] = window.scrollY;
-              navigateToSubpage(`/proposal/discussion/${proposal.threadId}`);
+              navigateToSubpage(getProposalUrlPath(ProposalType.OffchainThread, `${proposal.threadId}`, true));
               // avoid resetting scroll point
             },
           }, [

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -373,7 +373,7 @@ export const OnchainNavigationModule: m.Component<{}, {}> = {
         rounded: true,
         onclick: (e) => {
           e.preventDefault();
-          navigateToSubpage('/new/proposal/:type', { type: ProposalType.MolochProposal });
+          navigateToSubpage('/new/proposal');
         },
         label: 'New proposal',
       }),

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -8,7 +8,7 @@ import { Button, Icon, Icons, Tag } from 'construct-ui';
 
 import { slugify } from 'utils';
 import app from 'state';
-import { chainEntityTypeToProposalShortName } from 'identifiers';
+import { chainEntityTypeToProposalShortName, getProposalUrlPath } from 'identifiers';
 import {
   formatLastUpdated,
   link,
@@ -54,10 +54,7 @@ const DiscussionRow: m.Component<
     if (!proposal) return;
     const propType: OffchainThreadKind = proposal.kind;
     const pinned = proposal.pinned;
-    const discussionLink =
-      `/${app.activeId()}/proposal/${proposal.slug}/${proposal.identifier}-` +
-      `${slugify(proposal.title)}`;
-
+    const discussionLink = getProposalUrlPath(proposal.slug, `${proposal.identifier}-${slugify(proposal.title)}`);
     const rowHeader: any = link('a', discussionLink, proposal.title);
     const rowSubheader = [
       proposal.readOnly && [

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -425,7 +425,7 @@ const DiscussionsPage: m.Component<
 
     const returningFromThread =
       app.lastNavigatedBack() &&
-      app.lastNavigatedFrom().includes('/proposal/discussion/');
+      app.lastNavigatedFrom().includes('/discussion/');
     if (
       returningFromThread &&
       localStorage[`${app.activeId()}-discussions-scrollY`]

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -454,7 +454,7 @@ const DiscussionsPage: m.Component<
       topic || stage ? `${topic || ''}#${stage || ''}` : ALL_PROPOSALS_KEY;
     const returningFromThread =
       app.lastNavigatedBack() &&
-      app.lastNavigatedFrom().includes('/proposal/discussion/');
+      app.lastNavigatedFrom().includes('/discussion/');
     vnode.state.lookback[subpage] =
       returningFromThread &&
       localStorage[`${app.activeId()}-lookback-${subpage}`]

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -4,10 +4,10 @@ import app from 'state';
 import m from 'mithril';
 import moment from 'moment';
 import { OffchainThread, OffchainTopic } from 'models';
+import { getProposalUrlPath } from 'identifiers';
 import { link } from 'helpers';
 import { slugify } from 'utils';
 import { getLastUpdated, isHot } from './discussion_row';
-import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const SummaryRow: m.Component<
   {

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -7,6 +7,7 @@ import { OffchainThread, OffchainTopic } from 'models';
 import { link } from 'helpers';
 import { slugify } from 'utils';
 import { getLastUpdated, isHot } from './discussion_row';
+import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const SummaryRow: m.Component<
   {
@@ -37,9 +38,7 @@ const SummaryRow: m.Component<
       m(
         '.recent-threads',
         sortedThreads.slice(0, 3).map((thread) => {
-          const discussionLink =
-            `/${app.activeId()}/proposal/${thread.slug}/${thread.identifier}-` +
-            `${slugify(thread.title)}`;
+          const discussionLink = getProposalUrlPath(thread.slug, `${thread.identifier}-${slugify(thread.title)}`);
           return m('.thread-summary', [
             link('a', discussionLink, thread.title),
             m('span', thread.lastUpdated.format('MMM D YYYY')),

--- a/client/scripts/views/pages/new_proposal/index.ts
+++ b/client/scripts/views/pages/new_proposal/index.ts
@@ -3,11 +3,12 @@ import 'pages/new_proposal_page.scss';
 import m from 'mithril';
 import mixpanel from 'mixpanel-browser';
 import app from 'state';
+import { navigateToSubpage } from 'app';
 
 import Sublayout from 'views/sublayout';
 import PageLoading from 'views/pages/loading';
 import { ProposalType } from 'types';
-import { proposalSlugToClass, proposalSlugToFriendlyName } from 'identifiers';
+import { proposalSlugToClass, proposalSlugToFriendlyName, chainToProposalSlug } from 'identifiers';
 import { ProposalModule } from 'models';
 import NewProposalForm from 'views/pages/new_proposal/new_proposal_form';
 import PageNotFound from '../404';
@@ -17,22 +18,37 @@ const NewProposalPage: m.Component<{ type }, { typeEnum, titlePre }> = {
     vnode.state.typeEnum = vnode.attrs.type;
     vnode.state.titlePre = 'New';
 
-    // wait for chain if not offchain
-    if (vnode.state.typeEnum !== ProposalType.OffchainThread) {
-      if (app.chain?.failed)
-        return m(PageNotFound, {
-          title: 'Wrong Ethereum Provider Network!',
-          message: 'Change Metamask to point to Ethereum Mainnet',
-        });
-      if (!app.chain || !app.chain.loaded)
-        return m(PageLoading, { narrow: true, showNewProposalButton: true });
+    // auto-redirect to the new thread page if sent here accidentally
+    if (vnode.state.typeEnum === ProposalType.OffchainThread) {
+      navigateToSubpage('/new/thread');
+    }
 
-      // check if module is still initializing
-      const c = proposalSlugToClass().get(vnode.state.typeEnum) as ProposalModule<any, any, any>;
-      if (!c.ready) {
-        app.chain.loadModules([ c ]);
-        return m(PageLoading, { narrow: true, showNewProposalButton: true });
+    // wait for chain
+    if (app.chain?.failed)
+      return m(PageNotFound, {
+        title: 'Wrong Ethereum Provider Network!',
+        message: 'Change Metamask to point to Ethereum Mainnet',
+      });
+    if (!app.chain || !app.chain.loaded || !app.chain.meta)
+      return m(PageLoading, { narrow: true, showNewProposalButton: true });
+
+    // infer proposal type if possible
+    if (!vnode.state.typeEnum) {
+      try {
+        vnode.state.typeEnum = chainToProposalSlug(app.chain.meta.chain);
+      } catch (e) {
+        return m(PageNotFound, {
+          title: 'Invalid Page',
+          message: 'Cannot determine proposal type.',
+        });
       }
+    }
+
+    // check if module is still initializing
+    const c = proposalSlugToClass().get(vnode.state.typeEnum) as ProposalModule<any, any, any>;
+    if (!c.ready) {
+      app.chain.loadModules([ c ]);
+      return m(PageLoading, { narrow: true, showNewProposalButton: true });
     }
 
     return m(Sublayout, {
@@ -43,7 +59,7 @@ const NewProposalPage: m.Component<{ type }, { typeEnum, titlePre }> = {
       m('.forum-container', [
         m('h3', `${vnode.state.titlePre} ${proposalSlugToFriendlyName.get(vnode.state.typeEnum)}`),
         m(NewProposalForm, {
-          typeEnum: vnode.attrs.type,
+          typeEnum: vnode.state.typeEnum,
           onChangeSlugEnum: (value) => {
             if (value !== 'proposal') {
               vnode.state.titlePre = 'Note';
@@ -54,7 +70,7 @@ const NewProposalPage: m.Component<{ type }, { typeEnum, titlePre }> = {
             m.redraw();
           },
           callback: (proposal) => {
-            if (proposal && vnode.attrs.type !== ProposalType.PhragmenCandidacy) {
+            if (proposal && vnode.state.typeEnum !== ProposalType.PhragmenCandidacy) {
               mixpanel.track('Create Thread', {
                 'Step No': 3,
                 'Step' : 'Transaction Signed',

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -322,7 +322,7 @@ const NewProposalForm = {
           deposit
         ).then((result) => {
           done(result);
-          navigateToSubpage(`/proposal/${ProposalType.CosmosProposal}/${result}`);
+          navigateToSubpage(`/proposal/${result}`);
         }).catch((err) => notifyError(err.message));
         return;
       } else if (proposalTypeEnum === ProposalType.MolochProposal) {

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { Checkbox, Button, Icons, ListItem, Table, Tag, Grid, Col, SelectList, RadioGroup } from 'construct-ui';
 
 import app from 'state';
-import { ChainNetwork } from 'types';
+import { ChainNetwork, ProposalType } from 'types';
 import { NotificationSubscription, ChainInfo, CommunityInfo } from 'models';
 import { NotificationCategories } from 'types';
 
@@ -23,6 +23,7 @@ import { notifyError } from 'controllers/app/notifications';
 import Sublayout from 'views/sublayout';
 import PageLoading from 'views/pages/loading';
 import PageError from 'views/pages/error';
+import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const NOTIFICATION_TABLE_PRE_COPY = 'Off-chain discussion events';
 const CHAIN_NOTIFICATION_TABLE_PRE_COPY = 'On-chain events';
@@ -140,7 +141,9 @@ const BatchedSubscriptionRow: m.Component<{
               : subscription.objectId;
 
           return subscription.OffchainThread ? [
-            link('a', `/${chainOrCommunityId}/proposal/discussion/${subscription.OffchainThread.id}`,
+            link('a', `/${chainOrCommunityId}${
+              getProposalUrlPath(ProposalType.OffchainThread, subscription.OffchainThread.id, true)
+            }`,
               threadOrComment.toString(), { target: '_blank' }),
             m('span.item-metadata', moment(subscription.OffchainThread.created_at).fromNow()),
             m('span.item-metadata', NEW_COMMENTS_LABEL_SUFFIX),
@@ -156,7 +159,9 @@ const BatchedSubscriptionRow: m.Component<{
               ? decodeURIComponent(subscription.OffchainComment.id)
               : subscription.objectId;
           return subscription.OffchainThread ? [
-            link('a', `/${chainOrCommunityId}/proposal/discussion/${subscription.OffchainThread.id}`,
+            link('a', `/${chainOrCommunityId}${
+              getProposalUrlPath(ProposalType.OffchainThread, subscription.OffchainThread.id, true)
+            }`,
               threadOrComment.toString(), { target: '_blank' }),
             m('span.item-metadata', moment(subscription.OffchainThread.created_at).fromNow()),
             m('span.item-metadata', NEW_REACTIONS_LABEL_SUFFIX),
@@ -185,7 +190,9 @@ const BatchedSubscriptionRow: m.Component<{
           : subscription.objectId;
 
       return subscription.OffchainThread ? [
-        link('a', `/${chainOrCommunityId}/proposal/discussion/${subscription.OffchainThread.id}`,
+        link('a', `/${chainOrCommunityId}${
+              getProposalUrlPath(ProposalType.OffchainThread, subscription.OffchainThread.id, true)
+            }`,
           threadOrComment.toString(), { target: '_blank' }),
         m('span.item-metadata', moment(subscription.OffchainThread.created_at).fromNow()),
       ] : [ threadOrComment.toString() ];

--- a/client/scripts/views/pages/notifications.ts
+++ b/client/scripts/views/pages/notifications.ts
@@ -7,9 +7,9 @@ import moment from 'moment';
 import { Checkbox, Button, Icons, ListItem, Table, Tag, Grid, Col, SelectList, RadioGroup } from 'construct-ui';
 
 import app from 'state';
-import { ChainNetwork, ProposalType } from 'types';
+import { ChainNetwork, ProposalType, NotificationCategories } from 'types';
 import { NotificationSubscription, ChainInfo, CommunityInfo } from 'models';
-import { NotificationCategories } from 'types';
+import { getProposalUrlPath } from 'identifiers';
 
 import { link, pluralize } from 'helpers';
 import { sortSubscriptions } from 'helpers/notifications';
@@ -23,7 +23,6 @@ import { notifyError } from 'controllers/app/notifications';
 import Sublayout from 'views/sublayout';
 import PageLoading from 'views/pages/loading';
 import PageError from 'views/pages/error';
-import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const NOTIFICATION_TABLE_PRE_COPY = 'Off-chain discussion events';
 const CHAIN_NOTIFICATION_TABLE_PRE_COPY = 'On-chain events';

--- a/client/scripts/views/pages/profile/profile_comment_group.ts
+++ b/client/scripts/views/pages/profile/profile_comment_group.ts
@@ -4,11 +4,11 @@ import _ from 'lodash';
 import app from 'state';
 import { link } from 'helpers';
 import { OffchainThread, OffchainComment, AddressInfo, Account } from 'models';
+import { getProposalUrlPath } from 'identifiers';
 
 import User from 'views/components/widgets/user';
 import QuillFormattedText from 'views/components/quill_formatted_text';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
-import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 interface IProfileCommentGroupAttrs {
   proposal: OffchainThread | any;

--- a/client/scripts/views/pages/profile/profile_comment_group.ts
+++ b/client/scripts/views/pages/profile/profile_comment_group.ts
@@ -8,6 +8,7 @@ import { OffchainThread, OffchainComment, AddressInfo, Account } from 'models';
 import User from 'views/components/widgets/user';
 import QuillFormattedText from 'views/components/quill_formatted_text';
 import MarkdownFormattedText from 'views/components/markdown_formatted_text';
+import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 interface IProfileCommentGroupAttrs {
   proposal: OffchainThread | any;
@@ -32,7 +33,11 @@ const ProfileCommentGroup : m.Component<IProfileCommentGroupAttrs> = {
           (proposal.chain || proposal.community) && [
             ' on a ',
             link(
-              'a.link-bold', `/${proposal.chain || proposal.community}/proposal/${slug}/${identifier}`,
+              'a.link-bold', `/${
+                proposal.chain || proposal.community
+              }${
+                getProposalUrlPath(slug, identifier, true)
+              }`,
               ((proposal instanceof OffchainThread) ? 'thread' : 'proposal'), {},
               `profile-${account.address}-${account.chain}-${proposal.chain}-scrollY`
             ),

--- a/client/scripts/views/pages/profile/profile_proposal.ts
+++ b/client/scripts/views/pages/profile/profile_proposal.ts
@@ -5,8 +5,8 @@ import { slugify } from 'utils';
 import app from 'state';
 import { OffchainThread, OffchainThreadKind, AddressInfo } from 'models';
 import { link } from 'helpers';
+import { getProposalUrlPath } from 'identifiers';
 import User from 'views/components/widgets/user';
-import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const ProfileProposal : m.Component< { proposal: OffchainThread }, { revealThread: boolean } > = {
   view: (vnode) => {

--- a/client/scripts/views/pages/profile/profile_proposal.ts
+++ b/client/scripts/views/pages/profile/profile_proposal.ts
@@ -6,6 +6,7 @@ import app from 'state';
 import { OffchainThread, OffchainThreadKind, AddressInfo } from 'models';
 import { link } from 'helpers';
 import User from 'views/components/widgets/user';
+import { getProposalUrlPath } from 'client/scripts/identifiers';
 
 const ProfileProposal : m.Component< { proposal: OffchainThread }, { revealThread: boolean } > = {
   view: (vnode) => {
@@ -25,7 +26,9 @@ const ProfileProposal : m.Component< { proposal: OffchainThread }, { revealThrea
                 'Created a new ',
                 link(
                   'a.link-bold',
-                  `/${chain || community}/proposal/${slug}/${identifier}-${slugify(title)}`, 'thread', {},
+                  `/${chain || community}${
+                    getProposalUrlPath(slug, `${identifier}-${slugify(title)}`, true)
+                  }`, 'thread', {},
                   `profile-${author}-${proposal.authorChain}-${proposal.chain}-scrollY`
                 ),
                 ' in ',
@@ -37,7 +40,9 @@ const ProfileProposal : m.Component< { proposal: OffchainThread }, { revealThrea
       m('.activity.proposal', [
         proposal.kind === OffchainThreadKind.Forum || proposal.kind === OffchainThreadKind.Link
           ? link(
-            'a.proposal-title', `/${chain || community}/proposal/${slug}/${identifier}-${slugify(title)}`, title, {},
+            'a.proposal-title', `/${chain || community}${
+              getProposalUrlPath(slug, `${identifier}-${slugify(title)}`, true)
+            }`, title, {},
             `profile-${author}-${proposal.authorChain}-${proposal.chain}-scrollY`
           )
           : m('a.proposal-title', title),

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -100,9 +100,7 @@ const CompoundProposalStats: m.Component<{}, {}> = {
         ]),
         m(Button, {
           intent: 'primary',
-          onclick: (e) => navigateToSubpage('/new/proposal/:type', {
-            type: ProposalType.CompoundProposal
-          }),
+          onclick: (e) => navigateToSubpage('/new/proposal'),
           label: 'New proposal',
         }),
       ]),

--- a/client/scripts/views/pages/proposals.ts
+++ b/client/scripts/views/pages/proposals.ts
@@ -134,12 +134,7 @@ function getModules(): ProposalModule<any, any, any>[] {
 const ProposalsPage: m.Component<{}> = {
   oncreate: (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'ProposalsPage' });
-    let returningFromThread = false;
-    Object.values(ProposalType).forEach((type) => {
-      if (app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/${type}/`)) {
-        returningFromThread = true;
-      }
-    });
+    const returningFromThread = app.lastNavigatedBack() && app.lastNavigatedFrom().includes('/proposal/');
     if (returningFromThread && localStorage[`${app.activeId()}-proposals-scrollY`]) {
       setTimeout(() => {
         window.scrollTo(0, Number(localStorage[`${app.activeId()}-proposals-scrollY`]));

--- a/client/scripts/views/pages/referenda.ts
+++ b/client/scripts/views/pages/referenda.ts
@@ -70,12 +70,7 @@ function getModules() {
 const ReferendaPage: m.Component<{}> = {
   oncreate: (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'ReferendaPage' });
-    let returningFromThread = false;
-    Object.values(ProposalType).forEach((type) => {
-      if (app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/${type}/`)) {
-        returningFromThread = true;
-      }
-    });
+    const returningFromThread = app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/`);
     if (returningFromThread && localStorage[`${app.activeId()}-proposals-scrollY`]) {
       setTimeout(() => {
         window.scrollTo(0, Number(localStorage[`${app.activeId()}-proposals-scrollY`]));

--- a/client/scripts/views/pages/treasury.ts
+++ b/client/scripts/views/pages/treasury.ts
@@ -84,12 +84,7 @@ function getModules() {
 const TreasuryPage: m.Component<{}> = {
   oncreate: (vnode) => {
     mixpanel.track('PageVisit', { 'Page Name': 'TreasuryPage' });
-    let returningFromThread = false;
-    Object.values(ProposalType).forEach((type) => {
-      if (app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/${type}/`)) {
-        returningFromThread = true;
-      }
-    });
+    const returningFromThread = app.lastNavigatedBack() && app.lastNavigatedFrom().includes(`/proposal/`);
     if (returningFromThread && localStorage[`${app.activeId()}-proposals-scrollY`]) {
       setTimeout(() => {
         window.scrollTo(0, Number(localStorage[`${app.activeId()}-proposals-scrollY`]));

--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -536,7 +536,7 @@ export const ProposalBodySaveEdit: m.Component<{
             : JSON.stringify(quillEditorState.editor.getContents());
           if (item instanceof OffchainThread) {
             app.threads.edit(item, itemText, parentState.updatedTitle, parentState.updatedUrl).then(() => {
-              navigateToSubpage(`/proposal/${item.slug}/${item.id}`);
+              navigateToSubpage(`/discussion/${item.id}`);
               parentState.editing = false;
               parentState.saving = false;
               clearEditingLocalStorage(item, true);

--- a/client/scripts/views/pages/view_proposal/header.ts
+++ b/client/scripts/views/pages/view_proposal/header.ts
@@ -14,7 +14,7 @@ import {
   extractDomain,
   offchainThreadStageToLabel,
 } from 'helpers';
-import { proposalSlugToFriendlyName } from 'identifiers';
+import { getProposalUrlPath, proposalSlugToFriendlyName } from 'identifiers';
 import {
   OffchainThread,
   OffchainThreadKind,
@@ -287,7 +287,7 @@ export const ProposalHeaderThreadLink: m.Component<{ proposal: AnyProposal }> =
       return m('.ProposalHeaderThreadLink', [
         link(
           'a.thread-link',
-          `/${proposal['chain'] || app.activeId()}/proposal/discussion/${
+          `/${proposal['chain'] || app.activeId()}/discussion/${
             proposal.threadId
           }`,
           ['Go to discussion', m(Icon, { name: Icons.EXTERNAL_LINK })]
@@ -304,7 +304,7 @@ export const ProposalHeaderSnapshotThreadLink: m.Component<{
     if (!id) return;
     const proposalLink = `${
       app.isCustomDomain() ? '' : `/${app.activeId()}`
-    }/proposal/discussion/${id}`;
+    }/discussion/${id}`;
 
     return m('.ProposalHeaderThreadLink', [
       link('a.thread-link', proposalLink, [
@@ -490,10 +490,7 @@ export const ProposalTitleSaveEdit: m.Component<{
   view: (vnode) => {
     const { proposal, getSetGlobalEditingStatus, parentState } = vnode.attrs;
     if (!proposal) return;
-    const proposalLink =
-      `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/${
-        proposal.slug
-      }/${proposal.identifier}` + `-${slugify(proposal.title)}`;
+    const proposalLink = getProposalUrlPath(proposal.slug, `${proposal.identifier}-${slugify(proposal.title)}`);
 
     return m('.ProposalTitleSaveEdit', [
       m(

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -19,7 +19,7 @@ import app from 'state';
 import { navigateToSubpage } from 'app';
 import Sublayout from 'views/sublayout';
 import { ProposalType, ChainBase } from 'types';
-import { chainToProposalSlug, idToProposal, pathIsDiscussion, proposalSlugToClass } from 'identifiers';
+import { chainToProposalSlug, getProposalUrlPath, idToProposal, pathIsDiscussion, proposalSlugToClass } from 'identifiers';
 import { slugify } from 'utils';
 
 import Substrate from 'controllers/chain/substrate/main';
@@ -240,10 +240,7 @@ const ProposalHeader: m.Component<
       proposal instanceof OffchainThread
         ? (proposal as OffchainThread).attachments
         : false;
-    const proposalLink =
-      `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/${
-        proposal.slug
-      }/${proposal.identifier}-` + `${slugify(proposal.title)}`;
+    const proposalLink = getProposalUrlPath(proposal.slug, `${proposal.identifier}-${slugify(proposal.title)}`);
     const proposalTitleIsEditable =
       proposal instanceof SubstrateDemocracyProposal ||
       proposal instanceof SubstrateCollectiveProposal ||
@@ -555,12 +552,10 @@ const ProposalComment: m.Component<
       ? CommentParent.Comment
       : CommentParent.Proposal;
 
-    const commentLink =
-      `${app.isCustomDomain() ? '' : `/${app.activeId()}`}/proposal/${
-        proposal.slug
-      }/` +
-      `${proposal.identifier}-${slugify(proposal.title)}?comment=${comment.id}`;
-
+    const commentLink = getProposalUrlPath(
+      proposal.slug,
+      `${proposal.identifier}-${slugify(proposal.title)}?comment=${comment.id}`
+    );
     const commentReplyCount = app.comments
       .getByProposal(proposal)
       .filter((c) => c.parentComment === comment.id && !c.deleted).length;
@@ -975,7 +970,7 @@ const ViewProposalPage: m.Component<
     if (proposalRecentlyEdited) vnode.state.recentlyEdited = false;
     if (identifier !== `${proposalId}-${slugify(proposal.title)}`) {
       navigateToSubpage(
-        `/proposal/${proposal.slug}/${proposalId}-${slugify(proposal.title)}`,
+        getProposalUrlPath(proposal.slug, `${proposalId}-${slugify(proposal.title)}`, true),
         {},
         { replace: true }
       );

--- a/client/scripts/views/pages/view_proposal/sidebar.ts
+++ b/client/scripts/views/pages/view_proposal/sidebar.ts
@@ -7,6 +7,7 @@ import { link } from 'helpers';
 import {
   chainEntityTypeToProposalSlug,
   chainEntityTypeToProposalName,
+  getProposalUrlPath,
 } from 'identifiers';
 import { OffchainThread } from 'models';
 import { LinkedThreadRelation } from 'client/scripts/models/OffchainThread';
@@ -26,7 +27,7 @@ export const ProposalSidebarLinkedChainEntity: m.Component<{
 
     const proposalLink = `${
       app.isCustomDomain() ? '' : `/${proposal.chain}`
-    }/proposal/${slug}/${chainEntity.typeId}`;
+    }${getProposalUrlPath(slug, chainEntity.typeId)}`;
 
     return m('.ProposalSidebarLinkedChainEntity', [
       link('a', proposalLink, [

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -1,3 +1,5 @@
+import { ProposalType } from "./types";
+
 export const getNextOffchainPollEndingTime = (now) => {
   // Offchain polls should be open until 1st or 15th of the month,
   // and should always be open for at least 5 days.
@@ -26,6 +28,17 @@ export const slugify = (str: string): string => {
   return str.toLowerCase().trim().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
 };
 
+export const requiresTypeSlug = (type: ProposalType): boolean => {
+  return type === ProposalType.SubstrateDemocracyReferendum
+    || type === ProposalType.SubstrateDemocracyProposal
+    || type === ProposalType.SubstrateBountyProposal
+    || type === ProposalType.SubstrateTreasuryTip
+    || type === ProposalType.SubstrateCollectiveProposal
+    || type === ProposalType.SubstrateTechnicalCommitteeMotion
+    || type === ProposalType.PhragmenCandidacy
+    || type === ProposalType.SubstrateTreasuryProposal;
+}
+
 /* eslint-disable import/prefer-default-export */
 export const getProposalUrl = (type, proposal, comment?) => {
   const aId = (proposal.community) ? proposal.community : proposal.chain;
@@ -33,9 +46,19 @@ export const getProposalUrl = (type, proposal, comment?) => {
   const tTitle = proposal.title ? `-${slugify(proposal.title)}` : '';
   const cId = comment ? `?comment=${comment.id}` : '';
 
-  return (process.env.NODE_ENV === 'production')
-    ? `https://commonwealth.im/${aId}/proposal/${type}/${tId}${tTitle.toLowerCase()}${cId}`
-    : `http://localhost:8080/${aId}/proposal/${type}/${tId}${tTitle.toLowerCase()}${cId}`;
+  if (requiresTypeSlug(type)) {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/proposal/${type}/${tId}${tTitle.toLowerCase()}${cId}`
+      : `http://localhost:8080/${aId}/proposal/${type}/${tId}${tTitle.toLowerCase()}${cId}`;
+  } else if (type === ProposalType.OffchainThread) {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/discussion/${tId}${tTitle.toLowerCase()}${cId}`
+      : `http://localhost:8080/${aId}/discussion/${tId}${tTitle.toLowerCase()}${cId}`;
+  } else {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/proposal/${tId}${tTitle.toLowerCase()}${cId}`
+      : `http://localhost:8080/${aId}/proposal/${tId}${tTitle.toLowerCase()}${cId}`;
+  }
 };
 
 export const getProposalUrlWithoutObject = (type, proposalCommunity, proposalId, comment?) => {
@@ -43,9 +66,19 @@ export const getProposalUrlWithoutObject = (type, proposalCommunity, proposalId,
   const tId = proposalId;
   const cId = comment ? `?comment=${comment.id}` : '';
 
-  return (process.env.NODE_ENV === 'production')
-    ? `https://commonwealth.im/${aId}/proposal/${type}/${tId}${cId}`
-    : `http://localhost:8080/${aId}/proposal/${type}/${tId}${cId}`;
+  if (requiresTypeSlug(type)) {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/proposal/${type}/${tId}${cId}`
+      : `http://localhost:8080/${aId}/proposal/${type}/${tId}${cId}`;
+  } else if (type === ProposalType.OffchainThread) {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/discussion/${tId}${cId}`
+      : `http://localhost:8080/${aId}/discussion/${tId}${cId}`;
+  } else {
+    return (process.env.NODE_ENV === 'production')
+      ? `https://commonwealth.im/${aId}/proposal/${tId}${cId}`
+      : `http://localhost:8080/${aId}/proposal/${tId}${cId}`;
+  }
 };
 
 export const getCommunityUrl = (community) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds routes for /proposal/XXX and /discussion/XXX paths while preserving existing link formats.
- Changes all links to discussions/proposals to point to the new paths when applicable (non-substrate chains).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Client requests at being annoyed at having to link /proposal/compoundproposal/XXX especially when they're not technically using compound. The reason we require the /compoundproposal/ path component is because of Substrate, in which we had to distinguish between multiple sorts of proposals on the same chain. This is a non-issue for all other governance implementations.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Played around with the UI a bunch. **NEEDS MORE QA**

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no

Specifically it affects metadata/SEO for proposal and discussion pages.