### PR TITLE
Hotfix: rare keplr login race condition

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_ethereum_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_ethereum_web_wallet.ts
@@ -58,7 +58,7 @@ class EVMKeplrWebWalletController implements IWebWallet<AccountData> {
     const cosm = await import('@cosmjs/stargate');
     const client = await cosm.StargateClient.connect(url);
     const height = await client.getHeight();
-    const block = await client.getBlock(height - 1);
+    const block = await client.getBlock(height - 2); // validator pool may be out of sync
 
     return {
       number: block.header.height,

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
@@ -60,7 +60,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
     const cosm = await import('@cosmjs/stargate');
     const client = await cosm.StargateClient.connect(url);
     const height = await client.getHeight();
-    const block = await client.getBlock(height);
+    const block = await client.getBlock(height - 2); // validator pool may be out of sync
 
     return {
       number: block.header.height,


### PR DESCRIPTION
Sometimes the keplr validator pool is out of sync, causing getRecentBlock() to fail when querying for a block's info.

## Description

Gets a slightly older block.

## Motivation and Context

Fixes rare login failure

## How has this been tested?

Logged in using Keplr, Keplr (Evmos), Metamask (Evmos).

## Does this PR affect any server routes?

NO

## If this PR affects server routes, what are the security implications?

N/A

## Have you added the issue number here?

N/A
