### PR TITLE
Fix header link styles 

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import 'pages/view_proposal/proposal_header_links.scss';
+
 import app from 'state';
 import {
   externalLink,


### PR DESCRIPTION
Before:

<img width="215" alt="Screenshot 2023-03-17 at 9 02 21 PM" src="https://user-images.githubusercontent.com/13058678/226047324-3d800a80-a73d-41b5-bfc7-de59fccd2505.png">

After:

<img width="260" alt="Screenshot 2023-03-17 at 9 01 03 PM" src="https://user-images.githubusercontent.com/13058678/226047426-f5b21084-67f8-4173-836e-d00649f794cf.png">


