### PR TITLE
Fix paths in commonwealth tsconfig

### DIFF
--- a/packages/commonwealth/tsconfig.json
+++ b/packages/commonwealth/tsconfig.json
@@ -5,6 +5,12 @@
     "outDir": "./build",
     "baseUrl": ".",
     "paths": {
+      "common-common": ["../../packages/common-common"],
+      "common-common/*": ["../../packages/common-common/*"],
+      "chain-events": ["../../packages/chain-events"],
+      "chain-events/*": ["../../packages/chain-events/*"],
+      "token-balance-cache": ["../../packages/token-balance-cache"],
+      "token-balance-cache/*": ["../../packages/token-balance-cache/*"],
       "*": ["./*", "shared/*", "client/scripts/*"]
     }
   },


### PR DESCRIPTION
`paths` in commonwealth tsconfig was overriding the parent tsconfig `paths` which resulted in incorrect builds for chain-events.