### PR TITLE
Mods to EditThreads

### DIFF
--- a/server/routes/editThread.ts
+++ b/server/routes/editThread.ts
@@ -68,7 +68,7 @@ const editThread = async (models: DB, banCache: BanCache, req: Request, res: Res
     where: {
       chain_id: chain.id,
       address_id: { [Op.in]: userOwnedAddressIds },
-      permission: 'admin'
+      permission: ['admin', 'moderator']
     }
   });
 


### PR DESCRIPTION
1. Checks the Mod Permission to Edit Threads.

Note: should make sure we actually want this behavior. Fixes [Notion ticket](https://www.notion.so/hicommonwealth/CMN-Engineering-493b2a3ff2224d2985cf815ea0bdacdc?v=7b008f7d6b1f4ae6af6ff581ab2e88fc&p=5c433e93e6e14f3083fafcccf63ada6f)