### PR TITLE
Dashboard - Chain: navigate to chain ID on community name click

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
@@ -48,7 +48,7 @@ export const UserDashboardChainEventRow = (
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              navigate(`/${chain}`);
+              navigate(`/${chain?.id}`);
             }}
           >
             <CWText type="caption" fontWeight="medium">

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
@@ -48,7 +48,7 @@ export const UserDashboardChainEventRow = (
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              navigate(`/${chain?.id}`);
+              navigate(`/${chain?.id}`, {}, null);
             }}
           >
             <CWText type="caption" fontWeight="medium">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes #3116 

## Description of Changes
- fix click handler to point to chain ID instead of whole chain object


## Test Plan
- CA (click around) tested on local and frack:
  - http://localhost:8080/dashboard/chain-events
  - on a chain event, click the community name to go to community


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
 - NOTE: this does not fix the separate bug where an account page fails to load (if you click a whole chain event row)