### PR TITLE
Do not generate stats file on production build.

### DIFF
--- a/packages/commonwealth/webpack/webpack.prod.config.js
+++ b/packages/commonwealth/webpack/webpack.prod.config.js
@@ -25,7 +25,7 @@ module.exports = merge(common, {
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'disabled',
-      generateStatsFile: true,
+      generateStatsFile: false,
       statsOptions: { source: false },
     }),
   ],


### PR DESCRIPTION
Should reduce slug size massively.