### PR TITLE
Deletion of e.preventDefault() to solve some issues

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -99,8 +99,7 @@ export const getThreadSubScriptionMenuItem = (
     commentSubscription?.isActive && reactionSubscription?.isActive;
 
   return {
-    onClick: (e) => {
-      e.preventDefault();
+    onClick: () => {
       handleToggleSubscription(
         thread,
         getCommentSubscription(thread),

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
@@ -53,9 +53,7 @@ export const ThreadPreviewMenu = ({
             ...(hasAdminPermissions
               ? [
                   {
-                    onClick: (e) => {
-                      e.preventDefault();
-
+                    onClick: () => {
                       app.threads.pin({ proposal: thread }).then(() => {
                         navigate('/discussions');
                         redraw();
@@ -69,9 +67,7 @@ export const ThreadPreviewMenu = ({
             ...(hasAdminPermissions
               ? [
                   {
-                    onClick: (e) => {
-                      e.preventDefault();
-
+                    onClick: () => {
                       app.threads
                         .setPrivacy({
                           threadId: thread.id,
@@ -108,9 +104,7 @@ export const ThreadPreviewMenu = ({
             ...(isAuthor || hasAdminPermissions
               ? [
                   {
-                    onClick: async (e) => {
-                      e.preventDefault();
-
+                    onClick: async () => {
                       const confirmed = window.confirm(
                         'Delete this entire thread?'
                       );

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
@@ -92,8 +92,7 @@ export const ThreadPreviewMenu = ({
             ...(isAuthor || hasAdminPermissions
               ? [
                   {
-                    onClick: (e) => {
-                      e.preventDefault();
+                    onClick: () => {
                       setIsUpdateProposalStatusModalOpen(true);
                     },
                     label: 'Update status',

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -519,7 +519,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
               label: 'Delete',
               iconLeft: 'trash' as const,
               onClick: async (e) => {
-                e.preventDefault();
+                // e.preventDefault();
 
                 const confirmed = window.confirm('Delete this entire thread?');
 
@@ -538,7 +538,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
               label: thread.readOnly ? 'Unlock thread' : 'Lock thread',
               iconLeft: 'lock' as const,
               onClick: (e) => {
-                e.preventDefault();
+                // e.preventDefault();
                 app.threads
                   .setPrivacy({
                     threadId: thread.id,

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -518,9 +518,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             {
               label: 'Delete',
               iconLeft: 'trash' as const,
-              onClick: async (e) => {
-                // e.preventDefault();
-
+              onClick: async () => {
                 const confirmed = window.confirm('Delete this entire thread?');
 
                 if (!confirmed) return;
@@ -537,8 +535,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             {
               label: thread.readOnly ? 'Unlock thread' : 'Lock thread',
               iconLeft: 'lock' as const,
-              onClick: (e) => {
-                // e.preventDefault();
+              onClick: () => {
                 app.threads
                   .setPrivacy({
                     threadId: thread.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A simple removal solves #3002 and #3013.
#2990 is [already working](https://github.com/hicommonwealth/commonwealth/issues/2990#issuecomment-1458642022)

## Link to Issue
[PopoverMenu onClicks don't need e.preventDefault (or async in most cases)
](https://github.com/hicommonwealth/commonwealth/issues/3000)

## Description of Changes
- Removal of e.preventDefault() on thread preview menu for actions: pin, lock/unlock, delete, update status
- Removal of e.preventDefault() on view thread for actions: lock/unlock, delete

## Test Plan
- CA (click around) tested on local:
  - thread preview menu
  - thread preview
 - set admin for pin action

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Actions such as lock/unlock do not show a notify message like "Thread locked"