### PR TITLE
Remove awaits when calling emitNotifications

### DIFF
--- a/server/routes/addEditors.ts
+++ b/server/routes/addEditors.ts
@@ -118,7 +118,7 @@ const addEditors = async (
   await thread.save();
 
   if (collaborators?.length > 0) {
-    collaborators.map(async (collaborator) => {
+    collaborators.map((collaborator) => {
       if (!collaborator.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
       models.Subscription.emitNotifications(

--- a/server/routes/addEditors.ts
+++ b/server/routes/addEditors.ts
@@ -117,38 +117,38 @@ const addEditors = async (
 
   await thread.save();
 
-  if (collaborators?.length > 0)
-    await Promise.all(
-      collaborators.map(async (collaborator) => {
-        if (!collaborator.User) return; // some Addresses may be missing users, e.g. if the user removed the address
+  if (collaborators?.length > 0) {
+    collaborators.map(async (collaborator) => {
+      if (!collaborator.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
-        await models.Subscription.emitNotifications(
-          models,
-          NotificationCategories.NewCollaboration,
-          `user-${collaborator.User.id}`,
-          {
-            created_at: new Date(),
-            root_id: +thread.id,
-            root_type: ProposalType.OffchainThread,
-            root_title: thread.title,
-            comment_text: thread.body,
-            chain_id: thread.chain,
-            author_address: author.address,
-            author_chain: author.chain,
-          },
-          {
-            user: author.address,
-            url: getProposalUrl('discussion', thread),
-            title: req.body.title,
-            bodyUrl: req.body.url,
-            chain: thread.chain,
-            body: thread.body,
-          },
-          req.wss,
-          [author.address]
-        );
-      })
-    );
+      models.Subscription.emitNotifications(
+        models,
+        NotificationCategories.NewCollaboration,
+        `user-${collaborator.User.id}`,
+        {
+          created_at: new Date(),
+          root_id: +thread.id,
+          root_type: ProposalType.OffchainThread,
+          root_title: thread.title,
+          comment_text: thread.body,
+          chain_id: thread.chain,
+          author_address: author.address,
+          author_chain: author.chain,
+        },
+        {
+          user: author.address,
+          url: getProposalUrl('discussion', thread),
+          title: req.body.title,
+          bodyUrl: req.body.url,
+          chain: thread.chain,
+          body: thread.body,
+        },
+        req.wss,
+        [author.address]
+      );
+    })
+  }
+
 
   const finalCollaborations = await models.Collaboration.findAll({
     where: { offchain_thread_id: thread.id },

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -357,7 +357,7 @@ const createComment = async (
   excludedAddrs.push(finalComment.Address.address);
 
   // dispatch notifications to root thread
-  await models.Subscription.emitNotifications(
+  models.Subscription.emitNotifications(
     models,
     NotificationCategories.NewComment,
     root_id,
@@ -386,7 +386,7 @@ const createComment = async (
 
   // if child comment, dispatch notification to parent author
   if (parent_id && parentComment) {
-    await models.Subscription.emitNotifications(
+    models.Subscription.emitNotifications(
       models,
       NotificationCategories.NewComment,
       `comment-${parent_id}`,
@@ -418,13 +418,12 @@ const createComment = async (
 
   // notify mentioned users if they have permission to view the originating forum
   if (mentionedAddresses?.length > 0) {
-    await Promise.all(
       mentionedAddresses.map(async (mentionedAddress) => {
         if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
         const shouldNotifyMentionedUser = true;
         if (shouldNotifyMentionedUser)
-          await models.Subscription.emitNotifications(
+          models.Subscription.emitNotifications(
             models,
             NotificationCategories.NewMention,
             `user-${mentionedAddress.User.id}`,
@@ -450,8 +449,7 @@ const createComment = async (
             req.wss,
             [finalComment.Address.address]
           );
-      })
-    );
+      });
   }
 
   // update author.last_active (no await)

--- a/server/routes/createComment.ts
+++ b/server/routes/createComment.ts
@@ -418,7 +418,7 @@ const createComment = async (
 
   // notify mentioned users if they have permission to view the originating forum
   if (mentionedAddresses?.length > 0) {
-      mentionedAddresses.map(async (mentionedAddress) => {
+      mentionedAddresses.map((mentionedAddress) => {
         if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
         const shouldNotifyMentionedUser = true;

--- a/server/routes/createReaction.ts
+++ b/server/routes/createReaction.ts
@@ -220,7 +220,8 @@ const createReaction = async (
   const location = thread_id
     ? `discussion_${thread_id}`
     : proposal_id || `comment-${comment_id}`;
-  await models.Subscription.emitNotifications(
+
+  models.Subscription.emitNotifications(
     models,
     NotificationCategories.NewReaction,
     location,
@@ -236,6 +237,7 @@ const createReaction = async (
     req.wss,
     [finalReaction.Address.address]
   );
+
   // update author.last_active (no await)
   author.last_active = new Date();
   author.save();

--- a/server/routes/createThread.ts
+++ b/server/routes/createThread.ts
@@ -139,7 +139,7 @@ const dispatchHooks = async (
   excludedAddrs.push(finalThread.Address.address);
 
   // dispatch notifications to subscribers of the given chain
-  await models.Subscription.emitNotifications(
+  models.Subscription.emitNotifications(
     models,
     NotificationCategories.NewThread,
     location,

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -181,7 +181,7 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
 
     // notify mentioned users, given permissions are in place
     if (mentionedAddresses?.length > 0) {
-      mentionedAddresses.map(async (mentionedAddress) => {
+      mentionedAddresses.map((mentionedAddress) => {
         if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
         models.Subscription.emitNotifications(
           models,

--- a/server/routes/editComment.ts
+++ b/server/routes/editComment.ts
@@ -115,7 +115,7 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
     const root_title = typeof proposal === 'string' ? '' : (proposal.title || '');
 
     // dispatch notifications to subscribers of the comment/thread
-    await models.Subscription.emitNotifications(
+    models.Subscription.emitNotifications(
       models,
       NotificationCategories.CommentEdit,
       '',
@@ -181,9 +181,9 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
 
     // notify mentioned users, given permissions are in place
     if (mentionedAddresses?.length > 0) {
-      await Promise.all(mentionedAddresses.map(async (mentionedAddress) => {
+      mentionedAddresses.map(async (mentionedAddress) => {
         if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
-        await models.Subscription.emitNotifications(
+        models.Subscription.emitNotifications(
           models,
           NotificationCategories.NewMention,
           `user-${mentionedAddress.User.id}`,
@@ -209,7 +209,7 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
           req.wss,
           [ finalComment.Address.address ],
         );
-      }));
+      });
     }
 
     // update author.last_active (no await)

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -215,7 +215,7 @@ const editThread = async (models: DB, banCache: BanCache, req: Request, res: Res
 
     // notify mentioned users, given permissions are in place
     if (mentionedAddresses?.length > 0) {
-      mentionedAddresses.map(async (mentionedAddress) => {
+      mentionedAddresses.map((mentionedAddress) => {
         if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
         models.Subscription.emitNotifications(

--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -156,7 +156,7 @@ const editThread = async (models: DB, banCache: BanCache, req: Request, res: Res
     });
 
     // dispatch notifications to subscribers of the given chain
-    await models.Subscription.emitNotifications(
+    models.Subscription.emitNotifications(
       models,
       NotificationCategories.ThreadEdit,
       '',
@@ -214,35 +214,37 @@ const editThread = async (models: DB, banCache: BanCache, req: Request, res: Res
     }
 
     // notify mentioned users, given permissions are in place
-    if (mentionedAddresses?.length > 0) await Promise.all(mentionedAddresses.map(async (mentionedAddress) => {
-      if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
+    if (mentionedAddresses?.length > 0) {
+      mentionedAddresses.map(async (mentionedAddress) => {
+        if (!mentionedAddress.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
-      await models.Subscription.emitNotifications(
-        models,
-        NotificationCategories.NewMention,
-        `user-${mentionedAddress.User.id}`,
-        {
-          created_at: new Date(),
-          root_id: +finalThread.id,
-          root_type: ProposalType.OffchainThread,
-          root_title: finalThread.title,
-          comment_text: finalThread.body,
-          chain_id: finalThread.chain,
-          author_address: finalThread.Address.address,
-          author_chain: finalThread.Address.chain,
-        },
-        {
-          user: finalThread.Address.address,
-          url: getProposalUrl('discussion', finalThread),
-          title: req.body.title,
-          bodyUrl: req.body.url,
-          chain: finalThread.chain,
-          body: finalThread.body,
-        },
-        req.wss,
-        [ finalThread.Address.address ],
-      );
-    }));
+        models.Subscription.emitNotifications(
+          models,
+          NotificationCategories.NewMention,
+          `user-${mentionedAddress.User.id}`,
+          {
+            created_at: new Date(),
+            root_id: +finalThread.id,
+            root_type: ProposalType.OffchainThread,
+            root_title: finalThread.title,
+            comment_text: finalThread.body,
+            chain_id: finalThread.chain,
+            author_address: finalThread.Address.address,
+            author_chain: finalThread.Address.chain,
+          },
+          {
+            user: finalThread.Address.address,
+            url: getProposalUrl('discussion', finalThread),
+            title: req.body.title,
+            bodyUrl: req.body.url,
+            chain: finalThread.chain,
+            body: finalThread.body,
+          },
+          req.wss,
+          [ finalThread.Address.address ],
+        );
+      });
+    }
 
     // TODO: update author.last_active
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the `await` when calling `emitNotifications` across all server routes.

## Motivation and Context
The routes do not need `emitNotifications` to complete in order to return. Awaiting the result meant certain routes such as `createComment` took upwards of 20 seconds to complete when lots of notifications had to be emitted. It also meant that the more popular a thread became the longer it would take for the route to complete (essentially exponentially getting worse).

## How has this been tested?
Locally testing the routes.

## Does this PR affect any server routes?
- [X] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
No security implications.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
