### PR TITLE
Redis log improvements + node-redis bump

### DIFF
--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -163,7 +163,6 @@
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.0.0-beta.2",
     "ignore-loader": "^0.1.2",
-    "ioredis": "^5.2.2",
     "jdenticon": "^2.1.1",
     "jquery": "^3.3.1",
     "jsdom": "^16.5.0",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -45,7 +45,7 @@
     "migrate-db": "npx sequelize db:migrate",
     "dump-db-local": " pg_dump -U commonwealth --verbose --no-privileges --no-owner -f local_save.dump",
     "dump-db-limit": "yarn run dump-db &&  psql $(heroku config:get DATABASE_URL -a commonwealthapp) -a -f limited_dump.sql",
-    "load-db-limit": "yarn run reset-db && yarn run load-db && psql -d commonwealth -U commonwealth -a -f limited_load.sql" ,
+    "load-db-limit": "yarn run reset-db && yarn run load-db && psql -d commonwealth -U commonwealth -a -f limited_load.sql",
     "start-docker-setup": "chmod +rx ./scripts/start-docker-setup-help.sh && ./scripts/start-docker-setup-help.sh",
     "start-containers": "chmod +rx ./scripts/start-docker-containers.sh && ./scripts/start-docker-containers.sh",
     "stop-containers": "chmod +rx ./scripts/stop-docker-containers.sh && ./scripts/stop-docker-containers.sh"
@@ -204,7 +204,7 @@
     "quill-image-uploader": "^1.0.2",
     "quill-mention": "^2.2.7",
     "rascal": "^13.1.0",
-    "redis": "^4.0.4",
+    "redis": "4.2.0",
     "rollbar": "^2.6.1",
     "rxjs": "^7.3.0",
     "sass-loader": "^10.1.1",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -163,6 +163,7 @@
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.0.0-beta.2",
     "ignore-loader": "^0.1.2",
+    "ioredis": "^5.2.2",
     "jdenticon": "^2.1.1",
     "jquery": "^3.3.1",
     "jsdom": "^16.5.0",

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -183,15 +183,6 @@ export async function setupWebSocketServer(
 
   await Promise.all([pubClient.connect(), subClient.connect()]);
 
-  // setInterval(async () => {
-  //   try {
-  //     await pubClient.ping();
-  //     await subClient.ping();
-  //   } catch (e) {
-  //     log.error("Pub or Sub client could not ping Redis", e);
-  //   }
-  // }, 5000);
-
   // provide the redis connection instances to the socket.io adapters
   await io.adapter(<any>createAdapter(pubClient, subClient));
 

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -109,7 +109,7 @@ export async function setupWebSocketServer(
   } else {
     redisOptions['socket'] = {
       connectTimeout: 5000,
-      keepAlive: 4000,
+      keepAlive: true,
       tls: true,
       rejectUnauthorized: false,
       reconnectStrategy: redisRetryStrategy,
@@ -139,6 +139,15 @@ export async function setupWebSocketServer(
         );
     }
   });
