### PR TITLE
Fix `navigateToSubpage` - react routing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     // re-enable later -> currently bugged when paired with webpack
     // "plugin:import/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier"
   ],
   plugins: [

--- a/packages/commonwealth/client/scripts/controllers/chain/near/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/near/chain.ts
@@ -20,7 +20,7 @@ import { ApiStatus } from 'state';
 import type { NearAccount, NearAccounts } from './account';
 import type { NearSputnikConfig, NearSputnikPolicy } from './sputnik/types';
 import { isGroupRole } from './sputnik/types';
-import { redraw, dangerouslySetRoute } from 'mithrilInterop';
+import { redraw, _DEPRECATED_dangerouslySetRoute } from 'mithrilInterop';
 
 export interface IDaoInfo {
   contractId: string;
@@ -331,7 +331,7 @@ class NearChain implements IChainModule<NearToken, NearAccount> {
         failureUrl,
       });
     } else {
-      dangerouslySetRoute(successUrl);
+      _DEPRECATED_dangerouslySetRoute(successUrl);
     }
   }
 

--- a/packages/commonwealth/client/scripts/helpers/handleUpdateEmailConfirmation.ts
+++ b/packages/commonwealth/client/scripts/helpers/handleUpdateEmailConfirmation.ts
@@ -1,9 +1,9 @@
 import { notifySuccess } from 'controllers/app/notifications';
