### PR TITLE
Add passing of topic and stage to filter function

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
@@ -217,14 +217,7 @@ const getCommonDomainsRoutes = () => (
       })}
     />
     <Route
-      path="/:scope/discussions/topic/:topicName"
-      element={withLayout(DiscussionsPage, {
-        scoped: true,
-        deferChain: true,
-      })}
-    />
-    <Route
-      path="/:scope/discussions/stage/:stageName"
+      path="/:scope/discussions/:topicName"
       element={withLayout(DiscussionsPage, {
         scoped: true,
         deferChain: true,

--- a/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
@@ -217,7 +217,14 @@ const getCommonDomainsRoutes = () => (
       })}
     />
     <Route
-      path="/:scope/discussions/:topic"
+      path="/:scope/discussions/topic/:topicName"
+      element={withLayout(DiscussionsPage, {
+        scoped: true,
+        deferChain: true,
+      })}
+    />
+    <Route
+      path="/:scope/discussions/stage/:stageName"
       element={withLayout(DiscussionsPage, {
         scoped: true,
         deferChain: true,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -12,17 +12,13 @@ import { ThreadPreview } from './thread_preview';
 import { Footer } from '../../footer';
 
 type DiscussionsPageProps = {
-  topic?: string;
-  stage?: string;
+  topicName?: string;
+  stageName?: string;
 };
 
-const DiscussionsPage = ({ topic, stage }: DiscussionsPageProps) => {
+const DiscussionsPage = ({ topicName, stageName }: DiscussionsPageProps) => {
   const [threads, setThreads] = useState([]);
   const [initializing, setInitializing] = useState(true);
-  const params = useParams();
-  const topicName = params.topic;
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [stageName, setStageName] = useState<string>(searchParams.get('stage'));
 
   // setup initial threads
   useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import 'pages/discussions/index.scss';
 
@@ -11,13 +12,17 @@ import { ThreadPreview } from './thread_preview';
 import { Footer } from '../../footer';
 
 type DiscussionsPageProps = {
-  topicName?: string;
-  stageName?: string;
+  topic?: string;
+  stage?: string;
 };
 
-const DiscussionsPage = ({ topicName, stageName }: DiscussionsPageProps) => {
+const DiscussionsPage = ({ topic, stage }: DiscussionsPageProps) => {
   const [threads, setThreads] = useState([]);
   const [initializing, setInitializing] = useState(true);
+  const params = useParams();
+  const topicName = params.topic;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [stageName, setStageName] = useState<string>(searchParams.get('stage'));
 
   // setup initial threads
   useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
-import { useParams, useSearchParams } from 'react-router-dom';
 
 import 'pages/discussions/index.scss';
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
+import { useSearchParams } from 'react-router-dom';
 
 import 'pages/discussions/index.scss';
 
@@ -12,12 +13,13 @@ import { Footer } from '../../footer';
 
 type DiscussionsPageProps = {
   topicName?: string;
-  stageName?: string;
 };
 
-const DiscussionsPage = ({ topicName, stageName }: DiscussionsPageProps) => {
+const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const [threads, setThreads] = useState([]);
   const [initializing, setInitializing] = useState(true);
+  const [searchParams, _] = useSearchParams();
+  const stageName: string = searchParams.get('stage');
 
   // setup initial threads
   useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
@@ -76,7 +76,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                 isSelected={!stage}
                 onClick={(e) => {
                   e.preventDefault();
-                    navigate('/discussions');
+                  navigate('/discussions');
                 }}
               />
               <CWDivider />
@@ -86,7 +86,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                   isSelected={stage === targetStage}
                   onClick={(e) => {
                     e.preventDefault();
-                      navigate(`/discussions?stage=${targetStage}`);
+                    navigate(`/discussions?stage=${targetStage}`);
                   }}
                   label={`
                     ${threadStageToLabel(targetStage)} ${

--- a/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
@@ -86,7 +86,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                   isSelected={stage === targetStage}
                   onClick={(e) => {
                     e.preventDefault();
-                    navigate(`/discussions?stage=${targetStage}`);
+                    navigate(`/discussions/stage/${targetStage}`);
                   }}
                   label={`
                     ${threadStageToLabel(targetStage)} ${

--- a/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/stages_menu.tsx
@@ -86,7 +86,7 @@ export const StagesMenu = (props: StagesMenuProps) => {
                   isSelected={stage === targetStage}
                   onClick={(e) => {
                     e.preventDefault();
-                    navigate(`/discussions/stage/${targetStage}`);
+                    navigate(`/discussions?stage=${targetStage}`);
                   }}
                   label={`
                     ${threadStageToLabel(targetStage)} ${

--- a/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
@@ -94,7 +94,7 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
                         isSelected={active}
                         onClick={(e) => {
                           e.preventDefault();
-                          navigate(`/discussions/${name}`);
+                          navigate(`/discussions/topic/${name}`);
                         }}
                         iconRight={
                           app.roles?.isAdminOfEntity({

--- a/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/topics_menu.tsx
@@ -94,7 +94,7 @@ export const TopicsMenu = (props: TopicsMenuProps) => {
                         isSelected={active}
                         onClick={(e) => {
                           e.preventDefault();
-                          navigate(`/discussions/topic/${name}`);
+                          navigate(`/discussions/${name}`);
                         }}
                         iconRight={
                           app.roles?.isAdminOfEntity({

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
@@ -87,7 +87,7 @@ export const ThreadStage = (props: ThreadComponentProps) => {
       )}
       onClick={(e) => {
         e.preventDefault();
-        navigate(`?stage=${thread.stage}`);
+        navigate(`/discussions?stage=${thread.stage}`);
       }}
     >
       {threadStageToLabel(thread.stage)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Edited topic route variable name from
`path="/:scope/discussions/:topic"`
to
`path="/:scope/discussions/:topicName"`
so the value is passed correctly to params. Route is still the same.

Stage value is taken from url params.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
URL was changing but the filter data was not being passed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
