### PR TITLE
Added message to user in case of client or server error

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
@@ -24,14 +24,6 @@ export const FeedbackModal = (props: FeedbackModalProps) => {
   const [isSending, setIsSending] = React.useState<boolean>(false);
   const [status, setStatus] = React.useState<ValidationStatus | null>(null);
 
-  const errorMessage = (err: any): string => {
-    return err.status == 400
-      ? 'Please enter the feedback message.'
-      : err.status >= 401
-      ? 'Something went wrong. Please try again later.'
-      : err.responseJSON?.message || err.responseText;
-  };
-
   return (
     <div className="FeedbackModal">
       <div className="compact-modal-title">

--- a/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
@@ -24,6 +24,14 @@ export const FeedbackModal = (props: FeedbackModalProps) => {
   const [isSending, setIsSending] = React.useState<boolean>(false);
   const [status, setStatus] = React.useState<ValidationStatus | null>(null);
 
+  const errorMessage = (err: any): string => {
+    return err.status == 400
+      ? 'Please enter the feedback message.'
+      : err.status >= 401
+      ? 'Something went wrong. Please try again later.'
+      : err.responseJSON?.message || err.responseText;
+  };
+
   return (
     <div className="FeedbackModal">
       <div className="compact-modal-title">
@@ -61,7 +69,7 @@ export const FeedbackModal = (props: FeedbackModalProps) => {
               (err) => {
                 setIsSending(false);
                 setStatus('failure');
-                setMessage(err.responseJSON?.message || err.responseText);
+                setMessage(errorMessage(err));
                 redraw();
               }
             );

--- a/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
@@ -69,7 +69,7 @@ export const FeedbackModal = (props: FeedbackModalProps) => {
               (err) => {
                 setIsSending(false);
                 setStatus('failure');
-                setMessage(errorMessage(err));
+                setMessage(err.responseJSON?.error || err.responseText);
                 redraw();
               }
             );

--- a/packages/commonwealth/server/routes/sendFeedback.ts
+++ b/packages/commonwealth/server/routes/sendFeedback.ts
@@ -5,7 +5,8 @@ import { SLACK_FEEDBACK_WEBHOOK } from '../config';
 import type { DB } from '../models';
 
 export const Errors = {
-  NotSent: 'Nothing sent!',
+  NotSent: 'Please enter the feedback message.',
+  GenericError: 'Something went wrong. Please try again later.'
 };
 
 const sendFeedback = async (
@@ -16,6 +17,10 @@ const sendFeedback = async (
 ) => {
   if (!req.body.text) {
     return next(new AppError(Errors.NotSent));
+  }
+
+  if (!SLACK_FEEDBACK_WEBHOOK) {
+    return next(new AppError(Errors.GenericError));
   }
 
   const userText = !req.user

--- a/packages/commonwealth/server/routes/sendFeedback.ts
+++ b/packages/commonwealth/server/routes/sendFeedback.ts
@@ -3,11 +3,14 @@ import type { NextFunction, Request, Response } from 'express';
 import request from 'superagent';
 import { SLACK_FEEDBACK_WEBHOOK } from '../config';
 import type { DB } from '../models';
+import { factory, formatFilename } from 'common-common/src/logging';
 
 export const Errors = {
   NotSent: 'Please enter the feedback message.',
-  GenericError: 'Something went wrong. Please try again later.'
+  SlackWebhookError: 'SLACK_FEEDBACK_WEBHOOK missing.'
 };
+
+const log = factory.getLogger(formatFilename(__filename));
 
 const sendFeedback = async (
   models: DB,
@@ -20,7 +23,8 @@ const sendFeedback = async (
   }
 
   if (!SLACK_FEEDBACK_WEBHOOK) {
-    return next(new AppError(Errors.GenericError));
+    log.error("No slack webhook found");
+    return next(new ServerError(Errors.SlackWebhookError));
   }
 
   const userText = !req.user


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An environment variable (SLACK_FEEDBACK_WEBHOOK) was missing locally, so the response message below was being shown after the user clicked on "Send feedback" button 
`{"error":"The \"urlObject\" argument must be one of type object or string. Received undefined"}`

A more clear message now appears in case of an error.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
3 tests were made:
- without the environment variable
- with the env var but with a wrong value
- with the env var with right value

## Does this PR affect any server routes?
NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
