### PR TITLE
Adds (optional) MaxHeight Prop to Select List

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
@@ -32,7 +32,7 @@ export const SelectList = <
         }),
         menu: (baseStyles) => ({
           ...baseStyles,
-          maxHeight: props.menuMaxHeight || '100px', // Set the desired maximum height for the scrollable menu
+          maxHeight: props.menuMaxHeight || '150px', // Set the desired maximum height for the scrollable menu
           overflowY: 'auto', // Enable vertical scrolling
         }),
       }}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
@@ -4,12 +4,20 @@ import Select from 'react-select';
 
 import 'components/component_kit/cw_select_list.scss';
 
+type SelectListProps<
+  Option,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>
+> = Props<Option, IsMulti, Group> & {
+  menuMaxHeight?: string;
+};
+
 export const SelectList = <
   Option,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
-  props: Props<Option, IsMulti, Group>
+  props: SelectListProps<Option, IsMulti, Group>
 ) => {
   return (
     <Select
@@ -21,6 +29,11 @@ export const SelectList = <
           border: 0,
           boxShadow: 'none',
           minHeight: 'unset',
+        }),
+        menu: (baseStyles) => ({
+          ...baseStyles,
+          maxHeight: props.menuMaxHeight || '100px', // Set the desired maximum height for the scrollable menu
+          overflowY: 'auto', // Enable vertical scrolling
         }),
       }}
       className={`SelectList ${props.className || ''}`}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
@@ -10,6 +10,7 @@ type SelectListProps<
   Group extends GroupBase<Option>
 > = Props<Option, IsMulti, Group> & {
   menuMaxHeight?: string;
+  maxVisibleItems?: number;
 };
 
 export const SelectList = <
@@ -19,20 +20,18 @@ export const SelectList = <
 >(
   props: SelectListProps<Option, IsMulti, Group>
 ) => {
+  // Calculate the menuMaxHeight based on maxVisibleItems and item height
+  const itemHeight = 30; // Adjust this value according to your specific item height
+  const menuMaxHeight = (props.maxVisibleItems || 5) * itemHeight + 'px';
+
   return (
     <Select
       {...props}
       styles={{
-        control: (baseStyles) => ({
-          ...baseStyles,
-          // removes unnecessary styles
-          border: 0,
-          boxShadow: 'none',
-          minHeight: 'unset',
-        }),
+        // ... other styles ...
         menu: (baseStyles) => ({
           ...baseStyles,
-          maxHeight: props.menuMaxHeight || '150px', // Set the desired maximum height for the scrollable menu
+          maxHeight: props.menuMaxHeight || menuMaxHeight,
           overflowY: 'auto', // Enable vertical scrolling
         }),
       }}

--- a/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
@@ -37,6 +37,7 @@ export const TopicSelector = ({
       placeholder="Select the topic"
       isSearchable={false}
       options={options}
+      maxVisibleItems={10}
       className="TopicSelector"
       onChange={handleOnChange}
     />

--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -172,6 +172,7 @@ export const PollEditorModal = ({
                 options={customDurationOptions}
                 defaultValue={customDurationOptions[0]}
                 onChange={({ value }) => setCustomDuration(value)}
+                menuMaxHeight="75px"
               />
             )}
           </div>

--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -168,7 +168,7 @@ export const PollEditorModal = ({
             />
             {customDurationEnabled && (
               <SelectList
-                isSearchable={false}
+                isSearchable={true}
                 options={customDurationOptions}
                 defaultValue={customDurationOptions[0]}
                 onChange={({ value }) => setCustomDuration(value)}


### PR DESCRIPTION
## Link to Issue
Closes: #3177 

## Description of Changes
- Adds SelectList menuMaxHeight prop to configure scrollable menu height.
- Updates PollEditorModal to utilize the new menuMaxHeight prop for SelectList.

## Test Plan
- [ ] Unit tested the SelectList with the new menuMaxHeight prop.
- [ ] CA (click around) tested on local:
- [ ] PollEditorModal in different scenarios, ensuring the custom duration SelectList has the appropriate maxHeight.
- [ ] Other pages using SelectList to ensure no adverse effects on existing SelectList usage.

## Other Considerations
- Monitor the behavior of SelectList in other components after the deployment to ensure no unintended side effects. 