### PR TITLE
Fix navigation URL after clicking stage filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.env
 *.log
 */build/
+.idea

--- a/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
@@ -45,7 +45,7 @@ export class StagesMenu extends ClassComponent<StagesMenuAttrs> {
           {m(MenuItem, {
             onclick: (e) => {
               e.preventDefault();
-              navigateToSubpage('/');
+              navigateToSubpage('/discussions');
             },
             active: !stage,
             iconLeft: !stage ? Icons.CHECK : null,
@@ -58,7 +58,7 @@ export class StagesMenu extends ClassComponent<StagesMenuAttrs> {
               iconLeft: stage === targetStage ? Icons.CHECK : null,
               onclick: (e) => {
                 e.preventDefault();
-                navigateToSubpage(`/?stage=${targetStage}`);
+                navigateToSubpage(`/discussions?stage=${targetStage}`);
               },
               label: (
                 <div class="stages-item">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- There was a missing `/discussions` path on stage filter click handler 
## Motivation and Context
More context on [this thread](https://hicommonwealth.slack.com/archives/C026YCDF0QZ/p1671630623192979)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual on local env.
## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
