### PR TITLE
Add cascade for NotificationsRead on Subscription delete.

### DIFF
--- a/server/migrations/20220215201512-add-subscription-delete-cascade.js
+++ b/server/migrations/20220215201512-add-subscription-delete-cascade.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    const query = `ALTER TABLE "public"."NotificationsRead"
+      DROP CONSTRAINT "NotificationsRead_subscription_id_fkey",
+      ADD CONSTRAINT "NotificationsRead_subscription_id_fkey"
+        FOREIGN KEY ("subscription_id")
+        REFERENCES "public"."Subscriptions"("id")
+        ON DELETE CASCADE;`;
+    return queryInterface.sequelize.query(query);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    const query = `ALTER TABLE "public"."NotificationsRead"
+      DROP CONSTRAINT "NotificationsRead_subscription_id_fkey",
+      ADD CONSTRAINT "NotificationsRead_subscription_id_fkey"
+        FOREIGN KEY ("subscription_id") 
+        REFERENCES "public"."Subscriptions"("id");`;
+    return queryInterface.sequelize.query(query);
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deleting a thread with active subscriptions + notifications does not currently work because CASCADE is not set. This migration sets it so that /deleteThread works again.
