### PR TITLE
Access window prop rather than Terra lib for availability check.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/terra_station_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/terra_station_web_wallet.ts
@@ -23,7 +23,7 @@ class TerraStationWebWalletController implements IWebWallet<TerraAddress> {
   public readonly specificChains = ['terra'];
 
   public get available() {
-    return this._extension && this._extension.isAvailable;
+    return !!window.isTerraExtensionAvailable;
   }
 
   public get enabled() {


### PR DESCRIPTION
Closes: #2925 

Terra Wallet's `available()` getter uses the extension code to check whether the wallet is installed as an extension on the user's browser. However, lazy loading terra.js at enable time meant that this check could never succeed, so the wallet would never be marked available. The solution that preserves code splitting is to check the relevant property on the window object directly.

Tested by navigating to /terra and ensuring the wallet now appears in the list of available wallets.