### PR TITLE
Dark Mode Inverting Pfps Fix

### DIFF
--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -37,7 +37,8 @@ html.invert {
   -ms-filter: invert(90%);
 
   img,
-  .user-avatar {
+  .user-avatar:not(:has(.Avatar)),
+  .Avatar {
     filter: invert(90%);
     -webkit-filter: invert(90%);
     -moz-filter: invert(90%);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Dark mode no longer will invert the Pfp images that users upload. A BD request from the bug board. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
