### PR TITLE
Topic Fixes: Creating, Editing, Ordering Topics

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -37,6 +37,8 @@ class ChainInfo {
   public readonly blockExplorerIds: { [id: string]: string };
   public readonly collapsedOnHomepage: boolean;
   public defaultSummaryView: boolean;
+  // TODO Graham 8-12-22: We should consider removing this topic prop,
+  // as it does not stay in step with topic store, potentially causing problems
   public readonly topics: Topic[];
   public readonly chainObjectId: string;
   public adminsAndMods: RoleInfo[];

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
@@ -427,10 +427,12 @@ export class NewThreadForm implements m.ClassComponent<NewThreadFormAttrs> {
                     onclick={async (e) => {
                       this.saving = true;
 
-                      const { quillEditorState } = this;
-
                       try {
-                        await this._newThread(form, quillEditorState, author);
+                        await this._newThread(
+                          form,
+                          this.quillEditorState,
+                          author
+                        );
                         this.overwriteConfirmationModal = true;
                         this.saving = false;
                         if (
@@ -465,7 +467,6 @@ export class NewThreadForm implements m.ClassComponent<NewThreadFormAttrs> {
                     buttonType="tertiary-blue"
                     onclick={async (e) => {
                       // TODO Graham 7-19-22: This needs to be reduced / cleaned up / broken out
-                      const { quillEditorState } = this;
                       this.saving = true;
 
                       const existingDraftId =
@@ -476,7 +477,7 @@ export class NewThreadForm implements m.ClassComponent<NewThreadFormAttrs> {
                       try {
                         await this._saveDraft(
                           form,
-                          quillEditorState,
+                          this.quillEditorState,
                           existingDraftId
                         );
                         this.saving = false;

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -134,17 +134,6 @@ export class EditTopicModal implements m.ClassComponent<EditTopicModalAttrs> {
             inputValidationFn={(text: string) => {
               let errorMsg;
 
-              const currentCommunityTopicNames = app.topics
-                .getByCommunity(app.activeChainId())
-                .map((t) => t.name.toLowerCase());
-
-              if (currentCommunityTopicNames.includes(text.toLowerCase())) {
-                errorMsg = 'Topic name already used within community.';
-                this.error = errorMsg;
-                m.redraw();
-                return ['failure', errorMsg];
-              }
-
               const disallowedCharMatches = text.match(/["<>%{}|\\/^`]/g);
               if (disallowedCharMatches) {
                 errorMsg = `The ${pluralizeWithoutNumberPrefix(

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -72,6 +72,7 @@ export class EditTopicModal implements m.ClassComponent<EditTopicModalAttrs> {
     }
 
     const updateTopic = async (form) => {
+      console.log(form);
       if (form.featuredInNewPost) {
         if (!this.quillEditorState || this.quillEditorState?.isBlank()) {
           this.error = 'Must provide template.';

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -74,7 +74,7 @@ export class NewTopicModal implements m.ClassComponent {
             oninput={(e) => {
               this.form.name = (e.target as HTMLInputElement).value;
             }}
-            inputValidationFn={(text) => {
+            inputValidationFn={(text: string) => {
               let errorMsg;
 
               const currentCommunityTopicNames = app.topics

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -17,6 +17,7 @@ import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { CWLabel } from '../components/component_kit/cw_label';
 import { CWCheckbox } from '../components/component_kit/cw_checkbox';
 import { CWButton } from '../components/component_kit/cw_button';
+import { CWValidationText } from '../components/component_kit/cw_validation_text';
 
 type NewTopicModalForm = {
   description: string;
@@ -76,9 +77,9 @@ export class NewTopicModal implements m.ClassComponent {
             inputValidationFn={(text) => {
               let errorMsg;
 
-              const currentCommunityTopicNames = app.chain.meta.topics.map(
-                (t) => t.name.toLowerCase()
-              );
+              const currentCommunityTopicNames = app.topics
+                .getByCommunity(app.activeChainId())
+                .map((t) => t.name.toLowerCase());
 
               if (currentCommunityTopicNames.includes(text.toLowerCase())) {
                 errorMsg = 'Topic name already used within community.';
@@ -164,17 +165,17 @@ export class NewTopicModal implements m.ClassComponent {
           <CWButton
             label="Create topic"
             disabled={this.saving || this.error || disabled}
-            onclick={async (e) => {
+            onclick={async (e: Event) => {
               e.preventDefault();
-              const { quillEditorState, form } = this;
-
-              quillEditorState.disable();
-
-              const defaultOffchainTemplate =
-                quillEditorState.textContentsAsString;
-
-              app.topics
-                .add(
+              const { form } = this;
+              try {
+                let defaultOffchainTemplate;
+                if (this.quillEditorState) {
+                  this.quillEditorState.disable();
+                  defaultOffchainTemplate =
+                    this.quillEditorState.textContentsAsString;
+                }
+                await app.topics.add(
                   form.name,
                   form.description,
                   null,
@@ -182,20 +183,24 @@ export class NewTopicModal implements m.ClassComponent {
                   form.featuredInNewPost,
                   this.form.tokenThreshold || '0',
                   defaultOffchainTemplate as string
-                )
-                .then(() => {
-                  this.saving = false;
-                  m.redraw();
-                  $(e.target).trigger('modalexit');
-                })
-                .catch(() => {
-                  this.error = 'Error creating topic';
-                  this.saving = false;
-                  m.redraw();
-                });
+                );
+
+                this.saving = false;
+                m.redraw();
+                $(e.target).trigger('modalexit');
+              } catch (err) {
+                this.error = 'Error creating topic';
+                this.saving = false;
+                if (this.quillEditorState) {
+                  this.quillEditorState.enable();
+                }
+                m.redraw();
+              }
             }}
           />
-          {this.error && <div class="error-message">{this.error}</div>}
+          {this.error && (
+            <CWValidationText message={this.error} status="failure" />
+          )}{' '}
         </div>
       </div>
     );

--- a/packages/commonwealth/client/scripts/views/modals/order_topics_modal.ts
+++ b/packages/commonwealth/client/scripts/views/modals/order_topics_modal.ts
@@ -24,7 +24,6 @@ const storeNewTopicOrder = (
   state.topics = Array.from(HTMLContainer.childNodes).map((node: HTMLElement) =>
     getTopicFromElement(node, state.topics)
   );
-  console.log(state.topics);
   state.topics.forEach((t, idx) => {
     t.order = idx + 1;
   });
@@ -53,7 +52,6 @@ const OrderTopicsModal: m.Component<null, { topics: Topic[] }> = {
     dragula([document.querySelector('.featured-topic-list')]).on(
       'drop',
       async (draggedEle, targetDiv, sourceDiv) => {
-        console.log(sourceDiv);
         storeNewTopicOrder(sourceDiv, vnode.state);
       }
     );

--- a/packages/commonwealth/client/scripts/views/modals/order_topics_modal.ts
+++ b/packages/commonwealth/client/scripts/views/modals/order_topics_modal.ts
@@ -6,13 +6,14 @@ import { ListItem, Button, List, Icon, Icons } from 'construct-ui';
 import app from 'state';
 import { Topic } from 'models';
 import { notifyError } from 'controllers/app/notifications';
-import { confirmationModalWithText } from './confirm_modal';
 
 const getTopicFromElement = (
   htmlEle: HTMLElement,
   allTopics: Topic[]
 ): Topic => {
-  const topic = allTopics.find((t) => t.name === htmlEle.innerText);
+  const topic = allTopics.find(
+    (t: Topic) => t.name.trim() === htmlEle.innerText
+  );
   return topic;
 };
 
@@ -23,6 +24,7 @@ const storeNewTopicOrder = (
   state.topics = Array.from(HTMLContainer.childNodes).map((node: HTMLElement) =>
     getTopicFromElement(node, state.topics)
   );
+  console.log(state.topics);
   state.topics.forEach((t, idx) => {
     t.order = idx + 1;
   });
@@ -51,6 +53,7 @@ const OrderTopicsModal: m.Component<null, { topics: Topic[] }> = {
     dragula([document.querySelector('.featured-topic-list')]).on(
       'drop',
       async (draggedEle, targetDiv, sourceDiv) => {
+        console.log(sourceDiv);
         storeNewTopicOrder(sourceDiv, vnode.state);
       }
     );

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/body.ts
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/body.ts
@@ -659,9 +659,8 @@ export const ProposalBodySaveEdit: m.Component<{
               }
             }
             parentState.saving = true;
-            const { quillEditorState } = parentState;
-            quillEditorState.disable();
-            const itemText = quillEditorState.textContentsAsString;
+            parentState.quillEditorState.disable();
+            const itemText = parentState.quillEditorState.textContentsAsString;
             if (item instanceof Thread) {
               app.threads
                 .edit(

--- a/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
+++ b/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
@@ -16,6 +16,7 @@
 
   .buttons-row {
     display: flex;
+    margin: 8px 0;
     gap: 8px;
     width: 100%;
   }

--- a/packages/commonwealth/server/migrations/20220812184206-trim-all-topic-names.js
+++ b/packages/commonwealth/server/migrations/20220812184206-trim-all-topic-names.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface) => {
+    return queryInterface.sequelize.query(
+      `UPDATE "Topics" SET name=LTRIM(RTRIM(name));`
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return true;
+  },
+};

--- a/packages/commonwealth/server/routes/createTopic.ts
+++ b/packages/commonwealth/server/routes/createTopic.ts
@@ -9,7 +9,7 @@ export const Errors = {
   MustBeAdmin: 'Must be an admin',
   InvalidTokenThreshold: 'Invalid token threshold',
   DefaultTemplateRequired: 'Default Template required',
-  InvalidTopicName: 'Only alphanumeric chars allowed',
+  InvalidTopicName: 'Topic uses disallowed special characters',
 };
 
 const createTopic = async (

--- a/packages/commonwealth/server/routes/createTopic.ts
+++ b/packages/commonwealth/server/routes/createTopic.ts
@@ -21,14 +21,17 @@ const createTopic = async (
   const [chain, error] = await validateChain(models, req.body);
   if (error) return next(new Error(error));
   if (!req.user) return next(new Error(Errors.NotLoggedIn));
-  if (!req.body.name) return next(new Error(Errors.TopicRequired));
-  if (req.body.name.match(/["<>%{}|\\/^`]/g))
+
+  const name = req.body.name.trim();
+  if (!name) return next(new Error(Errors.TopicRequired));
+  if (req.body.name.match(/["<>%{}|\\/^`]/g)) {
     return next(new Error(Errors.InvalidTopicName));
-  if (
-    req.body.featured_in_new_post === 'true' &&
-    (!req.body.default_offchain_template ||
-      !req.body.default_offchain_template.trim())
-  ) {
+  }
+
+  const featured_in_sidebar = req.body.featured_in_sidebar === 'true';
+  const featured_in_new_post = req.body.featured_in_new_post === 'true';
+  const default_offchain_template = req.body.default_offchain_template?.trim();
+  if (featured_in_new_post && !default_offchain_template) {
     return next(new Error(Errors.DefaultTemplateRequired));
   }
 
@@ -50,20 +53,21 @@ const createTopic = async (
   if (Number.isNaN(token_threshold_test)) {
     return next(new Error(Errors.InvalidTokenThreshold));
   }
+
   const options = {
-    name: req.body.name,
+    name,
     description: req.body.description || '',
     token_threshold: req.body.token_threshold,
-    featured_in_sidebar: !!(req.body.featured_in_sidebar === 'true'),
-    featured_in_new_post: !!(req.body.featured_in_new_post === 'true'),
+    featured_in_sidebar,
+    featured_in_new_post,
     default_offchain_template: req.body.default_offchain_template || '',
     chain_id: chain.id,
   };
 
   const newTopic = await models.Topic.findOrCreate({
     where: {
+      name,
       chain_id: chain.id,
-      name: req.body.name,
     },
     defaults: options,
   });

--- a/packages/commonwealth/server/routes/createTopic.ts
+++ b/packages/commonwealth/server/routes/createTopic.ts
@@ -60,7 +60,7 @@ const createTopic = async (
     token_threshold: req.body.token_threshold,
     featured_in_sidebar,
     featured_in_new_post,
-    default_offchain_template: req.body.default_offchain_template || '',
+    default_offchain_template: default_offchain_template || '',
     chain_id: chain.id,
   };
 

--- a/packages/commonwealth/server/routes/editTopic.ts
+++ b/packages/commonwealth/server/routes/editTopic.ts
@@ -21,7 +21,7 @@ export const Errors = {
   TopicRequired: 'Topic name required',
   DefaultTemplateRequired: 'Default Template required',
   RuleNotFound: 'Rule not found',
-  InvalidTopicName: 'Only alphanumeric chars allowed',
+  InvalidTopicName: 'Topic uses disallowed special characters',
 };
 
 type EditTopicReq = {


### PR DESCRIPTION
Previously:
- DYDX tags had trailing whitespace in some tag names, because there was no .trim() in our routes. This led to errors being thrown in the order topic modal (which uses HTML nodes, which auto-trim whitespace). This branch adds backend trimming to names, plus and a migration to ensure all existing tags are trimmed.
- Quill editor was not always enabled in the topic creation/editor modal (since it is only instantiated for "new post" featured topics). This adds a check to ensure it exists, before attempting to enable/disable. 
- The check, in creating/editing topics, for existing topic names used `app.chain.meta.topics`, which does not keep up-to-date with the store. (This means recently added topics were not included in the list of checked names.)
- In general, the EditTopicModal did not have any of the important input validation checks that NewTopicModal possesses; they have been added.

In addition, there are some small changes to update the components to use kit error components, to ensure quillEditorState isn't destructured (which can sometimes cause context/`this` issues), and better check topic names.