### PR TITLE
Some routing bugs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -55,7 +55,7 @@ export const SidebarQuickSwitcher = () => {
             key={item.id}
             size="large"
             community={item}
-            onClick={link ? () => navigate(`/${item.id}`) : undefined}
+            onClick={link ? () => navigate(`/${item.id}`, {}, null) : undefined}
           />
         ))}
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -64,9 +64,7 @@ export const TopicSummaryRow = (props: TopicSummaryRowProps) => {
             className="topic-name-text"
             onClick={(e) => {
               e.preventDefault();
-              navigate(
-                `/${app.activeChainId()}/discussions/${encodeURI(topic.name)}`
-              );
+              navigate(`/discussions/${encodeURI(topic.name)}`);
             }}
           >
             {topic.name}


### PR DESCRIPTION
Fixes:

- Discussion overview topic links.
- Redundant chain names in URLs when clicking on community avatars in quick switcher.