### PR TITLE
Catch unhandled exception on decoding URI

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -322,7 +322,7 @@ class ThreadsController {
         kind: proposal.kind,
         stage: proposal.stage,
         body: encodeURIComponent(newBody),
-        title: newTitle,
+        title: encodeURIComponent(newTitle),
         url,
         'attachments[]': attachments,
         jwt: app.user.jwt,

--- a/packages/commonwealth/server/scripts/setupAppRoutes.ts
+++ b/packages/commonwealth/server/scripts/setupAppRoutes.ts
@@ -14,6 +14,15 @@ function cleanMalformedUrl(str: string) {
   return str.replace(/.*(https:\/\/.*https:\/\/)/, '$1');
 }
 
+const decodeTitle = (title: string) => {
+  try {
+    return decodeURIComponent(title);
+  } catch (err) {
+    console.error(`Could not decode title: "${title}"`);
+    return title;
+  }
+};
+
 const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) => {
   if (NO_CLIENT_SERVER) {
     return;
@@ -36,7 +45,7 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
     throw new Error('Template not found, cannot start production server');
   }
 
- 
+
   const renderWithMetaTags = (res, title, description, author, image) => {
     if (image) {
       image = cleanMalformedUrl(image);
@@ -138,7 +147,9 @@ const setupAppRoutes = (app, models: DB, devMiddleware, templateFile, sendFile) 
           include: [ models.OffchainProfile ]
         }],
       });
-      title = proposal ? decodeURIComponent(proposal.title) : '';
+
+      title = proposal ? decodeTitle(proposal.title) : '';
+
       description = proposal ? proposal.plaintext : '';
       image = chain ? `https://commonwealth.im${chain.icon_url}` : DEFAULT_COMMONWEALTH_LOGO;
       try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There are some routes in the app that are server side rendered (for better SEO). The code responsible for creating the markup on the backend was trying to `decodeURIComponent` - similarly as on the front end - but did not catch the errors, which was causing the server to return error page with info `{"error": "URI malformed"}`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some URLs that included % character were not available
[ticket](https://www.notion.so/hicommonwealth/DecodeURI-in-Thread-Title-bug-2539ab7768ed40ab93d4074be169434a)
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it on staging2 eg
https://commonwealth-staging2.herokuapp.com/terra/discussion/5395-terra-20-governance-proposal-349-shows-passed-without-50-of-vote
or
https://commonwealth-staging2.herokuapp.com/terra/discussion/8354-increase-terras-governance-quorum-from-10-to-334

## Does this PR affect any server routes?
- [ ] yes
- [x] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
