### PR TITLE
Sidebar scroll improvement

### DIFF
--- a/packages/commonwealth/client/styles/components/sidebar/index.scss
+++ b/packages/commonwealth/client/styles/components/sidebar/index.scss
@@ -5,7 +5,7 @@
   border-right: 1px solid $neutral-200;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: auto;
   min-width: $sidebar-width;
   overflow-y: auto;
   width: $sidebar-width;
@@ -15,7 +15,7 @@
   }
 
   .buttons-container {
-    margin: 24px 0;
+    margin-top: 24px;
 
     .subscription-button {
       display: flex;

--- a/packages/commonwealth/client/styles/sublayout.scss
+++ b/packages/commonwealth/client/styles/sublayout.scss
@@ -38,6 +38,7 @@
       .sidebar-inner-container {
         display: flex;
         height: 100%;
+        overflow: hidden;
         width: min-content;
       }
     }


### PR DESCRIPTION
Currently, tall sidebars (e.g. Edgeware's, on livesite) when expanded can crowd out the Notifications button at the bottom of the sidebar.

This SCSS patch sets better height and overflow props, so that the height of the sidebar expands automatically to fit all children heights, as it ought to.