### PR TITLE
Enforce unique user-address pairings.

### DIFF
--- a/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
+++ b/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
@@ -52,7 +52,9 @@ module.exports = {
         }
 
         // once mergeSet is maximal, remove all intersecting elements + reinsert the final set
-        userMergeSets = userMergeSets.filter((set) => !hasIntersection(set, mergeSet));
+        userMergeSets = userMergeSets.filter(
+          (set) => !hasIntersection(set, mergeSet)
+        );
         userMergeSets.push(mergeSet);
       }
 

--- a/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
+++ b/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const hasIntersection = (set1, set2) => {
+  return [...set1].filter(x => set2.has(x)).length > 0;
+}
+
+const inplaceSetUnion = (set1, set2) => {
+  for (const item of set2) {
+    set1.add(item);
+  }
+}
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      // 1. Locate addresses with duplicate users
+      const addressesWithDuplicateUsers = await queryInterface.sequelize.query(
+        `
+          SELECT a.id AS id, a.address AS address, a.user_id AS user_id
+          FROM "Addresses" AS a
+          JOIN "Addresses" AS a2
+          ON a.address = a2.address AND a.user_id != a2.user_id;
+        `,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      );
+
+      // 2. Produce mapping of addresses to duplicate users
+      const addressToUserMap = {}; // address => user[]
+      for (const address of addressesWithDuplicateUsers) {
+        if (!addressToUserMap[address.address]) {
+          addressToUserMap[address.address] = [];
+        }
+        addressToUserMap[address.address].push(address.user_id);
+      }
+
+      // 3. Walk map of addresses to produce lists of users to combine
+      const userMergeSets = []
+      for (const mergeGroup of Object.values(addressToUserMap)) {
+        const mergeSet = new Set(mergeGroup);
+        let found = false;
+        for (const existingSet of userMergeSets) {
+          // if existing set has any intersection with current set, merge them
+          if (hasIntersection(existingSet, mergeSet)) {
+            found = true;
+            inplaceSetUnion(existingSet, mergeSet);
+          }
+        }
+
+        // if no existing set has any intersection with current set, add it as a new set
+        if (!found) {
+          userMergeSets.push(mergeSet);
+        }
+      }
+
+      // at this point, all sets should be disjoint -- assert this
+      for (const set1 of userMergeSets) {
+        for (const set2 of userMergeSets) {
+          if (set1 !== set2) {
+            if (hasIntersection(set1, set2)) {
+              throw new Error('Sets should be disjoint');
+            }
+          }
+        }
+      }
+      console.log(`Found ${userMergeSets.length} sets of users to merge.`);
+
+      // query all identified users + profiles in order to select which to use
+      const usersToBeMerged = await queryInterface.sequelize.query(
+        `
+          SELECT
+            u.id AS user_id, u.email AS email, u.updated_at AS user_updated,
+            p.id AS profile_id, p.profile_name AS name, p.updated_at AS profile_updated
+          FROM "Users" AS u
+          JOIN "Profiles" AS p
+          ON u.id = p.user_id
+            AND u.id IN (${userMergeSets.map((set) => [...set].join(',')).join(',')});
+        `,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      );
+
+      // Produce object to transform addresses / profiles
+      /*
+        {
+          keptUser: user_id,
+          keptProfile: profile_id,
+          keptProfileName: string,
+          keptProfileNameId: profile_id,
+          mergedUsers: user_id[],
+        }
+      */
+      const userToKeepMap = [];
+      for (const userSet of userMergeSets) {
+        const userSetData = [...userSet].map(
+          (user_id) => usersToBeMerged.find((u) => u.user_id === user_id)
+        );
+        const userTransformData = {
+          keptUser: null,
+          keptProfile: null,
+          keptProfileName: null,
+          keptProfileNameId: null,
+          mergedUsers: [...userSet],
+        }
+
+        // Select which User will be kept -- most recently updated with email
+        const keptUser = userSetData.reduce((acc, cur) => {
+          if (!acc) return cur;
+          if (!cur.email && acc.email) return acc;
+          if (cur.email && !acc.email) return cur;
+          if (cur.user_updated > acc.user_updated) return cur;
+          return acc;
+        });
+        userTransformData.keptUser = keptUser.user_id;
+        userTransformData.keptProfile = keptUser.profile_id;
+
+        // Select which Profile will be kept -- most recently updated with name
+        const keptProfile = userSetData.reduce((acc, cur) => {
+          if (!acc) return cur;
+          if (!cur.name && acc.name) return acc;
+          if (cur.name && !acc.name) return cur;
+          if (cur.profile_updated > acc.profile_updated) return cur;
+          return acc;
+        });
+        userTransformData.keptProfileName = keptProfile.name;
+        userTransformData.keptProfileNameId = keptProfile.profile_id;
+        userToKeepMap.push(userTransformData);
+      }
+
+      // Update profile object on kept user to have selected name
+      let profilesUpdated = 0;
+      for (const { keptProfile, keptProfileName, keptProfileNameId } of userToKeepMap) {
+        if (keptProfileNameId !== keptProfile && keptProfileName) {
+          profilesUpdated++;
+          await queryInterface.sequelize.query(
+            `
+              UPDATE "Profiles"
+              SET profile_name = '${keptProfileName}'
+              WHERE id = ${keptProfile}
+            `,
+            { transaction }
+          );
+        }
+      }
+      console.log(`Updated ${profilesUpdated} profiles.`);
+
+      // Update address objects on merged users to have kept user
+      for (const { keptUser, keptProfile, mergedUsers } of userToKeepMap) {
+        await queryInterface.sequelize.query(
+          `
+            UPDATE "Addresses"
+            SET user_id = ${keptUser}, profile_id = ${keptProfile}
+            WHERE user_id IN (${mergedUsers.join(',')});
+          `,
+          { transaction }
+        );
+      }
+      console.log('Migration complete.');
+
+      // For another migration: remove dead (orphaned) users + profiles
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // NOT REVERSIBLE
+  }
+};

