### PR TITLE
Summary Page Bug Fix + Redesign

### DIFF
--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -88,7 +88,7 @@ class RecentActivityController {
     const params = {
       chain: chainId,
       community: communityId,
-      threads_per_topics: threadsPerTopic
+      threads_per_topic: threadsPerTopic
     };
 
     const response = await $.get(`${app.serverUrl()}/activeThreads`, params);
@@ -97,22 +97,18 @@ class RecentActivityController {
     }
 
     const { threads, activitySummary } = response.result;
-    return {
-      threads: threads.map((thread) => {
-        const modeledThread = modelThreadFromServer(thread);
-        if (!thread.Address) {
-          console.error('OffchainThread missing address');
-        }
-        try {
-          app.threads.store.add(modeledThread);
-        } catch (e) {
-          console.error(e.message);
-        }
-        return modeledThread;
-      }),
-      activitySummary,
-    };
-    return;
+    return threads.map((thread) => {
+      const modeledThread = modelThreadFromServer(thread);
+      if (!thread.Address) {
+        console.error('OffchainThread missing address');
+      }
+      try {
+        app.threads.store.add(modeledThread);
+      } catch (e) {
+        console.error(e.message);
+      }
+      return modeledThread;
+    });
   }
 
   // public addThreads(threads: IAbridgedThreadFromServer[], clear?: boolean) {

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -80,7 +80,7 @@ class RecentActivityController {
     chainId: string;
     communityId: string;
     threadsPerTopic?: number;
-  }): Promise<{ threads: OffchainThread[]; activitySummary }> {
+  }): Promise<OffchainThread[]> {
     const { chainId, communityId } = options;
     const threadsPerTopic = options.threadsPerTopic || 3;
     const params = {

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -106,6 +106,7 @@ class RecentActivityController {
       } catch (e) {
         console.error(e.message);
       }
+      console.log({ modeledThread });
       return modeledThread;
     });
   }

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -3,13 +3,11 @@ import {
   OffchainTopic,
   AbridgedThread,
   Profile,
-  OffchainComment,
   OffchainThread,
 } from 'models';
 import app from 'state';
 import $ from 'jquery';
 import { modelFromServer as modelThreadFromServer } from 'controllers/server/threads';
-import { modelFromServer as modelCommentFromServer } from 'controllers/server/comments';
 
 export interface IAbridgedThreadFromServer {
   id: number;

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -95,8 +95,9 @@ class RecentActivityController {
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful: ${response.status}`);
     }
+    console.log(response.result);
 
-    const { threads, activitySummary } = response.result;
+    const threads = response.result;
     return threads.map((thread) => {
       const modeledThread = modelThreadFromServer(thread);
       if (!thread.Address) {

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -78,26 +78,25 @@ class RecentActivityController {
     return this._activeUsers;
   }
 
-  public async getRecentCommunityActivity(options: {
+  public async getRecentTopicActivity(options: {
     chainId: string;
     communityId: string;
-    cutoffDate?: moment.Moment;
+    threadsPerTopic?: number;
   }): Promise<{ threads: OffchainThread[]; activitySummary }> {
     const { chainId, communityId } = options;
-    const cutoffDate =
-      options.cutoffDate || moment(Date.now() - 30 * 24 * 3600 * 1000);
-
+    const threadsPerTopic = options.threadsPerTopic || 3;
     const params = {
       chain: chainId,
       community: communityId,
-      cutoff_date: cutoffDate.toISOString(),
+      threads_per_topics: threadsPerTopic
     };
+
     const response = await $.get(`${app.serverUrl()}/activeThreads`, params);
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful: ${response.status}`);
     }
-    const { threads, activitySummary } = response.result;
 
+    const { threads, activitySummary } = response.result;
     return {
       threads: threads.map((thread) => {
         const modeledThread = modelThreadFromServer(thread);
@@ -113,6 +112,7 @@ class RecentActivityController {
       }),
       activitySummary,
     };
+    return;
   }
 
   // public addThreads(threads: IAbridgedThreadFromServer[], clear?: boolean) {

