### PR TITLE
Enable Quill image uploads

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/quill/quill_editor_internal.ts
+++ b/packages/commonwealth/client/scripts/views/components/quill/quill_editor_internal.ts
@@ -125,6 +125,7 @@ export default class QuillEditorInternal {
         'link',
         'blockquote',
         'code-block',
+        'image',
         'header',
         'list',
         'twitter',

--- a/packages/commonwealth/client/styles/components/quill/quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_editor.scss
@@ -58,6 +58,7 @@
 
     img {
       background-color: $neutral-400;
+      max-width: 80%;
     }
 
     code,


### PR DESCRIPTION
Closes #2731 .

Thanks @alexyoung23j for helping to debug on this!

## Description

Quill images were not being allowed in the rich text editor whitelist, which breaks image uploads.

We should also check if there are any other reasons images might not have been allowed.

## Motivation and Context

## How has this been tested?

Uploaded image by pasting and drag and drop.

## Does this PR affect any server routes?
NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
