### PR TITLE
Broke redirect loop between kong and cloudflare

### DIFF
--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -125,9 +125,13 @@ async function main() {
   const setupMiddleware = () => {
     // redirect from commonwealthapp.herokuapp.com to commonwealth.im
     app.all(/.*/, (req, res, next) => {
+      if (req.ip.includes(process.env.DISABLE_REDIRECT_URL)) {
+        next();
+      }
+
       const host = req.header('host');
-      if (host.match(/commonwealthapp.herokuapp.com/i)) {
-        res.redirect(301, `https://commonwealth.im${req.url}`);
+      if (host.match(`/${process.env.HEROKU_APP_NAME}.herokuapp.com/i`)) {
+        res.redirect(301, `${process.env.SERVER_URL}${req.url}`);
       } else {
         next();
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change it so that if the request to the server comes from kong, we don't forward it to the reverse proxy.

## Motivation and Context
The old way was causing a redirect loop between kong and the reverse proxy.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
