### PR TITLE
Fix oauth state

### DIFF
--- a/server/passport/socialAccount.ts
+++ b/server/passport/socialAccount.ts
@@ -192,6 +192,7 @@ export function useSocialAccountAuth(models: DB) {
     clientSecret: GITHUB_CLIENT_SECRET,
     callbackURL: GITHUB_OAUTH_CALLBACK,
     passReqToCallback: true,
+    store: true
   }, async (req: Request, accessToken, refreshToken, profile, cb) => {
     await authenticateSocialAccount(Providers.GITHUB, req, accessToken, refreshToken, profile, cb, models)
   }));

--- a/server/passport/socialAccount.ts
+++ b/server/passport/socialAccount.ts
@@ -140,6 +140,7 @@ export function useSocialAccountAuth(models: DB) {
     clientSecret: GITHUB_CLIENT_SECRET,
     callbackURL: GITHUB_OAUTH_CALLBACK,
     passReqToCallback: true,
+    state: true
   }, async (req: Request, accessToken, refreshToken, profile, cb) => {
     await authenticateSocialAccount(Providers.GITHUB, req, accessToken, refreshToken, profile, cb, models)
   }));
@@ -151,6 +152,7 @@ export function useSocialAccountAuth(models: DB) {
     passReqToCallback: true,
     authorizationURL: 'https://discord.com/api/oauth2/authorize?prompt=none',
     callbackURL: DISCORD_OAUTH_CALLBACK,
+    state: true
   }, async (req: Request, accessToken, refreshToken, profile, cb) => {
     await authenticateSocialAccount(Providers.DISCORD,  req, accessToken, refreshToken, profile, cb, models)
   }))

--- a/server/passport/socialAccount.ts
+++ b/server/passport/socialAccount.ts
@@ -13,6 +13,58 @@ import { NotificationCategories } from '../../shared/types';
 import { factory, formatFilename } from '../../shared/logging';
 const log = factory.getLogger(formatFilename(__filename));
 
+/**
+ * The OAuth 2.0 authentication strategy authenticates requests using the OAuth
+ * 2.0 framework.
+ *
+ * OAuth 2.0 provides a facility for delegated authentication, whereby users can
+ * authenticate using a third-party service such as Facebook.  Delegating in
+ * this manner involves a sequence of events, including redirecting the user to
+ * the third-party service for authorization.  Once authorization has been
+ * granted, the user is redirected back to the application and an authorization
+ * code can be used to obtain credentials.
+ *
+ * Applications must supply a `verify` callback, for which the function
+ * signature is:
+ *
+ *     function(accessToken, refreshToken, profile, done) { ... }
+ *
+ * The verify callback is responsible for finding or creating the user, and
+ * invoking `done` with the following arguments:
+ *
+ *     done(err, user, info);
+ *
+ * `user` should be set to `false` to indicate an authentication failure.
+ * Additional `info` can optionally be passed as a third argument, typically
+ * used to display informational messages.  If an exception occurred, `err`
+ * should be set.
+ *
+ * Options:
+ *
+ *   - `authorizationURL`  URL used to obtain an authorization grant
+ *   - `tokenURL`          URL used to obtain an access token
+ *   - `clientID`          identifies client to service provider
+ *   - `clientSecret`      secret used to establish ownership of the client identifer
+ *   - `callbackURL`       URL to which the service provider will redirect the user after obtaining authorization
+ *   - `passReqToCallback` when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *
+ * Examples:
+ *
+ *     passport.use(new OAuth2Strategy({
+ *         authorizationURL: 'https://www.example.com/oauth2/authorize',
+ *         tokenURL: 'https://www.example.com/oauth2/token',
+ *         clientID: '123-456-789',
+ *         clientSecret: 'shhh-its-a-secret'
+ *         callbackURL: 'https://www.example.net/auth/example/callback'
+ *       },
+ *       function(accessToken, refreshToken, profile, done) {
+ *         User.findOrCreate(..., function (err, user) {
+ *           done(err, user);
+ *         });
+ *       }
+ *     ));
+ */
+
 enum Providers {
   GITHUB = 'github',
   DISCORD = 'discord',
@@ -34,8 +86,8 @@ async function authenticateSocialAccount(
     where: { provider, provider_userid: profile.id }
   });
 
