### PR TITLE
CreateCommunity properly sets eth_chain_id on new communities.

### DIFF
--- a/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -40,7 +40,7 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
   }
 
   public async signLoginToken(message: string): Promise<string> {
-    const msgParams = constructTypedMessage(app.chain.meta.ethChainId, message);
+    const msgParams = constructTypedMessage(app.chain.meta.ethChainId || 1, message);
     const signature = await this._provider.wc.signTypedData([
       this.accounts[0],
       JSON.stringify(msgParams),
@@ -59,14 +59,12 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
     this._enabling = true;
     try {
       // Create WalletConnect Provider
-      if (!app.chain?.meta.ethChainId) {
-        throw new Error(`No chain id found!`);
-      }
+      const chainId = app.chain?.meta.ethChainId || 1;
 
       // use alt wallet url if available
-      const rpc = { [app.chain.meta.ethChainId]: app.chain.meta.altWalletUrl || app.chain.meta.url };
+      const rpc = { [chainId]: app.chain.meta.altWalletUrl || app.chain.meta.url };
       console.log(rpc);
-      this._provider = new WalletConnectProvider({ rpc, chainId: app.chain.meta.ethChainId });
+      this._provider = new WalletConnectProvider({ rpc, chainId });
 
       //  Enable session (triggers QR Code modal)
       await this._provider.enable();

--- a/client/scripts/views/components/metadata_rows.ts
+++ b/client/scripts/views/components/metadata_rows.ts
@@ -22,7 +22,7 @@ export const InputPropertyRow: m.Component<{
           placeholder,
           fluid: true,
           disabled: disabled || false,
-          onkeyup: (e) => { onChangeHandler((e.target as any).value); },
+          oninput: (e) => { onChangeHandler((e.target as any).value); },
         }),
       ]),
     ]);

--- a/client/scripts/views/pages/create_community/erc20_form.ts
+++ b/client/scripts/views/pages/create_community/erc20_form.ts
@@ -99,7 +99,6 @@ const ERC20Form: m.Component<ERC20FormAttrs, ERC20FormState> = {
               vnode.state.decimals = decimals || 18;
               vnode.state.status = 'Success!';
             } catch (e) {
-              console.log(e);
               vnode.state.name = '';
               vnode.state.id = '';
               vnode.state.symbol = '';

--- a/server/models/address.ts
+++ b/server/models/address.ts
@@ -335,7 +335,7 @@ export default (
       //
       try {
         const [ node ] = await chain.getChainNodes();
-        const typedMessage = constructTypedMessage(node.eth_chain_id, addressModel.verification_token.trim());
+        const typedMessage = constructTypedMessage(node.eth_chain_id || 1, addressModel.verification_token.trim());
         const address = recoverTypedSignature({
           data: typedMessage,
           signature: signatureString.trim(),

--- a/server/routes/createChain.ts
+++ b/server/routes/createChain.ts
@@ -82,12 +82,16 @@ const createChain = async (
   let eth_chain_id: number = null;
   let url = req.body.node_url;
   let altWalletUrl = req.body.alt_wallet_url;
-  if (req.body.base === ChainBase.Ethereum && req.body.type === ChainType.Offchain) {
+
+  // always generate a chain id
+  if (req.body.base === ChainBase.Ethereum) {
     if (!req.body.eth_chain_id || !+req.body.eth_chain_id) {
       return next(new Error(Errors.InvalidChainId));
     }
     eth_chain_id = +req.body.eth_chain_id;
   }
+
+  // if not offchain, also validate the address
   if (req.body.base === ChainBase.Ethereum && req.body.type !== ChainType.Offchain) {
     if (!Web3.utils.isAddress(req.body.address)) {
       return next(new Error(Errors.InvalidAddress));

--- a/server/routes/getTokenForum.ts
+++ b/server/routes/getTokenForum.ts
@@ -48,7 +48,7 @@ const getTokenForum = async (
     provider.disconnect(1000, 'finished');
     if (code === '0x') {
       // Account returns 0x, Smart contract returns bytecode
-      return res.json({ status: 'Failure', message: 'Must provide contract address' });
+      return res.json({ status: 'Failure', message: 'Must provide valid contract address' });
     }
     if (req.query.autocreate) {
       const result = await sequelize.transaction(async (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Chain ID now defaults to "1" if not present, + fixes issues with the /createCommunity page not populating the address state + the /createChain route not properly setting eth_chain_id.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes metamask issues with newly created communities.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually reproduced bug and verified successful cases post-changes.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no