### PR TITLE
Hide "Hiring" Button on Custom Domains

### DIFF
--- a/client/scripts/views/sublayout.ts
+++ b/client/scripts/views/sublayout.ts
@@ -116,7 +116,7 @@ const Sublayout: m.Component<{
       app.isLoggedIn() && m(NotificationsMenu),
       showNewProposalButton
       && (narrowBrowserWidth ? m(MobileNewProposalButton) : m(NewProposalButton, { fluid: false, threadOnly: !chain })),
-      hiringButton,
+      !app.isCustomDomain() && hiringButton,
       // above threadOnly option assumes all chains have proposals beyond threads
     ]);
 


### PR DESCRIPTION
It should go away so that it doesn't confuse the users of our custom domain communities.