### PR TITLE
Edit state change to Subscriptions (Notifications On/Off) button

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/subscription_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/subscription_button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { NotificationCategories } from 'common-common/src/types';
 import { isNotUndefined } from 'helpers/typeGuards';
@@ -13,6 +13,9 @@ export const SubscriptionButton = () => {
       v.category === NotificationCategories.NewThread &&
       v.objectId === app.activeChainId()
   );
+  const [notificationsOn, setNotificationsOn] = useState<boolean>(
+    isNotUndefined(communitySubscription)
+  );
   const communityOrChain = app.activeChainId();
 
   return (
@@ -20,24 +23,17 @@ export const SubscriptionButton = () => {
       onClick={(e) => {
         e.preventDefault();
         if (isNotUndefined(communitySubscription)) {
-          subscriptions.deleteSubscription(communitySubscription);
+          subscriptions
+            .deleteSubscription(communitySubscription)
+            .then(() => setNotificationsOn(false));
         } else {
-          subscriptions.subscribe(
-            NotificationCategories.NewThread,
-            communityOrChain
-          );
+          subscriptions
+            .subscribe(NotificationCategories.NewThread, communityOrChain)
+            .then(() => setNotificationsOn(true));
         }
       }}
-      label={
-        isNotUndefined(communitySubscription)
-          ? 'Notifications on'
-          : 'Notifications off'
-      }
-      buttonType={
-        isNotUndefined(communitySubscription)
-          ? 'primary-blue'
-          : 'secondary-blue'
-      }
+      label={notificationsOn ? 'Notifications on' : 'Notifications off'}
+      buttonType={notificationsOn ? 'primary-blue' : 'secondary-blue'}
     />
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
[Fix community subscription on-off button](https://github.com/hicommonwealth/commonwealth/issues/3125)

## Description of Changes
- Adds state change to Notifications on/off button

## Test Plan
- CA (click around) tested on local and frack:
- Checks on addition to community new thread creation; deletion of this subscription

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->