### PR TITLE
Temporary change in RPC

### DIFF
--- a/packages/chain-events/scripts/listenerUtils.ts
+++ b/packages/chain-events/scripts/listenerUtils.ts
@@ -9,7 +9,7 @@ import { EdgewareSpec } from './specs/edgeware';
 export const networkUrls = {
   clover: 'wss://api.clover.finance',
   hydradx: 'wss://rpc-01.snakenet.hydradx.io',
-  edgeware: 'ws://mainnet2.edgewa.re:9944',
+  edgeware: 'wss://edgeware-rpc.dwellir.com',
   'edgeware-local': 'ws://localhost:9944',
   'edgeware-testnet': 'wss://beresheet1.edgewa.re',
   kusama: 'wss://kusama-rpc.polkadot.io',


### PR DESCRIPTION
## Description
CW RPCs are currently down for a while and yet to undergo node upgrades. Hence switching to the RPC by Dwellir temporarily.

## Motivation and Context
It will solve login issue for Edgeware forum and will fetch on-chain governance events.

## How has this been tested?
No, I guess minor change like RPC switching doesn't need testing.

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
