### PR TITLE
Permit double proposal complete with warning.

### DIFF
--- a/client/scripts/models/Proposal.ts
+++ b/client/scripts/models/Proposal.ts
@@ -65,7 +65,7 @@ abstract class Proposal<
     store: ProposalStore<Proposal<ApiT, C, ConstructorT, VoteT>>
   ): void {
     if (this._completed) {
-      throw new Error('cannot update state once marked completed');
+      console.warn(`Warning: state marked as complete multiple times on proposal ${this.identifier}`);
     }
     this._completed = true;
     this._initialized = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows proposals to mark themselves "complete" multiple times.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue where we received multiple ProposalCanceled events from an Impact Market proposal. Current behavior of throwing an error is unnecessarily severe. Instead we create a warning.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Replicated state via selecting their chain events from production db, and ensured proposal page loads.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no