### PR TITLE
Remove OAuth state check.

### DIFF
--- a/server/passport.ts
+++ b/server/passport.ts
@@ -33,13 +33,14 @@ const JWTStrategy = passportJWT.Strategy;
 const ExtractJWT = passportJWT.ExtractJwt;
 
 async function authenticateSocialAccount(provider: Providers, req: Request, accessToken, refreshToken, profile, cb, models: DB) {
-  const str = '&state='
-  const splitState = req.url.substring(req.url.indexOf(str) + str.length)
-  const state = splitState.substring(splitState.indexOf('='));
-  if (state !== String(req.sessionID)) return cb(null, false)
+  // const str = '&state='
+  // const splitState = req.url.substring(req.url.indexOf(str) + str.length)
+  // const state = splitState.substring(splitState.indexOf('='));
+  // console.log(`State check: ${state} vs ${req.sessionID}`);
+  // if (state !== req.sessionID) return cb(null, false)
 
   const account = await models.SocialAccount.findOne({
-    where: {provider: provider, provider_userid: profile.id}
+    where: { provider, provider_userid: profile.id }
   });
 
   // Existing Github account. If there is already a user logged-in,
@@ -91,7 +92,7 @@ async function authenticateSocialAccount(provider: Providers, req: Request, acce
   // create a new user. As a result it's possible that we end up
   // with a user with multiple Github accounts linked.
   const newAccount = await models.SocialAccount.create({
-    provider: provider,
+    provider,
     provider_userid: profile.id,
     provider_username: profile.username,
     access_token: accessToken,
@@ -365,7 +366,6 @@ function setupPassport(models: DB) {
   if (DISCORD_CLIENT_ID && DISCORD_CLIENT_SECRET && DISCORD_OAUTH_CALLBACK) passport.use(new DiscordStrategy({
     clientID: DISCORD_CLIENT_ID,
     clientSecret: DISCORD_CLIENT_SECRET,
-    callbackURL: DISCORD_OAUTH_CALLBACK,
     scope: DISCORD_OAUTH_SCOPES,
     passReqToCallback: true,
     authorizationURL: 'https://discord.com/api/oauth2/authorize?prompt=none'

--- a/server/routes/startOAuthLogin.ts
+++ b/server/routes/startOAuthLogin.ts
@@ -34,13 +34,16 @@ const startOAuthLogin = async (
       )}`,
       successRedirect,
       failureRedirect,
-      state: String(req.sessionID)
+      // state: req.sessionID
     } as any)(req, res, next); // TODO: extend AuthenticateOptions typing used here
   else
     passport.authenticate('discord', {
+      callbackURL: `${DISCORD_OAUTH_CALLBACK}?from=${encodeURIComponent(
+        req.hostname
+      )}`,
       successRedirect,
       failureRedirect,
-      state: String(req.sessionID)
+      // state: req.sessionID
     } as any)(req, res, next)
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes state check in OAuth passport login (github, discord).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes OAuth login on custom domains.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Replicated bug, ensured that login worked locally once removed.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no