### PR TITLE
Ensure new chain nodes are immediately added to TBC.

### DIFF
--- a/packages/token-balance-cache/src/index.ts
+++ b/packages/token-balance-cache/src/index.ts
@@ -80,6 +80,13 @@ export default class TokenBalanceCache extends JobRunner<CacheT> {
     return this.start();
   }
 
+  public addNode(node: Omit<ChainNodeT, 'id'> & { id?: number }) {
+    const id = node.id;
+    if (id && !this._nodes[id]) {
+      this._nodes[id] = node as ChainNodeT;
+    }
+  }
+
   // query a user's balance on a given token contract and save in cache
   public async getBalance(
     nodeId: number,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Solves a problem with onboarding that required a dyno restart on adding a new cosmos community or a new eth chain node.

**NEEDS QA**: to test, make yourself a site admin, and then add a new cosmos community or a community on a new eth chain node. Then, set a topic threshold and ensure that the tokenBalance route returns as expected.