### PR TITLE
Update README.md - Correcting typos in the partial table load instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ heroku pg:psql -a <APP_NAME>
 \COPY (<QUERY>) TO '<LOCAL_PATH><FILENAME>.csv' WITH (delimiter ',', format CSV);
 # exit the remote server and log in to local instance
 exit
-psql -d commonwalth -U commonwealth
+psql -d commonwealth -U commonwealth
 # load the local .csv to the local database 
 # example: \COPY "ChainEvents" FROM '/var/www/html/commonwealth/ChainEvents.csv' CSV;
-\COPY "<TABLE_NAME>" FROM '<LOCAL_PATH><FILENAME>.csv' WITH (delimiter ',', format CSV);
+\COPY "<TABLE_NAME>" FROM '<LOCAL_PATH><FILENAME>.csv' CSV;
 
 ```
 


### PR DESCRIPTION
Correcting typos in the partial table load instructions

<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected misspelled "commonwealth" in psql login instructions, and removed paste artifacts from the final "\COPY" line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no