### PR TITLE
Fix Collaborations and edit threads

### DIFF
--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -152,13 +152,25 @@ const editThread = async (
 
     await thread.save();
     await attachFiles();
-    try {
-      await models.Collaboration.create({
+
+    const collaboration = await models.Collaboration.findOne({
+      where: {
         offchain_thread_id: thread_id,
         address_id: thread.address_id,
-      });
-    } catch (e) {
-      log.error(Errors.CollaborationsInsertError, e.message);
+      },
+    });
+
+    console.log(collaboration);
+
+    if (!collaboration){
+      try {
+        await models.Collaboration.create({
+          offchain_thread_id: thread_id,
+          address_id: thread.address_id,
+        });
+      } catch (e) {
+        log.error(Errors.CollaborationsInsertError, e.message);
+      }
     }
 
     const finalThread = await models.OffchainThread.findOne({

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -56,10 +56,11 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
   let thread;
   const userOwnedAddresses = await req.user.getAddresses();
   const userOwnedAddressIds = userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id);
-  const collaboration = await models.Collaboration.findOne({
+  const collaboration = await await models.Role.findOne({
     where: {
-      offchain_thread_id: thread_id,
-      address_id: { [Op.in]: userOwnedAddressIds }
+      chain_id: chain.id,
+      address_id: { [Op.in]: userOwnedAddressIds },
+      permission: 'moderator'
     }
   });
 

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -160,8 +160,6 @@ const editThread = async (
       },
     });
 
-    console.log(collaboration);
-
     if (!collaboration){
       try {
         await models.Collaboration.create({

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -4,7 +4,11 @@ import moment from 'moment';
 import { parseUserMentions } from '../util/parseUserMentions';
 import validateChain from '../util/validateChain';
 import lookupAddressIsOwnedByUser from '../util/lookupAddressIsOwnedByUser';
-import { getProposalUrl, renderQuillDeltaToText, validURL } from '../../shared/utils';
+import {
+  getProposalUrl,
+  renderQuillDeltaToText,
+  validURL,
+} from '../../shared/utils';
 import { NotificationCategories, ProposalType } from '../../shared/types';
 import { factory, formatFilename } from '../../shared/logging';
 import { DB } from '../database';
@@ -15,17 +19,26 @@ export const Errors = {
   NoThreadId: 'Must provide thread_id',
   NoBodyOrAttachment: 'Must provide body or attachment',
   IncorrectOwner: 'Not owned by this user',
-  InvalidLink: 'Invalid thread URL'
+  InvalidLink: 'Invalid thread URL',
 };
 
-const editThread = async (models: DB, req: Request, res: Response, next: NextFunction) => {
-  const { body, title, kind, stage, thread_id, version_history, url } = req.body;
+const editThread = async (
+  models: DB,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { body, title, kind, stage, thread_id, version_history, url } =
+    req.body;
   if (!thread_id) {
     return next(new Error(Errors.NoThreadId));
   }
 
   if (kind === 'forum') {
-    if ((!body || !body.trim()) && (!req.body['attachments[]'] || req.body['attachments[]'].length === 0)) {
+    if (
+      (!body || !body.trim()) &&
+      (!req.body['attachments[]'] || req.body['attachments[]'].length === 0)
+    ) {
       return next(new Error(Errors.NoBodyOrAttachment));
     }
   }
@@ -35,7 +48,10 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
   if (authorError) return next(new Error(authorError));
 
   const attachFiles = async () => {
-    if (req.body['attachments[]'] && typeof req.body['attachments[]'] === 'string') {
+    if (
+      req.body['attachments[]'] &&
+      typeof req.body['attachments[]'] === 'string'
+    ) {
       await models.OffchainAttachment.create({
         attachable: 'thread',
         attachment_id: thread_id,
@@ -43,40 +59,45 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
         description: 'image',
       });
     } else if (req.body['attachments[]']) {
-      await Promise.all(req.body['attachments[]']
-        .map((url_) => models.OffchainAttachment.create({
-          attachable: 'thread',
-          attachment_id: thread_id,
-          url: url_,
-          description: 'image',
-        })));
+      await Promise.all(
+        req.body['attachments[]'].map((url_) =>
+          models.OffchainAttachment.create({
+            attachable: 'thread',
+            attachment_id: thread_id,
+            url: url_,
+            description: 'image',
+          })
+        )
+      );
     }
   };
 
   let thread;
   const userOwnedAddresses = await req.user.getAddresses();
-  const userOwnedAddressIds = userOwnedAddresses.filter((addr) => !!addr.verified).map((addr) => addr.id);
-  const collaboration = await await models.Role.findOne({
+  const userOwnedAddressIds = userOwnedAddresses
+    .filter((addr) => !!addr.verified)
+    .map((addr) => addr.id);
+  const collaboration = await models.Role.findOne({
     where: {
       chain_id: chain.id,
       address_id: { [Op.in]: userOwnedAddressIds },
-      permission: 'moderator'
-    }
+      permission: 'moderator',
+    },
   });
 
   const admin = await models.Role.findOne({
     where: {
       chain_id: chain.id,
       address_id: { [Op.in]: userOwnedAddressIds },
-      permission: 'admin'
-    }
+      permission: 'admin',
+    },
   });
 
   if (collaboration || admin) {
     thread = await models.OffchainThread.findOne({
       where: {
-        id: thread_id
-      }
+        id: thread_id,
+      },
     });
   } else {
     thread = await models.OffchainThread.findOne({
@@ -97,12 +118,12 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
     }
     // If new comment body text has been submitted, create another version history entry
     if (decodeURIComponent(req.body.body) !== latestVersion) {
-      const recentEdit : any = {
+      const recentEdit: any = {
         timestamp: moment(),
         author: req.body.author,
-        body: decodeURIComponent(req.body.body)
+        body: decodeURIComponent(req.body.body),
       };
-      const versionHistory : string = JSON.stringify(recentEdit);
+      const versionHistory: string = JSON.stringify(recentEdit);
       const arr = thread.version_history;
       arr.unshift(versionHistory);
       thread.version_history = arr;
@@ -137,7 +158,7 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
         {
           model: models.Address,
           // through: models.Collaboration,
-          as: 'collaborators'
+          as: 'collaborators',
         },
         models.OffchainAttachment,
         { model: models.OffchainTopic, as: 'topic' },
@@ -155,12 +176,12 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
         root_type: ProposalType.OffchainThread,
         root_title: finalThread.title,
         chain_id: finalThread.chain,
-        author_address: finalThread.Address.address
+        author_address: finalThread.Address.address,
       },
       // don't send webhook notifications for edits
       null,
       req.wss,
-      [ userOwnedAddresses[0].address ],
+      [userOwnedAddresses[0].address]
     );
 
     let mentions;
@@ -170,7 +191,10 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
       mentions = currentDraftMentions.filter((addrArray) => {
         let alreadyExists = false;
         previousDraftMentions.forEach((addrArray_) => {
-          if (addrArray[0] === addrArray_[0] && addrArray[1] === addrArray_[1]) {
+          if (
+            addrArray[0] === addrArray_[0] &&
+            addrArray[1] === addrArray_[1]
+          ) {
             alreadyExists = true;
           }
         });
@@ -183,54 +207,59 @@ const editThread = async (models: DB, req: Request, res: Response, next: NextFun
     // grab mentions to notify tagged users
     let mentionedAddresses;
     if (mentions?.length > 0) {
-      mentionedAddresses = await Promise.all(mentions.map(async (mention) => {
-        try {
-          const user = await models.Address.findOne({
-            where: {
-              chain: mention[0],
-              address: mention[1],
-            },
-            include: [ models.User, models.Role ]
-          });
-          return user;
-        } catch (err) {
-          return null;
-        }
-      }));
+      mentionedAddresses = await Promise.all(
+        mentions.map(async (mention) => {
+          try {
+            const user = await models.Address.findOne({
+              where: {
+                chain: mention[0],
+                address: mention[1],
+              },
+              include: [models.User, models.Role],
+            });
+            return user;
+          } catch (err) {
+            return null;
+          }
+        })
+      );
       // filter null results
       mentionedAddresses = mentionedAddresses.filter((addr) => !!addr);
     }
 
     // notify mentioned users, given permissions are in place
-    if (mentionedAddresses?.length > 0) await Promise.all(mentionedAddresses.map(async (mentionedAddress) => {
-      if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
+    if (mentionedAddresses?.length > 0)
+      await Promise.all(
+        mentionedAddresses.map(async (mentionedAddress) => {
+          if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
-      await models.Subscription.emitNotifications(
-        models,
-        NotificationCategories.NewMention,
-        `user-${mentionedAddress.User.id}`,
-        {
-          created_at: new Date(),
-          root_id: +finalThread.id,
-          root_type: ProposalType.OffchainThread,
-          root_title: finalThread.title,
-          comment_text: finalThread.body,
-          chain_id: finalThread.chain,
-          author_address: finalThread.Address.address,
-          author_chain: finalThread.Address.chain,
-        },
-        {
-          user: finalThread.Address.address,
-          url: getProposalUrl('discussion', finalThread),
-          title: req.body.title,
-          bodyUrl: req.body.url,
-          chain: finalThread.chain,
-          body: finalThread.body,
-        },
-        req.wss,
-        [ finalThread.Address.address ],
+          await models.Subscription.emitNotifications(
+            models,
+            NotificationCategories.NewMention,
+            `user-${mentionedAddress.User.id}`,
+            {
+              created_at: new Date(),
+              root_id: +finalThread.id,
+              root_type: ProposalType.OffchainThread,
+              root_title: finalThread.title,
+              comment_text: finalThread.body,
+              chain_id: finalThread.chain,
+              author_address: finalThread.Address.address,
+              author_chain: finalThread.Address.chain,
+            },
+            {
+              user: finalThread.Address.address,
+              url: getProposalUrl('discussion', finalThread),
+              title: req.body.title,
+              bodyUrl: req.body.url,
+              chain: finalThread.chain,
+              body: finalThread.body,
+            },
+            req.wss,
+            [finalThread.Address.address]
+          );
+        })
       );
-    }));
 
     // TODO: update author.last_active
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes: https://www.notion.so/hicommonwealth/Collaborations-doesn-t-show-new-collaborators-or-let-them-fix-edit-thread-a7728238d48c45919d42703cc258d17b

## How has this been tested?

I used 2 users. One admin and one member. 

Admin (address ID: 22478) creates a thread:  
Thread ID: 3727

Member(address ID: 22482) creates a thread:
Thread ID: 3728

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/11271352/158468198-a126db98-fadc-4cc5-9a9c-66a0fb4359f2.png">

Admin is able to edit both threads:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/11271352/158468698-0b5d93b2-da98-44a8-94d6-583f5ae41ff7.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/11271352/158468719-972b34b3-1e2c-4b43-930b-3e5ddd2523e1.png">

Member is only able to edit the thread they authored:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/11271352/158468874-31df49b0-e5e3-4d77-a410-9891a1e2606c.png">

<img width="542" alt="image" src="https://user-images.githubusercontent.com/11271352/158468924-8ebd6217-dd82-4b07-bf99-d39db7b26808.png">


Entry in the Collaborations table:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/11271352/158471953-ea259cc7-6a05-4343-bb92-b7bd1e2d4a4e.png">

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no