### PR TITLE
Fix URI encoding for sidebar topics rows

### DIFF
--- a/client/scripts/views/components/sidebar/discussion_section.ts
+++ b/client/scripts/views/components/sidebar/discussion_section.ts
@@ -141,7 +141,7 @@ export const DiscussionSection: m.Component<{mobile: boolean}, {}> = {
             onclick: (e, toggle: boolean) => {
               e.preventDefault();
               setDiscussionsToggleTree(`children.${topic.name}.toggled_state`, toggle);
-              navigateToSubpage(`/discussions/${topic.name}`);
+              navigateToSubpage(`/discussions/${encodeURI(topic.name)}`);
             },
             display_data: null
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Topic rows in sidebar weren't routing to a URI encoded link, so some Notional topics that have trailing whitespace were failing. This fixes that. In the future, we should also sanitize inputs and add an identifier number as well to further harden our URLs + linking features. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no