### PR TITLE
Auto enable ce listener for aave and compound

### DIFF
--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -302,6 +302,7 @@ const createChain = async (
     chain_node_id: node.id,
     address,
     token_name,
+    has_chain_events_listener: network === 'aave' || network === 'compound'
   });
 
   const nodeJSON = node.toJSON();


### PR DESCRIPTION
Sets `has_chain_events_listener` to true for new chains that are on the Aave or Compound network.
