### PR TITLE
Dashboard bell icon - update on click

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/helpers.tsx
@@ -56,6 +56,7 @@ export const subscribeToThread = async (
     ]);
 
     notifySuccess('Unsubscribed!');
+    return Promise.resolve();
   } else if (!commentSubscription || !reactionSubscription) {
     await Promise.all([
       app.user.notifications.subscribe(
@@ -69,6 +70,7 @@ export const subscribeToThread = async (
     ]);
 
     notifySuccess('Subscribed!');
+    return Promise.resolve();
   } else {
     await app.user.notifications.enableSubscriptions([
       commentSubscription,
@@ -76,6 +78,7 @@ export const subscribeToThread = async (
     ]);
 
     notifySuccess('Subscribed!');
+    return Promise.resolve();
   }
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { NotificationCategories } from 'common-common/src/types';
 
@@ -12,6 +12,7 @@ import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { PopoverMenu } from '../../components/component_kit/cw_popover/cw_popover_menu';
 import { CWText } from '../../components/component_kit/cw_text';
 import { subscribeToThread } from './helpers';
+import { NotificationSubscription } from 'client/scripts/models';
 
 type UserDashboardRowBottomProps = {
   commentCount: number;
@@ -23,6 +24,22 @@ type UserDashboardRowBottomProps = {
 
 export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
   const { threadId, commentCount, commentId, chainId, commenters } = props;
+  const [update, setUpdate] = useState<boolean>(false);
+
+  const setSubscription = async (
+    threadId: string,
+    bothActive: boolean,
+    commentSubscription: NotificationSubscription,
+    reactionSubscription: NotificationSubscription
+  ) => {
+    await subscribeToThread(
+      threadId,
+      bothActive,
+      commentSubscription,
+      reactionSubscription
+    );
+    setUpdate(!update); // just to trigger a new render
+  };
 
   const adjustedId = `discussion_${threadId}`;
 
@@ -61,7 +78,7 @@ export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
           menuItems={[
             {
               onClick: () => {
-                subscribeToThread(
+                setSubscription(
                   threadId,
                   bothActive,
                   commentSubscription,

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { NotificationCategories } from 'common-common/src/types';
 
@@ -13,6 +13,7 @@ import { PopoverMenu } from '../../components/component_kit/cw_popover/cw_popove
 import { CWText } from '../../components/component_kit/cw_text';
 import { subscribeToThread } from './helpers';
 import { NotificationSubscription } from 'client/scripts/models';
+import useForceRerender from 'hooks/useForceRerender';
 
 type UserDashboardRowBottomProps = {
   commentCount: number;
@@ -24,7 +25,7 @@ type UserDashboardRowBottomProps = {
 
 export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
   const { threadId, commentCount, commentId, chainId, commenters } = props;
-  const [update, setUpdate] = useState<boolean>(false);
+  const forceRerender = useForceRerender();
 
   const setSubscription = async (
     threadId: string,
@@ -38,7 +39,7 @@ export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
       commentSubscription,
       reactionSubscription
     );
-    setUpdate(!update); // just to trigger a new render
+    forceRerender();
   };
 
   const adjustedId = `discussion_${threadId}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3114 

## Description of Changes
- trigger local state update after subscribe call
- Bell icon reflects current notification subscription click action

## Test Plan
- CA (click around) tested on local and frack:
  - http://localhost:8080/dashboard/for-you : click bell to subscribe / unsubscribe
  - expect icon to update

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 