--- a/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
+++ b/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const hasIntersection = (set1, set2) => {
-  return [...set1].filter(x => set2.has(x)).length > 0;
-}
+  return [...set1].filter((x) => set2.has(x)).length > 0;
+};
 
 const inplaceSetUnion = (set1, set2) => {
   for (const item of set2) {
     set1.add(item);
   }
-}
+};
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
@@ -37,7 +37,7 @@ module.exports = {
       }
 
       // 3. Walk map of addresses to produce sets of users to combine
-      const userMergeSets = []
+      const userMergeSets = [];
       for (const mergeGroup of Object.values(addressToUserMap)) {
         const mergeSet = new Set(mergeGroup);
         let found = false;
@@ -76,7 +76,9 @@ module.exports = {
           FROM "Users" AS u
           JOIN "Profiles" AS p
           ON u.id = p.user_id
-            AND u.id IN (${userMergeSets.map((set) => [...set].join(',')).join(',')});
+            AND u.id IN (${userMergeSets
+              .map((set) => [...set].join(','))
+              .join(',')});
         `,
         {
           type: queryInterface.sequelize.QueryTypes.SELECT,
@@ -96,8 +98,8 @@ module.exports = {
       */
       const userToKeepMap = [];
       for (const userSet of userMergeSets) {
-        const userSetData = [...userSet].map(
-          (user_id) => usersToBeMerged.find((u) => u.user_id === user_id)
+        const userSetData = [...userSet].map((user_id) =>
+          usersToBeMerged.find((u) => u.user_id === user_id)
         );
         const userTransformData = {
           keptUser: null,
@@ -105,7 +107,7 @@ module.exports = {
           keptProfileName: null,
           keptProfileNameId: null,
           mergedUsers: [...userSet],
-        }
+        };
 
         // Select which User will be kept -- most recently updated with email
         const keptUser = userSetData.reduce((acc, cur) => {
@@ -133,7 +135,11 @@ module.exports = {
 
       // 6. Update profile objects on kept users to have selected name
       let profilesUpdated = 0;
-      for (const { keptProfile, keptProfileName, keptProfileNameId } of userToKeepMap) {
+      for (const {
+        keptProfile,
+        keptProfileName,
+        keptProfileNameId,
+      } of userToKeepMap) {
         if (keptProfileNameId !== keptProfile && keptProfileName) {
           profilesUpdated++;
           await queryInterface.sequelize.query(
@@ -168,5 +174,5 @@ module.exports = {
 
   down: async (queryInterface, Sequelize) => {
     // NOT REVERSIBLE
-  }
+  },
 };

--- a/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
+++ b/packages/commonwealth/server/migrations/20230308203116-enforce-user-address-unique.js
@@ -123,6 +123,7 @@ module.exports = {
           if (!acc) return cur;
           if (!cur.name && acc.name) return acc;
           if (cur.name && !acc.name) return cur;
+          if (cur.profile_updated > acc.profile_updated) return cur;
           return acc;
         });
         userTransformData.keptProfileName = keptProfileName.name;

--- a/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
@@ -8,6 +8,7 @@ import { ADDRESS_TOKEN_EXPIRES_IN } from '../config';
 import type { DB } from '../models';
 import { createRole, findOneRole } from '../util/roles';
 import { factory, formatFilename } from 'common-common/src/logging';
+import assertAddressOwnership from '../util/assertAddressOwnership';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -153,6 +154,9 @@ const linkExistingAddressToChain = async (
 
       addressId = newObj.id;
     }
+
+    // assertion check
+    await assertAddressOwnership(models, encodedAddress);
 
     const existingProfile = await models.OffchainProfile.findOne({
       where: { address_id: addressId },

--- a/packages/commonwealth/server/routes/verifyAddress.ts
+++ b/packages/commonwealth/server/routes/verifyAddress.ts
@@ -1,16 +1,4 @@
-import { bech32 } from 'bech32';
-import bs58 from 'bs58';
-import { configure as configureStableStringify } from 'safe-stable-stringify';
-
-import type { KeyringOptions } from '@polkadot/keyring/types';
-import { hexToU8a, stringToHex } from '@polkadot/util';
-import type { KeypairType } from '@polkadot/util-crypto/types';
-import * as ethUtil from 'ethereumjs-util';
-
-import {
-  recoverTypedSignature,
-  SignTypedDataVersion,
-} from '@metamask/eth-sig-util';
+import { Op } from 'sequelize';
 
 import { AppError } from 'common-common/src/errors';
 import { factory, formatFilename } from 'common-common/src/logging';
@@ -21,35 +9,18 @@ import {
   WalletId,
 } from 'common-common/src/types';
 import type { NextFunction, Request, Response } from 'express';
-import Web3 from 'web3';
 
-import { validationTokenToSignDoc } from '../../shared/adapters/chain/cosmos/keys';
-import { constructTypedCanvasMessage } from '../../shared/adapters/chain/ethereum/keys';
 import { DynamicTemplate } from '../../shared/types';
 import { addressSwapper } from '../../shared/utils';
 import type { DB } from '../models';
-import type { AddressInstance } from '../models/address';
 import type { ChainInstance } from '../models/chain';
 import type { ProfileAttributes } from '../models/profile';
 import { mixpanelTrack } from '../util/mixpanelUtil';
 import { MixpanelLoginEvent } from '../../shared/analytics/types';
-import {
-  chainBaseToCanvasChain,
-  chainBaseToCanvasChainId,
-  constructCanvasMessage,
-} from '../../shared/adapters/shared';
-
-import type { SessionPayload } from '@canvas-js/interfaces';
+import assertAddressOwnership from '../util/assertAddressOwnership';
+import verifySignature from '../util/verifySignature';
 
 const log = factory.getLogger(formatFilename(__filename));
-
-// can't import from canvas es module, so we reimplement stringify here
-const sortedStringify = configureStableStringify({
-  bigint: false,
-  circularValue: Error,
-  strict: true,
-  deterministic: true,
-});
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const sgMail = require('@sendgrid/mail');
@@ -67,316 +38,7 @@ export const Errors = {
   WrongWallet: 'Verified with different wallet than created',
 };
 
-// Address.verifySignature
-const verifySignature = async (
-  models: DB,
-  chain: ChainInstance,
-  chain_id: string | number,
-  addressModel: AddressInstance,
-  user_id: number,
-  signatureString: string,
-  sessionAddress: string | null, // used when signing a block to login
-  sessionIssued: string | null, // used when signing a block to login
-  sessionBlockInfo: string | null // used when signing a block to login
-): Promise<boolean> => {
-  if (!chain) {
-    log.error('no chain provided to verifySignature');
-    return false;
-  }
-
-  // Reconstruct the expected canvas message.
-  const canvasChain = chainBaseToCanvasChain(chain.base);
-  const canvasChainId = chainBaseToCanvasChainId(chain.base, chain_id);
-  const canvasMessage = constructCanvasMessage(
-    canvasChain,
-    canvasChainId,
-    chain.base === ChainBase.Substrate
-      ? addressSwapper({
-          address: addressModel.address,
-          currentPrefix: 42,
-        })
-      : addressModel.address,
-    sessionAddress,
-    parseInt(sessionIssued, 10),
-    sessionBlockInfo
-      ? addressModel.block_info
-        ? JSON.parse(addressModel.block_info).hash
-        : null
-      : null
-  );
-
-  let isValid: boolean;
-  if (chain.base === ChainBase.Substrate) {
-    //
-    // substrate address handling
-    //
-    const polkadot = await import('@polkadot/keyring');
-    const address = polkadot.decodeAddress(addressModel.address);
-    const keyringOptions: KeyringOptions = { type: 'sr25519' };
-    if (
-      !addressModel.keytype ||
-      addressModel.keytype === 'sr25519' ||
-      addressModel.keytype === 'ed25519'
-    ) {
-      if (addressModel.keytype) {
-        keyringOptions.type = addressModel.keytype as KeypairType;
-      }
-      keyringOptions.ss58Format = chain.ss58_prefix ?? 42;
-      const signerKeyring = new polkadot.Keyring(keyringOptions).addFromAddress(
-        address
-      );
-      const message = stringToHex(sortedStringify(canvasMessage));
-
-      const signatureU8a =
-        signatureString.slice(0, 2) === '0x'
-          ? hexToU8a(signatureString)
-          : hexToU8a(`0x${signatureString}`);
-      isValid = signerKeyring.verify(message, signatureU8a, address);
-    } else {
-      log.error('Invalid keytype.');
-      isValid = false;
-    }
-  } else if (
-    chain.base === ChainBase.CosmosSDK &&
-    (addressModel.wallet_id === WalletId.CosmosEvmMetamask ||
-      addressModel.wallet_id === WalletId.KeplrEthereum)
-  ) {
-    //
-    // ethereum address handling on cosmos chains via metamask
-    //
-    const web3 = new Web3();
-    const address = web3.eth.accounts.recover(
-      sortedStringify(canvasMessage),
-      signatureString.trim()
-    );
-
-    try {
-      const b32Address = bech32.encode(
-        chain.bech32_prefix,
-        bech32.toWords(Buffer.from(address.slice(2), 'hex'))
-      );
-      if (addressModel.address === b32Address) isValid = true;
-    } catch (e) {
-      isValid = false;
-    }
-  } else if (
-    chain.base === ChainBase.CosmosSDK &&
-    chain.bech32_prefix === 'terra'
-  ) {
-    //
-    // cosmos-sdk address handling
-    //
-
-    // provided string should be serialized AminoSignResponse object
-    const stdSignature = JSON.parse(signatureString);
-
-    // we generate an address from the actual public key and verify that it matches,
-    // this prevents people from using a different key to sign the message than
-    // the account they registered with.
-    // TODO: ensure ion works
-    const bech32Prefix = chain.bech32_prefix;
-
-    const cosmCrypto = await import('@cosmjs/crypto');
-    if (!bech32Prefix) {
-      log.error('No bech32 prefix found.');
-      isValid = false;
-    } else {
-      const cosm = await import('@cosmjs/amino');
-      const generatedAddress = cosm.pubkeyToAddress(
-        stdSignature.pub_key,
-        bech32Prefix
-      );
-
-      if (generatedAddress === addressModel.address) {
-        try {
-          // directly verify the generated signature, generated via SignBytes
-          const { pubkey, signature } = cosm.decodeSignature(stdSignature);
-          const secpSignature =
-            cosmCrypto.Secp256k1Signature.fromFixedLength(signature);
-          const messageHash = new cosmCrypto.Sha256(
-            Buffer.from(sortedStringify(canvasMessage))
-          ).digest();
-
-          isValid = await cosmCrypto.Secp256k1.verifySignature(
-            secpSignature,
-            messageHash,
-            pubkey
-          );
-        } catch (e) {
-          isValid = false;
-        }
-      }
-    }
-  } else if (chain.base === ChainBase.CosmosSDK) {
-    //
-    // cosmos-sdk address handling
-    //
-    const stdSignature = JSON.parse(signatureString);
-
-    const bech32Prefix = chain.bech32_prefix;
-    if (!bech32Prefix) {
-      log.error('No bech32 prefix found.');
-      isValid = false;
-    } else {
-      const cosm = await import('@cosmjs/amino');
-      const generatedAddress = cosm.pubkeyToAddress(
-        stdSignature.pub_key,
-        bech32Prefix
-      );
-      const generatedAddressWithCosmosPrefix = cosm.pubkeyToAddress(
-        stdSignature.pub_key,
-        'cosmos'
-      );
-
-      if (
-        generatedAddress === addressModel.address ||
-        generatedAddressWithCosmosPrefix === addressModel.address
-      ) {
-        try {
-          // Generate sign doc from token and verify it against the signature
-          const generatedSignDoc = await validationTokenToSignDoc(
-            Buffer.from(sortedStringify(canvasMessage)),
-            generatedAddress
-          );
-
-          const { pubkey, signature } = cosm.decodeSignature(stdSignature);
-          const cosmCrypto = await import('@cosmjs/crypto');
-          const secpSignature =
-            cosmCrypto.Secp256k1Signature.fromFixedLength(signature);
-          const messageHash = new cosmCrypto.Sha256(
-            cosm.serializeSignDoc(generatedSignDoc)
-          ).digest();
-          isValid = await cosmCrypto.Secp256k1.verifySignature(
-            secpSignature,
-            messageHash,
-            pubkey
-          );
-          if (!isValid) {
-            log.error('Signature mismatch.');
-          }
-        } catch (e) {
-          log.error(`Signature verification failed: ${e.message}`);
-          isValid = false;
-        }
-      } else {
-        log.error(
-          `Address not matched. Generated ${generatedAddress}, found ${addressModel.address}.`
-        );
-        isValid = false;
-      }
-    }
-  } else if (chain.base === ChainBase.Ethereum) {
-    //
-    // ethereum address handling
-    //
-    try {
-      const typedCanvasMessage = constructTypedCanvasMessage(canvasMessage);
-
-      if (addressModel.block_info !== sessionBlockInfo) {
-        throw new Error(
-          `Eth verification failed for ${addressModel.address}: signed a different block than expected`
-        );
-      }
-      const address = recoverTypedSignature({
-        data: typedCanvasMessage,
-        signature: signatureString.trim(),
-        version: SignTypedDataVersion.V4,
-      });
-      isValid = addressModel.address.toLowerCase() === address.toLowerCase();
-      if (!isValid) {
-        log.info(
-          `Eth verification failed for ${addressModel.address}: does not match recovered address ${address}`
-        );
-      }
-    } catch (e) {
-      log.info(
-        `Eth verification failed for ${addressModel.address}: ${e.stack}`
-      );
-      isValid = false;
-    }
-  } else if (chain.base === ChainBase.NEAR) {
-    //
-    // near address handling
-    //
-
-    // both in base64 encoding
-    const nacl = await import('tweetnacl');
-    const { signature: sigObj, publicKey } = JSON.parse(signatureString);
-
-    isValid = nacl.sign.detached.verify(
-      Buffer.from(sortedStringify(canvasMessage)),
-      Buffer.from(sigObj, 'base64'),
-      Buffer.from(publicKey, 'base64')
-    );
-  } else if (chain.base === ChainBase.Solana) {
-    //
-    // solana address handling
-    //
-
-    // ensure address is base58 string length 32, cf @solana/web3 impl
-    try {
-      const decodedAddress = bs58.decode(addressModel.address);
-      if (decodedAddress.length === 32) {
-        const nacl = await import('tweetnacl');
-        isValid = nacl.sign.detached.verify(
-          Buffer.from(sortedStringify(canvasMessage)),
-          bs58.decode(signatureString),
-          decodedAddress
-        );
-      } else {
-        isValid = false;
-      }
-    } catch (e) {
-      isValid = false;
-    }
-  } else {
-    // invalid network
-    log.error(`invalid network: ${chain.network}`);
-    isValid = false;
-  }
-
-  addressModel.last_active = new Date();
-
-  if (isValid && user_id === null) {
-    // mark the address as verified, and if it doesn't have an associated user, create a new user
-    addressModel.verification_token_expires = null;
-    addressModel.verified = new Date();
-    if (!addressModel.user_id) {
-      const user = await models.User.createWithProfile(models, { email: null });
-      addressModel.profile_id = (user.Profiles[0] as ProfileAttributes).id;
-      await models.Subscription.create({
-        subscriber_id: user.id,
-        category_id: NotificationCategories.NewMention,
-        object_id: `user-${user.id}`,
-        is_active: true,
-      });
-      await models.Subscription.create({
-        subscriber_id: user.id,
-        category_id: NotificationCategories.NewCollaboration,
-        object_id: `user-${user.id}`,
-        is_active: true,
-      });
-      // Automatically create subscription to chat mentions
-      await models.Subscription.create({
-        subscriber_id: user.id,
-        category_id: NotificationCategories.NewChatMention,
-        object_id: `user-${user.id}`,
-        is_active: true,
-      });
-      addressModel.user_id = user.id;
-    }
-  } else if (isValid) {
-    // mark the address as verified
-    addressModel.verification_token_expires = null;
-    addressModel.verified = new Date();
-    addressModel.user_id = user_id;
-    const profile = await models.Profile.findOne({ where: { user_id } });
-    addressModel.profile_id = profile.id;
-  }
-  await addressModel.save();
-  return isValid;
-};
-
+// perform address / user modification logic
 const processAddress = async (
   models: DB,
   chain: ChainInstance,
@@ -389,36 +51,30 @@ const processAddress = async (
   sessionIssued: string | null,
   sessionBlockInfo: string | null
 ): Promise<void> => {
-  const existingAddress = await models.Address.scope('withPrivateData').findOne(
-    {
-      where: { chain: chain.id, address },
-    }
-  );
-  if (!existingAddress) {
+  const addressInstance = await models.Address.scope('withPrivateData').findOne({
+    where: { chain: chain.id, address }
+  });
+  if (!addressInstance) {
     throw new AppError(Errors.AddressNF);
   }
 
-  if (existingAddress.wallet_id !== wallet_id) {
+  if (addressInstance.wallet_id !== wallet_id) {
     throw new AppError(Errors.WrongWallet);
   }
 
-  // first, check whether the token has expired
+  // check whether the token has expired
   // (certain login methods e.g. jwt have no expiration token, so we skip the check in that case)
-  const expiration = existingAddress.verification_token_expires;
+  const expiration = addressInstance.verification_token_expires;
   if (expiration && +expiration <= +new Date()) {
     throw new AppError(Errors.ExpiredToken);
   }
-  // check for validity
-  const isAddressTransfer =
-    !!existingAddress.verified && user && existingAddress.user_id !== user.id;
-  const oldId = existingAddress.user_id;
+
+  // verify the signature matches the session information = verify ownership
   try {
     const valid = await verifySignature(
-      models,
       chain,
       chain_id,
-      existingAddress,
-      user ? user.id : null,
+      addressInstance,
       signature,
       sessionAddress,
       sessionIssued,
@@ -432,15 +88,75 @@ const processAddress = async (
     throw new AppError(Errors.CouldNotVerifySignature);
   }
 
-  // if someone else already verified it, send an email letting them know ownership
-  // has been transferred to someone else
-  if (isAddressTransfer) {
-    try {
-      const oldUser = await models.User.scope('withPrivateData').findOne({
-        where: { id: oldId },
+  addressInstance.last_active = new Date();
+
+  if (!user?.id) {
+    // user is not logged in
+    addressInstance.verification_token_expires = null;
+    addressInstance.verified = new Date();
+    if (!addressInstance.user_id) {
+      // address is not yet verified => create a new user
+      const newUser = await models.User.createWithProfile(models, { email: null });
+      addressInstance.profile_id = (newUser.Profiles[0] as ProfileAttributes).id;
+      await models.Subscription.create({
+        subscriber_id: newUser.id,
+        category_id: NotificationCategories.NewMention,
+        object_id: `user-${newUser.id}`,
+        is_active: true,
       });
-      if (!oldUser) {
-        // users who register thru github don't have emails by default
+      await models.Subscription.create({
+        subscriber_id: newUser.id,
+        category_id: NotificationCategories.NewCollaboration,
+        object_id: `user-${newUser.id}`,
+        is_active: true,
+      });
+      await models.Subscription.create({
+        subscriber_id: newUser.id,
+        category_id: NotificationCategories.NewChatMention,
+        object_id: `user-${newUser.id}`,
+        is_active: true,
+      });
+      addressInstance.user_id = newUser.id;
+    }
+  } else {
+    // user is already logged in => verify the newly created address
+    addressInstance.verification_token_expires = null;
+    addressInstance.verified = new Date();
+    addressInstance.user_id = user.id;
+    const profile = await models.Profile.findOne({ where: { user_id: user.id } });
+    addressInstance.profile_id = profile.id;
+  }
+  await addressInstance.save();
+
+  // if address has already been previously verified, update all other addresses
+  // to point to the new user = "transfer ownership".
+  const addressToTransfer = await models.Address.findOne({
+    where: {
+      address,
+      user_id: { [Op.ne]: addressInstance.user_id },
+      verified: { [Op.ne]: null },
+    }
+  });
+
+  if (addressToTransfer) {
+    // reassign the users and profiles of the transferred addresses
+    await models.Address.update({
+      user_id: addressInstance.user_id,
+      profile_id: addressInstance.profile_id,
+    }, {
+      where: {
+        address,
+        user_id: { [Op.ne]: addressInstance.user_id },
+        verified: { [Op.ne]: null },
+      }
+    });
+
+    try {
+      // send email to the old user (should only ever be one)
+      const oldUser = await models.User.scope('withPrivateData').findOne({
+        where: { id: addressToTransfer.user_id, email: { [Op.ne]: null } },
+      });
+      if (!oldUser?.email) {
         throw new AppError(Errors.NoEmail);
       }
       const msg = {
@@ -503,6 +219,9 @@ const verifyAddress = async (
     req.body.session_timestamp || null, // disallow empty strings
     req.body.session_block_data || null // disallow empty strings
   );
+
+  // assertion check
+  await assertAddressOwnership(models, address);
 
   if (req.user) {
     // if user was already logged in, we're done

--- a/packages/commonwealth/server/routes/verifyAddress.ts
+++ b/packages/commonwealth/server/routes/verifyAddress.ts
@@ -51,9 +51,11 @@ const processAddress = async (
   sessionIssued: string | null,
   sessionBlockInfo: string | null
 ): Promise<void> => {
-  const addressInstance = await models.Address.scope('withPrivateData').findOne({
-    where: { chain: chain.id, address }
-  });
+  const addressInstance = await models.Address.scope('withPrivateData').findOne(
+    {
+      where: { chain: chain.id, address },
+    }
+  );
   if (!addressInstance) {
     throw new AppError(Errors.AddressNF);
   }
@@ -96,8 +98,12 @@ const processAddress = async (
     addressInstance.verified = new Date();
     if (!addressInstance.user_id) {
       // address is not yet verified => create a new user
-      const newUser = await models.User.createWithProfile(models, { email: null });
-      addressInstance.profile_id = (newUser.Profiles[0] as ProfileAttributes).id;
+      const newUser = await models.User.createWithProfile(models, {
+        email: null,
+      });
+      addressInstance.profile_id = (
+        newUser.Profiles[0] as ProfileAttributes
+      ).id;
       await models.Subscription.create({
         subscriber_id: newUser.id,
         category_id: NotificationCategories.NewMention,
@@ -123,7 +129,9 @@ const processAddress = async (
     addressInstance.verification_token_expires = null;
     addressInstance.verified = new Date();
     addressInstance.user_id = user.id;
-    const profile = await models.Profile.findOne({ where: { user_id: user.id } });
+    const profile = await models.Profile.findOne({
+      where: { user_id: user.id },
+    });
     addressInstance.profile_id = profile.id;
   }
   await addressInstance.save();
@@ -135,21 +143,24 @@ const processAddress = async (
       address,
       user_id: { [Op.ne]: addressInstance.user_id },
       verified: { [Op.ne]: null },
-    }
+    },
   });
 
   if (addressToTransfer) {
     // reassign the users and profiles of the transferred addresses
-    await models.Address.update({
-      user_id: addressInstance.user_id,
-      profile_id: addressInstance.profile_id,
-    }, {
-      where: {
-        address,
-        user_id: { [Op.ne]: addressInstance.user_id },
-        verified: { [Op.ne]: null },
+    await models.Address.update(
+      {
+        user_id: addressInstance.user_id,
+        profile_id: addressInstance.profile_id,
+      },
+      {
+        where: {
+          address,
+          user_id: { [Op.ne]: addressInstance.user_id },
+          verified: { [Op.ne]: null },
+        },
       }
-    });
+    );
 
     try {
       // send email to the old user (should only ever be one)

--- a/packages/commonwealth/server/util/assertAddressOwnership.ts
+++ b/packages/commonwealth/server/util/assertAddressOwnership.ts
@@ -5,12 +5,15 @@ import { ServerError } from 'common-common/src/errors';
 
 const log = factory.getLogger(formatFilename(__filename));
 
-export default async function assertAddressOwnership(models: DB, address: string) {
+export default async function assertAddressOwnership(
+  models: DB,
+  address: string
+) {
   const addressUsers = await models.Address.findAll({
     where: {
       address,
       verified: { [Op.ne]: null },
-    }
+    },
   });
   const numUserIds = new Set(addressUsers.map((au) => au.user_id)).size;
   if (numUserIds !== 1) {

--- a/packages/commonwealth/server/util/assertAddressOwnership.ts
+++ b/packages/commonwealth/server/util/assertAddressOwnership.ts
@@ -1,0 +1,30 @@
+import type { DB } from '../models';
+import { Op } from 'sequelize';
+import { factory, formatFilename } from 'common-common/src/logging';
+import { ServerError } from 'common-common/src/errors';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+export default async function assertAddressOwnership(models: DB, address: string) {
+  const addressUsers = await models.Address.findAll({
+    where: {
+      address,
+      verified: { [Op.ne]: null },
+    }
+  });
+  const numUserIds = new Set(addressUsers.map((au) => au.user_id)).size;
+  if (numUserIds !== 1) {
+    log.error(`Address ${address} is not owned by a single user!`);
+    if (process.env.NODE_ENV !== 'production') {
+      throw new ServerError('Address failed assertion check');
+    }
+  }
+
+  const numProfileIds = new Set(addressUsers.map((au) => au.profile_id)).size;
+  if (numProfileIds !== 1) {
+    log.error(`Address ${address} relates to multiple profiles!`);
+    if (process.env.NODE_ENV !== 'production') {
+      throw new ServerError('Address failed assertion check');
+    }
+  }
+}

--- a/packages/commonwealth/server/util/verifySignature.ts
+++ b/packages/commonwealth/server/util/verifySignature.ts
@@ -1,0 +1,304 @@
+import { configure as configureStableStringify } from 'safe-stable-stringify';
+import type { KeyringOptions } from '@polkadot/keyring/types';
+import { hexToU8a, stringToHex } from '@polkadot/util';
+import type { KeypairType } from '@polkadot/util-crypto/types';
+import {
+  recoverTypedSignature,
+  SignTypedDataVersion,
+} from '@metamask/eth-sig-util';
+import { bech32 } from 'bech32';
+import bs58 from 'bs58';
+import Web3 from 'web3';
+import { factory, formatFilename } from 'common-common/src/logging';
+import { ChainBase, WalletId } from 'common-common/src/types';
+
+import { addressSwapper } from '../../shared/utils';
+import { validationTokenToSignDoc } from '../../shared/adapters/chain/cosmos/keys';
+import { constructTypedCanvasMessage } from '../../shared/adapters/chain/ethereum/keys';
+import {
+  chainBaseToCanvasChain,
+  chainBaseToCanvasChainId,
+  constructCanvasMessage,
+} from '../../shared/adapters/shared';
+import type { AddressInstance } from '../models/address';
+import type { ChainInstance } from '../models/chain';
+
+const log = factory.getLogger(formatFilename(__filename));
+
+// can't import from canvas es module, so we reimplement stringify here
+const sortedStringify = configureStableStringify({
+  bigint: false,
+  circularValue: Error,
+  strict: true,
+  deterministic: true,
+});
+
+const verifySignature = async (
+  chain: Readonly<ChainInstance>,
+  chain_id: string | number,
+  addressInstance: Readonly<AddressInstance>,
+  signatureString: string,
+  sessionAddress: string | null, // used when signing a block to login
+  sessionIssued: string | null, // used when signing a block to login
+  sessionBlockInfo: string | null // used when signing a block to login
+): Promise<boolean> => {
+  if (!chain) {
+    log.error('no chain provided to verifySignature');
+    return false;
+  }
+
+  // Reconstruct the expected canvas message.
+  const canvasChain = chainBaseToCanvasChain(chain.base);
+  const canvasChainId = chainBaseToCanvasChainId(chain.base, chain_id);
+  const canvasMessage = constructCanvasMessage(
+    canvasChain,
+    canvasChainId,
+    chain.base === ChainBase.Substrate
+      ? addressSwapper({
+          address: addressInstance.address,
+          currentPrefix: 42,
+        })
+      : addressInstance.address,
+    sessionAddress,
+    parseInt(sessionIssued, 10),
+    sessionBlockInfo
+      ? addressInstance.block_info
+        ? JSON.parse(addressInstance.block_info).hash
+        : null
+      : null
+  );
+
+  let isValid: boolean;
+  if (chain.base === ChainBase.Substrate) {
+    //
+    // substrate address handling
+    //
+    const polkadot = await import('@polkadot/keyring');
+    const address = polkadot.decodeAddress(addressInstance.address);
+    const keyringOptions: KeyringOptions = { type: 'sr25519' };
+    if (
+      !addressInstance.keytype ||
+      addressInstance.keytype === 'sr25519' ||
+      addressInstance.keytype === 'ed25519'
+    ) {
+      if (addressInstance.keytype) {
+        keyringOptions.type = addressInstance.keytype as KeypairType;
+      }
+      keyringOptions.ss58Format = chain.ss58_prefix ?? 42;
+      const signerKeyring = new polkadot.Keyring(keyringOptions).addFromAddress(
+        address
+      );
+      const message = stringToHex(sortedStringify(canvasMessage));
+
+      const signatureU8a =
+        signatureString.slice(0, 2) === '0x'
+          ? hexToU8a(signatureString)
+          : hexToU8a(`0x${signatureString}`);
+      isValid = signerKeyring.verify(message, signatureU8a, address);
+    } else {
+      log.error('Invalid keytype.');
+      isValid = false;
+    }
+  } else if (
+    chain.base === ChainBase.CosmosSDK &&
+    (addressInstance.wallet_id === WalletId.CosmosEvmMetamask ||
+      addressInstance.wallet_id === WalletId.KeplrEthereum)
+  ) {
+    //
+    // ethereum address handling on cosmos chains via metamask
+    //
+    const web3 = new Web3();
+    const address = web3.eth.accounts.recover(
+      sortedStringify(canvasMessage),
+      signatureString.trim()
+    );
+
+    try {
+      const b32Address = bech32.encode(
+        chain.bech32_prefix,
+        bech32.toWords(Buffer.from(address.slice(2), 'hex'))
+      );
+      if (addressInstance.address === b32Address) isValid = true;
+    } catch (e) {
+      isValid = false;
+    }
+  } else if (
+    chain.base === ChainBase.CosmosSDK &&
+    chain.bech32_prefix === 'terra'
+  ) {
+    //
+    // cosmos-sdk address handling
+    //
+
+    // provided string should be serialized AminoSignResponse object
+    const stdSignature = JSON.parse(signatureString);
+
+    // we generate an address from the actual public key and verify that it matches,
+    // this prevents people from using a different key to sign the message than
+    // the account they registered with.
+    // TODO: ensure ion works
+    const bech32Prefix = chain.bech32_prefix;
+
+    const cosmCrypto = await import('@cosmjs/crypto');
+    if (!bech32Prefix) {
+      log.error('No bech32 prefix found.');
+      isValid = false;
+    } else {
+      const cosm = await import('@cosmjs/amino');
+      const generatedAddress = cosm.pubkeyToAddress(
+        stdSignature.pub_key,
+        bech32Prefix
+      );
+
+      if (generatedAddress === addressInstance.address) {
+        try {
+          // directly verify the generated signature, generated via SignBytes
+          const { pubkey, signature } = cosm.decodeSignature(stdSignature);
+          const secpSignature =
+            cosmCrypto.Secp256k1Signature.fromFixedLength(signature);
+          const messageHash = new cosmCrypto.Sha256(
+            Buffer.from(sortedStringify(canvasMessage))
+          ).digest();
+
+          isValid = await cosmCrypto.Secp256k1.verifySignature(
+            secpSignature,
+            messageHash,
+            pubkey
+          );
+        } catch (e) {
+          isValid = false;
+        }
+      }
+    }
+  } else if (chain.base === ChainBase.CosmosSDK) {
+    //
+    // cosmos-sdk address handling
+    //
+    const stdSignature = JSON.parse(signatureString);
+
+    const bech32Prefix = chain.bech32_prefix;
+    if (!bech32Prefix) {
+      log.error('No bech32 prefix found.');
+      isValid = false;
+    } else {
+      const cosm = await import('@cosmjs/amino');
+      const generatedAddress = cosm.pubkeyToAddress(
+        stdSignature.pub_key,
+        bech32Prefix
+      );
+      const generatedAddressWithCosmosPrefix = cosm.pubkeyToAddress(
+        stdSignature.pub_key,
+        'cosmos'
+      );
+
+      if (
+        generatedAddress === addressInstance.address ||
+        generatedAddressWithCosmosPrefix === addressInstance.address
+      ) {
+        try {
+          // Generate sign doc from token and verify it against the signature
+          const generatedSignDoc = await validationTokenToSignDoc(
+            Buffer.from(sortedStringify(canvasMessage)),
+            generatedAddress
+          );
+
+          const { pubkey, signature } = cosm.decodeSignature(stdSignature);
+          const cosmCrypto = await import('@cosmjs/crypto');
+          const secpSignature =
+            cosmCrypto.Secp256k1Signature.fromFixedLength(signature);
+          const messageHash = new cosmCrypto.Sha256(
+            cosm.serializeSignDoc(generatedSignDoc)
+          ).digest();
+          isValid = await cosmCrypto.Secp256k1.verifySignature(
+            secpSignature,
+            messageHash,
+            pubkey
+          );
+          if (!isValid) {
+            log.error('Signature mismatch.');
+          }
+        } catch (e) {
+          log.error(`Signature verification failed: ${e.message}`);
+          isValid = false;
+        }
+      } else {
+        log.error(
+          `Address not matched. Generated ${generatedAddress}, found ${addressInstance.address}.`
+        );
+        isValid = false;
+      }
+    }
+  } else if (chain.base === ChainBase.Ethereum) {
+    //
+    // ethereum address handling
+    //
+    try {
+      const typedCanvasMessage = constructTypedCanvasMessage(canvasMessage);
+
+      if (addressInstance.block_info !== sessionBlockInfo) {
+        throw new Error(
+          `Eth verification failed for ${addressInstance.address}: signed a different block than expected`
+        );
+      }
+      const address = recoverTypedSignature({
+        data: typedCanvasMessage,
+        signature: signatureString.trim(),
+        version: SignTypedDataVersion.V4,
+      });
+      isValid = addressInstance.address.toLowerCase() === address.toLowerCase();
+      if (!isValid) {
+        log.info(
+          `Eth verification failed for ${addressInstance.address}: does not match recovered address ${address}`
+        );
+      }
+    } catch (e) {
+      log.info(
+        `Eth verification failed for ${addressInstance.address}: ${e.stack}`
+      );
+      isValid = false;
+    }
+  } else if (chain.base === ChainBase.NEAR) {
+    //
+    // near address handling
+    //
+
+    // both in base64 encoding
+    const nacl = await import('tweetnacl');
+    const { signature: sigObj, publicKey } = JSON.parse(signatureString);
+
+    isValid = nacl.sign.detached.verify(
+      Buffer.from(sortedStringify(canvasMessage)),
+      Buffer.from(sigObj, 'base64'),
+      Buffer.from(publicKey, 'base64')
+    );
+  } else if (chain.base === ChainBase.Solana) {
+    //
+    // solana address handling
+    //
+
+    // ensure address is base58 string length 32, cf @solana/web3 impl
+    try {
+      const decodedAddress = bs58.decode(addressInstance.address);
+      if (decodedAddress.length === 32) {
+        const nacl = await import('tweetnacl');
+        isValid = nacl.sign.detached.verify(
+          Buffer.from(sortedStringify(canvasMessage)),
+          bs58.decode(signatureString),
+          decodedAddress
+        );
+      } else {
+        isValid = false;
+      }
+    } catch (e) {
+      isValid = false;
+    }
+  } else {
+    // invalid network
+    log.error(`invalid network: ${chain.network}`);
+    isValid = false;
+  }
+
+  return isValid;
+};
+
+export default verifySignature;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3056 

## Description of Changes
- Enforces that each address as string is only owned by a single user (and profile). See migration for details on merging logic.
- Modify /verifyAddress route to ensure that this constraint is mandatory across application
- Refactor actual signature verification into util.
- Add assertion check to /verifyAddress and /linkExistingAddressToChain (throw disabled on prod).

## Test Plan
- CA testing on local, via all cases enumerated (logged in y/n, address already verified y/n, address exists on diff chains y/n, address on other chain is owned by another user y/n).

## Other Considerations
- Migration must go in prior to #3062 in particular.