### PR TITLE
New Profile Page

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -857,6 +857,19 @@ Promise.all([$.ready, $.get('/api/domain')]).then(
               scoped: false,
               hideSidebar: true,
             }),
+
+            // TODO: determine whether this should exist here as a scoped route or above as a custom domain route
+            // Profiles New  
+            '/profile/:address': importRoute('views/pages/new_profile', {
+              scoped: false,
+              hideSidebar: false,
+            }),
+            
+            '/:scope/profile/:address': importRoute('views/pages/new_profile', {
+              scoped: true,
+              hideSidebar: false,
+            }),
+
             // Notifications
             '/:scope/notifications': importRoute(
               'views/pages/notifications_page',
@@ -903,7 +916,7 @@ Promise.all([$.ready, $.get('/api/domain')]).then(
             '/:scope/discussions': redirectRoute((attrs) => `/${attrs.scope}/`),
             '/:scope': importRoute('views/pages/discussions', {
               scoped: true,
-              deferChain: true,
+              deferChain: true,  
             }),
             '/:scope/discussions/:topic': importRoute(
               'views/pages/discussions',

--- a/client/scripts/models/NewProfile.ts
+++ b/client/scripts/models/NewProfile.ts
@@ -1,0 +1,25 @@
+class NewProfile {
+  private _name: string;
+  private _email: string;
+  private _website: string;
+  private _bio: string;
+  private _isDefault: boolean;
+
+  get name() { return this._name; }
+  get email() { return this._email; }
+  get website() { return this._website; }
+  get bio() { return this._bio; }
+  get isDefault() { return this._isDefault; }
+
+  constructor() {}
+
+  initialize(name, email, website, bio, isDefault) {
+    this._name = name;
+    this._email = email;
+    this._website = website;
+    this._bio = bio;
+    this._isDefault = isDefault;
+  }
+}
+
+export default NewProfile;

--- a/client/scripts/models/index.ts
+++ b/client/scripts/models/index.ts
@@ -34,6 +34,7 @@ export { default as ChainEvent } from './ChainEvent';
 export { default as ChainEntity } from './ChainEntity';
 export { default as StarredCommunity } from './StarredCommunity';
 export { default as Webhook } from './Webhook';
+export {default as NewProfile } from './NewProfile'
 
 export { DepositVote, BinaryVote } from './votes';
 

--- a/client/scripts/views/pages/new_profile/index.tsx
+++ b/client/scripts/views/pages/new_profile/index.tsx
@@ -1,0 +1,76 @@
+/* @jsx m */
+
+import m from 'mithril';
+import app from 'state';
+import $ from 'jquery';
+
+import Sublayout from 'views/sublayout';
+import NewProfileHeader from './new_profile_header'
+import NewProfileActivity from './new_profile_activity'
+
+import Profile from 'client/scripts/models/Profile'
+import OffchainThread from 'client/scripts/models/OffchainThread'
+import ChainInfo from 'client/scripts/models/ChainInfo'
+import OffchainComment from 'client/scripts/models/OffchainComment'
+import AddressInfo from 'client/scripts/models/AddressInfo'
+import { IUniqueId } from 'client/scripts/models/interfaces';
+
+import 'pages/new_profile.scss';
+
+type ProfileState = {
+  address: string,
+  profile: Profile,
+  threads: Array<OffchainThread>,
+  comments: Array<OffchainComment<IUniqueId>>,
+  chains: Array<ChainInfo>,
+  addresses: Array<AddressInfo>, 
+};
+class NewProfile implements m.Component<{}, ProfileState> {
+
+  oninit(vnode) {
+    vnode.state.address = m.route.param("address")
+    this.getProfile(vnode, vnode.state.address)
+  }
+
+  getProfile = async (vnode, address: String) => {
+    const response = await $.get(`${app.serverUrl()}/profile/v2`, {
+      address,
+      jwt: app.user.jwt,
+    });
+    // TODO: status code error handling with better HTTP call library
+    vnode.state.profile = response.profile
+    vnode.state.threads = response.threads
+    vnode.state.comments = response.comments
+    vnode.state.chains = [... new Set<ChainInfo>(response.addresses.map(a => a.chain))]
+    vnode.state.addresses = response.addresses
+    m.redraw()
+  } 
+
+  view(vnode) {
+    return (
+      <div className="ProfilePage">
+        <NewProfileHeader profile={vnode.state.profile} />
+        <NewProfileActivity 
+          threads={vnode.state.threads} 
+          comments={vnode.state.comments} 
+          chains={vnode.state.chains} 
+          addresses={vnode.state.addresses} 
+        />
+      </div>
+    );
+  }
+}
+
+const NewProfilePage: m.Component = {
+  view: () => {
+    return m(
+      Sublayout,
+      {
+        class: 'Homepage',
+      },
+      [m(NewProfile)]
+    );
+  },
+};
+
+export default NewProfilePage;

--- a/client/scripts/views/pages/new_profile/index.tsx
+++ b/client/scripts/views/pages/new_profile/index.tsx
@@ -8,7 +8,7 @@ import Sublayout from 'views/sublayout';
 import NewProfileHeader from './new_profile_header'
 import NewProfileActivity from './new_profile_activity'
 
-import Profile from 'client/scripts/models/Profile'
+import {NewProfile as Profile} from 'client/scripts/models'
 import OffchainThread from 'client/scripts/models/OffchainThread'
 import ChainInfo from 'client/scripts/models/ChainInfo'
 import OffchainComment from 'client/scripts/models/OffchainComment'
@@ -38,7 +38,17 @@ class NewProfile implements m.Component<{}, ProfileState> {
       jwt: app.user.jwt,
     });
     // TODO: status code error handling with better HTTP call library
+
+    const profile = new Profile()
+    profile.initialize(
+      response.profile.name, 
+      response.profile.email,
+      response.profile.website,
+      response.profile.bio,
+      response.profile.isDefault,
+    );
     vnode.state.profile = response.profile
+    
     vnode.state.threads = response.threads
     vnode.state.comments = response.comments
     vnode.state.chains = response.chains

--- a/client/scripts/views/pages/new_profile/index.tsx
+++ b/client/scripts/views/pages/new_profile/index.tsx
@@ -43,13 +43,17 @@ class NewProfile implements m.Component<{}, ProfileState> {
     vnode.state.comments = response.comments
     vnode.state.chains = response.chains
     vnode.state.addresses = response.addresses
+    vnode.state.socialAccounts = response.socialAccounts
     m.redraw()
   } 
 
   view(vnode) {
     return (
       <div className="ProfilePage">
-        <NewProfileHeader profile={vnode.state.profile} />
+        <NewProfileHeader 
+          profile={vnode.state.profile} 
+          socialAccounts={vnode.state.socialAccounts}
+        />
         <NewProfileActivity 
           threads={vnode.state.threads} 
           comments={vnode.state.comments} 

--- a/client/scripts/views/pages/new_profile/index.tsx
+++ b/client/scripts/views/pages/new_profile/index.tsx
@@ -41,7 +41,7 @@ class NewProfile implements m.Component<{}, ProfileState> {
     vnode.state.profile = response.profile
     vnode.state.threads = response.threads
     vnode.state.comments = response.comments
-    vnode.state.chains = [... new Set<ChainInfo>(response.addresses.map(a => a.chain))]
+    vnode.state.chains = response.chains
     vnode.state.addresses = response.addresses
     m.redraw()
   } 

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -53,7 +53,18 @@ const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) =>
     )
   if (option === ProfileActivity.Threads)  
     return attrs.threads?.map(t => 
-      <div className="activity"> <p> { t.title } </p> </div>
+      <div className="activity"> 
+        <div className="thread-chain"> 
+          <p> in <span className="heavy"> { t.chain } </span> </p>
+        </div>
+        <div className="thread-date"> 
+          <p> { transformTimestamp(t.created_at) } </p> 
+        </div>
+        <div className="">
+          <p> { t.title } </p> 
+        </div>
+        
+      </div>
     )
   if (option === ProfileActivity.Communities)
     return attrs.chains?.map(c => 

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -1,0 +1,100 @@
+/* @jsx m */
+
+import m from 'mithril';
+
+import OffchainThread from 'client/scripts/models/OffchainThread'
+import ChainInfo from 'client/scripts/models/ChainInfo'
+import OffchainComment from 'client/scripts/models/OffchainComment'
+import AddressInfo from 'client/scripts/models/AddressInfo'
+import { IUniqueId } from 'client/scripts/models/interfaces';
+
+import 'pages/new_profile.scss';
+
+type ProfileActivityAttrs = {
+  threads: Array<OffchainThread>,
+  comments: Array<OffchainComment<IUniqueId>>,
+  chains: Array<ChainInfo>,
+  addresses: Array<AddressInfo>, 
+};
+
+enum ProfileActivity {
+  All,
+  Threads,
+  Communities,
+  Addresses,
+}
+
+type ProfileActivityState = {
+  selectedActivity: ProfileActivity
+}
+
+const handleClick = (option: ProfileActivity, state: ProfileActivityState) => {
+  state.selectedActivity = option
+}
+
+const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) => {
+  if (option === ProfileActivity.All)  
+    return attrs.comments?.map(c => 
+      <div className="activity"> <p> { c.plaintext } </p> </div>
+    )
+  if (option === ProfileActivity.Threads)  
+    return attrs.threads?.map(t => 
+      <div className="activity"> <p> { t.title } </p> </div>
+    )
+  if (option === ProfileActivity.Communities)
+    return attrs.chains?.map(c => 
+      <div className="activity"> <p> { c.name } </p> </div>
+    )
+  if (option == ProfileActivity.Addresses)
+    return attrs.addresses?.map(a => 
+      <div className="activity"> <p> { a.address } </p> </div>
+    )
+}
+
+const NewProfileActivity : m.Component<ProfileActivityAttrs, ProfileActivityState> = {
+
+  oninit(vnode) {
+    vnode.state.selectedActivity = ProfileActivity.All
+  },
+
+  view(vnode) {
+    return(
+      <div className="ProfileActivity">
+        <div className="activity-nav">
+          <div className={vnode.state.selectedActivity == ProfileActivity.All ? 
+              "activity-nav-option selected" : "activity-nav-option"} 
+            onclick={()=>{handleClick(ProfileActivity.All, vnode.state)}}
+          >
+            <h4> All </h4>
+          </div>
+          <div className={vnode.state.selectedActivity == ProfileActivity.Threads ? 
+              "activity-nav-option selected" : "activity-nav-option"}  
+            onclick={()=>{handleClick(ProfileActivity.Threads, vnode.state)}}
+          >
+            <h4> Threads </h4>
+          </div>
+          <div className={vnode.state.selectedActivity == ProfileActivity.Communities ? 
+              "activity-nav-option selected" : "activity-nav-option"}  
+            onclick={()=>{handleClick(ProfileActivity.Communities, vnode.state)}}
+          >
+            <h4> All Communities </h4>
+          </div>
+          <div className={vnode.state.selectedActivity == ProfileActivity.Addresses ? 
+              "activity-nav-option selected" : "activity-nav-option"}  
+            onclick={()=>{handleClick(ProfileActivity.Addresses, vnode.state)}}
+          >
+            <h4> All Addresses </h4>
+          </div>
+        </div>
+        <div className="activity-section">
+          {
+            renderActivity(vnode.state.selectedActivity, vnode.attrs)
+          }
+        </div>
+      </div>
+    )
+  }
+}
+
+export default NewProfileActivity;
+

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -57,7 +57,15 @@ const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) =>
     )
   if (option === ProfileActivity.Communities)
     return attrs.chains?.map(c => 
-      <div className="activity"> <p> { c.name } </p> </div>
+      <a href={"/" + c.id}>
+        <div className="chain-entity"> 
+          <div className="chain-info">
+            <img src={c.icon_url} />
+            <p> { c.symbol } </p>
+          </div>
+        </div>
+      </a>
+      
     )
   if (option == ProfileActivity.Addresses)
     return attrs.addresses?.map(a => 

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -66,13 +66,16 @@ const NewProfileActivity : m.Component<ProfileActivityAttrs, ProfileActivityStat
             onclick={()=>{handleClick(ProfileActivity.All, vnode.state)}}
           >
             <h4> All </h4>
+            <div className="activity-count"> <p> { vnode.attrs.comments?.length } </p> </div>
           </div>
           <div className={vnode.state.selectedActivity == ProfileActivity.Threads ? 
               "activity-nav-option selected" : "activity-nav-option"}  
             onclick={()=>{handleClick(ProfileActivity.Threads, vnode.state)}}
           >
             <h4> Threads </h4>
+            <div className="activity-count"> <p> { vnode.attrs.threads?.length } </p> </div>
           </div>
+          <div className="divider"></div>
           <div className={vnode.state.selectedActivity == ProfileActivity.Communities ? 
               "activity-nav-option selected" : "activity-nav-option"}  
             onclick={()=>{handleClick(ProfileActivity.Communities, vnode.state)}}

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -54,16 +54,21 @@ const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) =>
   if (option === ProfileActivity.Threads)  
     return attrs.threads?.map(t => 
       <div className="activity"> 
+        <div className="comment-icon">
+          <CWIcon iconName="feedback" iconSize="small" />
+        </div>
         <div className="thread-chain"> 
-          <p> in <span className="heavy"> { t.chain } </span> </p>
+          <p> Thread in <span className="heavy"> { t.chain } </span> </p>
         </div>
         <div className="thread-date"> 
           <p> { transformTimestamp(t.created_at) } </p> 
         </div>
-        <div className="">
+        <div className="thread-title">
           <p> { t.title } </p> 
         </div>
-        
+        <div className="thread-body">
+          <p> { t.plaintext } </p>
+        </div>
       </div>
     )
   if (option === ProfileActivity.Communities)
