### PR TITLE
Profiles BugFix: Add AddressInfo try/catch to edit profile page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -78,15 +78,21 @@ export default class EditProfileComponent extends ClassComponent<EditNewProfileA
       this.avatarUrl = this.profile.avatarUrl;
       this.backgroundImage = this.profile.backgroundImage;
       this.addresses = result.addresses.map(
-        (a) =>
-          new AddressInfo(
-            a.id,
-            a.address,
-            a.chain,
-            a.keytype,
-            a.wallet_id,
-            a.ghost_address
-          )
+        (a) =>{
+          try {
+            return new AddressInfo(
+              a.id,
+              a.address,
+              a.chain,
+              a.keytype,
+              a.wallet_id,
+              a.ghost_address
+            )
+          } catch (err) {
+            console.log(a.chain);
+            return null;
+          }
+        }
       );
       this.isOwner = result.isOwner;
     } catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3087 

## Description of Changes
- Adds a TryCatch, assuming a similar bug to the view profile page bug identified yesterday.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- @dillchen should CA this locally to make sure that it works?