-import { getRouteParam } from 'mithrilInterop';
+import { _DEPRECATED_getSearchParams } from 'mithrilInterop';
 
 const handleUpdateEmailConfirmation = () => {
-  if (getRouteParam('confirmation')) {
-    if (getRouteParam('confirmation') === 'success') {
+  if (_DEPRECATED_getSearchParams('confirmation')) {
+    if (_DEPRECATED_getSearchParams('confirmation') === 'success') {
       notifySuccess('Email confirmed!');
     }
   }

--- a/packages/commonwealth/client/scripts/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/helpers/index.ts
@@ -9,6 +9,7 @@ import type { ICardListItem } from 'models/interfaces';
 import moment from 'moment';
 import app from 'state';
 import type { Coin } from 'adapters/currency';
+import { NavigateFunction } from 'react-router-dom';
 
 export async function sleep(msec) {
   return new Promise((resolve) => setTimeout(resolve, msec));
@@ -381,7 +382,7 @@ export const isCommandClick = (
 
 // Handle command click and normal clicks
 export const handleRedirectClicks = (
-  _this,
+  navigate: any,
   e: React.MouseEvent<HTMLDivElement, MouseEvent>,
   redirectLink: string,
   activeChainId: string | null,
@@ -396,7 +397,7 @@ export const handleRedirectClicks = (
     return;
   }
 
-  _this.navigateToSubpage(redirectLink);
+  navigate(redirectLink);
   if (callback) {
     callback();
   }

--- a/packages/commonwealth/client/scripts/helpers/showLoginNotification.ts
+++ b/packages/commonwealth/client/scripts/helpers/showLoginNotification.ts
@@ -1,15 +1,15 @@
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import { getRouteParam } from 'mithrilInterop';
+import { _DEPRECATED_getSearchParams } from 'mithrilInterop';
 
 const showLoginNotification = () => {
-  const loggedIn = getRouteParam('loggedin');
-  const loginError = getRouteParam('loginerror');
+  const loggedIn = _DEPRECATED_getSearchParams('loggedin');
+  const loginError = _DEPRECATED_getSearchParams('loginerror');
 
   if (loggedIn) {
     notifySuccess('Logged in!');
   } else if (loginError) {
     notifyError('Could not log in');
-    console.error(getRouteParam('loginerror'));
+    console.error(_DEPRECATED_getSearchParams('loginerror'));
   }
 };
 

--- a/packages/commonwealth/client/scripts/identifiers.ts
+++ b/packages/commonwealth/client/scripts/identifiers.ts
@@ -12,7 +12,7 @@ import app from './state';
 export const getProposalUrlPath = (
   type: ProposalType,
   id: string,
-  omitActiveId = false,
+  omitActiveId = true,
   chainId?: string
 ): string => {
   let basePath: string;

--- a/packages/commonwealth/client/scripts/mithrilInterop/index.ts
+++ b/packages/commonwealth/client/scripts/mithrilInterop/index.ts
@@ -16,7 +16,7 @@ import type {
   NavigateOptions,
 } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
-import { features } from 'process';
+import { getScopePrefix } from 'navigation/helpers';
 
 // corresponds to Mithril's "Children" type -- RARELY USED
 export type Children = ReactNode | ReactNode[];
@@ -179,26 +179,17 @@ export abstract class ClassComponent<A = unknown> extends ReactComponent<
   }
 
   // replicates `m.route.set()` functionality via react-router
-  public setRoute(route: string, options?: NavigateOptions) {
+  public setRoute(
+    route: string,
+    options?: NavigateOptions,
+    prefix?: null | string
+  ) {
+    const scopePrefix = getScopePrefix(prefix);
     if (this.props.router.navigate) {
-      console.log('setting route: ', route, ' with options: ', options);
-      this.props.router.navigate(route, options);
+      const url = `${scopePrefix}${route}`;
+      this.props.router.navigate(url, options);
     } else {
       console.error('Prop "navigate" is not defined!');
-    }
-  }
-
-  // replicates navigation to scoped page functionality via react-router
-  // see `navigateToSubpage` in `app.tsx`
-  public navigateToSubpage(route: string) {
-    console.log('Redirecting to', route);
-    // hacky way to get the current scope
-    // @REACT @TODO: this will fail on custom domains
-    const scope = window.location.pathname.split('/')[1];
-    if (scope) {
-      this.setRoute(`/${scope}${route}`);
-    } else {
-      this.setRoute(route);
     }
   }
 }

--- a/packages/commonwealth/client/scripts/mithrilInterop/index.ts
+++ b/packages/commonwealth/client/scripts/mithrilInterop/index.ts
@@ -178,7 +178,7 @@ export abstract class ClassComponent<A = unknown> extends ReactComponent<
     this.forceUpdate();
   }
 
-  // replicates `m.route.set()` functionality via react-router
+  // It works very similar as useCommonNavigate but only for class components with withRouter() HOC
   public setRoute(
     route: string,
     options?: NavigateOptions,

--- a/packages/commonwealth/client/scripts/mithrilInterop/index.ts
+++ b/packages/commonwealth/client/scripts/mithrilInterop/index.ts
@@ -16,6 +16,7 @@ import type {
   NavigateOptions,
 } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
+import { features } from 'process';
 
 // corresponds to Mithril's "Children" type -- RARELY USED
 export type Children = ReactNode | ReactNode[];
@@ -224,31 +225,24 @@ export function rootRender(el: Element, vnodes: Children) {
 }
 
 // ROUTING FUNCTIONS
-// m.route.param() shim
-export function getRouteParam(name?: string) {
+// Do not use for new features. Instead, take a look on react-router hook => "useSearchParams"
+export function _DEPRECATED_getSearchParams(name?: string) {
   const search = new URLSearchParams(window.location.search);
   return search.get(name);
 }
 
 // m.route.get() shim
-export function getRoute() {
+// Do not use for new features. Instead, take a look on react-router hook => "useLocation"
+export function _DEPRECATED_getRoute() {
   return window.location.pathname;
 }
 
-type RouteOptions = {
-  replace?: boolean;
-};
-
 // This should not be used for setting the route, because it does not use react-router.
-// Instead it uses native history API, and because react router does not recognize the
+// Instead, it uses native history API, and because react router does not recognize the
 // path change, the page has to be reloaded programmatically.
 // This is only for legacy code, where react router is not accessible (eg in controllers or JS classes).
 // Always use "withRouter" for react class components or "useNavigate" for functional components.
-export function dangerouslySetRoute(
-  route: string,
-  data?: Record<string, unknown>,
-  options?: RouteOptions
-) {
+export function _DEPRECATED_dangerouslySetRoute(route: string) {
   window.history.pushState('', '', route);
   window.location.reload();
 

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -57,9 +57,9 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
     // and return false, so that the invoking selectChain fn can similarly
     // break, rather than complete.
     // if (
-    //   this.meta.id !== (this.app.customDomainId() || getRouteParam('scope'))
+    //   this.meta.id !== (this.app.customDomainId() || _DEPRECATED_getSearchParams('scope'))
     // ) {
-    //   console.log(this.meta.id, getRouteParam('scope'));
+    //   console.log(this.meta.id, _DEPRECATED_getSearchParams('scope'));
     //   return false;
     // }
 

--- a/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
@@ -159,6 +159,10 @@ const getCommonDomainsRoutes = () => (
       })}
     />
     <Route
+      path="/:scope/notification-settings"
+      element={<Navigate to="/notification-settings" />}
+    />
+    <Route
       path="/notifications"
       element={<Navigate to={'/edgeware/notifications'} />}
     />

--- a/packages/commonwealth/client/scripts/navigation/helpers.tsx
+++ b/packages/commonwealth/client/scripts/navigation/helpers.tsx
@@ -1,10 +1,55 @@
 import React from 'react';
+import type { To, NavigateOptions } from 'react-router-dom';
 import {
   useParams,
   useNavigate,
   useLocation,
   Navigate as ReactNavigate,
 } from 'react-router-dom';
+import app from 'state';
+
+type NavigateWithParamsProps = {
+  to: string | ((params: Record<string, string | undefined>) => string);
+};
+
+export const Navigate = ({ to }: NavigateWithParamsProps) => {
+  const params = useParams();
+  const navigateTo = typeof to === 'string' ? to : to(params);
+
+  return <ReactNavigate to={navigateTo} />;
+};
+
+const getScopePrefix = (scope: string, prefix?: null | string) => {
+  if (prefix === null) {
+    return '';
+  }
+
+  if (typeof prefix === 'string') {
+    return `/${prefix}`;
+  }
+
+  if (scope) {
+    return `/${scope}`;
+  }
+
+  return '';
+};
+
+export const useCommonNavigate = () => {
+  const navigate = useNavigate();
+
+  return (url: To, options?: NavigateOptions, prefix?: null | string) => {
+    if (prefix && prefix.startsWith('/')) {
+      console.warn('Prefix should not start with slash character!');
+    }
+
+    const activeChainIdPrefix = app.activeChainId() || '';
+    const scope = app.isCustomDomain() ? '' : activeChainIdPrefix;
+    const scopePrefix = getScopePrefix(scope, prefix);
+
+    return navigate(`${scopePrefix}${url}`, options);
+  };
+};
 
 // This helper should be used as a wrapper to Class Components
 // to access react-router functionalities
@@ -16,17 +61,6 @@ const withRouter = (Component) => {
 
     return <Component {...props} router={{ location, navigate, params }} />;
   };
-};
-
-type NavigateWithParamsProps = {
-  to: string | ((params: Record<string, string | undefined>) => string);
-};
-
-export const Navigate = ({ to }: NavigateWithParamsProps) => {
-  const params = useParams();
-  const navigateTo = typeof to === 'string' ? to : to(params);
-
-  return <ReactNavigate to={navigateTo} />;
 };
 
 export default withRouter;

--- a/packages/commonwealth/client/scripts/navigation/helpers.tsx
+++ b/packages/commonwealth/client/scripts/navigation/helpers.tsx
@@ -38,16 +38,30 @@ export const getScopePrefix = (prefix?: null | string) => {
   return '';
 };
 
+/**
+ *  This hook should be used for navigate from functional components.
+ */
 export const useCommonNavigate = () => {
   const navigate = useNavigate();
 
+  /**
+   * @param url Path for navigation starting with "/" character
+   * @param options Navigate Options from react-router
+   * @param {null | string} prefix If not set, the prefix will be calculated based on the
+   * "activeChainId" and "isCustomDomain", meaning that scope does not need to be passed to the "navigate" function.
+   *
+   *  To override prefix calculation, the string has to be passed.
+   *  navigate("/discussion", {}, "dydx")
+   *
+   *  To navigate without prefix whatsoever, the null has to be passed.
+   *  navigate("/privacy", {}, null)
+   */
   return (url: To, options?: NavigateOptions, prefix?: null | string) => {
     if (prefix && prefix.startsWith('/')) {
       console.warn('Prefix should not start with slash character!');
     }
 
     const scopePrefix = getScopePrefix(prefix);
-
     return navigate(`${scopePrefix}${url}`, options);
   };
 };

--- a/packages/commonwealth/client/scripts/navigation/helpers.tsx
+++ b/packages/commonwealth/client/scripts/navigation/helpers.tsx
@@ -19,7 +19,10 @@ export const Navigate = ({ to }: NavigateWithParamsProps) => {
   return <ReactNavigate to={navigateTo} />;
 };
 
-const getScopePrefix = (scope: string, prefix?: null | string) => {
+export const getScopePrefix = (prefix?: null | string) => {
+  const activeChainIdPrefix = app.activeChainId() || '';
+  const scope = app.isCustomDomain() ? '' : activeChainIdPrefix;
+
   if (prefix === null) {
     return '';
   }
@@ -43,9 +46,7 @@ export const useCommonNavigate = () => {
       console.warn('Prefix should not start with slash character!');
     }
 
-    const activeChainIdPrefix = app.activeChainId() || '';
-    const scope = app.isCustomDomain() ? '' : activeChainIdPrefix;
-    const scopePrefix = getScopePrefix(scope, prefix);
+    const scopePrefix = getScopePrefix(prefix);
 
     return navigate(`${scopePrefix}${url}`, options);
   };

--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -84,12 +84,12 @@ const shouldDeferChain = ({
 
 // DEPRECATED in favour of "Navigate" in "navigation/helpers.tsx"
 // Left here for now to not break the code in "getCustomDomainRoutes".
-// Should be removed after all occurrences of "redirectRoute" will be removed.
-const redirectRoute = (
+// Should be removed after all occurrences of "DO_NOT_USE_redirectRoute" will be removed.
+const DO_NOT_USE_redirectRoute = (
   path: string | ((attrs: Record<string, unknown>) => string)
 ) => ({
   render: (vnode) => {
-    // TODO remove when redirectRoute will be removed
+    // TODO remove when DO_NOT_USE_redirectRoute will be removed
     // setRoute(
     //   typeof path === 'string' ? path : path(vnode.attrs),
     //   {},
@@ -213,7 +213,7 @@ const getCustomDomainRoutes = (importRoute) => ({
   '/': importRoute(import('views/pages/discussions_redirect'), {
     scoped: true,
   }),
-  '/web3login': redirectRoute(() => '/'),
+  '/web3login': DO_NOT_USE_redirectRoute(() => '/'),
   '/search': importRoute(import('views/pages/search'), {
     deferChain: true,
   }),
@@ -252,7 +252,7 @@ const getCustomDomainRoutes = (importRoute) => ({
   ),
 
   // Discussions
-  '/home': redirectRoute((attrs) => `/${attrs.scope}/`),
+  '/home': DO_NOT_USE_redirectRoute((attrs) => `/${attrs.scope}/`),
   '/discussions': importRoute(import('views/pages/discussions'), {
     scoped: true,
     deferChain: true,
@@ -287,7 +287,7 @@ const getCustomDomainRoutes = (importRoute) => ({
     scoped: true,
     deferChain: true,
   }),
-  '/account': redirectRoute(() =>
+  '/account': DO_NOT_USE_redirectRoute(() =>
     app.user.activeAccount ? `/account/${app.user.activeAccount.address}` : '/'
   ),
 
@@ -302,7 +302,7 @@ const getCustomDomainRoutes = (importRoute) => ({
     import('views/pages/view_proposal/index'),
     { scoped: true }
   ),
-  '/:scope/proposal/discussion/:identifier': redirectRoute(
+  '/:scope/proposal/discussion/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/discussion/${attrs.identifier}`
   ),
   '/proposal/:identifier': importRoute(
@@ -359,71 +359,71 @@ const getCustomDomainRoutes = (importRoute) => ({
   ),
 
   // Redirects
-  '/:scope/dashboard': redirectRoute(() => '/'),
-  '/:scope/notifications': redirectRoute(() => '/notifications'),
-  '/:scope/notification-settings': redirectRoute(
+  '/:scope/dashboard': DO_NOT_USE_redirectRoute(() => '/'),
+  '/:scope/notifications': DO_NOT_USE_redirectRoute(() => '/notifications'),
+  '/:scope/notification-settings': DO_NOT_USE_redirectRoute(
     () => '/notification-settings'
   ),
-  '/:scope/overview': redirectRoute(() => '/overview'),
-  '/:scope/projects': redirectRoute(() => '/projects'),
-  '/:scope/backers': redirectRoute(() => '/backers'),
-  '/:scope/collectives': redirectRoute(() => '/collectives'),
-  '/:scope/finishNearLogin': redirectRoute(() => '/finishNearLogin'),
-  '/:scope/finishaxielogin': redirectRoute(() => '/finishaxielogin'),
-  '/:scope/home': redirectRoute(() => '/'),
-  '/:scope/discussions': redirectRoute(() => '/discussions'),
-  '/:scope': redirectRoute(() => '/'),
-  '/:scope/discussions/:topic': redirectRoute(
+  '/:scope/overview': DO_NOT_USE_redirectRoute(() => '/overview'),
+  '/:scope/projects': DO_NOT_USE_redirectRoute(() => '/projects'),
+  '/:scope/backers': DO_NOT_USE_redirectRoute(() => '/backers'),
+  '/:scope/collectives': DO_NOT_USE_redirectRoute(() => '/collectives'),
+  '/:scope/finishNearLogin': DO_NOT_USE_redirectRoute(() => '/finishNearLogin'),
+  '/:scope/finishaxielogin': DO_NOT_USE_redirectRoute(() => '/finishaxielogin'),
+  '/:scope/home': DO_NOT_USE_redirectRoute(() => '/'),
+  '/:scope/discussions': DO_NOT_USE_redirectRoute(() => '/discussions'),
+  '/:scope': DO_NOT_USE_redirectRoute(() => '/'),
+  '/:scope/discussions/:topic': DO_NOT_USE_redirectRoute(
     (attrs) => `/discussions/${attrs.topic}/`
   ),
-  '/:scope/search': redirectRoute(() => '/search'),
-  '/:scope/members': redirectRoute(() => '/members'),
-  '/:scope/sputnik-daos': redirectRoute(() => '/sputnik-daos'),
-  '/:scope/chat/:channel': redirectRoute((attrs) => `/chat/${attrs.channel}`),
-  '/:scope/new/discussion': redirectRoute(() => '/new/discussion'),
-  '/:scope/account/:address': redirectRoute(
+  '/:scope/search': DO_NOT_USE_redirectRoute(() => '/search'),
+  '/:scope/members': DO_NOT_USE_redirectRoute(() => '/members'),
+  '/:scope/sputnik-daos': DO_NOT_USE_redirectRoute(() => '/sputnik-daos'),
+  '/:scope/chat/:channel': DO_NOT_USE_redirectRoute((attrs) => `/chat/${attrs.channel}`),
+  '/:scope/new/discussion': DO_NOT_USE_redirectRoute(() => '/new/discussion'),
+  '/:scope/account/:address': DO_NOT_USE_redirectRoute(
     (attrs) => `/account/${attrs.address}/`
   ),
-  '/:scope/account': redirectRoute(() =>
+  '/:scope/account': DO_NOT_USE_redirectRoute(() =>
     app.user.activeAccount ? `/account/${app.user.activeAccount.address}` : '/'
   ),
-  '/:scope/referenda': redirectRoute(() => '/referenda'),
-  '/:scope/proposals': redirectRoute(() => '/proposals'),
-  '/:scope/proposal/:type/:identifier': redirectRoute(
+  '/:scope/referenda': DO_NOT_USE_redirectRoute(() => '/referenda'),
+  '/:scope/proposals': DO_NOT_USE_redirectRoute(() => '/proposals'),
+  '/:scope/proposal/:type/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/proposal/${attrs.type}/${attrs.identifier}/`
   ),
-  '/:scope/proposal/:identifier': redirectRoute(
+  '/:scope/proposal/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/proposal/${attrs.identifier}/`
   ),
-  '/:scope/discussion/:identifier': redirectRoute(
+  '/:scope/discussion/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/discussion/${attrs.identifier}/`
   ),
-  '/:scope/new/proposal/:type': redirectRoute(
+  '/:scope/new/proposal/:type': DO_NOT_USE_redirectRoute(
     (attrs) => `/new/proposal/${attrs.type}/`
   ),
-  '/:scope/new/proposal': redirectRoute(() => '/new/proposal'),
-  '/:scope/treasury': redirectRoute(() => '/treasury'),
-  '/:scope/bounties': redirectRoute(() => '/bounties'),
-  '/:scope/tips': redirectRoute(() => '/tips'),
-  '/:scope/validators': redirectRoute(() => '/validators'),
-  '/:scope/login': redirectRoute(() => '/login'),
-  '/:scope/settings': redirectRoute(() => '/settings'),
-  '/:scope/admin': redirectRoute(() => '/admin'),
-  '/:scope/manage': redirectRoute(() => '/manage'),
-  '/:scope/analytics': redirectRoute(() => '/analytics'),
-  '/:scope/snapshot-proposals/:snapshotId': redirectRoute(
+  '/:scope/new/proposal': DO_NOT_USE_redirectRoute(() => '/new/proposal'),
+  '/:scope/treasury': DO_NOT_USE_redirectRoute(() => '/treasury'),
+  '/:scope/bounties': DO_NOT_USE_redirectRoute(() => '/bounties'),
+  '/:scope/tips': DO_NOT_USE_redirectRoute(() => '/tips'),
+  '/:scope/validators': DO_NOT_USE_redirectRoute(() => '/validators'),
+  '/:scope/login': DO_NOT_USE_redirectRoute(() => '/login'),
+  '/:scope/settings': DO_NOT_USE_redirectRoute(() => '/settings'),
+  '/:scope/admin': DO_NOT_USE_redirectRoute(() => '/admin'),
+  '/:scope/manage': DO_NOT_USE_redirectRoute(() => '/manage'),
+  '/:scope/analytics': DO_NOT_USE_redirectRoute(() => '/analytics'),
+  '/:scope/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
     (attrs) => `/snapshot/${attrs.snapshotId}`
   ),
-  '/:scope/snapshot-proposal/:snapshotId/:identifier': redirectRoute(
+  '/:scope/snapshot-proposal/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   ),
-  '/:scope/new/snapshot-proposal/:snapshotId': redirectRoute(
+  '/:scope/new/snapshot-proposal/:snapshotId': DO_NOT_USE_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),
-  '/:scope/snapshot-proposals/:snapshotId/:identifier': redirectRoute(
+  '/:scope/snapshot-proposals/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
     (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   ),
-  '/:scope/new/snapshot-proposals/:snapshotId': redirectRoute(
+  '/:scope/new/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),
 });
@@ -452,7 +452,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   deferChain: true,
   // }),
   // Scoped routes
-  // '/:scope/proposal/discussion/:identifier': redirectRoute(
+  // '/:scope/proposal/discussion/:identifier': DO_NOT_USE_redirectRoute(
   //   (attrs) => `/${attrs.scope}/discussion/${attrs.identifier}`
   // ),
   // Notifications
@@ -460,7 +460,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   scoped: true,
   //   deferChain: true,
   // }),
-  // '/notifications': redirectRoute(() => '/edgeware/notifications'),
+  // '/notifications': DO_NOT_USE_redirectRoute(() => '/edgeware/notifications'),
   // '/notification-settings': importRoute(
   //   import('views/pages/notification_settings'),
   //   {
@@ -477,14 +477,14 @@ const getCommonDomainRoutes = (importRoute) => ({
   // ),
   // '/finishaxielogin': importRoute(import('views/pages/finish_axie_login')),
   // Settings
-  // '/settings': redirectRoute(() => '/edgeware/settings'),
+  // '/settings': DO_NOT_USE_redirectRoute(() => '/edgeware/settings'),
   // '/:scope/settings': importRoute(import('views/pages/settings'), {
   //   scoped: true,
   // }),
   // Discussions
-  // '/home': redirectRoute('/'), // legacy redirect, here for compatibility only
-  // '/discussions': redirectRoute('/'), // legacy redirect, here for compatibility only
-  // '/:scope/home': redirectRoute((attrs) => `/${attrs.scope}/`),
+  // '/home': DO_NOT_USE_redirectRoute('/'), // legacy redirect, here for compatibility only
+  // '/discussions': DO_NOT_USE_redirectRoute('/'), // legacy redirect, here for compatibility only
+  // '/:scope/home': DO_NOT_USE_redirectRoute((attrs) => `/${attrs.scope}/`),
   // '/:scope': importRoute(import('views/pages/discussions_redirect'), {
   //   scoped: true,
   // }),
@@ -533,7 +533,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   scoped: true,
   //   deferChain: true,
   // }),
-  // '/:scope/account': redirectRoute((a) =>
+  // '/:scope/account': DO_NOT_USE_redirectRoute((a) =>
   //   app.user.activeAccount
   //     ? `/${a.scope}/account/${app.user.activeAccount.address}`
   //     : `/${a.scope}/`
@@ -608,21 +608,21 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   'views/pages/new_snapshot_proposal',
   //   { scoped: true, deferChain: true }
   // ),
-  // '/:scope/snapshot-proposals/:snapshotId': redirectRoute(
+  // '/:scope/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
   //   (attrs) => `/${attrs.scope}/snapshot/${attrs.snapshotId}`
   // ),
-  // '/:scope/snapshot-proposal/:snapshotId/:identifier': redirectRoute(
+  // '/:scope/snapshot-proposal/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
   //   (attrs) =>
   //     `/${attrs.scope}/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   // ),
-  // '/:scope/new/snapshot-proposal/:snapshotId': redirectRoute(
+  // '/:scope/new/snapshot-proposal/:snapshotId': DO_NOT_USE_redirectRoute(
   //   (attrs) => `/${attrs.scope}/new/snapshot/${attrs.snapshotId}`
   // ),
-  // '/:scope/snapshot-proposals/:snapshotId/:identifier': redirectRoute(
+  // '/:scope/snapshot-proposals/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
   //   (attrs) =>
   //     `/${attrs.scope}/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   // ),
-  // '/:scope/new/snapshot-proposals/:snapshotId': redirectRoute(
+  // '/:scope/new/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
   //   (attrs) => `/${attrs.scope}/new/snapshot/${attrs.snapshotId}`
   // ),
 });

--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -76,12 +76,12 @@ const shouldDeferChain = ({
 
 // DEPRECATED in favour of "Navigate" in "navigation/helpers.tsx"
 // Left here for now to not break the code in "getCustomDomainRoutes".
-// Should be removed after all occurrences of "DO_NOT_USE_redirectRoute" will be removed.
-const DO_NOT_USE_redirectRoute = (
+// Should be removed after all occurrences of "_DEPRECATED_redirectRoute" will be removed.
+const _DEPRECATED_redirectRoute = (
   path: string | ((attrs: Record<string, unknown>) => string)
 ) => ({
   render: (vnode) => {
-    // TODO remove when DO_NOT_USE_redirectRoute will be removed
+    // TODO remove when _DEPRECATED_redirectRoute will be removed
     // setRoute(
     //   typeof path === 'string' ? path : path(vnode.attrs),
     //   {},
@@ -205,7 +205,7 @@ const getCustomDomainRoutes = (importRoute) => ({
   '/': importRoute(import('views/pages/discussions_redirect'), {
     scoped: true,
   }),
-  '/web3login': DO_NOT_USE_redirectRoute(() => '/'),
+  '/web3login': _DEPRECATED_redirectRoute(() => '/'),
   '/search': importRoute(import('views/pages/search'), {
     deferChain: true,
   }),
@@ -244,7 +244,7 @@ const getCustomDomainRoutes = (importRoute) => ({
   ),
 
   // Discussions
-  '/home': DO_NOT_USE_redirectRoute((attrs) => `/${attrs.scope}/`),
+  '/home': _DEPRECATED_redirectRoute((attrs) => `/${attrs.scope}/`),
   '/discussions': importRoute(import('views/pages/discussions'), {
     scoped: true,
     deferChain: true,
@@ -279,7 +279,7 @@ const getCustomDomainRoutes = (importRoute) => ({
     scoped: true,
     deferChain: true,
   }),
-  '/account': DO_NOT_USE_redirectRoute(() =>
+  '/account': _DEPRECATED_redirectRoute(() =>
     app.user.activeAccount ? `/account/${app.user.activeAccount.address}` : '/'
   ),
 
@@ -294,7 +294,7 @@ const getCustomDomainRoutes = (importRoute) => ({
     import('views/pages/view_proposal/index'),
     { scoped: true }
   ),
-  '/:scope/proposal/discussion/:identifier': DO_NOT_USE_redirectRoute(
+  '/:scope/proposal/discussion/:identifier': _DEPRECATED_redirectRoute(
     (attrs) => `/discussion/${attrs.identifier}`
   ),
   '/proposal/:identifier': importRoute(
@@ -351,74 +351,74 @@ const getCustomDomainRoutes = (importRoute) => ({
   ),
 
   // Redirects
-  '/:scope/dashboard': DO_NOT_USE_redirectRoute(() => '/'),
-  '/:scope/notifications': DO_NOT_USE_redirectRoute(() => '/notifications'),
-  // '/:scope/notification-settings': DO_NOT_USE_redirectRoute(
+  '/:scope/dashboard': _DEPRECATED_redirectRoute(() => '/'),
+  '/:scope/notifications': _DEPRECATED_redirectRoute(() => '/notifications'),
+  // '/:scope/notification-settings': _DEPRECATED_redirectRoute(
   //   () => '/notification-settings'
   // ),
-  '/:scope/overview': DO_NOT_USE_redirectRoute(() => '/overview'),
-  '/:scope/projects': DO_NOT_USE_redirectRoute(() => '/projects'),
-  '/:scope/backers': DO_NOT_USE_redirectRoute(() => '/backers'),
-  '/:scope/collectives': DO_NOT_USE_redirectRoute(() => '/collectives'),
-  '/:scope/finishNearLogin': DO_NOT_USE_redirectRoute(() => '/finishNearLogin'),
-  '/:scope/finishaxielogin': DO_NOT_USE_redirectRoute(() => '/finishaxielogin'),
-  '/:scope/home': DO_NOT_USE_redirectRoute(() => '/'),
-  '/:scope/discussions': DO_NOT_USE_redirectRoute(() => '/discussions'),
-  '/:scope': DO_NOT_USE_redirectRoute(() => '/'),
-  '/:scope/discussions/:topic': DO_NOT_USE_redirectRoute(
+  '/:scope/overview': _DEPRECATED_redirectRoute(() => '/overview'),
+  '/:scope/projects': _DEPRECATED_redirectRoute(() => '/projects'),
+  '/:scope/backers': _DEPRECATED_redirectRoute(() => '/backers'),
+  '/:scope/collectives': _DEPRECATED_redirectRoute(() => '/collectives'),
+  '/:scope/finishNearLogin': _DEPRECATED_redirectRoute(() => '/finishNearLogin'),
+  '/:scope/finishaxielogin': _DEPRECATED_redirectRoute(() => '/finishaxielogin'),
+  '/:scope/home': _DEPRECATED_redirectRoute(() => '/'),
+  '/:scope/discussions': _DEPRECATED_redirectRoute(() => '/discussions'),
+  '/:scope': _DEPRECATED_redirectRoute(() => '/'),
+  '/:scope/discussions/:topic': _DEPRECATED_redirectRoute(
     (attrs) => `/discussions/${attrs.topic}/`
   ),
-  '/:scope/search': DO_NOT_USE_redirectRoute(() => '/search'),
-  '/:scope/members': DO_NOT_USE_redirectRoute(() => '/members'),
-  '/:scope/sputnik-daos': DO_NOT_USE_redirectRoute(() => '/sputnik-daos'),
-  '/:scope/chat/:channel': DO_NOT_USE_redirectRoute(
+  '/:scope/search': _DEPRECATED_redirectRoute(() => '/search'),
+  '/:scope/members': _DEPRECATED_redirectRoute(() => '/members'),
+  '/:scope/sputnik-daos': _DEPRECATED_redirectRoute(() => '/sputnik-daos'),
+  '/:scope/chat/:channel': _DEPRECATED_redirectRoute(
     (attrs) => `/chat/${attrs.channel}`
   ),
-  // '/:scope/new/discussion': DO_NOT_USE_redirectRoute(() => '/new/discussion'),
-  '/:scope/account/:address': DO_NOT_USE_redirectRoute(
+  // '/:scope/new/discussion': _DEPRECATED_redirectRoute(() => '/new/discussion'),
+  '/:scope/account/:address': _DEPRECATED_redirectRoute(
     (attrs) => `/account/${attrs.address}/`
   ),
-  '/:scope/account': DO_NOT_USE_redirectRoute(() =>
+  '/:scope/account': _DEPRECATED_redirectRoute(() =>
     app.user.activeAccount ? `/account/${app.user.activeAccount.address}` : '/'
   ),
-  '/:scope/referenda': DO_NOT_USE_redirectRoute(() => '/referenda'),
-  '/:scope/proposals': DO_NOT_USE_redirectRoute(() => '/proposals'),
-  '/:scope/proposal/:type/:identifier': DO_NOT_USE_redirectRoute(
+  '/:scope/referenda': _DEPRECATED_redirectRoute(() => '/referenda'),
+  '/:scope/proposals': _DEPRECATED_redirectRoute(() => '/proposals'),
+  '/:scope/proposal/:type/:identifier': _DEPRECATED_redirectRoute(
     (attrs) => `/proposal/${attrs.type}/${attrs.identifier}/`
   ),
-  '/:scope/proposal/:identifier': DO_NOT_USE_redirectRoute(
+  '/:scope/proposal/:identifier': _DEPRECATED_redirectRoute(
     (attrs) => `/proposal/${attrs.identifier}/`
   ),
-  '/:scope/discussion/:identifier': DO_NOT_USE_redirectRoute(
+  '/:scope/discussion/:identifier': _DEPRECATED_redirectRoute(
     (attrs) => `/discussion/${attrs.identifier}/`
   ),
-  '/:scope/new/proposal/:type': DO_NOT_USE_redirectRoute(
+  '/:scope/new/proposal/:type': _DEPRECATED_redirectRoute(
     (attrs) => `/new/proposal/${attrs.type}/`
   ),
-  '/:scope/new/proposal': DO_NOT_USE_redirectRoute(() => '/new/proposal'),
-  '/:scope/treasury': DO_NOT_USE_redirectRoute(() => '/treasury'),
-  '/:scope/bounties': DO_NOT_USE_redirectRoute(() => '/bounties'),
-  '/:scope/tips': DO_NOT_USE_redirectRoute(() => '/tips'),
-  '/:scope/validators': DO_NOT_USE_redirectRoute(() => '/validators'),
-  '/:scope/login': DO_NOT_USE_redirectRoute(() => '/login'),
-  '/:scope/settings': DO_NOT_USE_redirectRoute(() => '/settings'),
-  '/:scope/admin': DO_NOT_USE_redirectRoute(() => '/admin'),
-  '/:scope/manage': DO_NOT_USE_redirectRoute(() => '/manage'),
-  '/:scope/analytics': DO_NOT_USE_redirectRoute(() => '/analytics'),
-  '/:scope/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
+  '/:scope/new/proposal': _DEPRECATED_redirectRoute(() => '/new/proposal'),
+  '/:scope/treasury': _DEPRECATED_redirectRoute(() => '/treasury'),
+  '/:scope/bounties': _DEPRECATED_redirectRoute(() => '/bounties'),
+  '/:scope/tips': _DEPRECATED_redirectRoute(() => '/tips'),
+  '/:scope/validators': _DEPRECATED_redirectRoute(() => '/validators'),
+  '/:scope/login': _DEPRECATED_redirectRoute(() => '/login'),
+  '/:scope/settings': _DEPRECATED_redirectRoute(() => '/settings'),
+  '/:scope/admin': _DEPRECATED_redirectRoute(() => '/admin'),
+  '/:scope/manage': _DEPRECATED_redirectRoute(() => '/manage'),
+  '/:scope/analytics': _DEPRECATED_redirectRoute(() => '/analytics'),
+  '/:scope/snapshot-proposals/:snapshotId': _DEPRECATED_redirectRoute(
     (attrs) => `/snapshot/${attrs.snapshotId}`
   ),
-  '/:scope/snapshot-proposal/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
+  '/:scope/snapshot-proposal/:snapshotId/:identifier': _DEPRECATED_redirectRoute(
     (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   ),
-  '/:scope/new/snapshot-proposal/:snapshotId': DO_NOT_USE_redirectRoute(
+  '/:scope/new/snapshot-proposal/:snapshotId': _DEPRECATED_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),
   '/:scope/snapshot-proposals/:snapshotId/:identifier':
-    DO_NOT_USE_redirectRoute(
+    _DEPRECATED_redirectRoute(
       (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
     ),
-  '/:scope/new/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
+  '/:scope/new/snapshot-proposals/:snapshotId': _DEPRECATED_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),
 });
@@ -447,7 +447,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   deferChain: true,
   // }),
   // Scoped routes
-  // '/:scope/proposal/discussion/:identifier': DO_NOT_USE_redirectRoute(
+  // '/:scope/proposal/discussion/:identifier': _DEPRECATED_redirectRoute(
   //   (attrs) => `/${attrs.scope}/discussion/${attrs.identifier}`
   // ),
   // Notifications
@@ -455,7 +455,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   scoped: true,
   //   deferChain: true,
   // }),
-  // '/notifications': DO_NOT_USE_redirectRoute(() => '/edgeware/notifications'),
+  // '/notifications': _DEPRECATED_redirectRoute(() => '/edgeware/notifications'),
   // '/notification-settings': importRoute(
   //   import('views/pages/notification_settings'),
   //   {
@@ -472,14 +472,14 @@ const getCommonDomainRoutes = (importRoute) => ({
   // ),
   // '/finishaxielogin': importRoute(import('views/pages/finish_axie_login')),
   // Settings
-  // '/settings': DO_NOT_USE_redirectRoute(() => '/edgeware/settings'),
+  // '/settings': _DEPRECATED_redirectRoute(() => '/edgeware/settings'),
   // '/:scope/settings': importRoute(import('views/pages/settings'), {
   //   scoped: true,
   // }),
   // Discussions
-  // '/home': DO_NOT_USE_redirectRoute('/'), // legacy redirect, here for compatibility only
-  // '/discussions': DO_NOT_USE_redirectRoute('/'), // legacy redirect, here for compatibility only
-  // '/:scope/home': DO_NOT_USE_redirectRoute((attrs) => `/${attrs.scope}/`),
+  // '/home': _DEPRECATED_redirectRoute('/'), // legacy redirect, here for compatibility only
+  // '/discussions': _DEPRECATED_redirectRoute('/'), // legacy redirect, here for compatibility only
+  // '/:scope/home': _DEPRECATED_redirectRoute((attrs) => `/${attrs.scope}/`),
   // '/:scope': importRoute(import('views/pages/discussions_redirect'), {
   //   scoped: true,
   // }),
@@ -528,7 +528,7 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   scoped: true,
   //   deferChain: true,
   // }),
-  // '/:scope/account': DO_NOT_USE_redirectRoute((a) =>
+  // '/:scope/account': _DEPRECATED_redirectRoute((a) =>
   //   app.user.activeAccount
   //     ? `/${a.scope}/account/${app.user.activeAccount.address}`
   //     : `/${a.scope}/`
@@ -603,21 +603,21 @@ const getCommonDomainRoutes = (importRoute) => ({
   //   'views/pages/new_snapshot_proposal',
   //   { scoped: true, deferChain: true }
   // ),
-  // '/:scope/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
+  // '/:scope/snapshot-proposals/:snapshotId': _DEPRECATED_redirectRoute(
   //   (attrs) => `/${attrs.scope}/snapshot/${attrs.snapshotId}`
   // ),
-  // '/:scope/snapshot-proposal/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
+  // '/:scope/snapshot-proposal/:snapshotId/:identifier': _DEPRECATED_redirectRoute(
   //   (attrs) =>
   //     `/${attrs.scope}/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   // ),
-  // '/:scope/new/snapshot-proposal/:snapshotId': DO_NOT_USE_redirectRoute(
+  // '/:scope/new/snapshot-proposal/:snapshotId': _DEPRECATED_redirectRoute(
   //   (attrs) => `/${attrs.scope}/new/snapshot/${attrs.snapshotId}`
   // ),
-  // '/:scope/snapshot-proposals/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
+  // '/:scope/snapshot-proposals/:snapshotId/:identifier': _DEPRECATED_redirectRoute(
   //   (attrs) =>
   //     `/${attrs.scope}/snapshot/${attrs.snapshotId}/${attrs.identifier}`
   // ),
-  // '/:scope/new/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
+  // '/:scope/new/snapshot-proposals/:snapshotId': _DEPRECATED_redirectRoute(
   //   (attrs) => `/${attrs.scope}/new/snapshot/${attrs.snapshotId}`
   // ),
 });

--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -49,17 +49,6 @@ window.onpopstate = (...args) => {
   }
 };
 
-const navigateToSubpage = (...args) => {
-  // prepend community if we are not on a custom domain
-  if (!app.isCustomDomain() && app.activeChainId()) {
-    args[0] = `/${app.activeChainId()}${args[0]}`;
-  }
-  app.sidebarMenu = 'default';
-  // app.sidebarRedraw.emit('redraw');
-  // TODO navigate should be passed as argument
-  // setRoute.apply(this, args);
-};
-
 const shouldDeferChain = ({
   deferChain,
   scope,
@@ -652,4 +641,4 @@ const getRoutes = (customDomain: string) => {
   };
 };
 
-export { getRoutes, navigateToSubpage, handleLoginRedirects };
+export { getRoutes, handleLoginRedirects };

--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -5,7 +5,10 @@ import {
   APPLICATION_UPDATE_ACTION,
   APPLICATION_UPDATE_MESSAGE,
 } from 'helpers/constants';
-import { getRoute, getRouteParam } from 'mithrilInterop';
+import {
+  _DEPRECATED_getRoute,
+  _DEPRECATED_getSearchParams,
+} from 'mithrilInterop';
 
 export const pathIsDiscussion = (
   scope: string | null,
@@ -39,7 +42,7 @@ interface ShouldDeferChainAttrs {
 const _onpopstate = window.onpopstate;
 window.onpopstate = (...args) => {
   app._lastNavigatedBack = true;
-  app._lastNavigatedFrom = getRoute();
+  app._lastNavigatedFrom = _DEPRECATED_getRoute();
 
   if (_onpopstate) {
     _onpopstate.apply(this, args);
@@ -102,7 +105,7 @@ const DO_NOT_USE_redirectRoute = (
 // TODO this function used to be in the app.ts but now
 // should be incorporated in new react flow
 const handleLoginRedirects = () => {
-  const routeParam = getRouteParam();
+  const routeParam = _DEPRECATED_getSearchParams();
   if (
     routeParam['loggedin'] &&
     routeParam['loggedin'].toString() === 'true' &&
@@ -116,14 +119,14 @@ const handleLoginRedirects = () => {
      else we identify to associate mixpanel events
     */
     if (
-      getRouteParam()['new'] &&
-      getRouteParam()['new'].toString() === 'true'
+      _DEPRECATED_getSearchParams()['new'] &&
+      _DEPRECATED_getSearchParams()['new'].toString() === 'true'
     ) {
       console.log('creating account');
     }
 
     // TODO setRoute outside of react router, might not work properly
-    // setRoute(getRouteParam['path'], {}, { replace: true });
+    // setRoute(_DEPRECATED_getSearchParams['path'], {}, { replace: true });
   } else if (
     localStorage &&
     localStorage.getItem &&
@@ -379,7 +382,9 @@ const getCustomDomainRoutes = (importRoute) => ({
   '/:scope/search': DO_NOT_USE_redirectRoute(() => '/search'),
   '/:scope/members': DO_NOT_USE_redirectRoute(() => '/members'),
   '/:scope/sputnik-daos': DO_NOT_USE_redirectRoute(() => '/sputnik-daos'),
-  '/:scope/chat/:channel': DO_NOT_USE_redirectRoute((attrs) => `/chat/${attrs.channel}`),
+  '/:scope/chat/:channel': DO_NOT_USE_redirectRoute(
+    (attrs) => `/chat/${attrs.channel}`
+  ),
   '/:scope/new/discussion': DO_NOT_USE_redirectRoute(() => '/new/discussion'),
   '/:scope/account/:address': DO_NOT_USE_redirectRoute(
     (attrs) => `/account/${attrs.address}/`
@@ -420,9 +425,10 @@ const getCustomDomainRoutes = (importRoute) => ({
   '/:scope/new/snapshot-proposal/:snapshotId': DO_NOT_USE_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),
-  '/:scope/snapshot-proposals/:snapshotId/:identifier': DO_NOT_USE_redirectRoute(
-    (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
-  ),
+  '/:scope/snapshot-proposals/:snapshotId/:identifier':
+    DO_NOT_USE_redirectRoute(
+      (attrs) => `/snapshot/${attrs.snapshotId}/${attrs.identifier}`
+    ),
   '/:scope/new/snapshot-proposals/:snapshotId': DO_NOT_USE_redirectRoute(
     (attrs) => `/new/snapshot/${attrs.snapshotId}`
   ),

--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -353,9 +353,9 @@ const getCustomDomainRoutes = (importRoute) => ({
   // Redirects
   '/:scope/dashboard': DO_NOT_USE_redirectRoute(() => '/'),
   '/:scope/notifications': DO_NOT_USE_redirectRoute(() => '/notifications'),
-  '/:scope/notification-settings': DO_NOT_USE_redirectRoute(
-    () => '/notification-settings'
-  ),
+  // '/:scope/notification-settings': DO_NOT_USE_redirectRoute(
+  //   () => '/notification-settings'
+  // ),
   '/:scope/overview': DO_NOT_USE_redirectRoute(() => '/overview'),
   '/:scope/projects': DO_NOT_USE_redirectRoute(() => '/projects'),
   '/:scope/backers': DO_NOT_USE_redirectRoute(() => '/backers'),
@@ -374,7 +374,7 @@ const getCustomDomainRoutes = (importRoute) => ({
   '/:scope/chat/:channel': DO_NOT_USE_redirectRoute(
     (attrs) => `/chat/${attrs.channel}`
   ),
-  '/:scope/new/discussion': DO_NOT_USE_redirectRoute(() => '/new/discussion'),
+  // '/:scope/new/discussion': DO_NOT_USE_redirectRoute(() => '/new/discussion'),
   '/:scope/account/:address': DO_NOT_USE_redirectRoute(
     (attrs) => `/account/${attrs.address}/`
   ),

--- a/packages/commonwealth/client/scripts/views/components/chat/chat_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/chat/chat_section.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import {
   ClassComponent,
-  getRoute,
-  getRouteParam,
+  _DEPRECATED_getRoute,
+  _DEPRECATED_getSearchParams,
   redraw,
 } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
@@ -154,7 +154,7 @@ class ChatSectionComponent extends ClassComponent<SidebarSectionAttrs> {
   view() {
     if (!app.socket) return;
     if (!this.loaded) return <CWSpinner />;
-    this.activeChannel = getRouteParam()['channel'];
+    this.activeChannel = _DEPRECATED_getSearchParams()['channel'];
     app.socket.chatNs.activeChannel = String(this.activeChannel);
 
     const isAdmin = app.roles.isAdminOfEntity({ chain: app.activeChainId() });
@@ -352,7 +352,7 @@ class ChatSectionComponent extends ClassComponent<SidebarSectionAttrs> {
         title: channel.name,
         rowIcon: true,
         isVisible: true,
-        isActive: onChannelPage(getRoute()),
+        isActive: onChannelPage(_DEPRECATED_getRoute()),
         isUpdated: channel.unread > 0,
         onClick: (e) => {
           handleRedirectClicks(

--- a/packages/commonwealth/client/scripts/views/components/chat/chat_window.tsx
+++ b/packages/commonwealth/client/scripts/views/components/chat/chat_window.tsx
@@ -9,7 +9,7 @@ import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 import {
   ClassComponent,
   ResultNode,
-  getRouteParam,
+  _DEPRECATED_getSearchParams,
   redraw,
 } from 'mithrilInterop';
 import moment from 'moment';
@@ -81,8 +81,8 @@ export class ChatWindow extends ClassComponent<ChatWindowAttrs> {
 
   private _messageIsHighlighted = (message: any): boolean => {
     return (
-      getRouteParam('message') &&
-      Number(getRouteParam('message')) === message.id
+      _DEPRECATED_getSearchParams('message') &&
+      Number(_DEPRECATED_getSearchParams('message')) === message.id
     );
   };
 
@@ -102,7 +102,7 @@ export class ChatWindow extends ClassComponent<ChatWindowAttrs> {
     if (this.hideChat) return;
 
     this.shouldScroll = true;
-    this.shouldScrollToHighlight = Boolean(getRouteParam('message'));
+    this.shouldScrollToHighlight = Boolean(_DEPRECATED_getSearchParams('message'));
 
     this.scrollToBottom = () => {
       const scroller = $(vnode.dom).find('.chat-messages')[0];

--- a/packages/commonwealth/client/scripts/views/components/comments/comments_tree.tsx
+++ b/packages/commonwealth/client/scripts/views/components/comments/comments_tree.tsx
@@ -42,7 +42,7 @@ export class CommentsTree extends ClassComponent<CommentsTreeAttrs> {
     } = vnode.attrs;
 
     // Jump to the comment indicated in the URL upon page load. Avoid
-    // using getRouteParam('comment') because it may return stale
+    // using _DEPRECATED_getSearchParams('comment') because it may return stale
     // results from a previous page if route transition hasn't finished
 
     if (this.dom && comments?.length > 0 && !this.highlightedComment) {

--- a/packages/commonwealth/client/scripts/views/components/community_card.tsx
+++ b/packages/commonwealth/client/scripts/views/components/community_card.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from "react-router-dom";
 
 import 'components/community_card.scss';
 
@@ -10,12 +9,13 @@ import { CWCard } from './component_kit/cw_card';
 import { CWCommunityAvatar } from './component_kit/cw_community_avatar';
 import { CWIconButton } from './component_kit/cw_icon_button';
 import { CWText } from './component_kit/cw_text';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type CommunityCardProps = { chain: ChainInfo };
 
 export const CommunityCard = (props: CommunityCardProps) => {
   const { chain } = props;
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   const redirectFunction = (e) => {
     e.preventDefault();

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
@@ -4,7 +4,7 @@ import 'components/component_kit/cw_breadcrumbs.scss';
 import { CWText } from './cw_text';
 
 import { ComponentType } from './types';
-import { useNavigate } from 'react-router-dom';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type BreadcrumbsType = {
   label: string;
@@ -17,7 +17,7 @@ type BreadcrumbsProps = {
 
 export const CWBreadcrumbs = (props: BreadcrumbsProps) => {
   const { breadcrumbs } = props;
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   return (
     <div className={ComponentType.Breadcrumbs}>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { redraw } from 'mithrilInterop';
-import { useNavigate } from 'react-router-dom';
 
 import 'components/component_kit/cw_sidebar_menu.scss';
 import { AddressInfo } from 'models';
@@ -17,7 +16,7 @@ import { ComponentType } from './types';
 import { useCommonNavigate } from 'navigation/helpers';
 
 export const CWSidebarMenuItem = (props: MenuItem) => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   if (props.type === 'default') {
     const { disabled, iconLeft, iconRight, isSecondary, label, onClick } =

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { redraw } from 'mithrilInterop';
-import { navigateToSubpage } from 'router';
 import { useNavigate } from 'react-router-dom';
 
 import 'components/component_kit/cw_sidebar_menu.scss';
@@ -15,6 +14,7 @@ import { CWText } from './cw_text';
 import { getClasses } from './helpers';
 import type { MenuItem } from './types';
 import { ComponentType } from './types';
+import { useCommonNavigate } from 'navigation/helpers';
 
 export const CWSidebarMenuItem = (props: MenuItem) => {
   const navigate = useNavigate();
@@ -110,7 +110,7 @@ type SidebarMenuProps = {
 
 export const CWSidebarMenu = (props: SidebarMenuProps) => {
   const { className, menuHeader, menuItems } = props;
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   return (
     <div
@@ -146,7 +146,7 @@ export const CWSidebarMenu = (props: SidebarMenuProps) => {
               app.sidebarToggled = false;
               app.sidebarMenu = 'default';
               app.sidebarRedraw.emit('redraw');
-              navigate('/communities');
+              navigate('/communities', {}, null);
             },
           },
           {
@@ -166,7 +166,7 @@ export const CWSidebarMenu = (props: SidebarMenuProps) => {
             iconLeft: 'bell',
             onClick: () => {
               if (app.activeChainId()) {
-                navigateToSubpage('/settings');
+                navigate('/settings');
               } else {
                 app.sidebarToggled = false;
                 app.sidebarMenu = 'default';

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 
 import { initAppState } from 'state';
-import { navigateToSubpage } from 'router';
 import { ChainBase, ChainNetwork } from 'common-common/src/types';
 import { addressSwapper } from 'commonwealth/shared/utils';
 import $ from 'jquery';
 import { redraw } from 'mithrilInterop';
-import { useNavigate } from 'react-router-dom';
 
 import _ from 'lodash';
 
@@ -36,6 +34,7 @@ import { UserBlock } from '../user/user_block';
 import { CWDivider } from '../component_kit/cw_divider';
 import { Popover, usePopover } from '../component_kit/cw_popover/cw_popover';
 import { Modal } from '../component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const CHAINBASE_SHORT = {
   [ChainBase.CosmosSDK]: 'Cosmos',
@@ -57,6 +56,7 @@ type LoginSelectorMenuLeftAttrs = {
 
 export const LoginSelectorMenuLeft = (props: LoginSelectorMenuLeftAttrs) => {
   const { activeAddressesWithRole, nAccountsWithoutRole } = props;
+  const navigate = useCommonNavigate();
 
   const [isEditProfileModalOpen, setIsEditProfileModalOpen] =
     React.useState<boolean>(false);
@@ -92,7 +92,7 @@ export const LoginSelectorMenuLeft = (props: LoginSelectorMenuLeftAttrs) => {
             onClick={() => {
               const pf = app.user.activeAccount.profile;
               if (app.chain) {
-                navigateToSubpage(`/account/${pf.address}`);
+                navigate(`/account/${pf.address}`);
               }
             }}
           >
@@ -158,7 +158,7 @@ export const LoginSelectorMenuLeft = (props: LoginSelectorMenuLeftAttrs) => {
 };
 
 export const LoginSelectorMenuRight = () => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
   const isDarkModeOn = localStorage.getItem('dark-mode-state') === 'on';
@@ -168,18 +168,11 @@ export const LoginSelectorMenuRight = () => {
       <div className="LoginSelectorMenu">
         <div
           className="login-menu-item"
-          onClick={() => navigate('/notification-settings')}
+          onClick={() => navigate('/notification-settings', {}, null)}
         >
           <CWText type="caption">Notification settings</CWText>
         </div>
-        <div
-          className="login-menu-item"
-          onClick={() =>
-            app.activeChainId()
-              ? navigateToSubpage('/settings')
-              : navigate('/settings')
-          }
-        >
+        <div className="login-menu-item" onClick={() => navigate('/settings')}>
           <CWText type="caption">Account settings</CWText>
         </div>
         <div className="login-menu-item">

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
@@ -7,7 +7,6 @@ import {
   redraw,
 } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
-import { navigateToSubpage } from 'router';
 
 import 'components/new_thread_form.scss';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
@@ -74,7 +73,7 @@ export class NewThreadForm extends ClassComponent<NewThreadFormAttrs> {
         form.url
       );
 
-      navigateToSubpage(`/discussion/${result.id}`);
+      this.setRoute(`/discussion/${result.id}`);
       updateTopicList(result.topic, app.chain);
     } catch (e) {
       quillEditorState.enable();
@@ -179,7 +178,7 @@ export class NewThreadForm extends ClassComponent<NewThreadFormAttrs> {
     this.form.topic = topic;
   }
 
-  oninit(vnode: ResultNode<NewThreadFormAttrs>) {
+  oncreate(vnode: ResultNode<NewThreadFormAttrs>) {
     const { isModal } = vnode.attrs;
     this.form = {
       topic: null,
@@ -330,7 +329,7 @@ export class NewThreadForm extends ClassComponent<NewThreadFormAttrs> {
               onClick={(e) => {
                 this.overwriteConfirmationModal = true;
                 localStorage.setItem(`${chainId}-from-draft`, `${fromDraft}`);
-                navigateToSubpage('/new/discussion');
+                this.setRoute('/new/discussion');
                 $(e.target).trigger('modalexit');
               }}
             />

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import {
   ClassComponent,
-  getRoute,
-  getRouteParam,
+  _DEPRECATED_getRoute,
+  _DEPRECATED_getSearchParams,
   redraw,
 } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
@@ -191,7 +191,7 @@ export class NewThreadForm extends ClassComponent<NewThreadFormAttrs> {
     this.overwriteConfirmationModal = false;
     try {
       this.activeTopic = isModal
-        ? getRouteParam('topic')
+        ? _DEPRECATED_getSearchParams('topic')
         : app.lastNavigatedFrom().split('/').indexOf('discussions') !== -1
         ? app.lastNavigatedFrom().split('/')[
             app.lastNavigatedFrom().split('/').indexOf('discussions') + 1
@@ -322,7 +322,7 @@ export class NewThreadForm extends ClassComponent<NewThreadFormAttrs> {
               isSelected={this.form.kind === ThreadKind.Link}
             />
           </CWTabBar>
-          {isModal && getRoute() !== `${chainId}/new/discussion` && (
+          {isModal && _DEPRECATED_getRoute() !== `${chainId}/new/discussion` && (
             <CWButton
               label="Full editor"
               iconLeft="expand"

--- a/packages/commonwealth/client/scripts/views/components/proposal_card/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposal_card/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { navigateToSubpage } from 'router';
 import { ProposalType } from 'common-common/src/types';
 
 import 'components/proposal_card/index.scss';
@@ -23,6 +22,7 @@ import {
   getStatusText,
 } from './helpers';
 import { ProposalTag } from './proposal_tag';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type ProposalCardProps = {
   injectedContent?: React.ReactNode;
@@ -31,6 +31,7 @@ type ProposalCardProps = {
 
 export const ProposalCard = (props: ProposalCardProps) => {
   const { proposal, injectedContent } = props;
+  const navigate = useCommonNavigate();
 
   const secondaryTagText = getSecondaryTagText(proposal);
 
@@ -52,7 +53,7 @@ export const ProposalCard = (props: ProposalCardProps) => {
           true
         );
 
-        navigateToSubpage(path); // avoid resetting scroll point
+        navigate(path); // avoid resetting scroll point
       }}
     >
       <div className="proposal-card-metadata">
@@ -107,7 +108,7 @@ export const ProposalCard = (props: ProposalCardProps) => {
               localStorage[`${app.activeChainId()}-proposals-scrollY`] =
                 window.scrollY;
 
-              navigateToSubpage(
+              navigate(
                 getProposalUrlPath(
                   ProposalType.Thread,
                   `${proposal.threadId}`,

--- a/packages/commonwealth/client/scripts/views/components/proposals/proposals_explainers.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/proposals_explainers.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { navigateToSubpage } from 'router';
 import BN from 'bn.js';
 import type Compound from 'controllers/chain/ethereum/compound/adapter';
 import { CountdownUntilBlock } from 'views/components/countdown';
 import { CWButton } from '../component_kit/cw_button';
 import { GovExplainer } from '../gov_explainer';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type SubstrateProposalStatsProps = { nextLaunchBlock: number };
 
@@ -42,6 +42,7 @@ type CompoundProposalStatsProps = { chain: Compound };
 
 export const CompoundProposalStats = (props: CompoundProposalStatsProps) => {
   const { chain } = props;
+  const navigate = useCommonNavigate();
 
   const symbol = chain.meta.default_symbol;
 
@@ -74,7 +75,7 @@ export const CompoundProposalStats = (props: CompoundProposalStatsProps) => {
       statAction={
         <CWButton
           buttonType="primary-blue"
-          onClick={() => navigateToSubpage('/new/proposal')}
+          onClick={() => navigate('/new/proposal')}
           label="New proposal"
         />
       }

--- a/packages/commonwealth/client/scripts/views/components/quill/quill_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/quill/quill_formatted_text.tsx
@@ -11,7 +11,7 @@ import { countLinesQuill } from './helpers';
 
 // import { loadScript } from 'helpers';
 import { renderQuillDelta } from './render_quill_delta';
-import { useNavigate } from 'react-router-dom';
+import { useCommonNavigate } from 'navigation/helpers';
 
 export type QuillTextParams = {
   collapse?: boolean;
@@ -33,7 +33,7 @@ export const QuillFormattedText: React.FC<QuillFormattedTextAttrs> = ({
   openLinksInNewTab,
   searchTerm,
 }) => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
   const [cachedDocWithHighlights, setCachedDocWithHighlights] = useState<any>();
   const [cachedResultWithHighlights, setCachedResultWithHighlights] =
     useState<any>();

--- a/packages/commonwealth/client/scripts/views/components/share_popover.tsx
+++ b/packages/commonwealth/client/scripts/views/components/share_popover.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getRoute } from 'mithrilInterop';
+import { _DEPRECATED_getRoute } from 'mithrilInterop';
 
 import { CWIconButton } from './component_kit/cw_icon_button';
 import { PopoverMenu } from './component_kit/cw_popover/cw_popover_menu';
@@ -28,7 +28,7 @@ export const SharePopover = (props: SharePopoverProps) => {
           label: 'Copy URL',
           onClick: async () => {
             const currentRouteSansCommentParam =
-              getRoute().split('?comment=')[0];
+              _DEPRECATED_getRoute().split('?comment=')[0];
             if (!commentId) {
               await navigator.clipboard.writeText(
                 `${domain}${currentRouteSansCommentParam}`
@@ -46,12 +46,12 @@ export const SharePopover = (props: SharePopoverProps) => {
           onClick: async () => {
             if (!commentId) {
               await window.open(
-                `https://twitter.com/intent/tweet?text=${domain}${getRoute()}`,
+                `https://twitter.com/intent/tweet?text=${domain}${_DEPRECATED_getRoute()}`,
                 '_blank'
               );
             } else {
               await window.open(
-                `https://twitter.com/intent/tweet?text=${domain}${getRoute()}?comment=${commentId}`,
+                `https://twitter.com/intent/tweet?text=${domain}${_DEPRECATED_getRoute()}?comment=${commentId}`,
                 '_blank'
               );
             }

--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -14,6 +14,7 @@ import type {
   ToggleTree,
 } from './types';
 import { Modal } from '../component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const setAdminToggleTree = (path: string, toggle: boolean) => {
   let currentTree = JSON.parse(
@@ -39,6 +40,8 @@ const setAdminToggleTree = (path: string, toggle: boolean) => {
 };
 
 const AdminSectionComponent = () => {
+  const navigate = useCommonNavigate();
+
   const [isEditTopicThresholdsModalOpen, setIsEditTopicThresholdsModalOpen] =
     React.useState<boolean>(false);
   const [isOrderTopicsModalOpen, setIsOrderTopicsModalOpen] =
@@ -57,7 +60,7 @@ const AdminSectionComponent = () => {
       isUpdated: false,
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
-        handleRedirectClicks(this, e, `/manage`, app.activeChainId(), () => {
+        handleRedirectClicks(navigate, e, `/manage`, app.activeChainId(), () => {
           setAdminToggleTree(`children.manageCommunity.toggledState`, toggle);
         });
       },
@@ -72,7 +75,7 @@ const AdminSectionComponent = () => {
       isUpdated: false,
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
-        handleRedirectClicks(this, e, `/analytics`, app.activeChainId(), () => {
+        handleRedirectClicks(navigate, e, `/analytics`, app.activeChainId(), () => {
           setAdminToggleTree(`children.analytics.toggledState`, toggle);
         });
       },

--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getRoute } from 'mithrilInterop';
+import { _DEPRECATED_getRoute } from 'mithrilInterop';
 import { handleRedirectClicks } from 'helpers';
 import app from 'state';
 import { EditTopicThresholdsModal } from '../../modals/edit_topic_thresholds_modal';
@@ -52,7 +52,7 @@ const AdminSectionComponent = () => {
       containsChildren: false,
       displayData: null,
       hasDefaultToggle: false,
-      isActive: getRoute().includes('/manage'),
+      isActive: _DEPRECATED_getRoute().includes('/manage'),
       isVisible: true,
       isUpdated: false,
       onClick: (e, toggle: boolean) => {
@@ -67,7 +67,7 @@ const AdminSectionComponent = () => {
       containsChildren: false,
       displayData: null,
       hasDefaultToggle: false,
-      isActive: getRoute().includes('/analytics'),
+      isActive: _DEPRECATED_getRoute().includes('/analytics'),
       isVisible: true,
       isUpdated: false,
       onClick: (e, toggle: boolean) => {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -15,7 +15,7 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 function setDiscussionsToggleTree(path: string, toggle: boolean) {
   let currentTree = JSON.parse(
@@ -35,7 +35,7 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
     JSON.stringify(newTree);
 }
 
-const DiscussionSectionComponent = () => {
+export const DiscussionSection = () => {
   const navigate = useCommonNavigate();
 
   // Conditional Render Details +
@@ -250,5 +250,3 @@ const DiscussionSectionComponent = () => {
 
   return <SidebarSectionGroup {...sidebarSectionData} />;
 };
-
-export const DiscussionSection = withRouter(DiscussionSectionComponent);

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -15,7 +15,7 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-import withRouter from 'navigation/helpers';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 function setDiscussionsToggleTree(path: string, toggle: boolean) {
   let currentTree = JSON.parse(
@@ -36,6 +36,8 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
 }
 
 const DiscussionSectionComponent = () => {
+  const navigate = useCommonNavigate();
+
   // Conditional Render Details +
   const onAllDiscussionPage = (p) => {
     const identifier = _DEPRECATED_getSearchParams('§');
@@ -143,7 +145,7 @@ const DiscussionSectionComponent = () => {
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
         handleRedirectClicks(
-          this,
+          navigate,
           e,
           `/discussions`,
           app.activeChainId(),
@@ -163,9 +165,15 @@ const DiscussionSectionComponent = () => {
       isActive: onOverviewDiscussionPage(_DEPRECATED_getRoute()),
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
-        handleRedirectClicks(this, e, `/overview`, app.activeChainId(), () => {
-          setDiscussionsToggleTree(`children.Overview.toggledState`, toggle);
-        });
+        handleRedirectClicks(
+          navigate,
+          e,
+          `/overview`,
+          app.activeChainId(),
+          () => {
+            setDiscussionsToggleTree(`children.Overview.toggledState`, toggle);
+          }
+        );
       },
       displayData: null,
     },
@@ -181,7 +189,7 @@ const DiscussionSectionComponent = () => {
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
         handleRedirectClicks(
-          this,
+          navigate,
           e,
           `/sputnik-daos`,
           app.activeChainId(),
@@ -210,7 +218,7 @@ const DiscussionSectionComponent = () => {
         onClick: (e, toggle: boolean) => {
           e.preventDefault();
           handleRedirectClicks(
-            this,
+            navigate,
             e,
             `/discussions/${encodeURI(topic.name)}`,
             app.activeChainId(),

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { getRoute, getRouteParam } from 'mithrilInterop';
+import {
+  _DEPRECATED_getRoute,
+  _DEPRECATED_getSearchParams,
+} from 'mithrilInterop';
 
 import 'components/sidebar/index.scss';
 import app from 'state';
@@ -35,7 +38,7 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
 const DiscussionSectionComponent = () => {
   // Conditional Render Details +
   const onAllDiscussionPage = (p) => {
-    const identifier = getRouteParam('identifier');
+    const identifier = _DEPRECATED_getSearchParams('§');
     if (identifier) {
       const thread = app.threads.store.getByIdentifier(
         identifier.slice(0, identifier.indexOf('-'))
@@ -52,7 +55,7 @@ const DiscussionSectionComponent = () => {
   };
 
   const onOverviewDiscussionPage = (p) => {
-    const identifier = getRouteParam('identifier');
+    const identifier = _DEPRECATED_getSearchParams('identifier');
     if (identifier) {
       const thread = app.threads.store.getByIdentifier(
         identifier.slice(0, identifier.indexOf('-'))
@@ -66,7 +69,7 @@ const DiscussionSectionComponent = () => {
   };
 
   const onFeaturedDiscussionPage = (p, topic) => {
-    const identifier = getRouteParam('identifier');
+    const identifier = _DEPRECATED_getSearchParams('identifier');
     if (identifier) {
       const thread = app.threads.store.getByIdentifier(
         identifier.slice(0, identifier.indexOf('-'))
@@ -136,7 +139,7 @@ const DiscussionSectionComponent = () => {
       hasDefaultToggle: false,
       isVisible: true,
       isUpdated: true,
-      isActive: onAllDiscussionPage(getRoute()),
+      isActive: onAllDiscussionPage(_DEPRECATED_getRoute()),
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
         handleRedirectClicks(
@@ -157,7 +160,7 @@ const DiscussionSectionComponent = () => {
       hasDefaultToggle: false,
       isVisible: true,
       isUpdated: true,
-      isActive: onOverviewDiscussionPage(getRoute()),
+      isActive: onOverviewDiscussionPage(_DEPRECATED_getRoute()),
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
         handleRedirectClicks(this, e, `/overview`, app.activeChainId(), () => {
@@ -173,7 +176,7 @@ const DiscussionSectionComponent = () => {
       isVisible: true,
       isUpdated: true,
       isActive:
-        onSputnikDaosPage(getRoute()) &&
+        onSputnikDaosPage(_DEPRECATED_getRoute()) &&
         (app.chain ? app.chain.serverLoaded : true),
       onClick: (e, toggle: boolean) => {
         e.preventDefault();
@@ -202,7 +205,7 @@ const DiscussionSectionComponent = () => {
         hasDefaultToggle: false,
         isVisible: true,
         isUpdated: true,
-        isActive: onFeaturedDiscussionPage(getRoute(), topic.name),
+        isActive: onFeaturedDiscussionPage(_DEPRECATED_getRoute(), topic.name),
         // eslint-disable-next-line no-loop-func
         onClick: (e, toggle: boolean) => {
           e.preventDefault();

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -19,7 +19,7 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 function setGovernanceToggleTree(path: string, toggle: boolean) {
   let currentTree = JSON.parse(
@@ -44,7 +44,7 @@ function setGovernanceToggleTree(path: string, toggle: boolean) {
     JSON.stringify(newTree);
 }
 
-const GovernanceSectionComponent = () => {
+export const GovernanceSection = () => {
   const navigate = useCommonNavigate();
 
   // Conditional Render Details
@@ -413,5 +413,3 @@ const GovernanceSectionComponent = () => {
 
   return <SidebarSectionGroup {...sidebarSectionData} />;
 };
-
-export const GovernanceSection = withRouter(GovernanceSectionComponent);

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getRoute } from 'mithrilInterop';
+import { _DEPRECATED_getRoute } from 'mithrilInterop';
 import {
   ChainBase,
   ChainNetwork,
@@ -197,7 +197,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     p.startsWith(`/${app.activeChainId()}/members`) ||
     p.startsWith(`/${app.activeChainId()}/account/`);
 
-  if (onNotificationsPage(getRoute())) return;
+  if (onNotificationsPage(_DEPRECATED_getRoute())) return;
 
   // ---------- Build Section Props ---------- //
 
@@ -209,7 +209,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     isVisible: true,
     isUpdated: true,
     isActive:
-      onMembersPage(getRoute()) && (app.chain ? app.chain.serverLoaded : true),
+      onMembersPage(_DEPRECATED_getRoute()) && (app.chain ? app.chain.serverLoaded : true),
     onClick: (e, toggle: boolean) => {
       console.log('this', this);
       handleRedirectClicks(this, e, '/members', app.activeChainId(), () => {
@@ -227,7 +227,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       ? toggleTreeState['children']['Snapshots']['toggledState']
       : false,
     isVisible: showSnapshotOptions,
-    isActive: onSnapshotProposal(getRoute()),
+    isActive: onSnapshotProposal(_DEPRECATED_getRoute()),
     isUpdated: true,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
@@ -282,7 +282,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     },
     isVisible: showProposals,
     isUpdated: true,
-    isActive: onProposalPage(getRoute()),
+    isActive: onProposalPage(_DEPRECATED_getRoute()),
     displayData: null,
   };
 
@@ -301,7 +301,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     },
     isVisible: showTreasury,
     isUpdated: true,
-    isActive: onTreasuryPage(getRoute()),
+    isActive: onTreasuryPage(_DEPRECATED_getRoute()),
     displayData: null,
   };
 
@@ -319,7 +319,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     },
     isVisible: showReferenda,
     isUpdated: true,
-    isActive: onReferendaPage(getRoute()),
+    isActive: onReferendaPage(_DEPRECATED_getRoute()),
     displayData: null,
   };
 
@@ -337,7 +337,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     },
     isVisible: showTips,
     isUpdated: true,
-    isActive: onTipsPage(getRoute()),
+    isActive: onTipsPage(_DEPRECATED_getRoute()),
     displayData: null,
   };
 
@@ -350,7 +350,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       : false,
     isVisible: showCompoundOptions,
     isUpdated: true,
-    isActive: getRoute() === `/${app.activeChainId()}/delegate`,
+    isActive: _DEPRECATED_getRoute() === `/${app.activeChainId()}/delegate`,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
       handleRedirectClicks(this, e, '/delegate', app.activeChainId(), () => {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -19,7 +19,7 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-import withRouter from 'navigation/helpers';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 function setGovernanceToggleTree(path: string, toggle: boolean) {
   let currentTree = JSON.parse(
@@ -44,7 +44,9 @@ function setGovernanceToggleTree(path: string, toggle: boolean) {
     JSON.stringify(newTree);
 }
 
-const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
+const GovernanceSectionComponent = () => {
+  const navigate = useCommonNavigate();
+
   // Conditional Render Details
   const hasProposals =
     app.chain &&
@@ -209,10 +211,10 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     isVisible: true,
     isUpdated: true,
     isActive:
-      onMembersPage(_DEPRECATED_getRoute()) && (app.chain ? app.chain.serverLoaded : true),
+      onMembersPage(_DEPRECATED_getRoute()) &&
+      (app.chain ? app.chain.serverLoaded : true),
     onClick: (e, toggle: boolean) => {
-      console.log('this', this);
-      handleRedirectClicks(this, e, '/members', app.activeChainId(), () => {
+      handleRedirectClicks(navigate, e, '/members', app.activeChainId(), () => {
         setGovernanceToggleTree('children.Members.toggledState', toggle);
       });
     },
@@ -236,7 +238,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       const snapshotSpaces = app.chain.meta.snapshot;
       if (snapshotSpaces.length > 1) {
         handleRedirectClicks(
-          this,
+          navigate,
           e,
           '/multiple-snapshots?action=select-space',
           app.activeChainId(),
@@ -245,7 +247,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       } else {
         if (snapshotSpaces[0].lastIndexOf('/') > -1) {
           handleRedirectClicks(
-            this,
+            navigate,
             e,
             `/snapshot/${snapshotSpaces[0]
               .slice(snapshotSpaces[0].lastIndexOf('/') + 1)
@@ -255,7 +257,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
           );
         } else {
           handleRedirectClicks(
-            this,
+            navigate,
             e,
             `/snapshot/${snapshotSpaces}`,
             app.activeChainId(),
@@ -276,9 +278,15 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       : false,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
-      handleRedirectClicks(this, e, '/proposals', app.activeChainId(), () => {
-        setGovernanceToggleTree('children.Proposals.toggledState', toggle);
-      });
+      handleRedirectClicks(
+        navigate,
+        e,
+        '/proposals',
+        app.activeChainId(),
+        () => {
+          setGovernanceToggleTree('children.Proposals.toggledState', toggle);
+        }
+      );
     },
     isVisible: showProposals,
     isUpdated: true,
@@ -295,9 +303,15 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       : false,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
-      handleRedirectClicks(this, e, '/treasury', app.activeChainId(), () => {
-        setGovernanceToggleTree('children.Treasury.toggledState', toggle);
-      });
+      handleRedirectClicks(
+        navigate,
+        e,
+        '/treasury',
+        app.activeChainId(),
+        () => {
+          setGovernanceToggleTree('children.Treasury.toggledState', toggle);
+        }
+      );
     },
     isVisible: showTreasury,
     isUpdated: true,
@@ -313,9 +327,15 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       : false,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
-      handleRedirectClicks(this, e, '/referenda', app.activeChainId(), () => {
-        setGovernanceToggleTree('children.Referenda.toggledState', toggle);
-      });
+      handleRedirectClicks(
+        navigate,
+        e,
+        '/referenda',
+        app.activeChainId(),
+        () => {
+          setGovernanceToggleTree('children.Referenda.toggledState', toggle);
+        }
+      );
     },
     isVisible: showReferenda,
     isUpdated: true,
@@ -331,7 +351,7 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
       : false,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
-      handleRedirectClicks(this, e, '/tips', app.activeChainId(), () => {
+      handleRedirectClicks(navigate, e, '/tips', app.activeChainId(), () => {
         setGovernanceToggleTree('children.Tips.toggledState', toggle);
       });
     },
@@ -353,9 +373,15 @@ const GovernanceSectionComponent = (props: SidebarSectionAttrs) => {
     isActive: _DEPRECATED_getRoute() === `/${app.activeChainId()}/delegate`,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();
-      handleRedirectClicks(this, e, '/delegate', app.activeChainId(), () => {
-        setGovernanceToggleTree('children.Delegate.toggledState', toggle);
-      });
+      handleRedirectClicks(
+        navigate,
+        e,
+        '/delegate',
+        app.activeChainId(),
+        () => {
+          setGovernanceToggleTree('children.Delegate.toggledState', toggle);
+        }
+      );
     },
     displayData: null,
   };

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, redraw, getRoute } from 'mithrilInterop';
+import { ClassComponent, redraw, _DEPRECATED_getRoute } from 'mithrilInterop';
 
 import 'components/sidebar/index.scss';
 import { Action } from 'commonwealth/shared/permissions';
@@ -38,7 +38,8 @@ class SidebarComponent extends ClassComponent {
 
     const currentChainInfo = app.chain?.meta;
 
-    const onHomeRoute = getRoute() === `/${app.activeChainId()}/feed`;
+    const onHomeRoute =
+      _DEPRECATED_getRoute() === `/${app.activeChainId()}/feed`;
 
     const hideChat =
       !currentChainInfo ||

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, redraw, _DEPRECATED_getRoute } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getRoute } from 'mithrilInterop';
 
 import 'components/sidebar/index.scss';
 import { Action } from 'commonwealth/shared/permissions';

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -9,11 +9,10 @@ import app from 'state';
 import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 import { CWDivider } from '../component_kit/cw_divider';
 import { CWIconButton } from '../component_kit/cw_icon_button';
-import withRouter from 'navigation/helpers';
-import { useNavigate } from 'react-router-dom';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 const SidebarQuickSwitcherComponent = () => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   const allCommunities = app.config.chains
     .getAll()

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 
 import 'components/sidebar/sidebar_quick_switcher.scss';
 
-import { navigateToSubpage } from 'router';
-import { MixpanelPageViewEvent } from 'analytics/types';
-import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 import { link } from 'helpers';
 import { ChainInfo } from 'models';
 
@@ -13,8 +10,11 @@ import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 import { CWDivider } from '../component_kit/cw_divider';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import withRouter from 'navigation/helpers';
+import { useNavigate } from 'react-router-dom';
 
 const SidebarQuickSwitcherComponent = () => {
+  const navigate = useNavigate();
+
   const allCommunities = app.config.chains
     .getAll()
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -58,7 +58,7 @@ const SidebarQuickSwitcherComponent = () => {
             key={item.id}
             size="large"
             community={item}
-            onClick={link ? () => navigateToSubpage(`/${item.id}`) : undefined}
+            onClick={link ? () => navigate(`/${item.id}`) : undefined}
           />
         ))}
       </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -9,9 +9,9 @@ import app from 'state';
 import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 import { CWDivider } from '../component_kit/cw_divider';
 import { CWIconButton } from '../component_kit/cw_icon_button';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
-const SidebarQuickSwitcherComponent = () => {
+export const SidebarQuickSwitcher = () => {
   const navigate = useCommonNavigate();
 
   const allCommunities = app.config.chains
@@ -64,5 +64,3 @@ const SidebarQuickSwitcherComponent = () => {
     </div>
   );
 };
-
-export const SidebarQuickSwitcher = withRouter(SidebarQuickSwitcherComponent);

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-script-url */
 import React from 'react';
 
-import { render, redraw } from 'mithrilInterop';
 import { link } from 'helpers';
 
 import 'components/user/user.scss';
@@ -15,8 +14,8 @@ import { CWButton } from '../component_kit/cw_button';
 import { BanUserModal } from '../../modals/ban_user_modal';
 import { Popover, usePopover } from '../component_kit/cw_popover/cw_popover';
 import { CWText } from '../component_kit/cw_text';
-import { useNavigate } from 'react-router-dom';
 import { Modal } from '../component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 // Address can be shown in full, autotruncated with formatAddressShort(),
 // or set to a custom max character length
@@ -50,7 +49,7 @@ export const User = (props: UserAttrs) => {
     popover,
     showRole,
   } = props;
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 

--- a/packages/commonwealth/client/scripts/views/components/user/user_block.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user_block.tsx
@@ -13,9 +13,8 @@ import { CWIcon } from '../component_kit/cw_icons/cw_icon';
 import { User } from './user';
 import type { AddressDisplayOptions } from './user';
 import { getClasses } from '../component_kit/helpers';
-import withRouter from 'navigation/helpers';
 
-const UserBlockComponent = (props: {
+export const UserBlock = (props: {
   addressDisplayOptions?: AddressDisplayOptions;
   avatarSize?: number;
   compact?: boolean;
@@ -137,5 +136,3 @@ const UserBlockComponent = (props: {
     </div>
   );
 };
-
-export const UserBlock = withRouter(UserBlockComponent);

--- a/packages/commonwealth/client/scripts/views/footer.tsx
+++ b/packages/commonwealth/client/scripts/views/footer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import 'footer.scss';
 
 import { isNotUndefined } from '../helpers/typeGuards';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const footercontents = [
   { text: 'About', redirectTo: '/whyCommonwealth' },
@@ -25,7 +25,7 @@ const footercontents = [
   },
 ];
 
-const FooterComponent = () => {
+export const Footer = () => {
   const navigate = useCommonNavigate();
 
   const redirectClick = (route) => {
@@ -63,5 +63,3 @@ const FooterComponent = () => {
     </div>
   );
 };
-
-export const Footer = withRouter(FooterComponent);

--- a/packages/commonwealth/client/scripts/views/footer.tsx
+++ b/packages/commonwealth/client/scripts/views/footer.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import 'footer.scss';
 
 import { isNotUndefined } from '../helpers/typeGuards';
-import withRouter from 'navigation/helpers';
-import { navigateToSubpage } from '../router';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 const footercontents = [
   { text: 'About', redirectTo: '/whyCommonwealth' },
@@ -27,8 +26,10 @@ const footercontents = [
 ];
 
 const FooterComponent = () => {
+  const navigate = useCommonNavigate();
+
   const redirectClick = (route) => {
-    navigateToSubpage(route);
+    navigate(route, {}, null);
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, redraw } from 'mithrilInterop';
-import { navigateToSubpage } from 'router';
+import { redraw } from 'mithrilInterop';
 import { ChainBase, ChainNetwork, ProposalType } from 'common-common/src/types';
 import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 import { MixpanelCommunityCreationEvent } from 'analytics/types';
@@ -13,7 +12,7 @@ import { PopoverMenu } from '../components/component_kit/cw_popover/cw_popover_m
 import { CWMobileMenu } from '../components/component_kit/cw_mobile_menu';
 
 import { CWSidebarMenu } from '../components/component_kit/cw_sidebar_menu';
-import withRouter from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
@@ -58,7 +57,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
             `${app.activeChainId()}-active-topic-default-template`
           );
         }
-        navigateToSubpage('/new/discussion');
+        navigate('/new/discussion');
       },
     }));
 
@@ -67,7 +66,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
       ? [
           {
             label: 'New On-Chain Proposal',
-            onClick: () => navigateToSubpage('/new/proposal'),
+            onClick: () => navigate('/new/proposal'),
             iconLeft: 'star',
           },
         ]
@@ -78,7 +77,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
       ? [
           {
             label: 'New Sputnik proposal',
-            onClick: () => navigateToSubpage('/new/proposal'),
+            onClick: () => navigate('/new/proposal'),
             iconLeft: 'democraticProposal',
           },
         ]
@@ -90,7 +89,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New treasury proposal',
             onClick: () =>
-              navigateToSubpage('/new/proposal/:type', {
+              navigate('/new/proposal/:type', {
                 type: ProposalType.SubstrateTreasuryProposal,
               }),
             iconLeft: 'treasuryProposal',
@@ -98,7 +97,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New democracy proposal',
             onClick: () =>
-              navigateToSubpage('/new/proposal/:type', {
+              navigate('/new/proposal/:type', {
                 type: ProposalType.SubstrateDemocracyProposal,
               }),
             iconLeft: 'democraticProposal',
@@ -106,7 +105,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New tip',
             onClick: () =>
-              navigateToSubpage('/new/proposal/:type', {
+              navigate('/new/proposal/:type', {
                 type: ProposalType.SubstrateTreasuryTip,
               }),
             iconLeft: 'jar',
@@ -123,11 +122,11 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
             onClick: () => {
               const snapshotSpaces = app.chain.meta.snapshot;
               if (snapshotSpaces.length > 1) {
-                navigateToSubpage('/multiple-snapshots', {
+                navigate('/multiple-snapshots', {
                   action: 'create-proposal',
                 });
               } else {
-                navigateToSubpage(`/new/snapshot/${snapshotSpaces}`);
+                navigate(`/new/snapshot/${snapshotSpaces}`);
               }
             },
           },
@@ -146,7 +145,8 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
       label: 'New Community',
       iconLeft: 'people',
       onClick: (e) => {
-        e.preventDefault();
+        console.log('e', e);
+        e?.preventDefault();
         mixpanelBrowserTrack({
           event: MixpanelCommunityCreationEvent.CREATE_BUTTON_PRESSED,
           chainBase: null,
@@ -156,14 +156,14 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
         app.sidebarToggled = false;
         app.sidebarMenu = 'default';
         app.sidebarRedraw.emit('redraw');
-        navigate('/createCommunity');
+        navigate('/createCommunity', {}, null);
       },
     },
     {
       label: 'Gate your Discord',
       iconLeft: 'discord',
       onClick: (e) => {
-        e.preventDefault();
+        e?.preventDefault();
         mixpanelBrowserTrack({
           event: MixpanelCommunityCreationEvent.CREATE_BUTTON_PRESSED,
           chainBase: null,
@@ -195,7 +195,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New Thread',
             onClick: () => {
-              navigateToSubpage('/new/discussion');
+              navigate('/new/discussion');
             },
             iconLeft: 'write',
           } as PopoverMenuItem,
@@ -214,78 +214,72 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   ];
 };
 
-class CreateContentSidebarComponent extends ClassComponent {
-  view() {
-    return (
-      <CWSidebarMenu
-        className="CreateContentSidebar"
-        menuHeader={{
-          label: 'Create',
-          onClick: async () => {
-            const sidebar = document.getElementsByClassName(
-              'CreateContentSidebar'
-            );
-            sidebar[0].classList.add('onremove');
-            setTimeout(() => {
-              app.sidebarToggled = false;
-              app.sidebarMenu = 'default';
-              app.sidebarRedraw.emit('redraw');
-              redraw();
-            }, 200);
-          },
-        }}
-        menuItems={getCreateContentMenuItems(this.setRoute)}
-      />
-    );
+export const CreateContentSidebar = () => {
+  const navigate = useCommonNavigate();
+
+  return (
+    <CWSidebarMenu
+      className="CreateContentSidebar"
+      menuHeader={{
+        label: 'Create',
+        onClick: async () => {
+          const sidebar = document.getElementsByClassName(
+            'CreateContentSidebar'
+          );
+          sidebar[0].classList.add('onremove');
+          setTimeout(() => {
+            app.sidebarToggled = false;
+            app.sidebarMenu = 'default';
+            app.sidebarRedraw.emit('redraw');
+            redraw();
+          }, 200);
+        },
+      }}
+      menuItems={getCreateContentMenuItems(navigate)}
+    />
+  );
+};
+
+export const CreateContentMenu = () => {
+  const navigate = useCommonNavigate();
+
+  return (
+    <CWMobileMenu
+      className="CreateContentMenu"
+      menuHeader={{
+        label: 'Create',
+        onClick: () => {
+          app.mobileMenu = 'MainMenu';
+          app.mobileMenuRedraw.emit('redraw');
+        },
+      }}
+      menuItems={getCreateContentMenuItems(navigate)}
+    />
+  );
+};
+
+export const CreateContentPopover = () => {
+  const navigate = useCommonNavigate();
+
+  if (
+    !app.isLoggedIn() ||
+    !app.chain ||
+    !app.activeChainId() ||
+    !app.user.activeAccount
+  ) {
+    return;
   }
-}
 
-export const CreateContentSidebar = withRouter(CreateContentSidebarComponent);
-
-class CreateContentMenuComponent extends ClassComponent {
-  view() {
-    return (
-      <CWMobileMenu
-        className="CreateContentMenu"
-        menuHeader={{
-          label: 'Create',
-          onClick: () => {
-            app.mobileMenu = 'MainMenu';
-            app.mobileMenuRedraw.emit('redraw');
-          },
-        }}
-        menuItems={getCreateContentMenuItems(this.setRoute)}
-      />
-    );
-  }
-}
-
-export const CreateContentMenu = withRouter(CreateContentMenuComponent);
-
-class CreateContentPopoverComponent extends ClassComponent {
-  view() {
-    if (
-      !app.isLoggedIn() ||
-      !app.chain ||
-      !app.activeChainId() ||
-      !app.user.activeAccount
-    ) {
-      return;
-    }
-
-    return (
-      <PopoverMenu
-        menuItems={getCreateContentMenuItems(this.setRoute)}
-        renderTrigger={(onclick) => (
-          <CWIconButton
-            iconButtonTheme="black"
-            iconName="plusCircle"
-            onClick={onclick}
-          />
-        )}
-      />
-    );
-  }
-}
-
-export const CreateContentPopover = withRouter(CreateContentPopoverComponent);
+  return (
+    <PopoverMenu
+      menuItems={getCreateContentMenuItems(navigate)}
+      renderTrigger={(onclick) => (
+        <CWIconButton
+          iconButtonTheme="black"
+          iconName="plusCircle"
+          onClick={onclick}
+        />
+      )}
+    />
+  );
+};

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -145,7 +145,6 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
       label: 'New Community',
       iconLeft: 'people',
       onClick: (e) => {
-        console.log('e', e);
         e?.preventDefault();
         mixpanelBrowserTrack({
           event: MixpanelCommunityCreationEvent.CREATE_BUTTON_PRESSED,

--- a/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
@@ -7,7 +7,6 @@ import ClickAwayListener from '@mui/base/ClickAwayListener';
 import 'components/header/notifications_menu.scss';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import { CWCustomIcon } from '../components/component_kit/cw_icons/cw_custom_icon';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
 import { CWButton } from '../components/component_kit/cw_button';
@@ -175,9 +174,7 @@ export class NotificationsMenuComponent extends ClassComponent {
             label="See all"
             buttonType="tertiary-black"
             onClick={() => {
-              app.activeChainId()
-                ? navigateToSubpage('/notifications')
-                : this.setRoute('/notifications');
+              this.setRoute('/notifications');
             }}
           />
           <CWDivider isVertical />

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { redraw } from 'mithrilInterop';
 import $ from 'jquery';
 import { pluralizeWithoutNumberPrefix } from 'helpers';
-import { navigateToSubpage } from 'router';
 
 import 'modals/edit_topic_modal.scss';
 import { Topic } from 'models';
@@ -19,6 +18,7 @@ import { CWValidationText } from '../components/component_kit/cw_validation_text
 import type { QuillEditor } from '../components/quill/quill_editor';
 import type { QuillTextContents } from '../components/quill/types';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type EditTopicModalProps = {
   defaultOffchainTemplate: string;
@@ -40,6 +40,8 @@ export const EditTopicModal = (props: EditTopicModalProps) => {
     onModalClose,
     name: nameProp,
   } = props;
+
+  const navigate = useCommonNavigate();
 
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
   const [quillEditorState, setQuillEditorState] = React.useState<QuillEditor>();
@@ -105,7 +107,7 @@ export const EditTopicModal = (props: EditTopicModalProps) => {
 
     await app.topics.remove(topicInfo);
 
-    navigateToSubpage('/');
+    navigate('/');
   };
 
   return (
@@ -187,7 +189,7 @@ export const EditTopicModal = (props: EditTopicModalProps) => {
                 .then((closeModal) => {
                   if (closeModal) {
                     $(e.target).trigger('modalexit');
-                    navigateToSubpage(
+                    navigate(
                       `/discussions/${encodeURI(name.toString().trim())}`
                     );
                   }
@@ -211,7 +213,7 @@ export const EditTopicModal = (props: EditTopicModalProps) => {
               deleteTopic()
                 .then(() => {
                   $(e.target).trigger('modalexit');
-                  navigateToSubpage('/');
+                  navigate('/');
                 })
                 .catch(() => {
                   setIsSaving(false);

--- a/packages/commonwealth/client/scripts/views/pages/chat.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/chat.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, getRouteParam } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getSearchParams } from 'mithrilInterop';
 
 import 'pages/chat.scss';
 
@@ -27,7 +27,7 @@ class ChatPage extends ClassComponent {
 
     if (!app.socket) navigateToSubpage('/'); // Stops un-logged in access
 
-    const channel_id = getRouteParam()['channel'];
+    const channel_id = _DEPRECATED_getSearchParams()['channel'];
 
     return !app.socket.chatNs.hasChannels() ? (
       <PageLoading />

--- a/packages/commonwealth/client/scripts/views/pages/chat.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/chat.tsx
@@ -5,14 +5,14 @@ import { ClassComponent, _DEPRECATED_getSearchParams } from 'mithrilInterop';
 import 'pages/chat.scss';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import { ChatWindow } from 'views/components/chat/chat_window';
 import { PageLoading } from 'views/pages/loading';
 import Sublayout from 'views/sublayout';
 import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 import { MixpanelChatEvents } from 'analytics/types';
+import withRouter from 'navigation/helpers';
 
-class ChatPage extends ClassComponent {
+class ChatPageComponent extends ClassComponent {
   oncreate() {
     mixpanelBrowserTrack({
       event: MixpanelChatEvents.CHAT_PAGE_VISIT,
@@ -25,7 +25,10 @@ class ChatPage extends ClassComponent {
     const activeEntity = app.chain;
     if (!activeEntity) return <PageLoading />;
 
-    if (!app.socket) navigateToSubpage('/'); // Stops un-logged in access
+    if (!app.socket) {
+      // Stops un-logged in access
+      this.setRoute('/');
+    }
 
     const channel_id = _DEPRECATED_getSearchParams()['channel'];
 
@@ -38,5 +41,7 @@ class ChatPage extends ClassComponent {
     );
   }
 }
+
+const ChatPage = withRouter(ChatPageComponent);
 
 export default ChatPage;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { ResultNode } from 'mithrilInterop';
-import { ClassComponent, getRouteParam } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getSearchParams } from 'mithrilInterop';
 import { debounce } from 'lodash';
 import { pluralize } from 'helpers';
 import { isNotUndefined } from 'helpers/typeGuards';
@@ -72,7 +72,7 @@ class DiscussionsPage extends ClassComponent<DiscussionPageAttrs> {
     }
 
     this.topicName = vnode.attrs.topic;
-    this.stageName = getRouteParam('stage');
+    this.stageName = _DEPRECATED_getSearchParams('stage');
 
     const { topicName, stageName } = this;
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { ClassComponent, redraw } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
-import { navigateToSubpage } from 'router';
 import { parseCustomStages } from 'helpers';
 import { isUndefined } from 'helpers/typeGuards';
 import { ThreadStage } from 'models';
@@ -16,6 +15,7 @@ import { CWText } from '../../components/component_kit/cw_text';
 import { isWindowExtraSmall } from '../../components/component_kit/helpers';
 import { StagesMenu } from './stages_menu';
 import { TopicsMenu } from './topics_menu';
+import withRouter from 'navigation/helpers';
 
 type RecentThreadsHeaderAttrs = {
   stage: string;
@@ -23,7 +23,7 @@ type RecentThreadsHeaderAttrs = {
   totalThreadCount: number;
 };
 
-export class RecentThreadsHeader extends ClassComponent<RecentThreadsHeaderAttrs> {
+class RecentThreadsHeaderComponent extends ClassComponent<RecentThreadsHeaderAttrs> {
   private isWindowExtraSmall: boolean;
 
   onResize() {
@@ -96,16 +96,16 @@ export class RecentThreadsHeader extends ClassComponent<RecentThreadsHeaderAttrs
                     iconName="plusCircle"
                     iconButtonTheme="black"
                     onClick={() => {
-                      navigateToSubpage('/new/discussion');
+                      this.setRoute('/new/discussion');
                     }}
                   />
                 ) : (
                   <CWButton
                     buttonType="mini-black"
-                    label="Create Thread"
+                    label="Create Threadasd"
                     iconLeft="plus"
                     onClick={() => {
-                      navigateToSubpage('/new/discussion');
+                      this.setRoute('/new/discussion');
                     }}
                   />
                 )}
@@ -141,3 +141,5 @@ export class RecentThreadsHeader extends ClassComponent<RecentThreadsHeaderAttrs
     );
   }
 }
+
+export const RecentThreadsHeader = withRouter(RecentThreadsHeaderComponent);

--- a/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
-import { navigateToSubpage } from 'router';
 import { threadStageToLabel } from 'helpers';
 import { ThreadStage } from 'models';
 
@@ -16,6 +15,7 @@ import {
   usePopover,
 } from '../../components/component_kit/cw_popover/cw_popover';
 import { getClasses } from '../../components/component_kit/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type ThreadsFilterMenuItemProps = {
   iconRight?: React.ReactNode;
@@ -52,6 +52,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
   const { selectedStage, stage, stages } = props;
 
   const popoverProps = usePopover();
+  const navigate = useCommonNavigate();
 
   return (
     <ClickAwayListener onClickAway={() => popoverProps.setAnchorEl(null)}>
@@ -75,7 +76,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                 isSelected={!stage}
                 onClick={(e) => {
                   e.preventDefault();
-                  navigateToSubpage('/discussions');
+                    navigate('/discussions');
                 }}
               />
               <CWDivider />
@@ -85,7 +86,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                   isSelected={stage === targetStage}
                   onClick={(e) => {
                     e.preventDefault();
-                    navigateToSubpage(`/discussions?stage=${targetStage}`);
+                      navigate(`/discussions?stage=${targetStage}`);
                   }}
                   label={`
                     ${threadStageToLabel(targetStage)} ${

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { redraw } from 'mithrilInterop';
-import { navigateToSubpage } from 'router';
 import type { Thread, ThreadStage, Topic } from 'models';
 import app from 'state';
 import { confirmationModalWithText } from '../../modals/confirm_modal';
@@ -10,6 +9,7 @@ import { ChangeTopicModal } from '../../modals/change_topic_modal';
 import { PopoverMenu } from '../../components/component_kit/cw_popover/cw_popover_menu';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { Modal } from '../../components/component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type ThreadPreviewMenuProps = {
   thread: Thread;
@@ -17,6 +17,7 @@ type ThreadPreviewMenuProps = {
 
 export const ThreadPreviewMenu = (props: ThreadPreviewMenuProps) => {
   const { thread } = props;
+  const navigate = useCommonNavigate();
 
   const [isChangeTopicModalOpen, setIsChangeTopicModalOpen] =
     React.useState<boolean>(false);
@@ -56,7 +57,7 @@ export const ThreadPreviewMenu = (props: ThreadPreviewMenuProps) => {
                       e.preventDefault();
 
                       app.threads.pin({ proposal: thread }).then(() => {
-                        navigateToSubpage('/discussions');
+                        navigate('/discussions');
                         redraw();
                       });
                     },
@@ -120,7 +121,7 @@ export const ThreadPreviewMenu = (props: ThreadPreviewMenuProps) => {
                       if (!confirmed) return;
 
                       app.threads.delete(thread).then(() => {
-                        navigateToSubpage('/discussions');
+                        navigate('/discussions');
                       });
                     },
                     label: 'Delete',

--- a/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
 import { navigateToSubpage } from 'router';
-import { getRoute } from 'mithrilInterop';
+import { _DEPRECATED_getRoute } from 'mithrilInterop';
 
 import 'pages/discussions/stages_menu.scss';
 
@@ -57,7 +57,7 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
             <div className="threads-filter-menu-items">
               <ThreadsFilterMenuItem
                 label="All Topics"
-                isSelected={getRoute() === `/${app.activeChainId()}` || !topic}
+                isSelected={_DEPRECATED_getRoute() === `/${app.activeChainId()}` || !topic}
                 onClick={() => {
                   navigateToSubpage('/discussions');
                 }}
@@ -78,7 +78,7 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
                     i
                   ) => {
                     const active =
-                      getRoute() ===
+                      _DEPRECATED_getRoute() ===
                         `/${app.activeChainId()}/discussions/${encodeURI(
                           name.toString().trim()
                         )}` ||

--- a/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
-import { navigateToSubpage } from 'router';
 import { _DEPRECATED_getRoute } from 'mithrilInterop';
 
 import 'pages/discussions/stages_menu.scss';
@@ -17,6 +16,7 @@ import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { ThreadsFilterMenuItem } from './stages_menu';
 import { Modal } from '../../components/component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type Topic = {
   defaultOffchainTemplate?: string;
@@ -39,6 +39,7 @@ type TopicsMenuProps = {
 export const TopicsMenu = (props: TopicsMenuProps) => {
   const { featuredTopics, otherTopics, selectedTopic, topic } = props;
 
+  const navigate = useCommonNavigate();
   const popoverProps = usePopover();
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
@@ -57,9 +58,11 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
             <div className="threads-filter-menu-items">
               <ThreadsFilterMenuItem
                 label="All Topics"
-                isSelected={_DEPRECATED_getRoute() === `/${app.activeChainId()}` || !topic}
+                isSelected={
+                  _DEPRECATED_getRoute() === `/${app.activeChainId()}` || !topic
+                }
                 onClick={() => {
-                  navigateToSubpage('/discussions');
+                  navigate('/discussions');
                 }}
               />
               <CWDivider />
@@ -91,7 +94,7 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
                         isSelected={active}
                         onClick={(e) => {
                           e.preventDefault();
-                          navigateToSubpage(`/discussions/${name}`);
+                          navigate(`/discussions/${name}`);
                         }}
                         iconRight={
                           app.roles?.isAdminOfEntity({

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
 
 import app from 'state';
-import { useNavigate } from 'react-router-dom';
 import { PageLoading } from './loading';
 import { DefaultPage } from '../../../../../common-common/src/types';
+import { useCommonNavigate } from 'navigation/helpers';
 
 export default function DiscussionsRedirect() {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   useEffect(() => {
     if (!app.chain) return;
@@ -22,16 +22,16 @@ export default function DiscussionsRedirect() {
 
     switch (view) {
       case DefaultPage.Overview:
-        navigate(`/${app.chain.id}/overview`);
+        navigate('/overview');
         break;
       case DefaultPage.Discussions:
-        navigate(`/${app.chain.id}/discussions`);
+        navigate('/discussions');
         break;
       case DefaultPage.Homepage:
-        navigate(`/${app.chain.id}/feed`);
+        navigate('/feed');
         break;
       default:
-        navigate(`/${app.chain.id}/discussions`);
+        navigate('/discussions');
     }
   });
 

--- a/packages/commonwealth/client/scripts/views/pages/finish_axie_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_axie_login.tsx
@@ -4,7 +4,7 @@ import { initAppState } from 'state';
 import { updateActiveAddresses } from 'controllers/app/login';
 import $ from 'jquery';
 import app from 'state';
-import { ClassComponent, getRouteParam, redraw } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getSearchParams, redraw } from 'mithrilInterop';
 
 import { PageLoading } from 'views/pages/loading';
 import ErrorPage from './error';
@@ -55,8 +55,8 @@ class FinishAxieLoginComponent extends ClassComponent<Record<string, unknown>> {
   public oninit() {
     // grab token
     // TODO: how to use state id?
-    const token = getRouteParam('token');
-    const stateId = getRouteParam('stateId');
+    const token = _DEPRECATED_getSearchParams('token');
+    const stateId = _DEPRECATED_getSearchParams('stateId');
 
     validate(token, stateId, 'axie-infinity', this.setRoute).then((res) => {
       if (typeof res === 'string') {

--- a/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import type { NavigateFunction } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
 import type { Chain } from '@canvas-js/interfaces';
 import { constructCanvasMessage } from 'adapters/shared';
 import { initAppState } from 'state';
-import { navigateToSubpage } from 'router';
 import BN from 'bn.js';
 import { _DEPRECATED_getSearchParams, redraw } from 'mithrilInterop';
 import { ChainBase, WalletId } from 'common-common/src/types';
@@ -30,6 +28,7 @@ import { CWText } from '../components/component_kit/cw_text';
 import { isWindowMediumSmallInclusive } from '../components/component_kit/helpers';
 import { LoginModal } from '../modals/login_modal';
 import { Modal } from '../components/component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 // TODO:
 //  - figure out how account switching will work
@@ -38,7 +37,7 @@ import { Modal } from '../components/component_kit/cw_modal';
 //  - test what happens if the wallet site fails
 //  - move some of this stuff into controllers
 
-const redirectToNextPage = (navigate: NavigateFunction) => {
+const redirectToNextPage = (navigate) => {
   if (
     localStorage &&
     localStorage.getItem &&
@@ -55,7 +54,7 @@ const redirectToNextPage = (navigate: NavigateFunction) => {
         localStorage.removeItem('nearPostAuthRedirect');
         navigate(postAuth.path, { replace: true });
       } else {
-        navigateToSubpage('/', { replace: true });
+        navigate('/', { replace: true });
       }
       return;
     } catch (e) {
@@ -63,11 +62,11 @@ const redirectToNextPage = (navigate: NavigateFunction) => {
     }
   }
 
-  navigateToSubpage('/', { replace: true });
+  navigate('/', { replace: true });
 };
 
 const FinishNearLogin = () => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
   const [validating, setValidating] = React.useState<boolean>(false);
   const [validationCompleted, setValidationCompleted] =
     React.useState<boolean>(false);

--- a/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
@@ -6,7 +6,7 @@ import { constructCanvasMessage } from 'adapters/shared';
 import { initAppState } from 'state';
 import { navigateToSubpage } from 'router';
 import BN from 'bn.js';
-import { getRouteParam, redraw } from 'mithrilInterop';
+import { _DEPRECATED_getSearchParams, redraw } from 'mithrilInterop';
 import { ChainBase, WalletId } from 'common-common/src/types';
 import {
   completeClientLogin,
@@ -138,7 +138,7 @@ const FinishNearLogin = () => {
     }
 
     // tx error handling
-    const failedTx = getRouteParam('tx_failure');
+    const failedTx = _DEPRECATED_getSearchParams('tx_failure');
 
     if (failedTx) {
       console.log(`Login failed: deleting storage key ${failedTx}`);
@@ -153,7 +153,7 @@ const FinishNearLogin = () => {
 
     // tx success handling
     // TODO: ensure that create() calls redirect correctly
-    const savedTx = getRouteParam('saved_tx');
+    const savedTx = _DEPRECATED_getSearchParams('saved_tx');
 
     if (savedTx && localStorage[savedTx]) {
       try {
@@ -182,7 +182,7 @@ const FinishNearLogin = () => {
     // create new chain handling
     // TODO: we need to figure out how to clean this localStorage entry up
     //   in the case of transaction failure!!
-    const chainName = getRouteParam('chain_name');
+    const chainName = _DEPRECATED_getSearchParams('chain_name');
 
     if (chainName && localStorage[chainName]) {
       try {

--- a/packages/commonwealth/client/scripts/views/pages/landing/landing_page_header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/landing/landing_page_header.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import 'pages/landing/landing_page_header.scss';
 
 import { LoginModal } from 'views/modals/login_modal';
 import { isWindowMediumSmallInclusive } from '../../components/component_kit/helpers';
 import { Modal } from '../../components/component_kit/cw_modal';
+import { useCommonNavigate } from 'navigation/helpers';
 
 // eslint-disable-next-line max-len
 const INITIAL_HEADER_STYLE = `bg-white static lg:flex lg:flex-row lg:justify-between
@@ -27,7 +26,7 @@ type HeaderLandingPageProps = {
 };
 
 export const HeaderLandingPage = (props: HeaderLandingPageProps) => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
   React.useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/index.tsx
@@ -6,7 +6,6 @@ import $ from 'jquery';
 import 'pages/manage_community/index.scss';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import type { Webhook } from 'models';
 import { AccessLevel, RoleInfo } from 'models';
 import { ChainMetadataRows } from './chain_metadata_rows';
@@ -14,8 +13,9 @@ import { AdminPanelTabs } from './admin_panel_tabs';
 import Sublayout from '../../sublayout';
 import { PageLoading } from '../loading';
 import { sortAdminsAndModsFirst } from './helpers';
+import withRouter from 'navigation/helpers';
 
-class ManageCommunityPage extends ClassComponent {
+class ManageCommunityPageComponent extends ClassComponent {
   private loadingFinished: boolean;
   private loadingStarted: boolean;
   private roleData: Array<RoleInfo>;
@@ -110,7 +110,7 @@ class ManageCommunityPage extends ClassComponent {
       });
 
     if (!isAdmin) {
-      navigateToSubpage(``);
+      this.setRoute('/');
     }
 
     this.loadingFinished = false;
@@ -166,5 +166,7 @@ class ManageCommunityPage extends ClassComponent {
     );
   }
 }
+
+const ManageCommunityPage = withRouter(ManageCommunityPageComponent);
 
 export default ManageCommunityPage;

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/webhooks_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/webhooks_form.tsx
@@ -16,7 +16,7 @@ import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
 import { Modal } from '../../components/component_kit/cw_modal';
-import {useNavigate} from "react-router-dom";
+import { useCommonNavigate } from 'navigation/helpers';
 
 type WebhooksFormProps = {
   webhooks: Array<Webhook>;
@@ -24,7 +24,7 @@ type WebhooksFormProps = {
 
 export const WebhooksForm = (props: WebhooksFormProps) => {
   const { webhooks } = props;
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
 
   const [disabled, setDisabled] = React.useState<boolean>(false);
   const [webhookUrl, setWebhookUrl] = React.useState<string>('');
@@ -172,7 +172,12 @@ export const WebhooksForm = (props: WebhooksFormProps) => {
           No webhooks yet. Slack, Discord, and Telegram webhooks are supported.
           For more information and examples for setting these up, please view
           our
-          {link('a', 'https://docs.commonwealth.im', [' documentation.'], navigate)}
+          {link(
+            'a',
+            'https://docs.commonwealth.im',
+            [' documentation.'],
+            navigate
+          )}
         </CWText>
       )}
       <CWTextInput

--- a/packages/commonwealth/client/scripts/views/pages/members.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/members.tsx
@@ -13,6 +13,7 @@ import { User } from 'views/components/user/user';
 import Sublayout from 'views/sublayout';
 import { CWSpinner } from '../components/component_kit/cw_spinner';
 import { CWText } from '../components/component_kit/cw_text';
+import withRouter from 'navigation/helpers';
 
 // The number of member profiles that are batch loaded
 const DEFAULT_MEMBER_REQ_SIZE = 20;
@@ -40,6 +41,7 @@ class MembersPage extends ClassComponent {
   private totalMembersCount: number;
 
   view() {
+    console.log('this. props', this.props)
     const activeEntity = app.chain;
 
     if (!activeEntity) return <PageLoading message="Loading members" />;
@@ -229,4 +231,5 @@ class MembersPage extends ClassComponent {
   }
 }
 
-export default MembersPage;
+const a = withRouter(MembersPage);
+export default a;

--- a/packages/commonwealth/client/scripts/views/pages/members.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/members.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Virtuoso } from 'react-virtuoso';
-import { ClassComponent, redraw } from 'mithrilInterop';
+import { ClassComponent } from 'mithrilInterop';
 import _ from 'lodash';
 import $ from 'jquery';
 import type { Profile } from 'models';
@@ -13,7 +13,6 @@ import { User } from 'views/components/user/user';
 import Sublayout from 'views/sublayout';
 import { CWSpinner } from '../components/component_kit/cw_spinner';
 import { CWText } from '../components/component_kit/cw_text';
-import withRouter from 'navigation/helpers';
 
 // The number of member profiles that are batch loaded
 const DEFAULT_MEMBER_REQ_SIZE = 20;
@@ -41,7 +40,6 @@ class MembersPage extends ClassComponent {
   private totalMembersCount: number;
 
   view() {
-    console.log('this. props', this.props)
     const activeEntity = app.chain;
 
     if (!activeEntity) return <PageLoading message="Loading members" />;
@@ -231,5 +229,4 @@ class MembersPage extends ClassComponent {
   }
 }
 
-const a = withRouter(MembersPage);
-export default a;
+export default MembersPage;

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { ClassComponent } from 'mithrilInterop';
 import { Any as ProtobufAny } from 'cosmjs-types/google/protobuf/any';
 
-import { navigateToSubpage } from 'router';
 import { notifyError } from 'controllers/app/notifications';
 import type CosmosAccount from 'controllers/chain/cosmos/account';
 import type Cosmos from 'controllers/chain/cosmos/adapter';
@@ -16,8 +15,9 @@ import { CWRadioGroup } from '../../components/component_kit/cw_radio_group';
 import { CWSpinner } from '../../components/component_kit/cw_spinner';
 import { CWTextArea } from '../../components/component_kit/cw_text_area';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
+import withRouter from 'navigation/helpers';
 
-export class CosmosProposalForm extends ClassComponent {
+class CosmosProposalFormComponent extends ClassComponent {
   private cosmosProposalType: 'textProposal' | 'communitySpend';
   private deposit: number;
   private description: string;
@@ -123,7 +123,7 @@ export class CosmosProposalForm extends ClassComponent {
             cosmos.governance
               .submitProposalTx(author, deposit, prop)
               .then((result) => {
-                navigateToSubpage(`/proposal/${result}`);
+                this.setRoute(`/proposal/${result}`);
               })
               .catch((err) => notifyError(err.message));
           }}
@@ -132,3 +132,5 @@ export class CosmosProposalForm extends ClassComponent {
     );
   }
 }
+
+export const CosmosProposalForm = withRouter(CosmosProposalFormComponent);

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { ClassComponent, redraw, parsePathname } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
 import moment from 'moment';
-import { navigateToSubpage } from 'router';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import type { SnapshotSpace } from 'helpers/snapshot_utils';
 import { getScore } from 'helpers/snapshot_utils';
@@ -24,12 +23,13 @@ import Sublayout from '../../sublayout';
 import { PageLoading } from '../loading';
 import { newLink } from './helpers';
 import type { ThreadForm } from './types';
+import withRouter from 'navigation/helpers';
 
 type NewSnapshotProposalPageAttrs = {
   snapshotId: string;
 };
 
-export class NewSnapshotProposalPage extends ClassComponent<NewSnapshotProposalPageAttrs> {
+class NewSnapshotProposalPageComponent extends ClassComponent<NewSnapshotProposalPageAttrs> {
   private form: ThreadForm;
   private initialized: boolean;
   private isFromExistingProposal: boolean;
@@ -265,7 +265,7 @@ export class NewSnapshotProposalPage extends ClassComponent<NewSnapshotProposalP
 
                 notifySuccess('Snapshot Created!');
 
-                navigateToSubpage(`/snapshot/${this.space.id}`);
+                this.setRoute(`/snapshot/${this.space.id}`);
               } catch (err) {
                 this.saving = false;
 
@@ -278,5 +278,7 @@ export class NewSnapshotProposalPage extends ClassComponent<NewSnapshotProposalP
     );
   }
 }
+
+const NewSnapshotProposalPage = withRouter(NewSnapshotProposalPageComponent);
 
 export default NewSnapshotProposalPage;

--- a/packages/commonwealth/client/scripts/views/pages/new_thread.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_thread.tsx
@@ -1,19 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { navigateToSubpage } from 'router';
 import { notifyInfo } from 'controllers/app/notifications';
 
 import app from 'state';
 import { PageLoading } from 'views/pages/loading';
 import Sublayout from 'views/sublayout';
 import { NewThreadForm } from '../components/new_thread_form/new_thread_form';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const NewThreadPage = () => {
-  if (!app.isLoggedIn()) {
-    notifyInfo('You need to log in first');
-    navigateToSubpage('/login');
-    return;
-  }
+  const navigate = useCommonNavigate();
+
+  useEffect(() => {
+    if (!app.isLoggedIn()) {
+      notifyInfo('You need to log in first');
+      navigate('/login', {}, null);
+      return;
+    }
+  }, [navigate]);
 
   if (!app.chain) return <PageLoading />;
 

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
@@ -7,28 +7,29 @@ import {
   redraw,
 } from 'mithrilInterop';
 import moment from 'moment';
-import { CWEvent, Label as ChainEventLabel } from 'chain-events/src';
+import type { CWEvent } from 'chain-events/src';
+import { Label as ChainEventLabel } from 'chain-events/src';
 
 import 'pages/notifications/notification_row.scss';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import { NotificationCategories } from 'common-common/src/types';
-import { Notification, AddressInfo } from 'models';
-import { link } from 'helpers';
+import type { Notification } from 'models';
+import { AddressInfo } from 'models';
 import { User } from 'views/components/user/user';
 import { UserGallery } from 'views/components/user/user_gallery';
 import { getBatchNotificationFields } from './helpers';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { CWSpinner } from '../../components/component_kit/cw_spinner';
 import { getClasses } from '../../components/component_kit/helpers';
+import withRouter from 'navigation/helpers';
 
 type NotificationRowAttrs = {
   notifications: Array<Notification>;
   onListPage?: boolean;
 };
 
-export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
+export class NotificationRowComponent extends ClassComponent<NotificationRowAttrs> {
   private markingRead: boolean;
   private scrollOrStop: boolean;
 
@@ -105,9 +106,7 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
 
       return (
         <div
-          onClick={() =>
-            navigateToSubpage(`/notifications?id=${notification.id}`)
-          }
+          onClick={() => this.setRoute(`/notifications?id=${notification.id}`)}
         >
           <div className="comment-body">
             <div className="comment-body-top chain-event-notification-top">
@@ -169,7 +168,7 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
       //   route,
 
       return (
-        <div onClick={() => navigateToSubpage(route)}>
+        <div onClick={() => this.setRoute(route)}>
           <User user={author} avatarOnly avatarSize={26} />
           <div className="comment-body">
             <div className="comment-body-title">
@@ -254,7 +253,7 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
       //   path.replace(/ /g, '%20'),
 
       return (
-        <div onClick={() => navigateToSubpage(path.replace(/ /g, '%20'))}>
+        <div onClick={() => this.setRoute(path.replace(/ /g, '%20'))}>
           {authorInfo.length === 1 ? (
             <User
               user={
@@ -337,3 +336,5 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
     }
   }
 }
+
+export const NotificationRow = withRouter(NotificationRowComponent);

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import type { ResultNode } from 'mithrilInterop';
 import {
   ClassComponent,
-  ResultNode,
-  getRouteParam,
+  _DEPRECATED_getSearchParams,
   redraw,
 } from 'mithrilInterop';
 import moment from 'moment';
@@ -34,9 +34,10 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
 
   oncreate(vnode: ResultNode<NotificationRowAttrs>) {
     if (
-      getRouteParam('id') &&
+      _DEPRECATED_getSearchParams('id') &&
       vnode.attrs.onListPage &&
-      getRouteParam('id') === vnode.attrs.notifications[0].id.toString()
+      _DEPRECATED_getSearchParams('id') ===
+        vnode.attrs.notifications[0].id.toString()
     ) {
       this.scrollOrStop = true;
     }
@@ -74,7 +75,7 @@ export class NotificationRow extends ClassComponent<NotificationRowAttrs> {
 
       if (this.scrollOrStop) {
         setTimeout(() => {
-          const el = document.getElementById(getRouteParam('id'));
+          const el = document.getElementById(_DEPRECATED_getSearchParams('id'));
           if (el) el.scrollIntoView();
         }, 1);
 

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -38,7 +38,6 @@ class OverviewPageComponent extends ClassComponent {
   }
 
   view() {
-    console.log('@@@@@ this ptops', this.props);
     const allMonthlyThreads = app.threads.overviewStore.getAll();
     const allPinnedThreads = app.threads.listingStore.getThreads({
       pinned: true,

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { ClassComponent, redraw } from 'mithrilInterop';
 import type { Thread, Topic } from 'models';
-import { navigateToSubpage } from 'router';
 import 'pages/overview/index.scss';
 
 import app from 'state';
@@ -14,8 +13,9 @@ import { isWindowExtraSmall } from '../../components/component_kit/helpers';
 import Sublayout from '../../sublayout';
 import { PageLoading } from '../loading';
 import { TopicSummaryRow } from './topic_summary_row';
+import withRouter from 'navigation/helpers';
 
-class OverviewPage extends ClassComponent {
+class OverviewPageComponent extends ClassComponent {
   private isWindowExtraSmall: boolean;
 
   onResize() {
@@ -38,6 +38,7 @@ class OverviewPage extends ClassComponent {
   }
 
   view() {
+    console.log('@@@@@ this ptops', this.props);
     const allMonthlyThreads = app.threads.overviewStore.getAll();
     const allPinnedThreads = app.threads.listingStore.getThreads({
       pinned: true,
@@ -86,7 +87,7 @@ class OverviewPage extends ClassComponent {
                 label="Latest Threads"
                 iconLeft="home"
                 onClick={() => {
-                  navigateToSubpage('/discussions');
+                  this.setRoute('/discussions');
                 }}
               />
             </div>
@@ -95,7 +96,7 @@ class OverviewPage extends ClassComponent {
                 iconName="plusCircle"
                 iconButtonTheme="black"
                 onClick={() => {
-                  navigateToSubpage('/new/discussion');
+                  this.setRoute('/new/discussion');
                 }}
               />
             ) : (
@@ -104,7 +105,7 @@ class OverviewPage extends ClassComponent {
                 label="Create Thread"
                 iconLeft="plus"
                 onClick={() => {
-                  navigateToSubpage('/new/discussion');
+                  this.setRoute('/new/discussion');
                 }}
               />
             )}
@@ -136,5 +137,7 @@ class OverviewPage extends ClassComponent {
     );
   }
 }
+
+const OverviewPage = withRouter(OverviewPageComponent);
 
 export default OverviewPage;

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { pluralize } from 'helpers';
 import { getProposalUrlPath } from 'identifiers';
-// import { navigateToSubpage } from 'router';
 import type { Thread, Topic } from 'models';
 import type { ResultNode } from 'mithrilInterop';
 import { ClassComponent } from 'mithrilInterop';
@@ -191,7 +190,6 @@ class TopicSummaryRowComponent extends ClassComponent<TopicSummaryRowAttrs> {
                                   if (!confirmed) return;
 
                                   app.threads.delete(thread).then(() => {
-                                    navigateToSubpage('/overview');
                                   });
                                 },
                               },

--- a/packages/commonwealth/client/scripts/views/pages/profile/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/profile/index.ts
@@ -1,11 +1,9 @@
+import type { Component } from 'mithrilInterop';
 import {
-  ClassComponent,
-  ResultNode,
   render,
-  getRoute,
-  getRouteParam,
+  _DEPRECATED_getRoute,
+  _DEPRECATED_getSearchParams,
   redraw,
-  Component,
 } from 'mithrilInterop';
 
 import {
@@ -143,7 +141,9 @@ const loadProfile = async (
   state: IProfilePageState
 ) => {
   const chain =
-    getRouteParam('base') || app.customDomainId() || getRouteParam('scope');
+    _DEPRECATED_getSearchParams('base') ||
+    app.customDomainId() ||
+    _DEPRECATED_getSearchParams('scope');
   const { address } = attrs;
   const chainInfo = app.config.chains.getById(chain);
   let valid = false;
@@ -284,10 +284,12 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
     vnode.state.comments = [];
     vnode.state.refreshProfile = false;
     const chain =
-      getRouteParam('base') || app.customDomainId() || getRouteParam('scope');
+      _DEPRECATED_getSearchParams('base') ||
+      app.customDomainId() ||
+      _DEPRECATED_getSearchParams('scope');
     const { address } = vnode.attrs;
     const chainInfo = app.config.chains.getById(chain);
-    const baseSuffix = getRouteParam('base');
+    const baseSuffix = _DEPRECATED_getSearchParams('base');
 
     if (chainInfo?.base === ChainBase.Substrate) {
       const decodedAddress = decodeAddress(address);
@@ -385,18 +387,18 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
       if (scrollPos > scrollHeight - 400) {
         if (tab === 0) {
           vnode.state.allContentCount += 20;
-          const thisUrl = getRoute();
-          if (getRoute() === thisUrl)
+          const thisUrl = _DEPRECATED_getRoute();
+          if (_DEPRECATED_getRoute() === thisUrl)
             window.location.hash = vnode.state.allContentCount.toString();
         } else if (tab === 1) {
           vnode.state.proposalsContentCount += 20;
-          const thisUrl = getRoute();
-          if (getRoute() === thisUrl)
+          const thisUrl = _DEPRECATED_getRoute();
+          if (_DEPRECATED_getRoute() === thisUrl)
             window.location.hash = vnode.state.proposalsContentCount.toString();
         } else {
           vnode.state.commentsContentCount += 20;
-          const thisUrl = getRoute();
-          if (getRoute() === thisUrl)
+          const thisUrl = _DEPRECATED_getRoute();
+          if (_DEPRECATED_getRoute() === thisUrl)
             window.location.hash = vnode.state.commentsContentCount.toString();
         }
         redraw();
@@ -481,7 +483,9 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
                   // eslint-disable-next-line max-len
                   localStorageScrollYKey: `profile-${
                     vnode.attrs.address
-                  }-${getRouteParam('base')}-${app.activeChainId()}-scrollY`,
+                  }-${_DEPRECATED_getSearchParams(
+                    'base'
+                  )}-${app.activeChainId()}-scrollY`,
                 }),
               vnode.state.tabSelected === 1 &&
                 render(ProfileContent, {
@@ -492,7 +496,9 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
                   // eslint-disable-next-line max-len
                   localStorageScrollYKey: `profile-${
                     vnode.attrs.address
-                  }-${getRouteParam('base')}-${app.activeChainId()}-scrollY`,
+                  }-${_DEPRECATED_getSearchParams(
+                    'base'
+                  )}-${app.activeChainId()}-scrollY`,
                 }),
               vnode.state.tabSelected === 2 &&
                 render(ProfileContent, {
@@ -503,7 +509,9 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
                   // eslint-disable-next-line max-len
                   localStorageScrollYKey: `profile-${
                     vnode.attrs.address
-                  }-${getRouteParam('base')}-${app.activeChainId()}-scrollY`,
+                  }-${_DEPRECATED_getSearchParams(
+                    'base'
+                  )}-${app.activeChainId()}-scrollY`,
                 }),
             ]),
             render('.xs-display-none .col-md-4', [

--- a/packages/commonwealth/client/scripts/views/pages/profile/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/profile/index.ts
@@ -11,7 +11,6 @@ import {
   decodeAddress,
   encodeAddress,
 } from '@polkadot/util-crypto';
-import { navigateToSubpage } from 'router';
 import { bech32 } from 'bech32';
 import bs58 from 'bs58';
 import { ChainBase } from 'common-common/src/types';
@@ -299,9 +298,9 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
       if (!valid) {
         try {
           const encoded = encodeAddress(decodedAddress, ss58Prefix);
-          navigateToSubpage(
-            `/account/${encoded}${baseSuffix ? `?base=${baseSuffix}` : ''}`
-          );
+          // navigateToSubpage(
+          //   `/account/${encoded}${baseSuffix ? `?base=${baseSuffix}` : ''}`
+          // );
         } catch (e) {
           // do nothing if can't encode address
         }
@@ -312,11 +311,11 @@ const ProfilePage: Component<IProfilePageAttrs, IProfilePageState> = {
       if (!valid) {
         try {
           const checksumAddress = toChecksumAddress(address);
-          navigateToSubpage(
-            `/account/${checksumAddress}${
-              baseSuffix ? `?base=${baseSuffix}` : ''
-            }`
-          );
+          // navigateToSubpage(
+          //   `/account/${checksumAddress}${
+          //     baseSuffix ? `?base=${baseSuffix}` : ''
+          //   }`
+          // );
         } catch (e) {
           // do nothing if can't get checksumAddress
         }

--- a/packages/commonwealth/client/scripts/views/pages/profile/profile_bio.ts
+++ b/packages/commonwealth/client/scripts/views/pages/profile/profile_bio.ts
@@ -1,18 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import _ from 'lodash';
 import type { Account } from 'models';
-import {
-  ClassComponent,
-  ResultNode,
-  render,
-  setRoute,
-  getRoute,
-  getRouteParam,
-  redraw,
-  Component,
-} from 'mithrilInterop';
+import type { Component } from 'mithrilInterop';
+import { render, redraw } from 'mithrilInterop';
 import { initChain } from 'helpers/chain';
 import { setActiveAccount } from '../../../controllers/app/login';
 import app from '../../../state';

--- a/packages/commonwealth/client/scripts/views/pages/search/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, getRouteParam, redraw } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getSearchParams, redraw } from 'mithrilInterop';
 import _, { capitalize } from 'lodash';
 import { notifyError } from 'controllers/app/notifications';
 
@@ -225,7 +225,7 @@ class SearchPageComponent extends ClassComponent<SearchPageAttrs> {
   private searchQuery: SearchQuery;
 
   view() {
-    const searchQuery = SearchQuery.fromUrlParams({ url: getRouteParam() });
+    const searchQuery = SearchQuery.fromUrlParams({ url: _DEPRECATED_getSearchParams() });
 
     const { chainScope, searchTerm } = searchQuery;
     const scope = app.isCustomDomain() ? app.customDomainId() : chainScope;

--- a/packages/commonwealth/client/scripts/views/pages/search/search_bar.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/search_bar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClassComponent, getRouteParam } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getSearchParams } from 'mithrilInterop';
 import { notifyError } from 'controllers/app/notifications';
 import { SearchQuery } from 'models';
 import { SearchScope } from 'models/SearchQuery';
@@ -118,7 +118,7 @@ class SearchBarComponent extends ClassComponent {
               isClearable: this.state.searchTerm?.length > 0,
             })}
             placeholder="Search Common"
-            defaultValue={getRouteParam('q') || this.state.searchTerm}
+            defaultValue={_DEPRECATED_getSearchParams('q') || this.state.searchTerm}
             // value={this.state.searchTerm}
             autoComplete="off"
             onFocus={() => {

--- a/packages/commonwealth/client/scripts/views/pages/settings/email_section.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/settings/email_section.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { ClassComponent, getRoute, redraw } from 'mithrilInterop';
+import { ClassComponent, _DEPRECATED_getRoute, redraw } from 'mithrilInterop';
 import $ from 'jquery';
 import type { SocialAccount } from 'models';
-import { navigateToSubpage } from 'router';
 
 import 'pages/settings/email_section.scss';
 
@@ -166,7 +165,7 @@ export class EmailSection extends ClassComponent {
                   'githubPostAuthRedirect',
                   JSON.stringify({
                     timestamp: (+new Date()).toString(),
-                    path: getRoute(),
+                    path: _DEPRECATED_getRoute(),
                   })
                 );
                 document.location = `${app.serverUrl()}/auth/github` as any;
@@ -197,7 +196,7 @@ export class EmailSection extends ClassComponent {
                   'discordPostAuthRedirect',
                   JSON.stringify({
                     timestamp: (+new Date()).toString(),
-                    path: getRoute(),
+                    path: _DEPRECATED_getRoute(),
                   })
                 );
                 document.location = `${app.serverUrl()}/auth/discord` as any;

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/snapshot_proposal_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/snapshot_proposal_card.tsx
@@ -9,17 +9,17 @@ import type { SnapshotProposal } from 'helpers/snapshot_utils';
 import moment from 'moment';
 
 import app from 'state';
-import { navigateToSubpage } from '../../../router';
 import { CWCard } from '../../components/component_kit/cw_card';
 import { CWText } from '../../components/component_kit/cw_text';
 import { ProposalTag } from '../../components/proposal_card/proposal_tag';
+import withRouter from 'navigation/helpers';
 
 type SnapshotProposalCardAttrs = {
   snapshotId: string;
   proposal: SnapshotProposal;
 };
 
-export class SnapshotProposalCard extends ClassComponent<SnapshotProposalCardAttrs> {
+class SnapshotProposalCardComponent extends ClassComponent<SnapshotProposalCardAttrs> {
   view(vnode: ResultNode<SnapshotProposalCardAttrs>) {
     const { proposal } = vnode.attrs;
 
@@ -40,9 +40,9 @@ export class SnapshotProposalCard extends ClassComponent<SnapshotProposalCardAtt
           if (app.chain) {
             localStorage[`${app.activeChainId()}-proposals-scrollY`] =
               window.scrollY;
-            navigateToSubpage(proposalLink);
+            this.setRoute(proposalLink);
           } else {
-            navigateToSubpage(proposalLink);
+            this.setRoute(proposalLink);
           }
         }}
       >
@@ -65,3 +65,5 @@ export class SnapshotProposalCard extends ClassComponent<SnapshotProposalCardAtt
     );
   }
 }
+
+export const SnapshotProposalCard = withRouter(SnapshotProposalCardComponent);

--- a/packages/commonwealth/client/scripts/views/pages/sputnikdaos.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/sputnikdaos.tsx
@@ -14,14 +14,14 @@ import { PageLoading } from 'views/pages/loading';
 import Sublayout from 'views/sublayout';
 import { CWText } from '../components/component_kit/cw_text';
 import { getClasses } from '../components/component_kit/helpers';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type SputnikDaoRowProps = {
   clickable: boolean;
   dao: IDaoInfo;
 };
 
-const SputnikDaoRowComponent = (props: SputnikDaoRowProps) => {
+const SputnikDaoRow = (props: SputnikDaoRowProps) => {
   const { dao, clickable } = props;
   const navigate = useCommonNavigate();
 
@@ -67,9 +67,7 @@ const SputnikDaoRowComponent = (props: SputnikDaoRowProps) => {
   );
 };
 
-const SputnikDaoRow = withRouter(SputnikDaoRowComponent);
-
-const SputnikDAOsPageComponent = () => {
+const SputnikDAOsPage = () => {
   const navigate = useCommonNavigate();
 
   const [daosList, setDaosList] = React.useState<Array<IDaoInfo>>();
@@ -149,8 +147,5 @@ const SputnikDAOsPageComponent = () => {
     </Sublayout>
   );
 };
-
-// TODO remove withRouter from FCs
-const SputnikDAOsPage = withRouter(SputnikDAOsPageComponent);
 
 export default SputnikDAOsPage;

--- a/packages/commonwealth/client/scripts/views/pages/sputnikdaos.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/sputnikdaos.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import type Near from 'controllers/chain/near/adapter';
 import type { IDaoInfo } from 'controllers/chain/near/chain';
@@ -14,8 +14,7 @@ import { PageLoading } from 'views/pages/loading';
 import Sublayout from 'views/sublayout';
 import { CWText } from '../components/component_kit/cw_text';
 import { getClasses } from '../components/component_kit/helpers';
-import withRouter from 'navigation/helpers';
-import { navigateToSubpage } from 'router';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 type SputnikDaoRowProps = {
   clickable: boolean;
@@ -24,6 +23,7 @@ type SputnikDaoRowProps = {
 
 const SputnikDaoRowComponent = (props: SputnikDaoRowProps) => {
   const { dao, clickable } = props;
+  const navigate = useCommonNavigate();
 
   const amountString = (app.chain as Near).chain
     .coins(new BN(dao.amount))
@@ -52,7 +52,7 @@ const SputnikDaoRowComponent = (props: SputnikDaoRowProps) => {
       onClick={(e) => {
         if (clickable) {
           e.preventDefault();
-          navigateToSubpage(`/${dao.contractId}`);
+          navigate(`/${dao.contractId}`, {}, null);
         }
       }}
     >
@@ -70,11 +70,16 @@ const SputnikDaoRowComponent = (props: SputnikDaoRowProps) => {
 const SputnikDaoRow = withRouter(SputnikDaoRowComponent);
 
 const SputnikDAOsPageComponent = () => {
+  const navigate = useCommonNavigate();
+
   const [daosList, setDaosList] = React.useState<Array<IDaoInfo>>();
   const [daosRequested, setDaosRequested] = React.useState<boolean>(false);
 
-  if (app.activeChainId() && app.activeChainId() !== 'near')
-    navigateToSubpage(`/${app.activeChainId()}`);
+  useEffect(() => {
+    if (app.activeChainId() && app.activeChainId() !== 'near') {
+      navigate(`/`);
+    }
+  }, [navigate]);
 
   const activeEntity = app.chain;
   const allCommunities = app.config.chains.getAll();
@@ -145,6 +150,7 @@ const SputnikDAOsPageComponent = () => {
   );
 };
 
+// TODO remove withRouter from FCs
 const SputnikDAOsPage = withRouter(SputnikDAOsPageComponent);
 
 export default SputnikDAOsPage;

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
@@ -9,8 +9,7 @@ import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import type { IconName } from '../../components/component_kit/cw_icons/cw_icon_lookup';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getClasses } from '../../components/component_kit/helpers';
-import withRouter from 'navigation/helpers';
-import { navigateToSubpage } from 'router';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardChainEventRowProps = {
   blockNumber: number;
@@ -22,6 +21,7 @@ export const UserDashboardChainEventRowComponent = (
   props: UserDashboardChainEventRowProps
 ) => {
   const { blockNumber, chain, label } = props;
+  const navigate = useCommonNavigate();
 
   return (
     <div
@@ -31,7 +31,7 @@ export const UserDashboardChainEventRowComponent = (
       )}
       onClick={() => {
         if (label.linkUrl) {
-          navigateToSubpage(label.linkUrl);
+          navigate(label.linkUrl);
         }
       }}
     >
@@ -48,7 +48,7 @@ export const UserDashboardChainEventRowComponent = (
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              this.setRoute(`/${chain}`);
+              navigate(`/${chain}`);
             }}
           >
             <CWText type="caption" fontWeight="medium">

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
@@ -9,7 +9,7 @@ import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import type { IconName } from '../../components/component_kit/cw_icons/cw_icon_lookup';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getClasses } from '../../components/component_kit/helpers';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardChainEventRowProps = {
   blockNumber: number;
@@ -17,7 +17,7 @@ type UserDashboardChainEventRowProps = {
   label: IEventLabel;
 };
 
-export const UserDashboardChainEventRowComponent = (
+export const UserDashboardChainEventRow = (
   props: UserDashboardChainEventRowProps
 ) => {
   const { blockNumber, chain, label } = props;
@@ -70,7 +70,3 @@ export const UserDashboardChainEventRowComponent = (
     </div>
   );
 };
-
-export const UserDashboardChainEventRow = withRouter(
-  UserDashboardChainEventRowComponent
-);

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
@@ -11,13 +11,13 @@ import { getClasses } from '../../components/component_kit/helpers';
 import { UserDashboardChainEventRow } from './user_dashboard_chain_event_row';
 import { UserDashboardRowBottom } from './user_dashboard_row_bottom';
 import { UserDashboardRowTop } from './user_dashboard_row_top';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardRowProps = {
   notification: DashboardActivityNotification;
 };
 
-const UserDashboardRowComponent = (props: UserDashboardRowProps) => {
+export const UserDashboardRow = (props: UserDashboardRowProps) => {
   const { notification } = props;
   const navigate = useCommonNavigate();
 
@@ -78,5 +78,3 @@ const UserDashboardRowComponent = (props: UserDashboardRowProps) => {
     </div>
   );
 };
-
-export const UserDashboardRow = withRouter(UserDashboardRowComponent);

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
@@ -11,8 +11,7 @@ import { getClasses } from '../../components/component_kit/helpers';
 import { UserDashboardChainEventRow } from './user_dashboard_chain_event_row';
 import { UserDashboardRowBottom } from './user_dashboard_row_bottom';
 import { UserDashboardRowTop } from './user_dashboard_row_top';
-import withRouter from 'navigation/helpers';
-import { navigateToSubpage } from 'router';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardRowProps = {
   notification: DashboardActivityNotification;
@@ -20,6 +19,7 @@ type UserDashboardRowProps = {
 
 const UserDashboardRowComponent = (props: UserDashboardRowProps) => {
   const { notification } = props;
+  const navigate = useCommonNavigate();
 
   const {
     commentCount,
@@ -64,7 +64,7 @@ const UserDashboardRowComponent = (props: UserDashboardRowProps) => {
         'UserDashboardRow'
       )}
       onClick={() => {
-        navigateToSubpage(path);
+        navigate(path);
       }}
     >
       <UserDashboardRowTop activityData={notification} category={categoryId} />

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
@@ -10,16 +10,14 @@ import app from 'state';
 import { User } from 'views/components/user/user';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getCommentPreview } from './helpers';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardRowTopProps = {
   activityData: any;
   category: string;
 };
 
-export const UserDashboardRowTopComponent = (
-  props: UserDashboardRowTopProps
-) => {
+export const UserDashboardRowTop = (props: UserDashboardRowTopProps) => {
   const { activityData, category } = props;
   const navigate = useCommonNavigate();
 
@@ -104,5 +102,3 @@ export const UserDashboardRowTopComponent = (
     </div>
   );
 };
-
-export const UserDashboardRowTop = withRouter(UserDashboardRowTopComponent);

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
@@ -10,8 +10,7 @@ import app from 'state';
 import { User } from 'views/components/user/user';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getCommentPreview } from './helpers';
-import withRouter from 'navigation/helpers';
-import { navigateToSubpage } from 'router';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 type UserDashboardRowTopProps = {
   activityData: any;
@@ -22,6 +21,7 @@ export const UserDashboardRowTopComponent = (
   props: UserDashboardRowTopProps
 ) => {
   const { activityData, category } = props;
+  const navigate = useCommonNavigate();
 
   const {
     created_at,
@@ -64,7 +64,7 @@ export const UserDashboardRowTopComponent = (
       onclick={(e: any) => {
         e.preventDefault();
         e.stopPropagation();
-        navigateToSubpage(`/${author_chain}/account/${author_address}`);
+        navigate(`/${author_chain}/account/${author_address}`);
       }}
     />
   );
@@ -80,7 +80,7 @@ export const UserDashboardRowTopComponent = (
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              navigateToSubpage(`/${chain_id}`);
+              navigate(`/${chain_id}`);
             }}
           >
             {communityName}

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/snapshot_space_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/snapshot_space_card.tsx
@@ -6,8 +6,8 @@ import type { Thread } from 'models';
 import 'pages/snapshot/snapshot_space_card.scss';
 import app from 'state';
 import { REDIRECT_ACTIONS } from '.';
-import { navigateToSubpage } from '../../../router';
 import { CWCard } from '../../components/component_kit/cw_card';
+import { useCommonNavigate } from 'navigation/helpers';
 
 function countActiveProposals(proposals: SnapshotProposal[]): number {
   return proposals.filter((proposal) => proposal.state === 'active').length;
@@ -22,6 +22,7 @@ type SnapshotSpaceCardProps = {
 
 export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
   const { space, proposals, redirectAction, proposal } = props;
+  const navigate = useCommonNavigate();
 
   if (!space || !proposals) return;
 
@@ -30,15 +31,15 @@ export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
   function handleClicks() {
     if (redirectAction === REDIRECT_ACTIONS.ENTER_SPACE) {
       app.snapshot.init(space.id).then(() => {
-        navigateToSubpage(`/snapshot/${space.id}`);
+        navigate(`/snapshot/${space.id}`);
       });
     } else if (redirectAction === REDIRECT_ACTIONS.NEW_PROPOSAL) {
       app.snapshot.init(space.id).then(() => {
-        navigateToSubpage(`/new/snapshot/${space.id}`);
+        navigate(`/new/snapshot/${space.id}`);
       });
     } else if (redirectAction === REDIRECT_ACTIONS.NEW_FROM_THREAD) {
       app.snapshot.init(space.id).then(() => {
-        navigateToSubpage(
+        navigate(
           `/new/snapshot/${app.chain.meta.snapshot}` +
             `?fromProposalType=${proposal.slug}&fromProposalId=${proposal.id}`
         );

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { navigateToSubpage } from 'router';
-import { ClassComponent, ResultNode, redraw } from 'mithrilInterop';
+import type { ResultNode } from 'mithrilInterop';
+import { ClassComponent, redraw } from 'mithrilInterop';
 
 import app from 'state';
 import Sublayout from 'views/sublayout';
@@ -34,6 +34,7 @@ import type { LinkedSubstrateProposal } from './linked_proposals_embed';
 import { LinkedProposalsEmbed } from './linked_proposals_embed';
 import type { SubheaderProposalType } from './proposal_components';
 import { ProposalSubheader } from './proposal_components';
+import withRouter from 'navigation/helpers';
 
 type ProposalPrefetch = {
   [identifier: string]: {
@@ -48,7 +49,7 @@ type ViewProposalPageAttrs = {
   type?: string;
 };
 
-class ViewProposalPage extends ClassComponent<ViewProposalPageAttrs> {
+class ViewProposalPageComponent extends ClassComponent<ViewProposalPageAttrs> {
   private comments: Comment<AnyProposal>[];
   private prefetch: ProposalPrefetch;
   private proposal: AnyProposal;
@@ -152,13 +153,12 @@ class ViewProposalPage extends ClassComponent<ViewProposalPageAttrs> {
     }
 
     if (identifier !== `${proposalId}-${slugify(this.proposal.title)}`) {
-      navigateToSubpage(
+      this.setRoute(
         getProposalUrlPath(
           this.proposal.slug,
           `${proposalId}-${slugify(this.proposal.title)}`,
           true
         ),
-        {},
         { replace: true }
       );
     }
@@ -310,5 +310,7 @@ class ViewProposalPage extends ClassComponent<ViewProposalPageAttrs> {
     );
   }
 }
+
+const ViewProposalPage = withRouter(ViewProposalPageComponent);
 
 export default ViewProposalPage;

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_proposals_embed.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/linked_proposals_embed.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { navigateToSubpage } from 'router';
-
 import 'pages/view_proposal/linked_proposals_embed.scss';
 
 import { ProposalType } from 'common-common/src/types';
@@ -16,6 +14,7 @@ import 'pages/view_proposal/linked_proposals_embed.scss';
 import app from 'state';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWText } from '../../components/component_kit/cw_text';
+import { useCommonNavigate } from 'navigation/helpers';
 
 export type LinkedSubstrateProposal =
   | SubstrateDemocracyProposal
@@ -28,6 +27,7 @@ type LinkedProposalsEmbedProps = {
 
 export const LinkedProposalsEmbed = (props: LinkedProposalsEmbedProps) => {
   const { proposal } = props;
+  const navigate = useCommonNavigate();
 
   // show link to treasury proposal if this is a proposal that passes a treasury spend
   if (
@@ -84,7 +84,7 @@ export const LinkedProposalsEmbed = (props: LinkedProposalsEmbedProps) => {
                   buttonType="tertiary-blue"
                   onClick={(e) => {
                     e.preventDefault();
-                    navigateToSubpage(
+                    navigate(
                       `/proposal/${ProposalType.SubstrateDemocracyReferendum}/${
                         proposal.getReferendum().identifier
                       }`
@@ -108,7 +108,7 @@ export const LinkedProposalsEmbed = (props: LinkedProposalsEmbedProps) => {
                   buttonType="tertiary-blue"
                   onClick={(e) => {
                     e.preventDefault();
-                    navigateToSubpage(
+                    navigate(
                       `/proposal/${
                         proposal.getProposalOrMotion(proposal.preimage).slug
                       }/${
@@ -167,7 +167,7 @@ export const LinkedProposalsEmbed = (props: LinkedProposalsEmbedProps) => {
                 buttonType="tertiary-blue"
                 onClick={(e) => {
                   e.preventDefault();
-                  navigateToSubpage(
+                  navigate(
                     `/proposal/${ProposalType.SubstrateDemocracyProposal}/${p.identifier}`
                   );
                 }}
@@ -190,7 +190,7 @@ export const LinkedProposalsEmbed = (props: LinkedProposalsEmbedProps) => {
                 buttonType="tertiary-blue"
                 onClick={(e) => {
                   e.preventDefault();
-                  navigateToSubpage(
+                  navigate(
                     `/proposal/${ProposalType.SubstrateDemocracyReferendum}/${r.identifier}`
                   );
                 }}

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
@@ -95,7 +95,7 @@ class SnapshotThreadLinkComponent extends ClassComponent<SnapshotThreadLinkAttrs
   view(vnode: ResultNode<SnapshotThreadLinkAttrs>) {
     const { id, title } = vnode.attrs.thread;
 
-    const proposalLink = getProposalUrlPath(ProposalType.Thread, id);
+    const proposalLink = getProposalUrlPath(ProposalType.Thread, id, true);
 
     return (
       <div className="HeaderLink">

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/edit_body.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/edit_body.tsx
@@ -10,7 +10,7 @@ import { CWButton } from '../../components/component_kit/cw_button';
 import type { QuillEditor } from '../../components/quill/quill_editor';
 import { QuillEditorComponent } from '../../components/quill/quill_editor_component';
 import { confirmationModalWithText } from '../../modals/confirm_modal';
-import { navigateToSubpage } from 'router';
+import { useCommonNavigate } from 'navigation/helpers';
 
 type EditBodyProps = {
   savedEdits: string;
@@ -21,6 +21,7 @@ type EditBodyProps = {
 };
 
 export const EditBody = (props: EditBodyProps) => {
+  const navigate = useCommonNavigate();
   const [quillEditorState, setQuillEditorState] = React.useState<QuillEditor>();
   const [saving, setSaving] = React.useState<boolean>(false);
   const { shouldRestoreEdits, savedEdits, thread, setIsEditing, title } = props;
@@ -77,7 +78,7 @@ export const EditBody = (props: EditBodyProps) => {
             const itemText = quillEditorState.textContentsAsString;
 
             app.threads.edit(thread, itemText, title).then(() => {
-              navigateToSubpage(`/discussion/${thread.id}`);
+              navigate(`/discussion/${thread.id}`);
               setSaving(false);
               clearEditingLocalStorage(thread.id, ContentType.Thread);
               setIsEditing(false);

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { navigateToSubpage } from 'router';
 import { ProposalType } from 'common-common/src/types';
 import { notifyError } from 'controllers/app/notifications';
 import TopicGateCheck from 'controllers/chain/ethereum/gatedTopic';
@@ -40,6 +39,7 @@ import { LinkedProposalsCard } from './linked_proposals_card';
 import { LinkedThreadsCard } from './linked_threads_card';
 import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
 import { ExternalLink, ThreadAuthor, ThreadStage } from './thread_components';
+import { useCommonNavigate } from 'navigation/helpers';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -57,7 +57,7 @@ type ViewThreadPageAttrs = {
 };
 
 const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
-  // React.Component<ViewThreadPageAttrs & { thread: Thread }> = () =>
+  const navigate = useCommonNavigate();
   const [comments, setComments] = useState<Array<Comment<Thread>>>();
   const [isEditingBody, setIsEditingBody] = useState<boolean>();
   const [isGloballyEditing, setIsGloballyEditing] = useState<boolean>();
@@ -197,13 +197,12 @@ const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
   }
 
   if (identifier !== `${threadId}-${slugify(thread.title)}`) {
-    navigateToSubpage(
+    navigate(
       getProposalUrlPath(
         thread.slug,
         `${threadId}-${slugify(thread.title)}`,
         true
       ),
-      {},
       { replace: true }
     );
   }
@@ -570,7 +569,7 @@ const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
                 if (!confirmed) return;
 
                 app.threads.delete(thread).then(() => {
-                  navigateToSubpage('/discussions');
+                  navigate('/discussions');
                 });
               },
             },
@@ -606,12 +605,9 @@ const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
                 const snapshotSpaces = app.chain.meta.snapshot;
 
                 if (snapshotSpaces.length > 1) {
-                  navigateToSubpage('/multiple-snapshots', {
-                    action: 'create-from-thread',
-                    thread,
-                  });
+                  navigate('/multiple-snapshots');
                 } else {
-                  navigateToSubpage(`/snapshot/${snapshotSpaces}`);
+                  navigate(`/snapshot/${snapshotSpaces}`);
                 }
               },
             },

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
@@ -58,7 +58,8 @@ export const LinkedThreadsCard = (props: LinkedThreadsCardProps) => {
                 {linkedThreads.map((t) => {
                   const discussionLink = getProposalUrlPath(
                     t.slug,
-                    `${t.identifier}-${slugify(t.title)}`
+                    `${t.identifier}-${slugify(t.title)}`,
+                    true
                   );
 
                   return <a href={discussionLink}>{t.title}</a>;

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
@@ -3,7 +3,6 @@ import { ClassComponent } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import {
   externalLink,
   extractDomain,
@@ -21,7 +20,7 @@ import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getClasses } from '../../components/component_kit/helpers';
 import { User } from '../../components/user/user';
-import withRouter from 'navigation/helpers';
+import withRouter, { useCommonNavigate } from 'navigation/helpers';
 
 type ThreadComponentProps = {
   thread: Thread;
@@ -68,6 +67,7 @@ export const ThreadAuthor = (props: ThreadComponentProps) => {
 
 export const ThreadStage = (props: ThreadComponentProps) => {
   const { thread } = props;
+  const navigate = useCommonNavigate();
 
   return (
     <CWText
@@ -89,7 +89,7 @@ export const ThreadStage = (props: ThreadComponentProps) => {
       )}
       onClick={(e) => {
         e.preventDefault();
-        navigateToSubpage(`?stage=${thread.stage}`);
+        navigate(`?stage=${thread.stage}`);
       }}
     >
       {threadStageToLabel(thread.stage)}

--- a/packages/commonwealth/client/scripts/views/pages/web3login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/web3login.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { link } from 'helpers';
 
-import { getRouteParam, redraw } from 'mithrilInterop';
+import { _DEPRECATED_getSearchParams, redraw } from 'mithrilInterop';
 import $ from 'jquery';
 
 import 'pages/web3login.scss';
@@ -24,7 +24,7 @@ const Web3LoginPage = () => {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
-  const token = getRouteParam('connect');
+  const token = _DEPRECATED_getSearchParams('connect');
 
   if (app.isCustomDomain() || !token) {
     // hide page if invalid arguments or via custom domain
@@ -89,10 +89,10 @@ const Web3LoginPage = () => {
                 }
               }}
             />
-            {getRouteParam('prev')
+            {_DEPRECATED_getSearchParams('prev')
               ? link(
                   'a.web3login-go-home',
-                  getRouteParam('prev'),
+                  _DEPRECATED_getSearchParams('prev'),
                   'Go back',
                   navigate
                 )

--- a/packages/commonwealth/client/scripts/views/pages/web3login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/web3login.tsx
@@ -16,10 +16,10 @@ import { PageNotFound } from './404';
 import { PageLoading } from './loading';
 import { isNonEmptyString } from 'helpers/typeGuards';
 import { Modal } from '../components/component_kit/cw_modal';
-import { useNavigate } from 'react-router-dom';
+import { useCommonNavigate } from 'navigation/helpers';
 
 const Web3LoginPage = () => {
-  const navigate = useNavigate();
+  const navigate = useCommonNavigate();
   const [errorMsg, setErrorMsg] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);

--- a/packages/commonwealth/client/scripts/views/pages/why_commonwealth.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/why_commonwealth.tsx
@@ -5,9 +5,11 @@ import { CWButton } from '../components/component_kit/cw_button';
 
 import { CWText } from '../components/component_kit/cw_text';
 import Sublayout from '../sublayout';
-import withRouter from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 
-const WhyCommonwealthPageComponent = () => {
+const WhyCommonwealthPage = () => {
+  const navigate = useCommonNavigate();
+
   return (
     <Sublayout>
       <div className="WhyCommonwealthPage">
@@ -35,7 +37,7 @@ const WhyCommonwealthPageComponent = () => {
             label="Explore Our Communities"
             onClick={(e) => {
               e.preventDefault();
-              this.setRoute('/communities');
+              navigate('/communities', {}, null);
             }}
           />
           <CWText>
@@ -71,7 +73,5 @@ const WhyCommonwealthPageComponent = () => {
     </Sublayout>
   );
 };
-
-const WhyCommonwealthPage = withRouter(WhyCommonwealthPageComponent);
 
 export default WhyCommonwealthPage;

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ClassComponent,
-  ResultNode,
-  getRouteParam,
-  redraw,
-} from 'mithrilInterop';
+import type { ResultNode} from 'mithrilInterop';
+import { ClassComponent, redraw } from 'mithrilInterop';
 
 import app from 'state';
 

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -270,6 +270,7 @@
     "chai-http": "^4.3.0",
     "esbuild-loader": "^2.16.0",
     "eslint-import-resolver-webpack": "^0.12.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "ganache-cli": "^6.9.1",
     "mocha": "^6.2.2",
     "nyc": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9537,6 +9537,11 @@ eslint-plugin-prettier@^3.1.2:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added `eslint-plugin-react-hooks` 
- changed names of four functions to indicate that they should not be used anymore for new development. 
  - `_DEPRECATED_getSearchParams`
  - `_DEPRECATED_getRoute`
  - `_DEPRECATED_dangerouslySetRoute`
  - `_DEPRECATED_redirectRoute`
- removed `navigateToSubpage` function
- created `useCommonNavigation` hook that since now should be always used for internal navigation from functional component
  - it handles scope internally but also gives ability to override prefix
  -  <img width="680" alt="image" src="https://user-images.githubusercontent.com/14819225/218747769-98e1456a-7c7f-4085-b579-91db5c46a469.png">
- removed unnecessary `withRouter` from functional components
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2748 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
