### PR TITLE
Migrate Addresses and SocialAccounts table for Twitter attestation modal

### DIFF
--- a/server/migrations/20220526203204-add-access-token-secret-and-attested-to-social-accounts.js
+++ b/server/migrations/20220526203204-add-access-token-secret-and-attested-to-social-accounts.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn('SocialAccounts', 'access_token_secret', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }, {
+        transaction: t
+      });
+      await queryInterface.addColumn('SocialAccounts', 'attested', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      }, {
+        transaction: t
+      });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('SocialAccounts', 'access_token_secret', { transaction: t });
+      await queryInterface.removeColumn('SocialAccounts', 'attested', { transaction: t });
+    });
+  }
+};

--- a/server/migrations/20220526203443-add-twitter-verified-and-twitter-verification-msg-to-addresses.js
+++ b/server/migrations/20220526203443-add-twitter-verified-and-twitter-verification-msg-to-addresses.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'Addresses',
+        'twitter_verified',
+        { type: Sequelize.BOOLEAN, allowNull: true },
+        { transaction : t }
+      );
+      await queryInterface.addColumn(
+        'Addresses',
+        'twitter_verification_msg',
+        { type: Sequelize.STRING, allowNull: true },
+        { transaction : t }
+      );
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        'Addresses',
+        'twitter_verified',
+        { transaction : t }
+      );
+      await queryInterface.removeColumn(
+        'Addresses',
+        'twitter_verification_msg',
+        { transaction : t }
+      );
+    });
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Migrate the SocialAccounts and Addresses table for the Twitter attestation modal.

## Description

Add the columns `access_token_secret` and `attested` to the SocialAccounts table.
Add the columns `twitter_verified` and `twitter_verification_msg` to the Addresses table.

## Motivation and Context


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes

## Does this PR affect any server routes?
- [ ] yes, and they are tested: [enter the % coverage here]
- [ ] yes, and they are not tested: [enter the % coverage here]
- [ ] yes, but I did not run tests
- [ ] no