### PR TITLE
Mobile layout fixes

### DIFF
--- a/client/scripts/views/components/quill_editor.ts
+++ b/client/scripts/views/components/quill_editor.ts
@@ -51,7 +51,7 @@ const instantiateEditor = (
   placeholder: string,
   editorNamespace: string,
   state: any,
-  onkeyboardSubmit: () => void,
+  onkeyboardSubmit: () => void
 ) => {
   const Delta = Quill.import('delta');
   const Keyboard = Quill.import('modules/keyboard');
@@ -82,7 +82,7 @@ const instantiateEditor = (
     const retain = range.index - url.length;
     const ops = (retain ? [{ retain }] : []) as any;
     ops.push(
-      { 'delete': url.length },
+      { delete: url.length },
       { insert: url, attributes: { link: url } }
     );
     quill.updateContents({ ops });
@@ -90,8 +90,10 @@ const instantiateEditor = (
   };
 
   const insertEmbeds = (text) => {
-    const twitterRe = /^(?:http[s]?:\/\/)?(?:www[.])?twitter[.]com\/.+?\/status\/(\d+)$/;
-    const videoRe = /^(?:http[s]?:\/\/)?(?:www[.])?((?:vimeo\.com|youtu\.be|youtube\.com)\/[^\s]+)$/;
+    const twitterRe =
+      /^(?:http[s]?:\/\/)?(?:www[.])?twitter[.]com\/.+?\/status\/(\d+)$/;
+    const videoRe =
+      /^(?:http[s]?:\/\/)?(?:www[.])?((?:vimeo\.com|youtu\.be|youtube\.com)\/[^\s]+)$/;
     const embeddableTweet = twitterRe.test(text);
     const embeddableVideo = videoRe.test(text);
     const insertionIdx = quill.getSelection().index;
@@ -104,8 +106,12 @@ const instantiateEditor = (
       setTimeout(() => {
         const embedEle = document.querySelectorAll(`div[data-id='${id}']`)[0];
         const widgetsEle = embedEle?.children[0];
-        const isRendered = widgetsEle && Array.from(widgetsEle.classList).includes('twitter-tweet-rendered');
-        const isVisible = (embedEle?.children[0] as HTMLElement)?.style['visibility'] !== 'hidden';
+        const isRendered =
+          widgetsEle &&
+          Array.from(widgetsEle.classList).includes('twitter-tweet-rendered');
+        const isVisible =
+          (embedEle?.children[0] as HTMLElement)?.style['visibility'] !==
+          'hidden';
         if (isRendered && isVisible) {
           quill.deleteText(insertionIdx - text.length, text.length + 1);
           quill.setSelection(insertionIdx - text.length + 1, 'silent');
@@ -113,10 +119,18 @@ const instantiateEditor = (
           // Nested setTimeouts ensure that the embedded URL is deleted both more quickly
           // and more reliably than would be the case with a single .750ms timeout
           setTimeout(() => {
-            const _embedEle = document.querySelectorAll(`div[data-id='${id}']`)[0];
+            const _embedEle = document.querySelectorAll(
+              `div[data-id='${id}']`
+            )[0];
             const _widgetsEle = _embedEle?.children[0];
-            const _isRendered = _widgetsEle && Array.from(_widgetsEle.classList).includes('twitter-tweet-rendered');
-            const _isVisible = (_embedEle?.children[0] as HTMLElement)?.style['visibility'] !== 'hidden';
+            const _isRendered =
+              _widgetsEle &&
+              Array.from(_widgetsEle.classList).includes(
+                'twitter-tweet-rendered'
+              );
+            const _isVisible =
+              (_embedEle?.children[0] as HTMLElement)?.style['visibility'] !==
+              'hidden';
             if (_isRendered && _isVisible) {
               quill.deleteText(insertionIdx - text.length, text.length + 1);
               quill.setSelection(insertionIdx - text.length + 1, 'silent');
@@ -167,8 +181,10 @@ const instantiateEditor = (
 
   // preemptively load Twitter Widgets, so users won't be confused by loading lag &
   // abandon an embed attempt
-  if (!(<any>window).twttr) loadScript('//platform.twitter.com/widgets.js')
-    .then(() => console.log('Twitter Widgets loaded'));
+  if (!(<any>window).twttr)
+    loadScript('//platform.twitter.com/widgets.js').then(() =>
+      console.log('Twitter Widgets loaded')
+    );
 
   const BlockEmbed = Quill.import('blots/block/embed');
   class TwitterBlot extends BlockEmbed {
@@ -265,16 +281,23 @@ const instantiateEditor = (
       const tip = document.createElement('span');
       tip.innerText = 'Type to tag a member';
       node.appendChild(tip);
-      formattedMatches = [{
-        link: '#',
-        name: '',
-        component: node.outerHTML,
-      }];
+      formattedMatches = [
+        {
+          link: '#',
+          name: '',
+          component: node.outerHTML,
+        },
+      ];
       renderList(formattedMatches, searchTerm);
     } else if (searchTerm.length > 0) {
-      members = await app.search.searchMentionableAddresses(searchTerm, { resultSize: 6 });
+      members = await app.search.searchMentionableAddresses(searchTerm, {
+        resultSize: 6,
+      });
       formattedMatches = members.map((addr) => {
-        const profile: Profile = app.profiles.getProfile(addr.chain, addr.address);
+        const profile: Profile = app.profiles.getProfile(
+          addr.chain,
+          addr.address
+        );
         const node = document.createElement('div');
 
         let avatar;
@@ -294,11 +317,16 @@ const instantiateEditor = (
         nameSpan.className = 'ql-mention-name';
 
         const addrSpan = document.createElement('span');
-        addrSpan.innerText = addr.chain === 'near' ? addr.address : `${addr.address.slice(0, 6)}...`;
+        addrSpan.innerText =
+          addr.chain === 'near'
+            ? addr.address
+            : `${addr.address.slice(0, 6)}...`;
         addrSpan.className = 'ql-mention-addr';
 
         const lastActiveSpan = document.createElement('span');
-        lastActiveSpan.innerText = profile.lastActive ? `Last active ${moment(profile.lastActive).fromNow()}` : null;
+        lastActiveSpan.innerText = profile.lastActive
+          ? `Last active ${moment(profile.lastActive).fromNow()}`
+          : null;
         lastActiveSpan.className = 'ql-mention-la';
 
         const textWrap = document.createElement('div');
@@ -310,11 +338,11 @@ const instantiateEditor = (
         textWrap.appendChild(lastActiveSpan);
         node.appendChild(textWrap);
 
-        return ({
+        return {
           link: `/${addr.chain}/account/${addr.address}`,
           name: addr.name,
           component: node.outerHTML,
-        });
+        };
       });
     }
     renderList(formattedMatches, searchTerm);
@@ -324,13 +352,18 @@ const instantiateEditor = (
     if (item.link === '#' && item.name === '') return;
     const text = quill.getText();
     const cursorIdx = quill.selection.savedRange.index;
-    const mentionLength = text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
+    const mentionLength =
+      text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
     const beforeText = text.slice(0, cursorIdx - mentionLength);
     const afterText = text.slice(cursorIdx).replace(/\n$/, '');
     if (isMarkdownMode()) {
-      const fullText = `${beforeText}[@${item.name}](${item.link}) ${afterText.replace(/^ /, '')}`;
+      const fullText = `${beforeText}[@${item.name}](${
+        item.link
+      }) ${afterText.replace(/^ /, '')}`;
       quill.setText(fullText);
-      quill.setSelection(fullText.length - afterText.length + (afterText.startsWith(' ') ? 1 : 0));
+      quill.setSelection(
+        fullText.length - afterText.length + (afterText.startsWith(' ') ? 1 : 0)
+      );
     } else {
       const delta = new Delta()
         .retain(beforeText.length)
@@ -338,14 +371,19 @@ const instantiateEditor = (
         .insert(`@${item.name}`, { link: item.link });
       if (!afterText.startsWith(' ')) delta.insert(' ');
       quill.updateContents(delta);
-      quill.setSelection(quill.getLength() - afterText.length - (afterText.startsWith(' ') ? 0 : 1), 0);
+      quill.setSelection(
+        quill.getLength() -
+          afterText.length -
+          (afterText.startsWith(' ') ? 0 : 1),
+        0
+      );
     }
   };
 
   // Setup custom keyboard bindings, override Quill default bindings where necessary
   const bindings = {
     // Don't insert hard tabs
-    'tab': {
+    tab: {
       key: 'Tab',
       handler: () => true,
     },
@@ -361,7 +399,7 @@ const instantiateEditor = (
         const isEmbed = insertEmbeds(textContent);
         // if embed, stopPropogation; otherwise continue
         return !isEmbed;
-      }
+      },
     },
     // Check for mentions on return
     'add-mention': {
@@ -377,10 +415,10 @@ const instantiateEditor = (
         } else {
           return true;
         }
-      }
+      },
     },
     // Submit on cmd-Enter/ctrl-Enter
-    'submit': {
+    submit: {
       key: 'Enter',
       shortKey: true,
       handler: () => {
@@ -390,7 +428,7 @@ const instantiateEditor = (
         } else {
           return true;
         }
-      }
+      },
     },
     // Close headers, code blocks, and blockquotes when backspacing the start of a line
     'header backspace': {
@@ -400,7 +438,7 @@ const instantiateEditor = (
       offset: 0,
       handler: (range, context) => {
         quill.format('header', false, 'user');
-      }
+      },
     },
     'blockquote backspace': {
       key: 'Backspace',
@@ -409,7 +447,7 @@ const instantiateEditor = (
       offset: 0,
       handler: (range, context) => {
         quill.format('blockquote', false, 'user');
-      }
+      },
     },
     'code backspace': {
       key: 'Backspace',
@@ -419,7 +457,7 @@ const instantiateEditor = (
       suffix: /^\s+$/,
       handler: (range, context) => {
         quill.format('code-block', false, 'user');
-      }
+      },
     },
     // Only start a list when 1. is typed, not other numeric indices.
     // Don't start lists in Markdown mode
@@ -453,41 +491,48 @@ const instantiateEditor = (
         quill.updateContents(delta, 'user');
         quill.history.cutoff();
         quill.setSelection(range.index - length, 'silent');
-      }
+      },
     },
     // Don't boldface, italicize, or underline text when hotkeys are pressed in Markdown mode
-    'bold': {
+    bold: {
       key: 'b',
       shortKey: true,
       handler: (range, context) => {
-        if (!isMarkdownMode()) quill.format('bold', !context.format.bold, Quill.sources.USER);
+        if (!isMarkdownMode())
+          quill.format('bold', !context.format.bold, Quill.sources.USER);
         return false;
-      }
+      },
     },
-    'italic': {
+    italic: {
       key: 'i',
       shortKey: true,
       handler: (range, context) => {
-        if (!isMarkdownMode()) quill.format('italic', !context.format.italic, Quill.sources.USER);
+        if (!isMarkdownMode())
+          quill.format('italic', !context.format.italic, Quill.sources.USER);
         return false;
-      }
+      },
     },
-    'underline': {
+    underline: {
       key: 'u',
       shortKey: true,
       handler: (range, context) => {
-        if (!isMarkdownMode()) quill.format('underline', !context.format.underline, Quill.sources.USER);
+        if (!isMarkdownMode())
+          quill.format(
+            'underline',
+            !context.format.underline,
+            Quill.sources.USER
+          );
         return false;
-      }
+      },
     },
     // Check for links
-    'autolinks': {
+    autolinks: {
       collapsed: true,
       key: ' ',
       prefix: REGEXP_WITH_PRECEDING_WS,
       handler: handleAutolinks,
     },
-    'autolinks2': {
+    autolinks2: {
       collapsed: true,
       key: 'Enter',
       prefix: REGEXP_WITH_PRECEDING_WS,
@@ -516,13 +561,15 @@ const instantiateEditor = (
     let n = bstr.length;
     const u8arr = new Uint8Array(n);
     while (n--) u8arr[n] = bstr.charCodeAt(n);
-    const filename = (new Date().getTime()).toString();
+    const filename = new Date().getTime().toString();
     return new File([u8arr], filename, { type });
   };
 
   const uploadImg = async (file) => {
     return new Promise((resolve, reject) => {
-      document.getElementsByClassName('ql-container')[0].appendChild(createSpinner());
+      document
+        .getElementsByClassName('ql-container')[0]
+        .appendChild(createSpinner());
       // TODO: Change to POST /uploadSignature
       // TODO: Reuse code since this is used in other places
       $.post(`${app.serverUrl()}/getUploadSignature`, {
@@ -530,36 +577,47 @@ const instantiateEditor = (
         mimetype: file.type, // image/png
         auth: true,
         jwt: app.user.jwt,
-      }).then((response) => {
-        if (response.status !== 'Success') {
+      })
+        .then((response) => {
+          if (response.status !== 'Success') {
+            document.getElementsByClassName('spinner-wrap')[0].remove();
+            alert('Upload failed');
+            return reject(
+              new Error(
+                `Failed to get an S3 signed upload URL: ${response.error}`
+              )
+            );
+          }
+          $.ajax({
+            type: 'PUT',
+            url: response.result,
+            contentType: file.type,
+            processData: false, // don't send as form
+            data: file,
+          })
+            .then(() => {
+              // file uploaded
+              const trimmedURL = response.result.slice(
+                0,
+                response.result.indexOf('?')
+              );
+              document.getElementsByClassName('spinner-wrap')[0].remove();
+              resolve(trimmedURL);
+              console.log(`Upload succeeded: ${trimmedURL}`);
+            })
+            .catch((err) => {
+              // file not uploaded
+              document.getElementsByClassName('spinner-wrap')[0].remove();
+              alert('Upload failed');
+              console.log(`Upload failed: ${response.result}`);
+              reject(new Error(`Upload failed: ${err}`));
+            });
+        })
+        .catch((err: any) => {
           document.getElementsByClassName('spinner-wrap')[0].remove();
-          alert('Upload failed');
-          return reject(new Error(`Failed to get an S3 signed upload URL: ${response.error}`));
-        }
-        $.ajax({
-          type: 'PUT',
-          url: response.result,
-          contentType: file.type,
-          processData: false, // don't send as form
-          data: file
-        }).then(() => {
-          // file uploaded
-          const trimmedURL = response.result.slice(0, response.result.indexOf('?'));
-          document.getElementsByClassName('spinner-wrap')[0].remove();
-          resolve(trimmedURL);
-          console.log(`Upload succeeded: ${trimmedURL}`);
-        }).catch((err) => {
-          // file not uploaded
-          document.getElementsByClassName('spinner-wrap')[0].remove();
-          alert('Upload failed');
-          console.log(`Upload failed: ${response.result}`);
-          reject(new Error(`Upload failed: ${err}`));
+          err = err.responseJSON ? err.responseJSON.error : err.responseText;
+          reject(new Error(`Failed to get an S3 signed upload URL: ${err}`));
         });
-      }).catch((err : any) => {
-        document.getElementsByClassName('spinner-wrap')[0].remove();
-        err = err.responseJSON ? err.responseJSON.error : err.responseText;
-        reject(new Error(`Failed to get an S3 signed upload URL: ${err}`));
-      });
     });
   };
 
@@ -572,48 +630,63 @@ const instantiateEditor = (
     const contents = quill.getContents();
     const indexesToFilter = [];
     contents.ops.forEach((op, idx) => {
-      if (op.insert?.image?.startsWith('data:image/jpeg;base64')
-          || op.insert?.image?.startsWith('data:image/gif;base64')
-          || op.insert?.image?.startsWith('data:image/png;base64')) indexesToFilter.push(idx);
+      if (
+        op.insert?.image?.startsWith('data:image/jpeg;base64') ||
+        op.insert?.image?.startsWith('data:image/gif;base64') ||
+        op.insert?.image?.startsWith('data:image/png;base64')
+      )
+        indexesToFilter.push(idx);
     });
-    contents.ops = contents.ops.filter((op, idx) => indexesToFilter.indexOf(idx) === -1);
+    contents.ops = contents.ops.filter(
+      (op, idx) => indexesToFilter.indexOf(idx) === -1
+    );
     quill.setContents(contents.ops); // must set contents to contents.ops for some reason
 
     const isMarkdown = $('.QuillEditor').hasClass('markdown-mode');
     const file = dataURLtoFile(imageDataUrl, type);
     quill.enable(false);
-    uploadImg(file).then((uploadURL) => {
-      quill.enable(true);
-      if (typeof uploadURL === 'string' && detectURL(uploadURL)) {
-        if (isMarkdown) {
-          quill.insertText(index, `![](${uploadURL})`, 'user');
-        } else {
-          quill.insertEmbed(index, 'image', uploadURL);
+    uploadImg(file)
+      .then((uploadURL) => {
+        quill.enable(true);
+        if (typeof uploadURL === 'string' && detectURL(uploadURL)) {
+          if (isMarkdown) {
+            quill.insertText(index, `![](${uploadURL})`, 'user');
+          } else {
+            quill.insertEmbed(index, 'image', uploadURL);
+          }
+          quill.setSelection(
+            index + (isMarkdown ? 5 + uploadURL.length : 1),
+            0
+          );
         }
-        quill.setSelection(index + (isMarkdown ? 5 + uploadURL.length : 1), 0);
-      }
-    }).catch((err) => {
-      notifyError('Failed to upload image. Was it a valid JPG, PNG, or GIF?');
-      console.log(err);
-      quill.enable(true);
-    });
+      })
+      .catch((err) => {
+        notifyError('Failed to upload image. Was it a valid JPG, PNG, or GIF?');
+        console.log(err);
+        quill.enable(true);
+      });
   };
 
   quill = new Quill($editor[0], {
     debug: 'error',
     modules: {
-      toolbar: hasFormats ? ([[{ header: 1 }, { header: 2 }]] as any).concat([
-        ['bold', 'italic', 'strike'], ['code-block', 'blockquote'],
-        [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }, 'link', 'preview'],
-      ]) : false,
+      toolbar: hasFormats
+        ? ([[{ header: 1 }, { header: 2 }]] as any).concat([
+            ['bold', 'italic', 'strike'],
+            ['link', 'code-block', 'blockquote'],
+            [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
+          ])
+        : false,
       imageDropAndPaste: {
-        handler: imageHandler
+        handler: imageHandler,
       },
       // TODO: Currently works, but throws Parchment error. Smooth functionality
       // requires troubleshooting
       imageUploader: false,
       markdownShortcuts: {
-        suppress: () => { return isMarkdownMode(); }
+        suppress: () => {
+          return isMarkdownMode();
+        },
       },
       keyboard: { bindings },
       mention: {
@@ -622,7 +695,10 @@ const instantiateEditor = (
         dataAttributes: ['name', 'link', 'component'],
         renderItem: (item) => item.component,
         onSelect: selectMention,
-        source: _.debounce(queryMentions, 300, { leading: true, trailing: true }),
+        source: _.debounce(queryMentions, 300, {
+          leading: true,
+          trailing: true,
+        }),
         isolateChar: true,
       },
       clipboard: {
@@ -638,17 +714,28 @@ const instantiateEditor = (
                   background: false,
                 })
               );
-            }
-          ]
-        ]
-      }
+            },
+          ],
+        ],
+      },
     },
     placeholder,
-    formats: hasFormats ? [
-      'bold', 'italic', 'strike', 'code',
-      'link', 'blockquote', 'code-block',
-      'header', 'list', 'twitter', 'video', 'mention',
-    ] : [],
+    formats: hasFormats
+      ? [
+          'bold',
+          'italic',
+          'strike',
+          'code',
+          'link',
+          'blockquote',
+          'code-block',
+          'header',
+          'list',
+          'twitter',
+          'video',
+          'mention',
+        ]
+      : [],
     theme,
   });
 
@@ -689,14 +776,18 @@ const instantiateEditor = (
     if (typeof fmt === 'string' && text.trim() === '') {
       return fmt + text;
     }
-    return text.split('\n').map((line, index) => {
-      if (typeof fmt === 'string' && line.trim() === '')
-        return line;
-      else if (typeof fmt === 'string')
-        return isInlineFormatter ? (fmt + line + fmt) : fmt + line;
-      else
-        return isInlineFormatter ? (fmt(index) + line + fmt(index)) : fmt(index) + line;
-    }).join('\n');
+    return text
+      .split('\n')
+      .map((line, index) => {
+        if (typeof fmt === 'string' && line.trim() === '') return line;
+        else if (typeof fmt === 'string')
+          return isInlineFormatter ? fmt + line + fmt : fmt + line;
+        else
+          return isInlineFormatter
+            ? fmt(index) + line + fmt(index)
+            : fmt(index) + line;
+      })
+      .join('\n');
   };
 
   const makeMarkdownToolbarHandlerInline = (handler, fmt) => {
@@ -708,7 +799,11 @@ const instantiateEditor = (
       if (length > 0) {
         const textBefore = text.slice(0, index);
         const textAfter = text.slice(index + length);
-        const formattedText = addFmt(fmt, text.slice(index, index + length), true);
+        const formattedText = addFmt(
+          fmt,
+          text.slice(index, index + length),
+          true
+        );
         quill.setText(textBefore + formattedText + textAfter);
         quill.setSelection(index, formattedText.length);
       } else {
@@ -735,12 +830,13 @@ const instantiateEditor = (
         // If there is a selection, insert (newline + fmt) before the selection
         // Then set the selection at the end of the line
         quill.setText(
-          text.slice(0, index)
-            + addFmt(fmt, text.slice(index, index + length)) + text.slice(index + length).trimRight()
+          text.slice(0, index) +
+            addFmt(fmt, text.slice(index, index + length)) +
+            text.slice(index + length).trimRight()
         );
         quill.setSelection(
-          text.slice(0, index).length
-            + addFmt(fmt, text.slice(index, index + length)).length
+          text.slice(0, index).length +
+            addFmt(fmt, text.slice(index, index + length)).length
         );
       } else {
         // If there is no selection, backtrack to the beginning of the current line
@@ -753,9 +849,14 @@ const instantiateEditor = (
 
         const textBefore = linesBefore.join('\n');
         const textAfter = linesAfter.join('\n');
-        const formattedLine = (linesBefore.length === 0 ? '' : '\n')
-          + addFmt(fmt, (thisBefore.length > 0 ? thisBefore[0] : '') + (thisAfter.length > 0 ? thisAfter[0] : ''))
-          + (linesAfter.length === 0 ? '' : '\n');
+        const formattedLine =
+          (linesBefore.length === 0 ? '' : '\n') +
+          addFmt(
+            fmt,
+            (thisBefore.length > 0 ? thisBefore[0] : '') +
+              (thisAfter.length > 0 ? thisAfter[0] : '')
+          ) +
+          (linesAfter.length === 0 ? '' : '\n');
         const result = textBefore + formattedLine + textAfter;
         quill.setText(result);
         quill.setSelection(textBefore.length + formattedLine.length - 1);
@@ -764,7 +865,11 @@ const instantiateEditor = (
   };
   makeMarkdownToolbarHandler('header', { 1: '# ', 2: '## ' });
   makeMarkdownToolbarHandler('blockquote', '> ');
-  makeMarkdownToolbarHandler('list', { ordered: ((index) => `${index + 1}. `), bullet: '- ', unchecked: '- [ ] ' });
+  makeMarkdownToolbarHandler('list', {
+    ordered: (index) => `${index + 1}. `,
+    bullet: '- ',
+    unchecked: '- [ ] ',
+  });
 
   // Set up remaining couple of Markdown toolbar options
   const defaultLinkHandler = quill.theme.modules.toolbar.handlers.link;
@@ -779,19 +884,28 @@ const instantiateEditor = (
       if (selectedText.indexOf('\n') !== -1) return;
       const linkPre = '[';
       const linkBetween = '](';
-      const linkHref = (selectedText.startsWith('https://') || selectedText.startsWith('http://'))
-        ? selectedText
-        : 'https://';
+      const linkHref =
+        selectedText.startsWith('https://') ||
+        selectedText.startsWith('http://')
+          ? selectedText
+          : 'https://';
       const linkPost = ')';
       quill.deleteText(index, length);
-      quill.insertText(index, linkPre + selectedText + linkBetween + linkHref + linkPost);
-      quill.setSelection(index + linkPre.length + selectedText.length + linkBetween.length, linkHref.length);
+      quill.insertText(
+        index,
+        linkPre + selectedText + linkBetween + linkHref + linkPost
+      );
+      quill.setSelection(
+        index + linkPre.length + selectedText.length + linkBetween.length,
+        linkHref.length
+      );
     } else {
       const linkText = prompt('Enter link text:');
       if (linkText === null) return;
-      let linkHref = (linkText.startsWith('https://') || linkText.startsWith('http://'))
-        ? linkText
-        : prompt('Enter link:', 'https://');
+      let linkHref =
+        linkText.startsWith('https://') || linkText.startsWith('http://')
+          ? linkText
+          : prompt('Enter link:', 'https://');
       if (linkHref === null) {
         // Insert link with placeholder href
         const linkPre = `[${linkText}](`;
@@ -810,15 +924,20 @@ const instantiateEditor = (
   });
 
   // Set up preview button in toolbar
-  $editor.parent().find('button.ql-preview').on('click', (e) => {
-    const markdownMode = isMarkdownMode();
-    app.modals.create({
-      modal: PreviewModal,
-      data: {
-        doc: markdownMode ? quill.getText() : JSON.stringify(quill.getContents()),
-      },
+  $editor
+    .parent()
+    .find('button.ql-preview')
+    .on('click', (e) => {
+      const markdownMode = isMarkdownMode();
+      app.modals.create({
+        modal: PreviewModal,
+        data: {
+          doc: markdownMode
+            ? quill.getText()
+            : JSON.stringify(quill.getContents()),
+        },
+      });
     });
-  });
 
   // Save editor content in localStorage
   state.unsavedChanges = new Delta();
@@ -846,7 +965,10 @@ const instantiateEditor = (
       if (quill.isEnabled()) {
         // Save the entire updated text to localStorage
         const data = JSON.stringify(quill.getContents());
-        localStorage.setItem(`${app.activeChainId()}-${editorNamespace}-storedText`, data);
+        localStorage.setItem(
+          `${app.activeChainId()}-${editorNamespace}-storedText`,
+          data
+        );
         state.unsavedChanges = new Delta();
       }
     }
@@ -883,7 +1005,10 @@ const QuillEditor: m.Component<IQuillEditorAttrs, IQuillEditorState> = {
     // Only bind the alert if we are actually trying to persist the user's changes
     if (!vnode.attrs.contentsDoc) {
       vnode.state.beforeunloadHandler = () => {
-        if (vnode.state.unsavedChanges && vnode.state.unsavedChanges.length() > 0) {
+        if (
+          vnode.state.unsavedChanges &&
+          vnode.state.unsavedChanges.length() > 0
+        ) {
           return 'There are unsaved changes. Are you sure you want to leave?';
         }
       };
@@ -897,30 +1022,48 @@ const QuillEditor: m.Component<IQuillEditorAttrs, IQuillEditorState> = {
   },
   view: (vnode) => {
     const theme = vnode.attrs.theme || 'snow';
-    const { imageUploader, placeholder, tabindex, editorNamespace, onkeyboardSubmit } = vnode.attrs;
+    const {
+      imageUploader,
+      placeholder,
+      tabindex,
+      editorNamespace,
+      onkeyboardSubmit,
+    } = vnode.attrs;
     const oncreateBind = vnode.attrs.oncreateBind || (() => null);
     // If this component is running for the first time, and the parent has not provided contentsDoc,
     // try to load it from the drafts and also set markdownMode appropriately
     let contentsDoc = vnode.attrs.contentsDoc;
-    if (!contentsDoc
-      && !vnode.state.markdownMode
-      && localStorage.getItem(`${app.activeChainId()}-${editorNamespace}-storedText`) !== null) {
+    if (
+      !contentsDoc &&
+      !vnode.state.markdownMode &&
+      localStorage.getItem(
+        `${app.activeChainId()}-${editorNamespace}-storedText`
+      ) !== null
+    ) {
       try {
-        contentsDoc = JSON.parse(localStorage.getItem(`${app.activeChainId()}-${editorNamespace}-storedText`));
+        contentsDoc = JSON.parse(
+          localStorage.getItem(
+            `${app.activeChainId()}-${editorNamespace}-storedText`
+          )
+        );
         if (!contentsDoc.ops) throw new Error();
         vnode.state.markdownMode = false;
       } catch (e) {
-        contentsDoc = localStorage.getItem(`${app.activeChainId()}-${editorNamespace}-storedText`);
+        contentsDoc = localStorage.getItem(
+          `${app.activeChainId()}-${editorNamespace}-storedText`
+        );
         vnode.state.markdownMode = true;
       }
     } else if (vnode.state.markdownMode === undefined) {
       if (localStorage.getItem(`${editorNamespace}-markdownMode`) === 'true') {
         vnode.state.markdownMode = true;
-      } else if (localStorage.getItem(`${editorNamespace}-markdownMode`) === 'false') {
+      } else if (
+        localStorage.getItem(`${editorNamespace}-markdownMode`) === 'false'
+      ) {
         vnode.state.markdownMode = false;
       } else {
         // Otherwise, just set vnode.state.markdownMode based on the app setting
-        vnode.state.markdownMode = !!(app.user?.disableRichText);
+        vnode.state.markdownMode = !!app.user?.disableRichText;
       }
     }
 
@@ -928,136 +1071,192 @@ const QuillEditor: m.Component<IQuillEditorAttrs, IQuillEditorState> = {
     if (vnode.state.clearUnsavedChanges === undefined) {
       vnode.state.clearUnsavedChanges = () => {
         localStorage.removeItem(`${editorNamespace}-markdownMode`);
-        localStorage.removeItem(`${app.activeChainId()}-${editorNamespace}-storedText`);
-        localStorage.removeItem(`${app.activeChainId()}-${editorNamespace}-storedTitle`);
-        if (localStorage.getItem(`${app.activeChainId()}-post-type`) === 'Link') {
+        localStorage.removeItem(
+          `${app.activeChainId()}-${editorNamespace}-storedText`
+        );
+        localStorage.removeItem(
+          `${app.activeChainId()}-${editorNamespace}-storedTitle`
+        );
+        if (
+          localStorage.getItem(`${app.activeChainId()}-post-type`) === 'Link'
+        ) {
           localStorage.removeItem(`${app.activeChainId()}-new-link-storedLink`);
         }
         localStorage.removeItem(`${app.activeChainId()}-post-type`);
       };
     }
-    return m('.QuillEditor', {
-      class: vnode.state.markdownMode ? 'markdown-mode' : 'richtext-mode',
-      oncreate: (childVnode) => {
-        const $editor = $(childVnode.dom).find('.quill-editor');
-        vnode.state.editor = instantiateEditor(
-          $editor, theme, true, imageUploader, placeholder, editorNamespace,
-          vnode.state, onkeyboardSubmit
-        );
-        // once editor is instantiated, it can be updated with a tabindex
-        $(childVnode.dom).find('.ql-editor').attr('tabindex', tabindex);
-        if (contentsDoc && typeof contentsDoc === 'string') {
-          const res = vnode.state.editor.setText(contentsDoc);
-          vnode.state.markdownMode = true;
-        } else if (contentsDoc && typeof contentsDoc === 'object') {
-          const res = vnode.state.editor.setContents(contentsDoc);
-          vnode.state.markdownMode = false;
-        }
-        oncreateBind(vnode.state);
+    return m(
+      '.QuillEditor',
+      {
+        class: vnode.state.markdownMode ? 'markdown-mode' : 'richtext-mode',
+        oncreate: (childVnode) => {
+          const $editor = $(childVnode.dom).find('.quill-editor');
+          vnode.state.editor = instantiateEditor(
+            $editor,
+            theme,
+            true,
+            imageUploader,
+            placeholder,
+            editorNamespace,
+            vnode.state,
+            onkeyboardSubmit
+          );
+          // once editor is instantiated, it can be updated with a tabindex
+          $(childVnode.dom).find('.ql-editor').attr('tabindex', tabindex);
+          if (contentsDoc && typeof contentsDoc === 'string') {
+            const res = vnode.state.editor.setText(contentsDoc);
+            vnode.state.markdownMode = true;
+          } else if (contentsDoc && typeof contentsDoc === 'object') {
+            const res = vnode.state.editor.setContents(contentsDoc);
+            vnode.state.markdownMode = false;
+          }
+          oncreateBind(vnode.state);
+        },
       },
-    }, [
-      m('.quill-editor'),
-      theme !== 'bubble' && m('.type-selector', [
-        vnode.state.markdownMode
-          ? m(Tooltip, {
-            trigger: m(Tag, {
-              label: 'Markdown',
-              size: 'xs',
-              onclick: (e) => {
-                if (!vnode.state.markdownMode) return;
-                const cachedContents = vnode.state.editor.getContents();
-                // switch editor to rich text
-                vnode.state.markdownMode = false;
-                const $editor = $(e.target).closest('.QuillEditor').find('.quill-editor');
-                vnode.state.editor.container.tabIndex = tabindex;
-                vnode.state.editor = instantiateEditor(
-                  $editor, theme, true, imageUploader, placeholder, editorNamespace,
-                  vnode.state, onkeyboardSubmit
-                );
-                // once editor is instantiated, it can be updated with a tabindex
-                $(e.target).closest('.QuillEditor').find('.ql-editor').attr('tabindex', tabindex);
-                vnode.state.editor.setContents(cachedContents);
-                vnode.state.editor.setSelection(vnode.state.editor.getText().length - 1);
-                vnode.state.editor.focus();
+      [
+        m('.quill-editor'),
+        theme !== 'bubble' &&
+          m('.type-selector', [
+            vnode.state.markdownMode
+              ? m(Tooltip, {
+                  trigger: m(Tag, {
+                    label: 'Markdown',
+                    size: 'xs',
+                    onclick: (e) => {
+                      if (!vnode.state.markdownMode) return;
+                      const cachedContents = vnode.state.editor.getContents();
+                      // switch editor to rich text
+                      vnode.state.markdownMode = false;
+                      const $editor = $(e.target)
+                        .closest('.QuillEditor')
+                        .find('.quill-editor');
+                      vnode.state.editor.container.tabIndex = tabindex;
+                      vnode.state.editor = instantiateEditor(
+                        $editor,
+                        theme,
+                        true,
+                        imageUploader,
+                        placeholder,
+                        editorNamespace,
+                        vnode.state,
+                        onkeyboardSubmit
+                      );
+                      // once editor is instantiated, it can be updated with a tabindex
+                      $(e.target)
+                        .closest('.QuillEditor')
+                        .find('.ql-editor')
+                        .attr('tabindex', tabindex);
+                      vnode.state.editor.setContents(cachedContents);
+                      vnode.state.editor.setSelection(
+                        vnode.state.editor.getText().length - 1
+                      );
+                      vnode.state.editor.focus();
 
-                // try to save setting
-                if (app.isLoggedIn()) {
-                  SettingsController.disableRichText(false);
-                }
-              },
-            }),
-            content: m('.quill-editor-tooltip', 'Click for rich text'),
-          })
-          : m(Tooltip, {
-            trigger: m(Tag, {
-              label: 'Rich text',
-              size: 'xs',
-              onclick: async (e) => {
-                if (vnode.state.markdownMode) return;
+                      // try to save setting
+                      if (app.isLoggedIn()) {
+                        SettingsController.disableRichText(false);
+                      }
+                    },
+                  }),
+                  content: m('.quill-editor-tooltip', 'Click for rich text'),
+                })
+              : m(Tooltip, {
+                  trigger: m(Tag, {
+                    label: 'Rich text',
+                    size: 'xs',
+                    onclick: async (e) => {
+                      if (vnode.state.markdownMode) return;
 
-                // confirm before removing formatting and switching to markdown mode
-                // first, we check if removeFormat() actually does anything; then we ask the user to confirm
-                let confirmed = false;
-                let cachedContents = vnode.state.editor.getContents();
-                vnode.state.editor.removeFormat(0, vnode.state.editor.getText().length - 1);
-                if (vnode.state.editor.getContents().ops.length === cachedContents.ops.length) {
-                  confirmed = true;
-                } else {
-                  vnode.state.editor.setContents(cachedContents);
-                  vnode.state.editor.setSelection(vnode.state.editor.getText().length - 1);
-                }
-                if (!confirmed) {
-                  confirmed = await confirmationModalWithText('All formatting and images will be lost. Continue?')();
-                }
-                if (!confirmed) return;
+                      // confirm before removing formatting and switching to markdown mode
+                      // first, we check if removeFormat() actually does anything; then we ask the user to confirm
+                      let confirmed = false;
+                      let cachedContents = vnode.state.editor.getContents();
+                      vnode.state.editor.removeFormat(
+                        0,
+                        vnode.state.editor.getText().length - 1
+                      );
+                      if (
+                        vnode.state.editor.getContents().ops.length ===
+                        cachedContents.ops.length
+                      ) {
+                        confirmed = true;
+                      } else {
+                        vnode.state.editor.setContents(cachedContents);
+                        vnode.state.editor.setSelection(
+                          vnode.state.editor.getText().length - 1
+                        );
+                      }
+                      if (!confirmed) {
+                        confirmed = await confirmationModalWithText(
+                          'All formatting and images will be lost. Continue?'
+                        )();
+                      }
+                      if (!confirmed) return;
 
-                // remove formatting, switch editor to markdown
-                vnode.state.editor.removeFormat(0, vnode.state.editor.getText().length - 1);
-                cachedContents = vnode.state.editor.getContents();
-                vnode.state.markdownMode = true;
-                const $editor = $(e.target).closest('.QuillEditor').find('.quill-editor');
-                vnode.state.editor = instantiateEditor(
-                  $editor, theme, true, imageUploader, placeholder, editorNamespace,
-                  vnode.state, onkeyboardSubmit
-                );
-                // once editor is instantiated, it can be updated with a tabindex
-                $(e.target).closest('.QuillEditor').find('.ql-editor').attr('tabindex', tabindex);
-                vnode.state.editor.container.tabIndex = tabindex;
-                vnode.state.editor.setContents(cachedContents);
-                vnode.state.editor.setSelection(vnode.state.editor.getText().length - 1);
-                vnode.state.editor.focus();
+                      // remove formatting, switch editor to markdown
+                      vnode.state.editor.removeFormat(
+                        0,
+                        vnode.state.editor.getText().length - 1
+                      );
+                      cachedContents = vnode.state.editor.getContents();
+                      vnode.state.markdownMode = true;
+                      const $editor = $(e.target)
+                        .closest('.QuillEditor')
+                        .find('.quill-editor');
+                      vnode.state.editor = instantiateEditor(
+                        $editor,
+                        theme,
+                        true,
+                        imageUploader,
+                        placeholder,
+                        editorNamespace,
+                        vnode.state,
+                        onkeyboardSubmit
+                      );
+                      // once editor is instantiated, it can be updated with a tabindex
+                      $(e.target)
+                        .closest('.QuillEditor')
+                        .find('.ql-editor')
+                        .attr('tabindex', tabindex);
+                      vnode.state.editor.container.tabIndex = tabindex;
+                      vnode.state.editor.setContents(cachedContents);
+                      vnode.state.editor.setSelection(
+                        vnode.state.editor.getText().length - 1
+                      );
+                      vnode.state.editor.focus();
 
-                // try to save setting
-                if (app.isLoggedIn()) {
-                  SettingsController.disableRichText(true);
-                }
-              },
-            }),
-            content: m('.quill-editor-tooltip', 'Click for Markdown'),
-          }),
-      ]),
-      m('.preview-button-wrap', [
-        m(Tag, {
-          label: m('.preview-button', [
-            m(CWIcon, { iconName: 'search', iconSize: 'small '}),
-            m('span', 'Preview')
+                      // try to save setting
+                      if (app.isLoggedIn()) {
+                        SettingsController.disableRichText(true);
+                      }
+                    },
+                  }),
+                  content: m('.quill-editor-tooltip', 'Click for Markdown'),
+                }),
           ]),
-          size: 'xs',
-          onclick: (e) => {
-            e.preventDefault();
-            app.modals.create({
-              modal: PreviewModal,
-              data: {
-                doc: vnode.state.markdownMode
-                  ? vnode.state.editor.getText()
-                  : JSON.stringify(vnode.state.editor.getContents()),
-              },
-            });
-          },
-        })
-      ])
-    ]);
-  }
+        m('.preview-button-wrap', [
+          m(Tag, {
+            label: m('.preview-button', [
+              m(CWIcon, { iconName: 'search', iconSize: 'small ' }),
+              m('span', 'Preview'),
+            ]),
+            size: 'xs',
+            onclick: (e) => {
+              e.preventDefault();
+              app.modals.create({
+                modal: PreviewModal,
+                data: {
+                  doc: vnode.state.markdownMode
+                    ? vnode.state.editor.getText()
+                    : JSON.stringify(vnode.state.editor.getContents()),
+                },
+              });
+            },
+          }),
+        ]),
+      ]
+    );
+  },
 };
 
 export default QuillEditor;

--- a/client/scripts/views/pages/discussions/discussion_row.ts
+++ b/client/scripts/views/pages/discussions/discussion_row.ts
@@ -176,7 +176,7 @@ const DiscussionRow: m.Component<
         ],
       ' ', // em space
       m(
-        '.created-at',
+        '.last-active.created-at',
         link(
           'a',
           discussionLink,
@@ -187,11 +187,6 @@ const DiscussionRow: m.Component<
       m('.activity-icons', [
         ' ', // en space
         isHot(proposal) && m('span', '🔥'),
-      ]),
-      m('.mobile-comment-count', [
-        ' ', // em space
-        m(Icon, { name: Icons.MESSAGE_SQUARE }),
-        app.comments.nComments(proposal),
       ]),
     ] as any;
 

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -792,7 +792,7 @@ const ProposalComments: m.Component<
           return m(
             `.threading-level-${threadLevel}`,
             {
-              style: `margin-left: calc(36px * ${threadLevel})`,
+              style: `margin-left: 32px`,
             },
             [
               m(ProposalComment, {

--- a/client/scripts/views/pages/view_proposal/sidebar.ts
+++ b/client/scripts/views/pages/view_proposal/sidebar.ts
@@ -175,7 +175,6 @@ export const ProposalLinkedThreadsEditorModule: m.Component<
         });
       return null;
     }
-    console.log(vnode.state.linkedThreads);
     if (allowLinking || proposal.linkedThreads.length) {
       return m('.ProposalLinkedThreadsEditorModule', [
         !!vnode.state.linkedThreads?.length &&

--- a/client/styles/components/listing_row.scss
+++ b/client/styles/components/listing_row.scss
@@ -47,7 +47,8 @@
       display: inline-flex;
       flex-direction: column;
       align-self: center;
-      max-width: 100%;
+      width: 100%;
+      overflow: hidden;
 
       .row-header,
       .row-header a {
@@ -60,10 +61,6 @@
       .row-subheader {
         margin-top: 5px;
         display: flex;
-
-        > * {
-          display: inline;
-        }
       }
 
       .row-subheader + .row-subheader {
@@ -79,7 +76,6 @@
       .row-subheader > a,
       .row-subheader > .User > a,
       .row-subheader > .created-at > a,
-      .row-subheader > .mobile-comment-count,
       > span {
         color: $text-color-light;
         font-size: $text-size-item-meta;
@@ -138,7 +134,9 @@
   @include xs-max {
     display: block;
 
-    .row-right {
+    .row-right,
+    .activity-icons,
+    .last-active {
       display: none;
     }
   }

--- a/client/styles/components/quill_editor.scss
+++ b/client/styles/components/quill_editor.scss
@@ -134,6 +134,12 @@
     white-space: nowrap;
     overflow-x: auto;
     min-height: 39px;
+    @include xs-max {
+      display: flex;
+      flex-wrap: wrap;
+      min-height: 78px;
+      overflow-x: hidden;
+    }
   }
   .ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-label {
     // border-color: #B37DBA;
@@ -161,11 +167,6 @@
       text-decoration: underline;
     }
   }
-  @include xs-max {
-    .ql-toolbar .ql-formats:last-child {
-      padding-right: 80px;
-    }
-  }
 
   // 5. toolbar markdown mode
   &.markdown-mode {
@@ -186,6 +187,9 @@
     display: flex;
     right: 100px;
     top: 6px;
+    @include xs-max {
+      top: 40px;
+    }
     user-select: none;
     .cui-tag {
       cursor: pointer;
@@ -198,6 +202,9 @@
     display: flex;
     right: 10px;
     top: 6px;
+    @include xs-max {
+      top: 40px;
+    }
     user-select: none;
     .preview-button {
       display: flex;

--- a/client/styles/pages/discussions/discussion_row.scss
+++ b/client/styles/pages/discussions/discussion_row.scss
@@ -1,132 +1,110 @@
 @import 'client/styles/shared';
 
 .DiscussionRow {
-    .row-left {
-        .ReactionButton {
-            background: $background-color-white;
-        }
-        .row-header {
-            a {
-                line-height: 1.2;
-            }
-        }
-        .row-subheader {
-            position: relative;
-            top: -2px;
-            > * {
-                display: inline-block !important;
-            }
-            // Styling specific to DiscussionRow subheader content
-            .discussion-locked {
-                .cui-tag.cui-xs .cui-icon svg {
-                    margin-right: 0;
-                }
-                &::after {
-                    content: ' ';
-                }
-            }
-            .discussion-row-linked-poll,
-            .discussion-row-linked-chain-entity,
-            .discussion-row-stage-btn {
-                font-size: 13px;
-                padding: 0 7px;
-                min-height: 19px;
-                height: initial;
-                pointer-events: none;
-                user-select: none;
-                position: relative;
-                top: -2px;
-                margin: -2px 0;
-                margin-right: 6px;
-                border: none;
-                line-height: 1.5;
-                opacity: 0.94;
-            }
-            a.proposal-topic {
-                display: inline-block;
-                color: $text-color-light;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                max-width: 100%;
-            }
-            .mobile-comment-count {
-                display: none !important;
-                color: $text-color-light;
-                white-space: nowrap;
-                @include xs-max {
-                    display: inline !important;
-                }
-                .cui-icon svg {
-                    position: relative;
-                    top: -1px;
-                    stroke: $text-color-light;
-                    opacity: 0.84;
-                    margin-right: 4px;
-                    height: 14px;
-                    width: 14px;
-                    min-height: 14px;
-                    min-height: 14px;
-                }
-            }
-            .discussion-link {
-                color: $text-color-light;
-            }
-            .proposal-collaborators {
-                color: $text-color-light;
-                position: relative;
-                font-size: 17px;
-            }
-            > .User {
-                display: inline-flex;
-                > .role-icon {
-                    position: relative;
-                    top: -1px;
-                }
-            }
-            > .User > a {
-                display: block;
-                text-decoration: none;
-                color: $text-color-light;
-                &:hover {
-                    color: darken($text-color-light, 8%);
-                    text-decoration: underline;
-                }
-                > a.user-display-name {
-                    color: $primary-bg-color;
-                }
-            }
-            .m-l-20 {
-                color: $text-color-light;
-                @media(min-width: 800px){
-                    margin-left: 10px;
-                }
-            }
-        }
+  .row-left {
+    .ReactionButton {
+      background: $background-color-white;
     }
-    .row-right {
-        .discussion-row-right-meta {
-            margin-left: 8px;
-            margin-right: 4px;
-            .offchain-voting {
-                position: relative;
-                top: -5px;
-                margin-top: 5px;
-                // styling
-                font-size: 16px;
-                height: 40px;
-                padding: 12px;
-                width: 100px;
-                border: 1px solid $border-color;
-                border-radius: 6px;
-            }
-        }
-        .discussion-row-menu {
-            width: 28px;
-            position: relative;
-            svg {
-                position: relative;
-                top: 1px;
-            }
-        }
+    .row-header {
+      a {
+        line-height: 1.2;
+      }
     }
+    .row-subheader {
+      position: relative;
+      top: -2px;
+      // Styling specific to DiscussionRow subheader content
+      .discussion-locked {
+        .cui-tag.cui-xs .cui-icon svg {
+          margin-right: 0;
+        }
+        &::after {
+          content: ' ';
+        }
+      }
+      .discussion-row-linked-poll,
+      .discussion-row-linked-chain-entity,
+      .discussion-row-stage-btn {
+        font-size: 13px;
+        padding: 0 7px;
+        min-height: 19px;
+        height: initial;
+        pointer-events: none;
+        user-select: none;
+        position: relative;
+        top: -2px;
+        margin: -2px 0;
+        margin-right: 6px;
+        border: none;
+        line-height: 1.5;
+        opacity: 0.94;
+      }
+      a.proposal-topic {
+        display: inline-block;
+        color: $text-color-light;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      .discussion-link {
+        color: $text-color-light;
+      }
+      .proposal-collaborators {
+        color: $text-color-light;
+        position: relative;
+        font-size: 17px;
+      }
+      > .User {
+        display: inline-flex;
+        > .role-icon {
+          position: relative;
+          top: -1px;
+        }
+      }
+      > .User > a {
+        display: block;
+        text-decoration: none;
+        color: $text-color-light;
+        &:hover {
+          color: darken($text-color-light, 8%);
+          text-decoration: underline;
+        }
+        > a.user-display-name {
+          color: $primary-bg-color;
+        }
+      }
+      .m-l-20 {
+        color: $text-color-light;
+        @media (min-width: 800px) {
+          margin-left: 10px;
+        }
+      }
+    }
+  }
+  .row-right {
+    .discussion-row-right-meta {
+      margin-left: 8px;
+      margin-right: 4px;
+      .offchain-voting {
+        position: relative;
+        top: -5px;
+        margin-top: 5px;
+        // styling
+        font-size: 16px;
+        height: 40px;
+        padding: 12px;
+        width: 100px;
+        border: 1px solid $border-color;
+        border-radius: 6px;
+      }
+    }
+    .discussion-row-menu {
+      width: 28px;
+      position: relative;
+      svg {
+        position: relative;
+        top: 1px;
+      }
+    }
+  }
 }

--- a/client/styles/pages/view_proposal/create_comment.scss
+++ b/client/styles/pages/view_proposal/create_comment.scss
@@ -2,71 +2,76 @@
 @import './index';
 
 .CreateComment {
-    display: flex;
-    padding-top: 40px;
-    &.new-thread-child {
-        margin-top: 30px;
+  display: flex;
+  padding-top: 40px;
+  &.new-thread-child {
+    margin-top: 30px;
+  }
+  .create-comment-body {
+    @include xs-max {
+      margin: 0;
     }
-    .create-comment-body {
-        flex: 1;
-        margin-left: 26px;
-        .form-bottom {
-            display: flex;
-            flex-direction: row-reverse;
-            justify-content: space-between;
-            width: 100%;
-            .form-buttons {
-                display: flex;
-                flex-direction: row-reverse;
-                .cui-button {
-                    box-sizing: border-box;
-                    border-radius: 8px;
-                    font-weight: 500;
-                    font-size: 18px;
-                    line-height: 22px;
-                    text-transform: uppercase;
-                }
-                .cui-button[type="submit"] {
-                    // background: linear-gradient(50.49deg, #91BFFF -6.12%, #91FFA0 30.17%, #FBFF91 62.49%, #FF9191 102.75%);
-                    // color: black;
-                    background: $primary-bg-color;
-                    color: white;
-                    border: none;
-                    margin-left: 20px;
-                }
-                .cui-button[type="cancel"] {
-                    background: #FFFFFF;
-                    border: 2px solid #DDDDDD;
-                    color: #999999;
-                }
-            }
-            .new-comment-error {
-                @include error-text;
-            }
+    flex: 1;
+    margin-left: 26px;
+    .form-bottom {
+      display: flex;
+      flex-direction: row-reverse;
+      justify-content: space-between;
+      width: 100%;
+      .form-buttons {
+        display: flex;
+        flex-direction: row-reverse;
+        .cui-button {
+          box-sizing: border-box;
+          border-radius: 8px;
+          font-weight: 500;
+          font-size: 18px;
+          line-height: 22px;
+          text-transform: uppercase;
         }
-        > .User {
-            font-size: $discussion-meta-font-size;
-            &, a.user-display-name {
-                color: $discussion-meta-color;
-            }
+        .cui-button[type='submit'] {
+          // background: linear-gradient(50.49deg, #91BFFF -6.12%, #91FFA0 30.17%, #FBFF91 62.49%, #FF9191 102.75%);
+          // color: black;
+          background: $primary-bg-color;
+          color: white;
+          border: none;
+          margin-left: 20px;
         }
+        .cui-button[type='cancel'] {
+          background: #ffffff;
+          border: 2px solid #dddddd;
+          color: #999999;
+        }
+      }
+      .new-comment-error {
+        @include error-text;
+      }
     }
+    > .User {
+      font-size: $discussion-meta-font-size;
+      &,
+      a.user-display-name {
+        color: $discussion-meta-color;
+      }
+    }
+  }
 
-    .QuillEditor {
-        margin: 14px 0 18px;
-        .ql-toolbar, .ql-editor {
-            background: $background-color-white;
-        }
-        .ql-editor {
-            min-height: 100px;
-            border-radius: 2px;
-        }
+  .QuillEditor {
+    margin: 14px 0 18px;
+    .ql-toolbar,
+    .ql-editor {
+      background: $background-color-white;
     }
-    .cui-callout {
-        margin-top: 20px;
+    .ql-editor {
+      min-height: 100px;
+      border-radius: 2px;
     }
-    .token-requirement {
-        color: $text-color-light;
-        margin-bottom:10px;
-    }
+  }
+  .cui-callout {
+    margin-top: 20px;
+  }
+  .token-requirement {
+    color: $text-color-light;
+    margin-bottom: 10px;
+  }
 }

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -4,6 +4,7 @@ $discussion-outer-padding: 60px;
 $discussion-meta-padding: 12px; // padding between comment meta & comment content
 $discussion-reaction-padding: 18px; // padding between comment content & comment reaction
 $discussion-comment-padding: 28px; // padding between comment content & avatar
+$discussion-comment-padding-mobile: 16px;
 
 $discussion-meta-font-size: 1rem;
 $discussion-meta-color: $text-color-light;
@@ -216,7 +217,7 @@ $discussion-title-font-size: 1.45rem;
       overflow-x: auto;
       margin-left: $discussion-comment-padding;
       @include xs-max {
-        margin-right: 10px;
+        margin-left: $discussion-comment-padding-mobile;
       }
       .proposal-content-meta {
         padding-bottom: $discussion-meta-padding;
@@ -289,6 +290,9 @@ $discussion-title-font-size: 1.45rem;
       flex: 1;
       overflow-x: auto;
       padding-left: $discussion-comment-padding;
+      @include xs-max {
+        padding-left: $discussion-comment-padding-mobile;
+      }
     }
     .comment-body-top {
       padding-bottom: $discussion-meta-padding;

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -1,9 +1,9 @@
 @import 'client/styles/shared';
 
 $discussion-outer-padding: 60px;
-$discussion-meta-padding: 12px;      // padding between comment meta & comment content
-$discussion-reaction-padding: 18px;  // padding between comment content & comment reaction
-$discussion-comment-padding: 28px;   // padding between comment content & avatar
+$discussion-meta-padding: 12px; // padding between comment meta & comment content
+$discussion-reaction-padding: 18px; // padding between comment content & comment reaction
+$discussion-comment-padding: 28px; // padding between comment content & avatar
 
 $discussion-meta-font-size: 1rem;
 $discussion-meta-color: $text-color-light;
@@ -11,545 +11,559 @@ $discussion-meta-color: $text-color-light;
 $discussion-title-font-size: 1.45rem;
 
 @mixin supports-jump-highlight() {
-    &.highlighted {
-        border-radius: 20px;
-        background-color: $background-color-new-comment;
-        .thread-connector {
-            background: #00C0A9;
-        }
+  &.highlighted {
+    border-radius: 20px;
+    background-color: $background-color-new-comment;
+    .thread-connector {
+      background: #00c0a9;
     }
-    &.highlighted.highlightAnimationComplete {
-        background-color: transparent;
-        transition: background-color 1s ease-in-out;
-        .thread-connector {
-            background: $background-color-light;
-            transition: background 1s ease-in-out;
-        }
+  }
+  &.highlighted.highlightAnimationComplete {
+    background-color: transparent;
+    transition: background-color 1s ease-in-out;
+    .thread-connector {
+      background: $background-color-light;
+      transition: background 1s ease-in-out;
     }
+  }
 }
 
 .ViewProposalPage {
-    .ProposalHeader {
-        .proposal-content {
-            position: relative;
+  .ProposalHeader {
+    .proposal-content {
+      position: relative;
+    }
+  }
+  .ProposalHeader,
+  .ProposalComment {
+    @include supports-jump-highlight();
+  }
+  .ProposalHeader,
+  .ProposalComment {
+    margin-top: 36px;
+    padding: 4px 0;
+    @include xs-max {
+      margin-top: 30px;
+    }
+  }
+  .ProposalComments.no-active-account {
+    padding-bottom: $discussion-outer-padding;
+  }
+  .proposal-body-bottom,
+  .comment-body-bottom {
+    display: flex;
+    justify-content: space-between;
+    .comment-response-row,
+    .proposal-response-row {
+      width: 100%;
+      display: flex;
+      max-width: 300px;
+      align-items: center;
+      .InlineReplyButton,
+      .ProposalBodyReaction {
+        border: 1px solid $text-color-medium;
+        margin-right: 7%;
+        padding: 6px;
+        cursor: pointer;
+        border-radius: 20px;
+        width: 70px;
+        height: 30px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-right: 10%;
+        padding: 6px;
+        cursor: pointer;
+        &:hover {
+          .cui-icon,
+          .reply-count,
+          .reactions-count {
+            color: #4723ad;
+          }
         }
-    }
-    .ProposalHeader,
-    .ProposalComment {
-        @include supports-jump-highlight();
-    }
-    .ProposalHeader,
-    .ProposalComment {
-        margin-top: 36px;
-        padding: 4px 0;
-        @include xs-max {
-            margin-top: 30px;
+        .active {
+          .cui-icon,
+          .reply-count,
+          .reactions-count {
+            color: #4723ad !important;
+          }
         }
+        .cui-icon,
+        .reply-count,
+        .reactions-count {
+          color: $text-color-medium;
+          font-weight: 500;
+        }
+        .cui-icon {
+          margin-right: 8px;
+        }
+        .reply-count,
+        .reactions-count {
+          position: relative;
+          top: 2px;
+        }
+      }
     }
-    .ProposalComments.no-active-account {
-        padding-bottom: $discussion-outer-padding;
+    .proposal-body-button-group,
+    .comment-body-bottom-right,
+    .comment-edit-buttons {
+      margin-top: 18px;
+      .cancel-editing {
+        margin-right: 15px;
+      }
     }
-    .proposal-body-bottom, .comment-body-bottom {
+  }
+  .threading-level-1 {
+    .new-comment-child {
+      margin-left: 108px !important;
+    }
+    @include xs-max {
+      margin-left: 0 !important;
+    }
+  }
+  .threading-level-2 {
+    .InlineReplyButton {
+      display: none !important;
+    }
+  }
+  h3 {
+    font-size: 23px;
+    line-height: 28px;
+    font-weight: 500;
+    margin-bottom: 8px;
+  }
+
+  //
+  // header
+  //
+  .ProposalHeader {
+    position: relative;
+    &.proposal-snapshot {
+      .snapshot-proposal-top {
+        display: flex;
+        border-bottom: 1px solid $background-color-light;
+      }
+      .proposal-content {
+        padding: 25px 0;
+      }
+    }
+    .proposal-top {
+      display: flex;
+      padding-bottom: 20px;
+      border-bottom: 1px solid $background-color-light;
+    }
+    .proposal-top-left {
+      flex: 1;
+      .cui-input {
+        width: 70%;
+        padding-bottom: 10px;
+      }
+      .proposal-body-meta {
+        margin-bottom: 12px;
+      }
+      .proposal-meta-top {
         display: flex;
         justify-content: space-between;
-        .comment-response-row,
-        .proposal-response-row {
-            width: 100%;
-            display: flex;
-            max-width: 300px;
-            align-items: center;
-            .InlineReplyButton,
-            .ProposalBodyReaction {
-                border: 1px solid $text-color-medium;
-                margin-right: 7%;
-                padding: 6px;
-                cursor: pointer;
-                border-radius: 20px;
-                width: 70px;
-                height: 30px;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                margin-right: 10%;
-                padding: 6px;
-                cursor: pointer;
-                &:hover {
-                    .cui-icon, .reply-count, .reactions-count {
-                        color: #4723AD;
-                    }
-                }
-                .active {
-                    .cui-icon, .reply-count, .reactions-count {
-                        color: #4723AD !important;
-                    }
-                }
-                .cui-icon, .reply-count, .reactions-count {
-                    color: $text-color-medium;
-                    font-weight: 500;
-                }
-                .cui-icon {
-                    margin-right: 8px;
-                }
-                .reply-count, .reactions-count {
-                    position: relative;
-                    top: 2px;
-                }
-            }
+        margin-bottom: 12px;
+        height: 35px;
+        button {
+          margin-left: 17px;
+          border-radius: 8px;
+          height: 39px;
+          font-size: 18px;
+          text-transform: uppercase;
         }
-        .proposal-body-button-group, .comment-body-bottom-right,
-        .comment-edit-buttons {
-            margin-top: 18px;
-            .cancel-editing {
-                margin-right: 15px;
-            }
+        .proposal-meta-top-left {
+          display: flex;
+          align-items: center;
         }
+        .proposal-meta-top-right {
+          display: flex;
+          .ExecuteButton,
+          .QueueButton {
+            button {
+              color: white;
+              background: linear-gradient(
+                268.96deg,
+                #00db8c 2.02%,
+                #1bdebb 94.68%
+              );
+            }
+          }
+          .CancelButton {
+            button {
+              color: #ff002e;
+              border: 1px solid #ff002e;
+              background: #ffffff;
+            }
+          }
+        }
+        .ProposalHeaderOnchainId {
+          font-size: 18px;
+          color: black;
+        }
+      }
     }
-    .threading-level-1 {
-        .new-comment-child {
-            margin-left: 108px !important;
-        }
+    .proposal-content {
+      display: flex;
+      padding-top: 40px;
     }
-    .threading-level-2 {
-        .InlineReplyButton {
-            display: none !important;
-        }
+    .proposal-content-left {
     }
-    h3 {
-        font-size: 23px;
-        line-height: 28px;
-        font-weight: 500;
-        margin-bottom: 8px;
-    }
-
-    //
-    // header
-    //
-    .ProposalHeader {
-        position: relative;
-        &.proposal-snapshot {
-            .snapshot-proposal-top {
-                display: flex;
-                border-bottom: 1px solid $background-color-light;
-            }
-            .proposal-content {
-                padding: 25px 0;
-            }
-        }
-        .proposal-top {
-            display: flex;
-            padding-bottom: 20px;
-            border-bottom: 1px solid $background-color-light;
-        }
-        .proposal-top-left {
-            flex: 1;
-            .cui-input {
-                width: 70%;
-                padding-bottom: 10px;
-            }
-            .proposal-body-meta {
-                margin-bottom: 12px;
-            }
-            .proposal-meta-top {
-                display: flex;
-                justify-content: space-between;
-                margin-bottom: 12px;
-                height: 35px;
-                button {
-                    margin-left: 17px;
-                    border-radius: 8px;
-                    height: 39px;
-                    font-size: 18px;
-                    text-transform: uppercase;
-                }
-                .proposal-meta-top-left {
-                    display: flex;
-                    align-items: center;
-                }
-                .proposal-meta-top-right {
-                    display: flex;
-                    .ExecuteButton, .QueueButton {
-                        button {
-                            color: white;
-                            background: linear-gradient(268.96deg, #00DB8C 2.02%, #1BDEBB 94.68%);
-                        }
-                    }
-                    .CancelButton {
-                        button {
-                            color: #FF002E;
-                            border: 1px solid #FF002E;
-                            background: #FFFFFF;
-                        }
-    
-                    }
-                }
-                .ProposalHeaderOnchainId {
-                    font-size: 18px;
-                    color: black;
-                }
-            }
-        }
-        .proposal-content {
-            display: flex;
-            padding-top: 40px;
-        }
-        .proposal-content-left {
-
-        }
-        .proposal-content-right {
-            flex: 1;
-            overflow-x: auto;
-            margin-left: $discussion-comment-padding;
-            @include xs-max {
-                margin-right: 10px;
-            }
-            .proposal-content-meta {
-                padding-bottom: $discussion-meta-padding;
-                font-size: $discussion-meta-font-size;
-            }
-        }
-        .social-right {
-            margin-right: 10px;
-        }
-        .proposal-title {
-            margin-bottom: 6px;
-            .ProposalHeaderTitle {
-                display: inline;
-                font-size: $discussion-title-font-size;
-                font-weight: 600;
-                flex: 1;
-                line-height: 1.1;
-                .cui-tag {
-                    font-weight: 400;
-                    margin-left: 12px;
-                    position: relative;
-                    top: -2px;
-                    .cui-icon {
-                        margin-right: 3px;
-                    }
-                }
-            }
-        }
-        .ProposalHeaderExternalLink,
-        .ProposalHeaderBlockExplorerLink,
-        .ProposalHeaderVotingInterfaceLink,
-        .ProposalHeaderThreadLink {
-            display: inline-block;
-            margin-right: 12px;
-            margin-top: 12px;
-            font-weight: 600;
-            a:link,
-            a:visited {
-                display: block;
-                padding: 12px 18px 6px;
-                border-radius: 99px;
-                background: $background-color-light;
-                color: $text-color-primary;
-                text-decoration: none !important;
-            }
-            svg {
-                stroke: $text-color-primary;
-                position: relative;
-                top: -1px;
-                margin-left: 5px;
-                $size: 14px;
-                height: $size;
-                width: $size;
-                min-height: $size;
-                min-width: $size;
-            }
-            a:hover {
-                background: darken($background-color-light, 1%);
-            }
-        }
-    }
-
-    //
-    // body
-    //
-    .ProposalComment {
-        position: relative;
-        display: flex;
-        .comment-body {
-            flex: 1;
-            overflow-x: auto;
-            padding-left: $discussion-comment-padding;
-        }
-        .comment-body-top {
-            padding-bottom: $discussion-meta-padding;
-            font-size: $discussion-meta-font-size;
-        }
-        .comment-body-bottom {
-            padding: 4px 0 2px;
-        }
-        .comment-body-content {
-            @include xs-max {
-                margin-right: 10px;
-            }
-        }
-    }
-
-    .ProposalHeader .proposal-content {
-        .ProposalBodyReaction, .InlineReplyButton {
-            margin-top: $discussion-reaction-padding;
-        }
-    }
-
-    .ProposalComments {
-        .threading-level {
-            margin-left: 54px;
-        }
-        .comment-child {
-            margin-left: 36px;
-        }
-        .new-comment-child {
-            margin-left: 72px;
-        }
-        .ProposalBodyReaction, .InlineReplyButton {
-            margin-top: $discussion-reaction-padding;
-        }
-    }
-
-    // proposal-meta
-    .ProposalHeaderStage,
-    .ProposalHeaderTopics,
-    .ProposalHeaderOnchainId,
-    .ProposalHeaderOnchainStatus,
-    .ProposalBodyAuthor,
-    .ProposalBodyCreated,
-    .ProposalBodyLastEnded,
-    .ProposalBodyDelete,
-    .ProposalBodyEdit,
-    .ProposalBodyDelete,
-    .ProposalBodyCancelEdit,
-    .ProposalBodySaveEdit,
-    .ViewCountBlock,
-    .ProposalHeaderExternalLink {
+    .proposal-content-right {
+      flex: 1;
+      overflow-x: auto;
+      margin-left: $discussion-comment-padding;
+      @include xs-max {
+        margin-right: 10px;
+      }
+      .proposal-content-meta {
+        padding-bottom: $discussion-meta-padding;
         font-size: $discussion-meta-font-size;
-        display: inline-block;
-        color: $discussion-meta-color;
-        margin-right: 17px;
-        > a:link,
-        > a:visited,
-        a.proposal-collaborators,
-        > .User a.user-display-name {
-            color: $discussion-meta-color;
-            text-decoration: none;
-            &:hover {
-                text-decoration: underline;
-            }
-        }
+      }
     }
-
-    .CommentSocialHeader,
-    .ProposalSocialHeader {
-        font-size: $discussion-meta-font-size;
-        display: inline-block;
-        color: $discussion-meta-color;
-        margin-left: 10px;
-        > a:link,
-        > a:visited,
-        a.proposal-collaborators,
-        > .User a.user-display-name {
-            color: $discussion-meta-color;
-            text-decoration: none;
-            &:hover {
-                text-decoration: underline;
-            }
-        }
-        svg {
-            stroke: $text-color-light;
-        }
-        svg:hover {
-            stroke: $text-color-medium;
-        }
+    .social-right {
+      margin-right: 10px;
     }
-
-    .ProposalTitleEditor {
-        .ProposalTitleSaveEdit {
-            font-size: $discussion-meta-font-size;
-            color: $discussion-meta-color;
+    .proposal-title {
+      margin-bottom: 6px;
+      .ProposalHeaderTitle {
+        display: inline;
+        font-size: $discussion-title-font-size;
+        font-weight: 600;
+        flex: 1;
+        line-height: 1.1;
+        .cui-tag {
+          font-weight: 400;
+          margin-left: 12px;
+          position: relative;
+          top: -2px;
+          .cui-icon {
+            margin-right: 3px;
+          }
         }
-        .cui-input {
-            margin-right: 10px;
-        }
-        .proposal-title-buttons {
-            display: inline-flex;
-            position: relative;
-            bottom: 5px;
-            .ProposalTitleCancelEdit {
-                margin-left: 5px;
-            }
-        }
+      }
     }
-    .ProposalHeaderStage {
-        &.primary {
-            color: tint($primary-bg-color, 10%);
-        }
-        &.positive {
-            color: tint($positive-bg-color, 10%);
-        }
-        &.negative {
-            color: tint($negative-bg-color, 10%);
-        }
-    }
-    .proposal-collaborators-popover {
-        color: $text-color-black;
-        .cui-popover-content {
-            padding-top: 22px;
-            .User {
-                display: block;
-            }
-        }
-    }
-
-    .ProposalSidebarLinkedViewer {
-        border-radius: 10px;
-        border: 1px solid tint($border-color-lightest, 26%);
-        padding: 22px 18px 21px;
-        margin-bottom: 24px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        .placeholder-copy {
-            margin-bottom: 10px;
-            font-weight: 500;
-        }   
-    }
-    
-    .ConnectProposalButtonWrapper {
-        margin-top: 10px;
-    }
-
-    .ProposalHeaderOffchainPoll,
-    .ProposalSidebarPollEditorModule,
-    .ProposalLinkedThreadsEditorModule {
-        border-radius: 10px;
-        border: 1px solid tint($border-color-lightest, 26%);
-        padding: 22px 18px 21px;
-        margin-bottom: 24px;
-    }
-    .ProposalLinkedThreadsEditorModule {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        a.linked-thread {
-            color: #9a9da4;
-        }
-        .cui-list-item {
-            &:first-child {
-                padding-top: 0 !important;
-            }
-            &:hover {
-                background: none;
-            }
-        }
-        .linked-threads-title {
-            margin-bottom: 10px;
-            font-weight: 500;
-        }
-    }
-    .ProposalSidebarPollEditorModule {
-        .placeholder-copy {
-            line-height: 1.2;
-            color: shade($text-color-light, 10%);
-            margin: 2px 0 12px;
-        }
-        .proposal-chain-entities {
-            margin-bottom: 12px;
-        }
-    }
-    .ProposalHeaderOffchainPoll {
-        .offchain-poll-header {
-            line-height: 1.2;
-            font-weight: 600;
-        }
-        .offchain-poll-options {
-            margin: 16px 0;
-            .offchain-poll-option {
-                display: flex;
-                .offchain-poll-option-left {
-                    margin: 6px 0;
-                    line-height: 1.1;
-                    flex: 1;
-                }
-            }
-        }
-        .offchain-poll-caption {
-            font-size: 16px;
-            color: $text-color-light;
-            margin-bottom: 24px;
-        }
-        .offchain-poll-invalid,
-        .offchain-poll-no-voters {
-            font-size: 16px;
-            color: $text-color-light;
-        }
-        .offchain-poll-voters {
-            margin-top: 10px;
-            .vote-synopsis {
-                margin-top: 10px;
-                .option-with-votes {
-                    margin: 10px 0;
-                    .poll-bar {
-                        height: 5px;
-                        border-radius: 5px;
-                        background-color: $primary-bg-color;
-                    }
-                    .option-results-label {
-                        display: flex;
-                    }
-                    a {
-                        margin-top: 10px;
-                        display: inline-block;
-                    }
-                }
-            }
-        }
-    }
-
-    .QuillEditor {
-        margin-top: 8px;
-    }
-    .ProposalBodyCancelEdit,
-    .ProposalBodySaveEdit {
-        margin-right: 12px;
-        margin-top: 14px;
-    }
-    .cui-icon.cui-icon-chevron-down.cui-icon-action > svg {
-        stroke: $text-color-light;
-        &:hover {
-            stroke: $text-color-medium;
-        }
-    }
-    .ProposalBodyReaction {
-        display: inline-block;
-    }
-    .InlineReplyButton {
-        display: flex;
-    }
-    .ProposalBodyText.proposal-body-placeholder {
-        &, .User .user-display-name {
-            color: $text-color-light;
-        }
-    }
-
-    .comments-error {
-        @include error-text();
-        margin: 30px 0;
-    }
-
-    .proposal-content,
-    .ProposalComment {
-        position: relative;
-    }
-    .thread-connector {
-        position: absolute;
-        top: 48px;
-        bottom: -40px;
+    .ProposalHeaderExternalLink,
+    .ProposalHeaderBlockExplorerLink,
+    .ProposalHeaderVotingInterfaceLink,
+    .ProposalHeaderThreadLink {
+      display: inline-block;
+      margin-right: 12px;
+      margin-top: 12px;
+      font-weight: 600;
+      a:link,
+      a:visited {
+        display: block;
+        padding: 12px 18px 6px;
+        border-radius: 99px;
         background: $background-color-light;
-        left: 19px;
-        width: 2px;
-        z-index: -1;
+        color: $text-color-primary;
+        text-decoration: none !important;
+      }
+      svg {
+        stroke: $text-color-primary;
+        position: relative;
+        top: -1px;
+        margin-left: 5px;
+        $size: 14px;
+        height: $size;
+        width: $size;
+        min-height: $size;
+        min-width: $size;
+      }
+      a:hover {
+        background: darken($background-color-light, 1%);
+      }
     }
-}
+  }
 
+  //
+  // body
+  //
+  .ProposalComment {
+    position: relative;
+    display: flex;
+    .comment-body {
+      flex: 1;
+      overflow-x: auto;
+      padding-left: $discussion-comment-padding;
+    }
+    .comment-body-top {
+      padding-bottom: $discussion-meta-padding;
+      font-size: $discussion-meta-font-size;
+    }
+    .comment-body-bottom {
+      padding: 4px 0 2px;
+    }
+    .comment-body-content {
+      @include xs-max {
+        margin-right: 10px;
+      }
+    }
+  }
+
+  .ProposalHeader .proposal-content {
+    .ProposalBodyReaction,
+    .InlineReplyButton {
+      margin-top: $discussion-reaction-padding;
+    }
+  }
+
+  .ProposalComments {
+    .new-comment-child {
+      margin-left: 72px;
+      @include xs-max {
+        margin-left: 0 !important;
+      }
+    }
+    .ProposalBodyReaction,
+    .InlineReplyButton {
+      margin-top: $discussion-reaction-padding;
+    }
+  }
+
+  // proposal-meta
+  .ProposalHeaderStage,
+  .ProposalHeaderTopics,
+  .ProposalHeaderOnchainId,
+  .ProposalHeaderOnchainStatus,
+  .ProposalBodyAuthor,
+  .ProposalBodyCreated,
+  .ProposalBodyLastEnded,
+  .ProposalBodyDelete,
+  .ProposalBodyEdit,
+  .ProposalBodyDelete,
+  .ProposalBodyCancelEdit,
+  .ProposalBodySaveEdit,
+  .ViewCountBlock,
+  .ProposalHeaderExternalLink {
+    font-size: $discussion-meta-font-size;
+    display: inline-block;
+    color: $discussion-meta-color;
+    margin-right: 17px;
+    > a:link,
+    > a:visited,
+    a.proposal-collaborators,
+    > .User a.user-display-name {
+      color: $discussion-meta-color;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .CommentSocialHeader,
+  .ProposalSocialHeader {
+    font-size: $discussion-meta-font-size;
+    display: inline-block;
+    color: $discussion-meta-color;
+    margin-left: 10px;
+    > a:link,
+    > a:visited,
+    a.proposal-collaborators,
+    > .User a.user-display-name {
+      color: $discussion-meta-color;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    svg {
+      stroke: $text-color-light;
+    }
+    svg:hover {
+      stroke: $text-color-medium;
+    }
+  }
+
+  .ProposalTitleEditor {
+    .ProposalTitleSaveEdit {
+      font-size: $discussion-meta-font-size;
+      color: $discussion-meta-color;
+    }
+    .cui-input {
+      margin-right: 10px;
+    }
+    .proposal-title-buttons {
+      display: inline-flex;
+      position: relative;
+      bottom: 5px;
+      .ProposalTitleCancelEdit {
+        margin-left: 5px;
+      }
+    }
+  }
+  .ProposalHeaderStage {
+    &.primary {
+      color: tint($primary-bg-color, 10%);
+    }
+    &.positive {
+      color: tint($positive-bg-color, 10%);
+    }
+    &.negative {
+      color: tint($negative-bg-color, 10%);
+    }
+  }
+  .proposal-collaborators-popover {
+    color: $text-color-black;
+    .cui-popover-content {
+      padding-top: 22px;
+      .User {
+        display: block;
+      }
+    }
+  }
+
+  .ProposalSidebarLinkedViewer {
+    border-radius: 10px;
+    border: 1px solid tint($border-color-lightest, 26%);
+    padding: 22px 18px 21px;
+    margin-bottom: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    .placeholder-copy {
+      margin-bottom: 10px;
+      font-weight: 500;
+    }
+  }
+
+  .ConnectProposalButtonWrapper {
+    margin-top: 10px;
+  }
+
+  .ProposalHeaderOffchainPoll,
+  .ProposalSidebarPollEditorModule,
+  .ProposalLinkedThreadsEditorModule {
+    border-radius: 10px;
+    border: 1px solid tint($border-color-lightest, 26%);
+    padding: 22px 18px 21px;
+    margin-bottom: 24px;
+  }
+  .ProposalLinkedThreadsEditorModule {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    a.linked-thread {
+      color: #9a9da4;
+    }
+    .cui-list-item {
+      &:first-child {
+        padding-top: 0 !important;
+      }
+      &:hover {
+        background: none;
+      }
+    }
+    .linked-threads-title {
+      margin-bottom: 10px;
+      font-weight: 500;
+    }
+  }
+  .ProposalSidebarPollEditorModule {
+    .placeholder-copy {
+      line-height: 1.2;
+      color: shade($text-color-light, 10%);
+      margin: 2px 0 12px;
+    }
+    .proposal-chain-entities {
+      margin-bottom: 12px;
+    }
+  }
+  .ProposalHeaderOffchainPoll {
+    .offchain-poll-header {
+      line-height: 1.2;
+      font-weight: 600;
+    }
+    .offchain-poll-options {
+      margin: 16px 0;
+      .offchain-poll-option {
+        display: flex;
+        .offchain-poll-option-left {
+          margin: 6px 0;
+          line-height: 1.1;
+          flex: 1;
+        }
+      }
+    }
+    .offchain-poll-caption {
+      font-size: 16px;
+      color: $text-color-light;
+      margin-bottom: 24px;
+    }
+    .offchain-poll-invalid,
+    .offchain-poll-no-voters {
+      font-size: 16px;
+      color: $text-color-light;
+    }
+    .offchain-poll-voters {
+      margin-top: 10px;
+      .vote-synopsis {
+        margin-top: 10px;
+        .option-with-votes {
+          margin: 10px 0;
+          .poll-bar {
+            height: 5px;
+            border-radius: 5px;
+            background-color: $primary-bg-color;
+          }
+          .option-results-label {
+            display: flex;
+          }
+          a {
+            margin-top: 10px;
+            display: inline-block;
+          }
+        }
+      }
+    }
+  }
+
+  .QuillEditor {
+    margin-top: 8px;
+  }
+  .ProposalBodyCancelEdit,
+  .ProposalBodySaveEdit {
+    margin-right: 12px;
+    margin-top: 14px;
+  }
+  .cui-icon.cui-icon-chevron-down.cui-icon-action > svg {
+    stroke: $text-color-light;
+    &:hover {
+      stroke: $text-color-medium;
+    }
+  }
+  .ProposalBodyReaction {
+    display: inline-block;
+  }
+  .InlineReplyButton {
+    display: flex;
+  }
+  .ProposalBodyText.proposal-body-placeholder {
+    &,
+    .User .user-display-name {
+      color: $text-color-light;
+    }
+  }
+
+  .comments-error {
+    @include error-text();
+    margin: 30px 0;
+  }
+
+  .proposal-content,
+  .ProposalComment {
+    position: relative;
+  }
+  .thread-connector {
+    position: absolute;
+    top: 48px;
+    bottom: -40px;
+    background: $background-color-light;
+    left: 19px;
+    width: 2px;
+    z-index: -1;
+  }
+}

--- a/client/styles/pages/view_proposal/index.scss
+++ b/client/styles/pages/view_proposal/index.scss
@@ -116,9 +116,10 @@ $discussion-title-font-size: 1.45rem;
   .threading-level-1 {
     .new-comment-child {
       margin-left: 108px !important;
-    }
-    @include xs-max {
-      margin-left: 0 !important;
+      @include xs-max {
+        margin-left: 0 !important;
+        width: 100%;
+      }
     }
   }
   .threading-level-2 {
@@ -315,6 +316,7 @@ $discussion-title-font-size: 1.45rem;
       margin-left: 72px;
       @include xs-max {
         margin-left: 0 !important;
+        width: 100%;
       }
     }
     .ProposalBodyReaction,

--- a/client/styles/sublayout.scss
+++ b/client/styles/sublayout.scss
@@ -151,6 +151,17 @@
     }
   }
 
+  // TODO: Graham 22.03.04 Necessity & presence of right sidebar
+  // should be assessed site-wide. This is merely a hot fix for
+  // comment threading.
+  &.ViewProposalPage {
+    .sublayout-right-col {
+      @include xs-max {
+        display: none;
+      }
+    }
+  }
+
   .hide-sidebar & {
     .sublayout-main-col {
       margin: 0 auto;


### PR DESCRIPTION
Previously, unnecessary whitespace around comments and comment editors made the actual comment text very narrow on mobile view, especially for threaded comments. This introduces some CSS patches that lessens unnecessary margins/whitespace.

Before:
![image](https://user-images.githubusercontent.com/22281010/157302656-a3aa405c-0613-4949-9908-0d9b09cc9fe2.png)

After:
![image](https://user-images.githubusercontent.com/22281010/157301827-07646812-1e04-4a15-9096-0ff297643ddd.png)

Previously, the Quill editor ran off the page, and its toolbar was not fully visible. This increases toolbar height and flexwraps the items, to ensure they stay visible even when creating threaded comments on mobile.

Before:
![image](https://user-images.githubusercontent.com/22281010/157302795-853e7ee8-b388-4882-93ea-d813bb808276.png)

After:
![image](https://user-images.githubusercontent.com/22281010/157302341-db7daf48-b3e5-4273-b20a-949c91ba4946.png)

Previously, the discussion row listings were so truncated on mobile as to render all their metadata illegible. Further, titles were not properly truncated, creating x-overflow.

Before:
![image](https://user-images.githubusercontent.com/22281010/157302543-b806d0db-0202-4f05-8072-189a762b12cd.png)

After:
![image](https://user-images.githubusercontent.com/22281010/157302477-c4435ae1-5ffb-44f0-aaab-de6def18f150.png)


The auto-lint on save has unfortunately made this PR significantly harder to read/scan over; apologies. 

However, the styling on these components has accumulated a lot of technical debt, and is generally quite messy. More engineering + design time should be invested to (1) create a dedicated mobile discussion row component, (2) rip out and re-write the styling for threads and comments, including:
1. A site-wide audit of when the right-hand sidebar column is used, and designs for how e.g. poll, linked threads, linked proposal modules should be displayed in mobile.
2. Work on the InlineReplyButton + jumpsToHighlight, so that when clicked on from a high level post, jumpsToHighlight that comment editor at bottom (or else floats the Quill editor upward); right now, given long comment chains, it appears as if that button isn't working.