### PR TITLE
Rjwebb/display reset walletconnect on terra walletconnect

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -23,6 +23,7 @@ import { ProfileRowAttrs } from '../components/component_kit/cw_profiles_list';
 import { LoginDesktop } from '../pages/login/login_desktop';
 import { LoginMobile } from '../pages/login/login_mobile';
 import { LoginBodyType, LoginSidebarType } from '../pages/login/types';
+import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/terra_walletconnect_web_wallet';
 
 type LoginModalAttrs = {
   initialBody?: LoginBodyType;
@@ -126,7 +127,7 @@ export class NewLoginModal implements m.ClassComponent<LoginModalAttrs> {
     const { onSuccess } = vnode.attrs;
     const wcEnabled = _.any(
       this.wallets,
-      (w) => w instanceof WalletConnectWebWalletController && w.enabled
+      (w) => (w instanceof WalletConnectWebWalletController || w instanceof TerraWalletConnectWebWalletController) && w.enabled
     );
 
     // Handles Magic Link Login

--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -11,6 +11,7 @@ import {
   loginWithMagicLink,
   updateActiveAddresses,
 } from 'controllers/app/login';
+import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/terra_walletconnect_web_wallet';
 import WalletConnectWebWalletController from 'controllers/app/webWallets/walletconnect_web_wallet';
 import { notifyError } from 'controllers/app/notifications';
 import { Account, IWebWallet } from 'models';
@@ -23,7 +24,6 @@ import { ProfileRowAttrs } from '../components/component_kit/cw_profiles_list';
 import { LoginDesktop } from '../pages/login/login_desktop';
 import { LoginMobile } from '../pages/login/login_mobile';
 import { LoginBodyType, LoginSidebarType } from '../pages/login/types';
-import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/terra_walletconnect_web_wallet';
 
 type LoginModalAttrs = {
   initialBody?: LoginBodyType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The "Reset WalletConnect" link currently only appears if the selected wallet is an instance of `WalletConnectWebWalletController`. This PR modifies the login modal code so that it also checks for `TerraWalletConnectWebWalletController`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
