### PR TITLE
Fix discussion page redirect for custom domains

### DIFF
--- a/packages/commonwealth/client/scripts/app.ts
+++ b/packages/commonwealth/client/scripts/app.ts
@@ -813,7 +813,7 @@ Promise.all([$.ready, $.get('/api/domain')]).then(
             '/:scope/finishNearLogin': redirectRoute(() => '/finishNearLogin'),
             '/:scope/finishaxielogin': redirectRoute(() => '/finishaxielogin'),
             '/:scope/home': redirectRoute(() => '/'),
-            '/:scope/discussions': redirectRoute(() => '/'),
+            '/:scope/discussions': redirectRoute(() => '/discussions'),
             '/:scope': redirectRoute(() => '/'),
             '/:scope/discussions/:topic': redirectRoute(
               (attrs) => `/discussions/${attrs.topic}/`

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -1,5 +1,6 @@
 /* @jsx m */
 
+import { navigateToSubpage } from 'app';
 import m from 'mithril';
 
 import app from 'state';
@@ -9,9 +10,9 @@ class DiscussionsRedirect implements m.ClassComponent {
   view() {
     if (app.chain) {
       if (app.chain.meta.defaultOverview) {
-        m.route.set(`${app.activeChainId()}/overview`);
+        navigateToSubpage('/overview');
       } else {
-        m.route.set(`${app.activeChainId()}/discussions`);
+        navigateToSubpage('/discussions');
       }
     } else {
       return <PageLoading />;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Edgeware reported a redirect loop on homepage => was appending /edgeware/ to the custom-domain url which caused a redirect home and the cycle continued.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
