### PR TITLE
Fix /tokenBalance Rollbar error: "AppError: Error: WHERE parameter "address" has invalid "undefined" value"

### DIFF
--- a/packages/commonwealth/server/routes/tokenBalance.ts
+++ b/packages/commonwealth/server/routes/tokenBalance.ts
@@ -31,7 +31,7 @@ const tokenBalance = async (
   }
 
   let chain: ChainInstance;
-  let author: AddressInstance;
+  // let author: AddressInstance;
   let error: string;
   let contract: ContractInstance;
   try {
@@ -40,12 +40,14 @@ const tokenBalance = async (
   } catch (err) {
     throw new AppError(err);
   }
-  try {
-    [author, error] = await lookupAddressIsOwnedByUser(models, req);
-    if (error) throw new AppError(error);
-  } catch (err) {
-    throw new AppError(err)
-  }
+
+  // NOTE: Removing validation of ownership of address, seemingly unnecessary for logic
+  // try {
+  //   [author, error] = await lookupAddressIsOwnedByUser(models, req);
+  //   if (error) throw new AppError(error);
+  // } catch (err) {
+  //   throw new AppError(err)
+  // }
 
   let chain_node_id = chain.ChainNode.id;
   if (
@@ -69,7 +71,8 @@ const tokenBalance = async (
   try {
     const balance = await tokenBalanceCache.getBalance(
       chain_node_id,
-      author.address,
+      // author.address, // NOTE: see above
+      req.body.address,
       contract?.address,
       chain.network === ChainNetwork.ERC20
         ? 'erc20' : chain.network === ChainNetwork.ERC721


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Error would throw bc users have owned address "associated to a different chain" (downstream of address owned by chain/community issue, to be generalized in later work). This would mean no "author" would be returned from the `lookupAddressIsOwnedByUser` call meaning that when we would check its address, it would be undefined. In the context of checking an address's balance in this route, which is only called within the adapters to show to the user what buttons are enabled/disabled, I think it is safe to not validate the address being passed in is owned by them or not. We use `validateTopicThreshold` to validate actions (new threads, comments, etc), so this is unrelated. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
