### PR TITLE
Added authorization to swagger docs

### DIFF
--- a/packages/commonwealth/server/swagger/swagger_external.json
+++ b/packages/commonwealth/server/swagger/swagger_external.json
@@ -8,6 +8,11 @@
   "host": "localhost:3000",
   "basePath": "/api",
   "schemes": ["http"],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
   "paths": {
     "/threads": {
       "get": {
@@ -947,6 +952,14 @@
           }
         }
       }
+    }
+  },
+  "securityDefinitions": {
+    "apiKey": {
+      "type": "apiKey",
+      "name": "apikey",
+      "in": "header",
+      "description": "You can request an API key from: https://commonwealthlabsinc8d1edcd2.us.portal.konghq.com/"
     }
   }
 }


### PR DESCRIPTION
Cloudflare needs to be updated so that it redirects external api endpoints to kong api gateway in order to validate the apiKey

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
