### PR TITLE
Change Edit Profile route

### DIFF
--- a/packages/commonwealth/client/scripts/router.ts
+++ b/packages/commonwealth/client/scripts/router.ts
@@ -318,13 +318,10 @@ const getCustomDomainRoutes = (importRoute) => ({
     scoped: true,
     deferChain: true,
   }),
-  '/profile/id/:profileId/edit': importRoute(
-    import('views/pages/edit_new_profile'),
-    {
-      scoped: true,
-      deferChain: true,
-    }
-  ),
+  '/profile/edit': importRoute(import('views/pages/edit_new_profile'), {
+    scoped: true,
+    deferChain: true,
+  }),
 
   // Governance
   '/referenda': importRoute(import('views/pages/referenda'), {
@@ -576,13 +573,10 @@ const getCommonDomainRoutes = (importRoute) => ({
     scoped: true,
     deferChain: true,
   }),
-  '/profile/id/:profileId/edit': importRoute(
-    import('views/pages/edit_new_profile'),
-    {
-      scoped: true,
-      deferChain: true,
-    }
-  ),
+  '/profile/edit': importRoute(import('views/pages/edit_new_profile'), {
+    scoped: true,
+    deferChain: true,
+  }),
 
   // Governance
   '/:scope/referenda': importRoute(import('views/pages/referenda'), {

--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -387,7 +387,7 @@ export default class EditProfileComponent extends ClassComponent {
                 addresses={this.addresses}
                 profile={this.profile}
                 refreshProfiles={(address: string) => {
-                  this.getProfile(vnode.attrs.profileId);
+                  this.getProfile();
                   // Remove from all address stores in the frontend state
                   const index = app.user.addresses.indexOf(
                     app.user.addresses.find((a) => a.address === address)

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -111,7 +111,7 @@ export class LoginSelectorMenuLeft extends ClassComponent<LoginSelectorMenuLeftA
         <div
           class="login-menu-item"
           onclick={() => {
-            m.route.set(`/profile/id/${this.profileId}/edit`);
+            m.route.set(`/profile/edit`);
           }}
         >
           <CWText type="caption">Edit profile</CWText>

--- a/packages/commonwealth/client/scripts/views/components/profile/profile_header.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_header.tsx
@@ -42,9 +42,7 @@ export class ProfileHeader extends ClassComponent<ProfileHeaderAttrs> {
               label="Edit"
               buttonType="mini-white"
               iconLeft="write"
-              onclick={() =>
-                navigateToSubpage(`/profile/id/${profile.id}/edit`)
-              }
+              onclick={() => navigateToSubpage(`/profile/edit`)}
             />
           )}
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/edit_new_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/edit_new_profile.tsx
@@ -4,25 +4,20 @@ import m from 'mithril';
 import ClassComponent from 'class_component';
 
 import app from 'state';
-import { navigateToSubpage } from 'router';
 import Sublayout from 'views/sublayout';
 import EditProfileComponent from '../components/edit_profile';
+import { PageNotFound } from '../pages/404';
 
 export default class EditNewProfile extends ClassComponent {
-  private profileId: string;
-
-  oninit() {
-    this.profileId = m.route.param('profileId');
-
-    if (!app.isLoggedIn()) {
-      navigateToSubpage(`/profile/id/${this.profileId}`);
-    }
-  }
-
   view() {
+    if (!app.isLoggedIn())
+      return (
+        <PageNotFound message="You must be logged in to edit your profile." />
+      );
+
     return (
       <Sublayout hideFooter={true}>
-        <EditProfileComponent profileId={this.profileId} />
+        <EditProfileComponent />
       </Sublayout>
     );
   }

--- a/packages/commonwealth/server/routes/getNewProfile.ts
+++ b/packages/commonwealth/server/routes/getNewProfile.ts
@@ -14,7 +14,7 @@ export const Errors = {
 };
 
 type GetNewProfileReq = {
-  profileId: string;
+  profileId?: string;
 };
 type GetNewProfileResp = {
   profile: ProfileInstance;
@@ -32,13 +32,21 @@ const getNewProfile = async (
   next: NextFunction
 ) => {
   const { profileId } = req.query;
-  if (!profileId) return next(new Error(Errors.NoIdentifierProvided));
+  let profile;
 
-  const profile = await models.Profile.findOne({
-    where: {
-      id: profileId,
-    },
-  });
+  if (profileId) {
+    profile = await models.Profile.findOne({
+      where: {
+        id: profileId,
+      },
+    });
+  } else {
+    profile = await models.Profile.findOne({
+      where: {
+        user_id: req.user.id,
+      },
+    });
+  }
 
   if (!profile) return next(new Error(Errors.NoProfileFound));
 


### PR DESCRIPTION
## Link to Issue
Closes: #[3173](https://github.com/hicommonwealth/commonwealth/issues/3173)

## Description of Changes
- Change `/profile/:id/edit` to `/profile/edit`
- Will automatically render the profile that is of the logged in user to edit
- When not logged in and accessing `/profile/edit` prompt user to log in and render edit profile page upon logging in

<img width="1509" alt="Screen Shot 2023-03-17 at 4 25 40 PM" src="https://user-images.githubusercontent.com/11875748/226030492-42bfb093-e839-4c42-bb17-4dd85c0b84d2.png">

<img width="1507" alt="Screen Shot 2023-03-17 at 4 26 56 PM" src="https://user-images.githubusercontent.com/11875748/226031115-99761f09-0b15-4d7d-98da-8805b50f177e.png">


