### PR TITLE
Fix collaborators modal (add + delete editors)

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
@@ -20,11 +20,13 @@ import { CWTextInput } from '../components/component_kit/cw_text_input';
 type EditCollaboratorsModalProps = {
   onModalClose: () => void;
   thread: Thread;
+  onCollaboratorsUpdated: (newEditors: IThreadCollaborator[]) => void
 };
 
 export const EditCollaboratorsModal = ({
   onModalClose,
   thread,
+  onCollaboratorsUpdated
 }: EditCollaboratorsModalProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState<
@@ -170,13 +172,14 @@ export const EditCollaboratorsModal = ({
                       author_chain: app.user.activeAccount.chain.id,
                       chain: app.activeChainId(),
                       thread_id: thread.id,
-                      editors: JSON.stringify(added),
+                      editors: added,
                       jwt: app.user.jwt,
                     }
                   );
 
                   if (response.data.status === 'Success') {
                     notifySuccess('Collaborators added');
+                    onCollaboratorsUpdated(response.data.result.collaborators);
                   } else {
                     notifyError('Failed to add collaborators');
                   }
@@ -202,13 +205,14 @@ export const EditCollaboratorsModal = ({
                       author_chain: app.user.activeAccount.chain.id,
                       chain: app.activeChainId(),
                       thread_id: thread.id,
-                      editors: JSON.stringify(deleted),
+                      editors: deleted,
                       jwt: app.user.jwt,
                     }
                   );
 
                   if (response.data.status === 'Success') {
                     notifySuccess('Collaborators removed');
+                    onCollaboratorsUpdated(response.data.result.collaborators);
                   } else {
                     throw new Error('Failed to remove collaborators');
                   }
@@ -218,7 +222,9 @@ export const EditCollaboratorsModal = ({
                   notifyError(errMsg);
                 }
               }
+
               onModalClose();
+
             }}
           />
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -39,6 +39,7 @@ import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
 import { ExternalLink, ThreadAuthor, ThreadStage } from './thread_components';
 import { useCommonNavigate } from 'navigation/helpers';
 import { Modal } from '../../components/component_kit/cw_modal';
+import { IThreadCollaborator } from 'client/scripts/models/Thread';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -740,6 +741,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           <EditCollaboratorsModal
             onModalClose={() => setIsEditCollaboratorsModalOpen(false)}
             thread={thread}
+            onCollaboratorsUpdated={(newEditors: IThreadCollaborator[]) => {
+              thread.collaborators = newEditors;
+              setThread(thread);
+            }}
           />
         }
         onClose={() => setIsEditCollaboratorsModalOpen(false)}

--- a/packages/commonwealth/server/routes/addEditors.ts
+++ b/packages/commonwealth/server/routes/addEditors.ts
@@ -1,3 +1,4 @@
+import { IThreadCollaborator } from 'client/scripts/models/Thread';
 import { AppError } from 'common-common/src/errors';
 import { NotificationCategories, ProposalType } from 'common-common/src/types';
 import type { NextFunction, Request, Response } from 'express';
@@ -14,6 +15,11 @@ export const Errors = {
   IncorrectOwner: 'Not owned by this user',
 };
 