-  // Existing Github account. If there is already a user logged-in,
-  // transfer the Github link to the current user.
+  // Existing account. If there is already a user logged-in,
+  // transfer the link to the current user.
   if (account !== null) {
     // Handle OAuth for custom domains.
     //
@@ -79,9 +131,9 @@ async function authenticateSocialAccount(
     }
   }
 
-  // New Github account. Either link it to the existing user, or
+  // New account. Either link it to the existing user, or
   // create a new user. As a result it's possible that we end up
-  // with a user with multiple Github accounts linked.
+  // with a user with multiple social accounts linked.
   const newAccount = await models.SocialAccount.create({
     provider,
     provider_userid: profile.id,
@@ -140,7 +192,6 @@ export function useSocialAccountAuth(models: DB) {
     clientSecret: GITHUB_CLIENT_SECRET,
     callbackURL: GITHUB_OAUTH_CALLBACK,
     passReqToCallback: true,
-    state: true
   }, async (req: Request, accessToken, refreshToken, profile, cb) => {
     await authenticateSocialAccount(Providers.GITHUB, req, accessToken, refreshToken, profile, cb, models)
   }));
@@ -152,7 +203,8 @@ export function useSocialAccountAuth(models: DB) {
     passReqToCallback: true,
     authorizationURL: 'https://discord.com/api/oauth2/authorize?prompt=none',
     callbackURL: DISCORD_OAUTH_CALLBACK,
-    state: true
+    store: true
+    // pass in the 'verify' callback
   }, async (req: Request, accessToken, refreshToken, profile, cb) => {
     await authenticateSocialAccount(Providers.DISCORD,  req, accessToken, refreshToken, profile, cb, models)
   }))

