### PR TITLE
Support title for compound proposal creation.

### DIFF
--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -366,8 +366,15 @@ const NewProposalForm = {
           calldatas.push(aaveProposal.calldata || '');
           signatures.push(aaveProposal.signature || '');
         }
+
+        // if they passed a title, use the JSON format for description.
+        // otherwise, keep description raw
+        let description = vnode.state.description;
+        if (vnode.state.title) {
+          description = JSON.stringify({ description: vnode.state.description, title: vnode.state.title });
+        }
         const details: CompoundProposalArgs = {
-          description: vnode.state.description,
+          description,
           targets,
           values,
           calldatas,
@@ -841,6 +848,18 @@ const NewProposalForm = {
                   showAddressWithDisplayName: true,
                 }),
               ]),
+            ]),
+            m(FormGroup, [
+              m(FormLabel, 'Proposal Title (leave blank for no title)'),
+              m(Input, {
+                name: 'title',
+                placeholder: 'Proposal Title',
+                oninput: (e) => {
+                  const result = (e.target as any).value;
+                  vnode.state.title = result;
+                  m.redraw();
+                },
+              }),
             ]),
             m(FormGroup, [
               m(FormLabel, 'Proposal Description'),

--- a/client/scripts/views/pages/new_proposal/new_proposal_form.ts
+++ b/client/scripts/views/pages/new_proposal/new_proposal_form.ts
@@ -863,7 +863,7 @@ const NewProposalForm = {
             ]),
             m(FormGroup, [
               m(FormLabel, 'Proposal Description'),
-              m(Input, {
+              m(TextArea, {
                 name: 'description',
                 placeholder: 'Proposal Description',
                 oninput: (e) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a title field for Compound proposal creation that JSON-stringifies the title/description fields into a JSON blob, which we then parse out at proposal load time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issues getting proper title/descriptions for compound communities, such as impactmarket.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran against a hardhat node + deployBravo.ts and verified it worked.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no