### PR TITLE
Quick Fix: Text input error text color

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -316,9 +316,6 @@ export default class EditProfileComponent extends ClassComponent<EditNewProfileA
                   }}
                   inputClassName={this.displayNameValid ? '' : 'failure'}
                   manualStatusMessage={this.displayNameValid ? '' : 'No input'}
-                  manualValidationStatus={
-                    this.displayNameValid ? 'success' : 'failure'
-                  }
                 />
                 {/* <CWTextInput
                   name="email-form-field"
@@ -408,7 +405,9 @@ export default class EditProfileComponent extends ClassComponent<EditNewProfileA
                   app.user.addresses.splice(index, 1);
                 }}
               />
-              <CWText type="caption" fontWeight="medium">Link new addresses via the profile dropdown menu</CWText>
+              <CWText type="caption" fontWeight="medium">
+                Link new addresses via the profile dropdown menu
+              </CWText>
             </CWFormSection>
           </CWForm>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
- Sets the color of text input in edit profile page correctly.

## Test Plan


## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 