### PR TITLE
Hotfix: preserve substrate profile identity.

### DIFF
--- a/packages/commonwealth/server/migrations/20230205170607-remove-judgements-from-op.js
+++ b/packages/commonwealth/server/migrations/20230205170607-remove-judgements-from-op.js
@@ -3,9 +3,6 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
-      await queryInterface.removeColumn('OffchainProfiles', 'identity', {
-        transaction: t,
-      });
       await queryInterface.removeColumn('OffchainProfiles', 'judgements', {
         transaction: t,
       });
@@ -15,15 +12,6 @@ module.exports = {
   down: async (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async (t) => {
       // data will be populated later, via `yarn migrate-identities`.
-      await queryInterface.addColumn(
-        'OffchainProfiles',
-        'identity',
-        {
-          type: Sequelize.STRING,
-          allowNull: true,
-        },
-        { transaction: t }
-      );
       await queryInterface.addColumn(
         'OffchainProfiles',
         'judgements',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#2657 caused a P0 outage, via `error: column OffchainProfile.identity does not exist` on the /bulkProfiles call. This was because we had removed the `identity` column from OffchainProfile without ensuring that this was safe to do so. The work to actually remove identities across the site can be found in #2697.

This PR removes that `removeColumn` from the migration, which fixes the error on fetching profiles. No other errors noticed at this time, but we should QA more extensively before our next deploy.