--- a/server/router.ts
+++ b/server/router.ts
@@ -697,19 +697,44 @@ function setupRouter(
   // login
   router.post('/login', startEmailLogin.bind(this, models));
   router.get('/finishLogin', finishEmailLogin.bind(this, models));
-
-  router.get('/auth/github', startOAuthLogin.bind(this, models, 'github'));
-  router.get(
-    '/auth/github/callback',
-    startOAuthLogin.bind(this, models, 'github')
-  );
   router.get('/finishOAuthLogin', finishOAuthLogin.bind(this, models));
 
-  router.get('/auth/discord', startOAuthLogin.bind(this, models, 'discord'));
-  router.get(
-    '/auth/discord/callback',
-    startOAuthLogin.bind(this, models, 'discord')
-  );
+
+
+
+  // router.get('/auth/github', startOAuthLogin.bind(this, models, 'github'));
+  // router.get(
+  //   '/auth/github/callback',
+  //   finishOAuthLogin.bind(this, models)
+  // );
+  router.get('/auth/github', (req, res, next) => {
+    passport.authenticate('github', <any>{state: {hostname: req.hostname}})(req, res, next);
+  })
+  router.get('auth/github/callback', passport.authenticate('github', {
+    failureRedirect: '/',
+  }), startOAuthLogin.bind(this, models, 'github'))
+
+  // The way this works is first the /auth.discord route is hit and passport.authenticate triggers for the first time
+  // to send a request for a code to the discord API passing along a state parameter and a callback. The Discord api
+  // adds the same state parameter to the callback URL (and a new code param) before returning. Once Discord returns,
+  // /auth/discord/callback is called which triggers passport.authenticate for a second time. On this second run the
+  // authenticateSocialAccount function in socialAccount.ts is called. If a successRedirect url is specified, in the
+  // passport.authenticate options then the passport.authenticate function will handle redirecting after the
+  // authenticateSocialAccount function.
+
+  // put any data you wish to persist post OAuth into the state object below. The data will be made available ONLY in
+  // the req.authInfo.state object in the callback i.e. startOAuthLogin.ts
+  router.get('/auth/discord', (req, res, next) => {
+    passport.authenticate('discord', <any>{state: {hostname: req.hostname}})(req, res, next);
+  });
+
+  router.get('/auth/discord/callback', passport.authenticate('discord', {
+    failureRedirect: '/',
+  }), startOAuthLogin.bind(this, models, 'discord'));
+
+
+
+
 
   router.post(
     '/auth/magic',

--- a/server/router.ts
+++ b/server/router.ts
@@ -699,14 +699,19 @@ function setupRouter(
   router.get('/finishLogin', finishEmailLogin.bind(this, models));
   router.get('/finishOAuthLogin', finishOAuthLogin.bind(this, models));
 
+  // OAuth2.0 for Discord and GitHub:
+  // The way this works is first the /auth.discord route is hit and passport.authenticate triggers for the first time
+  // to send a request for a code to the discord API passing along a state parameter and a callback. The Discord api
+  // adds the same state parameter to the callback URL (and a new code param) before returning. Once Discord returns,
+  // /auth/discord/callback is called which triggers passport.authenticate for a second time. On this second run the
+  // authenticateSocialAccount function in socialAccount.ts is called. If a successRedirect url is specified, in the
+  // passport.authenticate options then the passport.authenticate function will handle redirecting after the
+  // authenticateSocialAccount function and WILL NOT trigger the route handler for the callback routes (startOAuthLogin)
 
+  // You cac put any data you wish to persist post OAuth into the state object below. The data will be made available
+  // ONLY in the req.authInfo.state object in the callback i.e. startOAuthLogin.ts.
+  // NOTE: if a successfulRedirect url is used in the options then there is no way to access that data.
 
-
-  // router.get('/auth/github', startOAuthLogin.bind(this, models, 'github'));
-  // router.get(
-  //   '/auth/github/callback',
-  //   finishOAuthLogin.bind(this, models)
-  // );
   router.get('/auth/github', (req, res, next) => {
     passport.authenticate('github', <any>{state: {hostname: req.hostname}})(req, res, next);
   })
@@ -714,16 +719,6 @@ function setupRouter(
     failureRedirect: '/',
   }), startOAuthLogin.bind(this, models, 'github'))
 
-  // The way this works is first the /auth.discord route is hit and passport.authenticate triggers for the first time
-  // to send a request for a code to the discord API passing along a state parameter and a callback. The Discord api
-  // adds the same state parameter to the callback URL (and a new code param) before returning. Once Discord returns,
-  // /auth/discord/callback is called which triggers passport.authenticate for a second time. On this second run the
-  // authenticateSocialAccount function in socialAccount.ts is called. If a successRedirect url is specified, in the
-  // passport.authenticate options then the passport.authenticate function will handle redirecting after the
-  // authenticateSocialAccount function.
-
-  // put any data you wish to persist post OAuth into the state object below. The data will be made available ONLY in
-  // the req.authInfo.state object in the callback i.e. startOAuthLogin.ts
   router.get('/auth/discord', (req, res, next) => {
     passport.authenticate('discord', <any>{state: {hostname: req.hostname}})(req, res, next);
   });
@@ -731,10 +726,6 @@ function setupRouter(
   router.get('/auth/discord/callback', passport.authenticate('discord', {
     failureRedirect: '/',
   }), startOAuthLogin.bind(this, models, 'discord'));
-
-
-
-
 
   router.post(
     '/auth/magic',

--- a/server/routes/startOAuthLogin.ts
+++ b/server/routes/startOAuthLogin.ts
@@ -2,12 +2,6 @@ import passport from 'passport';
 import { Request, Response, NextFunction } from 'express';
 import { DB } from '../database';
 
-import {DISCORD_OAUTH_CALLBACK, GITHUB_OAUTH_CALLBACK} from '../config';
-
-interface AuthOptions extends passport.AuthenticateOptions {
-  callbackURL: string
-}
-
 interface AuthInfoExtended extends Express.AuthInfo {
   state?: {
     hostname: string

--- a/server/routes/startOAuthLogin.ts
+++ b/server/routes/startOAuthLogin.ts
@@ -4,6 +4,10 @@ import { DB } from '../database';
 
 import {DISCORD_OAUTH_CALLBACK, GITHUB_OAUTH_CALLBACK} from '../config';
 
+interface AuthOptions extends passport.AuthenticateOptions {
+  callbackURL: string
+}
+
 const startOAuthLogin = async (
   models: DB,
   provider: string,
@@ -11,6 +15,7 @@ const startOAuthLogin = async (
   res: Response,
   next: NextFunction,
 ) => {
+  console.log("Discord logging in");
   let successRedirect = '/';
   const failureRedirect = '#!/login';
   if (req.query.from) {
@@ -34,17 +39,15 @@ const startOAuthLogin = async (
       )}`,
       successRedirect,
       failureRedirect,
-      state: req.sessionID
-    } as any)(req, res, next); // TODO: extend AuthenticateOptions typing used here
+    } as AuthOptions)(req, res, next);
   }
-
   else {
     // TODO: figure out how to pass a callbackURL without error
+    console.log(`Authenticating with discord.`)
     passport.authenticate('discord', {
       successRedirect,
       failureRedirect,
-      state: req.sessionID
-    } as any)(req, res, next)
+    })(req, res, next)
   }
 };
 

--- a/server/routes/startOAuthLogin.ts
+++ b/server/routes/startOAuthLogin.ts
@@ -24,40 +24,23 @@ const startOAuthLogin = async (
   console.log("Auth info startOAuthLogin:", req.authInfo);
   let successRedirect = '/';
 
-  const hostname = (<AuthInfoExtended>req.authInfo)?.state?.hostname
-  if (hostname && hostname !== 'localhost') {
-    // Validate that req.query.from matches an existing Chain
-    try {
-      const chain = await models.Chain.findOne({ where: { custom_domain: hostname } });
-      if (chain) {
-        const tokenObj = await models.LoginToken.createForOAuth(hostname);
-        successRedirect = `https://${hostname}/api/finishOAuthLogin?token=${tokenObj.token}`;
-        (req as any).loginTokenForRedirect = tokenObj.id;
-      }
-    } catch (e) {
-      console.log('Error:', e);
-    }
-  }
+  // custom domain OAuth2.0 login logic. OAuth2.0 login is currently disabled for custom domains.
+  // const hostname = (<AuthInfoExtended>req.authInfo)?.state?.hostname
+  // if (hostname && hostname !== 'localhost') {
+  //   // Validate that req.query.from matches an existing Chain
+  //   try {
+  //     const chain = await models.Chain.findOne({ where: { custom_domain: hostname } });
+  //     if (chain) {
+  //       const tokenObj = await models.LoginToken.createForOAuth(hostname);
+  //       successRedirect = `https://${hostname}/api/finishOAuthLogin?token=${tokenObj.token}`;
+  //       (req as any).loginTokenForRedirect = tokenObj.id;
+  //     }
+  //   } catch (e) {
+  //     console.log('Error:', e);
+  //   }
+  // }
 
   res.redirect(successRedirect);
-
-  // if (provider === 'github') {
-  //   passport.authenticate('github', {
-  //     callbackURL: `${GITHUB_OAUTH_CALLBACK}?from=${encodeURIComponent(
-  //       req.hostname
-  //     )}`,
-  //     successRedirect,
-  //     failureRedirect,
-  //   } as AuthOptions)(req, res, next);
-  // }
-  // else {
-  //   // TODO: if you delete the state mid-request
-  //   console.log(`Authenticating with discord.`)
-  //   passport.authenticate('discord', {
-  //     successRedirect,
-  //     failureRedirect,
-  //   })(req, res, next)
-  // }
 };
 
 export default startOAuthLogin;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the OAuth state check by allowing Passport to handle the state generation + check.
Also adds an object 'state' (separate from the state string) which we can set to contain any data that needs to persist during the OAuth2.0 request.

## Motivation and Context
Patches the security vulnerability defined by Sushi.

## How has this been tested?
Logging into Discord and GitHub locally and on staging.

## Does this PR affect any server routes?
- [x] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
This refactors the OAuth routes to remove the broken manual state implementation and improper use of the passport package which resulted in convoluted execution of various authentication functions.

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
