### PR TITLE
Fix linked proposals sidebar.

### DIFF
--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -1301,6 +1301,7 @@ const ViewProposalPage: m.Component<
     }
     const showLinkedSnapshotOptions =
       (proposal as OffchainThread).snapshotProposal?.length > 0 ||
+      (proposal as OffchainThread).chainEntities?.length > 0 ||
       isAuthor ||
       isAdminOrMod;
     const showLinkedThreadOptions =


### PR DESCRIPTION
Previously the sidebar was only showing if snapshot proposals were linked. Now it accepts linked chain entities as well as snapshots.