### PR TITLE
Fix bad notifications CSS

### DIFF
--- a/packages/commonwealth/client/styles/components/header/notifications_menu.scss
+++ b/packages/commonwealth/client/styles/components/header/notifications_menu.scss
@@ -48,6 +48,7 @@
 
   .notification-list {
     align-items: center;
+    display: flex;
     height: 480px;
     justify-content: center;
   }


### PR DESCRIPTION
Ostensibly in the next couple months we'll have time for a full notifications menu refactor, but until then, a missing `display: flex` on the menu's inner wrap are preventing the justify-content & align-items styling from being properly applied. This leads to awkwardly positioned empty notification menu copy for new users.

If it's not worth merging that's fine, just opening up in case.

<img width="311" alt="image" src="https://user-images.githubusercontent.com/22281010/195144094-47800f40-7b90-4ea5-915d-48cfdc7f01d8.png">
