### PR TITLE
Fix Axie login post-checksum migration.

### DIFF
--- a/packages/commonwealth/server/models/address.ts
+++ b/packages/commonwealth/server/models/address.ts
@@ -6,7 +6,7 @@ import { UserAttributes, UserInstance } from './user';
 import { OffchainProfileAttributes, OffchainProfileInstance } from './offchain_profile';
 import { RoleAttributes, RoleInstance } from './role';
 import { ProfileInstance } from './profile';
-import { SsoTokenInstance } from './sso_token';
+import { SsoTokenAttributes, SsoTokenInstance } from './sso_token';
 import { WalletId } from 'common-common/src/types';
 
 export type AddressAttributes = {
@@ -32,6 +32,7 @@ export type AddressAttributes = {
 	User?: UserAttributes;
 	OffchainProfile?: OffchainProfileAttributes;
 	Roles?: RoleAttributes[];
+	SsoToken?: SsoTokenAttributes;
 }
 
 // eslint-disable-next-line no-use-before-define

--- a/packages/commonwealth/server/routes/finishSsoLogin.ts
+++ b/packages/commonwealth/server/routes/finishSsoLogin.ts
@@ -1,30 +1,24 @@
 import * as jwt from 'jsonwebtoken';
 import { isAddress, toChecksumAddress } from 'web3-utils';
+import {
+  NotificationCategories,
+  WalletId,
+} from 'common-common/src/types';
+import { factory, formatFilename } from 'common-common/src/logging';
 
 import { TypedRequestBody, TypedResponse, success } from '../types';
 import { AXIE_SHARED_SECRET } from '../config';
 import { sequelize, DB } from '../database';
 import { ProfileAttributes } from '../models/profile';
 import { DynamicTemplate } from '../../shared/types';
-import {
-  NotificationCategories,
-  WalletId,
-} from 'common-common/src/types';
 
 import { AppError, ServerError } from '../util/errors';
 import { UserAttributes } from '../models/user';
 import { AddressAttributes } from '../models/address';
 
-import { factory, formatFilename } from 'common-common/src/logging';
-import {
-  redirectWithLoginError,
-  redirectWithLoginSuccess,
-} from './finishEmailLogin';
+import { redirectWithLoginError } from './finishEmailLogin';
 import { mixpanelTrack } from '../util/mixpanelUtil';
-import {
-  MixpanelLoginEvent,
-  MixpanelLoginPayload,
-} from '../../shared/analytics/types';
+import { MixpanelLoginEvent } from '../../shared/analytics/types';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -140,12 +134,15 @@ const finishSsoLogin = async (
   const reqUser = req.user;
   const existingAddress = await models.Address.scope('withPrivateData').findOne(
     {
-      where: { address: checksumAddress },
+      where: {
+        address: checksumAddress,
+        chain: 'axie-infinity',
+      },
       include: [
         {
           model: models.SsoToken,
           where: { issuer: jwtPayload.iss },
-          required: true,
+          required: false,
         },
       ],
     }
@@ -171,18 +168,30 @@ const finishSsoLogin = async (
     // check login token, if the user has already logged in before with SSO
     const token = await existingAddress.getSsoToken();
 
-    // perform login on existing account
-    if (jwtPayload.iat <= token.issued_at) {
-      log.error('Replay attack detected.');
-      throw new AppError(Errors.ReplayAttack);
-    }
-    token.issued_at = jwtPayload.iat;
-    token.state_id = emptyTokenInstance.state_id;
-    await token.save();
+    if (token) {
+      // perform login on existing account
+      if (jwtPayload.iat <= token.issued_at) {
+        log.error('Replay attack detected.');
+        throw new AppError(Errors.ReplayAttack);
+      }
+      token.issued_at = jwtPayload.iat;
+      token.state_id = emptyTokenInstance.state_id;
+      await token.save();
 
-    // delete the empty token that was initialized on /auth/sso, because it is superceded
-    // by the existing token for this user
-    await emptyTokenInstance.destroy();
+      // delete the empty token that was initialized on /auth/sso, because it is superceded
+      // by the existing token for this user
+      await emptyTokenInstance.destroy();
+    } else {
+      // XXX: some tokens got dis-associated from accounts due to checksum migration.
+      //   To fix this, we attach new (current) tokens to them here.
+      //   The only possible vulnerability here would be a delayed replay attack using a token
+      //   issued before the migration, which will not work because those tokens would be
+      //   marked expired.
+      emptyTokenInstance.issuer = jwtPayload.iss;
+      emptyTokenInstance.issued_at = jwtPayload.iat;
+      emptyTokenInstance.address_id = existingAddress.id;
+      await emptyTokenInstance.save();
+    }
 
     if (reqUser) {
       // perform address transfer


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
After the Axie checksum migration, some addresses were dis-associated from their SsoToken objects in the database. The result is we have valid addresses with no associated SsoToken, which meant failure on login (specifically: it would try to create a new address, and then fail, because the address already exists).

This PR fixes this issue: if someone logs in with an existing address that does not have an associated SsoToken, we check for an SsoToken with the provided state id (generated when they click "log in"), and then update its info such that it acts as a valid SsoToken for the already-registered address.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
First, log in with Axie. Then, delete the generated SsoToken while maintaining the corresponding Address. This replicates the bug's state. Then, log out (fully) and log in again via Ronin. It should create a new token and log you in with the same address.

My sense is that this doesn't introduce any security vulnerabilities, as the only risk is a replay attack (given that we check the validity of the token before parsing it + setting values from it), but let me know if you think of anything.