### PR TITLE
Fix broken thread "linked proposal" module

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_proposals_card.tsx
@@ -38,7 +38,7 @@ class ProposalSidebarLinkedChainEntity
 
     const proposalLink = `${
       app.isCustomDomain() ? '' : `/${proposal.chain}`
-    }${getProposalUrlPath(slug, chainEntity.typeId)}`;
+    }${getProposalUrlPath(slug, chainEntity.typeId, true)}`;
 
     return link('a', proposalLink, [
       `${chainEntityTypeToProposalName(chainEntity.type)} #${


### PR DESCRIPTION
A missing argument in a getProposalUrlPath invocation resulted in duplication of the active chain id, breaking links to proposals from threads.