### PR TITLE
Fix cosmos account switching and balance query.

### DIFF
--- a/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
+++ b/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
@@ -19,6 +19,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
   private _enabled: boolean;
   private _enabling = false;
   private _chainId: string;
+  private _chain: string;
   private _offlineSigner: OfflineDirectSigner;
   private _client: SigningStargateClient;
 
@@ -44,6 +45,11 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
   public async validateWithAccount(account: Account<any>): Promise<void> {
     if (!this._chainId || !window.keplr?.signAmino)
       throw new Error('Missing or misconfigured web wallet');
+
+    if (this._chain !== app.chain.id) {
+      // disable then re-enable on chain switch
+      await this.enable();
+    }
 
     // Get the verification token & placeholder TX to send
     const signDoc = validationTokenToSignDoc(
@@ -138,6 +144,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
         };
         await window.keplr.experimentalSuggestChain(info);
         await window.keplr.enable(this._chainId);
+        this._chain = app.chain.id;
       }
       console.log(`Enabled web wallet for ${this._chainId}`);
 

--- a/server/util/tokenBalanceCache.ts
+++ b/server/util/tokenBalanceCache.ts
@@ -131,12 +131,6 @@ export class TokenBalanceProvider {
       throw new Error('No API key found for terra endpoint');
     }
 
-    // verify address is valid before making query
-    const decodedAddress = bech32.decodeUnsafe(userAddress);
-    if (!decodedAddress) {
-      throw new Error('invalid terra address');
-    }
-
     // make balance query
     const queryUrl = `${url}/cosmos/bank/v1beta1/balances/${
       userAddress
@@ -303,6 +297,13 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
       });
       if (!tokenMeta?.address) throw new Error('unsupported token');
       contractAddress = tokenMeta.address;
+    } else if (chain.bech32_prefix && chain.base === ChainBase.CosmosSDK) {
+      // re-encode address with given bech32 prefix if on cosmos
+      const decodedAddress = bech32.decodeUnsafe(address);
+      if (!decodedAddress) {
+        throw new Error('invalid terra address');
+      }
+      address = bech32.encode(chain.bech32_prefix, decodedAddress.words);
     }
 
     const url = node.private_url || node.url;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Re-enables keplr when already enabled on a different chain, so you can connect to multiple Cosmos communities in one session.
- Re-encodes bech32 prefix on balance queries for cosmos, preventing invalid prefix error.