@@ -80,7 +85,19 @@ const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) =>
     )
   if (option == ProfileActivity.Addresses)
     return attrs.addresses?.map(a => 
-      <div className="activity"> <p> { a.address } </p> </div>
+      <div className="activity"> 
+        <div className="address-icon">
+          <CWIcon iconName="account" iconSize="small" /> 
+        </div>
+        <div className="address-info">
+          <div className="address-text">
+            <p> You own address <span className="heavy"> { a.address } </span> </p> 
+          </div>
+          <div className="address-name">
+            <p> named <span className="heavy"> { a.name }  </span> on the <span className="heavy"> { a.chain }</span> chain. </p>
+          </div>
+        </div>
+      </div>
     )
 }
 

--- a/client/scripts/views/pages/new_profile/new_profile_activity.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_activity.tsx
@@ -9,6 +9,7 @@ import AddressInfo from 'client/scripts/models/AddressInfo'
 import { IUniqueId } from 'client/scripts/models/interfaces';
 
 import 'pages/new_profile.scss';
+import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 
 type ProfileActivityAttrs = {
   threads: Array<OffchainThread>,
@@ -35,7 +36,20 @@ const handleClick = (option: ProfileActivity, state: ProfileActivityState) => {
 const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) => {
   if (option === ProfileActivity.All)  
     return attrs.comments?.map(c => 
-      <div className="activity"> <p> { c.plaintext } </p> </div>
+      <div className="activity">
+        <div className="comment-icon">
+          <CWIcon iconName="feedback" iconSize="small" />
+        </div>
+        <div className="comment-chain">
+          <p> Commented in <span className="heavy"> { c.chain } </span> </p>
+        </div>
+        <div className="comment-date">
+          <p> { transformTimestamp(c.created_at) } </p> 
+        </div>
+        <div className="comment-text">
+          <p> { c.plaintext } </p> 
+        </div>
+      </div>
     )
   if (option === ProfileActivity.Threads)  
     return attrs.threads?.map(t => 
@@ -49,6 +63,13 @@ const renderActivity = (option: ProfileActivity, attrs: ProfileActivityAttrs) =>
     return attrs.addresses?.map(a => 
       <div className="activity"> <p> { a.address } </p> </div>
     )
+}
+
+const transformTimestamp = (timestamp) => {
+  let date = new Date(timestamp)
+  let dateString = date.toDateString()
+  let timeString = date.toLocaleTimeString()
+  return dateString + " " + timeString
 }
 
 const NewProfileActivity : m.Component<ProfileActivityAttrs, ProfileActivityState> = {

--- a/client/scripts/views/pages/new_profile/new_profile_header.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_header.tsx
@@ -1,0 +1,48 @@
+/* @jsx m */
+
+import m from 'mithril';
+
+import Profile from 'client/scripts/models/Profile'
+
+import { CWCard } from '../../components/component_kit/cw_card';
+import { CWAccount } from '../../components/component_kit/cw_icons/cw_icons';
+
+import 'pages/new_profile.scss';
+
+type ProfileHeaderAttrs = {
+  profile: Profile,
+};
+
+const NewProfileHeader : m.Component<ProfileHeaderAttrs> = {
+  view(vnode) {
+    const { profile } = vnode.attrs;
+    return(
+      <div className="ProfileHeader">
+        <div className="profile-image"> 
+            { /* profile image */ }
+        </div>
+
+        <CWCard
+          interactive={true}
+          fullWidth={true}
+          className="profile-content"
+        > 
+          <div className="section profile-name">
+            <h3> { profile?.profile_name } </h3>
+            <CWAccount className="profile-icon" iconName="account" iconSize="medium" />
+          </div>
+          
+          <div className="section">
+            <p> { profile?.bio } </p>
+          </div>
+
+          <div className="section">
+            <a> { profile?.website } </a>
+          </div>
+        </CWCard>
+      </div>
+    )
+  }
+}
+
+export default NewProfileHeader;

--- a/client/scripts/views/pages/new_profile/new_profile_header.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_header.tsx
@@ -2,20 +2,40 @@
 
 import m from 'mithril';
 
-import Profile from 'client/scripts/models/Profile'
+import { Profile } from 'client/scripts/models'
+import { SocialAccount } from 'client/scripts/models';
 
 import { CWCard } from '../../components/component_kit/cw_card';
 import { CWAccount } from '../../components/component_kit/cw_icons/cw_icons';
 
 import 'pages/new_profile.scss';
+import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 
 type ProfileHeaderAttrs = {
   profile: Profile,
+  socialAccounts: Array<SocialAccount>,
 };
 
+const renderSocialAccounts = (socialAccounts: Array<SocialAccount>) => {
+    return socialAccounts?.map(account => 
+      <div className="social-accounts">
+        <div className="social-account-icon">
+          {
+            account.provider == "github" ? <CWIcon iconName="github" iconSize="large" />
+            : account.provider == "discord" ? <CWIcon iconName="discord" iconSize="large" />
+            : account.provider == "telegram" ? <CWIcon iconName="telegram" iconSize="large" />
+            : <div />
+          }
+        </div>
+      </div>  
+    )
+}
+
 const NewProfileHeader : m.Component<ProfileHeaderAttrs> = {
+  
   view(vnode) {
-    const { profile } = vnode.attrs;
+    const { profile, socialAccounts } = vnode.attrs;
+
     return(
       <div className="ProfileHeader">
         <div className="profile-image"> 
@@ -27,19 +47,26 @@ const NewProfileHeader : m.Component<ProfileHeaderAttrs> = {
           fullWidth={true}
           className="profile-content"
         > 
-          <div className="section profile-name">
+          <section className="profile-name">
             <CWAccount className="profile-icon" iconName="account" iconSize="medium" />
             <h3> { profile?.profile_name } </h3>
-          </div>
-          
-          <div className="section">
-            <p> { profile?.bio } </p>
-          </div>
+          </section>
 
-          <div className="section">
+          <section>
+            <p> { profile?.bio } </p>
+          </section>
+
+          <section>
             <a> { profile?.website } </a>
-          </div>
+          </section>
+
+          <section>
+            { 
+              renderSocialAccounts(socialAccounts)
+            }
+          </section>
         </CWCard>
+
       </div>
     )
   }

--- a/client/scripts/views/pages/new_profile/new_profile_header.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_header.tsx
@@ -2,7 +2,7 @@
 
 import m from 'mithril';
 
-import { Profile } from 'client/scripts/models'
+import { NewProfile as Profile } from 'client/scripts/models'
 import { SocialAccount } from 'client/scripts/models';
 
 import { CWCard } from '../../components/component_kit/cw_card';
@@ -21,7 +21,7 @@ const renderSocialAccounts = (socialAccounts: Array<SocialAccount>) => {
       <div className="social-accounts">
         <div className="social-account-icon">
           {
-            account.provider == "github" ? <CWIcon iconName="github" iconSize="large" />
+            account.provider == "github" ? <a > <CWIcon iconName="github" iconSize="large" /> </a>
             : account.provider == "discord" ? <CWIcon iconName="discord" iconSize="large" />
             : account.provider == "telegram" ? <CWIcon iconName="telegram" iconSize="large" />
             : <div />
@@ -49,7 +49,7 @@ const NewProfileHeader : m.Component<ProfileHeaderAttrs> = {
         > 
           <section className="profile-name">
             <CWAccount className="profile-icon" iconName="account" iconSize="medium" />
-            <h3> { profile?.profile_name } </h3>
+            <h3> { profile?.name } </h3>
           </section>
 
           <section>

--- a/client/scripts/views/pages/new_profile/new_profile_header.tsx
+++ b/client/scripts/views/pages/new_profile/new_profile_header.tsx
@@ -28,8 +28,8 @@ const NewProfileHeader : m.Component<ProfileHeaderAttrs> = {
           className="profile-content"
         > 
           <div className="section profile-name">
-            <h3> { profile?.profile_name } </h3>
             <CWAccount className="profile-icon" iconName="account" iconSize="medium" />
+            <h3> { profile?.profile_name } </h3>
           </div>
           
           <div className="section">

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -69,7 +69,7 @@
         &:hover {
           cursor: pointer;
           h4 {
-            color: black;
+            color: $midi-gray;
           }
           
           .activity-count {
@@ -98,7 +98,7 @@
     }
 
     .activity-section {
-      margin: 30px 0;
+      margin: 40px 0;
 
       .activity {
         position: relative;
@@ -138,6 +138,45 @@
           font-weight: 600;
         }
       }
+
+      .chain-entity {
+        position: relative;
+        display: inline-block;
+        width: 140px;
+        height: 140px;
+        margin: 15px;
+
+        background-color: $background-gray;
+        border-radius: 6px;
+        border: 1px solid $background-gray;
+
+        &:hover {
+          cursor: pointer;
+          border: 1px solid #EEEEEE;
+        }
+
+        .chain-info {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -53%);
+          width: 65%;
+          height: 65%;
+
+          img {
+            width: 100%;
+            height: 100%;
+          }
+
+          p {
+            margin-top: 4px;
+            text-align: center;
+            color: $midi-gray;
+            font-size: 13px;
+          }
+        }
+      }
+
     }
 
   }

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -102,18 +102,18 @@
 
       .activity {
         position: relative;
-        height: 120px;
+        height: 130px;
         padding: 10px 25px;
         border-bottom: 1px solid $lite-gray;
 
-        .comment-icon {
+        .comment-icon, .address-icon {
           position: absolute;
-          top: 13px;
+          top: 14px;
           left: 0px;
         }
 
-        .comment-chain, .thread-chain {
-          margin-bottom: 15px;
+        .comment-chain, .thread-chain, .address-name {
+          margin-bottom: 10px;
           p {
             color: $midi-gray;
           }
@@ -132,6 +132,19 @@
           width: 85%;
           max-height: 90px;
           font-size: 16px;
+        }
+
+        .thread-title {
+          margin-bottom: 10px;
+        }
+
+        .thread-body {
+          width: 85%;
+          color: $midi-gray;
+        }
+
+        .address-text {
+          margin-bottom: 10px;
         }
 
         .heavy {
@@ -177,7 +190,6 @@
           }
         }
       }
-
     }
 
   }

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -13,7 +13,7 @@
     .profile-content {
       padding: 20px 40px;
 
-      .section {
+      section {
         margin: 5px 0;
       }
 
@@ -24,6 +24,15 @@
           margin: 5px 10px 0 0;
         }
       }
+
+      .social-accounts {
+        display: flex;
+
+        .social-account-icon {
+          margin-right: 15px;
+        }
+      }
+
     }
 
   } 

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -35,16 +35,53 @@
       display: flex;
 
       .activity-nav-option {
+        position: relative;
+        display: flex;
         min-width: 50px;
-        padding: 5px 0;
+        padding: 6px 0;
         margin-right: 20px;
         &:hover {
           cursor: pointer;
+          h4 {
+            color: black;
+          }
+        }
+        
+        h4 {
+          color: $lite-gray;
+          margin-top: 2px;
+          transition: color .2s ease-in;
+        }
+
+        .activity-count {
+          position: relative;
+          width: 45px;
+          height: 25px;
+          background-color: $background-gray;
+          border-radius: 12px;
+          margin-left: 12px;
+
+          p {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -60%);
+            font-size: small;
+            font-weight: 600;
+          }
         }
       }
-
       .selected {
         border-bottom: 2px solid #4723AD;
+        h4 {
+          color: black;
+        }
+      }
+      .divider {
+        width: 1px;
+        height: 24px;
+        border-right: 1px solid $lite-gray;
+        margin: 7px 20px 0 0;
       }
     }
 

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -40,12 +40,6 @@
         min-width: 50px;
         padding: 6px 0;
         margin-right: 20px;
-        &:hover {
-          cursor: pointer;
-          h4 {
-            color: black;
-          }
-        }
         
         h4 {
           color: $lite-gray;
@@ -57,9 +51,10 @@
           position: relative;
           width: 45px;
           height: 25px;
-          background-color: $background-gray;
+          background-color: white;
           border-radius: 12px;
           margin-left: 12px;
+          transition: background-color .2s ease-in;
 
           p {
             position: absolute;
@@ -70,13 +65,30 @@
             font-weight: 600;
           }
         }
-      }
-      .selected {
-        border-bottom: 2px solid #4723AD;
-        h4 {
-          color: black;
+
+        &:hover {
+          cursor: pointer;
+          h4 {
+            color: black;
+          }
+          
+          .activity-count {
+            background-color: $background-gray;
+          }
+        }
+
+        &.selected {
+          border-bottom: 2px solid #4723AD;
+          h4 {
+            color: black;
+          }
+
+          .activity-count {
+            background-color: $background-gray;
+          }
         }
       }
+
       .divider {
         width: 1px;
         height: 24px;
@@ -87,10 +99,44 @@
 
     .activity-section {
       margin: 30px 0;
+
       .activity {
-        height: 60px;
-        padding: 10px 10px;
+        position: relative;
+        height: 120px;
+        padding: 10px 25px;
         border-bottom: 1px solid $lite-gray;
+
+        .comment-icon {
+          position: absolute;
+          top: 13px;
+          left: 0px;
+        }
+
+        .comment-chain {
+          margin-bottom: 15px;
+          p {
+            color: $midi-gray;
+          }
+        }
+
+        .comment-date {
+          position: absolute;
+          top: 10px;
+          right: 10px;
+          p {
+            color: $midi-gray;
+          }
+        }
+
+        .comment-text {
+          width: 85%;
+          max-height: 90px;
+        }
+
+        .heavy {
+          color: black;
+          font-weight: 600;
+        }
       }
     }
 

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -21,7 +21,7 @@
         display: flex;
 
         .profile-icon {
-          margin: 5px 0 0 10px;
+          margin: 5px 10px 0 0;
         }
       }
     }
@@ -112,14 +112,14 @@
           left: 0px;
         }
 
