### PR TITLE
Fixed external API redirect loop (Alternative)

### DIFF
--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -123,16 +123,6 @@ async function main() {
   });
 
   const setupMiddleware = () => {
-    // redirect from commonwealthapp.herokuapp.com to commonwealth.im
-    app.all(/.*/, (req, res, next) => {
-      const host = req.header('host');
-      if (host.match(/commonwealthapp.herokuapp.com/i)) {
-        res.redirect(301, `https://commonwealth.im${req.url}`);
-      } else {
-        next();
-      }
-    });
-
     // redirect to https:// unless we are using a test domain
     app.use(
       redirectToHTTPS([/localhost:(\d{4})/, /127.0.0.1:(\d{4})/], [], 301)
@@ -140,22 +130,6 @@ async function main() {
 
     // dynamic compression settings used
     app.use(compression());
-
-    // static compression settings unused
-    // app.get('*.js', (req, res, next) => {
-    //   req.url = req.url + '.gz';
-    //   res.set('Content-Encoding', 'gzip');
-    //   res.set('Content-Type', 'application/javascript; charset=UTF-8');
-    //   next();
-    // });
-
-    // // static compression settings unused
-    // app.get('bundle.**.css', (req, res, next) => {
-    //   req.url = req.url + '.gz';
-    //   res.set('Content-Encoding', 'gzip');
-    //   res.set('Content-Type', 'text/css');
-    //   next();
-    // });
 
     // serve the compiled app
     if (!NO_CLIENT_SERVER) {


### PR DESCRIPTION
Redirect from heroku to cloudflare needs to be removed for this idea to work.

This is an alternative way of fixing the external API. The other options is:
https://github.com/hicommonwealth/commonwealth/pull/2644

But I think this is the better option, although we can discuss as a team. See idea 2 at bottom of notion doc:
https://www.notion.so/buildcommon/Dev-Docs-b882c4b6959b4a8ebce6dd410c7c4ef1?p=896b5ed101df435dbe8417cb5b4c765c&pm=s


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
