### PR TITLE
Edit dark mode when visiting 1inch

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/helpers/index.ts
@@ -411,3 +411,11 @@ export function getDecimals(chain: IChainAdapter<Coin, Account>): number {
 
   return decimals;
 }
+
+export const setDarkMode = (state: boolean) => {
+  const stateStr = state ? 'on' : 'off'
+  localStorage.setItem('dark-mode-state', stateStr);
+  state ?
+    document.getElementsByTagName('html')[0].classList.add('invert') :
+    document.getElementsByTagName('html')[0].classList.remove('invert');
+}

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -64,8 +64,11 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
     //   return false;
     // }
 
-    if (this.meta.id === '1inch' && !localStorage.getItem('user-dark-mode-state')) {
-      setDarkMode(true);
+    const darkModePreferenceSet = localStorage.getItem('user-dark-mode-state');
+    if (this.meta.id === '1inch') {
+      darkModePreferenceSet ?
+        setDarkMode(darkModePreferenceSet === 'on') :
+        setDarkMode(true);
     }
 
     const {

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -8,6 +8,7 @@ import type { IApp } from 'state';
 import { ApiStatus } from 'state';
 import { clearLocalStorage } from 'stores/PersistentStore';
 import type { Account, ProposalModule } from '.';
+import { setDarkMode } from '../helpers';
 import type ChainInfo from './ChainInfo';
 import type { IAccountsModule, IBlockInfo, IChainModule } from './interfaces';
 
@@ -63,15 +64,8 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
     //   return false;
     // }
 
-    if (this.meta.id === '1inch') {
-      if (localStorage.getItem('user-dark-mode-state') !== 'off') {
-        localStorage.setItem('dark-mode-state', 'on');
-        document.getElementsByTagName('html')[0].classList.add('invert');
-      }
-    } else {
-      if (localStorage.getItem('user-dark-mode-state') !== 'on') {
-        document.getElementsByTagName('html')[0].classList.remove('invert');
-      }
+    if (this.meta.id === '1inch' && !localStorage.getItem('user-dark-mode-state')) {
+      setDarkMode(true);
     }
 
     const {
@@ -143,6 +137,10 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
     if (this.app.snapshot) this.app.snapshot.deinit();
     this._loaded = false;
     console.log(`Stopping ${this.meta.id}...`);
+
+    if (this.meta.id === '1inch' && !localStorage.getItem('user-dark-mode-state')) {
+      setDarkMode(false);
+    }
   }
 
   public async loadModules(modules: ProposalModule<any, any, any>[]) {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_toggle.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_toggle.tsx
@@ -5,12 +5,11 @@ import 'components/component_kit/cw_toggle.scss';
 import type { BaseStyleProps } from './types';
 import { getClasses } from './helpers';
 import { ComponentType } from './types';
+import { setDarkMode } from '../../../helpers';
 
-export const toggleDarkMode = (on: boolean, stateFn: Function) => {
-  const state: string = on ? 'on' : 'off';
-  localStorage.setItem('dark-mode-state', state);
-  localStorage.setItem('user-dark-mode-state', state);
-  document.getElementsByTagName('html')[0].classList.toggle('invert');
+export const toggleDarkMode = (on: boolean, stateFn?: Function) => {
+  setDarkMode(on);
+  localStorage.setItem('user-dark-mode-state', on ? 'on' : 'off');
   stateFn(on);
 };
 

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -194,7 +194,8 @@ export const LoginSelectorMenuRight = ({
   const navigate = useCommonNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDarkModeOn, setIsDarkModeOn] = useState<boolean>(
-    localStorage.getItem('dark-mode-state') === 'on'
+    localStorage.getItem('dark-mode-state') === 'on' &&
+      !!localStorage.getItem('user-dark-mode-state')
   );
 
   return (
@@ -283,9 +284,8 @@ export const LoginSelector = () => {
   const forceRerender = useForceRerender();
   const [profileLoadComplete, setProfileLoadComplete] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-  const [isAccountSelectorModalOpen, setIsAccountSelectorModalOpen] = useState(
-    false
-  );
+  const [isAccountSelectorModalOpen, setIsAccountSelectorModalOpen] =
+    useState(false);
   const [isTOSModalOpen, setIsTOSModalOpen] = useState(false);
 
   const leftMenuProps = usePopover();
@@ -328,8 +328,9 @@ export const LoginSelector = () => {
 
   const activeAccountsByRole = app.roles.getActiveAccountsByRole();
 
-  const nAccountsWithoutRole = activeAccountsByRole.filter(([role]) => !role)
-    .length;
+  const nAccountsWithoutRole = activeAccountsByRole.filter(
+    ([role]) => !role
+  ).length;
 
   if (!profileLoadComplete && app.newProfiles.allLoaded()) {
     setProfileLoadComplete(true);

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -15,7 +15,7 @@ import {
   setActiveAccount,
 } from 'controllers/app/login';
 import { notifySuccess } from 'controllers/app/notifications';
-import { isSameAccount, pluralize } from 'helpers';
+import { isSameAccount, pluralize, setDarkMode } from 'helpers';
 import type { Account } from 'models';
 import { AddressInfo, ITokenAdapter } from 'models';
 
@@ -234,6 +234,8 @@ export const LoginSelectorMenuRight = ({
                 await initAppState();
                 notifySuccess('Logged out');
                 onLogout();
+                localStorage.removeItem('dark-mode-state');
+                localStorage.removeItem('user-dark-mode-state');
               })
               .catch(() => {
                 // eslint-disable-next-line no-restricted-globals

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -194,8 +194,7 @@ export const LoginSelectorMenuRight = ({
   const navigate = useCommonNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDarkModeOn, setIsDarkModeOn] = useState<boolean>(
-    localStorage.getItem('dark-mode-state') === 'on' &&
-      !!localStorage.getItem('user-dark-mode-state')
+    localStorage.getItem('dark-mode-state') === 'on'
   );
 
   return (
@@ -234,8 +233,7 @@ export const LoginSelectorMenuRight = ({
                 await initAppState();
                 notifySuccess('Logged out');
                 onLogout();
-                localStorage.removeItem('dark-mode-state');
-                localStorage.removeItem('user-dark-mode-state');
+                setDarkMode(false);
               })
               .catch(() => {
                 // eslint-disable-next-line no-restricted-globals

--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -28,6 +28,7 @@ import type { ProfileRowProps } from '../components/component_kit/cw_profiles_li
 import { LoginDesktop } from '../pages/login/login_desktop';
 import { LoginMobile } from '../pages/login/login_mobile';
 import type { LoginBodyType, LoginSidebarType } from '../pages/login/types';
+import { setDarkMode } from '../../helpers';
 
 type LoginModalAttrs = {
   initialBody?: LoginBodyType;
@@ -209,6 +210,9 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
       } else {
         // log in as the new user
         await initAppState(false);
+        if (localStorage.getItem('user-dark-mode-state') === 'on') {
+          setDarkMode(true);
+        }
         if (app.chain) {
           const chain =
             app.user.selectedChain ||

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -37,7 +37,10 @@ const Sublayout = ({
   });
 
   useEffect(() => {
-    if (localStorage.getItem('dark-mode-state') === 'on') {
+    if (
+      localStorage.getItem('dark-mode-state') === 'on' &&
+      localStorage.getItem('user-dark-mode-state')
+    ) {
       document.getElementsByTagName('html')[0].classList.add('invert');
     }
 

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -39,10 +39,10 @@ const Sublayout = ({
 
   useEffect(() => {
     if (
-      localStorage.getItem('dark-mode-state') === 'on' &&
-      localStorage.getItem('user-dark-mode-state')
+      localStorage.getItem('dark-mode-state') === 'on' ||
+      localStorage.getItem('user-dark-mode-state') === 'on'
     ) {
-      setDarkMode(true);
+      document.getElementsByTagName('html')[0].classList.add('invert');
     }
 
     const onResize = () => {

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -39,7 +39,7 @@ const Sublayout = ({
 
   useEffect(() => {
     if (
-      localStorage.getItem('dark-mode-state') === 'on' ||
+      localStorage.getItem('dark-mode-state') === 'on' &&
       localStorage.getItem('user-dark-mode-state') === 'on'
     ) {
       document.getElementsByTagName('html')[0].classList.add('invert');

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -10,6 +10,7 @@ import { Footer } from './footer';
 import { SublayoutBanners } from './sublayout_banners';
 import { SublayoutHeader } from './sublayout_header';
 import useForceRerender from 'hooks/useForceRerender';
+import { setDarkMode } from '../helpers';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -41,7 +42,7 @@ const Sublayout = ({
       localStorage.getItem('dark-mode-state') === 'on' &&
       localStorage.getItem('user-dark-mode-state')
     ) {
-      document.getElementsByTagName('html')[0].classList.add('invert');
+      setDarkMode(true);
     }
 
     const onResize = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
[Visiting 1inch switches entire site to darkmode, stays that way when i visit other communities, don't have to be logged in for this to happen](https://github.com/hicommonwealth/commonwealth/issues/2907)

## Description of Changes
- Edited logic when entering or leaving 1inch, based on dark mode set up before or not (local storage variable: "user-dark-mode-state")

## Test Plan
- Tested on all stories described on task
- Also when user is on 1inch pages then types on address bar the address of another page, outside of this community

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
 