### PR TITLE
Cleanup Addresses.profile_id.

### DIFF
--- a/packages/commonwealth/server/migrations/20230223012856-cleanup-address-profile-id.js
+++ b/packages/commonwealth/server/migrations/20230223012856-cleanup-address-profile-id.js
@@ -40,5 +40,5 @@ module.exports = {
 
   down: async (queryInterface, Sequelize) => {
     // IRREVERSIBLE
-  }
+  },
 };

--- a/packages/commonwealth/server/migrations/20230223012856-cleanup-address-profile-id.js
+++ b/packages/commonwealth/server/migrations/20230223012856-cleanup-address-profile-id.js
@@ -1,0 +1,44 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      // FIRST: if an address does not have a user_id, remove its profile_id
+      await queryInterface.sequelize.query(
+        `UPDATE "Addresses" SET profile_id = NULL WHERE user_id IS NULL;`,
+        { transaction }
+      );
+
+      // THEN, fix addresses by replacing their profile_id with the profile associated with their user_id
+      // This is safe because we have a mandatory 1-to-1 User <> Profile mapping, (verify this beforehand:
+      // `SELECT user_id, count(*) FROM "Profiles" GROUP BY user_id HAVING count(*) > 1;`) -- we expect
+      // to see ~450 Address rows updated. Check the log output to verify.
+      const [addresses] = await queryInterface.sequelize.query(
+        `
+          SELECT a.id
+          FROM "Addresses" a
+          JOIN "Profiles" p
+          ON a.user_id = p.user_id
+          WHERE a.user_id IS NOT NULL AND a.profile_id != p.id;
+        `,
+        { transaction }
+      );
+      const [, metadata] = await queryInterface.sequelize.query(
+        `
+          UPDATE "Addresses" a
+          SET profile_id = p.id
+          FROM "Profiles" p
+          WHERE a.user_id IS NOT NULL
+            AND a.user_id = p.user_id
+            AND a.id IN (${addresses.map((a) => a.id).join(',')});
+        `,
+        { transaction }
+      );
+      console.log(`Update ${metadata.rowCount} Addresses to new profile_id.`);
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // IRREVERSIBLE
+  }
+};

--- a/packages/commonwealth/server/routes/deleteAddress.ts
+++ b/packages/commonwealth/server/routes/deleteAddress.ts
@@ -38,8 +38,10 @@ const deleteAddress = async (
   }
 
   try {
+    addressObj.profile_id = null;
     addressObj.user_id = null;
     addressObj.verified = null;
+    addressObj.name = null;
     await addressObj.save();
     return res.json({ status: 'Success', response: 'Deleted address' });
   } catch (err) {

--- a/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
@@ -126,7 +126,7 @@ const linkExistingAddressToChain = async (
       // Address.updateWithTokenProvided
       existingAddress.user_id = userId;
       const profileId = await models.Profile.findOne({
-        where: { user_id: userId }
+        where: { user_id: userId },
       });
       existingAddress.profile_id = profileId?.id;
       existingAddress.keytype = req.body.keytype;

--- a/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
@@ -133,6 +133,7 @@ const linkExistingAddressToChain = async (
       existingAddress.verification_token = verificationToken;
       existingAddress.verification_token_expires = verificationTokenExpires;
       existingAddress.last_active = new Date();
+      existingAddress.name = originalAddress.name;
       const updatedObj = await existingAddress.save();
       addressId = updatedObj.id;
     } else {

--- a/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
@@ -125,6 +125,10 @@ const linkExistingAddressToChain = async (
       //   we can just update with userId. this covers both edge case (1) & (2)
       // Address.updateWithTokenProvided
       existingAddress.user_id = userId;
+      const profileId = await models.Profile.findOne({
+        where: { user_id: userId }
+      });
+      existingAddress.profile_id = profileId?.id;
       existingAddress.keytype = req.body.keytype;
       existingAddress.verification_token = verificationToken;
       existingAddress.verification_token_expires = verificationTokenExpires;

--- a/packages/commonwealth/server/util/createAddressHelper.ts
+++ b/packages/commonwealth/server/util/createAddressHelper.ts
@@ -110,6 +110,10 @@ export async function createAddressHelper(
     );
     if (updatedId) {
       existingAddress.user_id = updatedId;
+      const profileId = await models.Profile.findOne({
+        where: { user_id: updatedId }
+      });
+      existingAddress.profile_id = profileId?.id;
     }
     existingAddress.keytype = req.keytype;
     existingAddress.verification_token = verification_token;

--- a/packages/commonwealth/server/util/createAddressHelper.ts
+++ b/packages/commonwealth/server/util/createAddressHelper.ts
@@ -111,7 +111,7 @@ export async function createAddressHelper(
     if (updatedId) {
       existingAddress.user_id = updatedId;
       const profileId = await models.Profile.findOne({
-        where: { user_id: updatedId }
+        where: { user_id: updatedId },
       });
       existingAddress.profile_id = profileId?.id;
     }


### PR DESCRIPTION
## Description

Closes: #2903. Mandatory before merging #2508.

- Fixes the missing `profile_id` handling on `deleteAddress`, `createAddress`, and `linkExistingAddressToChain` routes.
- Adds a migration to cleanup mishandled addresses. Two cases here:
    - (1) if `user_id` is null (i.e. deleted), then we must also delete profile_id, and
    - (2) if the User referred to via `user_id` does not match the Profile referred to via `profile_id`, we update `profile_id` to match the expected Profile. As noted in the migration comment, this is safe because we enforce a 1-to-1 relationship between Users and Profiles.
    
    The mismatch occurs either when deleting an Address (which previously did not clear the `profile_id`) via /deleteAddress, and then re-creating it via /createAddress as a new User (which would set `user_id`, but leave the "dead" `profile_id`), or else taking ownership of it from another User who had already linked the same address on the same Chain via /linkExistingAddressToChain.

## Testing
- Verified the deleteAddress then createAddress case properly updated the Address row's `user_id` and `profile_id`.
- Verified the linkExistingAddressToChain case properly updated the transferred Address row's `user_id` and `profile_id`.

## Out of Scope
These cases have always has the potential to create orphaned User rows (i.e. Users who have no Addresses). We should take this into account in route logic and ensure they're properly deleted.