### PR TITLE
Fix notifications menu css for new users

### DIFF
--- a/packages/commonwealth/client/styles/components/header/notifications_menu.scss
+++ b/packages/commonwealth/client/styles/components/header/notifications_menu.scss
@@ -42,7 +42,6 @@
 
       .notification-list {
         align-items: center;
-        display: flex;
         height: 480px;
         justify-content: center;
       }


### PR DESCRIPTION
## Description

When there are less than a full page of notifications, notifications don't take up the full width of the dropdown.

Before and after:
<img width="428" alt="Screen Shot 2022-09-06 at 2 29 27 PM" src="https://user-images.githubusercontent.com/1273926/189178298-4201732b-6ff3-48f4-ada7-17437b566ee0.png">

<img width="412" alt="Screen Shot 2022-09-06 at 2 29 19 PM" src="https://user-images.githubusercontent.com/1273926/189178308-2d00c259-96dd-40e2-83cf-fa9714743fef.png">

## Motivation and Context

New user experience

## How has this been tested?

Tested on an account with one notification

## Does this PR affect any server routes?
- [ ] yes
- [X] no

## If this PR affects server routes, what are the security implications?

N/A

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
