### PR TITLE
Use snapshot graphql scores rather than manual sum.

### DIFF
--- a/client/scripts/views/pages/snapshot_proposals/index.ts
+++ b/client/scripts/views/pages/snapshot_proposals/index.ts
@@ -66,7 +66,7 @@ const SnapshotProposalsPage: m.Component<{ topic?: string, snapshotId: string },
       app.snapshot.init(snapshotId).then(() => {
         m.redraw();
       });
-      
+
       return m(Sublayout, {
         class: 'DiscussionsPage',
         title: 'Proposals',

--- a/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
+++ b/client/scripts/views/pages/snapshot_proposals/proposal_row.ts
@@ -20,6 +20,7 @@ const ProposalRow: m.Component<
     const time = moment(+proposal.end * 1000);
     const now = moment();
 
+    // TODO: display proposal.scores and proposal.scores_total on card
     return m('.ProposalCard', [
       m(
         '.proposal-card-top',

--- a/client/scripts/views/pages/view_snapshot_proposal/index.ts
+++ b/client/scripts/views/pages/view_snapshot_proposal/index.ts
@@ -217,7 +217,7 @@ const VoteAction: m.Component<
         });
         vnode.state.votingModalOpen = true;
       } catch (err) {
-        console.log(err);
+        console.error(err);
         notifyError('Voting failed');
       }
     };
@@ -296,7 +296,7 @@ const ViewProposalPage: m.Component<
           m.redraw();
         });
       } catch (e) {
-        console.log(`Failed to fetch threads: ${e}`);
+        console.error(`Failed to fetch threads: ${e}`);
       }
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We now use the graphql stored sum of scores from snapshot rather than doing it manually through js logic.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes discrepancy between dydx totals as displayed on CW vs on snapshot.org.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Verified changes against live site.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no