### PR TITLE
Remove inactive chains from profiles query.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/profile/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/index.tsx
@@ -57,23 +57,21 @@ export default class ProfileComponent extends ClassComponent<NewProfileAttrs> {
         return { ...c, thread };
       });
       this.comments = commentsWithAssociatedThread;
-      this.addresses = result.addresses.map(
-        (a) => {
-          try {
-            return new AddressInfo(
-              a.id,
-              a.address,
-              a.chain,
-              a.keytype,
-              a.wallet_id,
-              a.ghost_address
-            )
-          } catch (err) {
-            console.log(a.chain);
-            return null;
-          }
+      this.addresses = result.addresses.map((a) => {
+        try {
+          return new AddressInfo(
+            a.id,
+            a.address,
+            a.chain,
+            a.keytype,
+            a.wallet_id,
+            a.ghost_address
+          );
+        } catch (err) {
+          console.log(a.chain);
+          return null;
         }
-      );
+      });
       this.isOwner = result.isOwner;
     } catch (err) {
       this.error = ProfileError.NoProfileFound;

--- a/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
@@ -61,7 +61,9 @@ export class NewProfileActivityRow extends ClassComponent<ProfileActivityRowAttr
             </span>
             {isThread
               ? link('a', `/${chain}/discussion/${id}`, [`${title}`])
-              : link('a', `/${chain}/discussion/${comment.thread?.id}`, [`${decodedTitle}`,])}
+              : link('a', `/${chain}/discussion/${comment.thread?.id}`, [
+                  `${decodedTitle}`,
+                ])}
           </CWText>
         </div>
         <div className="content">

--- a/packages/commonwealth/scripts/reset-db.sh
+++ b/packages/commonwealth/scripts/reset-db.sh
@@ -13,4 +13,4 @@ else
   PGPASSWORD="${PGPASSWORD}"
 fi
 
-psql -d postgres -U commonwealth -c 'DROP DATABASE commonwealth WITH (FORCE);' && npx sequelize db:create
+psql -d postgres -U commonwealth -c 'DROP DATABASE commonwealth WITH (FORCE);'; npx sequelize db:create

--- a/packages/commonwealth/server/routes/getNewProfile.ts
+++ b/packages/commonwealth/server/routes/getNewProfile.ts
@@ -43,11 +43,13 @@ const getNewProfile = async (
   if (!profile) return next(new Error(Errors.NoProfileFound));
 
   const addresses = await profile.getAddresses({
-    include: [{
-      model: models.Chain,
-      required: true,
-      where: { active: true }
-    }],
+    include: [
+      {
+        model: models.Chain,
+        required: true,
+        where: { active: true },
+      },
+    ],
   });
 
   const addressIds = [...new Set<number>(addresses.map((a) => a.id))];
@@ -89,11 +91,13 @@ const getNewProfile = async (
         [Op.in]: commentThreadIds,
       },
     },
-    include: [{
-      model: models.Chain,
-      required: true,
-      where: { active: true }
-    }],
+    include: [
+      {
+        model: models.Chain,
+        required: true,
+        where: { active: true },
+      },
+    ],
   });
 
   return success(res, {

--- a/packages/commonwealth/server/routes/getNewProfile.ts
+++ b/packages/commonwealth/server/routes/getNewProfile.ts
@@ -42,7 +42,13 @@ const getNewProfile = async (
 
   if (!profile) return next(new Error(Errors.NoProfileFound));
 
-  const addresses = await profile.getAddresses();
+  const addresses = await profile.getAddresses({
+    include: [{
+      model: models.Chain,
+      required: true,
+      where: { active: true }
+    }],
+  });
 
   const addressIds = [...new Set<number>(addresses.map((a) => a.id))];
   const threads = await models.Thread.findAll({
@@ -51,7 +57,10 @@ const getNewProfile = async (
         [Op.in]: addressIds,
       },
     },
-    include: [{ model: models.Address, as: 'Address' }],
+    include: [
+      { model: models.Address, as: 'Address' },
+      { model: models.Chain, required: true, where: { active: true } },
+    ],
   });
 
   const comments = await models.Comment.findAll({
@@ -63,7 +72,10 @@ const getNewProfile = async (
         [Op.in]: addressIds,
       },
     },
-    include: [{ model: models.Address, as: 'Address' }],
+    include: [
+      { model: models.Address, as: 'Address' },
+      { model: models.Chain, required: true, where: { active: true } },
+    ],
   });
 
   const commentThreadIds = [
@@ -77,6 +89,11 @@ const getNewProfile = async (
         [Op.in]: commentThreadIds,
       },
     },
+    include: [{
+      model: models.Chain,
+      required: true,
+      where: { active: true }
+    }],
   });
 
   return success(res, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3087 

## Description of Changes
- Adds required chain includes on profiles route, to avoid inactive communities in response.
- Change to reset-db script to create db if not exists.

## Test Plan
- CA test pass on profile in ticket.
- Pushed to frack for CA testing.
