### PR TITLE
Mixpanel Fix

### DIFF
--- a/client/scripts/app.ts
+++ b/client/scripts/app.ts
@@ -1108,10 +1108,16 @@ Promise.all([$.ready, $.get('/api/domain')]).then(
         document.location.host.startsWith('localhost') ||
         document.location.host.startsWith('127.0.0.1')
       ) {
-        mixpanel.init(MIXPANEL_DEV_TOKEN, { debug: true });
+        mixpanel.init(MIXPANEL_DEV_TOKEN, {
+          debug: true,
+          disable_persistence: true,
+        });
       } else {
         // Production Mixpanel Project
-        mixpanel.init(MIXPANEL_PROD_TOKEN, { debug: true });
+        mixpanel.init(MIXPANEL_PROD_TOKEN, {
+          debug: true,
+          disable_persistence: true,
+        });
       }
     } catch (e) {
       console.error('Mixpanel initialization error');

--- a/server/util/mixpanelUtil.ts
+++ b/server/util/mixpanelUtil.ts
@@ -6,11 +6,15 @@ var Mixpanel = require('mixpanel');
 var mixpanelNode;
 
 if (process.env.NODE_ENV === 'production') {
-  mixpanelNode = Mixpanel.init(process.env.MIXPANEL_PROD_TOKEN); //TODO: Swap with prod token when tested
+  mixpanelNode = Mixpanel.init(process.env.MIXPANEL_PROD_TOKEN, {
+    disable_persistence: true,
+  }); //TODO: Swap with prod token when tested
 } else if (process.env.NODE_ENV === 'development') {
   // NOTE: Only works if NODE_ENV defined in .env
   // Make sure that is set to development if you want to use backend Mixpanel locally.
-  mixpanelNode = Mixpanel.init(process.env.MIXPANEL_DEV_TOKEN);
+  mixpanelNode = Mixpanel.init(process.env.MIXPANEL_DEV_TOKEN, {
+    disable_persistence: true,
+  });
 }
 
 // ----- Server Side Mixpanel Library Utils ------ //


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A small change needed to stop a Mixpanel token cookie from preventing the init using our production project token.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Production project was not receiving events. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally. 

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [x] no