### PR TITLE
Ensure body-less proposals and comments don't throw errors

### DIFF
--- a/client/scripts/views/pages/view_proposal/body.ts
+++ b/client/scripts/views/pages/view_proposal/body.ts
@@ -740,7 +740,7 @@ const formatBody = (vnode) => {
       vnode.state.collapsed = true;
     }
   }
-}
+};
 
 export const ProposalBodyText: m.Component<
   {
@@ -757,6 +757,7 @@ export const ProposalBodyText: m.Component<
   },
   view: (vnode) => {
     const { body } = vnode.state;
+    if (!body) return;
 
     const getPlaceholder = () => {
       if (!(vnode.attrs.item instanceof OffchainThread)) return;
@@ -800,7 +801,7 @@ export const ProposalBodyText: m.Component<
 
           return m('.show-more-wrap', [
             m(QuillFormattedText, {
-              doc: doc,
+              doc,
               cutoffText: vnode.state.collapsed
                 ? QUILL_PROPOSAL_LINES_CUTOFF_LENGTH
                 : doc.ops.length,
@@ -814,7 +815,7 @@ export const ProposalBodyText: m.Component<
               ]),
           ]);
         } catch (e) {
-          if (body.toString().trim() === '') {
+          if (body?.toString().trim() === '') {
             return getPlaceholder();
           }
           return m('.show-more-wrap', [


### PR DESCRIPTION
Aurora fix.

Long-term we need to (1) add DELETE CASCADE to a buncha our forum models, (2) purge all Discourse-imported comments/threads that don't have populated text/body columns (i.e. where text/body = '')