### PR TITLE
Fix 2 discussions page bugs

### DIFF
--- a/client/scripts/views/pages/discussions/index.tsx
+++ b/client/scripts/views/pages/discussions/index.tsx
@@ -365,14 +365,12 @@ class DiscussionsPage implements m.ClassComponent<DiscussionsPageAttrs> {
       >
         {app.chain && (
           <div class="DiscussionsPage">
-            {!isEmpty && (
-              <DiscussionFilterBar
-                topic={topicName}
-                stage={stage}
-                parentState={this}
-                disabled={isLoading || stillFetching}
-              />
-            )}
+            <DiscussionFilterBar
+              topic={topicName}
+              stage={stage}
+              parentState={this}
+              disabled={isLoading || stillFetching}
+            />
             {onSummaryView
               ? isLoading
                 ? m(LoadingRow)
@@ -388,13 +386,13 @@ class DiscussionsPage implements m.ClassComponent<DiscussionsPageAttrs> {
                   topicName,
                 })
               : m(Listing, { content: sortedListing })}
-            {postsDepleted ? (
+            {postsDepleted && !onSummaryView ? (
               <div class="infinite-scroll-reached-end">
                 Showing {allThreads.length} of{' '}
                 {pluralize(allThreads.length, 'thread')}
                 {topic ? ` under the topic '${topic}'` : ''}
               </div>
-            ) : isEmpty ? null : (
+            ) : (isEmpty || onSummaryView) ? null : (
               <div class="infinite-scroll-spinner-wrap">
                 <Spinner active={!this.postsDepleted[subpage]} size="lg" />
               </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- [x] On an empty topic page, the filter-bar would disappear. Fixed
- [x] On the Summary View of the discussions listing, there was a spinner always hanging out and would show "showing all xxx threads" if you'd made it to the bottom of the previously selected topic. Both removed. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unkempt!

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no