### PR TITLE
Profiles BugFix: TryCatch AddressInfo malformation when community doesn't exist anymore

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/profile/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/index.tsx
@@ -58,15 +58,21 @@ export default class ProfileComponent extends ClassComponent<NewProfileAttrs> {
       });
       this.comments = commentsWithAssociatedThread;
       this.addresses = result.addresses.map(
-        (a) =>
-          new AddressInfo(
-            a.id,
-            a.address,
-            a.chain,
-            a.keytype,
-            a.wallet_id,
-            a.ghost_address
-          )
+        (a) => {
+          try {
+            return new AddressInfo(
+              a.id,
+              a.address,
+              a.chain,
+              a.keytype,
+              a.wallet_id,
+              a.ghost_address
+            )
+          } catch (err) {
+            console.log(a.chain);
+            return null;
+          }
+        }
       );
       this.isOwner = result.isOwner;
     } catch (err) {

--- a/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
@@ -29,6 +29,13 @@ export class NewProfileActivityRow extends ClassComponent<ProfileActivityRowAttr
     const comment = activity as CommentWithAssociatedThread;
     const domain = document.location.origin;
     const iconUrl = app.config.chains.getById(chain)?.iconUrl;
+    let decodedTitle;
+    try {
+      decodedTitle = decodeURIComponent(title);
+    } catch (err) {
+      console.error(`Could not decode title: "${title}"`);
+      decodedTitle = title;
+    }
 
     return (
       <div className="ProfileActivityRow">
@@ -54,9 +61,7 @@ export class NewProfileActivityRow extends ClassComponent<ProfileActivityRowAttr
             </span>
             {isThread
               ? link('a', `/${chain}/discussion/${id}`, [`${title}`])
-              : link('a', `/${chain}/discussion/${comment.thread?.id}`, [
-                  `${decodeURIComponent(comment.thread?.title)}`,
-                ])}
+              : link('a', `/${chain}/discussion/${comment.thread?.id}`, [`${decodedTitle}`,])}
           </CWText>
         </div>
         <div className="content">


### PR DESCRIPTION
For users who have old content on deleted communities, we try to construct addressInfo based on dead communities and it blows up the render cycle. Added a try/catch but this doesn't solve the problem that old community content is being rendered on the profile page and linking to dead communities. We should fix this soon.