### PR TITLE
Write User Setting Route Fix

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/user.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/user.ts
@@ -199,12 +199,16 @@ export class UserController {
 
   public setEmailInterval(emailInterval: string): void {
     this._setEmailInterval(emailInterval);
+  }
+
+  public updateEmailInterval(emailInterval: string): void {
     try {
       $.post(`${app.serverUrl()}/writeUserSetting`, {
         jwt: app.user.jwt,
         key: 'updateEmailInterval',
         value: emailInterval,
       });
+      this._setEmailInterval(emailInterval);
     } catch (e) {
       console.log(e);
       notifyError('Unable to set email interval');

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -88,13 +88,13 @@ class NotificationSettingsPage extends ClassComponent {
                 {
                   label: 'Once a week',
                   onclick: () => {
-                    app.user.setEmailInterval('weekly');
+                    app.user.updateEmailInterval('weekly');
                   },
                 },
                 {
                   label: 'Never',
                   onclick: () => {
-                    app.user.setEmailInterval('never');
+                    app.user.updateEmailInterval('never');
                   },
                 },
               ]}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3189 

## Description of Changes
- /writeUserSetting route was being called unnecessarily on login- fixed so its only called when user actually switches their email notification preference. 

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 