-        .comment-chain {
+        .comment-chain, .thread-chain {
           margin-bottom: 15px;
           p {
             color: $midi-gray;
           }
         }
 
-        .comment-date {
+        .comment-date, .thread-date {
           position: absolute;
           top: 10px;
           right: 10px;
@@ -131,6 +131,7 @@
         .comment-text {
           width: 85%;
           max-height: 90px;
+          font-size: 16px;
         }
 
         .heavy {

--- a/client/styles/pages/new_profile.scss
+++ b/client/styles/pages/new_profile.scss
@@ -1,0 +1,65 @@
+@import 'client/styles/shared';
+@import 'construct-ui/src/_shared/_colors';
+
+.ProfilePage {
+  position: relative;
+  max-width: 1000px;
+  margin: 0 auto;
+
+  .ProfileHeader {
+
+    margin: 30px 0;
+
+    .profile-content {
+      padding: 20px 40px;
+
+      .section {
+        margin: 5px 0;
+      }
+
+      .profile-name {
+        display: flex;
+
+        .profile-icon {
+          margin: 5px 0 0 10px;
+        }
+      }
+    }
+
+  } 
+
+  .ProfileActivity {
+    margin: 30px 0;
+
+    .activity-nav {
+      display: flex;
+
+      .activity-nav-option {
+        min-width: 50px;
+        padding: 5px 0;
+        margin-right: 20px;
+        &:hover {
+          cursor: pointer;
+        }
+      }
+
+      .selected {
+        border-bottom: 2px solid #4723AD;
+      }
+    }
+
+    .activity-section {
+      margin: 30px 0;
+      .activity {
+        height: 60px;
+        padding: 10px 10px;
+        border-bottom: 1px solid $lite-gray;
+      }
+    }
+
+  }
+
+}
+
+
+

--- a/server/models/social_account.ts
+++ b/server/models/social_account.ts
@@ -7,6 +7,7 @@ export type SocialAccountAttributes = {
   provider: string;
   provider_username: string;
   provider_userid: string;
+  user_id: string,
   access_token: string;
   refresh_token: string;
   id?: number;
@@ -33,6 +34,7 @@ export default (
     provider: { type: dataTypes.STRING },
     provider_username: { type: dataTypes.STRING },
     provider_userid: { type: dataTypes.STRING },
+    user_id: { type: dataTypes.STRING },
     access_token: { type: dataTypes.STRING },
     refresh_token: { type: dataTypes.STRING },
     created_at: { type: dataTypes.DATE, allowNull: false },

--- a/server/router.ts
+++ b/server/router.ts
@@ -51,6 +51,7 @@ import addMember from './routes/addMember';
 import upgradeMember from './routes/upgradeMember';
 import deleteSocialAccount from './routes/deleteSocialAccount';
 import getProfile from './routes/getProfile';
+import getNewProfile from './routes/getNewProfile';
 
 import createRole from './routes/createRole';
 import deleteRole from './routes/deleteRole';
@@ -311,6 +312,7 @@ function setupRouter(
   router.get('/searchComments', searchComments.bind(this, models));
 
   router.get('/profile', getProfile.bind(this, models));
+  router.get('/profile/v2', getNewProfile.bind(this, models));
 
   // offchain discussion drafts
   router.post(

--- a/server/routes/getNewProfile.ts
+++ b/server/routes/getNewProfile.ts
@@ -35,6 +35,15 @@ const getNewProfile = async (models: DB, req: Request, res: Response, next: Next
     }
   })
 
+  const chainIds = [... new Set<string>(addresses.map(a => a.chain))]
+  const chains = await models.Chain.findAll({
+    where: {
+      id: {
+        [Op.in]: chainIds,
+      },
+    }
+  })
+
   const threads = await models.OffchainThread.findAll({
     where: {
       address_id: addressModel.id
@@ -54,7 +63,8 @@ const getNewProfile = async (models: DB, req: Request, res: Response, next: Next
       profile: profileModel,
       addresses: addresses.map((a) => a.toJSON()),
       threads: threads.map((t) => t.toJSON()), 
-      comments: comments.map((c) => c.toJSON())
+      comments: comments.map((c) => c.toJSON()),
+      chains: chains.map((c) => c.toJSON()),
     })
 }
 

--- a/server/routes/getNewProfile.ts
+++ b/server/routes/getNewProfile.ts
@@ -1,0 +1,61 @@
+import { Request, Response, NextFunction } from 'express';
+import { Op } from 'sequelize';
+import { factory, formatFilename } from '../../shared/logging';
+const log = factory.getLogger(formatFilename(__filename));
+import { DB } from '../database';
+
+export const Errors = {
+  NoAddressProvided: 'No address provided in query',
+  NoAddressFound: 'No address found',
+  NoProfileFound: 'No profile found',
+};
+
+const getNewProfile = async (models: DB, req: Request, res: Response, next: NextFunction) => {
+  const { address } = req.query;
+  if (!address) return next(new Error(Errors.NoAddressProvided));
+
+  const addressModel = await models.Address.findOne({
+    where: {
+      address,
+    },
+    include: [ models.OffchainProfile, ],
+  });
+  if (!addressModel) return next(new Error(Errors.NoAddressFound));
+
+  const profileModel = await models.Profile.findOne({
+    where: {
+      id: addressModel.profile_id,
+    },
+  });
+  if (!profileModel) return next(new Error(Errors.NoProfileFound));
+
+  const addresses = await models.Address.findAll({
+    where: {
+      profile_id: profileModel.id,
+    }
+  })
+
+  const threads = await models.OffchainThread.findAll({
+    where: {
+      address_id: addressModel.id
+    },
+    include: [ { model: models.Address, as: 'Address' } ],
+  });
+
+  const comments = await models.OffchainComment.findAll({
+    where: {
+      address_id: addressModel.id,
+    },
+  });
+
+  return res
+    .status(200)
+    .json({
+      profile: profileModel,
+      addresses: addresses.map((a) => a.toJSON()),
+      threads: threads.map((t) => t.toJSON()), 
+      comments: comments.map((c) => c.toJSON())
+    })
+}
+
+export default getNewProfile;

--- a/server/routes/getNewProfile.ts
+++ b/server/routes/getNewProfile.ts
@@ -22,16 +22,16 @@ const getNewProfile = async (models: DB, req: Request, res: Response, next: Next
   });
   if (!addressModel) return next(new Error(Errors.NoAddressFound));
 
-  const profileModel = await models.Profile.findOne({
+  const profile = await models.Profile.findOne({
     where: {
       id: addressModel.profile_id,
     },
   });
-  if (!profileModel) return next(new Error(Errors.NoProfileFound));
+  if (!profile) return next(new Error(Errors.NoProfileFound));
 
   const addresses = await models.Address.findAll({
     where: {
-      profile_id: profileModel.id,
+      profile_id: profile.id,
     }
   })
 
@@ -57,14 +57,21 @@ const getNewProfile = async (models: DB, req: Request, res: Response, next: Next
     },
   });
 
+  const socialAccounts = await models.SocialAccount.findAll({
+    where: {
+      user_id: profile.user_id
+    },
+  })
+
   return res
     .status(200)
     .json({
-      profile: profileModel,
-      addresses: addresses.map((a) => a.toJSON()),
-      threads: threads.map((t) => t.toJSON()), 
-      comments: comments.map((c) => c.toJSON()),
-      chains: chains.map((c) => c.toJSON()),
+      profile,
+      addresses: addresses.map(a => a.toJSON()),
+      threads: threads.map(t => t.toJSON()), 
+      comments: comments.map(c => c.toJSON()),
+      chains: chains.map(c => c.toJSON()),
+      socialAccounts: socialAccounts.map(s => s.toJSON()),
     })
 }
 


### PR DESCRIPTION
This Draft PR sets up the scaffolding and preliminary styling for a new profile page. This is _not_ final and will be reviewed and iterated on.

## Description
The new profile page is chain agnostic and can be accessed via `profile/:address`.
This PR contains the new route to display the profile page (`profile/:address`), a new endpoint to retrieve the requisite data, and some bare bones styling based on old Figma designs.

## Outstanding Questions and Concerns
- The new Profile schema doesn’t contain an avatarURL to display.
- SocialAccount schema doesn’t contain a URL for the social account
- Is there a `thread` icon that’s distinct from the comment icon?



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no