### PR TITLE
bug fix: use chain.chain when getting chain response from status api endpoint

### DIFF
--- a/packages/commonwealth/client/scripts/app.ts
+++ b/packages/commonwealth/client/scripts/app.ts
@@ -69,7 +69,7 @@ export async function initAppState(
             delete chain.chain.ChainNode;
             return app.config.chains.add(
               ChainInfo.fromJSON({
-                ChainNode: app.config.nodes.getById(chain.chain_node_id),
+                ChainNode: app.config.nodes.getById(chain.chain.chain_node_id),
                 snapshot: chain.snapshot,
                 ...chain.chain,
               })


### PR DESCRIPTION
## Description
Bug fix

When you navigate to a page that makes use of a blockchain RPC, e.g. https://commonwealth.im/edgeware/council then the following error (sometimes?) occurs:
<img width="1304" alt="Screenshot 2023-01-03 at 12 27 24 pm" src="https://user-images.githubusercontent.com/457206/210357217-fbb1c5f1-4f53-4f39-91c2-c681fab0b724.png">

AFAIK this is just a result of the `/status` API changing in https://github.com/hicommonwealth/commonwealth/pull/2295

## How has this been tested?
Manual QA, navigated to a governance page and saw that the page loaded correctly

## Does this PR affect any server routes?
- [ ] yes
- [x] no, this is just a change to the frontend code

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
