### PR TITLE
Fix broken "Change Topics" functionality

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/topics.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/topics.ts
@@ -91,7 +91,6 @@ class TopicsController {
         topic_name: topicName,
         address: app.user.activeAccount.address,
       });
-      console.log(response.result);
       const result = new Topic(response.result);
       if (this._store.getById(result.id)) {
         this._store.remove(this._store.getById(result.id));

--- a/packages/commonwealth/client/scripts/controllers/server/topics.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/topics.ts
@@ -91,6 +91,7 @@ class TopicsController {
         topic_name: topicName,
         address: app.user.activeAccount.address,
       });
+      console.log(response.result);
       const result = new Topic(response.result);
       if (this._store.getById(result.id)) {
         this._store.remove(this._store.getById(result.id));

--- a/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
@@ -13,7 +13,7 @@ type TopicSelectorAttrs = {
   defaultTopic?: Topic | string | boolean;
   tabindex?: number;
   topics: Topic[];
-  updateFormData: (topic: Topic, topicId?: string) => void;
+  updateFormData: (topic: Topic) => void;
 };
 
 export class TopicSelector implements m.ClassComponent<TopicSelectorAttrs> {
@@ -49,13 +49,13 @@ export class TopicSelector implements m.ClassComponent<TopicSelectorAttrs> {
 
     const oncreate = () => {
       if (selectedTopic) {
-        updateFormData(selectedTopic.name, selectedTopic.id);
+        updateFormData(selectedTopic);
       }
     };
 
     const onSelect = (item: Topic) => {
       selectedTopic = item;
-      updateFormData(item.name, item.id);
+      updateFormData(selectedTopic);
     };
 
     const sortTopics = (topics_: Topic[]) => {

--- a/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
@@ -12,25 +12,17 @@ import { TopicSelector } from '../components/topic_selector';
 import { ModalExitButton } from '../components/component_kit/cw_modal';
 
 type ChangeTopicModalAttrs = {
-  onChangeHandler: () => void;
+  onChangeHandler: (topic: Topic) => void;
   thread: Thread;
 };
 
 export class ChangeTopicModal
   implements m.ClassComponent<ChangeTopicModalAttrs>
 {
-  private activeTopic: Topic | string;
-  private topicId: number;
-  private topicName: string;
-
-  oncreate(vnode) {
-    if (!vnode.attrs.thread.topic) return;
-
-    this.topicName = vnode.attrs.thread.topic.name;
-    this.topicId = vnode.attrs.thread.topic.id;
-  }
+  private activeTopic: Topic;
 
   oninit(vnode) {
+    if (!vnode.attrs.thread.topic) return;
     this.activeTopic = vnode.attrs.thread.topic;
   }
 
@@ -47,9 +39,9 @@ export class ChangeTopicModal
           <TopicSelector
             defaultTopic={this.activeTopic}
             topics={app.topics.getByCommunity(app.activeChainId())}
-            updateFormData={(topicName, topicId?) => {
-              vnode.attrs.onChangeHandler(topicName, topicId);
-              this.activeTopic = topicName;
+            updateFormData={(topic: Topic) => {
+              vnode.attrs.onChangeHandler(topic);
+              this.activeTopic = topic;
             }}
           />
           <div class="buttons-row">
@@ -63,13 +55,12 @@ export class ChangeTopicModal
             <CWButton
               label="Save changes"
               onclick={async (e) => {
-                const { topicName, topicId } = this;
-
+                const { activeTopic } = this;
                 try {
                   const topic: Topic = await app.topics.update(
                     thread.id,
-                    topicName,
-                    topicId
+                    activeTopic.name,
+                    activeTopic.id
                   );
 
                   vnode.attrs.onChangeHandler(topic);

--- a/packages/commonwealth/server/routes/updateTopic.ts
+++ b/packages/commonwealth/server/routes/updateTopic.ts
@@ -57,8 +57,6 @@ const updateTopic = async (
     newTopic = await models.Topic.findOne({
       where: { id: req.body.topic_id },
     });
-    console.log('if');
-    console.log(newTopic);
   } else {
     [newTopic] = await models.Topic.findOrCreate({
       where: {
@@ -66,8 +64,6 @@ const updateTopic = async (
         chain_id: thread.chain,
       },
     });
-    console.log('else');
-    console.log(newTopic);
     thread.topic_id = newTopic.id;
     await thread.save();
   }

--- a/packages/commonwealth/server/routes/updateTopic.ts
+++ b/packages/commonwealth/server/routes/updateTopic.ts
@@ -7,7 +7,7 @@ enum UpdateTopicErrors {
   NoUser = 'Not logged in',
   NoThread = 'Must provide thread_id',
   NoAddr = 'Must provide address',
-  NoTopic = 'Must provide topic_name',
+  NoTopic = 'Must provide topic_name or topic_id',
   InvalidAddr = 'Invalid address',
   NoPermission = `You do not have permission to edit post topic`,
 }
@@ -19,9 +19,11 @@ const updateTopic = async (
   next: NextFunction
 ) => {
   if (!req.user) return next(new AppError(UpdateTopicErrors.NoUser));
-  if (!req.body.thread_id) return next(new AppError(UpdateTopicErrors.NoThread));
+  if (!req.body.thread_id)
+    return next(new AppError(UpdateTopicErrors.NoThread));
   if (!req.body.address) return next(new AppError(UpdateTopicErrors.NoAddr));
-  if (!req.body.topic_name) return next(new AppError(UpdateTopicErrors.NoTopic));
+  if (!req.body.topic_name && !req.body.topic_id)
+    return next(new AppError(UpdateTopicErrors.NoTopic));
 
   const userAddresses = await req.user.getAddresses();
   const userAddress = userAddresses.find(
@@ -55,6 +57,8 @@ const updateTopic = async (
     newTopic = await models.Topic.findOne({
       where: { id: req.body.topic_id },
     });
+    console.log('if');
+    console.log(newTopic);
   } else {
     [newTopic] = await models.Topic.findOrCreate({
       where: {
@@ -62,6 +66,8 @@ const updateTopic = async (
         chain_id: thread.chain,
       },
     });
+    console.log('else');
+    console.log(newTopic);
     thread.topic_id = newTopic.id;
     await thread.save();
   }


### PR DESCRIPTION
Our /updateTopic route, and the ChangeTopicModal which calls it, are both in pretty neglected shape and could use a serious clean-up/refactor.

As a result of messy logic, /updateTopic was incorrectly receiving a thread's _current_ topic as if it were the _new_ topic being updated against. 

This makes some steps toward cleaning up the modal/route while more immediately ensuring that the admin feature works as desired.