--- a/client/scripts/controllers/app/recent_activity.ts
+++ b/client/scripts/controllers/app/recent_activity.ts
@@ -93,7 +93,6 @@ class RecentActivityController {
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful: ${response.status}`);
     }
-    console.log(response.result);
 
     const threads = response.result;
     return threads.map((thread) => {
@@ -106,7 +105,6 @@ class RecentActivityController {
       } catch (e) {
         console.error(e.message);
       }
-      console.log({ modeledThread });
       return modeledThread;
     });
   }

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -62,7 +62,6 @@ export const modelFromServer = (thread) => {
     last_commented_on,
     linked_threads,
   } = thread;
-  console.log({ last_commented_on });
 
   const attachments = OffchainAttachments
     ? OffchainAttachments.map(

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -59,7 +59,7 @@ export const modelFromServer = (thread) => {
     offchain_voting_ends_at,
     offchain_voting_votes,
     reactions,
-    latestCommCreatedAt,
+    latest_comm_created_at,
     linked_threads,
   } = thread;
 
@@ -161,8 +161,8 @@ export const modelFromServer = (thread) => {
     offchainVotingOptions: offchain_voting_options,
     offchainVotingEndsAt: offchain_voting_ends_at,
     offchainVotingNumVotes: offchain_voting_votes,
-    latestCommCreatedAt: latestCommCreatedAt
-      ? moment(latestCommCreatedAt)
+    latestCommCreatedAt: latest_comm_created_at
+      ? moment(latest_comm_created_at)
       : null,
     linkedThreads: linked_threads,
   });

--- a/client/scripts/controllers/server/threads.ts
+++ b/client/scripts/controllers/server/threads.ts
@@ -59,9 +59,10 @@ export const modelFromServer = (thread) => {
     offchain_voting_ends_at,
     offchain_voting_votes,
     reactions,
-    latest_comm_created_at,
+    last_commented_on,
     linked_threads,
   } = thread;
+  console.log({ last_commented_on });
 
   const attachments = OffchainAttachments
     ? OffchainAttachments.map(
@@ -161,8 +162,8 @@ export const modelFromServer = (thread) => {
     offchainVotingOptions: offchain_voting_options,
     offchainVotingEndsAt: offchain_voting_ends_at,
     offchainVotingNumVotes: offchain_voting_votes,
-    latestCommCreatedAt: latest_comm_created_at
-      ? moment(latest_comm_created_at)
+    lastCommentedOn: last_commented_on
+      ? moment(last_commented_on)
       : null,
     linkedThreads: linked_threads,
   });

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -131,7 +131,6 @@ class OffchainThread implements IUniqueId {
     attachments,
     id,
     createdAt,
-    updatedAt,
     topic,
     kind,
     stage,

--- a/client/scripts/models/OffchainThread.ts
+++ b/client/scripts/models/OffchainThread.ts
@@ -47,7 +47,7 @@ class OffchainThread implements IUniqueId {
   public readonly identifier: string;
   public readonly id: number;
   public readonly createdAt: moment.Moment;
-  public readonly latestCommCreatedAt: moment.Moment;
+  public readonly lastCommentedOn: moment.Moment;
   public topic: OffchainTopic;
   public readonly slug = ProposalType.OffchainThread;
   public readonly url: string;
@@ -131,6 +131,7 @@ class OffchainThread implements IUniqueId {
     attachments,
     id,
     createdAt,
+    updatedAt,
     topic,
     kind,
     stage,
@@ -153,7 +154,7 @@ class OffchainThread implements IUniqueId {
     offchainVotingEndsAt,
     offchainVotingNumVotes,
     offchainVotes,
-    latestCommCreatedAt,
+    lastCommentedOn,
     linkedThreads,
   }: {
     author: string;
@@ -161,7 +162,7 @@ class OffchainThread implements IUniqueId {
     attachments: OffchainAttachment[];
     id: number;
     createdAt: moment.Moment;
-    latestCommCreatedAt: moment.Moment;
+    lastCommentedOn: moment.Moment;
     topic: OffchainTopic;
     kind: OffchainThreadKind;
     stage: OffchainThreadStage;
@@ -204,7 +205,7 @@ class OffchainThread implements IUniqueId {
     this.chain = chain;
     this.readOnly = readOnly;
     this.collaborators = collaborators || [];
-    this.latestCommCreatedAt = latestCommCreatedAt;
+    this.lastCommentedOn = lastCommentedOn;
     this.chainEntities = chainEntities
       ? chainEntities.map((ce) => {
           return {

--- a/client/scripts/views/components/sidebar/index.ts
+++ b/client/scripts/views/components/sidebar/index.ts
@@ -132,7 +132,7 @@ export const OffchainNavigationModule: m.Component<{}, { dragulaInitialized: tru
           class: 'sub-button',
           onclick: (e) => {
             e.preventDefault();
-            navigateToSubpage(`/discussions/${t.name}`);
+            navigateToSubpage(`/discussions/${encodeURI(t.name)}`);
           },
         })
       )),

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -32,11 +32,13 @@ import ListingRow from 'views/components/listing_row';
 import DiscussionRowMenu from './discussion_row_menu';
 
 export const getLastUpdated = (proposal) => {
-  const { latestCommCreatedAt } = proposal;
-  const lastComment = latestCommCreatedAt
-    ? Number(latestCommCreatedAt.utc())
+  // console.log(proposal);
+  const { lastCommentedOn } = proposal;
+  const lastComment = lastCommentedOn
+    ? Number(lastCommentedOn.utc())
     : 0;
   const createdAt = Number(proposal.createdAt.utc());
+  // console.log({ createdAt, lastCommentedOn });
   const lastUpdate = Math.max(createdAt, lastComment);
   return moment(lastUpdate);
 };

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -32,13 +32,11 @@ import ListingRow from 'views/components/listing_row';
 import DiscussionRowMenu from './discussion_row_menu';
 
 export const getLastUpdated = (proposal) => {
-  // console.log(proposal);
   const { lastCommentedOn } = proposal;
   const lastComment = lastCommentedOn
     ? Number(lastCommentedOn.utc())
     : 0;
   const createdAt = Number(proposal.createdAt.utc());
-  // console.log({ createdAt, lastCommentedOn });
   const lastUpdate = Math.max(createdAt, lastComment);
   return moment(lastUpdate);
 };

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -491,7 +491,7 @@ const DiscussionsPage: m.Component<
     if (onSummaryView && !vnode.state.activityFetched && !vnode.state.loadingRecentThreads) {
       vnode.state.loadingRecentThreads = true;
       app.recentActivity
-        .getRecentCommunityActivity({
+        .getRecentTopicActivity({
           communityId: app.activeCommunityId(),
           chainId: app.activeChainId(),
         })

--- a/client/scripts/views/pages/discussions/index.ts
+++ b/client/scripts/views/pages/discussions/index.ts
@@ -394,8 +394,8 @@ const DiscussionFilterBar: m.Component<
 // comparator
 const orderDiscussionsbyLastComment = (a, b) => {
   // tslint:disable-next-line
-  const tsB = Math.max(+b.createdAt, +(b.latestCommCreatedAt || 0));
-  const tsA = Math.max(+a.createdAt, +(a.latestCommCreatedAt || 0));
+  const tsB = Math.max(+b.createdAt, +(b.lastCommentedOn || 0));
+  const tsA = Math.max(+a.createdAt, +(a.lastCommentedOn || 0));
   return tsB - tsA;
 };
 
@@ -412,7 +412,7 @@ const DiscussionsPage: m.Component<
     onscroll: any;
     summaryView: boolean;
     summaryViewInitialized: boolean;
-    recentThreads: { threads: OffchainThread[]; activitySummary };
+    recentThreads: OffchainThread[];
     loadingRecentThreads: boolean;
     activityFetched: boolean;
   }

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -52,14 +52,14 @@ const SummaryRow: m.Component<
 };
 
 export const SummaryListing: m.Component<
-  { recentThreads: { threads: OffchainThread[]; activitySummary } },
+  { recentThreads: OffchainThread[] },
   {}
 > = {
   view: (vnode) => {
     const topicScopedThreads = {};
     const topics = app.topics.getByCommunity(app.activeId());
     topics.forEach((topic) => {
-      topicScopedThreads[topic.id] = vnode.attrs.recentThreads.threads.filter(
+      topicScopedThreads[topic.id] = vnode.attrs.recentThreads.filter(
         (thread) => thread.topic?.id === topic?.id
       );
     });
@@ -80,7 +80,6 @@ export const SummaryListing: m.Component<
           return m(SummaryRow, {
             topic,
             monthlyThreads: topicScopedThreads[topic.id],
-            activitySummary: vnode.attrs.recentThreads.activitySummary,
           });
         })
       ),

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -24,7 +24,12 @@ const SummaryRow: m.Component<
     });
     return m('.SummaryRow', [
       m('.topic', [
-        m('h3', topic.name),
+        m('h3', {
+          onclick: (e) => {
+            e.preventDefault();
+            m.route.set(`/${app.activeId()}/discussions/${encodeURI(topic.name)}`);
+          },
+        }, topic.name),
         m('p', topic.description)
       ]),
       m(

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -16,7 +16,6 @@ const SummaryRow: m.Component<
 > = {
   view: (vnode) => {
     const { topic, monthlyThreads } = vnode.attrs;
-    console.log({ topic, monthlyThreads });
     if (!topic?.name) return null;
     const sortedThreads = monthlyThreads.sort((a, b) => {
       const aLastUpdated = a.lastCommentedOn || a.createdAt;

--- a/client/scripts/views/pages/discussions/summary_listing.ts
+++ b/client/scripts/views/pages/discussions/summary_listing.ts
@@ -35,8 +35,8 @@ const SummaryRow: m.Component<
             `/${app.activeId()}/proposal/${thread.slug}/${thread.identifier}-` +
             `${slugify(thread.title)}`;
           return m('.thread-summary', [
-            link('a', discussionLink, thread.title),
-            m('', [
+            link('a.discussion-title', discussionLink, thread.title),
+            m('.last-updated', [
               m('span', formatLastUpdated(getLastUpdated(thread))),
               isHot(thread) && m('span', '🔥'),
             ])
@@ -60,8 +60,8 @@ export const SummaryListing: m.Component<
       );
     });
     const sortedTopics = topics.sort((a, b) => {
-      if (a.name < b.name) { return -1; }
-      if (a.name > b.name) { return 1; }
+      if (a.name.toLowerCase() < b.name.toLowerCase()) { return -1; }
+      if (a.name.toLowerCase() > b.name.toLowerCase()) { return 1; }
       return 0;
     });
     return m('.SummaryListing', [

--- a/client/styles/pages/discussions/summary_listing.scss
+++ b/client/styles/pages/discussions/summary_listing.scss
@@ -17,10 +17,11 @@
     .row-header {
         color: $midi-gray;
         font-size: 18px;
+        margin-bottom: 10px;
+        display: flex;
         h4 {
             font-weight: 500;
         }
-        display: flex;
     }
     .row-wrap {
         display: flex;
@@ -30,7 +31,7 @@
 
 .SummaryRow {
     display: flex;
-    padding: 20px 0;
+    padding: 15px 0;
     border-top: 1px solid $disable-gray;
     max-width: 100%;
     .recent-threads {
@@ -39,16 +40,25 @@
         .thread-summary {
             display: flex;
             justify-content: space-between;
-            margin-bottom: 10px;
-            a {
+            margin-bottom: 15px;
+            &:last-child {
+                margin-bottom: 0;
+            }
+            a.discussion-title {
+                flex: 4;
                 color: $purp-blue;
                 &:hover {
                     text-decoration: none;
                 }
             }
-            span {
-                color: $lite-gray;
-                margin-left: 10px;
+            .last-updated {
+                flex: 1;
+                min-width: max-content;
+                margin-left: 48px;
+                span {
+                    color: $lite-gray;
+                    margin-left: 10px;
+                }
             }
         }
     }

--- a/client/styles/pages/discussions/summary_listing.scss
+++ b/client/styles/pages/discussions/summary_listing.scss
@@ -1,3 +1,7 @@
+@import 'client/styles/shared';
+@import 'client/styles/facelift';
+
+
 .SummaryListing {
     display: flex;
     flex-direction: column;
@@ -11,7 +15,7 @@
         flex: 4;
     }
     .row-header {
-        color: #666666;
+        color: $midi-gray;
         font-size: 18px;
         h4 {
             font-weight: 500;
@@ -27,34 +31,25 @@
 .SummaryRow {
     display: flex;
     padding: 20px 0;
-    border-bottom: 1px solid #DDDDDD;
+    border-top: 1px solid $disable-gray;
     max-width: 100%;
-    &:last-child {
-        border-bottom: none;
-    }
     .recent-threads {
         display: flex;
         flex-direction: column;
         .thread-summary {
+            display: flex;
+            justify-content: space-between;
             margin-bottom: 10px;
             a {
-                color: #4723AD;
+                color: $purp-blue;
                 &:hover {
                     text-decoration: none;
                 }
             }
             span {
-                color: #9b9b9b;
+                color: $lite-gray;
                 margin-left: 10px;
             }
-        }
-    }
-    .last-updated {
-        .time {
-            font-weight: 500;
-        }
-        .date {
-            font-weight: 400;
         }
     }
     .topic {

--- a/client/styles/pages/discussions/summary_listing.scss
+++ b/client/styles/pages/discussions/summary_listing.scss
@@ -53,6 +53,7 @@
             }
             .last-updated {
                 flex: 1;
+                text-align: left;
                 min-width: max-content;
                 margin-left: 48px;
                 span {
@@ -67,6 +68,7 @@
         h3 {
             font-size: 24px;
             font-weight: 500;
+            cursor: pointer;
         }
     }
 }

--- a/server/database.ts
+++ b/server/database.ts
@@ -164,7 +164,7 @@ export const sequelize = new Sequelize(DATABASE_URI, {
     process.env.NODE_ENV === 'test'
       ? false
       : (msg) => {
-          log.trace(msg);
+          log.info(msg);
         },
   dialectOptions:
     process.env.NODE_ENV !== 'production'

--- a/server/database.ts
+++ b/server/database.ts
@@ -164,7 +164,7 @@ export const sequelize = new Sequelize(DATABASE_URI, {
     process.env.NODE_ENV === 'test'
       ? false
       : (msg) => {
-          log.info(msg);
+          log.trace(msg);
         },
   dialectOptions:
     process.env.NODE_ENV !== 'production'

--- a/server/migrations/20220104220331-add_last_commented_col_to_threads.js
+++ b/server/migrations/20220104220331-add_last_commented_col_to_threads.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'OffchainThreads',
+        'last_commented_on',
+        {
+          type: Sequelize.DATE,
+          allowNull: true
+        },
+        {
+          transaction: t
+        }
+      );
+      const threadLastCommentedOn = {};
+      const allComments = await queryInterface.sequelize.query(`SELECT root_id, created_at FROM "OffchainComments"`, {
+        transaction: t
+      });
+      console.log(allComments[0][0]);
+      allComments[0].forEach((comment) => {
+        const discussionId = comment.root_id.split('_')[1];
+        if (discussionId.includes('0x') || Number.isNaN(Number(discussionId))) return;
+        if (!threadLastCommentedOn[discussionId] ||
+          comment.created_at > threadLastCommentedOn[discussionId]) {
+            threadLastCommentedOn[discussionId] = comment.created_at;
+          }
+      });
+      console.log(threadLastCommentedOn[2413]);
+      console.log(typeof threadLastCommentedOn[2413]);
+      const ex = threadLastCommentedOn[2413];
+      // throw Error();
+      await Promise.all(Object.keys(threadLastCommentedOn).map(async (threadId) => {
+        await queryInterface.sequelize.query(
+          `UPDATE "OffchainThreads" SET last_commented_on=TO_TIMESTAMP(${(new Date(threadLastCommentedOn[threadId]).getTime() / 1000).toFixed(0)}) WHERE id=${threadId}`,
+          { transaction: t }
+        );
+      }))
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('OffchainThreads', 'last_commented_on');
+  }
+};

--- a/server/migrations/20220104220331-add_last_commented_col_to_threads.js
+++ b/server/migrations/20220104220331-add_last_commented_col_to_threads.js
@@ -15,10 +15,10 @@ module.exports = {
         }
       );
       const threadLastCommentedOn = {};
-      const allComments = await queryInterface.sequelize.query(`SELECT root_id, created_at FROM "OffchainComments"`, {
+      const allComments = await queryInterface.sequelize.query(
+        `SELECT root_id, created_at FROM "OffchainComments"`, {
         transaction: t
       });
-      console.log(allComments[0][0]);
       allComments[0].forEach((comment) => {
         const discussionId = comment.root_id.split('_')[1];
         if (discussionId.includes('0x') || Number.isNaN(Number(discussionId))) return;
@@ -27,13 +27,10 @@ module.exports = {
             threadLastCommentedOn[discussionId] = comment.created_at;
           }
       });
-      console.log(threadLastCommentedOn[2413]);
-      console.log(typeof threadLastCommentedOn[2413]);
-      const ex = threadLastCommentedOn[2413];
-      // throw Error();
       await Promise.all(Object.keys(threadLastCommentedOn).map(async (threadId) => {
+        const unixTimestamp = (new Date(threadLastCommentedOn[threadId]).getTime() / 1000).toFixed(0);
         await queryInterface.sequelize.query(
-          `UPDATE "OffchainThreads" SET last_commented_on=TO_TIMESTAMP(${(new Date(threadLastCommentedOn[threadId]).getTime() / 1000).toFixed(0)}) WHERE id=${threadId}`,
+          `UPDATE "OffchainThreads" SET last_commented_on=TO_TIMESTAMP(${unixTimestamp}) WHERE id=${threadId}`,
           { transaction: t }
         );
       }))

--- a/server/models/offchain_thread.ts
+++ b/server/models/offchain_thread.ts
@@ -34,6 +34,7 @@ export interface OffchainThreadAttributes {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+  last_commented_on?: Date;
 
   // associations
   Chain?: ChainAttributes;
@@ -102,6 +103,7 @@ export default (
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },
       deleted_at: { type: dataTypes.DATE, allowNull: true },
+      last_commented_on: { type: dataTypes.DATE, allowNull: true }
     },
     {
       timestamps: true,

--- a/server/routes/activeThreads.ts
+++ b/server/routes/activeThreads.ts
@@ -56,6 +56,14 @@ const activeThreads = async (
         limit: threads_per_topic,
         order: [['last_commented_on', 'DESC']]
       });
+      if (topic.id === 112) {
+        console.log(recentTopicThreads.map((t) => ({
+            title: t.title,
+            created_at: t.created_at,
+            last_comment: t.last_commented_on
+          })
+        ));
+      }
 
       // In absence of X threads with recent activity (comments),
       // commentless threads are fetched and included as active

--- a/server/routes/activeThreads.ts
+++ b/server/routes/activeThreads.ts
@@ -39,11 +39,11 @@ const activeThreads = async (
           topic_id: topic.id,
         },
         limit: threads_per_topic,
-        order: ['updated_at', 'DESC']
+        order: [['last_commented_on', 'DESC']]
       });
-      allThreads.push(recentTopicThreads);
+      allThreads.concat(recentTopicThreads);
     }));
-    console.log(allThreads.length);
+    console.log({ length: allThreads.length });
 
     return res.json({
       status: 'Success',

--- a/server/routes/activeThreads.ts
+++ b/server/routes/activeThreads.ts
@@ -56,14 +56,6 @@ const activeThreads = async (
         limit: threads_per_topic,
         order: [['last_commented_on', 'DESC']]
       });
-      if (topic.id === 112) {
-        console.log(recentTopicThreads.map((t) => ({
-            title: t.title,
-            created_at: t.created_at,
-            last_comment: t.last_commented_on
-          })
-        ));
-      }
 
       // In absence of X threads with recent activity (comments),
       // commentless threads are fetched and included as active

--- a/server/routes/activeThreads.ts
+++ b/server/routes/activeThreads.ts
@@ -21,7 +21,7 @@ const activeThreads = async (
   );
   if (error) return next(new Error(error));
   let { threads_per_topic } = req.query;
-  if (!threads_per_topic || !Number.isNaN(threads_per_topic || threads_per_topic < 0 || threads_per_topic > 10)) {
+  if (!threads_per_topic || Number.isNaN(threads_per_topic) || threads_per_topic < 0 || threads_per_topic > 10) {
     threads_per_topic = 3;
   }
 
@@ -31,7 +31,9 @@ const activeThreads = async (
     else communityWhere['community_id'] = community.id;
     const communityTopics = await models.OffchainTopic.findAll({ where: communityWhere });
     const allThreads = [];
+    console.log(communityTopics?.length);
     await Promise.all(communityTopics.map(async (topic) => {
+      console.log(topic.id);
       const recentTopicThreads = await models.OffchainThread.findAll({
         where: {
           topic_id: topic.id,
@@ -50,7 +52,7 @@ const activeThreads = async (
       },
     });
   } catch (err) {
-    return next(new Error());
+    return next(new Error(err));
   }
 
 };

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -122,7 +122,6 @@ const bulkThreads = async (
 
     const root_ids = [];
     threads = preprocessedThreads.map((t) => {
-      const { latest_comm_created_at } = t;
       const root_id = `discussion_${t.thread_id}`;
       root_ids.push(root_id);
       const collaborators = JSON.parse(t.collaborators[0]).address?.length
@@ -157,7 +156,7 @@ const bulkThreads = async (
         offchain_voting_options: t.offchain_voting_options,
         offchain_voting_votes: t.offchain_voting_votes,
         offchain_voting_ends_at: t.offchain_voting_ends_at,
-        latestCommCreatedAt: latest_comm_created_at,
+        latest_comm_created_at: t.latest_comm_created_at,
         Address: {
           id: t.addr_id,
           address: t.addr_address,

--- a/server/routes/bulkThreads.ts
+++ b/server/routes/bulkThreads.ts
@@ -40,6 +40,7 @@ const bulkThreads = async (
   bind['created_at'] = cutoff_date;
 
   // Threads
+  // TODO: Transition latest_comm_created_at to use the thread last_commented_on column
   let threads;
   if (cutoff_date) {
     const query = `
@@ -156,7 +157,7 @@ const bulkThreads = async (
         offchain_voting_options: t.offchain_voting_options,
         offchain_voting_votes: t.offchain_voting_votes,
         offchain_voting_ends_at: t.offchain_voting_ends_at,
-        latest_comm_created_at: t.latest_comm_created_at,
+        last_commented_on: t.latest_comm_created_at,
         Address: {
           id: t.addr_id,
           address: t.addr_address,

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -393,8 +393,10 @@ const createComment = async (
   author.save();
 
   // update proposal updated_at timestamp
-  proposal.changed('updated_at', true);
-  proposal.save();
+  if (prefix === ProposalType.OffchainThread) {
+    proposal.last_commented_on = Date.now();
+    proposal.save();
+  }
 
   return res.json({ status: 'Success', result: finalComment.toJSON() });
 };

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -225,6 +225,10 @@ const createComment = async (
     return next(new Error(Errors.CantCommentOnReadOnly));
   }
 
+  proposal.updated_at = new Date();
+  console.log(proposal);
+  proposal.save();
+
   // craft commonwealth url
   const cwUrl = typeof proposal === 'string'
     ? getProposalUrlWithoutObject(prefix, (finalComment.chain || finalComment.community), proposal, finalComment)

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -225,10 +225,6 @@ const createComment = async (
     return next(new Error(Errors.CantCommentOnReadOnly));
   }
 
-  proposal.updated_at = new Date();
-  console.log(proposal);
-  proposal.save();
-
   // craft commonwealth url
   const cwUrl = typeof proposal === 'string'
     ? getProposalUrlWithoutObject(prefix, (finalComment.chain || finalComment.community), proposal, finalComment)
@@ -395,6 +391,10 @@ const createComment = async (
   // update author.last_active (no await)
   author.last_active = new Date();
   author.save();
+
+  // update proposal updated_at timestamp
+  proposal.changed('updated_at', true);
+  proposal.save();
 
   return res.json({ status: 'Success', result: finalComment.toJSON() });
 };


### PR DESCRIPTION
This branch addresses a client complaint whereby older threads were absent from the Summary Page overview. It also incorporates recent [design changes](https://www.figma.com/file/O89IoWQvhXz8C2IACjb3zI/Discussion-Summary?node-id=2%3A31) to the summary rows.

Previously, the Summary Page only searched for activity from within the previous month. This confused clients, who expected that stale threads would still appear in the recent thread list.

This branch introduces a conceptual change whereby the Summary Page will show the three most recently active threads for each topic, irrespective of when that activity occurred.

This branch also introduces a new column to the OffchainThread model, `last_commented_on`, which is updated whenever a comment is created on a thread. This column spares us from writing further tedious, complicated raw SQL queries similar to `/bulkThreads` (since there are complex string manipulations of comment root_ids, simultaneous limiting + ordering, maxing required which are not possible using Sequelize methods). Such lengthy raw queries are very hard to read and maintain, and should be phased out when possible via improvements to the db architecture, e.g. improving our root_id comment system. Once this is done, we can come up with a game plan + template for efficiently fetching relevant comment data (e.g. recent commenting addresses, latest comment timestamp, etc) alongside threads.

The user gallery (of recent commenters) included in the Summary Page redesign has not been added to the layout in this branch. The data such a gallery requires will be more efficient to grab once the aforementioned database & route improvements have been made. However, if a user gallery is a high priority, I can add it in next week in ~half a day.