### PR TITLE
Email Digest Script Date Fix

### DIFF
--- a/packages/commonwealth/server/scripts/emailDigest.ts
+++ b/packages/commonwealth/server/scripts/emailDigest.ts
@@ -52,7 +52,8 @@ export const getTopThreads = async (
         COUNT(DISTINCT c.id) AS comment_count,
         COUNT(DISTINCT r.id) AS view_count,
         a.address AS author_address,
-        t.id AS thread_id
+        t.id AS thread_id,
+        t.created_at AS created_at
       FROM 
         "Threads" t
         LEFT JOIN "Comments" c ON t.id = CAST(substring(c.root_id from '[0-9]+$') AS INTEGER)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3169 

## Description of Changes
- Gets the correct thread post date for usage in the email digest. Was previously defaulting to "today" due to a null value.

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 