### PR TITLE
Fix web and mobile sidebar

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useForceRerender.ts
+++ b/packages/commonwealth/client/scripts/hooks/useForceRerender.ts
@@ -1,10 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 const useForceRerender = () => {
-  const [, setState] = useState(true);
+  const [, setState] = useState({});
 
   const forceRerender = useCallback(() => {
-    setState((prevState) => !prevState);
+    setState({});
   }, []);
 
   return forceRerender;

--- a/packages/commonwealth/client/scripts/state.ts
+++ b/packages/commonwealth/client/scripts/state.ts
@@ -95,7 +95,6 @@ export interface IApp {
   toasts: ToastStore;
 
   mobileMenu: MobileMenuName;
-  mobileMenuRedraw: EventEmitter;
   sidebarMenu: SidebarMenuName;
   sidebarRedraw: EventEmitter;
 
@@ -196,7 +195,6 @@ const app: IApp = {
 
   // Global nav state
   mobileMenu: null,
-  mobileMenuRedraw: new EventEmitter(),
   sidebarMenu: 'default',
   sidebarRedraw: new EventEmitter(),
   sidebarToggled: false,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_mobile_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_mobile_menu.tsx
@@ -24,7 +24,7 @@ const CWMobileMenuItem = (props: MenuItem) => {
         onClick={(e) => {
           // Graham TODO 22.10.06: Temporary solution as we transition Notifications
           app.mobileMenu = null;
-          app.mobileMenuRedraw.emit('redraw');
+          app.sidebarRedraw.emit('redraw');
           onClick(e);
         }}
       >
@@ -50,7 +50,7 @@ const CWMobileMenuItem = (props: MenuItem) => {
         onClick={(e) => {
           // Graham TODO 22.10.06: Temporary solution as we transition Notifications
           app.mobileMenu = null;
-          app.mobileMenuRedraw.emit('redraw');
+          app.sidebarRedraw.emit('redraw');
           onClick(e);
         }}
       >

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import 'components/sidebar/index.scss';
@@ -15,7 +15,6 @@ import { SidebarQuickSwitcher } from './sidebar_quick_switcher';
 import { CWIcon } from '../component_kit/cw_icons/cw_icon';
 import { CWText } from '../component_kit/cw_text';
 import { useCommonNavigate } from '../../../navigation/helpers';
-import useForceRerender from 'hooks/useForceRerender';
 
 export type SidebarMenuName =
   | 'default'
@@ -24,16 +23,7 @@ export type SidebarMenuName =
 
 export const Sidebar = () => {
   const navigate = useCommonNavigate();
-  const forceRerender = useForceRerender();
   const { pathname } = useLocation();
-
-  useEffect(() => {
-    app.sidebarRedraw.on('redraw', () => forceRerender());
-
-    return () => {
-      app.sidebarRedraw.off('redraw', () => forceRerender());
-    };
-  });
 
   const onHomeRoute = pathname === `/${app.activeChainId()}/feed`;
 

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -33,8 +33,7 @@ export const SidebarQuickSwitcher = () => {
           <CWIconButton
             iconName="plusCircle"
             iconButtonTheme="black"
-            onClick={(e) => {
-              e.preventDefault();
+            onClick={() => {
               app.sidebarMenu = 'createContent';
               app.sidebarRedraw.emit('redraw');
             }}
@@ -43,10 +42,9 @@ export const SidebarQuickSwitcher = () => {
         <CWIconButton
           iconName="compass"
           iconButtonTheme="black"
-          onClick={(e) => {
-            e.preventDefault();
-            app.sidebarRedraw.emit('redraw');
+          onClick={() => {
             app.sidebarMenu = 'exploreCommunities';
+            app.sidebarRedraw.emit('redraw');
           }}
         />
       </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
@@ -75,7 +75,8 @@ const SubSectionGroup = (props: SectionGroupAttrs) => {
       setToggled(!toggled);
     }
 
-    app.sidebarToggled = false;
+    app.sidebarToggled = true;
+    app.sidebarRedraw.emit('redraw');
 
     onClick(e, toggled);
   };

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -249,7 +249,7 @@ export const CreateContentMenu = () => {
         label: 'Create',
         onClick: () => {
           app.mobileMenu = 'MainMenu';
-          app.mobileMenuRedraw.emit('redraw');
+          app.sidebarRedraw.emit('redraw');
         },
       }}
       menuItems={getCreateContentMenuItems(navigate)}

--- a/packages/commonwealth/client/scripts/views/menus/help_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/help_menu.tsx
@@ -18,7 +18,7 @@ export const HelpMenu = () => {
           label: 'Help',
           onClick: () => {
             app.mobileMenu = 'MainMenu';
-            app.mobileMenuRedraw.emit('redraw');
+            app.sidebarRedraw.emit('redraw');
           },
         }}
         menuItems={[

--- a/packages/commonwealth/client/scripts/views/menus/main_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/main_menu.tsx
@@ -14,7 +14,7 @@ export const getMainMenuItems = (): Array<MenuItem> => {
             iconRight: 'chevronRight',
             onClick: () => {
               app.mobileMenu = 'CreateContentMenu';
-              app.mobileMenuRedraw.emit('redraw');
+              app.sidebarRedraw.emit('redraw');
             },
           },
         ]
@@ -25,7 +25,7 @@ export const getMainMenuItems = (): Array<MenuItem> => {
       iconRight: 'chevronRight',
       onClick: () => {
         app.mobileMenu = 'HelpMenu';
-        app.mobileMenuRedraw.emit('redraw');
+        app.sidebarRedraw.emit('redraw');
       },
     },
     ...((app.isLoggedIn()
@@ -38,7 +38,7 @@ export const getMainMenuItems = (): Array<MenuItem> => {
             hasUnreads: !!app.user?.notifications.numUnread,
             onClick: () => {
               app.mobileMenu = 'NotificationsMenu';
-              app.mobileMenuRedraw.emit('redraw');
+              app.sidebarRedraw.emit('redraw');
             },
           },
         ]

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -9,6 +9,7 @@ import { isWindowSmallInclusive } from './components/component_kit/helpers';
 import { Footer } from './footer';
 import { SublayoutBanners } from './sublayout_banners';
 import { SublayoutHeader } from './sublayout_header';
+import useForceRerender from 'hooks/useForceRerender';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -22,9 +23,18 @@ const Sublayout = ({
   hideSearch,
   onScroll,
 }: SublayoutProps) => {
+  const forceRerender = useForceRerender();
   const [isWindowSmall, setIsWindowSmall] = useState(
     isWindowSmallInclusive(window.innerWidth)
   );
+
+  useEffect(() => {
+    app.sidebarRedraw.on('redraw', () => forceRerender());
+
+    return () => {
+      app.sidebarRedraw.off('redraw', () => forceRerender());
+    };
+  });
 
   useEffect(() => {
     if (localStorage.getItem('dark-mode-state') === 'on') {

--- a/packages/commonwealth/client/scripts/views/sublayout_header.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header.tsx
@@ -50,6 +50,7 @@ export const SublayoutHeader = ({
             iconName={app.sidebarToggled ? 'sidebarCollapse' : 'sidebarExpand'}
             onClick={() => {
               app.sidebarToggled = !app.sidebarToggled;
+              app.sidebarRedraw.emit('redraw');
             }}
           />
         )}
@@ -63,7 +64,7 @@ export const SublayoutHeader = ({
             onClick={() => {
               app.sidebarToggled = false;
               app.mobileMenu = app.mobileMenu ? null : 'MainMenu';
-              app.mobileMenuRedraw.emit('redraw');
+              app.sidebarRedraw.emit('redraw');
             }}
           />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- there was some problem with forceRerender hook but I tweaked the implementation a bit and it seem to fix the issue (creating new object makes sure that the state is rerendered, previousyly true/false was used so I think that because of many redraws, React might get hiccup)
- also, moved forceRerender hook a component higher to make sure that both `sidebarToggled` and `sidebarMenu` and `mobileMenu` will be recalculated on event emit
- mobile issue was that there was `mobileMenuRedraw` event emmited which was not catched anywhere. We don't need two separate events => `sidebarRedraw` works fine for both desktop and mobile

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #2905 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
