### PR TITLE
Add filter to viewNotifications for custom domains

### DIFF
--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -153,10 +153,8 @@ class NotificationsController {
     if (!app.user || !app.user.jwt) {
       throw new Error('must be logged in to refresh notifications');
     }
-    const chainFilter = app.isCustomDomain() ? app.activeChainId() : null;
-    const options = chainFilter ? { chain_filter: chainFilter, } : {};
+    const options = app.isCustomDomain() ? { chain_filter: app.activeChainId() } : {};
     // TODO: Change to GET /notifications
-    console.log('options', options);
     return post('/viewNotifications', options, (result) => {
       this._store.clear();
       this._subscriptions = [];

--- a/client/scripts/controllers/server/notifications.ts
+++ b/client/scripts/controllers/server/notifications.ts
@@ -153,8 +153,11 @@ class NotificationsController {
     if (!app.user || !app.user.jwt) {
       throw new Error('must be logged in to refresh notifications');
     }
+    const chainFilter = app.isCustomDomain() ? app.activeChainId() : null;
+    const options = chainFilter ? { chain_filter: chainFilter, } : {};
     // TODO: Change to GET /notifications
-    return post('/viewNotifications', { }, (result) => {
+    console.log('options', options);
+    return post('/viewNotifications', options, (result) => {
       this._store.clear();
       this._subscriptions = [];
       for (const subscriptionJSON of result) {

--- a/server/routes/viewNotifications.ts
+++ b/server/routes/viewNotifications.ts
@@ -32,6 +32,11 @@ export default async (
       }
     });
   }
+  if (req.body.chain_filter) {
+    searchParams.push({
+      chain_id: req.body.chain_filter,
+    });
+  }
 
   const notificationParams: any = {
     model: models.NotificationsRead,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Notifications are broken on custom domains, malformed URI related issue. 
While this isn't a direct fix, it should work by limiting the notifications experienced through a custom domain to be only those within the community.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Need to be

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no