### PR TITLE
Re-instate cmd click new tab on discussion rows

### DIFF
--- a/client/scripts/views/pages/discussions/discussion_row.tsx
+++ b/client/scripts/views/pages/discussions/discussion_row.tsx
@@ -17,7 +17,6 @@ import {
   link,
   externalLink,
   extractDomain,
-  pluralize,
   offchainThreadStageToLabel,
 } from 'helpers';
 import {
@@ -46,7 +45,6 @@ export class DiscussionRow implements m.ClassComponent<DiscussionRowAttrs> {
       proposal.slug,
       `${proposal.identifier}-${slugify(proposal.title)}`
     );
-
     return (
       <div
         class="DiscussionRow"
@@ -55,7 +53,10 @@ export class DiscussionRow implements m.ClassComponent<DiscussionRowAttrs> {
             return vnode.attrs.onSelect();
           }
           if ($(e.target).hasClass('cui-tag')) return;
-          if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) return;
+          if (e.metaKey || e.altKey || e.shiftKey || e.ctrlKey) {
+            window.open(discussionLink, '_blank');
+            return;
+          }
           e.preventDefault();
           const scrollEle = document.getElementsByClassName('Body')[0];
           localStorage[`${app.activeChainId()}-discussions-scrollY`] =


### PR DESCRIPTION
There are several ways to approach this, none seemed optimal, I picked one. Tagged @affordances to see if he had an opinion on different approaches.

Cmd-click support for discussion rows disappeared over the last few months of refactoring. Previously, discussion row titles were `link()` components, using the `link` helper function with cmd-click support. This title was nested within a larger discussion row div, featuring an `onclick` listener, which used `m.route.set`. Note: AFAICT from online docs, m.route.set does not provide support for opening links in new tabs. 

This wasn't optimal because it nested a link within a link, assigning different behaviors to the different nesting levels.

This branch attaches a `window.open()` invocation to the top-level discussion row div `onclick` listener, triggered when the user holds down cmd key (or ctrl, or meta). 

I don't love that window.open is a non-native, non-Mithril solution—I worry about potential edgecases w/r/t preserving state data. Moreover, history from the previous tab is not preserved in the new tab.

An alternative is to use a high-level `a` tag, with `div` tags nested inside it, which is semantically incorrect but perhaps functionally more elegant. This provides normal `href` support, relieving us of the need for `window.open`, and allowing native cmd-click support.

Additionally, Zak or Gabe might be aware of Mithril routing or history API features that can mitigate issues with the present solution.