### PR TITLE
Add comments count to thread previews

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
@@ -3,7 +3,7 @@ import { Topic, AbridgedThread, Profile, Thread } from 'models';
 import app from 'state';
 import $ from 'jquery';
 import { modelFromServer as modelThreadFromServer } from 'controllers/server/threads';
-import ChainEntityController from "controllers/server/chain_entities";
+import ChainEntityController from 'controllers/server/chain_entities';
 
 export interface IAbridgedThreadFromServer {
   id: number;
@@ -77,9 +77,9 @@ class RecentActivityController {
       threads_per_topic: 3,
     };
 
-    const [response,] = await Promise.all([
+    const [response] = await Promise.all([
       $.get(`${app.serverUrl()}/activeThreads`, params),
-      app.chainEntities.refresh(params.chain)
+      app.chainEntities.refresh(params.chain),
     ]);
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful: ${response.status}`);

--- a/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
@@ -3,7 +3,6 @@ import { Topic, AbridgedThread, Profile, Thread } from 'models';
 import app from 'state';
 import $ from 'jquery';
 import { modelFromServer as modelThreadFromServer } from 'controllers/server/threads';
-import ChainEntityController from 'controllers/server/chain_entities';
 
 export interface IAbridgedThreadFromServer {
   id: number;

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -54,6 +54,7 @@ export const modelFromServer = (thread) => {
     reactions,
     last_commented_on,
     linked_threads,
+    numberOfComments,
   } = thread;
 
   const attachments = Attachments
@@ -157,6 +158,7 @@ export const modelFromServer = (thread) => {
     polls: polls.map((p) => new Poll(p)),
     lastCommentedOn: last_commented_on ? moment(last_commented_on) : null,
     linkedThreads,
+    numberOfComments,
   });
 };
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -59,6 +59,7 @@ class Thread implements IUniqueId {
   public readonly polls: Poll[];
   public readonly linkedThreads: LinkedThreadRelation[];
   public snapshotProposal: string;
+  private numberOfComments: number;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -89,6 +90,7 @@ class Thread implements IUniqueId {
     hasPoll,
     lastCommentedOn,
     linkedThreads,
+    numberOfComments,
   }: {
     author: string;
     title: string;
@@ -114,6 +116,7 @@ class Thread implements IUniqueId {
     hasPoll: boolean;
     linkedThreads: LinkedThreadRelation[];
     polls?: Poll[];
+    numberOfComments?: number;
   }) {
     this.author = author;
     this.title = title;
@@ -150,6 +153,7 @@ class Thread implements IUniqueId {
     this.snapshotProposal = snapshotProposal;
     this.lastEdited = lastEdited;
     this.linkedThreads = linkedThreads || [];
+    this.numberOfComments = numberOfComments || 0;
   }
 }
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -59,7 +59,7 @@ class Thread implements IUniqueId {
   public readonly polls: Poll[];
   public readonly linkedThreads: LinkedThreadRelation[];
   public snapshotProposal: string;
-  private numberOfComments: number;
+  public numberOfComments: number;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
@@ -158,7 +158,7 @@ export class ThreadPreview extends ClassComponent<ThreadPreviewAttrs> {
           </div>
           <div class="title-row">
             <CWText type="h5" fontWeight="semiBold">
-              {thread.title}
+              {(thread as unknown as any).numberOfComments}: {thread.title}
             </CWText>
             {thread.hasPoll && <CWTag label="Poll" type="poll" />}
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
@@ -12,7 +12,7 @@ import {
   getProposalUrlPath,
 } from 'identifiers';
 import { slugify } from 'utils';
-import { isCommandClick } from 'helpers';
+import { isCommandClick, pluralize } from 'helpers';
 import { AddressInfo, Thread } from 'models';
 import { ThreadPreviewReactionButton } from '../../components/reaction_button/thread_preview_reaction_button';
 import User from '../../components/widgets/user';
@@ -33,7 +33,6 @@ import {
   isWindowSmallInclusive,
 } from '../../components/component_kit/helpers';
 import { ThreadReactionButton } from '../../components/reaction_button/thread_reaction_button';
-// import { ThreadPreviewMenu } from './thread_preview_menu';
 
 type ThreadPreviewAttrs = {
   thread: Thread;
@@ -64,28 +63,9 @@ export class ThreadPreview extends ClassComponent<ThreadPreviewAttrs> {
   view(vnode: m.Vnode<ThreadPreviewAttrs>) {
     const { thread } = vnode.attrs;
 
-    // const commentsCount = app.comments.nComments(thread);
-
     const isSubscribed =
       getCommentSubscription(thread)?.isActive &&
       getReactionSubscription(thread)?.isActive;
-
-    // const hasAdminPermissions =
-    //   app.user.activeAccount &&
-    //   (app.roles.isRoleOfCommunity({
-    //     role: 'admin',
-    //     chain: app.activeChainId(),
-    //   }) ||
-    //     app.roles.isRoleOfCommunity({
-    //       role: 'moderator',
-    //       chain: app.activeChainId(),
-    //     }));
-
-    // const isAuthor =
-    //   app.user.activeAccount &&
-    //   thread.author === app.user.activeAccount.address;
-
-    // const canSeeMenu = hasAdminPermissions || isAuthor;
 
     return (
       <div
@@ -158,7 +138,7 @@ export class ThreadPreview extends ClassComponent<ThreadPreviewAttrs> {
           </div>
           <div class="title-row">
             <CWText type="h5" fontWeight="semiBold">
-              {(thread as unknown as any).numberOfComments}: {thread.title}
+              {thread.title}
             </CWText>
             {thread.hasPoll && <CWTag label="Poll" type="poll" />}
 
@@ -199,11 +179,10 @@ export class ThreadPreview extends ClassComponent<ThreadPreviewAttrs> {
               {this.isWindowSmallInclusive && (
                 <ThreadReactionButton thread={thread} />
               )}
-              {/* TODO Gabe 12/7/22 - Comment count isn't available before the comments store is initialized */}
-              {/* <CWIcon iconName="feedback" iconSize="small" />
+              <CWIcon iconName="feedback" iconSize="small" />
               <CWText type="caption">
-                {commentsCount} {!this.isWindowSmallInclusive && `comments`}
-              </CWText> */}
+                {pluralize(thread.numberOfComments, 'comment')}
+              </CWText>
             </div>
             <div class="row-bottom-menu">
               <div

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -11,6 +11,7 @@ import app from 'state';
 import { Thread, Topic } from 'models';
 import { getProposalUrlPath } from 'identifiers';
 import { slugify } from 'utils';
+import { pluralize } from 'helpers';
 import { CWText } from '../../components/component_kit/cw_text';
 import User from '../../components/widgets/user';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
@@ -126,19 +127,24 @@ export class TopicSummaryRow extends ClassComponent<TopicSummaryRowAttrs> {
                       {thread.pinned && <CWIcon iconName="pin" />}
                     </div>
                   </div>
+
                   <CWText type="b2" fontWeight="bold">
                     {thread.title}
                   </CWText>
+
+                  <CWText type="caption" className="thread-preview">
+                    {thread.plaintext}
+                  </CWText>
+
                   <div class="row-bottom">
                     <div class="comments-and-users">
-                      <CWText type="caption" className="thread-preview">
-                        {thread.plaintext}
-                      </CWText>
                       {/* TODO Gabe 12/7/22 - Comment count isn't available before the comments store is initialized */}
-                      {/* <div class="comments-count">
+                      <div class="comments-count">
                         <CWIcon iconName="feedback" iconSize="small" />
-                        <CWText type="caption">{commentsCount} comments</CWText>
-                      </div> */}
+                        <CWText type="caption">
+                          {pluralize(thread.numberOfComments, 'comment')}
+                        </CWText>
+                      </div>
                       {/* TODO Gabe 10/3/22 - user gallery blocked by changes to user model */}
                       {/* <div class="user-gallery">
                         <div class="avatars-row">

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -138,7 +138,6 @@ export class TopicSummaryRow extends ClassComponent<TopicSummaryRowAttrs> {
 
                   <div class="row-bottom">
                     <div class="comments-and-users">
-                      {/* TODO Gabe 12/7/22 - Comment count isn't available before the comments store is initialized */}
                       <div class="comments-count">
                         <CWIcon iconName="feedback" iconSize="small" />
                         <CWText type="caption">

--- a/packages/commonwealth/client/styles/pages/overview/topic_summary_row.scss
+++ b/packages/commonwealth/client/styles/pages/overview/topic_summary_row.scss
@@ -109,6 +109,11 @@
         color: $neutral-500;
       }
 
+      .thread-preview {
+        @include multiline-text-ellipsis(2);
+        word-break: break-word;
+      }
+
       .row-bottom {
         display: flex;
         justify-content: space-between;
@@ -116,11 +121,6 @@
         .comments-and-users {
           display: flex;
           gap: 16px;
-
-          .thread-preview {
-            @include multiline-text-ellipsis(2);
-            word-break: break-word;
-          }
 
           .comments-count {
             align-items: center;

--- a/packages/commonwealth/server/routes/bulkThreads.ts
+++ b/packages/commonwealth/server/routes/bulkThreads.ts
@@ -42,7 +42,7 @@ const bulkThreads = async (
         thread_chain, thread_created, threads.kind,
         threads.read_only, threads.body, threads.stage, threads.snapshot_proposal,
         threads.has_poll, threads.plaintext,
-        threads.url, threads.pinned, topics.id AS topic_id, topics.name AS topic_name,
+        threads.url, threads.pinned, threads.number_of_comments, topics.id AS topic_id, topics.name AS topic_name,
         topics.description AS topic_description, topics.chain_id AS topic_chain,
         topics.telegram AS topic_telegram,
         collaborators, chain_entity_meta, linked_threads
@@ -50,7 +50,7 @@ const bulkThreads = async (
       RIGHT JOIN (
         SELECT t.id AS thread_id, t.title AS thread_title, t.address_id, t.last_commented_on,
           t.created_at AS thread_created,
-          t.chain AS thread_chain, t.read_only, t.body,
+          t.chain AS thread_chain, t.read_only, t.body, comments.number_of_comments,
           t.has_poll,
           t.plaintext,
           t.stage, t.snapshot_proposal, t.url, t.pinned, t.topic_id, t.kind, ARRAY_AGG(DISTINCT
@@ -77,12 +77,19 @@ const bulkThreads = async (
         ON collaborations.address_id = editors.id
         LEFT JOIN "ChainEntityMeta" AS entity_meta
         ON t.id = entity_meta.thread_id
+        LEFT JOIN (
+            SELECT root_id, COUNT(*) AS number_of_comments
+            FROM "Comments"
+            WHERE deleted_at IS NULL
+            GROUP BY root_id
+        ) comments
+        ON CONCAT(t.kind, '_', t.id) = comments.root_id
         WHERE t.deleted_at IS NULL
           AND t.chain = $chain 
           ${topicOptions}
           AND COALESCE(t.last_commented_on, t.created_at) < $created_at
           AND t.pinned = false
-          GROUP BY (t.id, COALESCE(t.last_commented_on, t.created_at))
+          GROUP BY (t.id, COALESCE(t.last_commented_on, t.created_at), comments.number_of_comments)
           ORDER BY COALESCE(t.last_commented_on, t.created_at) DESC LIMIT 20
         ) threads
       ON threads.address_id = addr.id
@@ -137,6 +144,7 @@ const bulkThreads = async (
           address: t.addr_address,
           chain: t.addr_chain,
         },
+        numberOfComments: t.number_of_comments,
       };
       if (t.topic_id) {
         data['topic'] = {

--- a/packages/commonwealth/server/util/getThreadCommentsCount.ts
+++ b/packages/commonwealth/server/util/getThreadCommentsCount.ts
@@ -1,0 +1,40 @@
+import { Op } from 'sequelize';
+import { DB } from '../models';
+import { ThreadAttributes } from '../models/thread';
+
+interface GetThreadsWithCommentCount {
+  threads: ThreadAttributes[];
+  models: DB;
+  chainId: string;
+}
+
+const getThreadsWithCommentCount = async ({
+  threads,
+  models,
+  chainId,
+}: GetThreadsWithCommentCount) => {
+  const rootIds = threads.map((thread) => `${thread.kind}_${thread.id}`);
+
+  const commentsCount = await models.Comment.count({
+    attributes: ['root_id'],
+    where: {
+      chain: chainId,
+      root_id: { [Op.in]: rootIds },
+      deleted_at: null,
+    },
+    group: 'root_id',
+  });
+
+  return threads.map((thread) => {
+    const numberOfComment = commentsCount.find(
+      (el) => el.root_id === `${thread.kind}_${thread.id}`
+    );
+
+    return {
+      ...thread,
+      numberOfComments: numberOfComment?.count || 0,
+    };
+  });
+};
+
+export default getThreadsWithCommentCount;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- There was a counter before but did not work properly as the comments were not loaded until the specific thread was opened and the counter relied on loaded comments. 

I run into couple problems along the way:
- For some reason there are multiple places in the app where the threads are loaded (`bulkOffchain.ts`, `activeThreads.ts`, `bulkThreads.ts`)  => The change had to be checked and implemented in all those places. 
- Some of the queries are raw SQL and some use Sequelize => Had to make sure that two approaches returns the same data.
- There is no direct relationship between `Threads` and `Comments` tables =>  Had to use `kind` + `_` + `id` from Thread to be able to connect it with Comment with `root_id`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[ticket](https://www.notion.so/hicommonwealth/Get-Comment-Count-Back-in-Thread-Overview-Page-291afbbfa9d54ba496f02215309c056c)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
https://www.loom.com/share/74559e77f5c5408793b5952111238f1d

Tested it locally, going to overview page and topic page, number should be visible under the thread preview

## Does this PR affect any server routes?
- [x] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
no - added one field thread object from DB
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [x] yes
