### PR TITLE
Better Recent Threads Count

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
@@ -54,12 +54,7 @@ class CommunityPreviewCard implements m.ClassComponent<{ chain: ChainInfo }> {
         {!!monthlyThreadCount && (
           <>
             <CWText className="card-subtext" type="b2" fontWeight="medium">
-              {monthlyThreadCount > 20
-                ? `${pluralize(
-                    Math.floor(monthlyThreadCount / 5),
-                    'thread'
-                  )} this week`
-                : `${pluralize(monthlyThreadCount, 'thread')} this month`}
+              {`${pluralize(monthlyThreadCount, 'thread')} this month`}
             </CWText>
             {isMember && (
               <>

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
@@ -54,7 +54,7 @@ class CommunityPreviewCard implements m.ClassComponent<{ chain: ChainInfo }> {
         {!!monthlyThreadCount && (
           <>
             <CWText className="card-subtext" type="b2" fontWeight="medium">
-              {`${pluralize(monthlyThreadCount, 'thread')} this month`}
+              {`${pluralize(monthlyThreadCount, 'new thread')} this month`}
             </CWText>
             {isMember && (
               <>

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -51,9 +51,10 @@ const status = async (
           `
         SELECT "Threads".chain, COUNT("Threads".id) 
         FROM "Threads"
-        WHERE "Threads".deleted_at IS NULL
-        AND NOT "Threads".pinned
+        WHERE "Threads".created_at > :thirtyDaysAgo
+        AND "Threads".deleted_at IS NULL
         AND "Threads".chain IS NOT NULL
+        AND NOT "Threads".pinned
         GROUP BY "Threads".chain;
         `,
           { replacements: { thirtyDaysAgo }, type: QueryTypes.SELECT }
@@ -81,7 +82,10 @@ const status = async (
       disableRichText,
       lastVisited,
     ] = await Promise.all([
-      unfilteredAddresses.filter((address) => !!address.verified && chains.map((c) => c.id).includes(address.chain)),
+      unfilteredAddresses.filter(
+        (address) =>
+          !!address.verified && chains.map((c) => c.id).includes(address.chain)
+      ),
       user.getSocialAccounts(),
       user.getSelectedChain(),
       user.isAdmin,

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -54,7 +54,6 @@ const status = async (
         WHERE "Threads".created_at > :thirtyDaysAgo
         AND "Threads".deleted_at IS NULL
         AND "Threads".chain IS NOT NULL
-        AND NOT "Threads".pinned
         GROUP BY "Threads".chain;
         `,
           { replacements: { thirtyDaysAgo }, type: QueryTypes.SELECT }
@@ -115,10 +114,9 @@ const status = async (
         `
       SELECT "Threads".chain, COUNT("Threads".id) 
       FROM "Threads"
-      WHERE 
-        "Threads".deleted_at IS NULL
-          AND NOT "Threads".pinned
-          AND "Threads".chain IS NOT NULL
+      WHERE "Threads".created_at > :thirtyDaysAgo
+      AND "Threads".deleted_at IS NULL
+      AND "Threads".chain IS NOT NULL
       GROUP BY "Threads".chain;
       `,
         {


### PR DESCRIPTION
Previously, we had a completely insane non-working system for counting recent threads by chain.

This makes that system more sane by (1) reinstating thirty-date gating (2) using a bright-line ontology (new threads, i.e. thread creation) (3) removing the hacky months/weeks distinction