### PR TITLE
Add backup meta description to communities that lack descriptions

### DIFF
--- a/server/scripts/setupAppRoutes.ts
+++ b/server/scripts/setupAppRoutes.ts
@@ -33,6 +33,7 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
   }
 
   const renderWithMetaTags = (res, title, description, author, image) => {
+    description = description || `${title}: a decentralized community on Commonwealth.im.`;
     const $tmpl = cheerio.load(templateFile);
     $tmpl('meta[name="title"]').attr('content', title);
     $tmpl('meta[name="description"]').attr('content', description);


### PR DESCRIPTION
Right now, communities that lack descriptions end up with search result text in the vein of `{CommunityName}/Discussions. Log in. We’re hiring! DISCUSSIONS. All. Product. GOVERNANCE. Members. Snapshots. Connected. All Topics. Summary`

This branch adds an autogenerated description to a community's header `meta` info, so description-less communities have clearer search result text.