### PR TITLE
Fix login button breaking on medium viewports

### DIFF
--- a/packages/commonwealth/client/styles/pages/landing/landing_page_header.scss
+++ b/packages/commonwealth/client/styles/pages/landing/landing_page_header.scss
@@ -75,6 +75,7 @@
 
 .LandingPageHeaderLoginButton {
   cursor: pointer;
+  white-space: nowrap;
   img {
     position: relative;
     top: -2px;
@@ -85,7 +86,6 @@
   }
 }
 li.LandingPageHeaderLoginButton.ml-10.pt-2 {
-  white-space: nowrap;
   a.btn-primary.pb-3.text-white {
     padding-top: 14px;
     padding-bottom: 9px;


### PR DESCRIPTION
## Description

Fix:

<img width="311" alt="image" src="https://user-images.githubusercontent.com/1273926/191301570-83a9af2b-014f-40ba-b99a-ebf75647e5a3.png">

After:

<img width="352" alt="image" src="https://user-images.githubusercontent.com/1273926/191301656-d9a3bd42-a106-488d-9c5a-b2b2cfa48bb8.png">


## Motivation and Context

css

## How has this been tested?

check with medium viewport

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
