### PR TITLE
Fix refresh bug on viewProposal page

### DIFF
--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -717,6 +717,31 @@ const countLinesMarkdown = (text) => {
   return text.split('\n').length - 1;
 };
 
+const formatBody = (vnode) => {
+  const { item } = vnode.attrs;
+  if (!item) return;
+
+  const body =
+    item instanceof OffchainComment
+      ? item.text
+      : item instanceof OffchainThread
+      ? item.body
+      : item.description;
+  if (!body) return;
+
+  vnode.state.body = body;
+  try {
+    const doc = JSON.parse(body);
+    if (countLinesQuill(doc.ops) > QUILL_PROPOSAL_LINES_CUTOFF_LENGTH) {
+      vnode.state.collapsed = true;
+    }
+  } catch (e) {
+    if (countLinesMarkdown(body) > MARKDOWN_PROPOSAL_LINES_CUTOFF_LENGTH) {
+      vnode.state.collapsed = true;
+    }
+  }
+}
+
 export const ProposalBodyText: m.Component<
   {
     item: AnyProposal | OffchainThread | OffchainComment<any>;
@@ -725,28 +750,10 @@ export const ProposalBodyText: m.Component<
 > = {
   oninit: (vnode) => {
     vnode.state.collapsed = false;
-    const { item } = vnode.attrs;
-    if (!item) return;
-
-    const body =
-      item instanceof OffchainComment
-        ? item.text
-        : item instanceof OffchainThread
-        ? item.body
-        : item.description;
-    if (!body) return;
-
-    vnode.state.body = body;
-    try {
-      const doc = JSON.parse(body);
-      if (countLinesQuill(doc.ops) > QUILL_PROPOSAL_LINES_CUTOFF_LENGTH) {
-        vnode.state.collapsed = true;
-      }
-    } catch (e) {
-      if (countLinesMarkdown(body) > MARKDOWN_PROPOSAL_LINES_CUTOFF_LENGTH) {
-        vnode.state.collapsed = true;
-      }
-    }
+    formatBody(vnode);
+  },
+  onupdate: (vnode) => {
+    formatBody(vnode);
   },
   view: (vnode) => {
     const { body } = vnode.state;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- When going between threads via notification redirects, the proposal body and comment bodies wouldn't update (if already rendered). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
