### PR TITLE
Remove Footer from all but landing page (React)

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -9,7 +9,6 @@ import Sublayout from '../../sublayout';
 import { PageLoading } from '../loading';
 import { RecentThreadsHeader } from './recent_threads_header';
 import { ThreadPreview } from './thread_preview';
-import { Footer } from '../../footer';
 
 type DiscussionsPageProps = {
   topicName?: string;
@@ -60,7 +59,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     return <PageLoading />;
   }
   return (
-    <Sublayout hideFooter>
+    <Sublayout>
       <div className="DiscussionsPage">
         <RecentThreadsHeader
           topic={topicName}
@@ -75,11 +74,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
           }}
           endReached={loadMore}
           overscan={200}
-          components={{
-            Footer: () => {
-              return <Footer />;
-            },
-          }}
         />
       </div>
     </Sublayout>

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -19,7 +19,7 @@ type SublayoutProps = {
 
 const Sublayout = ({
   children,
-  hideFooter = false,
+  hideFooter = true,
   hideSearch,
   onScroll,
 }: SublayoutProps) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Before**
<img width="1163" alt="Screen Shot 2023-01-23 at 10 39 50 AM" src="https://user-images.githubusercontent.com/5334557/226164500-4651f350-22a6-435e-8c0b-986af51a7ec5.png">

**After**
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/5334557/226164480-e0bc856c-b598-4953-93a5-cbf09f844ac5.png">

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 