### PR TITLE
Force browser to update favicon cache

### DIFF
--- a/packages/commonwealth/client/index.html
+++ b/packages/commonwealth/client/index.html
@@ -101,7 +101,7 @@
       as="font"
       crossorigin="anonymous"
     />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="/favicon.ico?v=2" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
By adding the query tag to the favicon.ico link, browsers will override their static file cache and serve up the new icon.