### PR TITLE
Show loader in dashboard tabs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -7,7 +7,7 @@ import type { DashboardActivityNotification } from 'models';
 
 import { UserDashboardRow } from '../pages/user_dashboard/user_dashboard_row';
 import { PageNotFound } from '../pages/404';
-import { PageLoading } from '../pages/loading';
+import { CWSpinner } from './component_kit/cw_spinner';
 
 type FeedProps = {
   fetchData: () => Promise<any>;
@@ -58,6 +58,8 @@ export const Feed = ({
     getData();
   }, []);
 
+  if (loading) return <CWSpinner />;
+
   if (error) {
     return <PageNotFound message="There was an error rendering the feed." />;
   }
@@ -72,9 +74,7 @@ export const Feed = ({
 
   if (currentCount > data.length) setCurrentCount(data.length);
 
-  return loading ? (
-    <PageLoading />
-  ) : (
+  return (
     <div className="Feed">
       <Virtuoso
         totalCount={currentCount}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3115 

## Description of Changes
- Adds CWSpinner when loading, as in Prod

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - http://localhost:8080/dashboard/chain-events
  - throttle data load to slower if needed
  - click to "For You" and "Global" to make sure loader appears while waiting for data


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 