### PR TITLE
Fix Profiles Fetching for Comments on Proposals

### DIFF
--- a/packages/commonwealth/server/routes/getNewProfile.ts
+++ b/packages/commonwealth/server/routes/getNewProfile.ts
@@ -56,6 +56,9 @@ const getNewProfile = async (
 
   const comments = await models.Comment.findAll({
     where: {
+      root_id: {
+        [Op.like]: 'discussion%',
+      },
       address_id: {
         [Op.in]: addressIds,
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes bug where query explodes searching for comments with NaN thread Ids generated by assuming all comment root_ids are on threads. 

## Description of Changes
- Adds FIXME widget to TODO page.
- 

