### PR TITLE
Add comments + eliminate address chain dependency in creation flow.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/search.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/search.ts
@@ -184,11 +184,10 @@ class SearchController {
     params: SearchParams,
     order?: string[]
   ) => {
-    const { resultSize, communityScope, chainScope } = params;
+    const { resultSize, chainScope } = params;
     try {
       const response = await $.get(`${app.serverUrl()}/bulkAddresses`, {
         chain: chainScope,
-        community: communityScope,
         limit: resultSize,
         searchTerm,
         order,

--- a/packages/commonwealth/client/scripts/models/SearchQuery.ts
+++ b/packages/commonwealth/client/scripts/models/SearchQuery.ts
@@ -14,7 +14,6 @@ export enum SearchSort {
 }
 
 export interface SearchParams {
-  communityScope?: string;
   chainScope?: string;
   isSearchPreview?: boolean;
   searchScope?: Array<SearchScope>;

--- a/packages/commonwealth/server/middleware/lookupAddressIsOwnedByUser.ts
+++ b/packages/commonwealth/server/middleware/lookupAddressIsOwnedByUser.ts
@@ -21,7 +21,6 @@ export const filterAddressOwnedByUser = async (
   addressIds: number[]
 ): Promise<{ owned: AddressInstance[]; unowned: UnownedAddresses[] }> => {
   const where = {
-    chain: { [Op.in]: chains },
     user_id,
   };
 
@@ -34,7 +33,7 @@ export const filterAddressOwnedByUser = async (
 
   // get the list of addresses owned by user
   let addressesOwnedByUser: AddressInstance[] = await models.Address.findAll({
-    where,
+    where
   });
   addressesOwnedByUser = addressesOwnedByUser.filter((a) => a.verified);
 
@@ -69,7 +68,6 @@ const lookupAddressIsOwnedByUser = async (
 
   const author = await models.Address.findOne({
     where: {
-      chain: req.body.author_chain,
       address: req.body.address,
       user_id: req.user.id,
     },

--- a/packages/commonwealth/server/routes/bulkAddresses.ts
+++ b/packages/commonwealth/server/routes/bulkAddresses.ts
@@ -40,6 +40,8 @@ const bulkAddresses = async (models: DB, req, res) => {
   }
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
+  // TODO: this is going to cause TROUBLE -- we should consider deprecating, or at least
+  //  rethinking the mentioning feature.
   const addresses = await models.Address.findAll(options);
   return res.json({
     status: 'Success',

--- a/packages/commonwealth/server/routes/bulkAddresses.ts
+++ b/packages/commonwealth/server/routes/bulkAddresses.ts
@@ -1,25 +1,34 @@
 /* eslint-disable dot-notation */
 import Sequelize from 'sequelize';
+import type { FindOptions } from 'sequelize'
+import type { AddressAttributes } from '../models/address';
 import type { DB } from '../models';
 
 const { Op } = Sequelize;
 
 // the bulkAddress route takes a chain/community (mandatory) and a limit & order (both optional)
-// If a chain is supplied, queried addresses are limited to being on said chain.
-// If a community is supplied, all addresses with names (i.e. registered with profiles) are queried.
+// If a chain is supplied, queried addresses are limited to having roles on said chain.
 // If a limit is supplied, the query will only return X results.
 // If an order is supplied (e.g. ['name', 'ASC'], the results will be first & accordingly sorted.
 // Otherwise, it defaults to returning them in order of ['created_at', 'DESC'] (following to /bulkMembers).
 
 const bulkAddresses = async (models: DB, req, res) => {
-  const options = {
-    order: req.query.order ? [[req.query.order]] : [['created_at', 'DESC']],
+  const options: FindOptions<AddressAttributes> = {
+    order: req.query.order ? [req.query.order as [string, string]] : [['created_at', 'DESC']],
   };
 
-  if (req.query.limit) options['limit'] = req.query.limit;
+  if (req.query.limit) options.limit = req.query.limit;
 
   if (req.query.chain) {
-    options['where'] = { chain: req.query.chain };
+    options.include = {
+      model: models.RoleAssignment,
+      required: true,
+      include: [{
+        model: models.CommunityRole,
+        required: true,
+        where: { chain_id: req.query.chain }
+      }],
+    };
   }
 
   if (req.query.searchTerm?.length) {
@@ -34,14 +43,9 @@ const bulkAddresses = async (models: DB, req, res) => {
         },
       ],
     };
-    options['where'] = options['where']
-      ? Object.assign(options['where'], subStr)
-      : subStr;
+    options.where = subStr;
   }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // TODO: this is going to cause TROUBLE -- we should consider deprecating, or at least
-  //  rethinking the mentioning feature.
+
   const addresses = await models.Address.findAll(options);
   return res.json({
     status: 'Success',

--- a/packages/commonwealth/server/routes/bulkProfiles.ts
+++ b/packages/commonwealth/server/routes/bulkProfiles.ts
@@ -36,6 +36,7 @@ const bulkProfiles = async (
   let addrObjs;
   // if all profiles are on the same chain, make a fast query, otherwise, make multiple queries
   if (_.uniq(chains).length === 1) {
+    // TODO: this is now an invalid query. what to do? use roles instead?
     addrObjs = await models.Address.findAll({
       where: {
         chain: chains[0],

--- a/packages/commonwealth/server/routes/communities/putCommunities.ts
+++ b/packages/commonwealth/server/routes/communities/putCommunities.ts
@@ -91,7 +91,6 @@ export async function putCommunities(
           const r: CreateAddressReq = {
             address,
             chain: community.id,
-            community: community.id,
             wallet_id: null,
           };
 

--- a/packages/commonwealth/server/routes/createAddress.ts
+++ b/packages/commonwealth/server/routes/createAddress.ts
@@ -18,8 +18,6 @@ export type CreateAddressReq = {
   address: string;
   chain: string;
   wallet_id: WalletId;
-  community?: string;
-  keytype?: string;
   block_info?: string;
 };
 

--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -385,6 +385,7 @@ const createChain = async (
   let role: RoleInstanceWithPermission | undefined;
   let addressToBeAdmin: AddressInstance | undefined;
 
+  // TODO: how do we move away from chain here?
   if (chain.base === ChainBase.Ethereum) {
     addressToBeAdmin = await models.Address.findOne({
       where: {

--- a/packages/commonwealth/server/routes/createComment.ts
+++ b/packages/commonwealth/server/routes/createComment.ts
@@ -325,6 +325,7 @@ const createComment = async (
     if (mentions && mentions.length > 0) {
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
+          // TODO: how do we remove chain here?
           const user = await models.Address.findOne({
             where: {
               chain: mention[0] || null,

--- a/packages/commonwealth/server/routes/createThread.ts
+++ b/packages/commonwealth/server/routes/createThread.ts
@@ -117,6 +117,7 @@ const dispatchHooks = async (
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
           try {
+            // TODO: how do we move away from chain here?
             return models.Address.findOne({
               where: {
                 chain: mention[0] || null,

--- a/packages/commonwealth/server/routes/deleteAddress.ts
+++ b/packages/commonwealth/server/routes/deleteAddress.ts
@@ -27,6 +27,7 @@ const deleteAddress = async (
     return next(new AppError(Errors.NeedChain));
   }
 
+  // TODO: is this safe to remove chain here? is this called where we expect to remove roles?
   const addressObj = await models.Address.findOne({
     where: { chain: req.body.chain, address: req.body.address },
   });

--- a/packages/commonwealth/server/routes/deleteChain.ts
+++ b/packages/commonwealth/server/routes/deleteChain.ts
@@ -161,6 +161,7 @@ const deleteChain = async (
         transaction: t,
       });
 
+      // TODO: delete roles instead?
       const addresses = await models.Address.findAll({
         where: { chain: chain.id },
       });

--- a/packages/commonwealth/server/routes/deleteEditors.ts
+++ b/packages/commonwealth/server/routes/deleteEditors.ts
@@ -42,6 +42,7 @@ const deleteEditors = async (
 
   await Promise.all(
     editors.map(async (editor: any) => {
+      // TODO: how to move away from Chain here?
       const address = await models.Address.findOne({
         where: {
           chain: editor.chain,

--- a/packages/commonwealth/server/routes/editComment.ts
+++ b/packages/commonwealth/server/routes/editComment.ts
@@ -201,6 +201,7 @@ const editComment = async (
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
           try {
+            // TODO: how to move away from Chain here?
             const user = await models.Address.findOne({
               where: {
                 chain: mention[0],

--- a/packages/commonwealth/server/routes/editSubstrateSpec.ts
+++ b/packages/commonwealth/server/routes/editSubstrateSpec.ts
@@ -6,6 +6,7 @@ import { findAllRoles } from '../util/roles';
 
 import testSubstrateSpec from '../util/testSubstrateSpec';
 
+// TODO: deprecate / delete outright
 const editSubstrateSpec = async (
   models: DB,
   req: Request,

--- a/packages/commonwealth/server/routes/editThread.ts
+++ b/packages/commonwealth/server/routes/editThread.ts
@@ -230,6 +230,7 @@ const editThread = async (
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
           try {
+            // TODO: how to move away from Chain here?
             const user = await models.Address.findOne({
               where: {
                 chain: mention[0],

--- a/packages/commonwealth/server/routes/finishSsoLogin.ts
+++ b/packages/commonwealth/server/routes/finishSsoLogin.ts
@@ -136,7 +136,6 @@ const finishSsoLogin = async (
     {
       where: {
         address: checksumAddress,
-        chain: 'axie-infinity',
       },
       include: [
         {

--- a/packages/commonwealth/server/routes/getAddressStatus.ts
+++ b/packages/commonwealth/server/routes/getAddressStatus.ts
@@ -11,6 +11,7 @@ export const Errors = {
   InvalidChain: 'Invalid chain',
 };
 
+// TODO: where is this used? can we get rid of chain?
 const getAddressStatus = async (
   models: DB,
   req: Request,

--- a/packages/commonwealth/server/routes/getProfile.ts
+++ b/packages/commonwealth/server/routes/getProfile.ts
@@ -29,6 +29,7 @@ const getProfile = async (
   if (!chain) throw new AppError(Errors.NoChain);
   if (!address) throw new AppError(Errors.NoAddress);
 
+  // TODO: how to move away from Chain here?
   const addressModel = await models.Address.findOne({
     where: {
       address,

--- a/packages/commonwealth/server/routes/setDefaultRole.ts
+++ b/packages/commonwealth/server/routes/setDefaultRole.ts
@@ -10,6 +10,7 @@ export const Errors = {
   RoleDNE: 'Role does not exist',
 };
 
+// TODO: what does this do & how to move away from Chain here?
 const setDefaultRole = async (
   models: DB,
   req,

--- a/packages/commonwealth/server/routes/updateAddress.ts
+++ b/packages/commonwealth/server/routes/updateAddress.ts
@@ -25,6 +25,7 @@ const updateAddress = async (
   const transaction = await sequelize.transaction();
   try {
     if (req.user.id) {
+      // TODO: how to move away from Chain here?
       const { id: ghostAddressId } =
         (await models.Address.scope('withPrivateData').findOne({
           where: { chain, ghost_address: true, user_id: req.user.id },

--- a/packages/commonwealth/server/routes/updateProfile.ts
+++ b/packages/commonwealth/server/routes/updateProfile.ts
@@ -19,6 +19,7 @@ export const Errors = {
   BioTooLong: `Bio must be less than ${PROFILE_BIO_MAX_CHARS} characters`,
 };
 
+// TODO: how to move away from Chain here?
 const updateProfile = async (
   models: DB,
   req: Request,

--- a/packages/commonwealth/server/routes/upgradeMember.ts
+++ b/packages/commonwealth/server/routes/upgradeMember.ts
@@ -40,6 +40,8 @@ const upgradeMember = async (
 
   if (requesterAdminRoles.length < 1 && !req.user.isAdmin)
     return next(new AppError(Errors.MustBeAdmin));
+
+  // TODO: how to move away from Chain here?
   const memberAddress = await models.Address.findOne({
     where: {
       address,

--- a/packages/commonwealth/server/ruleTypes/adminOnly.ts
+++ b/packages/commonwealth/server/ruleTypes/adminOnly.ts
@@ -22,7 +22,7 @@ export default class AdminOnlyRule extends RuleType<SchemaT> {
     transaction?: Transaction
   ): Promise<boolean> {
     const addressInstance = await models.Address.findOne({
-      where: { address, chain },
+      where: { address },
     });
     const role = await findOneRole(
       models,

--- a/packages/commonwealth/server/scripts/setupAppRoutes.ts
+++ b/packages/commonwealth/server/scripts/setupAppRoutes.ts
@@ -107,6 +107,7 @@ const setupAppRoutes = (
   app.get('/:scope/account/:address', async (req, res) => {
     // Retrieve title, description, and author from the database
     let title, description, author, profileData, image;
+    // TODO: how to move away from Chain here?
     const address = await models.Address.findOne({
       where: { chain: req.params.scope, address: req.params.address },
       include: [models.OffchainProfile],

--- a/packages/commonwealth/server/socket/chatNs.ts
+++ b/packages/commonwealth/server/socket/chatNs.ts
@@ -36,6 +36,7 @@ const handleMentions = async (
     if (mentions && mentions.length > 0) {
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
+          // TODO: how to move away from Chain here?
           const user = await models.Address.findOne({
             where: {
               chain: mention[0] || null,

--- a/packages/commonwealth/server/socket/createChatNamespace.ts
+++ b/packages/commonwealth/server/socket/createChatNamespace.ts
@@ -33,6 +33,7 @@ const handleMentions = async (
     if (mentions && mentions.length > 0) {
       mentionedAddresses = await Promise.all(
         mentions.map(async (mention) => {
+          // TODO: how to move away from Chain here?
           const user = await models.Address.findOne({
             where: {
               chain: mention[0] || null,

--- a/packages/commonwealth/server/util/banCheckCache.ts
+++ b/packages/commonwealth/server/util/banCheckCache.ts
@@ -48,24 +48,6 @@ export default class BanCache extends JobRunner<CacheT> {
       return [false, BanErrors.Banned];
     }
 
-    // then, validate against db
-    // const addressInstance = await this._models.Address.findOne({
-    //   where: {
-    //     chain: chain_id, address
-    //   }
-    // });
-    // if (!addressInstance?.user_id) {
-    //   // TODO: is this the correct behavior when address is not found?
-    //   return [false, BanErrors.NoAddress];
-    // }
-
-    // const allAddressesOwnedByUser = await this._models.Address.findAll({
-    //   where: {
-    //     user_id: addressInstance.user_id,
-    //     chain: chain_id,
-    //   }
-    // });
-
     const ban = await this._models.Ban.findOne({
       where: {
         chain_id,

--- a/packages/commonwealth/server/webhookNotifier.ts
+++ b/packages/commonwealth/server/webhookNotifier.ts
@@ -125,7 +125,6 @@ const send = async (models, content: WebhookContent) => {
     address = await models.Address.findOne({
       where: {
         address: content.user,
-        chain: content.author_chain,
       },
     });
   } catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #2796 

## Description
<!--- Describe your changes in detail -->
- Modifies creation flow from `createAddress (unverified, no user) -> createRole -> verifyAddress (verified, has user)` to `createAddress -> verifyAddress -> createRole` (i.e. we should ONLY have roles on verified addresses).
- Starts identifying places where we query address based on their chain -- unfortunately there are a lot of places. The question is, how shall we resolve this broken model?
