### PR TITLE
Linked threads modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector.tsx
@@ -1,19 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import 'components/chain_entities_selector.scss';
-import type { ChainEntity, Thread } from 'models';
+import type { ChainEntity } from 'models';
 
 import app from 'state';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
 import { ChainEntitiesSelectorItem } from 'views/components/chain_entities_selector/chain_entities_selector_item';
 import { chainEntityTypeToProposalName } from 'identifiers';
-
-type ChainEntitiesSelectorProps = {
-  chainEntitiesToSet: Array<ChainEntity>;
-  onSelect: (ce: ChainEntity) => void;
-  thread: Thread;
-};
 
 const sortChainEntities = (a: ChainEntity, b: ChainEntity) => {
   if (!a.threadId && b.threadId) {
@@ -39,6 +33,11 @@ const filterChainEntities = (ce: ChainEntity, searchTerm: string) => {
       .toLowerCase()
       .includes(searchTerm.toLowerCase())
   );
+};
+
+type ChainEntitiesSelectorProps = {
+  chainEntitiesToSet: Array<ChainEntity>;
+  onSelect: (ce: ChainEntity) => void;
 };
 
 export const ChainEntitiesSelector = ({

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import 'components/snapshot_proposal_selector.scss';
 import type { SnapshotProposal } from 'helpers/snapshot_utils';
 import { loadMultipleSpacesData } from 'helpers/snapshot_utils';
-import type { Thread } from 'models';
 
 import app from 'state';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
@@ -13,12 +12,10 @@ import { SnapshotProposalSelectorItem } from 'views/components/snapshot_proposal
 type SnapshotProposalSelectorProps = {
   onSelect: (sn: SnapshotProposal) => void;
   snapshotProposalsToSet: SnapshotProposal[];
-  thread: Thread;
 };
 
 export const SnapshotProposalSelector = ({
   onSelect,
-  thread,
   snapshotProposalsToSet,
 }: SnapshotProposalSelectorProps) => {
   const [allProposals, setAllProposals] = useState<Array<SnapshotProposal>>([]);

--- a/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 
 import 'components/thread_selector.scss';
-import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import { notifyError } from 'controllers/app/notifications';
 import type { Thread } from 'models';
 import type { SearchParams } from 'models/SearchQuery';
 import app from 'state';
@@ -9,21 +9,16 @@ import { CWTextInput } from '../component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
 import { ThreadSelectorItem } from 'views/components/thread_selector/thread_selector_item';
 
-// The thread-to-thread relationship is comprised of linked and linking threads,
-// i.e. child and parent nodes.
-
 type ThreadSelectorProps = {
-  linkedThreads: Array<Thread>;
-  linkingThread: Thread;
+  linkedThreadsToSet: Array<Thread>;
+  onSelect: (selectedThread: Thread) => void;
 };
 
 export const ThreadSelector = ({
-  linkedThreads: linkedThreadsProp = [],
-  linkingThread,
+  linkedThreadsToSet,
+  onSelect,
 }: ThreadSelectorProps) => {
   const [inputTimeout, setInputTimeout] = useState(null);
-  const [linkedThreads, setLinkedThreads] =
-    useState<Thread[]>(linkedThreadsProp);
   const [loading, setLoading] = useState(false);
   const [searchResults, setSearchResults] = useState<Thread[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -36,46 +31,13 @@ export const ThreadSelector = ({
       return 'Query too short';
     } else if (queryLength >= 5 && !searchResults.length) {
       return 'No threads found';
-    } else if (!linkedThreads?.length) {
+    } else if (!linkedThreadsToSet?.length) {
       return 'No currently linked threads';
     }
   };
 
   const options =
-    showOnlyLinkedThreads && !queryLength ? linkedThreads : searchResults;
-
-  const handleClick = useCallback(
-    (thread: Thread) => {
-      const selectedThreadIdx = linkedThreads.findIndex(
-        (linkedThread) => linkedThread.id === thread.id
-      );
-
-      if (selectedThreadIdx !== -1) {
-        app.threads
-          .removeLinkedThread(linkingThread.id, thread.id)
-          .then(() => {
-            const newLinkedThreads = linkedThreads.splice(selectedThreadIdx, 1);
-            setLinkedThreads(newLinkedThreads);
-            notifySuccess('Thread unlinked.');
-          })
-          .catch(() => {
-            notifyError('Thread failed to unlink.');
-          });
-      } else {
-        app.threads
-          .addLinkedThread(linkingThread.id, thread.id)
-          .then(() => {
-            const newLinkedThreads = [...linkedThreads, thread];
-            setLinkedThreads(newLinkedThreads);
-            notifySuccess('Thread linked.');
-          })
-          .catch(() => {
-            notifyError('Thread failed to link.');
-          });
-      }
-    },
-    [linkedThreads, linkingThread?.id]
-  );
+    showOnlyLinkedThreads && !queryLength ? linkedThreadsToSet : searchResults;
 
   const handleInputChange = (e) => {
     const target = e.target as HTMLInputElement;
@@ -119,17 +81,17 @@ export const ThreadSelector = ({
 
   const renderItem = useCallback(
     (i: number, thread: Thread) => {
-      const isSelected = linkedThreads.some((lt) => +lt.id === +thread.id);
+      const isSelected = linkedThreadsToSet.some((lt) => +lt.id === +thread.id);
 
       return (
         <ThreadSelectorItem
           thread={thread}
-          onClick={handleClick}
+          onClick={onSelect}
           isSelected={isSelected}
         />
       );
     },
-    [handleClick, linkedThreads]
+    [linkedThreadsToSet, onSelect]
   );
 
   const EmptyComponent = () => (

--- a/packages/commonwealth/client/scripts/views/modals/linked_thread_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/linked_thread_modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import 'modals/linked_thread_modal.scss';
 
@@ -6,34 +6,116 @@ import type { Thread } from 'models';
 import { ThreadSelector } from 'views/components/thread_selector';
 import { CWButton } from '../components/component_kit/cw_button';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
+import app from 'state';
+import { notifyError } from 'controllers/app/notifications';
 
 type LinkedThreadModalProps = {
   linkedThreads: Thread[];
-  linkingThread: Thread;
+  thread: Thread;
   onModalClose: () => void;
+  onSave?: (linkedThreads: Thread[]) => void;
 };
 
-export const LinkedThreadModal = (props: LinkedThreadModalProps) => {
-  const { linkingThread, linkedThreads, onModalClose } = props;
+const getAddedAndDeleted = (
+  tempLinkedThreads: Thread[],
+  initialLinkedThreads: Thread[]
+) => {
+  const toAdd = tempLinkedThreads.reduce((acc, curr) => {
+    const wasSelected = initialLinkedThreads.find(({ id }) => curr.id === id);
+
+    if (wasSelected) {
+      return acc;
+    }
+
+    return [...acc, curr];
+  }, []);
+
+  const toDelete = initialLinkedThreads.reduce((acc, curr) => {
+    const isSelected = tempLinkedThreads.find(({ id }) => curr.id === id);
+
+    if (isSelected) {
+      return acc;
+    }
+
+    return [...acc, curr];
+  }, []);
+
+  return { toAdd, toDelete };
+};
+
+export const LinkedThreadModal = ({
+  thread,
+  linkedThreads: initialLinkedThreads = [],
+  onModalClose,
+  onSave,
+}: LinkedThreadModalProps) => {
+  const [tempLinkedThreads, setTempLinkedThreads] =
+    useState<Array<Thread>>(initialLinkedThreads);
+
+  const handleSaveChanges = async () => {
+    const { toAdd, toDelete } = getAddedAndDeleted(
+      tempLinkedThreads,
+      initialLinkedThreads
+    );
+
+    try {
+      if (toAdd.length) {
+        await Promise.all(
+          toAdd.map((linkedThread) =>
+            app.threads.addLinkedThread(thread.id, linkedThread.id)
+          )
+        );
+      }
+
+      if (toDelete.length) {
+        await Promise.all(
+          toDelete.map((linkedThread) =>
+            app.threads.removeLinkedThread(thread.id, linkedThread.id)
+          )
+        );
+      }
+
+      onModalClose();
+      onSave(tempLinkedThreads);
+    } catch (err) {
+      console.error(err);
+      notifyError('Failed to update linked threads');
+      onModalClose();
+    }
+  };
+
+  const handleSelectThread = (selectedThread: Thread) => {
+    const isSelected = tempLinkedThreads.find(
+      ({ id }) => selectedThread.id === id
+    );
+
+    const updatedLinkedThreads = isSelected
+      ? tempLinkedThreads.filter(({ id }) => selectedThread.id !== id)
+      : [...tempLinkedThreads, selectedThread];
+
+    setTempLinkedThreads(updatedLinkedThreads);
+  };
 
   return (
     <div className="LinkedThreadModal">
       <div className="compact-modal-title">
         <h3>Link to Existing Threads</h3>
-        <CWIconButton iconName="close" onClick={() => onModalClose()} />
+        <CWIconButton iconName="close" onClick={onModalClose} />
       </div>
       <div className="compact-modal-body">
         <ThreadSelector
-          linkingThread={linkingThread}
-          linkedThreads={linkedThreads}
+          linkedThreadsToSet={tempLinkedThreads}
+          onSelect={handleSelectThread}
         />
-        <CWButton
-          label="Close"
-          onClick={(e) => {
-            e.preventDefault();
-            onModalClose();
-          }}
-        />
+
+        <div className="buttons-row">
+          <CWButton
+            label="Cancel"
+            buttonType="secondary-blue"
+            onClick={onModalClose}
+          />
+          <CWButton label="Save changes" onClick={handleSaveChanges} />
+        </div>
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -140,14 +140,12 @@ export const UpdateProposalStatusModal = ({
         )}
         {showSnapshot && (
           <SnapshotProposalSelector
-            thread={thread}
             onSelect={handleSelectProposal}
             snapshotProposalsToSet={tempSnapshotProposals}
           />
         )}
         {app.chainEntities && (
           <ChainEntitiesSelector
-            thread={thread}
             onSelect={handleSelectChainEntity}
             chainEntitiesToSet={tempChainEntities}
           />
@@ -156,9 +154,7 @@ export const UpdateProposalStatusModal = ({
           <CWButton
             label="Cancel"
             buttonType="secondary-blue"
-            onClick={() => {
-              onModalClose();
-            }}
+            onClick={onModalClose}
           />
           <CWButton label="Save changes" onClick={handleSaveChanges} />
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/index.tsx
@@ -8,8 +8,8 @@ import type { SnapshotProposal } from 'helpers/snapshot_utils';
 import { getProposalUrlPath, idToProposal } from 'identifiers';
 import $ from 'jquery';
 
-import type { ChainEntity, Comment, Poll, Thread, Topic } from 'models';
-import { ThreadStage as ThreadStageType } from 'models';
+import type { ChainEntity, Comment, Poll, Topic } from 'models';
+import { ThreadStage as ThreadStageType, Thread } from 'models';
 
 import 'pages/view_thread/index.scss';
 
@@ -39,7 +39,7 @@ import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
 import { ExternalLink, ThreadAuthor, ThreadStage } from './thread_components';
 import { useCommonNavigate } from 'navigation/helpers';
 import { Modal } from '../../components/component_kit/cw_modal';
-import { IThreadCollaborator } from 'models/Thread';
+import type { IThreadCollaborator } from 'models/Thread';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -463,6 +463,36 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const hasEditPerms = isAuthor || isEditor;
 
+  const handleLinkedThreadChange = (linkedThreads: Thread[]) => {
+    const linkedThreadsRelations = linkedThreads.map((t) => ({
+      id: '',
+      linkedThread: String(t.id),
+      linkingThread: String(thread.id),
+    }));
+
+    const updatedThread = new Thread({
+      ...thread,
+      linkedThreads: linkedThreadsRelations,
+    });
+
+    setThread(updatedThread);
+  };
+
+  const handleLinkedProposalChange = (
+    stage: ThreadStageType,
+    chainEntities: ChainEntity[] = [],
+    snapshotProposal: SnapshotProposal[] = []
+  ) => {
+    const newThread = {
+      ...thread,
+      stage,
+      chainEntities,
+      snapshotProposal: snapshotProposal[0]?.id,
+    } as Thread;
+
+    setThread(newThread);
+  };
+
   const getActionMenuItems = () => {
     return [
       ...(hasEditPerms && !thread.readOnly
@@ -659,27 +689,16 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                       <div className="cards-column">
                         {showLinkedProposalOptions && (
                           <LinkedProposalsCard
-                            onChangeHandler={(
-                              stage: ThreadStageType,
-                              chainEntities: ChainEntity[] = [],
-                              snapshotProposal: SnapshotProposal[] = []
-                            ) => {
-                              const newThread = {
-                                ...thread,
-                                stage,
-                                chainEntities,
-                                snapshotProposal: snapshotProposal[0]?.id,
-                              } as Thread;
-                              setThread(newThread);
-                            }}
+                            onChangeHandler={handleLinkedProposalChange}
                             thread={thread}
                             showAddProposalButton={isAuthor || isAdminOrMod}
                           />
                         )}
                         {showLinkedThreadOptions && (
                           <LinkedThreadsCard
-                            threadId={thread.id}
+                            thread={thread}
                             allowLinking={isAuthor || isAdminOrMod}
+                            onChangeHandler={handleLinkedThreadChange}
                           />
                         )}
                       </div>

--- a/packages/commonwealth/client/styles/modals/linked_thread_modal.scss
+++ b/packages/commonwealth/client/styles/modals/linked_thread_modal.scss
@@ -6,4 +6,10 @@
   @include smallInclusive {
     width: 100%;
   }
+
+  .buttons-row {
+    justify-content: end;
+    display: flex;
+    gap: 8px;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #2876 

## Description of Changes
- added loader when discussions are loading in the card
- changed a logic a bit so it is now the same as in linked proposal modal (select threads and then save) => better UX and similar in the code which make things simpler

https://user-images.githubusercontent.com/14819225/224355992-1b2afff6-8bfc-476d-a0ca-8472578bd1b3.mov

## Test Plan
- Go to thread and click "Link Discussion"
- select/unselect some threads and after clicking "save" they should be updated in the card
