### PR TITLE
Add vnodes to components part 1

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_empty_state.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_empty_state.tsx
@@ -14,8 +14,9 @@ type EmptyStateAttrs = {
 };
 
 export class CWEmptyState implements m.ClassComponent<EmptyStateAttrs> {
-  view(vnode) {
+  view(vnode: m.Vnode<EmptyStateAttrs>) {
     const { content, iconName } = vnode.attrs;
+
     return (
       <div class="EmptyState">
         <div class="inner-content">

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icon_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icon_button.tsx
@@ -3,11 +3,11 @@
 import m from 'mithril';
 
 import { CWIcon } from './cw_icons/cw_icon';
-import { IconAttrs } from './cw_icons/types';
+import { IconComponentAttrs } from './cw_icons/types';
 import { ComponentType } from './types';
 
-export class CWIconButton implements m.ClassComponent<IconAttrs> {
-  view(vnode) {
+export class CWIconButton implements m.ClassComponent<IconComponentAttrs> {
+  view(vnode: m.Vnode<IconComponentAttrs>) {
     const {
       componentType = ComponentType.IconButton,
       disabled = false,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icon.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icon.tsx
@@ -14,7 +14,7 @@ export class CWCustomIcon implements m.ClassComponent<CustomIconAttrs> {
       componentType = ComponentType.CustomIcon,
       iconName,
       iconSize = 'medium',
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
 
     const CustomIcon = customIconLookup[iconName];
@@ -23,7 +23,7 @@ export class CWCustomIcon implements m.ClassComponent<CustomIconAttrs> {
       <CustomIcon
         componentType={componentType}
         iconSize={iconSize}
-        {...domAttrs}
+        {...otherAttrs}
       />
     );
   }

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icon.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icon.tsx
@@ -9,7 +9,7 @@ import { CustomIconAttrs } from './types';
 import { ComponentType } from '../types';
 
 export class CWCustomIcon implements m.ClassComponent<CustomIconAttrs> {
-  view(vnode) {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const {
       componentType = ComponentType.CustomIcon,
       iconName,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icons.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /* @jsx m */
 
 /* eslint-disable max-len */
@@ -18,8 +19,8 @@ import { CustomIconAttrs, CustomIconStyleAttrs } from './types';
 // (2) Extra attention must be paid to the JSX conversion output, since distortions
 //     of width, height, and coloration have been observed with some regularity
 
-export const CWCosmosEvmMetamask: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWCosmosEvmMetamask implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -37,11 +38,11 @@ export const CWCosmosEvmMetamask: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWKeplr: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWKeplr implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -68,11 +69,11 @@ export const CWKeplr: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWMagic: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWMagic implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -90,11 +91,11 @@ export const CWMagic: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWMetaMask: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWMetaMask implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -192,11 +193,11 @@ export const CWMetaMask: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWNearWallet: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWNearWallet implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -214,11 +215,11 @@ export const CWNearWallet: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPhantom: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWPhantom implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, ...customIconStyleAttrs } = vnode.attrs;
     return (
       <svg
@@ -275,11 +276,11 @@ export const CWPhantom: m.Component<CustomIconAttrs> = {
         </defs>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPolkadot: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWPolkadot implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -301,11 +302,11 @@ export const CWPolkadot: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWRonin: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWRonin implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -323,11 +324,11 @@ export const CWRonin: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWTerraStation: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWTerraStation implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -378,12 +379,11 @@ export const CWTerraStation: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-
-export const CWTerraStation2: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWTerraStation2 implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -396,50 +396,116 @@ export const CWTerraStation2: m.Component<CustomIconAttrs> = {
         viewBox="0 0 64 64"
         {...domAttrs}
       >
-        <path fill="#FFF" d="M0 0h64v64H0z" opacity="0"/>
-        <linearGradient id="a" x1="43.755" x2="43.755" y1="605.123" y2="575.012" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#4366c2"/>
-        <stop offset=".15" stop-color="#3458b8"/>
-        <stop offset=".4" stop-color="#2348ac"/>
-        <stop offset=".67" stop-color="#193fa5"/>
-        <stop offset="1" stop-color="#163ca3"/>
+        <path fill="#FFF" d="M0 0h64v64H0z" opacity="0" />
+        <linearGradient
+          id="a"
+          x1="43.755"
+          x2="43.755"
+          y1="605.123"
+          y2="575.012"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#4366c2" />
+          <stop offset=".15" stop-color="#3458b8" />
+          <stop offset=".4" stop-color="#2348ac" />
+          <stop offset=".67" stop-color="#193fa5" />
+          <stop offset="1" stop-color="#163ca3" />
         </linearGradient>
-        <path fill="url(#a)" d="M27.5 50.9c1.8 6.5 8 11.5 11.2 11.3.1 0 12-2.2 18.6-13.2 5.1-8.5 3.4-16.7-3.6-16.9-2.4.1-29.5 6.4-26.2 18.8"/>
-        <linearGradient id="b" x1="35.363" x2="35.363" y1="572.988" y2="544.859" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#4366c2"/>
-        <stop offset=".15" stop-color="#3458b8"/>
-        <stop offset=".4" stop-color="#2348ac"/>
-        <stop offset=".67" stop-color="#193fa5"/>
-        <stop offset="1" stop-color="#163ca3"/>
+        <path
+          fill="url(#a)"
+          d="M27.5 50.9c1.8 6.5 8 11.5 11.2 11.3.1 0 12-2.2 18.6-13.2 5.1-8.5 3.4-16.7-3.6-16.9-2.4.1-29.5 6.4-26.2 18.8"
+        />
+        <linearGradient
+          id="b"
+          x1="35.363"
+          x2="35.363"
+          y1="572.988"
+          y2="544.859"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#4366c2" />
+          <stop offset=".15" stop-color="#3458b8" />
+          <stop offset=".4" stop-color="#2348ac" />
+          <stop offset=".67" stop-color="#193fa5" />
+          <stop offset="1" stop-color="#163ca3" />
         </linearGradient>
-        <path fill="url(#b)" d="M53.1 9.1c-8.9-7.6-21.3-9.4-32-4.6-.7.3-1.3.6-1.9.9-.4.2-.8.5-1.2.7h.1c-1.3.9-2.4 1.9-3.3 3.1-8.6 11.5 20.5 19.9 36.1 19.9 7.2 5.2 9.2-14.5 2.2-20z"/>
-        <linearGradient id="c" x1="3.311" x2="23.727" y1="554.677" y2="554.677" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#58c66b"/>
-        <stop offset="1" stop-color="#5491f6"/>
+        <path
+          fill="url(#b)"
+          d="M53.1 9.1c-8.9-7.6-21.3-9.4-32-4.6-.7.3-1.3.6-1.9.9-.4.2-.8.5-1.2.7h.1c-1.3.9-2.4 1.9-3.3 3.1-8.6 11.5 20.5 19.9 36.1 19.9 7.2 5.2 9.2-14.5 2.2-20z"
+        />
+        <linearGradient
+          id="c"
+          x1="3.311"
+          x2="23.727"
+          y1="554.677"
+          y2="554.677"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#58c66b" />
+          <stop offset="1" stop-color="#5491f6" />
         </linearGradient>
-        <path fill="url(#c)" d="M22.9 9.3c-4 6-17.4 10.3-19.6 9.6l.3-.6c.7-1.5 1.6-2.9 2.6-4.3 2-2.6 4.3-5 7-6.9.8-.6 1.7-1.2 2.5-1.7 1.3-.8 2.9-1.2 4.4-1.2 6 .1 2.8 4.9 2.8 4.9"/>
-        <linearGradient id="d" x1="0" x2="19.717" y1="585.099" y2="585.099" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#58c66b"/>
-        <stop offset="1" stop-color="#5491f6"/>
-        </linearGradient><path fill="url(#d)" d="M19.6 52c.3 1.9 0 9.4-.4 10-.3 0-1 .1-3-1.1-1.1-.6-2.1-1.3-3.1-2-1.3-1-2.5-2-3.7-3.2-1.2-1.1-2.2-2.4-3.2-3.7-2-2.7-3.5-5.6-4.5-8.8-.5-1.6-1-3.3-1.2-4.9-.6-3.4-.6-7 0-10.4.3-1.7.7-3.3 1.2-4.9.1-.3.2-.6.3-1 2.3 3.1 4.9 5.9 7.2 9s5.1 7.8 5.7 8.8c3.8 6.5 4.4 10.4 4.7 12.2"/>
-        <linearGradient id="e" x1="17.27" x2="64" y1="569.606" y2="569.606" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#58c66b"/>
-        <stop offset="1" stop-color="#5491f6"/>
+        <path
+          fill="url(#c)"
+          d="M22.9 9.3c-4 6-17.4 10.3-19.6 9.6l.3-.6c.7-1.5 1.6-2.9 2.6-4.3 2-2.6 4.3-5 7-6.9.8-.6 1.7-1.2 2.5-1.7 1.3-.8 2.9-1.2 4.4-1.2 6 .1 2.8 4.9 2.8 4.9"
+        />
+        <linearGradient
+          id="d"
+          x1="0"
+          x2="19.717"
+          y1="585.099"
+          y2="585.099"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#58c66b" />
+          <stop offset="1" stop-color="#5491f6" />
         </linearGradient>
-        <path fill="url(#e)" d="M64 33.1c0 4-.8 8-2.2 11.8-3.8 4-29.2-5.9-29.4-6-3.5-1.5-14.1-6.2-15-13.5C16 14.9 37.2 7.6 46.5 7.3c1.1 0 4.5 0 6.5 1.7 7 6.1 11 14.9 11 24.1"/>
-        <linearGradient id="f" x1="41.637" x2="59.921" y1="598.293" y2="598.293" gradientTransform="translate(0 -543)" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stop-color="#58c66b"/>
-        <stop offset="1" stop-color="#5491f6"/>
+        <path
+          fill="url(#d)"
+          d="M19.6 52c.3 1.9 0 9.4-.4 10-.3 0-1 .1-3-1.1-1.1-.6-2.1-1.3-3.1-2-1.3-1-2.5-2-3.7-3.2-1.2-1.1-2.2-2.4-3.2-3.7-2-2.7-3.5-5.6-4.5-8.8-.5-1.6-1-3.3-1.2-4.9-.6-3.4-.6-7 0-10.4.3-1.7.7-3.3 1.2-4.9.1-.3.2-.6.3-1 2.3 3.1 4.9 5.9 7.2 9s5.1 7.8 5.7 8.8c3.8 6.5 4.4 10.4 4.7 12.2"
+        />
+        <linearGradient
+          id="e"
+          x1="17.27"
+          x2="64"
+          y1="569.606"
+          y2="569.606"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#58c66b" />
+          <stop offset="1" stop-color="#5491f6" />
         </linearGradient>
-        <path fill="url(#f)" d="M46.8 61.6c-2.8 1.3-5.8.4-5-2.4 1.5-5.2 14.8-10.5 17.7-10.8.4 0 .5.2.4.5-3.1 5.4-7.7 9.8-13.1 12.7"/>
+        <path
+          fill="url(#e)"
+          d="M64 33.1c0 4-.8 8-2.2 11.8-3.8 4-29.2-5.9-29.4-6-3.5-1.5-14.1-6.2-15-13.5C16 14.9 37.2 7.6 46.5 7.3c1.1 0 4.5 0 6.5 1.7 7 6.1 11 14.9 11 24.1"
+        />
+        <linearGradient
+          id="f"
+          x1="41.637"
+          x2="59.921"
+          y1="598.293"
+          y2="598.293"
+          gradientTransform="translate(0 -543)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stop-color="#58c66b" />
+          <stop offset="1" stop-color="#5491f6" />
+        </linearGradient>
+        <path
+          fill="url(#f)"
+          d="M46.8 61.6c-2.8 1.3-5.8.4-5-2.4 1.5-5.2 14.8-10.5 17.7-10.8.4 0 .5.2.4.5-3.1 5.4-7.7 9.8-13.1 12.7"
+        />
       </svg>
     );
-  },
-};
+  }
+}
 
-
-export const CWUnreads: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWUnreads implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -460,11 +526,11 @@ export const CWUnreads: m.Component<CustomIconAttrs> = {
         <circle cx="23.75" cy="9" r="4" fill="#EC79DE"></circle>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWWalletConnect: m.Component<CustomIconAttrs> = {
-  view: (vnode) => {
+export class CWWalletConnect implements m.ClassComponent<CustomIconAttrs> {
+  view(vnode: m.Vnode<CustomIconAttrs>) {
     const { componentType, iconSize, ...domAttrs } = vnode.attrs;
     return (
       <svg
@@ -482,5 +548,5 @@ export const CWWalletConnect: m.Component<CustomIconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_custom_icons.tsx
@@ -21,7 +21,7 @@ import { CustomIconAttrs, CustomIconStyleAttrs } from './types';
 
 export class CWCosmosEvmMetamask implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -30,7 +30,7 @@ export class CWCosmosEvmMetamask implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#000"
@@ -43,7 +43,7 @@ export class CWCosmosEvmMetamask implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWKeplr implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -52,7 +52,7 @@ export class CWKeplr implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#207afe"
@@ -74,7 +74,7 @@ export class CWKeplr implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWMagic implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -83,7 +83,7 @@ export class CWMagic implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#6452F6"
@@ -96,7 +96,7 @@ export class CWMagic implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWMetaMask implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -105,7 +105,7 @@ export class CWMetaMask implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#E2761B"
@@ -198,7 +198,7 @@ export class CWMetaMask implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWNearWallet implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -207,7 +207,7 @@ export class CWNearWallet implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#000"
@@ -281,7 +281,7 @@ export class CWPhantom implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWPolkadot implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -290,7 +290,7 @@ export class CWPolkadot implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#D32D79"
@@ -307,7 +307,7 @@ export class CWPolkadot implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWRonin implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -316,7 +316,7 @@ export class CWRonin implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#1374E9"
@@ -329,7 +329,7 @@ export class CWRonin implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWTerraStation implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -338,7 +338,7 @@ export class CWTerraStation implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#0E3CA5"
@@ -384,7 +384,7 @@ export class CWTerraStation implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWTerraStation2 implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -394,7 +394,7 @@ export class CWTerraStation2 implements m.ClassComponent<CustomIconAttrs> {
         fill="none"
         transform="scale(0.5)"
         viewBox="0 0 64 64"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path fill="#FFF" d="M0 0h64v64H0z" opacity="0" />
         <linearGradient
@@ -506,7 +506,7 @@ export class CWTerraStation2 implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWUnreads implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -515,7 +515,7 @@ export class CWUnreads implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#342E37"
@@ -531,7 +531,7 @@ export class CWUnreads implements m.ClassComponent<CustomIconAttrs> {
 
 export class CWWalletConnect implements m.ClassComponent<CustomIconAttrs> {
   view(vnode: m.Vnode<CustomIconAttrs>) {
-    const { componentType, iconSize, ...domAttrs } = vnode.attrs;
+    const { componentType, iconSize, ...otherAttrs } = vnode.attrs;
     return (
       <svg
         class={getClasses<CustomIconStyleAttrs>({ iconSize }, componentType)}
@@ -540,7 +540,7 @@ export class CWWalletConnect implements m.ClassComponent<CustomIconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill="#3B99FC"

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon.tsx
@@ -18,7 +18,7 @@ export class CWIcon implements m.ClassComponent<IconComponentAttrs> {
       iconSize = 'medium',
       onclick,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
 
     const Icon = iconLookup[iconName];
@@ -31,7 +31,7 @@ export class CWIcon implements m.ClassComponent<IconComponentAttrs> {
         iconSize={iconSize}
         onclick={onclick}
         selected={selected}
-        {...domAttrs}
+        {...otherAttrs}
       />
     );
   }

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon.tsx
@@ -5,11 +5,11 @@ import m from 'mithril';
 import 'components/component_kit/cw_icon.scss';
 
 import { iconLookup } from './cw_icon_lookup';
-import { IconAttrs } from './types';
+import { IconComponentAttrs } from './types';
 import { ComponentType } from '../types';
 
-export class CWIcon implements m.ClassComponent<IconAttrs> {
-  view(vnode) {
+export class CWIcon implements m.ClassComponent<IconComponentAttrs> {
+  view(vnode: m.Vnode<IconComponentAttrs>) {
     const {
       className,
       componentType = ComponentType.Icon,
@@ -22,6 +22,7 @@ export class CWIcon implements m.ClassComponent<IconAttrs> {
     } = vnode.attrs;
 
     const Icon = iconLookup[iconName];
+
     return (
       <Icon
         className={className}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
@@ -37,7 +37,7 @@ import { IconAttrs, IconStyleAttrs } from './types';
 //   iconButtonTheme,
 //   iconSize,
 //   selected,
-//   ...domAttrs
+//   ...otherAttrs
 // } = vnode.attrs;
 // return (
 //   <svg
@@ -50,7 +50,7 @@ import { IconAttrs, IconStyleAttrs } from './types';
 //     height="32"
 //     fill="none"
 //     viewBox="0 0 32 32"
-//     {...domAttrs}
+//     {...otherAttrs}
 //       {/* INSERT PATH HERE */}
 //       </svg>
 //     );
@@ -66,7 +66,7 @@ export class CWArrowLeft implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -79,7 +79,7 @@ export class CWArrowLeft implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -100,7 +100,7 @@ export class CWArrowRight implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -113,7 +113,7 @@ export class CWArrowRight implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -134,7 +134,7 @@ export class CWBacker implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -147,7 +147,7 @@ export class CWBacker implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -175,7 +175,7 @@ export class CWBadge implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -188,7 +188,7 @@ export class CWBadge implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M15.56 5.391a.5.5 0 01.88 0l2.75 5.06a.5.5 0 00.453.262l5.758-.148a.5.5 0 01.439.761l-3.007 4.913a.5.5 0 000 .522l3.007 4.913a.5.5 0 01-.44.76l-5.757-.147a.5.5 0 00-.453.261l-2.75 5.06a.5.5 0 01-.88 0l-2.75-5.06a.5.5 0 00-.453-.26l-5.758.147a.5.5 0 01-.439-.761l3.007-4.913a.5.5 0 000-.522L6.16 11.326a.5.5 0 01.44-.76l5.757.147a.5.5 0 00.453-.261l2.75-5.06z"></path>
         <path d="M17.083 4.583a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM17.083 28.417a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM27.183 22.458a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM6.882 22.458a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM6.882 10.64a1.083 1.083 0 11-2.167 0 1.083 1.083 0 012.167 0zM27.183 10.64a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0z"></path>
@@ -206,7 +206,7 @@ export class CWBell implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -219,7 +219,7 @@ export class CWBell implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M19.456 27.043a3.456 3.456 0 11-6.913.001 3.456 3.456 0 016.913 0zM18.42 4.747a2.247 2.247 0 11-4.494 0 2.247 2.247 0 014.493 0z"></path>
         <path
@@ -241,7 +241,7 @@ export class CWCautionCircle implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -254,7 +254,7 @@ export class CWCautionCircle implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M15.333 9.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v8.502a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V9.75zM17.667 21.836a1.334 1.334 0 11-2.667 0 1.334 1.334 0 012.667 0z"></path>
         <path d="M15.333 9.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v8.502a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V9.75zM17.667 21.836a1.334 1.334 0 11-2.667 0 1.334 1.334 0 012.667 0z"></path>
@@ -277,7 +277,7 @@ export class CWCautionTriangle implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -290,7 +290,7 @@ export class CWCautionTriangle implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -313,7 +313,7 @@ export class CWCheck implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -326,7 +326,7 @@ export class CWCheck implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -347,7 +347,7 @@ export class CWChevronDown implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -360,7 +360,7 @@ export class CWChevronDown implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -381,7 +381,7 @@ export class CWChevronLeft implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -394,7 +394,7 @@ export class CWChevronLeft implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -415,7 +415,7 @@ export class CWChevronRight implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -428,7 +428,7 @@ export class CWChevronRight implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -449,7 +449,7 @@ export class CWChevronUp implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -462,7 +462,7 @@ export class CWChevronUp implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -483,7 +483,7 @@ export class CWClock implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -496,7 +496,7 @@ export class CWClock implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -517,7 +517,7 @@ export class CWClose implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -530,7 +530,7 @@ export class CWClose implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <g clip-path="url(#clip0_402_12158)">
           <path d="M6.454 6.247c.195-.195.6-.107.904.196l18.699 18.7c.303.303.391.708.196.903l-.707.707c-.195.195-.6.107-.904-.197L5.943 7.858c-.303-.304-.391-.709-.196-.904l.707-.707z"></path>
@@ -555,7 +555,7 @@ export class CWCloud implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -568,7 +568,7 @@ export class CWCloud implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <circle cx="16.069" cy="9.273" r="7.273"></circle>
         <circle cx="16.069" cy="9.273" r="7.273"></circle>
@@ -593,7 +593,7 @@ export class CWCollapse implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -606,7 +606,7 @@ export class CWCollapse implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -627,7 +627,7 @@ export class CWCommonLogo implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -639,7 +639,7 @@ export class CWCommonLogo implements m.ClassComponent<IconAttrs> {
         height="32"
         viewBox="0 0 32 32"
         xmlns="http://www.w3.org/2000/svg"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M11.0929 16.1265C11.0999 14.7619 11.4109 13.416 12.0029 12.1872C12.5951 10.9584 13.4533 9.87773 14.5152 9.02407L12.4159 6.919C12.1133 6.6157 11.7029 6.44531 11.2751 6.44531C10.8473 6.44531 10.4369 6.6157 10.1343 6.919L2.21849 14.8565C1.91601 15.1599 1.74609 15.5714 1.74609 16.0004C1.74609 16.4294 1.91601 16.8409 2.21849 17.1443L10.1343 25.0818C10.4369 25.3851 10.8473 25.5555 11.2751 25.5555C11.7029 25.5555 12.1133 25.3851 12.4159 25.0818L14.3547 23.1333C13.3342 22.2747 12.5134 21.2026 11.9499 19.9922C11.3865 18.7817 11.0939 17.4623 11.0929 16.1265Z" />
         <path d="M20.6647 6.81642C18.4119 6.81295 16.2273 7.59355 14.482 9.02568L20.2675 14.8461C20.4171 14.9957 20.5358 15.1736 20.6168 15.3695C20.6978 15.5654 20.7395 15.7754 20.7395 15.9876C20.7395 16.1998 20.6978 16.4098 20.6168 16.6057C20.5358 16.8016 20.4171 16.9795 20.2675 17.1291L14.3223 23.1058C16.0939 24.6149 18.3426 25.4398 20.6647 25.4322C25.958 25.4322 30.2539 21.2697 30.2539 16.1308C30.2539 10.9918 25.9493 6.81642 20.6647 6.81642Z" />
@@ -657,7 +657,7 @@ export class CWCompass implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -670,7 +670,7 @@ export class CWCompass implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M16 18.428c1.657 0 3-1.303 3-2.91 0-1.606-1.343-2.909-3-2.909s-3 1.303-3 2.91c0 1.606 1.343 2.909 3 2.909z"></path>
         <path
@@ -692,7 +692,7 @@ export class CWCopy implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -705,7 +705,7 @@ export class CWCopy implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -727,7 +727,7 @@ export class CWCouncilProposal implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -740,7 +740,7 @@ export class CWCouncilProposal implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M14.586 8.914a2 2 0 012.828 0l6.364 6.364a2 2 0 010 2.829l-6.364 6.364a2 2 0 01-2.828 0l-6.364-6.364a2 2 0 010-2.829l6.364-6.364zM11 8.5a3 3 0 11-6 0 3 3 0 016 0zM27 8.5a3 3 0 11-6 0 3 3 0 016 0zM11 24.5a3 3 0 11-6 0 3 3 0 016 0zM27 24.5a3 3 0 11-6 0 3 3 0 016 0z"></path>
       </svg>
@@ -757,7 +757,7 @@ export class CWCow implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -770,7 +770,7 @@ export class CWCow implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -791,7 +791,7 @@ export class CWCurator implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -804,7 +804,7 @@ export class CWCurator implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -827,7 +827,7 @@ export class CWDemocraticProposal implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -840,7 +840,7 @@ export class CWDemocraticProposal implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -861,7 +861,7 @@ export class CWDiscord implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -874,7 +874,7 @@ export class CWDiscord implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M26.182 8.864s-2.918-2.285-6.364-2.546l-.31.622c3.114.763 4.543 1.854 6.037 3.196C22.97 8.822 20.43 7.591 16 7.591c-4.43 0-6.97 1.23-9.545 2.545 1.494-1.342 3.194-2.555 6.037-3.196l-.31-.622c-3.615.34-6.364 2.546-6.364 2.546S2.56 13.589 2 22.864c3.284 3.788 8.273 3.818 8.273 3.818l1.043-1.39a12.748 12.748 0 01-5.498-3.701c2.06 1.559 5.17 3.182 10.182 3.182 5.011 0 8.121-1.623 10.182-3.182a12.74 12.74 0 01-5.498 3.701l1.043 1.39s4.99-.03 8.273-3.818c-.56-9.275-3.818-14-3.818-14zM11.864 20.318c-1.231 0-2.228-1.139-2.228-2.545 0-1.407.997-2.546 2.228-2.546 1.23 0 2.227 1.14 2.227 2.546s-.997 2.545-2.227 2.545zm8.272 0c-1.23 0-2.227-1.139-2.227-2.545 0-1.407.997-2.546 2.227-2.546 1.231 0 2.228 1.14 2.228 2.546s-.997 2.545-2.228 2.545z"></path>
       </svg>
@@ -891,7 +891,7 @@ export class CWDots implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -904,7 +904,7 @@ export class CWDots implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M8.059 16a3 3 0 11-6 0 3 3 0 016 0zM18.858 16a3 3 0 11-6 0 3 3 0 016 0zM30.058 16c0 1.657-1.432 3-3.2 3-1.767 0-3.2-1.343-3.2-3s1.433-3 3.2-3c1.768 0 3.2 1.343 3.2 3z"></path>
       </svg>
@@ -921,7 +921,7 @@ export class CWDotsVertical implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -934,7 +934,7 @@ export class CWDotsVertical implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M16 8.059a3 3 0 110-6 3 3 0 010 6zM16 18.858a3 3 0 110-6 3 3 0 010 6zM16 30.058c-1.657 0-3-1.432-3-3.2 0-1.767 1.343-3.2 3-3.2s3 1.433 3 3.2c0 1.768-1.343 3.2-3 3.2z"></path>
       </svg>
@@ -951,7 +951,7 @@ export class CWDownvote implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -964,7 +964,7 @@ export class CWDownvote implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M16.73 27.828a.843.843 0 01-1.46 0L2.113 5.018a.845.845 0 01.731-1.268h26.31c.65 0 1.055.704.73 1.267l-13.154 22.81z"></path>
       </svg>
@@ -981,7 +981,7 @@ export class CWElement implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -994,7 +994,7 @@ export class CWElement implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1015,7 +1015,7 @@ export class CWExpand implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1028,7 +1028,7 @@ export class CWExpand implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1049,7 +1049,7 @@ export class CWExploreCommunities implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1062,7 +1062,7 @@ export class CWExploreCommunities implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1084,7 +1084,7 @@ export class CWExternalLink implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1097,7 +1097,7 @@ export class CWExternalLink implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1118,7 +1118,7 @@ export class CWFeedback implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1131,7 +1131,7 @@ export class CWFeedback implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1152,7 +1152,7 @@ export class CWFilter implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1165,7 +1165,7 @@ export class CWFilter implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1186,7 +1186,7 @@ export class CWFlag implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1199,7 +1199,7 @@ export class CWFlag implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1220,7 +1220,7 @@ export class CWFlame implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1233,7 +1233,7 @@ export class CWFlame implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M19.909 30.332c-.215.043-.378-.314-.244-.487 1.575-2.034-.621-6.082-2.787-8.747a1.122 1.122 0 00-1.756 0c-2.166 2.665-4.362 6.713-2.787 8.747.134.173-.029.53-.244.487C-.757 27.749 7.91 11.445 15.085 2.93a1.189 1.189 0 011.83 0c7.176 8.515 15.842 24.82 2.994 27.402z"></path>
       </svg>
@@ -1250,7 +1250,7 @@ export class CWGear implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1263,7 +1263,7 @@ export class CWGear implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <rect width="4" height="6" x="14" y="2.5" rx="0.5"></rect>
         <rect width="4" height="6" x="14" y="24.5" rx="0.5"></rect>
@@ -1334,7 +1334,7 @@ export class CWGithub implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1347,7 +1347,7 @@ export class CWGithub implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1368,7 +1368,7 @@ export class CWHamburger implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1380,7 +1380,7 @@ export class CWHamburger implements m.ClassComponent<IconAttrs> {
         width="32"
         height="32"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M2 20c0-.276.348-.5.778-.5h26.444c.43 0 .778.224.778.5v1c0 .276-.348.5-.778.5H2.778c-.43 0-.778-.224-.778-.5v-1zM30 13c0 .276-.348.5-.778.5H2.778c-.43 0-.778-.224-.778-.5v-1c0-.276.348-.5.778-.5h26.444c.43 0 .778.224.778.5v1z"></path>
       </svg>
@@ -1397,7 +1397,7 @@ export class CWHash implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1410,7 +1410,7 @@ export class CWHash implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1431,7 +1431,7 @@ export class CWHeartEmpty implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1444,7 +1444,7 @@ export class CWHeartEmpty implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1465,7 +1465,7 @@ export class CWHeartFilled implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1478,7 +1478,7 @@ export class CWHeartFilled implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1499,7 +1499,7 @@ export class CWHelp implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1512,7 +1512,7 @@ export class CWHelp implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1533,7 +1533,7 @@ export class CWHome implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1546,7 +1546,7 @@ export class CWHome implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1567,7 +1567,7 @@ export class CWInfoEmpty implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1580,7 +1580,7 @@ export class CWInfoEmpty implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M17 21.61c0 .343-.336.621-.75.621h-.5c-.415 0-.75-.278-.75-.622v-7.05c0-.344.335-.623.75-.623h.5c.414 0 .75.279.75.622v7.051zM14.667 11.102a1.334 1.334 0 112.667 0 1.334 1.334 0 01-2.667 0z"></path>
         <path
@@ -1602,7 +1602,7 @@ export class CWImageUpload implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1615,7 +1615,7 @@ export class CWImageUpload implements m.ClassComponent<IconAttrs> {
         viewBox="0 0 32 32"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M25.3332 17.8488C24.9795 17.8488 24.6404 17.9893 24.3904 18.2393C24.1403 18.4894 23.9998 18.8285 23.9998 19.1822V19.6888L22.0265 17.7155C21.3297 17.0242 20.388 16.6363 19.4065 16.6363C18.425 16.6363 17.4833 17.0242 16.7865 17.7155L15.8532 18.6488L12.5465 15.3422C11.84 14.6696 10.9019 14.2945 9.9265 14.2945C8.95108 14.2945 8.01301 14.6696 7.3065 15.3422L5.33317 17.3155V9.84882C5.33317 9.4952 5.47365 9.15606 5.72369 8.90601C5.97374 8.65596 6.31288 8.51549 6.6665 8.51549H15.9998C16.3535 8.51549 16.6926 8.37501 16.9426 8.12496C17.1927 7.87491 17.3332 7.53578 17.3332 7.18215C17.3332 6.82853 17.1927 6.48939 16.9426 6.23934C16.6926 5.9893 16.3535 5.84882 15.9998 5.84882H6.6665C5.60564 5.84882 4.58822 6.27025 3.83808 7.02039C3.08793 7.77054 2.6665 8.78795 2.6665 9.84882V25.8488C2.6665 26.9097 3.08793 27.9271 3.83808 28.6772C4.58822 29.4274 5.60564 29.8488 6.6665 29.8488H22.6665C23.7274 29.8488 24.7448 29.4274 25.4949 28.6772C26.2451 27.9271 26.6665 26.9097 26.6665 25.8488V19.1822C26.6665 18.8285 26.526 18.4894 26.276 18.2393C26.0259 17.9893 25.6868 17.8488 25.3332 17.8488ZM6.6665 27.1822C6.31288 27.1822 5.97374 27.0417 5.72369 26.7916C5.47365 26.5416 5.33317 26.2024 5.33317 25.8488V21.0888L9.19984 17.2222C9.39572 17.0355 9.65592 16.9314 9.9265 16.9314C10.1971 16.9314 10.4573 17.0355 10.6532 17.2222L14.8798 21.4488L20.6132 27.1822H6.6665ZM23.9998 25.8488C23.9979 26.1041 23.9138 26.3519 23.7598 26.5555L17.7465 20.5155L18.6798 19.5822C18.7754 19.4846 18.8895 19.4071 19.0154 19.3542C19.1414 19.3013 19.2766 19.274 19.4132 19.274C19.5498 19.274 19.685 19.3013 19.8109 19.3542C19.9368 19.4071 20.0509 19.4846 20.1465 19.5822L23.9998 23.4622V25.8488ZM30.2798 6.23549L26.2798 2.23549C26.153 2.1141 26.0035 2.01895 25.8398 1.95549C25.5152 1.82213 25.1511 1.82213 24.8265 1.95549C24.6628 2.01895 24.5133 2.1141 24.3865 2.23549L20.3865 6.23549C20.1354 6.48656 19.9944 6.82708 19.9944 7.18215C19.9944 7.53722 20.1354 7.87775 20.3865 8.12882C20.6376 8.37989 20.9781 8.52094 21.3332 8.52094C21.6882 8.52094 22.0288 8.37989 22.2798 8.12882L23.9998 6.39549V13.8488C23.9998 14.2024 24.1403 14.5416 24.3904 14.7916C24.6404 15.0417 24.9795 15.1822 25.3332 15.1822C25.6868 15.1822 26.0259 15.0417 26.276 14.7916C26.526 14.5416 26.6665 14.2024 26.6665 13.8488V6.39549L28.3865 8.12882C28.5105 8.25379 28.6579 8.35298 28.8204 8.42067C28.9829 8.48837 29.1572 8.52322 29.3332 8.52322C29.5092 8.52322 29.6835 8.48837 29.8459 8.42067C30.0084 8.35298 30.1559 8.25379 30.2798 8.12882C30.4048 8.00487 30.504 7.8574 30.5717 7.69492C30.6394 7.53244 30.6742 7.35817 30.6742 7.18215C30.6742 7.00614 30.6394 6.83186 30.5717 6.66938C30.504 6.50691 30.4048 6.35944 30.2798 6.23549Z" />
       </svg>
@@ -1632,7 +1632,7 @@ export class CWInfoFilled implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1645,7 +1645,7 @@ export class CWInfoFilled implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1666,7 +1666,7 @@ export class CWJar implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1679,7 +1679,7 @@ export class CWJar implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1701,7 +1701,7 @@ export class CWLink implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1714,7 +1714,7 @@ export class CWLink implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1735,7 +1735,7 @@ export class CWLock implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1748,7 +1748,7 @@ export class CWLock implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1769,7 +1769,7 @@ export class CWLogout implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1782,7 +1782,7 @@ export class CWLogout implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1808,7 +1808,7 @@ export class CWMail implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1821,7 +1821,7 @@ export class CWMail implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1842,7 +1842,7 @@ export class CWMute implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1855,7 +1855,7 @@ export class CWMute implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M25.92 4.707a1 1 0 111.415 1.414L6.12 27.335a1 1 0 01-1.414-1.415L25.92 4.707z"></path>
         <path
@@ -1877,7 +1877,7 @@ export class CWPeople implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1890,7 +1890,7 @@ export class CWPeople implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M17.18 18.244a3.998 3.998 0 00-1.555-7.68 3.997 3.997 0 00-1.552 7.68 6.501 6.501 0 00-4.926 5.81c-.021.275.204.5.48.5h12a.472.472 0 00.482-.5 6.501 6.501 0 00-4.93-5.81z"></path>
         <path
@@ -1912,7 +1912,7 @@ export class CWPerson implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1925,7 +1925,7 @@ export class CWPerson implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -1946,7 +1946,7 @@ export class CWPin implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1959,7 +1959,7 @@ export class CWPin implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M7 18a.5.5 0 01.5-.5h17a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-17A.5.5 0 017 19v-1z"></path>
         <path d="M16.5 7.5c.276 0 .5.275.5.615v20.902c0 .615-.724 1.483-1 1.483s-1-.868-1-1.483V8.115c0-.34.224-.615.5-.615h1zM9 3c0-.276.174-.5.389-.5H22.61c.215 0 .389.224.389.5v1c0 .276-.174.5-.389.5H9.39C9.174 4.5 9 4.276 9 4V3z"></path>
@@ -1978,7 +1978,7 @@ export class CWPlus implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -1991,7 +1991,7 @@ export class CWPlus implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M2 16c0-.276.348-.5.778-.5h26.444c.43 0 .778.224.778.5v1c0 .276-.348.5-.778.5H2.778c-.43 0-.778-.224-.778-.5v-1z"></path>
         <path d="M16.5 2.5c.276 0 .5.348.5.778v26.444c0 .43-.224.778-.5.778h-1c-.276 0-.5-.348-.5-.778V3.278c0-.43.224-.778.5-.778h1z"></path>
@@ -2009,7 +2009,7 @@ export class CWPlusCircle implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2022,7 +2022,7 @@ export class CWPlusCircle implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2043,7 +2043,7 @@ export class CWSearch implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2056,7 +2056,7 @@ export class CWSearch implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2077,7 +2077,7 @@ export class CWSend implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2090,7 +2090,7 @@ export class CWSend implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2111,7 +2111,7 @@ export class CWShare implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2124,7 +2124,7 @@ export class CWShare implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2145,7 +2145,7 @@ export class CWShare2 implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2158,7 +2158,7 @@ export class CWShare2 implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2179,7 +2179,7 @@ export class CWSidebarCollapse implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2191,7 +2191,7 @@ export class CWSidebarCollapse implements m.ClassComponent<IconAttrs> {
         width="32"
         height="32"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M29.604 15.666c0-.276-.242-.5-.54-.5H10.172v2h18.892c.298 0 .54-.224.54-.5v-1zM29.828 23.334c0-.276-.223-.5-.498-.5H12.396a.5.5 0 00-.498.5v1a.5.5 0 00.498.5H29.33a.499.499 0 00.498-.5v-1zM11.69 8.666c0 .276.224.5.499.5h16.934a.499.499 0 00.498-.5v-1c0-.276-.223-.5-.498-.5H12.19a.499.499 0 00-.498.5v1z"></path>
         <path
@@ -2213,7 +2213,7 @@ export class CWSidebarExpand implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2225,7 +2225,7 @@ export class CWSidebarExpand implements m.ClassComponent<IconAttrs> {
         width="32"
         height="32"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M2.396 15.666c0-.276.242-.5.54-.5h18.892v2H2.936c-.298 0-.54-.224-.54-.5v-1zM2.172 23.334a.5.5 0 01.498-.5h16.934c.275 0 .498.224.498.5v1c0 .276-.223.5-.498.5H2.67a.5.5 0 01-.498-.5v-1zM20.31 8.666c0 .276-.224.5-.499.5H2.877a.499.499 0 01-.498-.5v-1c0-.276.223-.5.498-.5h16.934c.275 0 .498.224.498.5v1z"></path>
         <path
@@ -2247,7 +2247,7 @@ export class CWStar implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2260,7 +2260,7 @@ export class CWStar implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M13.065 1.469c.326-.861 1.544-.861 1.87 0l1.422 3.753a1 1 0 001.483.482l3.357-2.2c.77-.506 1.755.21 1.513 1.099l-1.056 3.872a1 1 0 00.917 1.262l4.01.192c.919.044 1.295 1.203.577 1.779l-3.13 2.512a1 1 0 000 1.56l3.13 2.512c.718.576.342 1.735-.578 1.779l-4.009.192a1 1 0 00-.917 1.262l1.056 3.873c.242.888-.743 1.604-1.513 1.099l-3.357-2.201a1 1 0 00-1.483.482l-1.422 3.753c-.326.861-1.544.861-1.87 0l-1.422-3.753a1 1 0 00-1.484-.482l-3.356 2.2c-.77.506-1.755-.21-1.513-1.098l1.056-3.873a1 1 0 00-.917-1.262l-4.01-.192C.5 20.027.125 18.868.843 18.292l3.13-2.512a1 1 0 000-1.56l-3.13-2.512C.124 11.132.5 9.973 1.42 9.929l4.009-.192a1 1 0 00.917-1.262L5.29 4.603c-.242-.889.743-1.605 1.513-1.1l3.356 2.201a1 1 0 001.484-.482l1.422-3.753z"></path>
       </svg>
@@ -2277,7 +2277,7 @@ export class CWSun implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2290,7 +2290,7 @@ export class CWSun implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <circle cx="16" cy="16" r="8"></circle>
         <rect width="2" height="5" x="15" y="2" rx="0.5"></rect>
@@ -2357,7 +2357,7 @@ export class CWTelegram implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2370,7 +2370,7 @@ export class CWTelegram implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2391,7 +2391,7 @@ export class CWTrash implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2404,7 +2404,7 @@ export class CWTrash implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M7.119 11.612A2 2 0 019.116 9.5h13.768a2 2 0 011.997 2.112l-.9 16a2 2 0 01-1.997 1.888H10.016a2 2 0 01-1.997-1.888l-.9-16z"></path>
         <path
@@ -2426,7 +2426,7 @@ export class CWTreasuryProposal implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2439,7 +2439,7 @@ export class CWTreasuryProposal implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2460,7 +2460,7 @@ export class CWTwitter implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2473,7 +2473,7 @@ export class CWTwitter implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M28.553 8.978c.02.306.02.613.02.919 0 9.34-6.517 20.103-18.428 20.103-3.67 0-7.078-1.16-9.946-3.172.522.066 1.023.088 1.564.088 3.028 0 5.815-1.116 8.041-3.02-2.847-.065-5.233-2.1-6.056-4.9.401.067.803.11 1.224.11.581 0 1.163-.087 1.704-.24-2.968-.657-5.194-3.5-5.194-6.935v-.087a6.119 6.119 0 002.928.897c-1.744-1.27-2.887-3.435-2.887-5.885 0-1.312.32-2.515.882-3.565 3.188 4.287 7.98 7.087 13.355 7.393a8.668 8.668 0 01-.16-1.618C15.6 5.172 18.486 2 22.075 2c1.865 0 3.55.853 4.732 2.231a12.125 12.125 0 004.11-1.706c-.48 1.64-1.503 3.019-2.846 3.894 1.303-.153 2.566-.547 3.73-1.094a14.679 14.679 0 01-3.25 3.653z"></path>
       </svg>
@@ -2490,7 +2490,7 @@ export class CWUpvote implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2503,7 +2503,7 @@ export class CWUpvote implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M15.27 4.172a.843.843 0 011.46 0l13.156 22.81a.845.845 0 01-.731 1.268H2.845a.845.845 0 01-.73-1.267l13.154-22.81z"></path>
       </svg>
@@ -2520,7 +2520,7 @@ export class CWViews implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2533,7 +2533,7 @@ export class CWViews implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path d="M22 16a6 6 0 11-12 0 6 6 0 0112 0z"></path>
         <path
@@ -2555,7 +2555,7 @@ export class CWWallet implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2568,7 +2568,7 @@ export class CWWallet implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2595,7 +2595,7 @@ export class CWWebsite implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2608,7 +2608,7 @@ export class CWWebsite implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"
@@ -2629,7 +2629,7 @@ export class CWWrite implements m.ClassComponent<IconAttrs> {
       iconButtonTheme,
       iconSize,
       selected,
-      ...domAttrs
+      ...otherAttrs
     } = vnode.attrs;
     return (
       <svg
@@ -2642,7 +2642,7 @@ export class CWWrite implements m.ClassComponent<IconAttrs> {
         height="32"
         fill="none"
         viewBox="0 0 32 32"
-        {...domAttrs}
+        {...otherAttrs}
       >
         <path
           fill-rule="evenodd"

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /* @jsx m */
 
 /* eslint-disable max-len */
@@ -27,8 +28,8 @@ import { IconAttrs, IconStyleAttrs } from './types';
 // If added properly, the icon should auto-display in the component kit.
 
 // ICON TEMPLATE
-// export const CWIconName: m.Component<IconAttrs> = {
-//   view: (vnode: m.VnodeDOM<IconAttrs>) => {
+// export class CWIconName implements m.ClassComponent<IconAttrs> {
+//   view(vnode: m.Vnode<IconAttrs>){
 // const {
 //   className,
 //   componentType,
@@ -53,11 +54,11 @@ import { IconAttrs, IconStyleAttrs } from './types';
 //       {/* INSERT PATH HERE */}
 //       </svg>
 //     );
-//   },
-// };
+//   }
+// }
 
-export const CWArrowLeft: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWArrowLeft implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -87,11 +88,11 @@ export const CWArrowLeft: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWArrowRight: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWArrowRight implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -121,11 +122,11 @@ export const CWArrowRight: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWBacker: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWBacker implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -162,11 +163,11 @@ export const CWBacker: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWBadge: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWBadge implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -193,11 +194,11 @@ export const CWBadge: m.Component<IconAttrs> = {
         <path d="M17.083 4.583a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM17.083 28.417a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM27.183 22.458a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM6.882 22.458a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0zM6.882 10.64a1.083 1.083 0 11-2.167 0 1.083 1.083 0 012.167 0zM27.183 10.64a1.083 1.083 0 11-2.166 0 1.083 1.083 0 012.166 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWBell: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWBell implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -228,11 +229,11 @@ export const CWBell: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCautionCircle: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCautionCircle implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -264,11 +265,11 @@ export const CWCautionCircle: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCautionTriangle: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCautionTriangle implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -300,11 +301,11 @@ export const CWCautionTriangle: m.Component<IconAttrs> = {
         <path d="M14.67 11.585a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v8.503a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75v-8.503zM17.003 23.672a1.334 1.334 0 11-2.667 0 1.334 1.334 0 012.667 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCheck: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCheck implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -334,11 +335,11 @@ export const CWCheck: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWChevronDown: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWChevronDown implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -368,11 +369,11 @@ export const CWChevronDown: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWChevronLeft: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWChevronLeft implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -402,11 +403,11 @@ export const CWChevronLeft: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWChevronRight: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWChevronRight implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -436,11 +437,11 @@ export const CWChevronRight: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWChevronUp: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWChevronUp implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -470,11 +471,11 @@ export const CWChevronUp: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWClock: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWClock implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -504,11 +505,11 @@ export const CWClock: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWClose: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWClose implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -542,11 +543,11 @@ export const CWClose: m.Component<IconAttrs> = {
         </defs>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCloud: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCloud implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -580,11 +581,11 @@ export const CWCloud: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCollapse: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCollapse implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -614,11 +615,11 @@ export const CWCollapse: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCommonLogo: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCommonLogo implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -644,11 +645,11 @@ export const CWCommonLogo: m.Component<IconAttrs> = {
         <path d="M20.6647 6.81642C18.4119 6.81295 16.2273 7.59355 14.482 9.02568L20.2675 14.8461C20.4171 14.9957 20.5358 15.1736 20.6168 15.3695C20.6978 15.5654 20.7395 15.7754 20.7395 15.9876C20.7395 16.1998 20.6978 16.4098 20.6168 16.6057C20.5358 16.8016 20.4171 16.9795 20.2675 17.1291L14.3223 23.1058C16.0939 24.6149 18.3426 25.4398 20.6647 25.4322C25.958 25.4322 30.2539 21.2697 30.2539 16.1308C30.2539 10.9918 25.9493 6.81642 20.6647 6.81642Z" />
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCompass: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCompass implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -679,11 +680,11 @@ export const CWCompass: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCopy: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCopy implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -714,11 +715,11 @@ export const CWCopy: m.Component<IconAttrs> = {
         <path d="M26 6a.5.5 0 00-.5-.5h-11a.5.5 0 00-.5.5v3.5h-2V4a.5.5 0 01.5-.5h15a.5.5 0 01.5.5v19a.5.5 0 01-.5.5H19v-2h6.5a.5.5 0 00.5-.5V6z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCouncilProposal: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCouncilProposal implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -744,11 +745,11 @@ export const CWCouncilProposal: m.Component<IconAttrs> = {
         <path d="M14.586 8.914a2 2 0 012.828 0l6.364 6.364a2 2 0 010 2.829l-6.364 6.364a2 2 0 01-2.828 0l-6.364-6.364a2 2 0 010-2.829l6.364-6.364zM11 8.5a3 3 0 11-6 0 3 3 0 016 0zM27 8.5a3 3 0 11-6 0 3 3 0 016 0zM11 24.5a3 3 0 11-6 0 3 3 0 016 0zM27 24.5a3 3 0 11-6 0 3 3 0 016 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCow: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCow implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -778,11 +779,11 @@ export const CWCow: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWCurator: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWCurator implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -814,11 +815,11 @@ export const CWCurator: m.Component<IconAttrs> = {
         <path d="M10.428 23.347a2 2 0 013.404 0l2.25 3.648H8.178l2.248-3.648zM11.706 18.049a1.829 1.829 0 100-3.658 1.829 1.829 0 000 3.658z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWDemocraticProposal: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWDemocraticProposal implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -848,11 +849,11 @@ export const CWDemocraticProposal: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWDiscord: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWDiscord implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -878,11 +879,11 @@ export const CWDiscord: m.Component<IconAttrs> = {
         <path d="M26.182 8.864s-2.918-2.285-6.364-2.546l-.31.622c3.114.763 4.543 1.854 6.037 3.196C22.97 8.822 20.43 7.591 16 7.591c-4.43 0-6.97 1.23-9.545 2.545 1.494-1.342 3.194-2.555 6.037-3.196l-.31-.622c-3.615.34-6.364 2.546-6.364 2.546S2.56 13.589 2 22.864c3.284 3.788 8.273 3.818 8.273 3.818l1.043-1.39a12.748 12.748 0 01-5.498-3.701c2.06 1.559 5.17 3.182 10.182 3.182 5.011 0 8.121-1.623 10.182-3.182a12.74 12.74 0 01-5.498 3.701l1.043 1.39s4.99-.03 8.273-3.818c-.56-9.275-3.818-14-3.818-14zM11.864 20.318c-1.231 0-2.228-1.139-2.228-2.545 0-1.407.997-2.546 2.228-2.546 1.23 0 2.227 1.14 2.227 2.546s-.997 2.545-2.227 2.545zm8.272 0c-1.23 0-2.227-1.139-2.227-2.545 0-1.407.997-2.546 2.227-2.546 1.231 0 2.228 1.14 2.228 2.546s-.997 2.545-2.228 2.545z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWDots: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWDots implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -908,11 +909,11 @@ export const CWDots: m.Component<IconAttrs> = {
         <path d="M8.059 16a3 3 0 11-6 0 3 3 0 016 0zM18.858 16a3 3 0 11-6 0 3 3 0 016 0zM30.058 16c0 1.657-1.432 3-3.2 3-1.767 0-3.2-1.343-3.2-3s1.433-3 3.2-3c1.768 0 3.2 1.343 3.2 3z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWDotsVertical: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWDotsVertical implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -938,11 +939,11 @@ export const CWDotsVertical: m.Component<IconAttrs> = {
         <path d="M16 8.059a3 3 0 110-6 3 3 0 010 6zM16 18.858a3 3 0 110-6 3 3 0 010 6zM16 30.058c-1.657 0-3-1.432-3-3.2 0-1.767 1.343-3.2 3-3.2s3 1.433 3 3.2c0 1.768-1.343 3.2-3 3.2z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWDownvote: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWDownvote implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -968,11 +969,11 @@ export const CWDownvote: m.Component<IconAttrs> = {
         <path d="M16.73 27.828a.843.843 0 01-1.46 0L2.113 5.018a.845.845 0 01.731-1.268h26.31c.65 0 1.055.704.73 1.267l-13.154 22.81z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWElement: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWElement implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1002,11 +1003,11 @@ export const CWElement: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWExpand: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWExpand implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1036,11 +1037,11 @@ export const CWExpand: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWExploreCommunities: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWExploreCommunities implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1071,11 +1072,11 @@ export const CWExploreCommunities: m.Component<IconAttrs> = {
         <path d="M18.561 12.813a2.303 2.303 0 11-4.607 0 2.303 2.303 0 014.607 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWExternalLink: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWExternalLink implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1105,11 +1106,11 @@ export const CWExternalLink: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWFeedback: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWFeedback implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1139,11 +1140,11 @@ export const CWFeedback: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWFilter: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWFilter implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1173,11 +1174,11 @@ export const CWFilter: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWFlag: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWFlag implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1207,11 +1208,11 @@ export const CWFlag: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWFlame: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWFlame implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1237,11 +1238,11 @@ export const CWFlame: m.Component<IconAttrs> = {
         <path d="M19.909 30.332c-.215.043-.378-.314-.244-.487 1.575-2.034-.621-6.082-2.787-8.747a1.122 1.122 0 00-1.756 0c-2.166 2.665-4.362 6.713-2.787 8.747.134.173-.029.53-.244.487C-.757 27.749 7.91 11.445 15.085 2.93a1.189 1.189 0 011.83 0c7.176 8.515 15.842 24.82 2.994 27.402z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWGear: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWGear implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1321,11 +1322,11 @@ export const CWGear: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWGithub: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWGithub implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1355,11 +1356,11 @@ export const CWGithub: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHamburger: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHamburger implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1384,11 +1385,11 @@ export const CWHamburger: m.Component<IconAttrs> = {
         <path d="M2 20c0-.276.348-.5.778-.5h26.444c.43 0 .778.224.778.5v1c0 .276-.348.5-.778.5H2.778c-.43 0-.778-.224-.778-.5v-1zM30 13c0 .276-.348.5-.778.5H2.778c-.43 0-.778-.224-.778-.5v-1c0-.276.348-.5.778-.5h26.444c.43 0 .778.224.778.5v1z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHash: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHash implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1418,11 +1419,11 @@ export const CWHash: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHeartEmpty: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHeartEmpty implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1452,11 +1453,11 @@ export const CWHeartEmpty: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHeartFilled: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHeartFilled implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1486,11 +1487,11 @@ export const CWHeartFilled: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHelp: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHelp implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1520,11 +1521,11 @@ export const CWHelp: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWHome: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWHome implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1554,11 +1555,11 @@ export const CWHome: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWInfoEmpty: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWInfoEmpty implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1589,11 +1590,11 @@ export const CWInfoEmpty: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWImageUpload: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWImageUpload implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1619,11 +1620,11 @@ export const CWImageUpload: m.Component<IconAttrs> = {
         <path d="M25.3332 17.8488C24.9795 17.8488 24.6404 17.9893 24.3904 18.2393C24.1403 18.4894 23.9998 18.8285 23.9998 19.1822V19.6888L22.0265 17.7155C21.3297 17.0242 20.388 16.6363 19.4065 16.6363C18.425 16.6363 17.4833 17.0242 16.7865 17.7155L15.8532 18.6488L12.5465 15.3422C11.84 14.6696 10.9019 14.2945 9.9265 14.2945C8.95108 14.2945 8.01301 14.6696 7.3065 15.3422L5.33317 17.3155V9.84882C5.33317 9.4952 5.47365 9.15606 5.72369 8.90601C5.97374 8.65596 6.31288 8.51549 6.6665 8.51549H15.9998C16.3535 8.51549 16.6926 8.37501 16.9426 8.12496C17.1927 7.87491 17.3332 7.53578 17.3332 7.18215C17.3332 6.82853 17.1927 6.48939 16.9426 6.23934C16.6926 5.9893 16.3535 5.84882 15.9998 5.84882H6.6665C5.60564 5.84882 4.58822 6.27025 3.83808 7.02039C3.08793 7.77054 2.6665 8.78795 2.6665 9.84882V25.8488C2.6665 26.9097 3.08793 27.9271 3.83808 28.6772C4.58822 29.4274 5.60564 29.8488 6.6665 29.8488H22.6665C23.7274 29.8488 24.7448 29.4274 25.4949 28.6772C26.2451 27.9271 26.6665 26.9097 26.6665 25.8488V19.1822C26.6665 18.8285 26.526 18.4894 26.276 18.2393C26.0259 17.9893 25.6868 17.8488 25.3332 17.8488ZM6.6665 27.1822C6.31288 27.1822 5.97374 27.0417 5.72369 26.7916C5.47365 26.5416 5.33317 26.2024 5.33317 25.8488V21.0888L9.19984 17.2222C9.39572 17.0355 9.65592 16.9314 9.9265 16.9314C10.1971 16.9314 10.4573 17.0355 10.6532 17.2222L14.8798 21.4488L20.6132 27.1822H6.6665ZM23.9998 25.8488C23.9979 26.1041 23.9138 26.3519 23.7598 26.5555L17.7465 20.5155L18.6798 19.5822C18.7754 19.4846 18.8895 19.4071 19.0154 19.3542C19.1414 19.3013 19.2766 19.274 19.4132 19.274C19.5498 19.274 19.685 19.3013 19.8109 19.3542C19.9368 19.4071 20.0509 19.4846 20.1465 19.5822L23.9998 23.4622V25.8488ZM30.2798 6.23549L26.2798 2.23549C26.153 2.1141 26.0035 2.01895 25.8398 1.95549C25.5152 1.82213 25.1511 1.82213 24.8265 1.95549C24.6628 2.01895 24.5133 2.1141 24.3865 2.23549L20.3865 6.23549C20.1354 6.48656 19.9944 6.82708 19.9944 7.18215C19.9944 7.53722 20.1354 7.87775 20.3865 8.12882C20.6376 8.37989 20.9781 8.52094 21.3332 8.52094C21.6882 8.52094 22.0288 8.37989 22.2798 8.12882L23.9998 6.39549V13.8488C23.9998 14.2024 24.1403 14.5416 24.3904 14.7916C24.6404 15.0417 24.9795 15.1822 25.3332 15.1822C25.6868 15.1822 26.0259 15.0417 26.276 14.7916C26.526 14.5416 26.6665 14.2024 26.6665 13.8488V6.39549L28.3865 8.12882C28.5105 8.25379 28.6579 8.35298 28.8204 8.42067C28.9829 8.48837 29.1572 8.52322 29.3332 8.52322C29.5092 8.52322 29.6835 8.48837 29.8459 8.42067C30.0084 8.35298 30.1559 8.25379 30.2798 8.12882C30.4048 8.00487 30.504 7.8574 30.5717 7.69492C30.6394 7.53244 30.6742 7.35817 30.6742 7.18215C30.6742 7.00614 30.6394 6.83186 30.5717 6.66938C30.504 6.50691 30.4048 6.35944 30.2798 6.23549Z" />
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWInfoFilled: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWInfoFilled implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1653,11 +1654,11 @@ export const CWInfoFilled: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWJar: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWJar implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1688,11 +1689,11 @@ export const CWJar: m.Component<IconAttrs> = {
         <path d="M19 18.5a3 3 0 11-6 0 3 3 0 016 0zM15.026 24.5a3 3 0 11-6 0 3 3 0 016 0zM22.974 24.5a3 3 0 11-6 0 3 3 0 016 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWLink: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWLink implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1722,11 +1723,11 @@ export const CWLink: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWLock: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWLock implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1756,11 +1757,11 @@ export const CWLock: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWLogout: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWLogout implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1795,11 +1796,11 @@ export const CWLogout: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWMail: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWMail implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1829,11 +1830,11 @@ export const CWMail: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWMute: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWMute implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1864,11 +1865,11 @@ export const CWMute: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPeople: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWPeople implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1899,11 +1900,11 @@ export const CWPeople: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPerson: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWPerson implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1933,11 +1934,11 @@ export const CWPerson: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPin: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWPin implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1965,11 +1966,11 @@ export const CWPin: m.Component<IconAttrs> = {
         <path d="M10.556 2.5h10.888L23 19.5H9l1.556-17z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPlus: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWPlus implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -1996,11 +1997,11 @@ export const CWPlus: m.Component<IconAttrs> = {
         <path d="M16.5 2.5c.276 0 .5.348.5.778v26.444c0 .43-.224.778-.5.778h-1c-.276 0-.5-.348-.5-.778V3.278c0-.43.224-.778.5-.778h1z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWPlusCircle: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWPlusCircle implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2030,11 +2031,11 @@ export const CWPlusCircle: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWSearch: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWSearch implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2064,11 +2065,11 @@ export const CWSearch: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWSend: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWSend implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2098,11 +2099,11 @@ export const CWSend: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWShare: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWShare implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2132,11 +2133,11 @@ export const CWShare: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWShare2: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWShare2 implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2166,11 +2167,11 @@ export const CWShare2: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWSidebarCollapse: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWSidebarCollapse implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2200,11 +2201,11 @@ export const CWSidebarCollapse: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWSidebarExpand: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWSidebarExpand implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2234,11 +2235,11 @@ export const CWSidebarExpand: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWStar: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWStar implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2264,11 +2265,11 @@ export const CWStar: m.Component<IconAttrs> = {
         <path d="M13.065 1.469c.326-.861 1.544-.861 1.87 0l1.422 3.753a1 1 0 001.483.482l3.357-2.2c.77-.506 1.755.21 1.513 1.099l-1.056 3.872a1 1 0 00.917 1.262l4.01.192c.919.044 1.295 1.203.577 1.779l-3.13 2.512a1 1 0 000 1.56l3.13 2.512c.718.576.342 1.735-.578 1.779l-4.009.192a1 1 0 00-.917 1.262l1.056 3.873c.242.888-.743 1.604-1.513 1.099l-3.357-2.201a1 1 0 00-1.483.482l-1.422 3.753c-.326.861-1.544.861-1.87 0l-1.422-3.753a1 1 0 00-1.484-.482l-3.356 2.2c-.77.506-1.755-.21-1.513-1.098l1.056-3.873a1 1 0 00-.917-1.262l-4.01-.192C.5 20.027.125 18.868.843 18.292l3.13-2.512a1 1 0 000-1.56l-3.13-2.512C.124 11.132.5 9.973 1.42 9.929l4.009-.192a1 1 0 00.917-1.262L5.29 4.603c-.242-.889.743-1.605 1.513-1.1l3.356 2.201a1 1 0 001.484-.482l1.422-3.753z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWSun: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWSun implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2344,11 +2345,11 @@ export const CWSun: m.Component<IconAttrs> = {
         ></rect>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWTelegram: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWTelegram implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2378,11 +2379,11 @@ export const CWTelegram: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWTrash: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWTrash implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2413,11 +2414,11 @@ export const CWTrash: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWTreasuryProposal: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWTreasuryProposal implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2447,11 +2448,11 @@ export const CWTreasuryProposal: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWTwitter: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWTwitter implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2477,11 +2478,11 @@ export const CWTwitter: m.Component<IconAttrs> = {
         <path d="M28.553 8.978c.02.306.02.613.02.919 0 9.34-6.517 20.103-18.428 20.103-3.67 0-7.078-1.16-9.946-3.172.522.066 1.023.088 1.564.088 3.028 0 5.815-1.116 8.041-3.02-2.847-.065-5.233-2.1-6.056-4.9.401.067.803.11 1.224.11.581 0 1.163-.087 1.704-.24-2.968-.657-5.194-3.5-5.194-6.935v-.087a6.119 6.119 0 002.928.897c-1.744-1.27-2.887-3.435-2.887-5.885 0-1.312.32-2.515.882-3.565 3.188 4.287 7.98 7.087 13.355 7.393a8.668 8.668 0 01-.16-1.618C15.6 5.172 18.486 2 22.075 2c1.865 0 3.55.853 4.732 2.231a12.125 12.125 0 004.11-1.706c-.48 1.64-1.503 3.019-2.846 3.894 1.303-.153 2.566-.547 3.73-1.094a14.679 14.679 0 01-3.25 3.653z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWUpvote: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWUpvote implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2507,11 +2508,11 @@ export const CWUpvote: m.Component<IconAttrs> = {
         <path d="M15.27 4.172a.843.843 0 011.46 0l13.156 22.81a.845.845 0 01-.731 1.268H2.845a.845.845 0 01-.73-1.267l13.154-22.81z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWViews: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWViews implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2542,11 +2543,11 @@ export const CWViews: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWWallet: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWWallet implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2582,11 +2583,11 @@ export const CWWallet: m.Component<IconAttrs> = {
         <path d="M27.145 18.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWWebsite: m.Component<IconAttrs> = {
-  view: (vnode: m.VnodeDOM<IconAttrs>) => {
+export class CWWebsite implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2616,11 +2617,11 @@ export const CWWebsite: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}
 
-export const CWWrite: m.Component<IconAttrs> = {
-  view: (vnode) => {
+export class CWWrite implements m.ClassComponent<IconAttrs> {
+  view(vnode: m.Vnode<IconAttrs>) {
     const {
       className,
       componentType,
@@ -2650,5 +2651,5 @@ export const CWWrite: m.Component<IconAttrs> = {
         ></path>
       </svg>
     );
-  },
-};
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
@@ -15,7 +15,7 @@ export type IconStyleAttrs = {
 
 export type IconAttrs = IconStyleAttrs & {
   componentType?: ComponentType;
-  onclick?: () => void; // should be used by icon button, not by plain icons
+  onclick?: (e?: MouseEvent) => void; // should be used by icon button, not by plain icons
 };
 
 export type IconComponentAttrs = IconAttrs & { iconName: IconName };

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from '../types';
-import { IconName } from './cw_icon_lookup';
+import { CustomIconName, IconName } from './cw_icon_lookup';
 
 export type IconButtonTheme = 'black' | 'neutral' | 'primary' | 'hasBackground';
 
@@ -8,22 +8,23 @@ export type IconSize = 'small' | 'medium' | 'large' | 'xl' | 'xxl';
 export type IconStyleAttrs = {
   className?: string;
   disabled?: boolean;
-  iconButtonTheme: IconButtonTheme;
+  iconButtonTheme?: IconButtonTheme;
   iconSize?: IconSize;
   selected?: boolean;
 };
 
 export type IconAttrs = IconStyleAttrs & {
-  componentType: ComponentType;
-  iconName: IconName;
+  componentType?: ComponentType;
   onclick?: () => void; // should be used by icon button, not by plain icons
 };
+
+export type IconComponentAttrs = IconAttrs & { iconName: IconName };
 
 export type CustomIconStyleAttrs = {
   iconSize?: IconSize;
 };
 
 export type CustomIconAttrs = {
-  componentType: ComponentType;
-  iconName: IconName;
+  componentType?: ComponentType;
+  iconName?: CustomIconName;
 } & CustomIconStyleAttrs;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_text.tsx
@@ -37,10 +37,10 @@ type TextStyleAttrs = {
   className?: string;
   disabled?: boolean;
   fontStyle?: FontStyle;
-  fontWeight: FontWeight;
+  fontWeight?: FontWeight;
   isCentered?: boolean;
   noWrap?: boolean; // parent must be flex container and have definite width for this to work
-  type: FontType;
+  type?: FontType;
 };
 
 type TextAttrs = {
@@ -59,7 +59,7 @@ const getFontWeight = (type: FontType) => {
 };
 
 export class CWText implements m.ClassComponent<TextAttrs> {
-  view(vnode) {
+  view(vnode: m.Vnode<TextAttrs>) {
     const {
       className,
       disabled = false,

--- a/packages/commonwealth/client/scripts/views/components/notification_row.ts
+++ b/packages/commonwealth/client/scripts/views/components/notification_row.ts
@@ -13,10 +13,10 @@ import { link, pluralize } from 'helpers';
 import User from 'views/components/widgets/user';
 import UserGallery from 'views/components/widgets/user_gallery';
 import { getProposalUrl, getCommunityUrl } from '../../../../shared/utils';
-import { CWIcon } from './component_kit/cw_icons/cw_icon';
 import { MarkdownFormattedText } from './quill/markdown_formatted_text';
 import { QuillFormattedText } from './quill/quill_formatted_text';
 import { CWSpinner } from './component_kit/cw_spinner';
+import { CWIconButton } from './component_kit/cw_icon_button';
 
 const jumpHighlightNotification = (
   commentId,
@@ -368,12 +368,8 @@ const NotificationRow: m.Component<
             m('.comment-body-top.chain-event-notification-top', [
               `${label.heading} on ${chainName}`,
               !vnode.attrs.onListPage &&
-                m(CWIcon, {
+                m(CWIconButton, {
                   iconName: 'close',
-                  onmousedown: (e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  },
                   onclick: (e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/new_proposal_form.ts
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/new_proposal_form.ts
@@ -31,9 +31,9 @@ import {
   getVersion,
   createProposal,
 } from 'helpers/snapshot_utils';
-import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { QuillEditor } from '../../components/quill/quill_editor';
 import { CWSpinner } from '../../components/component_kit/cw_spinner';
+import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 
 // TODO Graham 7-20-22: Reconcile against NewThreadForm
 interface IThreadForm {
@@ -343,10 +343,9 @@ const NewProposalForm: m.Component<
                       contentRight:
                         idx > 1 &&
                         idx === vnode.state.form.choices.length - 1 &&
-                        m(CWIcon, {
+                        m(CWIconButton, {
                           iconName: 'trash',
                           iconSize: 'large',
-                          style: 'cursor: pointer;',
                           onclick: () => {
                             vnode.state.form.choices.pop();
                             m.redraw();


### PR DESCRIPTION
Also updates icons to class components.

After some tests, seems fine to do `m.Vnode<IconComponentAttrs>` instead of `m.VnodeDOM<IconComponentAttrs, this>`. Most components don't need `dom` and typing of `this` is unaffected.