### PR TITLE
Renamed Threads.recently_commented_on to latest_activity, and added to external API topics

### DIFF
--- a/packages/common-common/src/api/extApiTypes.ts
+++ b/packages/common-common/src/api/extApiTypes.ts
@@ -132,7 +132,7 @@ export type PostTopicsReq = {
   topics: (TopicAttributes & { community_id: string })[];
 };
 
-export type GetTopicsResp = { topics?: TopicAttributes[]; count: number };
+export type GetTopicsResp = { topics?: (TopicAttributes & {latest_activity: string})[]; count: number };
 
 export type GetRolesReq = {
   community_id: string;

--- a/packages/common-common/src/api/extApiTypes.ts
+++ b/packages/common-common/src/api/extApiTypes.ts
@@ -132,7 +132,10 @@ export type PostTopicsReq = {
   topics: (TopicAttributes & { community_id: string })[];
 };
 
-export type GetTopicsResp = { topics?: (TopicAttributes & {latest_activity: string})[]; count: number };
+export type GetTopicsResp = {
+  topics?: (TopicAttributes & { latest_activity: string })[];
+  count: number;
+};
 
 export type GetRolesReq = {
   community_id: string;

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -135,7 +135,7 @@ class ThreadsController {
       has_poll,
       polls = [], // associated Polls
       reactions,
-      last_commented_on,
+      latest_activity,
       linked_threads,
       numberOfComments,
     } = thread;
@@ -239,7 +239,7 @@ class ThreadsController {
       lastEdited: lastEditedProcessed,
       hasPoll: has_poll,
       polls: polls.map((p) => new Poll(p)),
-      lastCommentedOn: last_commented_on ? moment(last_commented_on) : null,
+      latestActivity: latest_activity ? moment(latest_activity) : null,
       linkedThreads,
       numberOfComments,
     });
@@ -693,7 +693,7 @@ class ThreadsController {
       const lastThread = modeledThreads.sort(orderDiscussionsbyLastComment)[
         modeledThreads.length - 1
       ];
-      const cutoffDate = lastThread.lastCommentedOn || lastThread.createdAt;
+      const cutoffDate = lastThread.latestActivity || lastThread.createdAt;
       this.listingStore.setCutoffDate(options, cutoffDate);
     }
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -37,7 +37,7 @@ class Thread implements IUniqueId {
   public readonly identifier: string;
   public readonly id: number;
   public readonly createdAt: moment.Moment;
-  public readonly lastCommentedOn: moment.Moment;
+  public readonly latestActivity: moment.Moment;
   public topic: Topic;
   public readonly slug = ProposalType.Thread;
   public readonly url: string;
@@ -77,7 +77,7 @@ class Thread implements IUniqueId {
     lastEdited,
     snapshotProposal,
     hasPoll,
-    lastCommentedOn,
+    latestActivity,
     linkedThreads,
     numberOfComments,
   }: {
@@ -86,7 +86,7 @@ class Thread implements IUniqueId {
     attachments: Attachment[];
     id: number;
     createdAt: moment.Moment;
-    lastCommentedOn: moment.Moment;
+    latestActivity: moment.Moment;
     topic: Topic;
     kind: ThreadKind;
     stage: ThreadStage;
@@ -125,7 +125,7 @@ class Thread implements IUniqueId {
     this.chain = chain;
     this.readOnly = readOnly;
     this.collaborators = collaborators || [];
-    this.lastCommentedOn = lastCommentedOn;
+    this.latestActivity = latestActivity;
     this.chainEntities = chainEntities
       ? chainEntities.map((ce) => {
           return {

--- a/packages/commonwealth/client/scripts/stores/RecentListingStore.ts
+++ b/packages/commonwealth/client/scripts/stores/RecentListingStore.ts
@@ -168,7 +168,7 @@ class RecentListingStore extends IdStore<Thread> {
       : stageName
       ? this._fetchState.stageCutoffDate[stageName]
       : this._fetchState.allThreadsCutoffDate;
-    const lastUpdate = thread.lastCommentedOn || thread.createdAt;
+    const lastUpdate = thread.latestActivity || thread.createdAt;
     return (pinned && thread.pinned) || +lastUpdate >= +listingCutoff;
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -7,8 +7,8 @@ import app from 'state';
 import { NotificationCategories } from '../../../../../../common-common/src/types';
 
 export const getLastUpdated = (thread: Thread) => {
-  const { lastCommentedOn } = thread;
-  const lastComment = lastCommentedOn ? Number(lastCommentedOn.utc()) : 0;
+  const { latestActivity } = thread;
+  const lastComment = latestActivity ? Number(latestActivity.utc()) : 0;
   const createdAt = Number(thread.createdAt.utc());
   const lastUpdate = Math.max(createdAt, lastComment);
   return moment(lastUpdate);
@@ -22,7 +22,7 @@ export const isHot = (thread: Thread) => {
 };
 
 export const getLastUpdate = (thread: Thread): number => {
-  const lastComment = thread.lastCommentedOn?.unix() || 0;
+  const lastComment = thread.latestActivity?.unix() || 0;
   const createdAt = thread.createdAt?.unix() || 0;
   const lastUpdate = Math.max(createdAt, lastComment);
   return lastUpdate;
@@ -32,8 +32,8 @@ export const onFeaturedDiscussionPage = (p, topic) =>
   decodeURI(p).endsWith(`/discussions/${topic}`);
 
 export const orderDiscussionsbyLastComment = (a, b) => {
-  const tsB = Math.max(+b.createdAt, +(b.lastCommentedOn || 0));
-  const tsA = Math.max(+a.createdAt, +(a.lastCommentedOn || 0));
+  const tsB = Math.max(+b.createdAt, +(b.latestActivity || 0));
+  const tsA = Math.max(+a.createdAt, +(a.latestActivity || 0));
   return tsB - tsA;
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -35,8 +35,8 @@ export class TopicSummaryRow extends ClassComponent<TopicSummaryRowAttrs> {
 
     const topSortedThreads = monthlyThreads
       .sort((a, b) => {
-        const aLastUpdated = a.lastCommentedOn || a.createdAt;
-        const bLastUpdated = b.lastCommentedOn || b.createdAt;
+        const aLastUpdated = a.latestActivity || a.createdAt;
+        const bLastUpdated = b.latestActivity || b.createdAt;
         return bLastUpdated.valueOf() - aLastUpdated.valueOf();
       })
       .slice(0, 5 - monthlyThreads.length);

--- a/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
+++ b/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
@@ -10,9 +10,24 @@ UPDATE "Threads" SET last_commented_on=created_at WHERE last_commented_on is NUL
       allowNull: false,
       defaultValue: Sequelize.NOW,
     });
+
+    return await queryInterface.renameColumn(
+      'Threads',
+      'last_commented_on',
+      'latest_activity'
+    );
   },
 
   down: async (queryInterface, Sequelize) => {
-    return Promise.resolve();
+    await queryInterface.renameColumn(
+      'Threads',
+      'latest_activity',
+      'last_commented_on'
+    );
+
+    return await queryInterface.changeColumn('Threads', 'last_commented_on', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
   },
 };

--- a/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
+++ b/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
@@ -8,5 +8,5 @@ UPDATE "Threads" SET last_commented_on=created_at WHERE last_commented_on is NUL
 
   down: async (queryInterface, Sequelize) => {
     return Promise.resolve();
-  }
+  },
 };

--- a/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
+++ b/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query(`
+UPDATE "Threads" SET last_commented_on=created_at WHERE last_commented_on is NULL`);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return Promise.resolve();
+  }
+};

--- a/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
+++ b/packages/commonwealth/server/migrations/20230206164605-default-thread-last-commented-on.js
@@ -2,8 +2,14 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.query(`
+    await queryInterface.sequelize.query(`
 UPDATE "Threads" SET last_commented_on=created_at WHERE last_commented_on is NULL`);
+
+    await queryInterface.changeColumn('Threads', 'last_commented_on', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.NOW,
+    });
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/packages/commonwealth/server/models/thread.ts
+++ b/packages/commonwealth/server/models/thread.ts
@@ -94,7 +94,7 @@ export default (
       last_commented_on: {
         type: dataTypes.DATE,
         allowNull: false,
-        defaultValue: Sequelize.NOW
+        defaultValue: Sequelize.NOW,
       },
     },
     {

--- a/packages/commonwealth/server/models/thread.ts
+++ b/packages/commonwealth/server/models/thread.ts
@@ -1,4 +1,4 @@
-import type * as Sequelize from 'sequelize';
+import * as Sequelize from 'sequelize';
 import type { DataTypes } from 'sequelize';
 import type { AddressAttributes } from './address';
 import type { AttachmentAttributes } from './attachment';
@@ -91,7 +91,11 @@ export default (
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },
       deleted_at: { type: dataTypes.DATE, allowNull: true },
-      last_commented_on: { type: dataTypes.DATE, allowNull: true },
+      last_commented_on: {
+        type: dataTypes.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
     },
     {
       timestamps: true,

--- a/packages/commonwealth/server/models/thread.ts
+++ b/packages/commonwealth/server/models/thread.ts
@@ -30,7 +30,7 @@ export type ThreadAttributes = {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
-  last_commented_on?: Date;
+  latest_activity?: Date;
 
   // associations
   Chain?: ChainAttributes;
@@ -91,7 +91,7 @@ export default (
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },
       deleted_at: { type: dataTypes.DATE, allowNull: true },
-      last_commented_on: {
+      latest_activity: {
         type: dataTypes.DATE,
         allowNull: false,
         defaultValue: Sequelize.NOW,

--- a/packages/commonwealth/server/routes/activeThreads.ts
+++ b/packages/commonwealth/server/routes/activeThreads.ts
@@ -48,7 +48,7 @@ const activeThreads = async (
         limit: threads_per_topic,
         order: [
           ['created_at', 'DESC'],
-          ['last_commented_on', 'DESC'],
+          ['latest_activity', 'DESC'],
         ],
       });
 
@@ -68,7 +68,7 @@ const activeThreads = async (
       //   const commentlessTopicThreads = await models.OffchainThread.findAll({
       //     where: {
       //       topic_id: topic.id,
-      //       last_commented_on: {
+      //       latest_activity: {
       //         [Op.is]: null,
       //       }
       //     },

--- a/packages/commonwealth/server/routes/topics/getTopics.ts
+++ b/packages/commonwealth/server/routes/topics/getTopics.ts
@@ -30,21 +30,21 @@ export const getTopics = async (
 
   const where = { chain_id: community_id };
 
-  // Join in last_commented_on of thread that is most recently commented on
+  // Join in latest_activity of thread that is most recently commented on
   const include = [
     {
       model: models.Thread,
       as: 'threads',
       where: {
         [Op.and]: [
-          Sequelize.literal(` "threads"."last_commented_on" = (
-      Select MAX(last_commented_on)
+          Sequelize.literal(` "threads"."latest_activity" = (
+      Select MAX(latest_activity)
       FROM "Threads"
       WHERE
       "Threads"."topic_id" = "Topic"."id")`),
         ],
       },
-      attributes: ['last_commented_on'],
+      attributes: ['latest_activity'],
     },
   ];
 
@@ -64,11 +64,11 @@ export const getTopics = async (
     });
   }
 
-  // rename the threads.last_commented_on field
+  // remove the "threads" from threads.latest_activity
   topics.forEach((t) => {
-    if (t['threads.last_commented_on']) {
-      t['latest_activity'] = t['threads.last_commented_on'];
-      delete t['threads.last_commented_on'];
+    if (t['threads.latest_activity']) {
+      t['latest_activity'] = t['threads.latest_activity'];
+      delete t['threads.latest_activity'];
     }
   });
 

--- a/packages/commonwealth/test/integration/api/external/getTopics.spec.ts
+++ b/packages/commonwealth/test/integration/api/external/getTopics.spec.ts
@@ -18,6 +18,7 @@ describe('getTopics Tests', () => {
     const resp = await get('/api/topics', r);
 
     chai.assert.lengthOf(resp.result.topics, 2);
+    chai.assert.isNotNull(resp.result.topics.latest_activity);
   });
 
   it('should return count only when specified correctly', async () => {

--- a/packages/commonwealth/test/integration/api/external/getTopics.spec.ts
+++ b/packages/commonwealth/test/integration/api/external/getTopics.spec.ts
@@ -18,7 +18,9 @@ describe('getTopics Tests', () => {
     const resp = await get('/api/topics', r);
 
     chai.assert.lengthOf(resp.result.topics, 2);
-    chai.assert.isNotNull(resp.result.topics.latest_activity);
+    resp.result.topics.forEach((t) =>
+      chai.assert.isNotEmpty(t.latest_activity)
+    );
   });
 
   it('should return count only when specified correctly', async () => {


### PR DESCRIPTION
Created migration to fill all the last_commented_on field if null (sets to thread.created_at)

Updated GET external/topics

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Needed so we can query Topics by most recently active in the external API

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
