### PR TITLE
Boilerplate for typed routes.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,6 +93,12 @@
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/explicit-module-boundary-types": 0,
-    "prettier/prettier": 0
+    "prettier/prettier": 0,
+    "@typescript-eslint/no-empty-interface": [
+      "error",
+      {
+        "allowSingleExtends": true
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "rxjs": "^7.3.0",
     "sass-loader": "^10.1.1",
     "secp256k1": "^4.0.2",
-    "sequelize": "^6.6.5",
+    "sequelize": "^6.16.1",
     "sequelize-cli": "^6.2.0",
     "serve-favicon": "^2.5.0",
     "simplepicker": "^2.0.4",

--- a/server/models/offchain_vote.ts
+++ b/server/models/offchain_vote.ts
@@ -1,9 +1,9 @@
 import * as Sequelize from 'sequelize';
-import { DataTypes, Model } from 'sequelize';
-import { ModelStatic } from './types';
+import { DataTypes } from 'sequelize';
+import { ModelStatic, ModelInstance } from './types';
 import { OffchainThreadAttributes } from './offchain_thread';
 
-export interface OffchainVoteAttributes {
+export type OffchainVoteAttributes = {
   thread_id: number;
   option: string;
   address: string;
@@ -17,8 +17,7 @@ export interface OffchainVoteAttributes {
   thread?: OffchainThreadAttributes | OffchainThreadAttributes['id'];
 }
 
-export interface OffchainVoteInstance
-extends Model<OffchainVoteAttributes>, OffchainVoteAttributes {}
+export type OffchainVoteInstance = ModelInstance<OffchainVoteAttributes>;
 
 export type OffchainVoteModelStatic = ModelStatic<OffchainVoteInstance>
 

--- a/server/models/types.ts
+++ b/server/models/types.ts
@@ -1,5 +1,8 @@
 import { BuildOptions, Model } from 'sequelize';
+import { DB } from '../database';
+
+export type ModelInstance<Attrs extends Record<string, unknown>> = Model<Attrs> & Attrs;
 
 export type ModelStatic<T extends Model> = typeof Model
-    & { associate: (models: any) => void }
-    & { new(values?: Record<string, unknown>, options?: BuildOptions): T }
+  & { associate: (models: DB) => void }
+  & { new(values?: Record<string, unknown>, options?: BuildOptions): T };

--- a/server/routes/viewOffchainVotes.ts
+++ b/server/routes/viewOffchainVotes.ts
@@ -1,18 +1,23 @@
-import { Request, Response, NextFunction } from 'express';
 import lookupCommunityIsVisibleToUser from '../util/lookupCommunityIsVisibleToUser';
 import { DB } from '../database';
 import { AppError, ServerError } from '../util/errors';
+import { OffchainVoteAttributes } from '../models/offchain_vote';
+import { TypedRequestQuery, TypedResponse, success } from '../types';
 
 export const Errors = {
   InvalidThread: 'Invalid thread',
 };
 
+type ViewOffchainVotesReq = { thread_id: string, chain: string };
+type ViewOffchainVotesResp = OffchainVoteAttributes[];
+
 const viewOffchainVotes = async (
   models: DB,
-  req: Request,
-  res: Response,
-  next: NextFunction
+  req: TypedRequestQuery<ViewOffchainVotesReq>,
+  res: TypedResponse<ViewOffchainVotesResp>
 ) => {
+  // TODO: runtime validation based on params
+  //   maybe something like https://www.npmjs.com/package/runtime-typescript-checker
   let chain, error;
   try {
     [chain, error] = await lookupCommunityIsVisibleToUser(
@@ -36,10 +41,7 @@ const viewOffchainVotes = async (
     const votes = await models.OffchainVote.findAll({
       where: { thread_id: req.query.thread_id, chain: chain.id },
     });
-    return res.json({
-      status: 'Success',
-      result: votes.map((v) => v.toJSON()),
-    });
+    return success(res, votes.map((v) => v.toJSON()));
   } catch (err) {
     throw new ServerError(err);
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,11 +1,41 @@
-import WebSocket from 'ws';
+import { Request, Response } from 'express';
 import { UserInstance } from './models/user';
 
-// create req.session.passport.user type on standard Request object
-// and extend User to be "any" (really should be a models.User instance,
-// but we don't support typescript on server yet)
-// based on: https://stackoverflow.com/questions/27637609/understanding-passport-serialize-deserialize
+export type TypedRequestQuery<
+  Q extends Record<string, unknown> = Record<string, unknown>
+> = Request & {
+  user?: Express.User & UserInstance;
+  query?: Q;
+}
+
+export type TypedRequestBody<
+  B extends Record<string, unknown> = Record<string, unknown>
+> = Request & {
+  user?: Express.User & UserInstance;
+  body?: B;
+}
+
+export type TypedRequest<
+  B extends Record<string, unknown> = Record<string, unknown>,
+  Q extends Record<string, unknown> = Record<string, unknown>
+> = Request & {
+  user?: Express.User & UserInstance;
+  body?: B;
+  query?: Q;
+}
+
+export type TypedResponse<T> = Response<{ result: T } & { status: 'Success' | 'Failure' | number }>;
+
+export function success<T>(res: TypedResponse<T>, result: T) {
+  return res.json({
+    status: 'Success',
+    result,
+  });
+}
+
+// TODO: legacy overrides, convert all routes and remove
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface User extends UserInstance {
       [key: string]: any;
@@ -13,15 +43,11 @@ declare global {
 
     interface Request {
       user?: User;
-      wss: WebSocket.Server;
+
+      // TODO: remove these once websocket PR merged!
       session: any;
       sessionID: any;
-    }
-
-    interface SessionData {
-      passport?: {
-        user?: number;
-      }
+      wss: any;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,6 +3090,13 @@
   resolved "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz"
   integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/ethereumjs-util@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#9dabd7302ec9728a7d99be15f4143977c33cd5ac"
@@ -3271,6 +3278,11 @@
   integrity sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=
   dependencies:
     moment "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node-fetch@^2.5.12":
   version "2.5.12"
@@ -4235,11 +4247,6 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
-
-any-promise@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -6939,6 +6946,13 @@ debug@^4.0.1, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 decache@^3.0.5:
   version "3.1.0"
   resolved "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz"
@@ -7373,9 +7387,9 @@ dotenv@^8.2.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
-dottie@^2.0.0:
+dottie@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/dottie/-/dottie-2.0.2.tgz#cc91c0726ce3a054ebf11c55fbc92a7f266dd154"
   integrity sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==
 
 dragula@^3.7.2:
@@ -10544,10 +10558,10 @@ infer-owner@^1.0.3:
   resolved "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-inflection@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz"
-  integrity sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==
+inflection@^1.13.1:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.2.tgz#15e8c797c6c3dadf31aa658f8df8a4ea024798b0"
+  integrity sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -12918,14 +12932,14 @@ moment-locales-webpack-plugin@^1.1.0:
   dependencies:
     lodash.difference "^4.5.0"
 
-moment-timezone@^0.5.31:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+moment-timezone@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
   dependencies:
     moment ">= 2.9.0"
 
-moment@*, "moment@>= 2.9.0", moment@^2.10.2, moment@^2.23.0, moment@^2.25.0, moment@^2.26.0, moment@^2.29.1:
+moment@*, "moment@>= 2.9.0", moment@^2.10.2, moment@^2.23.0, moment@^2.25.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -16482,12 +16496,10 @@ ret@~0.1.10:
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry-as-promised@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz"
-  integrity sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==
-  dependencies:
-    any-promise "^1.3.0"
+retry-as-promised@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-5.0.0.tgz#f4ecc25133603a2d2a7aff4a128691d7bc506d54"
+  integrity sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA==
 
 retry@^0.12.0:
   version "0.12.0"
@@ -16865,7 +16877,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4:
+semver@^7.2.1, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -16935,28 +16947,30 @@ sequelize-cli@^6.2.0:
     umzug "^2.3.0"
     yargs "^13.1.0"
 
-sequelize-pool@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz"
-  integrity sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
+sequelize-pool@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-7.1.0.tgz#210b391af4002762f823188fd6ecfc7413020768"
+  integrity sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==
 
-sequelize@^6.6.5:
-  version "6.6.5"
-  resolved "https://registry.npmjs.org/sequelize/-/sequelize-6.6.5.tgz"
-  integrity sha512-QyRrJrDRiwuiILqTMHUA1yWOPIL12KlfmgZ3hnzQwbMvp2vJ6fzu9bYJQB+qPMosck4mBUggY4Cjoc6Et8FBIQ==
+sequelize@^6.16.1:
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.16.1.tgz#2c84036ae0a64843cdfa52c8e3d0bee9c52ce116"
+  integrity sha512-YFGqrwkmEhSbpZBxay5+PRKMiZNNUJzgIixCyFkLm9+/5Rqq5jBADEjTAC8RYHzwsOGNboYh18imXrYNCjBZCQ==
   dependencies:
-    debug "^4.1.1"
-    dottie "^2.0.0"
-    inflection "1.13.1"
-    lodash "^4.17.20"
-    moment "^2.26.0"
-    moment-timezone "^0.5.31"
-    retry-as-promised "^3.2.0"
-    semver "^7.3.2"
-    sequelize-pool "^6.0.0"
+    "@types/debug" "^4.1.7"
+    debug "^4.3.3"
+    dottie "^2.0.2"
+    inflection "^1.13.1"
+    lodash "^4.17.21"
+    moment "^2.29.1"
+    moment-timezone "^0.5.34"
+    pg-connection-string "^2.5.0"
+    retry-as-promised "^5.0.0"
+    semver "^7.3.5"
+    sequelize-pool "^7.1.0"
     toposort-class "^1.0.1"
-    uuid "^8.1.0"
-    validator "^13.6.0"
+    uuid "^8.3.2"
+    validator "^13.7.0"
     wkx "^0.5.0"
 
 serialize-javascript@^1.4.0:
@@ -19170,7 +19184,7 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.1.0, uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -19198,7 +19212,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.6.0:
+validator@^13.7.0:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Provides a basic technique for creating typed routes + simplifies model declaration.
- ModelInstance wraps Sequelize's native Instance type. Use `& { getChains()... }`  to declare association getters.
- Upgraded Sequelize minor version to support types on `toJSON()` (I had previously written a solution for this, but it was added in a more recent release of the library).
- `TypedRequest` and `TypedResponse` wrap Express's native types and allow us to declare types explicitly for the query/body (although it wont check them at runtime) and for the response.
- Adds a `success` helper function for returning successful results.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lets us add explicit types to our API routes, which makes them far easier to document.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ensured it built + ran.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no