### PR TITLE
Allow resetting walletconnect

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -56,6 +56,13 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
     return account.validate(webWalletSignature);
   }
 
+    public async reset() {
+    console.log('Attempting to reset WalletConnect');
+    const ks = await this._provider.wc.killSession();
+    this._provider.disconnect();
+    this._enabled = false;
+  }
+
   public async enable() {
     console.log('Attempting to enable WalletConnect');
     this._enabling = true;
@@ -93,8 +100,6 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
     });
     // TODO: chainChanged, disconnect events
   }
-
-  // TODO: disconnect
 }
 
 export default WalletConnectWebWalletController;

--- a/packages/commonwealth/client/scripts/models/IWebWallet.ts
+++ b/packages/commonwealth/client/scripts/models/IWebWallet.ts
@@ -9,6 +9,7 @@ interface IWebWallet<AccountT extends { address: string } | string> {
   enabling: boolean;
   accounts: readonly AccountT[];
   enable: () => Promise<void>;
+  reset?: () => Promise<void>;
   validateWithAccount: (account: Account) => Promise<void>;
 
   chain: ChainBase;

--- a/packages/commonwealth/client/scripts/views/modals/link_new_address_modal.ts
+++ b/packages/commonwealth/client/scripts/views/modals/link_new_address_modal.ts
@@ -444,6 +444,14 @@ const LinkNewAddressModal: m.Component<
                           'p.small-text',
                           'Use your wallet to switch between accounts.'
                         ),
+                        webWallet.reset && m('p.small-text', [
+                          m('a', {
+                            href: '#',
+                            onclick: async () => {
+                              await webWallet.reset();
+                            }
+                          }, `Reset ${webWallet.label}`),
+                        ]),
                       ];
                     } else {
                       return [


### PR DESCRIPTION
## Description

After starting a WalletConnect session, it isn't possible to disconnect it from the browser. This is problematic if the user connects to a session with a WalletConnect device but then wants to switch to another device, or leaves their signer somewhere else.

/cc @alexyoung23j since this is another login related PR, and @jnaviask @zakhap @dillchen to coordinate on merge

## Motivation and Context

Improving WalletConnect UX.

## How has this been tested?

Tested connecting and disconnecting and reconnecting, with extra care to observe any unintended side effects. The only (preexisting) issue is that cancelling WC leaves one with an empty login dialog, which is okay since we're deprecating the current login dialog anyway.

## Does this PR affect any server routes?
- [ ] yes
- [X] no

## If this PR affects server routes, what are the security implications?

N/A

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
