### PR TITLE
Ensure no client/scripts prefixes in client imports.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/create_community/cosmos_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/cosmos_form.tsx
@@ -11,7 +11,7 @@ import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 import { initAppState } from 'app';
 import { slugifyPreserveDashes } from 'utils';
 import { ChainBase, ChainType } from 'common-common/src/types';
-import { linkExistingAddressToChainOrCommunity } from 'client/scripts/controllers/app/login';
+import { linkExistingAddressToChainOrCommunity } from 'controllers/app/login';
 import { initChainForm, defaultChainRows } from './chain_input_rows';
 import { ChainFormFields, ChainFormState, EthFormFields } from './types';
 import { IdRow, InputRow } from '../../components/metadata_rows';

--- a/packages/commonwealth/client/scripts/views/pages/create_community/substrate_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/substrate_form.tsx
@@ -18,7 +18,7 @@ import {
   MixpanelCommunityCreationPayload,
 } from 'analytics/types';
 import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
-import { linkExistingAddressToChainOrCommunity } from 'client/scripts/controllers/app/login';
+import { linkExistingAddressToChainOrCommunity } from 'controllers/app/login';
 import { initChainForm, defaultChainRows } from './chain_input_rows';
 import { ChainFormFields, ChainFormState } from './types';
 import { CWButton } from '../../components/component_kit/cw_button';

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { Thread } from 'client/scripts/models';
+import { Thread } from 'models';
 
 export const getLastUpdated = (proposal) => {
   const { lastCommentedOn } = proposal;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/pinned_listing.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/pinned_listing.tsx
@@ -2,7 +2,7 @@
 
 import m from 'mithril';
 
-import { Thread } from 'client/scripts/models';
+import { Thread } from 'models';
 import { DiscussionRow } from 'views/pages/discussions/discussion_row';
 import { orderDiscussionsbyLastComment } from './helpers';
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/summary_listing.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/summary_listing.tsx
@@ -4,7 +4,7 @@ import 'pages/discussions/summary_listing.scss';
 
 import m from 'mithril';
 import app from 'state';
-import { Topic } from 'client/scripts/models';
+import { Topic } from 'models';
 import { LoadingRow } from '../../components/loading_row';
 import SummaryRow from './summary_row';
 import { isWindowSmallInclusive } from '../../components/component_kit/helpers';

--- a/packages/commonwealth/client/scripts/views/pages/members.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/members.tsx
@@ -12,7 +12,7 @@ import { navigateToSubpage } from 'app';
 import { PageLoading } from 'views/pages/loading';
 import User from 'views/components/widgets/user';
 import Sublayout from 'views/sublayout';
-import { Profile } from 'client/scripts/models';
+import { Profile } from 'models';
 import { BreadcrumbsTitleTag } from '../components/breadcrumbs_title_tag';
 import { CWText } from '../components/component_kit/cw_text';
 

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
@@ -6,7 +6,7 @@ import { Tag } from 'construct-ui';
 import 'pages/user_dashboard/dashboard_communities_preview.scss';
 
 import app from 'state';
-import { ChainInfo } from 'client/scripts/models';
+import { ChainInfo } from 'models';
 import { pluralize } from 'helpers';
 import { CWCard } from '../../components/component_kit/cw_card';
 import { CWCommunityAvatar } from '../../components/component_kit/cw_community_avatar';

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/index.tsx
@@ -11,7 +11,7 @@ import {
   SnapshotProposal,
   SnapshotSpace,
 } from 'helpers/snapshot_utils';
-import { Thread } from 'client/scripts/models';
+import { Thread } from 'models';
 import { SnapshotSpaceCard } from './snapshot_space_card';
 import { PageLoading } from '../loading';
 import { CardsCollection } from '../../components/cards_collection';

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/snapshot_space_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/snapshot_space_card.tsx
@@ -4,7 +4,7 @@ import m from 'mithril';
 
 import 'pages/snapshot/snapshot_space_card.scss';
 
-import { Thread } from 'client/scripts/models';
+import { Thread } from 'models';
 import app from 'state';
 import { SnapshotProposal, SnapshotSpace } from 'helpers/snapshot_utils';
 import { navigateToSubpage } from '../../../app';

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.ts
@@ -62,7 +62,7 @@ import { SocialSharingCarat } from 'views/components/social_sharing_carat';
 import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
 import { modelFromServer as modelReactionCountFromServer } from 'controllers/server/reactionCounts';
 import { SnapshotProposal } from 'helpers/snapshot_utils';
-import Poll from 'client/scripts/models/Poll';
+import Poll from 'models/Poll';
 import {
   ProposalHeaderTopics,
   ProposalHeaderTitle,

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_threads_card.tsx
@@ -8,7 +8,7 @@ import app from 'state';
 import { link } from 'helpers';
 import { getProposalUrlPath } from 'identifiers';
 import { Thread } from 'models';
-import { LinkedThreadRelation } from 'client/scripts/models/Thread';
+import { LinkedThreadRelation } from 'models/Thread';
 import { LinkedThreadModal } from '../../modals/linked_thread_modal';
 import { slugify } from '../../../../../shared/utils';
 import { CWButton } from '../../components/component_kit/cw_button';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Heroku build is broken because we reference "client/scripts" in the packages/commonwealth/client folder. We need to ensure we omit that prefix when referencing local files.

To test: run `cd packages/commonwealth && yarn heroku-postbuild` and ensure the build completes successfully. Should take about a minute to run.
