### PR TITLE
Banner overflow bug

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/cw_banner.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_banner.scss
@@ -4,7 +4,7 @@
   align-items: flex-start;
   display: flex;
   justify-content: space-between;
-  height: 56px;
+  min-height: 56px;
   padding: 16px 16px 16px 192px;
 
   @include mediumSmall {


### PR DESCRIPTION
Before:

<img width="360" alt="Screen Shot 2022-07-28 at 2 02 39 PM" src="https://user-images.githubusercontent.com/13058678/181511877-48b470ff-eccd-4938-a97c-62393b8999a8.png">

After:

<img width="359" alt="Screen Shot 2022-07-28 at 2 02 26 PM" src="https://user-images.githubusercontent.com/13058678/181511862-805fc4a0-3655-4439-8299-09b3ce2952ee.png">

