### PR TITLE
Fix quill trim bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/quill/quill_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/quill/quill_formatted_text.tsx
@@ -113,10 +113,7 @@ export const QuillFormattedText: React.FC<QuillFormattedTextAttrs> = ({ doc, hid
   } else {
     return (
       <div
-      className={getClasses<{ collapsed?: boolean }>(
-        { collapsed: isTruncated },
-        'QuillFormattedText'
-      )}
+        className='QuillFormattedText'
       // oncreate={() => {
       // if (!(<any>window).twttr) {
       //   loadScript('//platform.twitter.com/widgets.js').then(() => {
@@ -128,7 +125,7 @@ export const QuillFormattedText: React.FC<QuillFormattedTextAttrs> = ({ doc, hid
           renderQuillDelta(
             truncatedDoc,
             hideFormatting,
-            isTruncated,
+            false,
             openLinksInNewTab,
             navigate
           )}


### PR DESCRIPTION
Fixes bug where the quill component only shows a single line while in the collapsed state. Now it renders correctly, matching production.

## Link to Issue
Closes: #2869

## Description of Changes
- Applies a minimal code change to disable the `.collapsed` style and `renderQuillDelta` `collapse` argument, which are the root cause of the original bug. The underlying style and logic have not been removed, since another branch of logic uses them.

## Test Plan
- Go to `http://localhost:8080/dydx/discussion/1482-dydx-governance-community-forum-guidelines`
- Confirm that the page contents render to the full height of the screen while in collapsed state

## Deployment Plan
N/A

## Other Considerations
- Not sure which other parts of the app I should check for regressions