### PR TITLE
Fix cancel support for OZ.

### DIFF
--- a/client/scripts/controllers/chain/ethereum/compound/proposal.ts
+++ b/client/scripts/controllers/chain/ethereum/compound/proposal.ts
@@ -365,7 +365,6 @@ export default class CompoundProposal extends Proposal<
           this.data.calldatas,
           descriptionHash
         );
-        console.log(gasLimit);
         tx = await ozContract.cancel(
           this.data.targets,
           this.data.values,
@@ -511,7 +510,6 @@ export default class CompoundProposal extends Proposal<
         this.data.identifier,
         +vote.choice
       );
-      console.log(gasLimit);
       tx = await contract.castVote(
         this.data.identifier,
         +vote.choice,

--- a/client/scripts/controllers/chain/ethereum/compound/proposal.ts
+++ b/client/scripts/controllers/chain/ethereum/compound/proposal.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 import BN from 'bn.js';
 import { capitalize } from 'lodash';
 import { ContractTransaction, utils } from 'ethers';
-import { GovernorCompatibilityBravo } from 'eth/types';
+import { GovernorCompatibilityBravo, GovernorMock, GovernorMock__factory } from 'eth/types';
 
 import { CompoundTypes } from '@commonwealth/chain-events';
 import { ProposalType } from 'types';
@@ -341,16 +341,44 @@ export default class CompoundProposal extends Proposal<
       throw new Error('proposal already cancelled');
     }
 
-    // TODO: condition check for who can cancel
-
     const address = this._Gov.app.user.activeAccount.address;
+    let tx: ContractTransaction;
     const contract = await attachSigner(this._Gov.app.wallets, address, this._Gov.api.Contract);
-
-    const gasLimit = await contract.estimateGas.cancel(this.data.identifier);
-    const tx = await contract.cancel(
-      this.data.identifier,
-      { gasLimit }
-    );
+    try {
+      const gasLimit = await contract.estimateGas['cancel(uint256)'](this.data.identifier);
+      tx = await contract['cancel(uint256)'](
+        this.data.identifier,
+        { gasLimit }
+      );
+    } catch (e) {
+      // workaround for Oz without BravoCompatLayer
+      // uses GovernorMock because it supports the proper cancel ABI vs BravoCompat
+      const contractNoSigner = GovernorMock__factory.connect(this._Gov.api.contractAddress, this._Gov.api.Provider);
+      const ozContract = await attachSigner(this._Gov.app.wallets, address, contractNoSigner);
+      const descriptionHash = utils.keccak256(
+        utils.toUtf8Bytes(this.data.description)
+      );
+      try {
+        const gasLimit = await ozContract.estimateGas.cancel(
+          this.data.targets,
+          this.data.values,
+          this.data.calldatas,
+          descriptionHash
+        );
+        console.log(gasLimit);
+        tx = await ozContract.cancel(
+          this.data.targets,
+          this.data.values,
+          this.data.calldatas,
+          descriptionHash,
+          { gasLimit }
+        );
+      } catch (eInner) {
+        // both errored out -- fail
+        console.error(eInner.message);
+        throw eInner;
+      }
+    }
     const txReceipt = await tx.wait();
     if (txReceipt.status !== 1) {
       throw new Error('failed to cancel proposal');
@@ -483,6 +511,7 @@ export default class CompoundProposal extends Proposal<
         this.data.identifier,
         +vote.choice
       );
+      console.log(gasLimit);
       tx = await contract.castVote(
         this.data.identifier,
         +vote.choice,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cancel support falls back to using different ABI if BravoCompat calls fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no