### PR TITLE
Fix emitNotifications NULL user_id

### DIFF
--- a/server/models/subscription.ts
+++ b/server/models/subscription.ts
@@ -217,10 +217,15 @@ export default (
     let query = `INSERT INTO "NotificationsRead" VALUES `;
     const replacements = [];
     for (const subscription of subscriptions) {
-      query += `(?, ?, ?, ?, (SELECT COALESCE(MAX(id), 0) + 1 FROM "NotificationsRead" WHERE user_id = ?))`
-      if (subscriptions[subscriptions.length - 1] == subscription) query += ';';
-      else query += ', ';
-      replacements.push(notification.id, subscription.id, false, subscription.subscriber_id, subscription.subscriber_id);
+      if (subscription.subscriber_id) {
+        query += `(?, ?, ?, ?, (SELECT COALESCE(MAX(id), 0) + 1 FROM "NotificationsRead" WHERE user_id = ?))`
+        if (subscriptions[subscriptions.length - 1] == subscription) query += ';';
+        else query += ', ';
+        replacements.push(notification.id, subscription.id, false, subscription.subscriber_id, subscription.subscriber_id);
+      } else {
+        // TODO: rollbar reported issue originates from here
+        log.info(`${JSON.stringify(subscription.toJSON)}`);
+      }
     }
     if (subscriptions.length > 0) {
       await models.sequelize.query(query, { replacements, type: QueryTypes.INSERT });

--- a/server/routes/viewNotifications.ts
+++ b/server/routes/viewNotifications.ts
@@ -26,11 +26,6 @@ export default async (
     return next(new Error(Errors.NotLoggedIn));
   }
 
-  return res.json({
-    status: 'Success',
-    result: { subscriptions: [], numNotifications: 0, numUnread: 0 },
-  });
-
   // locate active subscriptions, filter by category if specified
   const searchParams: any[] = [{ subscriber_id: req.user.id }];
   if (req.body.active_only) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bypasses the bug and adds logs allowing us to debug.

## Motivation and Context
Some calls to `emitNotifications` resulted in failed db queries due to a NULL `user_id`.


## How has this been tested?
Locally testing by creating threads, comments, reactions.

## Does this PR affect any server routes?
- [ ] yes
- [X] no

## If this PR affects server routes, what are the security implications?
None.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
