### PR TITLE
View thread page refactor

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { ProposalType } from 'common-common/src/types';
 import { notifyError } from 'controllers/app/notifications';
@@ -33,7 +33,6 @@ import { ChangeTopicModal } from '../../modals/change_topic_modal';
 import { EditCollaboratorsModal } from '../../modals/edit_collaborators_modal';
 import { getThreadSubScriptionMenuItem } from '../discussions/helpers';
 import { EditBody } from './edit_body';
-import { activeQuillEditorHasText } from './helpers';
 import { LinkedProposalsCard } from './linked_proposals_card';
 import { LinkedThreadsCard } from './linked_threads_card';
 import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
@@ -52,75 +51,53 @@ export type ThreadPrefetch = {
   };
 };
 
-type ViewThreadPageAttrs = {
+type ViewThreadPageProps = {
   identifier: string;
 };
 
-const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
+const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const navigate = useCommonNavigate();
-  const [comments, setComments] = useState<Array<Comment<Thread>>>();
-  const [isEditingBody, setIsEditingBody] = useState<boolean>();
-  const [isGloballyEditing, setIsGloballyEditing] = useState<boolean>();
-  const [polls, setPolls] = useState<Array<Poll>>();
+
+  const [comments, setComments] = useState<Array<Comment<Thread>>>([]);
+  const [isEditingBody, setIsEditingBody] = useState(false);
+  const [isGloballyEditing, setIsGloballyEditing] = useState(false);
+  const [polls, setPolls] = useState<Array<Poll>>([]);
   const [prefetch, setPrefetch] = useState<ThreadPrefetch>({});
-  const [recentlyEdited, setRecentlyEdited] = useState<boolean>();
-  const [savedEdits, setSavedEdits] = useState<string>();
-  const [shouldRestoreEdits, setShouldRestoreEdits] = useState<boolean>();
-  const [thread, setThread] = useState<Thread>();
-  const [threadFetched, setThreadFetched] = useState<boolean>();
-  const [threadFetchFailed, setThreadFetchFailed] = useState<boolean>();
-  const [title, setTitle] = useState<string>();
-  const [viewCount, setViewCount] = useState<number>();
-  const [initializedComments, setInitializedComments] =
-    useState<boolean>(false);
-  const [initializedPolls, setInitializedPolls] = useState<boolean>(false);
-  const [isChangeTopicModalOpen, setIsChangeTopicModalOpen] =
-    React.useState<boolean>(false);
+  const [recentlyEdited, setRecentlyEdited] = useState(false);
+  const [savedEdits, setSavedEdits] = useState('');
+  const [shouldRestoreEdits, setShouldRestoreEdits] = useState(false);
+  const [thread, setThread] = useState<Thread>(null);
+  const [threadFetched, setThreadFetched] = useState(false);
+  const [threadFetchFailed, setThreadFetchFailed] = useState(false);
+  const [title, setTitle] = useState('');
+  const [viewCount, setViewCount] = useState(null);
+  const [initializedComments, setInitializedComments] = useState(false);
+  const [initializedPolls, setInitializedPolls] = useState(false);
+  const [isChangeTopicModalOpen, setIsChangeTopicModalOpen] = useState(false);
   const [isEditCollaboratorsModalOpen, setIsEditCollaboratorsModalOpen] =
-    React.useState<boolean>(false);
-
-  // editorListener(e) {
-  //   if (this.isGloballyEditing || activeQuillEditorHasText()) {
-  //     e.preventDefault();
-  //     e.returnValue = '';
-  //   }
-  // }
-
-  // oninit() {
-  //   window.addEventListener('beforeunload', (e) => {
-  //     this.editorListener(e);
-  //   });
-  // }
-
-  // onremove() {
-  //   window.removeEventListener('beforeunload', (e) => {
-  //     this.editorListener(e);
-  //   });
-  // }
-
-  if (!app.chain?.meta) {
-    return (
-      <PageLoading
-      // title="Loading..."
-      />
-    );
-  }
-
-  if (typeof identifier !== 'string') {
-    return (
-      <PageNotFound
-      // title={headerTitle}
-      />
-    );
-  }
+    useState(false);
 
   const threadId = identifier.split('-')[0];
   const threadIdAndType = `${threadId}-${ProposalType.Thread}`;
+  const threadDoesNotMatch =
+    +thread?.identifier !== +threadId || thread?.slug !== ProposalType.Thread;
+
+  const updatedCommentsCallback = useCallback(() => {
+    if (!thread) {
+      return;
+    }
+
+    const _comments =
+      app.comments
+        .getByProposal(thread)
+        .filter((c) => c.parentComment === null) || [];
+    setComments(_comments);
+  }, [thread]);
 
   // we will want to prefetch comments, profiles, and viewCount on the page before rendering anything
   if (!prefetch[threadIdAndType]) {
-    setPrefetch({
-      ...prefetch,
+    setPrefetch((prevState) => ({
+      ...prevState,
       [threadIdAndType]: {
         commentsStarted: false,
         pollsStarted: false,
@@ -128,294 +105,305 @@ const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
         profilesStarted: false,
         profilesFinished: false,
       },
-    });
+    }));
   }
 
-  if (threadFetchFailed) {
-    return (
-      <PageNotFound
-      // title={headerTitle}
-      />
-    );
+  useEffect(() => {
+    if (recentlyEdited) {
+      setRecentlyEdited(false);
+    }
+  }, [recentlyEdited]);
+
+  useEffect(() => {
+    // load thread, and return PageLoading
+    if (!thread || recentlyEdited) {
+      try {
+        const _thread = idToProposal(ProposalType.Thread, threadId);
+        if (_thread === undefined) {
+          throw new Error();
+        }
+        setThread(_thread);
+      } catch (e) {
+        // proposal might be loading, if it's not an thread
+        if (!threadFetched) {
+          app.threads
+            .fetchThreadsFromId([+threadId])
+            .then((res) => {
+              setThread(res[0]);
+            })
+            .catch(() => {
+              notifyError('Thread not found');
+              setThreadFetchFailed(true);
+            });
+          setThreadFetched(true);
+        }
+      }
+    }
+  }, [recentlyEdited, thread, threadFetched, threadId]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load proposal
+    if (!prefetch[threadIdAndType]['threadReactionsStarted']) {
+      app.threads.fetchReactionsCount([thread]).then(() => {
+        setThread(thread);
+      });
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadIdAndType]: {
+          ...prevState[threadIdAndType],
+          threadReactionsStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, threadIdAndType]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    if (thread && identifier !== `${threadId}-${slugify(thread?.title)}`) {
+      const url = getProposalUrlPath(
+        thread.slug,
+        `${threadId}-${slugify(thread?.title)}`,
+        true
+      );
+      navigate(url, { replace: true });
+    }
+  }, [identifier, navigate, thread, thread?.slug, thread?.title, threadId]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    if (!prefetch[threadIdAndType]['commentsStarted']) {
+      app.comments
+        .refresh(thread, app.activeChainId())
+        .then(async () => {
+          // fetch comments
+          const _comments = app.comments
+            .getByProposal(thread)
+            .filter((c) => c.parentComment === null);
+          setComments(_comments);
+
+          // fetch reactions
+          const { result: reactionCounts } = await $.ajax({
+            type: 'POST',
+            url: `${app.serverUrl()}/reactionsCounts`,
+            headers: {
+              'content-type': 'application/json',
+            },
+            data: JSON.stringify({
+              proposal_ids: [threadId],
+              comment_ids: app.comments
+                .getByProposal(thread)
+                .map((comment) => comment.id),
+              active_address: app.user.activeAccount?.address,
+            }),
+          });
+
+          // app.reactionCounts.deinit()
+          for (const rc of reactionCounts) {
+            const id = app.reactionCounts.store.getIdentifier({
+              threadId: rc.thread_id,
+              proposalId: rc.proposal_id,
+              commentId: rc.comment_id,
+            });
+
+            app.reactionCounts.store.add(
+              modelReactionCountFromServer({ ...rc, id })
+            );
+          }
+        })
+        .catch(() => {
+          notifyError('Failed to load comments');
+          setComments([]);
+        });
+
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadIdAndType]: {
+          ...prevState[threadIdAndType],
+          commentsStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, threadId, threadIdAndType]);
+
+  useEffect(() => {
+    if (!initializedComments) {
+      setInitializedComments(true);
+      updatedCommentsCallback();
+    }
+  }, [initializedComments, updatedCommentsCallback]);
+
+  useEffect(() => {
+    if (!initializedPolls) {
+      setInitializedPolls(true);
+      setPolls(app.polls.getByThreadId(thread?.id));
+    }
+  }, [initializedPolls, thread?.id]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load polls
+    if (!prefetch[threadIdAndType]['pollsStarted']) {
+      app.polls
+        .fetchPolls(app.activeChainId(), thread?.id)
+        .then(() => {
+          setPolls(app.polls.getByThreadId(thread.id));
+        })
+        .catch(() => {
+          notifyError('Failed to load polls');
+          setPolls([]);
+        });
+
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadIdAndType]: {
+          ...prevState[threadIdAndType],
+          pollsStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, thread?.id, threadIdAndType]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load view count
+    if (!prefetch[threadIdAndType]['viewCountStarted']) {
+      $.post(`${app.serverUrl()}/viewCount`, {
+        chain: app.activeChainId(),
+        object_id: thread.id,
+      })
+        .then((response) => {
+          if (response.status !== 'Success') {
+            setViewCount(0);
+            throw new Error(`got unsuccessful status: ${response.status}`);
+          } else {
+            setViewCount(response.result.view_count);
+          }
+        })
+        .catch(() => {
+          setViewCount(0);
+          throw new Error('could not load view count');
+        });
+
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadIdAndType]: {
+          ...prevState[threadIdAndType],
+          viewCountStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, thread?.id, threadIdAndType]);
+
+  useEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load profiles
+    if (!prefetch[threadIdAndType]['profilesStarted']) {
+      app.profiles.getProfile(thread.authorChain, thread.author);
+
+      comments.forEach((comment) => {
+        app.profiles.getProfile(comment.authorChain, comment.author);
+      });
+
+      app.profiles.isFetched.on('redraw', () => {
+        if (!prefetch[threadIdAndType]['profilesFinished']) {
+          setPrefetch((prevState) => ({
+            ...prevState,
+            [threadIdAndType]: {
+              ...prevState[threadIdAndType],
+              profilesFinished: true,
+            },
+          }));
+        }
+      });
+
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadIdAndType]: {
+          ...prevState[threadIdAndType],
+          profilesStarted: true,
+        },
+      }));
+    }
+  }, [
+    comments,
+    prefetch,
+    thread,
+    thread?.author,
+    thread?.authorChain,
+    threadIdAndType,
+  ]);
+
+  useEffect(() => {
+    if (threadDoesNotMatch) {
+      setThread(undefined);
+      setRecentlyEdited(false);
+      setThreadFetched(false);
+    }
+  }, [threadDoesNotMatch]);
+
+  useEffect(() => {
+    if (comments?.length > 0) {
+      const mismatchedComments = comments.filter((c) => {
+        return c.rootProposal !== `${ProposalType.Thread}_${threadId}`;
+      });
+
+      if (mismatchedComments.length) {
+        setPrefetch((prevState) => ({
+          ...prevState,
+          [threadIdAndType]: {
+            ...prevState[threadIdAndType],
+            commentsStarted: false,
+          },
+        }));
+      }
+    }
+  }, [comments, threadId, threadIdAndType]);
+
+  if (typeof identifier !== 'string') {
+    return <PageNotFound />;
+  }
+
+  if (!app.chain?.meta) {
+    return <PageLoading />;
   }
 
   // load app controller
   if (!app.threads.initialized) {
-    return (
-      <PageLoading
-      // title={headerTitle}
-      />
-    );
+    return <PageLoading />;
   }
 
