### PR TITLE
Redis_url undefined fix

### DIFF
--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -101,13 +101,12 @@ export async function setupWebSocketServer(
   log.info(`Socket instance connecting to Redis at: ${REDIS_URL}`);
 
   const redisOptions = {};
+  redisOptions['url'] = REDIS_URL;
   if (isLocalhost || isVultr) {
-    redisOptions['url'] = REDIS_URL;
     redisOptions['socket'] = {
       reconnectStrategy: redisRetryStrategy,
     };
   } else {
-    redisOptions['url'] = REDIS_URL;
     redisOptions['socket'] = {
       connectTimeout: 5000,
       keepAlive: 4000,

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -44,25 +44,19 @@ export class RedisCache {
     }
     log.info(`Connecting to Redis at: ${REDIS_URL}`);
 
-    const localRedis = REDIS_URL.includes('localhost') || REDIS_URL.includes('127.0.0.1');
-    const vultrRedis = REDIS_URL.includes(VULTR_IP);
+    const localRedis = REDIS_URL?.includes('localhost') || REDIS_URL?.includes('127.0.0.1');
+    const vultrRedis = REDIS_URL?.includes(VULTR_IP);
 
-    let finalRedisUrl;
     if (!this.client) {
       const redisOptions = {};
 
-      if (localRedis) {
-        redisOptions['socket'] = {
-          reconnectStrategy: redisRetryStrategy
-        };
-        finalRedisUrl = "redis://localhost:6379"
-      } else if (vultrRedis) {
+      if (localRedis || vultrRedis) {
         redisOptions['url'] = REDIS_URL;
         redisOptions['socket'] = {
           reconnectStrategy: redisRetryStrategy
         };
-        finalRedisUrl = REDIS_URL;
       } else {
+        redisOptions['url'] = REDIS_URL;
         redisOptions['socket'] = {
           connectTimeout: 5000,
           keepAlive: 4000,
@@ -70,7 +64,6 @@ export class RedisCache {
           rejectUnauthorized: false,
           reconnectStrategy: redisRetryStrategy
         };
-        finalRedisUrl = REDIS_URL;
       }
 
       this.client = createClient(redisOptions);
@@ -79,7 +72,7 @@ export class RedisCache {
     this.client.on('error', (err) => {
       if (err instanceof ConnectionTimeoutError) {
         log.error(
-          `RedisCache connection to ${finalRedisUrl} timed out!`
+          `RedisCache connection to ${REDIS_URL} timed out!`
         );
       } else if (err instanceof ReconnectStrategyError) {
         log.error(`RedisCache max connection retries exceeded!`);

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -49,14 +49,13 @@ export class RedisCache {
 
     if (!this.client) {
       const redisOptions = {};
+      redisOptions['url'] = REDIS_URL;
 
       if (localRedis || vultrRedis) {
-        redisOptions['url'] = REDIS_URL;
         redisOptions['socket'] = {
           reconnectStrategy: redisRetryStrategy
         };
       } else {
-        redisOptions['url'] = REDIS_URL;
         redisOptions['socket'] = {
           connectTimeout: 5000,
           keepAlive: 4000,

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -44,8 +44,8 @@ export class RedisCache {
     }
     log.info(`Connecting to Redis at: ${REDIS_URL}`);
 
-    const localRedis = REDIS_URL?.includes('localhost') || REDIS_URL?.includes('127.0.0.1');
-    const vultrRedis = REDIS_URL?.includes(VULTR_IP);
+    const localRedis = REDIS_URL.includes('localhost') || REDIS_URL.includes('127.0.0.1');
+    const vultrRedis = REDIS_URL.includes(VULTR_IP);
 
     if (!this.client) {
       const redisOptions = {};

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -134,6 +134,13 @@ export class RedisCache {
     namespace: RedisNamespaces,
     key: string
   ): Promise<string> {
+    if (!this.initialized) {
+      log.error(
+        'Redis client is not initialized. Run RedisCache.init() first!'
+      );
+      return;
+    }
+
     const finalKey = namespace + '_' + key;
     return await this.client.get(finalKey);
   }


### PR DESCRIPTION
If the `REDIS_URL` is undefined that means there is no production Redis instance, no vultr Redis instance, and no local Redis instance. If this is the case, the script prints a message and returns. Websockets + RedisCache are fully disabled if no Redis instance is found.
