### PR TITLE
Moved webpack DuplicatesPlugin to be enabled by SHOW_DUPLICATE_DEPS

### DIFF
--- a/packages/commonwealth/webpack/webpack.dev.config.js
+++ b/packages/commonwealth/webpack/webpack.dev.config.js
@@ -29,12 +29,6 @@ module.exports = merge(common, {
       'process.env.NODE_ENV': JSON.stringify('development'),
       CHAT_SERVER: JSON.stringify(process.env.CHAT_SERVER || 'localhost:3001'),
     }),
-    new DuplicatesPlugin({
-      // Emit compilation warning or error? (Default: `false`)
-      emitErrors: false,
-      // Display full duplicates information? (Default: `false`)
-      verbose: false,
-    }),
   ],
 });
 
@@ -46,6 +40,19 @@ if (!process.env.EXTERNAL_WEBPACK) {
     },
     plugins: [
       new webpack.HotModuleReplacementPlugin(), // used for hot reloading
+    ],
+  });
+}
+
+if (process.env.SHOW_DUPLICATE_DEPS) {
+  module.exports = merge(module.exports, {
+    plugins: [
+      new DuplicatesPlugin({
+        // Emit compilation warning or error? (Default: `false`)
+        emitErrors: false,
+        // Display full duplicates information? (Default: `false`)
+        verbose: false,
+      }),
     ],
   });
 }


### PR DESCRIPTION
The duplicatesDependency logs to much to console and as a result has been requested to be removed. Also it runs every hot-reload, so it slows down the hot reload speed
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
- [ ] yes
- [ ] no

## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have proper tags been added (for bug, enhancement, breaking change)?
- [ ] yes
