### PR TITLE
Support flag for admin only poll creation.

### DIFF
--- a/client/scripts/models/ChainInfo.ts
+++ b/client/scripts/models/ChainInfo.ts
@@ -36,6 +36,7 @@ class ChainInfo {
   public readonly bech32Prefix: string;
   public decimals: number;
   public substrateSpec: RegisteredTypes;
+  public adminOnlyPolling: boolean;
 
   constructor({
     id,
@@ -65,6 +66,7 @@ class ChainInfo {
     type,
     decimals,
     substrateSpec,
+    adminOnlyPolling,
   }) {
     this.id = id;
     this.network = network;
@@ -94,6 +96,7 @@ class ChainInfo {
     this.bech32Prefix = bech32_prefix;
     this.decimals = decimals;
     this.substrateSpec = substrateSpec;
+    this.adminOnlyPolling = adminOnlyPolling;
   }
 
   public static fromJSON({
@@ -124,6 +127,7 @@ class ChainInfo {
     type,
     decimals,
     substrate_spec,
+    admin_only_polling,
   }) {
     let blockExplorerIdsParsed;
     try {
@@ -160,6 +164,7 @@ class ChainInfo {
       type,
       decimals: parseInt(decimals, 10),
       substrateSpec: substrate_spec,
+      adminOnlyPolling: admin_only_polling,
     });
   }
 

--- a/client/scripts/views/pages/view_proposal/index.ts
+++ b/client/scripts/views/pages/view_proposal/index.ts
@@ -1376,6 +1376,7 @@ const ViewProposalPage: m.Component<
               m(ProposalHeaderOffchainPoll, { proposal }),
             proposal instanceof OffchainThread &&
               isAuthor &&
+              (!app.chain?.meta?.chain?.adminOnlyPolling || isAdminOnly) &&
               !proposal.offchainVotingEnabled &&
               m(PollEditorCard, {
                 proposal,

--- a/server/migrations/20220502181130-admin-only-polling.js
+++ b/server/migrations/20220502181130-admin-only-polling.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn('Chains', 'admin_only_polling', {
+        type: Sequelize.BOOLEAN,
+        allowNull: true
+      }, { transaction: t });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('Chains', 'admin_only_polling', { transaction: t });
+    });
+  }
+};

--- a/server/models/chain.ts
+++ b/server/models/chain.ts
@@ -40,6 +40,7 @@ export type ChainAttributes = {
   has_chain_events_listener?: boolean;
   default_summary_view?: boolean;
   terms?: string;
+  admin_only_polling?: boolean;
   snapshot?: string[];
   bech32_prefix?: string;
 
@@ -126,6 +127,7 @@ export default (
       },
       terms: { type: dataTypes.STRING, allowNull: true },
       bech32_prefix: { type: dataTypes.STRING, allowNull: true },
+      admin_only_polling: { type: dataTypes.BOOLEAN, allowNull: true },
     },
     {
       tableName: 'Chains',

--- a/server/routes/updateThreadPolling.ts
+++ b/server/routes/updateThreadPolling.ts
@@ -51,7 +51,7 @@ const updateThreadPolling = async (models: DB, req: Request, res: Response, next
           chain_id: thread.Chain.id,
         }
       });
-      if (role?.permission !== 'admin') {
+      if (role?.permission !== 'admin' && !req.user.isAdmin) {
         return next(new Error(Errors.MustBeAdmin));
       }
     }

--- a/server/routes/updateThreadPolling.ts
+++ b/server/routes/updateThreadPolling.ts
@@ -13,6 +13,7 @@ export const Errors = {
   InvalidContent: 'Invalid poll content',
   NotAuthor: 'Only the thread author can start polling',
   InvalidDuration: 'Invalid poll duration',
+  MustBeAdmin: 'Must be admin to create poll',
 };
 
 const updateThreadPolling = async (models: DB, req: Request, res: Response, next: NextFunction) => {
@@ -32,6 +33,7 @@ const updateThreadPolling = async (models: DB, req: Request, res: Response, next
       where: {
         id: thread_id,
       },
+      include: models.Chain,
     });
     if (!thread) return next(new Error(Errors.NoThread));
     const userOwnedAddressIds = (await req.user.getAddresses())
@@ -39,6 +41,19 @@ const updateThreadPolling = async (models: DB, req: Request, res: Response, next
     // We should allow collaborators to start polling too
     if (!req.user || !userOwnedAddressIds.includes(thread.address_id)) {
       return next(new Error(Errors.NotAuthor));
+    }
+
+    // check if admin_only flag is set
+    if (thread.Chain?.admin_only_polling) {
+      const role = await models.Role.findOne({
+        where: {
+          address_id: thread.address_id,
+          chain_id: thread.Chain.id,
+        }
+      });
+      if (role?.permission !== 'admin') {
+        return next(new Error(Errors.MustBeAdmin));
+      }
     }
 
     // Check that req.body.content is valid JSON, matching { name: string, choices: string[] }


### PR DESCRIPTION
- Adds a column to Chain that gates poll creation on admin role.
- Hide polling creation box for non-admins when flag is set.