### PR TITLE
Tablet "New Thread" button fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/new_proposal_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_proposal_button.tsx
@@ -198,14 +198,14 @@ export class MobileNewProposalButton implements m.ClassComponent {
             disabled={!app.user.activeAccount}
             label={<Icon name={Icons.PLUS} />}
             inline={true}
-            position="bottom-start"
-            closeOnContentClick={true}
-            menuAttrs={{
-              align: 'left',
-            }}
-            content={<NewProposalMenu />}
-          />
-        }
+            />
+          }
+        position="bottom-start"
+        closeOnContentClick={true}
+        menuAttrs={{
+          align: 'left',
+        }}
+        content={<NewProposalMenu />}
       />
     );
   }


### PR DESCRIPTION
Previously, bad attributes in our New Thread mobile button popover prevented the trigger from working. This moves the attributes from the trigger to the popover proper.