+  pubClient.on('ready', () => {
+    log.info("Redis pub-client ready");
+  })
+  pubClient.on('reconnect', () => {
+    log.info("Redis pub-client reconnecting");
+  })
+  pubClient.on('end', () => {
+    log.info('Redis pub-client disconnected');
+  })
   subClient.on('error', (err) => {
     if (err instanceof ConnectionTimeoutError) {
       log.error(
@@ -159,6 +168,15 @@ export async function setupWebSocketServer(
         );
     }
   });
+  subClient.on('ready', () => {
+    log.info("Redis sub-client ready");
+  })
+  subClient.on('reconnect', () => {
+    log.info("Redis sub-client reconnecting");
+  })
+  subClient.on('end', () => {
+    log.info('Redis sub-client disconnected');
+  })
 
   await Promise.all([pubClient.connect(), subClient.connect()]);
   // provide the redis connection instances to the socket.io adapters

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -109,7 +109,6 @@ export async function setupWebSocketServer(
   } else {
     redisOptions['socket'] = {
       tls: true,
-      keepAlive: 5000,
       rejectUnauthorized: false,
       reconnectStrategy: redisRetryStrategy,
     };

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -109,6 +109,7 @@ export async function setupWebSocketServer(
   } else {
     redisOptions['socket'] = {
       tls: true,
+      keepAlive: 5000,
       rejectUnauthorized: false,
       reconnectStrategy: redisRetryStrategy,
     };

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -108,9 +108,8 @@ export async function setupWebSocketServer(
     };
   } else {
     redisOptions['socket'] = {
-      connectTimeout: 5000,
-      keepAlive: true,
       tls: true,
+      keepAlive: 120,
       rejectUnauthorized: false,
       reconnectStrategy: redisRetryStrategy,
     };
@@ -183,6 +182,16 @@ export async function setupWebSocketServer(
   })
 
   await Promise.all([pubClient.connect(), subClient.connect()]);
+
+  // setInterval(async () => {
+  //   try {
+  //     await pubClient.ping();
+  //     await subClient.ping();
+  //   } catch (e) {
+  //     log.error("Pub or Sub client could not ping Redis", e);
+  //   }
+  // }, 5000);
+
   // provide the redis connection instances to the socket.io adapters
   await io.adapter(<any>createAdapter(pubClient, subClient));
 

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -109,7 +109,6 @@ export async function setupWebSocketServer(
   } else {
     redisOptions['socket'] = {
       tls: true,
-      keepAlive: 120,
       rejectUnauthorized: false,
       reconnectStrategy: redisRetryStrategy,
     };

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -58,6 +58,7 @@ export class RedisCache {
       } else {
         redisOptions['socket'] = {
           connectTimeout: 5000,
+          keepAlive: 5000,
           tls: true,
           rejectUnauthorized: false,
           reconnectStrategy: redisRetryStrategy

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -57,8 +57,6 @@ export class RedisCache {
         };
       } else {
         redisOptions['socket'] = {
-          connectTimeout: 5000,
-          keepAlive: 5000,
           tls: true,
           rejectUnauthorized: false,
           reconnectStrategy: redisRetryStrategy

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -58,7 +58,6 @@ export class RedisCache {
       } else {
         redisOptions['socket'] = {
           connectTimeout: 5000,
-          keepAlive: 120,
           tls: true,
           rejectUnauthorized: false,
           reconnectStrategy: redisRetryStrategy

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -87,13 +87,13 @@ export class RedisCache {
     });
 
     this.client.on('ready', () => {
-      log.info("Redis RedisCache ready");
+      log.info("RedisCache connection ready");
     })
     this.client.on('reconnecting', () => {
-      log.info("Redis RedisCache reconnecting");
+      log.info("RedisCache reconnecting");
     })
     this.client.on('end', () => {
-      log.info('Redis RedisCache disconnected');
+      log.info('RedisCache disconnected');
     })
 
     if (!this.client.isOpen) {

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -58,7 +58,7 @@ export class RedisCache {
       } else {
         redisOptions['socket'] = {
           connectTimeout: 5000,
-          keepAlive: 4000,
+          keepAlive: 120,
           tls: true,
           rejectUnauthorized: false,
           reconnectStrategy: redisRetryStrategy
@@ -100,6 +100,15 @@ export class RedisCache {
 
     if (!this.client.isOpen) {
       await this.client.connect();
+
+      // setInterval(async () => {
+      //   try {
+      //     await this.client.ping();
+      //     await this.client.ping();
+      //   } catch (e) {
+      //     log.error("RedisCache client could not ping Redis", e);
+      //   }
+      // }, 5000);
     }
 
     this.initialized = !!this.client.isOpen;

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -86,6 +86,16 @@ export class RedisCache {
       }
     });
 
+    this.client.on('ready', () => {
+      log.info("Redis RedisCache ready");
+    })
+    this.client.on('reconnect', () => {
+      log.info("Redis RedisCache reconnecting");
+    })
+    this.client.on('end', () => {
+      log.info('Redis RedisCache disconnected');
+    })
+
     if (!this.client.isOpen) {
       await this.client.connect();
     }

--- a/packages/commonwealth/server/util/redisCache.ts
+++ b/packages/commonwealth/server/util/redisCache.ts
@@ -100,15 +100,6 @@ export class RedisCache {
 
     if (!this.client.isOpen) {
       await this.client.connect();
-
-      // setInterval(async () => {
-      //   try {
-      //     await this.client.ping();
-      //     await this.client.ping();
-      //   } catch (e) {
-      //     log.error("RedisCache client could not ping Redis", e);
-      //   }
-      // }, 5000);
     }
 
     this.initialized = !!this.client.isOpen;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,41 +3227,6 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
   integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
 
-"@node-redis/bloom@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@node-redis/bloom/-/bloom-1.0.1.tgz#144474a0b7dc4a4b91badea2cfa9538ce0a1854e"
-  integrity sha512-mXEBvEIgF4tUzdIN89LiYsbi6//EdpFA7L8M+DHCvePXg+bfHWi+ct5VI6nHUFQE5+ohm/9wmgihCH3HSkeKsw==
-
-"@node-redis/client@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@node-redis/client/-/client-1.0.4.tgz#fe185750df3bcc07524f63fe8dbc8d14d22d6cbb"
-  integrity sha512-IM/NRAqg7MvNC3bIRQipXGrEarunrdgvrbAzsd3ty93LSHi/M+ybQulOERQi8a3M+P5BL8HenwXjiIoKm6ml2g==
-  dependencies:
-    cluster-key-slot "1.1.0"
-    generic-pool "3.8.2"
-    redis-parser "3.0.0"
-    yallist "4.0.0"
-
-"@node-redis/graph@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-redis/graph/-/graph-1.0.0.tgz#baf8eaac4a400f86ea04d65ec3d65715fd7951ab"
-  integrity sha512-mRSo8jEGC0cf+Rm7q8mWMKKKqkn6EAnA9IA2S3JvUv/gaWW/73vil7GLNwion2ihTptAm05I9LkepzfIXUKX5g==
-
-"@node-redis/json@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@node-redis/json/-/json-1.0.2.tgz#8ad2d0f026698dc1a4238cc3d1eb099a3bee5ab8"
-  integrity sha512-qVRgn8WfG46QQ08CghSbY4VhHFgaTY71WjpwRBGEuqGPfWwfRcIf3OqSpR7Q/45X+v3xd8mvYjywqh0wqJ8T+g==
-
-"@node-redis/search@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@node-redis/search/-/search-1.0.3.tgz#7c3d026bf994caf82019fd0c3924cfc09f041a29"
-  integrity sha512-rsrzkGWI84di/uYtEctS/4qLusWt0DESx/psjfB0TFpORDhe7JfC0h8ary+eHulTksumor244bXLRSqQXbFJmw==
-
-"@node-redis/time-series@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@node-redis/time-series/-/time-series-1.0.2.tgz#5dd3638374edd85ebe0aa6b0e87addc88fb9df69"
-  integrity sha512-HGQ8YooJ8Mx7l28tD7XjtB3ImLEjlUxG1wC1PAjxu6hPJqjPshUZxAICzDqDjtIbhDTf48WXXUcx8TQJB1XTKA==
-
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -3591,6 +3556,40 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@redis/bloom@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.0.2.tgz#42b82ec399a92db05e29fffcdfd9235a5fc15cdf"
+  integrity sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==
+
+"@redis/client@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.2.0.tgz#be2ef974881e57276123cb76d08756c03eed946f"
+  integrity sha512-a8Nlw5fv2EIAFJxTDSSDVUT7yfBGpZO96ybZXzQpgkyLg/dxtQ1uiwTc0EGfzg1mrPjZokeBSEGTbGXekqTNOg==
+  dependencies:
+    cluster-key-slot "1.1.0"
+    generic-pool "3.8.2"
+    yallist "4.0.0"
+
+"@redis/graph@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.0.1.tgz#eabc58ba99cd70d0c907169c02b55497e4ec8a99"
+  integrity sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==
+
+"@redis/json@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.3.tgz#a13fde1d22ebff0ae2805cd8e1e70522b08ea866"
+  integrity sha512-4X0Qv0BzD9Zlb0edkUoau5c1bInWSICqXAGrpwEltkncUwcxJIGEcVryZhLgb0p/3PkKaLIWkjhHRtLe9yiA7Q==
+
+"@redis/search@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.0.6.tgz#53d7451c2783f011ebc48ec4c2891264e0b22f10"
+  integrity sha512-pP+ZQRis5P21SD6fjyCeLcQdps+LuTzp2wdUbzxEmNhleighDDTD5ck8+cYof+WLec4csZX7ks+BuoMw0RaZrA==
+
+"@redis/time-series@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.3.tgz#4cfca8e564228c0bddcdf4418cba60c20b224ac4"
+  integrity sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==
 
 "@scure/base@~1.1.0":
   version "1.1.1"
@@ -17386,29 +17385,17 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redis-errors@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
-  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
-
-redis-parser@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
-  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+redis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.2.0.tgz#1278a265b8aa1e096a585d103bdead027cd04e43"
+  integrity sha512-bCR0gKVhIXFg8zCQjXEANzgI01DDixtPZgIUZHBCmwqixnu+MK3Tb2yqGjh+HCLASQVVgApiwhNkv+FoedZOGQ==
   dependencies:
-    redis-errors "^1.0.0"
-
-redis@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-4.0.4.tgz#b567f82f59086df38433982f7f424b48e924ec7a"
-  integrity sha512-KaM1OAj/nGrSeybmmOWSMY0LXTGT6FVWgUZZrd2MYzXKJ+VGtqVaciGQeNMfZiQX+kDM8Ke4uttb54m2rm6V0A==
-  dependencies:
-    "@node-redis/bloom" "1.0.1"
-    "@node-redis/client" "1.0.4"
-    "@node-redis/graph" "1.0.0"
-    "@node-redis/json" "1.0.2"
-    "@node-redis/search" "1.0.3"
-    "@node-redis/time-series" "1.0.2"
+    "@redis/bloom" "1.0.2"
+    "@redis/client" "1.2.0"
+    "@redis/graph" "1.0.1"
+    "@redis/json" "1.0.3"
+    "@redis/search" "1.0.6"
+    "@redis/time-series" "1.0.3"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,11 +3015,6 @@
   dependencies:
     browser-headers "^0.4.1"
 
-"@ioredis/commands@^1.1.1":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
-  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
-
 "@iov/crypto@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@iov/crypto/-/crypto-2.1.0.tgz#10e91b6692e154958c11626dfd096a80e8a481a4"
@@ -7019,7 +7014,7 @@ clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-cluster-key-slot@1.1.0, cluster-key-slot@^1.1.0:
+cluster-key-slot@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
   integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
@@ -7930,7 +7925,7 @@ debug@4, debug@4.3.1, debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.4, debug@^4.3.1, debug@^4.3.4:
+debug@4.3.4, debug@^4.3.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -8166,11 +8161,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-denque@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
-  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -11997,21 +11987,6 @@ io-ts@1.10.4:
   dependencies:
     fp-ts "^1.0.0"
 
-ioredis@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.2.tgz#212467e04f6779b4e0e800cece7bb7d3d7b546d2"
-  integrity sha512-wryKc1ur8PcCmNwfcGkw5evouzpbDXxxkMkzPK8wl4xQfQf7lHe11Jotell5ikMVAtikXJEu/OJVaoV51BggRQ==
-  dependencies:
-    "@ioredis/commands" "^1.1.1"
-    cluster-key-slot "^1.1.0"
-    debug "^4.3.4"
-    denque "^2.0.1"
-    lodash.defaults "^4.2.0"
-    lodash.isarguments "^3.1.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.1.0"
-
 ip-regex@^2.0.0, ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
@@ -13528,11 +13503,6 @@ lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
-
-lodash.isarguments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -17415,18 +17385,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redis-errors@^1.0.0, redis-errors@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
-  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
-
-redis-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
-  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
-  dependencies:
-    redis-errors "^1.0.0"
-
 redis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.2.0.tgz#1278a265b8aa1e096a585d103bdead027cd04e43"
@@ -18854,11 +18812,6 @@ stacktrace-parser@^0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
-
-standard-as-callback@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
-  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 stashback@^1.1.2:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,6 +3015,11 @@
   dependencies:
     browser-headers "^0.4.1"
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@iov/crypto@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@iov/crypto/-/crypto-2.1.0.tgz#10e91b6692e154958c11626dfd096a80e8a481a4"
@@ -7014,7 +7019,7 @@ clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-cluster-key-slot@1.1.0:
+cluster-key-slot@1.1.0, cluster-key-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
   integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
@@ -7925,7 +7930,7 @@ debug@4, debug@4.3.1, debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.4, debug@^4.3.1:
+debug@4.3.4, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -8161,6 +8166,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+denque@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -11987,6 +11997,21 @@ io-ts@1.10.4:
   dependencies:
     fp-ts "^1.0.0"
 
+ioredis@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.2.tgz#212467e04f6779b4e0e800cece7bb7d3d7b546d2"
+  integrity sha512-wryKc1ur8PcCmNwfcGkw5evouzpbDXxxkMkzPK8wl4xQfQf7lHe11Jotell5ikMVAtikXJEu/OJVaoV51BggRQ==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.0.1"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ip-regex@^2.0.0, ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
@@ -13503,6 +13528,11 @@ lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -17385,6 +17415,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 redis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.2.0.tgz#1278a265b8aa1e096a585d103bdead027cd04e43"
@@ -18812,6 +18854,11 @@ stacktrace-parser@^0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 stashback@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# NOTE
This PR should be paired with the following command: `heroku redis:timeout redis-clear-28026 -a commonwealthapp -s 21600`

## Description
Improved Redis client logging and reverted `keepAlive` + `connectTimeout` to default `node-redis` values. 'Socket closed unexpectedly' errors don't log critical errors in Rollbar anymore.

Adds a log, specifically on the `ready` Redis client event which helps us tell if the Redis client is connected and functioning properly.

The above command sets the Redis ClientTimeout to 6 hours. In other words, if no cross-server chat message is sent within 6 hours, the Redis client will be disconnected and will have to reconnect.

## Motivation and Context
Improved Redis client debugging and error tracing.

## How has this been tested?
Staging-2 + local + Vultr

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
NA

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
