### PR TITLE
switched swagger to serve on route /docs instead of /external/docs

### DIFF
--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -271,7 +271,7 @@ async function main() {
 
   // new API
   addExternalRoutes('/external', app, models, tokenBalanceCache);
-  addSwagger('/external/docs', app);
+  addSwagger('/docs', app);
 
   setupCosmosProxy(app, models);
   setupIpfsProxy(app);


### PR DESCRIPTION
Since the docs were server on /external/, they also required api_key gating to be served. Switched it to /docs to not require the API key.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
