### PR TITLE
Proposal user fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/widgets/user.ts
+++ b/packages/commonwealth/client/scripts/views/components/widgets/user.ts
@@ -172,7 +172,7 @@ const User: m.Component<
           '.User',
           {
             key: profile?.address || '-',
-            class: linkify ? 'linkified' : '',
+            class: linkify && profile?.id ? 'linkified' : '',
           },
           [
             showAvatar &&
@@ -185,7 +185,7 @@ const User: m.Component<
               ),
             [
               // non-substrate name
-              linkify
+              linkify && profile?.id
                 ? link(
                     'a.user-display-name.username',
                     profile ? `/profile/id/${profile.id}` : 'javascript:',
@@ -205,8 +205,13 @@ const User: m.Component<
                     ]
                   )
                 : m('a.user-display-name.username', [
-                    !profile
-                      ? addrShort
+                    !profile || !profile?.id
+                      ? !profile?.id
+                        ? `${profile.address.slice(
+                            0,
+                            8
+                          )}...${profile.address.slice(-5)}`
+                        : addrShort
                       : !showAddressWithDisplayName
                       ? profile.name
                       : [
@@ -238,21 +243,27 @@ const User: m.Component<
       [
         m('.user-avatar', [!profile ? null : profileAvatarPopover]),
         m('.user-name', [
-          link(
-            'a.user-display-name',
-            profile ? `/profile/id/${profile.id}` : 'javascript:',
-            !profile
-              ? addrShort
-              : !showAddressWithDisplayName
-              ? profile.name
-              : [
-                  profile.name,
-                  m(
-                    '.id-short',
-                    formatAddressShort(profile.address, profile.chain)
-                  ),
-                ]
-          ),
+          profile &&
+            profile?.id &&
+            link(
+              'a.user-display-name',
+              `/profile/id/${profile.id}`,
+              !profile || !profile?.id
+                ? !profile?.id
+                  ? `${profile.address.slice(0, 8)}...${profile.address.slice(
+                      -5
+                    )}`
+                  : addrShort
+                : !showAddressWithDisplayName
+                ? profile.name
+                : [
+                    profile.name,
+                    m(
+                      '.id-short',
+                      formatAddressShort(profile.address, profile.chain)
+                    ),
+                  ]
+            ),
         ]),
         profile?.address &&
           m(


### PR DESCRIPTION
## Link to Issue
Closes: #[3157](https://github.com/hicommonwealth/commonwealth/issues/3157)

## Description of Changes
- When a profile doesn't have an `id`, do not render a link and only show the truncated address
- In the user popover, do not render a link and only show the truncated address

<img width="818" alt="Screen Shot 2023-03-17 at 2 08 06 PM" src="https://user-images.githubusercontent.com/11875748/225985385-7d05d2ea-5034-420f-877a-253f0595a0da.png">
<img width="185" alt="Screen Shot 2023-03-17 at 2 12 46 PM" src="https://user-images.githubusercontent.com/11875748/225985390-90447e8a-36d2-4e96-80ef-50dd3e01c296.png">
