### PR TITLE
Permit non URI compliant text in quill text body.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/quill/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/quill/helpers.ts
@@ -25,7 +25,12 @@ export const renderQuillTextBody = (textBody: any, params: QuillTextParams) => {
     if (!doc.ops) throw new Error();
     return m(QuillFormattedText, { ...params, doc });
   } catch (e) {
-    const doc = decodeURIComponent(textBody);
+    let doc;
+    try {
+      doc = decodeURIComponent(textBody);
+    } catch (e2) {
+      return m(MarkdownFormattedText, { ...params, textBody });
+    }
     return m(MarkdownFormattedText, { ...params, doc });
   }
 };


### PR DESCRIPTION
Fixes issue with dydx members page rendering.