### PR TITLE
Fix Forum Notifications

### DIFF
--- a/packages/commonwealth/server/models/subscription.ts
+++ b/packages/commonwealth/server/models/subscription.ts
@@ -1,5 +1,4 @@
-import { DataTypes, QueryTypes } from 'sequelize';
-import * as Sequelize from 'sequelize';
+import Sequelize, { DataTypes, QueryTypes } from 'sequelize';
 import { ChainBase, ChainType } from 'common-common/src/types';
 import { factory, formatFilename } from 'common-common/src/logging';
 import send, { WebhookContent } from '../webhookNotifier';

--- a/packages/commonwealth/server/models/subscription.ts
+++ b/packages/commonwealth/server/models/subscription.ts
@@ -1,5 +1,5 @@
-import WebSocket from 'ws';
-import Sequelize, { DataTypes, QueryTypes } from 'sequelize';
+import { DataTypes, QueryTypes } from 'sequelize';
+import * as Sequelize from 'sequelize';
 import { ChainBase, ChainType } from 'common-common/src/types';
 import { factory, formatFilename } from 'common-common/src/logging';
 import send, { WebhookContent } from '../webhookNotifier';
@@ -7,7 +7,7 @@ import { SERVER_URL } from '../config';
 import { UserAttributes } from './user';
 import { DB } from '../models';
 import { NotificationCategoryAttributes } from './notification_category';
-import { ModelStatic } from './types';
+import {ModelInstance, ModelStatic} from './types';
 import {
   IPostNotificationData,
   ICommunityNotificationData,
@@ -55,8 +55,7 @@ export type SubscriptionAttributes = {
   Comment?: CommentAttributes;
 }
 
-export interface SubscriptionInstance
-extends Sequelize.Model<SubscriptionAttributes>, SubscriptionAttributes {
+export type SubscriptionInstance = ModelInstance<SubscriptionAttributes> & {
   getNotificationsRead: Sequelize.HasManyGetAssociationsMixin<NotificationsReadInstance>;
 }
 

--- a/packages/commonwealth/server/routes/addEditors.ts
+++ b/packages/commonwealth/server/routes/addEditors.ts
@@ -148,7 +148,6 @@ const addEditors = async (
           chain: thread.chain,
           body: thread.body,
         },
-        req.wss,
         [author.address]
       );
     });

--- a/packages/commonwealth/server/routes/createComment.ts
+++ b/packages/commonwealth/server/routes/createComment.ts
@@ -358,7 +358,6 @@ const createComment = async (
       chain: finalComment.chain,
       body: finalComment.text,
     },
-    req.wss,
     excludedAddrs
   );
 
@@ -389,7 +388,6 @@ const createComment = async (
         chain: finalComment.chain,
         body: finalComment.text,
       },
-      req.wss,
       excludedAddrs
     );
   }
@@ -424,7 +422,6 @@ const createComment = async (
             chain: finalComment.chain,
             body: finalComment.text,
           }, // TODO: add webhook data for mentions
-          req.wss,
           [finalComment.Address.address]
         );
     });

--- a/packages/commonwealth/server/routes/createReaction.ts
+++ b/packages/commonwealth/server/routes/createReaction.ts
@@ -240,7 +240,6 @@ const createReaction = async (
       chain: finalReaction.chain,
       body: comment_id ? comment.text : '',
     },
-    req.wss,
     [finalReaction.Address.address]
   );
 

--- a/packages/commonwealth/server/routes/createThread.ts
+++ b/packages/commonwealth/server/routes/createThread.ts
@@ -167,7 +167,6 @@ const dispatchHooks = async (
       chain: finalThread.chain,
       body: finalThread.body,
     },
-    req.wss,
     excludedAddrs
   );
 
@@ -199,7 +198,6 @@ const dispatchHooks = async (
           chain: finalThread.chain,
           body: finalThread.body,
         },
-        req.wss,
         [finalThread.Address.address]
       );
     });

--- a/packages/commonwealth/server/routes/editComment.ts
+++ b/packages/commonwealth/server/routes/editComment.ts
@@ -138,7 +138,6 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
         title: proposal.title || '',
         chain: finalComment.chain,
       },
-      req.wss,
       [ finalComment.Address.address ],
     );
 
@@ -207,7 +206,6 @@ const editComment = async (models: DB, banCache: BanCache, req: Request, res: Re
             chain: finalComment.chain,
             body: finalComment.text,
           },
-          req.wss,
           [ finalComment.Address.address ],
         );
       });

--- a/packages/commonwealth/server/routes/editThread.ts
+++ b/packages/commonwealth/server/routes/editThread.ts
@@ -190,7 +190,6 @@ const editThread = async (
       },
       // don't send webhook notifications for edits
       null,
-      req.wss,
       [userOwnedAddresses[0].address]
     );
 
@@ -264,7 +263,6 @@ const editThread = async (
             chain: finalThread.chain,
             body: finalThread.body,
           },
-          req.wss,
           [finalThread.Address.address]
         );
       });

--- a/packages/commonwealth/server/types.ts
+++ b/packages/commonwealth/server/types.ts
@@ -44,10 +44,9 @@ declare global {
     interface Request {
       user?: User;
 
-      // TODO: remove these once websocket PR merged!
+      // TODO: session is used in logout.ts -> remove?
       session: any;
       sessionID: any;
-      wss: any;
     }
   }
 }

--- a/packages/commonwealth/tsconfig.json
+++ b/packages/commonwealth/tsconfig.json
@@ -24,8 +24,8 @@
     "./shared",
     "./test",
     "./globals.d.ts",
-    "server/*",
-    "server.ts"
+    "./server",
+    "./server.ts"
   ],
   "exclude": ["./node_modules"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The microservice PR removed websockets from `emitNotifications` but did not refactor all calls to `emitNotifications` some of which still included `req.wss`. 

This was not caught because `req.wss` had type `any` and therefore matched the type of any of `emitNotifications` parameters.

- Refactored `emitNotifications` calls
- Removed `req.wss` type from `Request`
- Edited `commonwealth/tsconfig.json` to include all server files rather than just root

### NOTE: should `session` and `sessionID` be removed from `Request` interface in `server/types`??

## Motivation and Context
Fixes emitting forum notifications

## How has this been tested?
Locally created threads/comments to check if notifications were created and emitted.

## Does this PR affect any server routes?
- [x] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
No

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
