### PR TITLE
Add required true to addresses in getMembers

### DIFF
--- a/packages/commonwealth/server/routes/bulkMembers.ts
+++ b/packages/commonwealth/server/routes/bulkMembers.ts
@@ -10,7 +10,10 @@ const bulkMembers = async (models: DB, req: Request, res: Response, next: NextFu
 
   const members = await models.Role.findAll({
     where: { chain_id: chain.id },
-    include: [ models.Address ],
+    include: [{
+      model: models.Address,
+      required: true,
+    }],
     order: [['created_at', 'DESC']],
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Front-end expected an address when returning Roles, and for some reason (TBD, needs postmortem) a few Roles were being returned with undefined addresses blowing up the axie admin management panel. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Broken Front-end for axie admins

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [x] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