+export interface AddEditorsBody {
+  thread_id: string
+  editors: IThreadCollaborator[]
+}
+
 const addEditors = async (
   models: DB,
   req: Request,
@@ -23,11 +29,11 @@ const addEditors = async (
   if (!req.body?.thread_id) {
     return next(new AppError(Errors.InvalidThread));
   }
-  const { thread_id } = req.body;
-  let editors;
-  try {
-    editors = JSON.parse(req.body.editors);
-  } catch (e) {
+
+  const { thread_id, editors } = req.body as AddEditorsBody;
+
+  // Ensure editors is an array
+  if (!Array.isArray(editors)) {
     return next(new AppError(Errors.InvalidEditorFormat));
   }
 
@@ -47,9 +53,12 @@ const addEditors = async (
   if (!thread) return next(new AppError(Errors.InvalidThread));
 
   const collaborators = await Promise.all(
-    Object.values(editors).map((editor: any) => {
+    editors.map((editor) => {
       return models.Address.findOne({
-        where: { id: editor.id },
+        where: {
+          chain: editor.chain,
+          address: editor.address,
+        },
         include: [models.RoleAssignment, models.User],
       });
     })
@@ -122,7 +131,7 @@ const addEditors = async (
   await thread.save();
 
   if (collaborators?.length > 0) {
-    collaborators.map((collaborator) => {
+    collaborators.forEach((collaborator) => {
       if (!collaborator.User) return; // some Addresses may be missing users, e.g. if the user removed the address
 
       emitNotifications(
@@ -162,14 +171,12 @@ const addEditors = async (
     ],
   });
 
-  const finalAddresses = await Promise.all(
-    finalCollaborations.map((e) => e.getAddress())
-  );
-
   return res.json({
     status: 'Success',
     result: {
-      collaborators: finalAddresses.map((a) => a.toJSON()),
+      collaborators: finalCollaborations
+        .map((c) => c.toJSON())
+        .map((c) => c.Address)
     },
   });
 };

--- a/packages/commonwealth/server/routes/deleteEditors.ts
+++ b/packages/commonwealth/server/routes/deleteEditors.ts
@@ -1,3 +1,4 @@
+import { IThreadCollaborator } from 'client/scripts/models/Thread';
 import { AppError } from 'common-common/src/errors';
 import type { NextFunction, Request, Response } from 'express';
 import { Op } from 'sequelize';
@@ -11,6 +12,11 @@ export const Errors = {
   InvalidAddress: 'Must provide editor address and chain',
 };
 
+interface DeleteEditorsBody {
+  thread_id: string
+  editors: IThreadCollaborator[]
+}
+
 const deleteEditors = async (
   models: DB,
   req: Request,
@@ -20,12 +26,11 @@ const deleteEditors = async (
   if (!req.body.thread_id) {
     return next(new AppError(Errors.InvalidThread));
   }
-  const { thread_id } = req.body;
-  let editors;
-  try {
-    const editorsObj = JSON.parse(req.body.editors);
-    editors = Object.values(editorsObj);
-  } catch (e) {
+
+  const { thread_id, editors } = req.body as DeleteEditorsBody;
+
+  // Ensure editors is an array
+  if (!Array.isArray(editors)) {
     return next(new AppError(Errors.InvalidEditorFormat));
   }
 
@@ -41,7 +46,7 @@ const deleteEditors = async (
   if (!thread) return next(new AppError(Errors.InvalidThread));
 
   await Promise.all(
-    editors.map(async (editor: any) => {
+    editors.map(async (editor: IThreadCollaborator) => {
       const address = await models.Address.findOne({
         where: {
           chain: editor.chain,
@@ -65,18 +70,17 @@ const deleteEditors = async (
     include: [
       {
         model: models.Address,
+        as: 'Address',
       },
     ],
   });
 
-  const finalAddresses = await Promise.all(
-    finalCollaborations.map((e) => e.getAddress())
-  );
-
   return res.json({
     status: 'Success',
     result: {
-      collaborators: finalAddresses.map((a) => a.toJSON()),
+      collaborators: finalCollaborations
+        .map((c) => c.toJSON())
+        .map((c) => c.Address)
     },
   });
 };


### PR DESCRIPTION
Fixes issue where the thread collaborators modal did not properly add editors. Also ensures that it can properly deletes editors.

## Link to Issue
Closes: #3008 

## Description of Changes
- Updates the request body shape in `addEditor` and `deleteEditor`
- Updates the collaborators modal UI to send a properly shaped request body
- Updates the collaborators modal UI to update the UI after collaborators have been updated

## Test Plan
- Create a thread
- Add a collaborator, confirm that the UI is updated to show the new collaborator
- Remove the collaborator, confirm that the UI is updated to show no collaborators

## Deployment Plan
N/A

## Other Considerations
I noticed that when updating partial state, there are instances of mutating the state directly like this:
```js
thread.foo = 'bar';
setThread(thread);
```
It's generally not good practice to mutate state directly, but since `Thread` is a class and not a plain object, we can't use the spread operator. As a result, we'll need to continue applying the mutation pattern. Just an FYI though I'm sure we all know this already.