### PR TITLE
add dummy url param to force twitter reset cache

### DIFF
--- a/packages/commonwealth/server/scripts/setupAppRoutes.ts
+++ b/packages/commonwealth/server/scripts/setupAppRoutes.ts
@@ -20,13 +20,13 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
   }
   log.info('setupAppRoutes');
   // Development: serve everything through devMiddleware
-  // if (DEV) {
-  //   app.get('*', (req, res, next) => {
-  //     req.url = '/build/';
-  //     devMiddleware(req, res, next);
-  //   });
-  //   return;
-  // }
+  if (DEV) {
+    app.get('*', (req, res, next) => {
+      req.url = '/build/';
+      devMiddleware(req, res, next);
+    });
+    return;
+  }
 
   // Production: serve SEO-optimized routes where possible
   //

--- a/packages/commonwealth/server/scripts/setupAppRoutes.ts
+++ b/packages/commonwealth/server/scripts/setupAppRoutes.ts
@@ -20,13 +20,13 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
   }
   log.info('setupAppRoutes');
   // Development: serve everything through devMiddleware
-  if (DEV) {
-    app.get('*', (req, res, next) => {
-      req.url = '/build/';
-      devMiddleware(req, res, next);
-    });
-    return;
-  }
+  // if (DEV) {
+  //   app.get('*', (req, res, next) => {
+  //     req.url = '/build/';
+  //     devMiddleware(req, res, next);
+  //   });
+  //   return;
+  // }
 
   // Production: serve SEO-optimized routes where possible
   //
@@ -39,6 +39,8 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
  
   const renderWithMetaTags = (res, title, description, author, image) => {
     image = cleanMalformedUrl(image);
+    // add a dummy param onto the end of the url to force twitter to update the card
+    image = `${image}?foo=bar`;
 
     description = description || `${title}: a decentralized community on Commonwealth.im.`;
     const $tmpl = cheerio.load(templateFile);
@@ -67,6 +69,8 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
       /<meta name="twitter:image:src" content="(.*?)">/g,
       '<meta name="twitter:image" content="$1">'
     );
+
+    console.log('renderWithMetaTags', twitterSafeHtml);
 
     res.send(twitterSafeHtml);
   };

--- a/packages/commonwealth/server/scripts/setupAppRoutes.ts
+++ b/packages/commonwealth/server/scripts/setupAppRoutes.ts
@@ -70,8 +70,8 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
       '<meta name="twitter:image" content="$1">'
     );
 
-    console.log('renderWithMetaTags', twitterSafeHtml);
 
+    log.info(`rendering metadata: ${twitterSafeHtml}`);
     res.send(twitterSafeHtml);
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
from a solution on SO, add a dummy param to the url so the url wont be in Twitter's cache. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
