### PR TITLE
Bring back reset walletconnect flow

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -12,6 +12,7 @@ import { notifyInfo } from 'controllers/app/notifications';
 import { createUserWithAddress } from 'controllers/app/login';
 import Near from 'controllers/chain/near/main';
 import Substrate from 'controllers/chain/substrate/main';
+import WalletConnectWebWalletController from 'controllers/app/webWallets/walletconnect_web_wallet';
 import { addressSwapper } from 'commonwealth/shared/utils';
 import { CWText } from './cw_text';
 import { CWWalletOptionRow } from './cw_wallet_option_row';
@@ -135,7 +136,7 @@ export class AccountSelector
 type WalletsListAttrs = {
   connectAnotherWayOnclick: () => void;
   darkMode?: boolean;
-  resetWalletConnectLink?: boolean;
+  showResetWalletConnect: boolean;
   hasNoWalletsLink?: boolean;
   wallets: Array<IWebWallet<any>>;
   setBodyType: (bodyType: string) => void;
@@ -149,7 +150,7 @@ export class CWWalletsList implements m.ClassComponent<WalletsListAttrs> {
     const {
       connectAnotherWayOnclick,
       darkMode,
-      resetWalletConnectLink = true,
+      showResetWalletConnect,
       hasNoWalletsLink = true,
       wallets,
       setSelectedWallet,
@@ -182,6 +183,14 @@ export class CWWalletsList implements m.ClassComponent<WalletsListAttrs> {
         console.log(err);
       }
     }
+
+    const resetWalletConnectOnclick = async (wallets) => {
+      const wallet = wallets.find((w) => w instanceof WalletConnectWebWalletController);
+      await wallet.reset();
+      $('.AccountSelector').trigger('modalexit');
+      m.redraw();
+    }
+
     return (
       <div class="WalletsList">
         <div class="wallets-and-link-container">
@@ -284,16 +293,15 @@ export class CWWalletsList implements m.ClassComponent<WalletsListAttrs> {
             ))}
           </div>
           <div className="wallet-list-links">
-            {resetWalletConnectLink && (
+            {showResetWalletConnect && (
               <CWText
-                onClick={async () => await webWallet.reset()}
                 type="caption"
                 className={getClasses<{ darkMode?: boolean }>(
                   { darkMode },
                   'reset-wc-link'
                 )}
                 >
-                Reset WalletConnect
+                <a href="#" onclick={resetWalletConnectOnclick.bind(this, wallets)}>Reset WalletConnect</a>
               </CWText>
             )}
             {hasNoWalletsLink && (

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -135,6 +135,7 @@ export class AccountSelector
 type WalletsListAttrs = {
   connectAnotherWayOnclick: () => void;
   darkMode?: boolean;
+  resetWalletConnectLink?: boolean;
   hasNoWalletsLink?: boolean;
   wallets: Array<IWebWallet<any>>;
   setBodyType: (bodyType: string) => void;
@@ -148,6 +149,7 @@ export class CWWalletsList implements m.ClassComponent<WalletsListAttrs> {
     const {
       connectAnotherWayOnclick,
       darkMode,
+      resetWalletConnectLink = true,
       hasNoWalletsLink = true,
       wallets,
       setSelectedWallet,
@@ -281,36 +283,50 @@ export class CWWalletsList implements m.ClassComponent<WalletsListAttrs> {
               />
             ))}
           </div>
-          {hasNoWalletsLink && (
-            <CWTooltip
-              interactionType="click"
-              tooltipContent={
-                <>
-                  <CWText type="caption">
-                    If you don’t see your wallet then make sure:
-                  </CWText>
-                  <CWText type="caption">
-                    • Your wallet chrome extension installed?
-                  </CWText>
-                  <CWText type="caption">
-                    • Your wallet chrome extension active?
-                  </CWText>
-                </>
-              }
-              tooltipType="solidArrow"
-              trigger={
-                <CWText
-                  type="caption"
-                  className={getClasses<{ darkMode?: boolean }>(
-                    { darkMode },
-                    'no-wallet-link'
-                  )}
+          <div className="wallet-list-links">
+            {resetWalletConnectLink && (
+              <CWText
+                onClick={async () => await webWallet.reset()}
+                type="caption"
+                className={getClasses<{ darkMode?: boolean }>(
+                  { darkMode },
+                  'reset-wc-link'
+                )}
                 >
-                  Don't see your wallet?
-                </CWText>
-              }
-            />
-          )}
+                Reset WalletConnect
+              </CWText>
+            )}
+            {hasNoWalletsLink && (
+              <CWTooltip
+                interactionType="click"
+                tooltipContent={
+                  <>
+                    <CWText type="caption">
+                      If you don’t see your wallet then make sure:
+                    </CWText>
+                    <CWText type="caption">
+                      • Your wallet chrome extension installed?
+                    </CWText>
+                    <CWText type="caption">
+                      • Your wallet chrome extension active?
+                    </CWText>
+                  </>
+                }
+                tooltipType="solidArrow"
+                trigger={
+                  <CWText
+                    type="caption"
+                    className={getClasses<{ darkMode?: boolean }>(
+                      { darkMode },
+                      'no-wallet-link'
+                    )}
+                  >
+                    Don't see your wallet?
+                  </CWText>
+                }
+              />
+            )}
+          </div>
         </div>
         <CWText
           type="b2"

--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -19,6 +19,7 @@ import { ProfileRowAttrs } from '../components/component_kit/cw_profiles_list';
 import { LoginDesktop } from '../pages/login/login_desktop';
 import { LoginMobile } from '../pages/login/login_mobile';
 import { LoginBodyType, LoginSidebarType } from '../pages/login/types';
+import WalletConnectWebWalletController from 'controllers/app/webWallets/walletconnect_web_wallet';
 
 type LoginModalAttrs = {
   initialBody?: LoginBodyType;
@@ -93,6 +94,7 @@ export class NewLoginModal implements m.ClassComponent<LoginModalAttrs> {
 
   view(vnode) {
     const { onSuccess } = vnode.attrs;
+    const wcEnabled = _.any(this.wallets, (w) => w instanceof WalletConnectWebWalletController && w.enabled);
 
     // Handles Magic Link Login
     const handleEmailLoginCallback = async () => {
@@ -337,6 +339,7 @@ export class NewLoginModal implements m.ClassComponent<LoginModalAttrs> {
         handleEmailLoginCallback={handleEmailLoginCallback}
         saveProfileInfoCallback={saveProfileInfoCallback}
         performLinkingCallback={performLinkingCallback}
+        showResetWalletConnect={wcEnabled}
       />
     ) : (
       <LoginDesktop
@@ -381,6 +384,7 @@ export class NewLoginModal implements m.ClassComponent<LoginModalAttrs> {
         handleEmailLoginCallback={handleEmailLoginCallback}
         saveProfileInfoCallback={saveProfileInfoCallback}
         performLinkingCallback={performLinkingCallback}
+        showResetWalletConnect={wcEnabled}
       />
     );
   }

--- a/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
@@ -45,6 +45,7 @@ export class LoginDesktop implements m.ClassComponent<LoginAttrs> {
       performLinkingCallback,
       setSelectedLinkingWallet,
       magicLoading,
+      showResetWalletConnect,
     } = vnode.attrs;
 
     return (
@@ -71,6 +72,7 @@ export class LoginDesktop implements m.ClassComponent<LoginAttrs> {
                 setBodyType={setBodyType}
                 accountVerifiedCallback={accountVerifiedCallback}
                 linking={false}
+                showResetWalletConnect={showResetWalletConnect}
               />
             </div>
           )}
@@ -185,6 +187,7 @@ export class LoginDesktop implements m.ClassComponent<LoginAttrs> {
                 setSelectedWallet={setSelectedWallet}
                 hasNoWalletsLink={false}
                 wallets={wallets}
+                showResetWalletConnect={showResetWalletConnect}
               />
             </div>
           )}
@@ -215,6 +218,7 @@ export class LoginDesktop implements m.ClassComponent<LoginAttrs> {
                 setBodyType={setBodyType}
                 accountVerifiedCallback={accountVerifiedCallback}
                 linking={true}
+                showResetWalletConnect={showResetWalletConnect}
               />
             </div>
           )}

--- a/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
@@ -47,6 +47,7 @@ export class LoginMobile implements m.ClassComponent<LoginAttrs> {
       performLinkingCallback,
       setSelectedLinkingWallet,
       magicLoading,
+      showResetWalletConnect,
     } = vnode.attrs;
 
     const hasBoilerplate =
@@ -88,6 +89,7 @@ export class LoginMobile implements m.ClassComponent<LoginAttrs> {
               setSidebarType={setSidebarType}
               setBodyType={setBodyType}
               accountVerifiedCallback={accountVerifiedCallback}
+              showResetWalletConnect={showResetWalletConnect}
               linking={false}
             />
           )}
@@ -103,6 +105,7 @@ export class LoginMobile implements m.ClassComponent<LoginAttrs> {
               setSelectedWallet={setSelectedLinkingWallet}
               setBodyType={setBodyType}
               accountVerifiedCallback={accountVerifiedCallback}
+              showResetWalletConnect={showResetWalletConnect}
               linking={true}
             />
           )}

--- a/packages/commonwealth/client/scripts/views/pages/login/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/login/types.ts
@@ -41,4 +41,5 @@ export type LoginAttrs = {
   logInWithAccountCallback: () => void;
   saveProfileInfoCallback: () => void;
   performLinkingCallback: () => void;
+  showResetWalletConnect: boolean;
 };

--- a/packages/commonwealth/client/styles/components/component_kit/cw_wallets_list.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_wallets_list.scss
@@ -16,7 +16,7 @@
       row-gap: 4px;
       width: 284px;
       // preserves box shadow in scroll container
-      height: 174px;
+      height: 176px;
       margin-bottom: -4px;
       padding-bottom: 4px;
 
@@ -29,6 +29,23 @@
         padding-bottom: 0;
 
         @include visibleScrollbar(dark);
+      }
+    }
+
+    .wallet-list-links {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 4px;
+    }
+
+    .reset-wc-link {
+      align-self: flex-start;
+      color: $neutral-500;
+      cursor: pointer;
+      margin: 8px 12px 8px 0;
+
+      &.darkMode {
+        color: $neutral-400;
       }
     }
 

--- a/packages/commonwealth/client/styles/components/component_kit/cw_wallets_list.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_wallets_list.scss
@@ -40,11 +40,12 @@
 
     .reset-wc-link {
       align-self: flex-start;
-      color: $neutral-500;
-      cursor: pointer;
-      margin: 8px 12px 8px 0;
-
-      &.darkMode {
+      a {
+        color: $neutral-500;
+        cursor: pointer;
+        margin: 8px 12px 8px 0;
+      }
+      &.darkMode a {
         color: $neutral-400;
       }
     }


### PR DESCRIPTION
## Description

Brings back #2106. FYI this PR is made against Alex's branch /cc @alexyoung23j .

## Motivation and Context

Otherwise it's possible to end up with broken WC on the client.

## How has this been tested?

login with wc, logout, login again, logout, reset, login again. do this for both desktop and mobile login modals

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
