### PR TITLE
Suppress webpack warnings from external libraries

### DIFF
--- a/packages/commonwealth/webpack/webpack.config.dev.js
+++ b/packages/commonwealth/webpack/webpack.config.dev.js
@@ -10,6 +10,14 @@ module.exports = merge(common, {
       'app.ts',
     ],
   },
+  ignoreWarnings: [
+    { module: /client\/styles\/construct.scss/ },
+    { module: /node_modules\/magic-sdk\/dist\/es\/index.mjs/ }
+  ],
+  stats: {
+    assets: false,
+    modules: false,
+  },
   mode: 'development',
   target: 'web',
   devtool: 'eval-cheap-source-map',


### PR DESCRIPTION
Webpack gives us warnings for `construct-ui` and `magic-sdk` which we don't need to see while developing. This silences those warnings with a filter.

## Description

## Motivation and Context

Just dev experience cleanup

## How has this been tested?

Inspect code, run and verify everything works

## Does this PR affect any server routes?
- [ ] yes
- [X] no

## If this PR affects server routes, what are the security implications?

n/a

## Have proper tags been added (for bug, enhancement, breaking change)?
- [X] yes
