### PR TITLE
Ensure getSupportedEthChains only returns w addresses.

### DIFF
--- a/server/util/supportedEthChains.ts
+++ b/server/util/supportedEthChains.ts
@@ -18,6 +18,9 @@ export async function getSupportedEthChainIds(models: DB): Promise<{
           [Op.ne]: null,
           [Op.ne]: 0,
         }
+      },
+      address: {
+        [Op.ne]: null,
       }
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
/createCommunity was failing for Eth Mainnet ERC20s, because Ion has a eth_chain_id in the database. Now we restrict the lookup only to ChainNodes with addresses. In theory we should query against Chains as well, for ChainBase.Ethereum, but couldn't figure out the sequelize syntax for it + will be moot once we reorient the Chains table in a coming PR.

For testing: try hitting populate fields for an ERC20 on Eth Mainnet.