### PR TITLE
Fix broken Manage Community /bulkProfiles fix

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/profiles.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/profiles.ts
@@ -9,7 +9,9 @@ import { Profile } from 'models';
 class ProfilesController {
   private _store: ProfileStore = new ProfileStore();
 
-  public get store() { return this._store; }
+  public get store() {
+    return this._store;
+  }
 
   private _unfetched: Profile[];
 
@@ -48,25 +50,27 @@ class ProfilesController {
         data: JSON.stringify(data),
         auth: true,
         jwt: app.user.jwt,
-      }).then(({ result }) => {
-        if (!account.profile) {
-          const profile = new Profile(account.chain.id, account.address);
-          this._store.add(profile);
-          this._refreshProfile(profile);
-        }
-        if (result.updatedProfileAddress) {
-          const { address, chain } = result.updatedProfileAddress;
-          const profile = this._store.getByAddress(address);
-          if (profile) {
+      })
+        .then(({ result }) => {
+          if (!account.profile) {
+            const profile = new Profile(account.chain.id, account.address);
+            this._store.add(profile);
             this._refreshProfile(profile);
-          } else {
-            this._refreshProfile(new Profile(chain, address));
           }
-        }
-        resolve(result.profile);
-      }).catch((error) => {
-        reject(error);
-      });
+          if (result.updatedProfileAddress) {
+            const { address, chain } = result.updatedProfileAddress;
+            const profile = this._store.getByAddress(address);
+            if (profile) {
+              this._refreshProfile(profile);
+            } else {
+              this._refreshProfile(new Profile(chain, address));
+            }
+          }
+          resolve(result.profile);
+        })
+        .catch((error) => {
+          reject(error);
+        });
     });
   }
 
@@ -78,42 +82,63 @@ class ProfilesController {
   private async _refreshProfiles(profiles: Profile[]): Promise<Profile[]> {
     // refresh in chunks of 20 to avoid making the body too large
     const chunkedProfiles = _.chunk(profiles, 20);
-    const ps = await Promise.all(chunkedProfiles.map(async (chunk): Promise<Profile[]> => {
-      const fetchedProfiles = chunk; // keep a list of the profiles we just fetched
-      try {
-        // TODO: Change to GET /profiles
-        const result = await $.post(`${app.serverUrl()}/bulkProfiles`, {
-          'addresses[]': chunk.map((profile) => profile.address),
-          'chains[]': chunk.map((profile) => profile.chain),
-        });
-        fetchedProfiles.map((profile) => profile.initializeEmpty());
-        return result.result.map((profileData) => {
-          const profile = fetchedProfiles.find((p) => p.chain === profileData.Address.chain
-            && p.address === profileData.Address.address);
-          if (!profile) return null;
-          const pInfo = profileData.data ? JSON.parse(profileData.data) : {};
-          const lastActive = profileData.Address.last_active;
-          const isCouncillor = profileData.Address.is_councillor;
-          const isValidator = profileData.Address.is_validator;
-          // ignore off-chain name if substrate id exists
-          if (profileData.identity) {
-            profile.initializeWithChain(
-              profileData.identity, pInfo.headline, pInfo.bio, pInfo.avatarUrl,
-              profileData.judgements, lastActive, isCouncillor, isValidator
-            );
-          } else {
-            profile.initialize(
-              pInfo.name, pInfo.headline, pInfo.bio, pInfo.avatarUrl,
-              lastActive, isCouncillor, isValidator
-            );
-          }
-          return profile;
-        }).filter((p) => p !== null);
-      } catch (e) {
-        console.error(e);
-        return [];
-      }
-    }));
+    const ps = await Promise.all(
+      chunkedProfiles.map(async (chunk): Promise<Profile[]> => {
+        const fetchedProfiles = chunk; // keep a list of the profiles we just fetched
+        try {
+          // TODO: Change to GET /profiles
+          console.log(chunk);
+          const result = await $.post(`${app.serverUrl()}/bulkProfiles`, {
+            'addresses[]': chunk.map((profile) => profile.address),
+            'chains[]': chunk.map((profile) => profile.chain),
+          });
+          fetchedProfiles.map((profile) => profile.initializeEmpty());
+          return result.result
+            .map((profileData) => {
+              const profile = fetchedProfiles.find(
+                (p) =>
+                  p.chain === profileData.Address.chain &&
+                  p.address === profileData.Address.address
+              );
+              if (!profile) return null;
+              const pInfo = profileData.data
+                ? JSON.parse(profileData.data)
+                : {};
+              const lastActive = profileData.Address.last_active;
+              const isCouncillor = profileData.Address.is_councillor;
+              const isValidator = profileData.Address.is_validator;
+              // ignore off-chain name if substrate id exists
+              if (profileData.identity) {
+                profile.initializeWithChain(
+                  profileData.identity,
+                  pInfo.headline,
+                  pInfo.bio,
+                  pInfo.avatarUrl,
+                  profileData.judgements,
+                  lastActive,
+                  isCouncillor,
+                  isValidator
+                );
+              } else {
+                profile.initialize(
+                  pInfo.name,
+                  pInfo.headline,
+                  pInfo.bio,
+                  pInfo.avatarUrl,
+                  lastActive,
+                  isCouncillor,
+                  isValidator
+                );
+              }
+              return profile;
+            })
+            .filter((p) => p !== null);
+        } catch (e) {
+          console.error(e);
+          return [];
+        }
+      })
+    );
     m.redraw();
     return _.flatten(ps);
   }

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -35,6 +35,7 @@ export class UpgradeRolesForm
 
     const nonAdminNames: string[] = nonAdmins.map((role) => {
       // Graham 9.19.23: Temporary patch while Addresses are unreliable.
+      // @TODO: @Profiles upgrade, clean this up
       const chainId =
         role.chain_id || typeof role.Address.chain === 'string'
           ? role.Address.chain

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -34,6 +34,7 @@ export class UpgradeRolesForm
     });
 
     const nonAdminNames: string[] = nonAdmins.map((role) => {
+      // Graham 9.19.23: Temporary patch while Addresses are unreliable.
       const chainId =
         role.chain_id || typeof role.Address.chain === 'string'
           ? role.Address.chain

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -34,8 +34,12 @@ export class UpgradeRolesForm
     });
 
     const nonAdminNames: string[] = nonAdmins.map((role) => {
+      const chainId =
+        role.chain_id || typeof role.Address.chain === 'string'
+          ? role.Address.chain
+          : role.Address.chain?.id;
       const displayName = app.profiles.getProfile(
-        role.Address.chain.id,
+        chainId as string,
         role.Address.address
       ).displayName;
 


### PR DESCRIPTION
Currently, the Address objects attached to Profiles/Roles (and perhaps more generally) appear to be highly unreliable. Sometimes Address.chain (typed to ChainInfo) references a ChainInfo object, but more often it references a string chainId. Sometimes Address contains a chainId (a required field) but often it possesses no such reference. There are also doublings of UserId and user_id in (incorrect to boot) camelCase and snake_case, respectively. 

In light of the unreliability of Address objects, I have attached a short-term fix to correctly and reliably pass chainIds to the /bulkProfile fetch called on the Admin Manage Community page.

See the 2nd commit, "[Fix missing chain id](https://github.com/hicommonwealth/commonwealth/commit/63e9d0271212ca88e30716c0abed8fe5dac11226)," for the actual bug patch, and the 3rd commit for documentation. 

(The 1st commit accidentally introduced linting which the 4th reverts)