### PR TITLE
React: Fix redraw loop by commenting out react on thread preview.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview.tsx
@@ -101,9 +101,9 @@ class ThreadPreviewComponent extends ClassComponent<ThreadPreviewAttrs> {
         }}
         key={thread.id}
       >
-        {!this.isWindowSmallInclusive && (
+        {/* !this.isWindowSmallInclusive && (
           <ThreadPreviewReactionButton thread={thread} />
-        )}
+        )*/ }
         <div className="main-content">
           <div className="top-row">
             <div className="user-and-date">


### PR DESCRIPTION
Thread preview reaction button was causing a redraw loop, which broke discussions page loading. This PR comments it out, temporarily, to ensure that everyone has a working discussions page for REACT-A-THON.