### PR TITLE
Revert "Fix CI Lint (#2691)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,14 +154,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout master
+      - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: master
-          fetch-depth: 0
-
-      - name: Checkout branch
-        run: git checkout ${{ github.ref_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This reverts commit e329cbc65c85d8103ab41e7a68dfb8ddc28a3937 = #2691. Linter runs out of memory, breaking job run. See https://github.com/hicommonwealth/commonwealth/actions/runs/4118172428/jobs/7110379581 for details.
