### PR TITLE
Fix FYP feed ordering

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -45,8 +45,7 @@ class UserDashboard implements m.ClassComponent<{ type: string }> {
         this.fyNotifications = activity.result
           .map((notification) =>
             DashboardActivityNotification.fromJSON(notification)
-          )
-          .reverse();
+          );
         this.loadingData = false;
         m.redraw();
       });

--- a/packages/commonwealth/server/routes/viewGlobalActivity.ts
+++ b/packages/commonwealth/server/routes/viewGlobalActivity.ts
@@ -9,17 +9,17 @@ const viewGlobalActivity = async (
 ) => {
   const query = `
     SELECT nt.thread_id, nts.created_at as last_activity, nts.notification_data, nts.category_id,
-      MAX(ovc.view_count) as view_count, 
+      MAX(ovc.view_count) as view_count,
       COUNT(DISTINCT oc.id) AS comment_count,
       COUNT(DISTINCT tr.id) + COUNT(DISTINCT cr.id) AS reaction_count
-    FROM 
+    FROM
       (SELECT nnn.mx_not_id, nnn.thread_id,
           ROW_NUMBER() OVER (ORDER BY mx_not_id DESC) as thread_rank
         FROM
-        (SELECT DISTINCT nn.thread_id, nn.mx_not_id 
+        (SELECT DISTINCT nn.thread_id, nn.mx_not_id
           FROM (SELECT (n.notification_data::jsonb->>'root_id') AS thread_id,
                   MAX(n.id) OVER (PARTITION BY (n.notification_data::jsonb->>'root_id')) AS mx_not_id
-                FROM "Notifications" n 
+                FROM "Notifications" n
                 WHERE n.category_id IN('new-thread-creation','new-comment-creation')
                 ORDER BY id DESC
                 FETCH FIRST 500 ROWS ONLY
@@ -27,7 +27,7 @@ const viewGlobalActivity = async (
           ) nnn
       ) nt
     INNER JOIN "Notifications" nts ON nt.mx_not_id = nts.id
-    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = ovc.object_id
+    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = CAST(ovc.object_id AS VARCHAR)
     LEFT JOIN "Comments" oc ON 'discussion_'||CAST(nt.thread_id AS VARCHAR) = oc.root_id
       --TODO: eval execution path with alternate aggregations
     LEFT JOIN "Reactions" tr ON nt.thread_id = CAST(tr.thread_id AS VARCHAR)

--- a/packages/commonwealth/server/routes/viewUserActivity.ts
+++ b/packages/commonwealth/server/routes/viewUserActivity.ts
@@ -18,26 +18,26 @@ export default async (
 
   const query = `
     SELECT nt.thread_id, nts.created_at as last_activity, nts.notification_data, nts.category_id,
-      MAX(ovc.view_count) as view_count, 
+      MAX(ovc.view_count) as view_count,
       COUNT(DISTINCT oc.id) AS comment_count,
       COUNT(DISTINCT tr.id) + COUNT(DISTINCT cr.id) AS reaction_count
-    FROM 
+    FROM
       (SELECT nnn.mx_not_id, nnn.thread_id,
           ROW_NUMBER() OVER (ORDER BY mx_not_id DESC) as thread_rank
         FROM
-        (SELECT DISTINCT nn.thread_id, nn.mx_not_id 
+        (SELECT DISTINCT nn.thread_id, nn.mx_not_id
           FROM (SELECT (n.notification_data::jsonb->>'root_id') AS thread_id,
                   MAX(n.id) OVER (PARTITION BY (n.notification_data::jsonb->>'root_id')) AS mx_not_id
-                FROM "Notifications" n 
+                FROM "Notifications" n
                 WHERE n.category_id IN('new-thread-creation','new-comment-creation')
-                  AND n.chain_id IN(SELECT a."chain" FROM "Addresses" a WHERE a.user_id = ?) 
+                  AND n.chain_id IN(SELECT a."chain" FROM "Addresses" a WHERE a.user_id = ?)
                 ORDER BY id DESC
                 FETCH FIRST 500 ROWS ONLY
                 ) nn
           ) nnn
       ) nt
     INNER JOIN "Notifications" nts ON nt.mx_not_id = nts.id
-    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = ovc.object_id
+    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = CAST(ovc.object_id AS VARCHAR)
     LEFT JOIN "Comments" oc ON 'discussion_'||CAST(nt.thread_id AS VARCHAR) = oc.root_id
       --TODO: eval execution path with alternate aggregations
     LEFT JOIN "Reactions" tr ON nt.thread_id = CAST(tr.thread_id AS VARCHAR)


### PR DESCRIPTION
## Description

Fix ordering of "for you" feed page. *Needs to be tested on a prod db dump.*

## Motivation and Context

Otherwise Commonwealth appears far more inactive than it is

## How has this been tested?

- Adding a cast to ovc.object_id was necessary to get the feed to work on a db migrated from scratch.
- Tested fyp and global feed pages.

## Does this PR affect any server routes?
- [X] yes
- [ ] no

## If this PR affects server routes, what are the security implications?

None, no security affecting changes

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
