### PR TITLE
Add UI/UX changes for toggle dark/light mode switch

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -169,7 +169,9 @@ export const LoginSelectorMenuRight = ({
 }: LoginSelectorMenuRightProps) => {
   const navigate = useCommonNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const isDarkModeOn = localStorage.getItem('dark-mode-state') === 'on';
+  const [isDarkModeOn, setIsDarkModeOn] = useState<boolean>(
+    localStorage.getItem('dark-mode-state') === 'on'
+  );
 
   return (
     <>
@@ -192,19 +194,23 @@ export const LoginSelectorMenuRight = ({
                 localStorage.setItem('user-dark-mode-state', 'off');
                 document
                   .getElementsByTagName('html')[0]
-                  .classList.remove('invert');
+                  .classList.toggle('invert');
+                setIsDarkModeOn(false);
               } else {
                 document
                   .getElementsByTagName('html')[0]
-                  .classList.add('invert');
+                  .classList.toggle('invert');
                 localStorage.setItem('dark-mode-state', 'on');
                 localStorage.setItem('user-dark-mode-state', 'on');
+                setIsDarkModeOn(true);
               }
               e.stopPropagation();
               redraw();
             }}
           />
-          <CWText type="caption">Dark mode</CWText>
+          <CWText type="caption">
+            {isDarkModeOn ? 'Light mode' : 'Dark mode'}
+          </CWText>
         </div>
         <CWDivider />
         <div className="login-menu-item" onClick={() => setIsModalOpen(true)}>

--- a/packages/commonwealth/client/styles/components/component_kit/cw_toggle.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_toggle.scss
@@ -21,7 +21,7 @@
     position: absolute;
     top: 2px;
     width: 20px;
-    transition: all ease-in-out 0.3s;
+    transition: all ease-in-out 0.2s;
   }
 
   &.checked {

--- a/packages/commonwealth/client/styles/components/component_kit/cw_toggle.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_toggle.scss
@@ -1,13 +1,13 @@
 @import '../../shared';
 
 .Toggle {
-  background-color: $neutral-300;
+  background-color: $primary-300;
   border-radius: $border-radius-rounded-corners;
   display: inline-block;
   height: 24px;
   position: relative;
-  transition: all ease-in-out 0.2s;
   width: 48px;
+  cursor: pointer;
 
   .toggle-input {
     @include hideInput;
@@ -16,22 +16,16 @@
   .slider {
     background-color: $white;
     border-radius: $border-radius-round;
-    cursor: pointer;
     height: 20px;
     left: 2px;
     position: absolute;
     top: 2px;
     width: 20px;
-    transition: all ease-in-out 0.2s;
+    transition: all ease-in-out 0.3s;
   }
 
   &.checked {
-    background-color: $primary-300;
-    transition: all ease-in-out 0.2s;
-
-    .slider {
-      transform: translateX(24px);
-    }
+    background-color: $neutral-300;
 
     &.disabled {
       background-color: $primary-200;

--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -52,7 +52,7 @@ html.invert {
 
   .slider {
     background-color: $primary-300;
-    transition: all ease-in-out 0.3s;
+    transition: all ease-in-out 0.2s;
     transform: translateX(24px);
   }
 }

--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -49,6 +49,12 @@ html.invert {
     -o-filter: invert(90%);
     -ms-filter: invert(90%);
   }
+
+  .slider {
+    background-color: $primary-300;
+    transition: all ease-in-out 0.3s;
+    transform: translateX(24px);
+  }
 }
 
 // global css


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
[Dark mode toggle state](https://github.com/hicommonwealth/commonwealth/issues/3064)

## Description of Changes
UI for dark/light mode toggle switch wasn't changing after user clicked on it.
Changes:

- transition of toggle switch slider
- user can toggle to switch to dark or light mode at will, without the need to click away on the popover
- label changes to "Light mode" or "Dark mode", being the option opposite to current state
- cursor:pointer on whole toggle component

## Test Plan
- CA (click around) tested on local

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 