### PR TITLE
Fix mentions!

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/quill/quill_editor_internal.ts
+++ b/packages/commonwealth/client/scripts/views/components/quill/quill_editor_internal.ts
@@ -88,7 +88,7 @@ export default class QuillEditorInternal {
           mentionDenotationChars: ['@'],
           dataAttributes: ['name', 'link', 'component'],
           renderItem: (item) => item.component,
-          onSelect: this._selectMention,
+          onSelect: (item: QuillMention) => this._selectMention(item),
           source: _.debounce(this._queryMentions, 300, {
             leading: true,
             trailing: true,
@@ -926,7 +926,6 @@ export default class QuillEditorInternal {
 
   private _listAutofillHandler(range, context) {
     if (this._activeMode === 'markdown') return true;
-    debugger;
     const length = context.prefix.length;
     const [line, offset] = this._quill.getLine(range.index);
 


### PR DESCRIPTION
Missing `this` in Quill editor meant the mentions handler had no context for inserting/handling mentions.