### PR TITLE
Introduce generic ChainId store

### DIFF
--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -1,0 +1,35 @@
+import { IHasChainId } from './interfaces';
+import Store from './Store';
+
+class ChainIdStore<T extends IHasChainId> extends Store<T> {
+  private _storeChainId: { [chainId: string]: T } = {};
+
+  public add(n: T) {
+    super.add(n);
+    this._storeChainId[n.chainId] = n;
+    return this;
+  }
+
+  public remove(n: T) {
+    super.remove(n);
+    delete this._storeChainId[n.chainId.toString()];
+    return this;
+  }
+
+  public update(n: T) {
+    super.update(n, (a) => a.chainId === n.chainId);
+    this._storeChainId[n.chainId.toString()] = n;
+    return this;
+  }
+
+  public clear() {
+    super.clear();
+    this._storeChainId = {};
+  }
+
+  public getByChain(chainId: string): T {
+    return this._storeChainId[chainId];
+  }
+}
+
+export default ChainIdStore;

--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -35,6 +35,8 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
   }
 
   public remove(n: T): ChainIdStore<T> {
+    super.remove(n, this._searchFn);
+
     // Locate object
     const idx = this._searchFn
       ? this._storeChainId[n.chainId].findIndex(this._searchFn)
@@ -48,6 +50,8 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
   }
 
   public update(n: T): ChainIdStore<T> {
+    super.update(n, this._searchFn);
+
     // Locate object
     const idx = this._searchFn
       ? this._storeChainId[n.chainId].findIndex(this._searchFn)

--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -2,32 +2,54 @@ import { IHasChainId } from './interfaces';
 import Store from './Store';
 
 class ChainIdStore<T extends IHasChainId> extends Store<T> {
-  private _storeChainId: { [chainId: string]: T } = {};
+  private _storeChainId: { [chainId: string]: Array<T> } = {};
+  private _sortingFunction: (a: T, b: T) => number;
 
-  public add(n: T) {
+  constructor(sortingFunction: (a: T, b: T) => number) {
+    super();
+    this._sortingFunction = sortingFunction;
+  }
+
+  public add(n: T): ChainIdStore<T> {
     super.add(n);
-    this._storeChainId[n.chainId] = n;
+
+    // Create chain-scoped store if it does not exist
+    if (!this._storeChainId[n.chainId]) {
+      this._storeChainId[n.chainId] = [] as Array<T>;
+    }
+
+    // Add to chain-scoped store
+    this._storeChainId[n.chainId].push(n);
+
+    // Sort store
+    if (this._sortingFunction) {
+      this._storeChainId[n.chainId].sort(this._sortingFunction);
+    }
+
     return this;
   }
 
-  public remove(n: T) {
-    super.remove(n);
-    delete this._storeChainId[n.chainId.toString()];
+  public remove(n: T): ChainIdStore<T> {
+    const idx = this._storeChainId[n.chainId].indexOf(n);
+    if (idx === -1) throw new Error('Object not in store.');
+    this._storeChainId[n.chainId].splice(idx, 1);
     return this;
   }
 
-  public update(n: T) {
-    super.update(n, (a) => a.chainId === n.chainId);
-    this._storeChainId[n.chainId.toString()] = n;
+  public update(n: T, eqFn: (a: T) => boolean): ChainIdStore<T> {
+    const idx = this._storeChainId[n.chainId].findIndex(eqFn);
+    if (idx === -1) throw new Error('Object not in store.');
+    this._storeChainId[n.chainId][idx] = n;
     return this;
   }
 
-  public clear() {
+  public clear(): ChainIdStore<T> {
     super.clear();
     this._storeChainId = {};
+    return this;
   }
 
-  public getByChain(chainId: string): T {
+  public getByChainId(chainId: string): Array<T> {
     return this._storeChainId[chainId];
   }
 }

--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -3,11 +3,16 @@ import Store from './Store';
 
 class ChainIdStore<T extends IHasChainId> extends Store<T> {
   private readonly _storeChainId: { [chainId: string]: Array<T> } = {};
-  private readonly _sortingFunction?: (a: T, b: T) => number;
+  private readonly _sortFn?: (a: T, b: T) => number;
+  private readonly _searchFn?: (a: T) => boolean;
 
-  constructor(sortingFunction?: (a: T, b: T) => number) {
+  constructor(params: {
+    sortFn?: (a: T, b: T) => number;
+    searchFn?: (a: T) => boolean;
+  }) {
     super();
-    this._sortingFunction = sortingFunction;
+    this._sortFn = params.sortFn;
+    this._searchFn = params.searchFn;
   }
 
   public add(n: T): ChainIdStore<T> {
@@ -22,8 +27,8 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
     this._storeChainId[n.chainId].push(n);
 
     // Sort store
-    if (this._sortingFunction) {
-      this._storeChainId[n.chainId].sort(this._sortingFunction);
+    if (this._sortFn) {
+      this._storeChainId[n.chainId].sort(this._sortFn);
     }
 
     return this;
@@ -31,7 +36,9 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
 
   public remove(n: T): ChainIdStore<T> {
     // Locate object
-    const idx = this._storeChainId[n.chainId].indexOf(n);
+    const idx = this._searchFn
+      ? this._storeChainId[n.chainId].findIndex(this._searchFn)
+      : this._storeChainId[n.chainId].indexOf(n);
     if (idx === -1) throw new Error('Object not in store.');
 
     // Replace object
@@ -40,10 +47,11 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
     return this;
   }
 
-  public update(n: T, eqFn: (a: T) => boolean): ChainIdStore<T> {
-    t;
+  public update(n: T): ChainIdStore<T> {
     // Locate object
-    const idx = this._storeChainId[n.chainId].findIndex(eqFn);
+    const idx = this._searchFn
+      ? this._storeChainId[n.chainId].findIndex(this._searchFn)
+      : this._storeChainId[n.chainId].indexOf(n);
     if (idx === -1) throw new Error('Object not in store.');
 
     // Update object

--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -2,10 +2,10 @@ import { IHasChainId } from './interfaces';
 import Store from './Store';
 
 class ChainIdStore<T extends IHasChainId> extends Store<T> {
-  private _storeChainId: { [chainId: string]: Array<T> } = {};
-  private _sortingFunction: (a: T, b: T) => number;
+  private readonly _storeChainId: { [chainId: string]: Array<T> } = {};
+  private readonly _sortingFunction?: (a: T, b: T) => number;
 
-  constructor(sortingFunction: (a: T, b: T) => number) {
+  constructor(sortingFunction?: (a: T, b: T) => number) {
     super();
     this._sortingFunction = sortingFunction;
   }

--- a/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ChainIdStore.ts
@@ -30,22 +30,33 @@ class ChainIdStore<T extends IHasChainId> extends Store<T> {
   }
 
   public remove(n: T): ChainIdStore<T> {
+    // Locate object
     const idx = this._storeChainId[n.chainId].indexOf(n);
     if (idx === -1) throw new Error('Object not in store.');
+
+    // Replace object
     this._storeChainId[n.chainId].splice(idx, 1);
+
     return this;
   }
 
   public update(n: T, eqFn: (a: T) => boolean): ChainIdStore<T> {
+    t;
+    // Locate object
     const idx = this._storeChainId[n.chainId].findIndex(eqFn);
     if (idx === -1) throw new Error('Object not in store.');
+
+    // Update object
     this._storeChainId[n.chainId][idx] = n;
+
     return this;
   }
 
   public clear(): ChainIdStore<T> {
     super.clear();
-    this._storeChainId = {};
+    Object.keys(this._storeChainId).forEach(
+      (chainId: string) => delete this._storeChainId[chainId]
+    );
     return this;
   }
 

--- a/packages/commonwealth/client/scripts/stores/interfaces.ts
+++ b/packages/commonwealth/client/scripts/stores/interfaces.ts
@@ -16,3 +16,7 @@ export interface IHasId {
 export interface IHasAddress {
   address: string;
 }
+
+export interface IHasChainId {
+  chainId: string;
+}


### PR DESCRIPTION
Per #cmn-engineering conversation:
> Know how we have a generic IdStore that can be used for any object with an id? What do y’all thinking of creating a CommunityIdStore but for objects that also contain chain ids (i.e. community ids—soon to be consolidated as we move toward renaming…)? So that we’re not building a custom store each time we want a `_threadsByCommunity` or `_draftsByCommunity` or `_topicsByCommunity` sub-store/getter options?

This pull introduces a ChainIdStore (named for clarity with current naming system). Down the line, I assume it will be renamed to CommunityIdStore, as we are moving to decouple chains and communities from a one-to-one relation, to a many-to-one.

This pull does not update any existing stores to use the new ChainIdStore. This will require some testing and refactoring (e.g. many of our frontend objects have the property `chain` rather than `chainId`; this should be reconciled before we switch naming schemas to `community` or similar) that can be accomplished later. The primary purpose of opening this PR now is to be used on the Crowdfund (i.e. projects) controller for chain-scoping and filtering of projects on the project listing page.