### PR TITLE
Adding redraw event emitter and listener across notifications views a…

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/notifications.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/notifications.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-syntax */
 import $ from 'jquery';
-import m from 'mithril';
 import { ChainEventType, Notification, NotificationSubscription } from 'models';
 import { modelFromServer } from 'models/NotificationSubscription';
+import { EventEmitter } from 'events';
 
 import app from 'state';
 
@@ -48,6 +48,8 @@ class NotificationsController {
 
   private _numPages = 0;
   private _numUnread = 0;
+
+  public isUpdated = new EventEmitter();
 
   public get numPages(): number {
     return this._numPages;
@@ -260,10 +262,12 @@ class NotificationsController {
   public update(n: Notification) {
     if (n.chainEvent && !this._chainEventStore.getById(n.id)) {
       this._chainEventStore.add(n);
-      m.redraw();
+      console.log('emitting redraw');
+      this.isUpdated.emit('redraw');
     } else if (!n.chainEvent && !this._discussionStore.getById(n.id)) {
       this._discussionStore.add(n);
-      m.redraw();
+      console.log('emitting redraw');
+      this.isUpdated.emit('redraw');
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/components/notification_row.ts
+++ b/packages/commonwealth/client/scripts/views/components/notification_row.ts
@@ -322,6 +322,10 @@ const NotificationRow: m.Component<
     const { notifications } = vnode.attrs;
     const notification = notifications[0];
     const { category } = notifications[0].subscription;
+
+    app.user.notifications.isUpdated.on('redraw', () => {
+      m.redraw();
+    });
     if (category === NotificationCategories.ChainEvent) {
       if (!notification.chainEvent) {
         throw new Error('chain event notification does not have expected data');

--- a/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
@@ -86,6 +86,10 @@ export class NotificationsMenu extends ClassComponent {
         this.minChainEventsNotification + MAX_NOTIFS
       );
 
+    app.user.notifications.isUpdated.on('redraw', () => {
+      m.redraw();
+    });
+
     return (
       <div class="NotificationsMenu">
         <div class="NotificationsMenuHeader">

--- a/packages/commonwealth/client/scripts/views/pages/notifications_page.ts
+++ b/packages/commonwealth/client/scripts/views/pages/notifications_page.ts
@@ -113,6 +113,10 @@ const NotificationsPage: m.Component = {
     const chainEventNotifications =
       app.user.notifications.chainEventNotifications;
 
+    app.user.notifications.isUpdated.on('redraw', () => {
+      m.redraw();
+    });
+
     // const sortedNotifications = sortNotifications(app.user.notifications.allNotifications).reverse();
     // console.log("Sorted Notifications:", sortedNotifications);
 


### PR DESCRIPTION
Fix redraws in the controller layer. From my search, I think only NotificationsController required this refactor. I replaced usage of redraw with an event emitter and I added a listener on the view pages for notifications.