### PR TITLE
Bug fixes and display improvements for global nav

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
@@ -1,9 +1,9 @@
 /* @jsx m */
 
-import m from 'mithril';
-
 import 'components/sidebar/sidebar_section.scss';
 
+import m from 'mithril';
+import app from 'state';
 import { isNotUndefined } from 'helpers/typeGuards';
 import {
   SubSectionAttrs,
@@ -86,7 +86,7 @@ class SubSectionGroup implements m.ClassComponent<SectionGroupAttrs> {
       if (containsChildren) {
         this.toggled = !toggled;
       }
-      localStorage.setItem('sidebar-toggle', 'false');
+      localStorage.setItem(`${app.activeChainId()}-sidebar-toggle`, 'false');
       onclick(e, this.toggled);
     };
 

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -54,8 +54,9 @@ class Sublayout implements m.ClassComponent<SublayoutAttrs> {
       this.isSidebarToggled = !isOnMobile || storedSidebarToggleState;
       this.isSwitcherToggled = this.isSidebarToggled;
     }
-    const isCommunityHeaderToggled =
-      this.isSidebarToggled && this.isSwitcherToggled && app.chain;
+    const { isSidebarToggled, isSwitcherToggled } = this;
+    const isSidebarContainerToggled = isSidebarToggled || isSwitcherToggled;
+    const isCommunityHeaderToggled = isSidebarToggled && isSwitcherToggled;
 
     if (m.route.param('triggerInvite') === 't') {
       setTimeout(() => handleEmailInvites(this), 0);
@@ -66,9 +67,9 @@ class Sublayout implements m.ClassComponent<SublayoutAttrs> {
         <div class="header-and-body-container">
           <div class="header-container">
             <SublayoutHeaderLeft
-              isSidebarToggled={this.isSidebarToggled}
+              isSidebarToggled={isSidebarToggled}
               toggleSidebar={() => {
-                this.isSidebarToggled = !this.isSidebarToggled;
+                this.isSidebarToggled = !isSidebarToggled;
               }}
             />
             {!hideSearch && <SearchBar />}
@@ -78,14 +79,14 @@ class Sublayout implements m.ClassComponent<SublayoutAttrs> {
             />
           </div>
           <div class="sidebar-and-body-container">
-            {this.isSidebarToggled && this.isSwitcherToggled && (
+            {isSidebarContainerToggled && (
               <div class="sidebar-container">
                 {isCommunityHeaderToggled && (
                   <CommunityHeader meta={app.chain.meta} />
                 )}
                 <div class="sidebar-inner-container">
-                  {this.isSwitcherToggled && <SidebarQuickSwitcher />}
-                  {this.isSidebarToggled && <Sidebar />}
+                  {isSwitcherToggled && <SidebarQuickSwitcher />}
+                  {isSidebarToggled && <Sidebar />}
                 </div>
               </div>
             )}

--- a/packages/commonwealth/client/scripts/views/sublayout_header_left.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header_left.tsx
@@ -9,7 +9,7 @@ import { CommunityOptionsPopover } from './components/community_options_popover'
 import { CWCommunityAvatar } from './components/component_kit/cw_community_avatar';
 import { CWIconButton } from './components/component_kit/cw_icon_button';
 import { CWDivider } from './components/component_kit/cw_divider';
-import { isWindowMediumSmallInclusive } from './components/component_kit/helpers';
+import { isWindowSmallInclusive } from './components/component_kit/helpers';
 
 type SublayoutHeaderLeftAttrs = {
   isSidebarToggled: boolean;
@@ -32,21 +32,19 @@ export class SublayoutHeaderLeft
             m.route.set('/');
           }}
         />
-        {isWindowMediumSmallInclusive(window.innerWidth) && (
-          <CWDivider isVertical />
-        )}
+        {isWindowSmallInclusive(window.innerWidth) && <CWDivider isVertical />}
         {app.chain && <CommunityOptionsPopover />}
-        {!isSidebarToggled && app.activeChainId() && (
+        {!isSidebarToggled && app.chain && (
           <CWCommunityAvatar size="large" community={app.chain.meta} />
         )}
-        {isWindowMediumSmallInclusive(window.innerWidth) && app.chain && (
+        {isWindowSmallInclusive(window.innerWidth) && app.chain && (
           <CWIconButton
             iconButtonTheme="black"
             iconName={isSidebarToggled ? 'sidebarCollapse' : 'sidebarExpand'}
             onclick={() => {
               toggleSidebar();
               localStorage.setItem(
-                'sidebar-toggle',
+                `${app.activeChainId()}-sidebar-toggle`,
                 (!isSidebarToggled).toString()
               );
               m.redraw();

--- a/packages/commonwealth/client/styles/components/sidebar/index.scss
+++ b/packages/commonwealth/client/styles/components/sidebar/index.scss
@@ -11,7 +11,7 @@
   width: $sidebar-width;
 
   @include smallInclusive {
-    width: 100%;
+    width: calc(100vw - 56px);
   }
 
   .buttons-container {

--- a/packages/commonwealth/client/styles/sublayout.scss
+++ b/packages/commonwealth/client/styles/sublayout.scss
@@ -34,14 +34,6 @@
       display: flex;
       flex-direction: column;
 
-      @include mediumSmallInclusive {
-        display: none;
-
-        &.isSidebarToggled {
-          display: flex;
-        }
-      }
-
       @include smallInclusive {
         width: 100%;
       }
@@ -57,14 +49,6 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-
-      @include smallInclusive {
-        display: flex;
-
-        &.isSidebarToggled {
-          display: none;
-        }
-      }
 
       .Body {
         display: flex;

--- a/packages/commonwealth/client/styles/sublayout.scss
+++ b/packages/commonwealth/client/styles/sublayout.scss
@@ -33,15 +33,12 @@
     .sidebar-container {
       display: flex;
       flex-direction: column;
-
-      @include smallInclusive {
-        width: 100%;
-      }
+      width: min-content;
 
       .sidebar-inner-container {
         display: flex;
         height: 100%;
-        width: 100%;
+        width: min-content;
       }
     }
 


### PR DESCRIPTION
This branch introduces:
- chain-scoped localStorage of sidebar toggles
- a new breakpoint at which the sidebar becomes toggleable (previously tablet-sized, i.e. medium-small-inclusive; now mobile-sized, i.e. small-inclusive)
- new conditional structure to ensure the quickSwitcher is visible on non-chain pages (e.g. user dashboard, projects index)
- a bug fix to ensure that body containers are not hidden on mobile offchain pages

**Various states that require testing in QA:**
- Chain-scoped large, medium, and medium-small breakpoints should always show a sidebar + switcher
- Chain-scoped small and extra-small breakpoints should show a toggleable sidebar + switcher, which toggle ("travel") together. At both browser sizes, the sidebar+switcher combo should occupy the entire screen.
- Non-chain-scoped large pages of all sizes should always show a switcher, but no sidebar