### PR TITLE
Use query rather than param for ipfs proxy.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/aave/proposal.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/aave/proposal.ts
@@ -283,7 +283,7 @@ export default class AaveProposal extends Proposal<
 
   public async init() {
     // fetch IPFS information
-    $.get(`${this._Gov.app.serverUrl()}/ipfsProxy/${this._ipfsAddress}`)
+    $.get(`${this._Gov.app.serverUrl()}/ipfsProxy?hash=${this._ipfsAddress}`)
       .then((ipfsData) => {
         if (typeof ipfsData === 'string') {
           this._ipfsData = JSON.parse(ipfsData);

--- a/packages/commonwealth/server/util/ipfsProxy.ts
+++ b/packages/commonwealth/server/util/ipfsProxy.ts
@@ -6,9 +6,9 @@ const log = factory.getLogger(formatFilename(__filename));
 
 function setupIpfsProxy(app: Express) {
   // using bodyParser here because cosmjs generates text/plain type headers
-  app.get('/api/ipfsProxy/:hash', async function cosmosProxy(req, res, next) {
+  app.get('/api/ipfsProxy', async function cosmosProxy(req, res, next) {
     try {
-      const hash = req.params.hash;
+      const hash = req.query.hash;
       const response = await axios.get(`https://cloudflare-ipfs.com/ipfs/${hash}#x-ipfs-companion-no-redirect`, {
         headers: {
           origin: 'https://commonwealth.im'


### PR DESCRIPTION
Prevents us from making many spurious datadog metrics, since we ingest the request path directly as a tag.