### PR TITLE
Reinstate thread and comment preview functionality

### DIFF
--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -20,6 +20,7 @@ import SettingsController from 'controllers/app/settings';
 import { Profile } from 'models';
 import { confirmationModalWithText } from 'views/modals/confirm_modal';
 import PreviewModal from 'views/modals/preview_modal';
+import { CWIcon } from './component_kit/cw_icons/cw_icon';
 
 // Rich text and Markdown editor.
 //
@@ -1035,6 +1036,26 @@ const QuillEditor: m.Component<IQuillEditorAttrs, IQuillEditorState> = {
             content: m('.quill-editor-tooltip', 'Click for Markdown'),
           }),
       ]),
+      m('.preview-button-wrap', [
+        m(Tag, {
+          label: m('.preview-button', [
+            m(CWIcon, { iconName: 'search', iconSize: 'small '}),
+            m('span', 'Preview')
+          ]),
+          size: 'xs',
+          onclick: (e) => {
+            e.preventDefault();
+            app.modals.create({
+              modal: PreviewModal,
+              data: {
+                doc: vnode.state.markdownMode
+                  ? vnode.state.editor.getText()
+                  : JSON.stringify(vnode.state.editor.getContents()),
+              },
+            });
+          },
+        })
+      ])
     ]);
   }
 };

--- a/client/scripts/views/modals/preview_modal.ts
+++ b/client/scripts/views/modals/preview_modal.ts
@@ -14,8 +14,7 @@ const PreviewModal: m.Component<{ title: string; doc: string }> = {
         m('h3', title ? `Preview: ${title}` : 'Preview'),
         m(CompactModalExitButton),
       ]),
-      m(
-        '.compact-modal-body',
+      m('.compact-modal-body',
         (() => {
           try {
             const doc = JSON.parse(vnode.attrs.doc);

--- a/client/styles/components/quill_editor.scss
+++ b/client/styles/components/quill_editor.scss
@@ -185,13 +185,33 @@
     .type-selector {
         position: absolute;
         display: flex;
-        right: 10px;
+        right: 100px;
         top: 6px;
         user-select: none;
         .cui-tag {
             cursor: pointer;
             margin-top: 3px;
             margin-right: 0;
+        }
+    }
+    .preview-button-wrap {
+        position: absolute;
+        display: flex;
+        right: 10px;
+        top: 6px;
+        user-select: none;
+        .preview-button {
+            display: flex;
+        }
+        .cui-tag {
+            cursor: pointer;
+            margin-top: 3px;
+            margin-right: 0;
+        }
+        svg {
+            margin-right: 5px;
+            top: -1px;
+            position: relative;
         }
     }
 

--- a/client/styles/modals/preview_modal.scss
+++ b/client/styles/modals/preview_modal.scss
@@ -1,18 +1,14 @@
 @import 'client/styles/shared';
 
 .PreviewModal {
-    .compact-modal-body {
+    .QuillFormattedText {
         width: 640px;
-        padding-top: 31px;
+        max-height: 64vh;
+        overflow-y: auto;
+        margin: 25px 0;
         @include xs-max {
             width: initial;
         }
-    }
-    .compact-modal-attachments {
-        margin-top: 10px;
-        margin-bottom: 30px;
-        padding: 0 25px;
-        @include attachments;
     }
     .empty-preview {
         text-align: center;


### PR DESCRIPTION
This adds a preview button to the toolbar, now next to the Markdown/RichText toggle. On click, the previously unused preview modal is launched.