### PR TITLE
Add global activity cache.

### DIFF
--- a/packages/commonwealth/server-test.ts
+++ b/packages/commonwealth/server-test.ts
@@ -23,6 +23,7 @@ import setupPassport from './server/passport';
 import models from './server/database';
 import ViewCountCache from './server/util/viewCountCache';
 import BanCache from './server/util/banCheckCache';
+import GlobalActivityCache from './server/util/globalActivityCache';
 import setupErrorHandlers from 'common-common/src/scripts/setupErrorHandlers';
 import RuleCache from './server/util/rules/ruleCache';
 import { MockTokenBalanceProvider } from './test/util/modelUtils';
@@ -352,9 +353,11 @@ const setupServer = () => {
 };
 
 const banCache = new BanCache(models);
+const globalActivityCache = new GlobalActivityCache(models);
+globalActivityCache.start();
 setupPassport(models);
 // TODO: mock RabbitMQController
-setupAPI(app, models, viewCountCache, tokenBalanceCache, ruleCache, banCache);
+setupAPI(app, models, viewCountCache, tokenBalanceCache, ruleCache, banCache, globalActivityCache);
 
 const rollbar = new Rollbar({
   accessToken: ROLLBAR_SERVER_TOKEN,

--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -39,6 +39,7 @@ import migrateCouncillorValidatorFlags from './server/scripts/migrateCouncillorV
 import expressStatsdInit from './server/scripts/setupExpressStats';
 import { StatsDController } from 'common-common/src/statsd';
 import {BrokerConfig} from "rascal";
+import GlobalActivityCache from './server/util/globalActivityCache';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -244,6 +245,9 @@ async function main() {
   if (!NO_TOKEN_BALANCE_CACHE) await tokenBalanceCache.start();
   await ruleCache.start();
   const banCache = new BanCache(models);
+  const globalActivityCache = new GlobalActivityCache(models);
+  // TODO: should we await this? it will block server startup -- but not a big deal locally
+  await globalActivityCache.start();
   setupAPI(
     app,
     models,
@@ -251,6 +255,7 @@ async function main() {
     tokenBalanceCache,
     ruleCache,
     banCache,
+    globalActivityCache,
   );
   setupCosmosProxy(app, models);
   setupIpfsProxy(app);

--- a/packages/commonwealth/server/router.ts
+++ b/packages/commonwealth/server/router.ts
@@ -160,6 +160,7 @@ import {getChain} from "./routes/getChain";
 import {getChainNode} from "./routes/getChainNode";
 import {getChainContracts} from "./routes/getChainContracts";
 import {getSubscribedChains} from "./routes/getSubscribedChains";
+import GlobalActivityCache from './util/globalActivityCache';
 
 
 
@@ -170,6 +171,7 @@ function setupRouter(
   tokenBalanceCache: TokenBalanceCache,
   ruleCache: RuleCache,
   banCache: BanCache,
+  globalActivityCache: GlobalActivityCache,
 ) {
   const router = express.Router();
 
@@ -600,7 +602,7 @@ function setupRouter(
     viewUserActivity.bind(this, models)
   );
   router.post('/viewChainIcons', viewChainIcons.bind(this, models));
-  router.post('/viewGlobalActivity', viewGlobalActivity.bind(this, models));
+  router.post('/viewGlobalActivity', viewGlobalActivity.bind(this, models, globalActivityCache));
   router.post(
     '/markNotificationsRead',
     passport.authenticate('jwt', { session: false }),

--- a/packages/commonwealth/server/routes/viewGlobalActivity.ts
+++ b/packages/commonwealth/server/routes/viewGlobalActivity.ts
@@ -1,49 +1,16 @@
-import { Request, Response, NextFunction } from 'express';
+import { TypedRequestBody, TypedResponse, success } from '../types';
 import { DB } from '../models';
+import { GlobalActivity } from '../util/queryGlobalActivity';
+import GlobalActivityCache from '../util/globalActivityCache';
 
 const viewGlobalActivity = async (
   models: DB,
-  req: Request,
-  res: Response,
-  next: NextFunction
+  globalActivityCache: GlobalActivityCache,
+  req: TypedRequestBody<Record<string, never>>,
+  res: TypedResponse<GlobalActivity>,
 ) => {
-  const query = `
-    SELECT nt.thread_id, nts.created_at as last_activity, nts.notification_data, nts.category_id,
-      MAX(ovc.view_count) as view_count,
-      COUNT(DISTINCT oc.id) AS comment_count,
-      COUNT(DISTINCT tr.id) + COUNT(DISTINCT cr.id) AS reaction_count
-    FROM
-      (SELECT nnn.mx_not_id, nnn.thread_id,
-          ROW_NUMBER() OVER (ORDER BY mx_not_id DESC) as thread_rank
-        FROM
-        (SELECT DISTINCT nn.thread_id, nn.mx_not_id
-          FROM (SELECT (n.notification_data::jsonb->>'root_id') AS thread_id,
-                  MAX(n.id) OVER (PARTITION BY (n.notification_data::jsonb->>'root_id')) AS mx_not_id
-                FROM "Notifications" n
-                WHERE n.category_id IN('new-thread-creation','new-comment-creation')
-                ORDER BY id DESC
-                FETCH FIRST 500 ROWS ONLY
-                ) nn
-          ) nnn
-      ) nt
-    INNER JOIN "Notifications" nts ON nt.mx_not_id = nts.id
-    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = CAST(ovc.object_id AS VARCHAR)
-    LEFT JOIN "Comments" oc ON 'discussion_'||CAST(nt.thread_id AS VARCHAR) = oc.root_id
-      --TODO: eval execution path with alternate aggregations
-    LEFT JOIN "Reactions" tr ON nt.thread_id = CAST(tr.thread_id AS VARCHAR)
-    LEFT JOIN "Reactions" cr ON oc.id = cr.comment_id
-    LEFT JOIN "Threads" thr ON thr.id = CAST(nt.thread_id AS int)
-    WHERE nt.thread_rank <= 50
-    GROUP BY nt.thread_id, nts.created_at, nts.notification_data, nts.category_id
-    ORDER BY nts.created_at DESC;
-  `;
-
-  const notifications = await models.sequelize.query(query, {
-    type: 'SELECT',
-    raw: true,
-  });
-
-  return res.json({ status: 'Success', result: notifications });
+  const activity = await globalActivityCache.globalActivity();
+  return success(res, activity);
 };
 
 export default viewGlobalActivity;

--- a/packages/commonwealth/server/util/globalActivityCache.ts
+++ b/packages/commonwealth/server/util/globalActivityCache.ts
@@ -1,0 +1,32 @@
+import JobRunner from 'common-common/src/cacheJobRunner';
+
+import { default as queryGlobalActivity, GlobalActivity } from './queryGlobalActivity';
+import { DB } from '../models';
+
+type CacheT = { activity: GlobalActivity };
+
+export default class GlobalActivityCache extends JobRunner<CacheT> {
+  constructor(
+    private _models: DB,
+    _time: number = 60 * 5,   // 5 minutes
+  ) {
+    super({ activity: [] }, _time, false);
+  }
+
+  public async start() {
+    await this.run();
+    super.start();
+  }
+
+  public async globalActivity(): Promise<GlobalActivity> {
+    return this.access<GlobalActivity>(async (c) => c.activity);
+  }
+
+  // prunes all expired cache entries based on initialized time-to-live
+  protected async _job(): Promise<void> {
+    const globalActivity = await queryGlobalActivity(this._models);
+    await this.write(async (c) => {
+      c.activity = globalActivity;
+    });
+  }
+}

--- a/packages/commonwealth/server/util/queryGlobalActivity.ts
+++ b/packages/commonwealth/server/util/queryGlobalActivity.ts
@@ -1,0 +1,50 @@
+import { DB } from '../models';
+
+export type GlobalActivity = Array<{
+  category_id: string,
+  comment_count: string,
+  last_activity: string,
+  notification_data: string, // actually object but stringified
+  reaction_count: string,
+  thread_id: string,
+  view_count: number,
+}>;
+
+export default async function queryGlobalActivity(models: DB): Promise<GlobalActivity> {
+  const query = `
+    SELECT nt.thread_id, nts.created_at as last_activity, nts.notification_data, nts.category_id,
+      MAX(ovc.view_count) as view_count,
+      COUNT(DISTINCT oc.id) AS comment_count,
+      COUNT(DISTINCT tr.id) + COUNT(DISTINCT cr.id) AS reaction_count
+    FROM
+      (SELECT nnn.mx_not_id, nnn.thread_id,
+          ROW_NUMBER() OVER (ORDER BY mx_not_id DESC) as thread_rank
+        FROM
+        (SELECT DISTINCT nn.thread_id, nn.mx_not_id
+          FROM (SELECT (n.notification_data::jsonb->>'root_id') AS thread_id,
+                  MAX(n.id) OVER (PARTITION BY (n.notification_data::jsonb->>'root_id')) AS mx_not_id
+                FROM "Notifications" n
+                WHERE n.category_id IN('new-thread-creation','new-comment-creation')
+                ORDER BY id DESC
+                FETCH FIRST 500 ROWS ONLY
+                ) nn
+          ) nnn
+      ) nt
+    INNER JOIN "Notifications" nts ON nt.mx_not_id = nts.id
+    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = CAST(ovc.object_id AS VARCHAR)
+    LEFT JOIN "Comments" oc ON 'discussion_'||CAST(nt.thread_id AS VARCHAR) = oc.root_id
+      --TODO: eval execution path with alternate aggregations
+    LEFT JOIN "Reactions" tr ON nt.thread_id = CAST(tr.thread_id AS VARCHAR)
+    LEFT JOIN "Reactions" cr ON oc.id = cr.comment_id
+    LEFT JOIN "Threads" thr ON thr.id = CAST(nt.thread_id AS int)
+    WHERE nt.thread_rank <= 50
+    GROUP BY nt.thread_id, nts.created_at, nts.notification_data, nts.category_id
+    ORDER BY nts.created_at DESC;
+  `;
+
+  const notifications = await models.sequelize.query(query, {
+    type: 'SELECT',
+    raw: true,
+  });
+  return notifications;
+}

--- a/packages/commonwealth/server/util/queryGlobalActivity.ts
+++ b/packages/commonwealth/server/util/queryGlobalActivity.ts
@@ -46,5 +46,6 @@ export default async function queryGlobalActivity(models: DB): Promise<GlobalAct
     type: 'SELECT',
     raw: true,
   });
-  return notifications;
+  // TODO: verify output type
+  return notifications as GlobalActivity;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Caches global activity at startup + every 5 minutes. Reads activity from cache on query.
- JobRunner: adds flag to disable writelock on `job` + adds `write()` call to manually perform write.