### PR TITLE
Fix email login flow falsy check bug.

### DIFF
--- a/server/passport/magic.ts
+++ b/server/passport/magic.ts
@@ -198,7 +198,7 @@ export function useMagicAuth(models: DB) {
           include: [ models.Address ],
         });
         return cb(null, newUser);
-      } else if (existingUser.Addresses) {
+      } else if (existingUser.Addresses?.length > 0) {
         // each user should only ever have one token issued by Magic
         const ssoToken = await models.SsoToken.findOne({
           where: {

--- a/server/routes/startEmailLogin.ts
+++ b/server/routes/startEmailLogin.ts
@@ -58,7 +58,7 @@ const startEmailLogin = async (models: DB, req: Request, res: Response, next: Ne
   const magicChain = chain;
 
   const isNewRegistration = !previousUser;
-  const isExistingMagicUser = previousUser && !!previousUser.Addresses;
+  const isExistingMagicUser = previousUser && previousUser.Addresses?.length > 0;
   if (isExistingMagicUser // existing magic users should always use magic login, even if they're in the wrong community
       || (isNewRegistration && magicChain?.base && MAGIC_SUPPORTED_BASES.includes(magicChain.base)
           && !req.body.forceEmailLogin)) {

--- a/server/routes/updateEmail.ts
+++ b/server/routes/updateEmail.ts
@@ -49,7 +49,7 @@ const updateEmail = async (models: DB, req: Request, res: Response, next: NextFu
     }],
   });
   if (!user) return next(new Error(Errors.NoUser));
-  if (user.Addresses && (await user.Addresses.length) > 0) return next(new Error(Errors.NoUpdateForMagic));
+  if (user.Addresses?.length > 0) return next(new Error(Errors.NoUpdateForMagic));
   // ensure no more than 3 tokens have been created in the last 5 minutes
   const recentTokens = await models.LoginToken.findAndCountAll({
     where: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apparently `user.Addresses` is not "false" when it is `[]`. This has been changed to an explicit length check.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes login issues with email users.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Replicated bug and ensured fix.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [x] yes, but I did not run tests
- [ ] no