### PR TITLE
Update starter_community_form.tsx

### DIFF
--- a/client/scripts/views/pages/create_community/starter_community_form.tsx
+++ b/client/scripts/views/pages/create_community/starter_community_form.tsx
@@ -110,7 +110,19 @@ export class StarterCommunityForm implements m.ClassComponent {
                 break;
               }
             }
-            const { iconUrl } = this.state.form;
+            const {
+              id,
+              name,
+              symbol,
+              iconUrl,
+              description,
+              website,
+              discord,
+              telegram,
+              github,
+              element,
+              base,
+             } = this.state.form;
             try {
               const res = await $.post(`${app.serverUrl()}/createChain`, {
                 jwt: app.user.jwt,
@@ -118,7 +130,16 @@ export class StarterCommunityForm implements m.ClassComponent {
                 type: ChainType.Offchain,
                 network: baseToNetwork(this.state.form.base),
                 icon_url: iconUrl,
-                ...this.state.form,
+                id,
+                name,
+                symbol,
+                base,
+                description,
+                discord,
+                element,
+                github,
+                telegram,
+                website,
                 ...additionalArgs,
               });
               await initAppState(false);

--- a/client/scripts/views/pages/create_community/starter_community_form.tsx
+++ b/client/scripts/views/pages/create_community/starter_community_form.tsx
@@ -110,12 +110,14 @@ export class StarterCommunityForm implements m.ClassComponent {
                 break;
               }
             }
+            const { iconUrl } = this.state.form;
             try {
               const res = await $.post(`${app.serverUrl()}/createChain`, {
                 jwt: app.user.jwt,
                 address: '',
                 type: ChainType.Offchain,
                 network: baseToNetwork(this.state.form.base),
+                icon_url: iconUrl,
                 ...this.state.form,
                 ...additionalArgs,
               });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes:  [Issue](https://www.notion.so/hicommonwealth/Logos-not-being-added-to-new-forums-32b7a7ddda80432d92726f48ea6b5ffe)



## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Screenshot of the new community with a logo:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/11271352/159789654-9cbd6bb5-b22e-469a-bc8a-fc949cfdad33.png">



The body of the request object had the attribute as iconUrl while the code expected it to be icon_url. This prevented the url being uploaded:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/11271352/159737551-dea544d9-98e3-4b68-95ca-d9477e973aec.png">


Table after the fix:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/11271352/159789612-16d66ec8-ef57-438c-991e-a657b53e2410.png">



```
req.body:  [Object: null prototype] {
  jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTkyMjgsImVtYWlsIjoicmFnaGF2YTYxNjJAZ21haWwuY29tIiwiaWF0IjoxNjQ3OTU0ODc0fQ.WwOzm7TGsZgVfmFD-f7PThC2IMTvoVibQtOVzn41Qtc',
  address: '',
  type: 'offchain',
  network: 'ethereum',
  id: 'logo-test3',
  name: 'logo-test3',
  symbol: 'XYZ',
  base: 'ethereum',
  description: '',
  discord: '',
  element: '',
  github: '',
  iconUrl: 'https://commonwealth-uploads.s3.us-east-2.amazonaws.com/229191ba-f186-4916-b52a-cdae683b1cd9.png',
  telegram: '',
  uploadInProgress: 'false',
  website: '',
  eth_chain_id: '1',
  node_url: 'wss://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr',
  alt_wallet_url: 'https://eth-mainnet.alchemyapi.io/v2/cNC4XfxR7biwO2bfIO5aKcs9EMPxTQfr'
}
```


## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no