### PR TITLE
Made eslint not require type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,6 @@ module.exports = {
     // this rule has not been updated to ESLint 8 so it is incompatible with our ESLint setup
     // Error: Rules with suggestions must set the `meta.hasSuggestions` property to `true`. `meta.docs.suggestion` is ignored by ESLint.
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-namespace": "off",
-    '@typescript-eslint/consistent-type-imports': 'error'
+    "@typescript-eslint/no-namespace": "off"
   }
 }


### PR DESCRIPTION
## Description
The reason I added this eslint rule is becaue I found that typescript loads in the file, even on type import. But we just care about the type for type checking at static type-check time. It is not needed during runtime. So as a result this rule caught these cases and forced it just to use the type import. The issue is that mithril needs to be imported even for type only imports. 

I think a good solution is just to keep it removed for master, and keep it enabled in react. This way when we eventually switch to react, it will be there.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this PR affect any server routes?
chose YES or NO


## If this PR affects server routes, what are the security implications?
<!--- Please describe which security concerns were considered, -->
<!--- such as argument validation, private data leaking, etc. -->

## Have you added the issue number here?
(In the right sidebar, under "development")
