### PR TITLE
Add private url field to chain node.

### DIFF
--- a/server/migrations/20220403192148-add-private-url.js
+++ b/server/migrations/20220403192148-add-private-url.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('ChainNodes', 'private_url', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('ChainNodes', 'private_url');
+  }
+};

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -47,7 +47,14 @@ export default (
       timestamps: false,
       underscored: true,
       indexes: [{ fields: ['chain'] }],
-    }
+      defaultScope: {
+        attributes: {
+          exclude: [
+            'private_url'
+          ],
+        }
+      },
+    },
   );
 
   ChainNode.associate = (models) => {

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -12,6 +12,7 @@ export type ChainNodeAttributes = {
   ce_verbose?: boolean;
   eth_chain_id?: number;
   alt_wallet_url?: string;
+  private_url?: string;
 
   // associations
   Chain?: ChainAttributes;
@@ -39,6 +40,7 @@ export default (
       ce_verbose: { type: dataTypes.BOOLEAN, allowNull: true },
       eth_chain_id: { type: dataTypes.INTEGER, allowNull: true },
       alt_wallet_url: { type: dataTypes.STRING, allowNull: true },
+      private_url: { type: dataTypes.STRING, allowNull: true },
     },
     {
       tableName: 'ChainNodes',

--- a/server/models/chain_node.ts
+++ b/server/models/chain_node.ts
@@ -54,6 +54,9 @@ export default (
           ],
         }
       },
+      scopes: {
+        withPrivateData: {}
+      }
     },
   );
 

--- a/server/routes/createChain.ts
+++ b/server/routes/createChain.ts
@@ -145,7 +145,6 @@ const createChain = async (
       return next(new Error(Errors.ChainAddressExists));
     }
 
-    console.log(privateUrl, url);
     const provider = new Web3.providers.WebsocketProvider(privateUrl || url);
     const web3 = new Web3(provider);
     const code = await web3.eth.getCode(req.body.address);

--- a/server/routes/getSupportedEthChains.ts
+++ b/server/routes/getSupportedEthChains.ts
@@ -15,7 +15,7 @@ const getSupportedEthChains = async (
   if (req.query.chain_id) {
     const chainId = +req.query.chain_id;
     try {
-      const supportedChainUrls = await getUrlsForEthChainId(models, chainId);
+      const supportedChainUrls = await getUrlsForEthChainId(models, chainId, false);
       return res.json({ status: 'Success', result: { [chainId]: supportedChainUrls } });
     } catch (e) {
       return res.json({ status: 'Failure', message: e.message });

--- a/server/routes/getTokenForum.ts
+++ b/server/routes/getTokenForum.ts
@@ -29,7 +29,7 @@ const getTokenForum = async (
   const urls = await getUrlsForEthChainId(models, chain_id);
   let url;
   if (urls) {
-    url = urls.url;
+    url = urls.private_url || urls.url;
   } else {
     url = req.query.url;
     if (!url) {

--- a/server/scripts/dbNode.ts
+++ b/server/scripts/dbNode.ts
@@ -122,7 +122,7 @@ async function mainProcess(
     );
 
   let query =
-    'SELECT "Chains"."id", "substrate_spec", "url", "address", "base", "type", "network", "ce_verbose" FROM "Chains" JOIN "ChainNodes" ON "Chains"."id"="ChainNodes"."chain" WHERE "Chains"."has_chain_events_listener"=\'true\';';
+    'SELECT "Chains"."id", "substrate_spec", "url", "private_url", "address", "base", "type", "network", "ce_verbose" FROM "Chains" JOIN "ChainNodes" ON "Chains"."id"="ChainNodes"."chain" WHERE "Chains"."has_chain_events_listener"=\'true\';';
   const allChains = (await pool.query(query)).rows;
 
   // gets the chains specific to this node
@@ -294,7 +294,7 @@ async function mainProcess(
         listeners[chain.id] = await createListener(chain.id, network, {
           address: chain.address,
           archival: false,
-          url: chain.url,
+          url: chain.private_url || chain.url,
           spec: chain.substrate_spec,
           skipCatchup: false,
           verbose: false, // using this will print event before chain is added to it

--- a/server/util/supportedEthChains.ts
+++ b/server/util/supportedEthChains.ts
@@ -33,15 +33,20 @@ export async function getSupportedEthChainIds(models: DB): Promise<{
   return results;
 }
 
-export async function getUrlsForEthChainId(models: DB, chainId: number): Promise<
+export async function getUrlsForEthChainId(models: DB, chainId: number, includePrivateUrl = true): Promise<
   { url: string, alt_wallet_url: string, private_url?: string } | null
 > {
   const chainIds = await getSupportedEthChainIds(models);
   const chain = chainIds[chainId];
-  const nodeInstance = await models.ChainNode.findOne({ where: {
-    eth_chain_id: chainId,
-    url: chain.url,
-    alt_wallet_url: chain.alt_wallet_url,
-  }});
+  if (!includePrivateUrl) {
+    return chain;
+  }
+  const nodeInstance = await models.ChainNode.scope('withPrivateData').findOne({
+    where: {
+      eth_chain_id: chainId,
+      url: chain.url,
+      alt_wallet_url: chain.alt_wallet_url,
+    },
+  });
   return { ...chain, private_url: nodeInstance.private_url };
 }

--- a/server/util/supportedEthChains.ts
+++ b/server/util/supportedEthChains.ts
@@ -9,7 +9,7 @@ export async function getSupportedEthChainIds(models: DB): Promise<{
   [id: number]: { url: string, alt_wallet_url: string }
 }> {
   const supportedChainIds = await models.ChainNode.findAll({
-    attributes: ['url', 'eth_chain_id', 'alt_wallet_url' ],
+    attributes: ['url', 'eth_chain_id', 'alt_wallet_url'],
     group: ['url', 'eth_chain_id', 'alt_wallet_url'],
     where: {
       // get all nodes that have a valid chain id
@@ -34,8 +34,14 @@ export async function getSupportedEthChainIds(models: DB): Promise<{
 }
 
 export async function getUrlsForEthChainId(models: DB, chainId: number): Promise<
-  { url: string, alt_wallet_url: string } | null
+  { url: string, alt_wallet_url: string, private_url?: string } | null
 > {
   const chainIds = await getSupportedEthChainIds(models);
-  return chainIds[chainId] || null;
+  const chain = chainIds[chainId];
+  const nodeInstance = await models.ChainNode.findOne({ where: {
+    eth_chain_id: chainId,
+    url: chain.url,
+    alt_wallet_url: chain.alt_wallet_url,
+  }});
+  return { ...chain, private_url: nodeInstance.private_url };
 }

--- a/server/util/tokenBalanceCache.ts
+++ b/server/util/tokenBalanceCache.ts
@@ -175,7 +175,7 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
       if (!urls) {
         throw new Error(`unsupported eth chain id ${chainId}`);
       }
-      const url = urls.url;
+      const url = urls.private_url || urls.url;
       try {
         balance = await this._balanceProvider.getEthTokenBalance(url, contractAddress, address);
       } catch (e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a private url field with a websocket url for eth chains that only gets used on the backend / chain events. Frontend still uses standard url and alt_wallet_url fields.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevents our backend key from being stolen, and allows us to use a whitelist for the frontend key.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no