### PR TITLE
Render new proposal page

### DIFF
--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -150,7 +150,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
       throw new Error('secondary loading cmd called before chain load');
     }
     // TODO: does this need debouncing?
-    if (modules.some((mod) => !mod.initializing && !mod.ready)) {
+    if (modules.some((mod) => !!mod && !mod.initializing && !mod.ready)) {
       await Promise.all(
         modules.map((mod) => mod.init(this.chain, this.accounts))
       );

--- a/packages/commonwealth/client/scripts/views/components/proposals/voting_actions.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/voting_actions.tsx
@@ -63,6 +63,10 @@ export const VotingActions = (props: VotingActionsProps) => {
     app.loginStateEmitter.once('redraw', () => {
       setIsLoggedIn(app.isLoggedIn());
     });
+
+    return () => {
+      app.loginStateEmitter.removeAllListeners();
+    };
   }, [app.loginState]);
 
   if (

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/aave_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/aave_proposal_form.tsx
@@ -51,6 +51,7 @@ export const AaveProposalForm = () => {
         <div className="executors-container">
           {aave.governance.api.Executors.map((r) => (
             <div
+              key={r.address}
               className={`executor ${
                 executor === r.address && 'selected-executor'
               }`}
@@ -78,6 +79,7 @@ export const AaveProposalForm = () => {
         <CWTabBar>
           {aaveProposalState.map((_, index) => (
             <CWTab
+              key={`Call ${index + 1}`}
               label={`Call ${index + 1}`}
               isSelected={activeTabIndex === index}
               onClick={() => {

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ChainNetwork, ProposalType } from 'common-common/src/types';
 import {
@@ -27,6 +27,13 @@ type NewProposalPageProps = {
 const NewProposalPage = (props: NewProposalPageProps) => {
   const { type } = props;
   const [internalType, setInternalType] = React.useState<ProposalType>(type);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    app.chainModuleReady.once('ready', () => {
+      setLoaded(app.chain.loaded);
+    });
+  }, [app.chain.loaded]);
 
   // wait for chain
   if (app.chain?.failed) {
@@ -38,9 +45,10 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     );
   }
 
-  if (!app.chain || !app.chain.loaded || !app.chain.meta) {
+  if (!app.chain || !loaded || !app.chain.meta) {
     return <PageLoading />;
   }
+  console.log('internalType', internalType);
 
   // infer proposal type if possible
   if (!internalType) {
@@ -56,14 +64,18 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     }
   }
 
+  console.log('app.chain.loaded', app.chain.loaded);
+
   // check if module is still initializing
-  const c = proposalSlugToClass().get(internalType) as ProposalModule<
+  const c = proposalSlugToClass()?.get(internalType) as ProposalModule<
     any,
     any,
     any
   >;
 
-  if (!c.ready) {
+  console.log('c', c);
+
+  if (!c || !c.ready) {
     app.chain.loadModules([c]);
     return <PageLoading />;
   }

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -48,7 +48,6 @@ const NewProposalPage = (props: NewProposalPageProps) => {
   if (!app.chain || !loaded || !app.chain.meta) {
     return <PageLoading />;
   }
-  console.log('internalType', internalType);
 
   // infer proposal type if possible
   if (!internalType) {
@@ -64,16 +63,12 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     }
   }
 
-  console.log('app.chain.loaded', app.chain.loaded);
-
   // check if module is still initializing
   const c = proposalSlugToClass()?.get(internalType) as ProposalModule<
     any,
     any,
     any
   >;
-
-  console.log('c', c);
 
   if (!c || !c.ready) {
     app.chain.loadModules([c]);

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -39,7 +39,7 @@ const NewProposalPage = (props: NewProposalPageProps) => {
 
   useEffect(() => {
     app.loginStateEmitter.on('redraw', () => {
-      setIsLoggedIn(app.isLoggedIn);
+      setIsLoggedIn(app.isLoggedIn());
     });
 
     return () => {

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -29,16 +29,19 @@ const NewProposalPage = (props: NewProposalPageProps) => {
   const [internalType, setInternalType] = useState<ProposalType>(type);
   const [isLoaded, setIsLoaded] = useState(app.chain?.loaded);
   // isLoggedIn is not referenced, but is used to trigger re-render
-  const [isLoggedIn, setIsLoggedIn] = useState(app.isLoggedIn);
+  const [isLoggedIn, setIsLoggedIn] = useState(app.isLoggedIn());
 
   useEffect(() => {
     app.runWhenReady(() => {
+      console.log('app.chain.loaded', app.chain.loaded);
+
       setIsLoaded(app.chain.loaded);
     });
   }, [app.chain?.loaded]);
 
   useEffect(() => {
     app.loginStateEmitter.on('redraw', () => {
+      console.log('app.isLoggedIn()', app.isLoggedIn());
       setIsLoggedIn(app.isLoggedIn());
     });
 

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -41,6 +41,10 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     app.loginStateEmitter.on('redraw', () => {
       setIsLoggedIn(app.isLoggedIn);
     });
+
+    return () => {
+      app.loginStateEmitter.removeAllListeners();
+    };
   }, [app.loginState]);
 
   // wait for chain

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -26,14 +26,22 @@ type NewProposalPageProps = {
 
 const NewProposalPage = (props: NewProposalPageProps) => {
   const { type } = props;
-  const [internalType, setInternalType] = React.useState<ProposalType>(type);
-  const [loaded, setLoaded] = useState(false);
+  const [internalType, setInternalType] = useState<ProposalType>(type);
+  const [isLoaded, setIsLoaded] = useState(app.chain?.loaded);
+  // isLoggedIn is not referenced, but is used to trigger re-render
+  const [isLoggedIn, setIsLoggedIn] = useState(app.isLoggedIn);
 
   useEffect(() => {
-    app.chainModuleReady.once('ready', () => {
-      setLoaded(app.chain.loaded);
+    app.runWhenReady(() => {
+      setIsLoaded(app.chain.loaded);
     });
-  }, [app.chain.loaded]);
+  }, [app.chain?.loaded]);
+
+  useEffect(() => {
+    app.loginStateEmitter.on('redraw', () => {
+      setIsLoggedIn(app.isLoggedIn);
+    });
+  }, [app.loginState]);
 
   // wait for chain
   if (app.chain?.failed) {
@@ -45,7 +53,7 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     );
   }
 
-  if (!app.chain || !loaded || !app.chain.meta) {
+  if (!app.chain || !isLoaded || !app.chain.meta) {
     return <PageLoading />;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3016 

## Description of Changes
- fixes render of new proposal page
- in new_proposal, listen for chainReady or log in/out to trigger local state update

## Test Plan
- CA (click around) tested on local and frack:
  - http://localhost:8080/dydx/new/proposal
  - http://localhost:8080/aave/new/proposal
  - http://localhost:8080/osmosis/new/proposal
  - http://localhost:8080/regen/new/proposal
  - also click + button, and "New on-chain proposal"
  - log in and out to test re-render


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 