-  const threadDoesNotMatch =
-    thread &&
-    (+thread.identifier !== +threadId || thread.slug !== ProposalType.Thread);
-
-  if (threadDoesNotMatch) {
-    setThread(undefined);
-    setRecentlyEdited(false);
-    setThreadFetched(false);
-  }
-
-  // load thread, and return PageLoading
-  if (!thread || recentlyEdited) {
-    try {
-      const _thread = idToProposal(ProposalType.Thread, threadId);
-      if (_thread === undefined) throw new Error();
-      setThread(_thread);
-    } catch (e) {
-      // proposal might be loading, if it's not an thread
-      if (!threadFetched) {
-        app.threads
-          .fetchThreadsFromId([+threadId])
-          .then((res) => {
-            setThread(res[0]);
-          })
-          .catch(() => {
-            notifyError('Thread not found');
-            setThreadFetchFailed(true);
-          });
-
-        setThreadFetched(true);
-      }
-    }
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
-  }
-
-  if (recentlyEdited) {
-    setRecentlyEdited(false);
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
-  }
-
-  if (identifier !== `${threadId}-${slugify(thread.title)}`) {
-    navigate(
-      getProposalUrlPath(
-        thread.slug,
-        `${threadId}-${slugify(thread.title)}`,
-        true
-      ),
-      { replace: true }
-    );
-  }
-
-  // load proposal
-  if (!prefetch[threadIdAndType]['threadReactionsStarted']) {
-    app.threads.fetchReactionsCount([thread]).then(() => setThread(thread));
-    setPrefetch({
-      ...prefetch,
-      [threadIdAndType]: {
-        ...prefetch[threadIdAndType],
-        threadReactionsStarted: true,
-      },
-    });
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
-  }
-
-  // load comments
-  if (!prefetch[threadIdAndType]['commentsStarted']) {
-    app.comments
-      .refresh(thread, app.activeChainId())
-      .then(async () => {
-        // fetch comments
-        const _comments = app.comments
-          .getByProposal(thread)
-          .filter((c) => c.parentComment === null);
-        setComments(_comments);
-
-        // fetch reactions
-        const { result: reactionCounts } = await $.ajax({
-          type: 'POST',
-          url: `${app.serverUrl()}/reactionsCounts`,
-          headers: {
-            'content-type': 'application/json',
-          },
-          data: JSON.stringify({
-            proposal_ids: [threadId],
-            comment_ids: app.comments
-              .getByProposal(thread)
-              .map((comment) => comment.id),
-            active_address: app.user.activeAccount?.address,
-          }),
-        });
-
-        // app.reactionCounts.deinit()
-        for (const rc of reactionCounts) {
-          const id = app.reactionCounts.store.getIdentifier({
-            threadId: rc.thread_id,
-            proposalId: rc.proposal_id,
-            commentId: rc.comment_id,
-          });
-
-          app.reactionCounts.store.add(
-            modelReactionCountFromServer({ ...rc, id })
-          );
-        }
-      })
-      .catch(() => {
-        notifyError('Failed to load comments');
-        setComments([]);
-      });
-
-    setPrefetch({
-      ...prefetch,
-      [threadIdAndType]: {
-        ...prefetch[threadIdAndType],
-        commentsStarted: true,
-      },
-    });
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
-  }
-
-  if (comments && comments.length > 0) {
-    const mismatchedComments = comments.filter((c) => {
-      return c.rootProposal !== `${ProposalType.Thread}_${threadId}`;
-    });
-
-    if (mismatchedComments.length) {
-      setPrefetch({
-        ...prefetch,
-        [threadIdAndType]: {
-          ...prefetch[threadIdAndType],
-          commentsStarted: false,
-        },
-      });
-      return (
-        <PageLoading
-        //  title={headerTitle}
-        />
-      );
-    }
-  }
-
-  const updatedCommentsCallback = () => {
-    const _comments =
-      app.comments
-        .getByProposal(thread)
-        .filter((c) => c.parentComment === null) || [];
-    setComments(_comments);
-  };
-  if (!initializedComments) {
-    setInitializedComments(true);
-    updatedCommentsCallback();
-  }
-
-  // load polls
-  if (!prefetch[threadIdAndType]['pollsStarted']) {
-    app.polls.fetchPolls(app.activeChainId(), thread.id).catch(() => {
-      notifyError('Failed to load comments');
-      setComments([]);
-      setPolls(app.polls.getByThreadId(thread.id));
-    });
-
-    setPrefetch({
-      ...prefetch,
-      [threadIdAndType]: {
-        ...prefetch[threadIdAndType],
-        pollsStarted: true,
-      },
-    });
-  }
-  if (!initializedPolls) {
-    setInitializedPolls(true);
-    setPolls(app.polls.getByThreadId(thread.id));
-  }
-
-  // load view count
-  if (!prefetch[threadIdAndType]['viewCountStarted']) {
-    $.post(`${app.serverUrl()}/viewCount`, {
-      chain: app.activeChainId(),
-      object_id: thread.id,
-    })
-      .then((response) => {
-        if (response.status !== 'Success') {
-          setViewCount(0);
-          throw new Error(`got unsuccessful status: ${response.status}`);
-        } else {
-          setViewCount(response.result.view_count);
-        }
-      })
-      .catch(() => {
-        setViewCount(0);
-        throw new Error('could not load view count');
-      });
-
-    setPrefetch({
-      ...prefetch,
-      [threadIdAndType]: {
-        ...prefetch[threadIdAndType],
-        viewCountStarted: true,
-      },
-    });
-  }
-
-  if (comments === undefined || viewCount === undefined) {
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
-  }
-
-  // load profiles
-  if (!prefetch[threadIdAndType]['profilesStarted']) {
-    app.profiles.getProfile(thread.authorChain, thread.author);
-
-    comments.forEach((comment) => {
-      app.profiles.getProfile(comment.authorChain, comment.author);
-    });
-
-    app.profiles.isFetched.on('redraw', () => {
-      if (!prefetch[threadIdAndType]['profilesFinished']) {
-        setPrefetch({
-          ...prefetch,
-          [threadIdAndType]: {
-            ...prefetch[threadIdAndType],
-            profilesFinished: true,
-          },
-        });
-      }
-    });
-
-    setPrefetch({
-      ...prefetch,
-      [threadIdAndType]: {
-        ...prefetch[threadIdAndType],
-        profilesStarted: true,
-      },
-    });
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
+  if (threadFetchFailed) {
+    return <PageNotFound />;
   }
 
   if (
     !app.profiles.allLoaded() &&
     !prefetch[threadIdAndType]['profilesFinished']
   ) {
-    return (
-      <PageLoading
-      //  title={headerTitle}
-      />
-    );
+    return <PageLoading />;
+  }
+
+  if (!thread) {
+    return <PageLoading />;
   }
 
   const commentCount = app.comments.nComments(thread);
@@ -592,9 +580,7 @@ const ViewThreadPage: React.FC<ViewThreadPageAttrs> = ({ identifier }) => {
   };
 
   return (
-    <Sublayout
-    //  title={headerTitle}
-    >
+    <Sublayout>
       <CWContentPage
         contentBodyLabel="Thread"
         showSidebar={

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -509,9 +509,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             {
               label: 'Change topic',
               iconLeft: 'write' as const,
-              onClick: (e) => {
-                e.preventDefault();
-
+              onClick: () => {
                 setIsChangeTopicModalOpen(true);
               },
             },

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { redraw } from 'mithrilInterop';
 import type { SnapshotProposal, SnapshotSpace } from 'helpers/snapshot_utils';
 import { loadMultipleSpacesData } from 'helpers/snapshot_utils';
 import {
@@ -53,37 +52,35 @@ type LinkedProposalsCardProps = {
   thread: Thread;
 };
 
-export const LinkedProposalsCard = (props: LinkedProposalsCardProps) => {
-  const { onChangeHandler, thread, showAddProposalButton } = props;
+export const LinkedProposalsCard = ({
+  onChangeHandler,
+  thread,
+  showAddProposalButton,
+}: LinkedProposalsCardProps) => {
+  const [snapshot, setSnapshot] = useState<SnapshotProposal>(null);
+  const [snapshotProposalsLoaded, setSnapshotProposalsLoaded] = useState(false);
+  const [space, setSpace] = useState<SnapshotSpace>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const [initialized, setInitialized] = React.useState<boolean>(false);
-  const [snapshot, setSnapshot] = React.useState<SnapshotProposal>();
-  const [snapshotProposalsLoaded, setSnapshotProposalsLoaded] =
-    React.useState<boolean>(false);
-  const [space, setSpace] = React.useState<SnapshotSpace>();
-  const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
+  useEffect(() => {
+    if (thread.snapshotProposal?.length > 0) {
+      loadMultipleSpacesData(app.chain.meta.snapshot).then((data) => {
+        for (const { space: _space, proposals } of data) {
+          const matchingSnapshot = proposals.find(
+            (sn) => sn.id === thread.snapshotProposal
+          );
 
-  if (!initialized && thread.snapshotProposal?.length > 0) {
-    setInitialized(true);
-
-    loadMultipleSpacesData(app.chain.meta.snapshot).then((data) => {
-      for (const { space: _space, proposals } of data) {
-        const matchingSnapshot = proposals.find(
-          (sn) => sn.id === thread.snapshotProposal
-        );
-
-        if (matchingSnapshot) {
-          setSnapshot(matchingSnapshot);
-          setSpace(_space);
-          break;
+          if (matchingSnapshot) {
+            setSnapshot(matchingSnapshot);
+            setSpace(_space);
+            break;
+          }
         }
-      }
 
-      setSnapshotProposalsLoaded(true);
-      setInitialized(false);
-      redraw();
-    });
-  }
+        setSnapshotProposalsLoaded(true);
+      });
+    }
+  }, [thread.snapshotProposal]);
 
   let snapshotUrl = '';
 
@@ -97,7 +94,7 @@ export const LinkedProposalsCard = (props: LinkedProposalsCardProps) => {
     thread.snapshotProposal?.length > 0 && snapshotProposalsLoaded;
 
   return (
-    <React.Fragment>
+    <>
       <CWContentPageCard
         header="Linked Proposals"
         content={
@@ -155,6 +152,6 @@ export const LinkedProposalsCard = (props: LinkedProposalsCardProps) => {
         onClose={() => setIsModalOpen(false)}
         open={isModalOpen}
       />
-    </React.Fragment>
+    </>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { getProposalUrlPath } from 'identifiers';
 import type { Thread } from 'models';
@@ -19,36 +19,34 @@ type LinkedThreadsCardProps = {
   threadId: number;
 };
 
-export const LinkedThreadsCard = (props: LinkedThreadsCardProps) => {
-  const { allowLinking, threadId } = props;
-
-  const [initialized, setInitialized] = React.useState<boolean>(false);
-  const [linkedThreads, setLinkedThreads] = React.useState<Array<Thread>>([]);
-  const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
+export const LinkedThreadsCard = ({
+  allowLinking,
+  threadId,
+}: LinkedThreadsCardProps) => {
+  const [linkedThreads, setLinkedThreads] = useState<Array<Thread>>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const thread = app.threads.getById(threadId);
 
-  if (thread.linkedThreads.length > 0 && !initialized) {
-    setInitialized(true);
-
-    app.threads
-      .fetchThreadsFromId(
-        thread.linkedThreads.map(
-          (relation: LinkedThreadRelation) => relation.linkedThread
+  useEffect(() => {
+    if (thread.linkedThreads.length > 0) {
+      app.threads
+        .fetchThreadsFromId(
+          thread.linkedThreads.map(
+            (relation: LinkedThreadRelation) => relation.linkedThread
+          )
         )
-      )
-      .then((result) => {
-        setLinkedThreads(result);
-        setInitialized(false);
-      })
-      .catch((err) => {
-        console.error(err);
-        setInitialized(false);
-      });
-  }
+        .then((result) => {
+          setLinkedThreads(result);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+  }, [thread?.linkedThreads]);
 
   return (
-    <React.Fragment>
+    <>
       <CWContentPageCard
         header="Linked Discussions"
         content={
@@ -62,7 +60,11 @@ export const LinkedThreadsCard = (props: LinkedThreadsCardProps) => {
                     true
                   );
 
-                  return <a href={discussionLink}>{t.title}</a>;
+                  return (
+                    <a key={t.id} href={discussionLink}>
+                      {t.title}
+                    </a>
+                  );
                 })}
               </div>
             ) : (
@@ -94,6 +96,6 @@ export const LinkedThreadsCard = (props: LinkedThreadsCardProps) => {
         onClose={() => setIsModalOpen(false)}
         open={isModalOpen}
       />
-    </React.Fragment>
+    </>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- we encountered many infinite loops eg when opening sidebar, when thread had another linked thread etc. The reason for that was that we were setting state in the render method which is forbidden in react world. UseEffect should be used for this type of manipulations
- also important thing: when we setting state based on the previous state, we always have to use syntax with the callback function => this way we can be sure that we use previous state (otherwise the state can be outdated)
```
// ✅ GOOD

      setPrefetch((prevState) => ({
        ...prevState,
        [threadIdAndType]: {
          ...prevState[threadIdAndType],
          pollsStarted: true,
        },
      }));


// 🛑 BAD
    setPrefetch({
      ...prefetch,
      [threadIdAndType]: {
        ...prefetch[threadIdAndType],
        pollsStarted: true,
      },
    });
```
- fixed issue with polls that are not showing up #2873 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closed #2971 
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
