### PR TITLE
Update `UpdateProposalStatusModal`

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -410,6 +410,7 @@ class ThreadsController {
       },
       error: (err) => {
         console.log('Failed to update stage');
+        notifyError(`Failed to update stage: ${err.responseJSON.error}`);
         throw new Error(
           err.responseJSON && err.responseJSON.error
             ? err.responseJSON.error
@@ -483,7 +484,8 @@ class ThreadsController {
         return thread;
       },
       error: (err) => {
-        console.log('Failed to update linked snapshot proposal');
+        notifyError(`Could not update Snapshot Linked Proposal: ${err.responseJSON.error}`);
+        console.error('Failed to update linked snapshot proposal');
         throw new Error(
           err.responseJSON && err.responseJSON.error
             ? err.responseJSON.error
@@ -523,6 +525,7 @@ class ThreadsController {
       },
       error: (err) => {
         console.log('Failed to update linked proposals');
+        notifyError(`Failed to update linked proposals: ${err.responseJSON.error}`);
         throw new Error(
           err.responseJSON && err.responseJSON.error
             ? err.responseJSON.error

--- a/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector_item.tsx
@@ -19,13 +19,13 @@ const ChainEntitiesSelectorItem = ({
     <div className="chain-entity" onClick={() => onClick(chainEntity)}>
       <div className="selected">{isSelected && <CWCheck />}</div>
       <div className="text">
-        <CWText fontWeight="medium" noWrap>
+        <CWText fontWeight="medium" truncate noWrap>
           {chainEntityTypeToProposalName(chainEntity.type) +
             (chainEntity.typeId.startsWith('0x')
               ? ` ${chainEntity.typeId.slice(0, 6)}...`
               : ` #${chainEntity.typeId}`)}
         </CWText>
-        <CWText type="caption">
+        <CWText type="caption" truncate>
           {chainEntity.threadTitle !== 'undefined'
             ? decodeURIComponent(chainEntity.threadTitle)
             : 'No thread title'}

--- a/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/chain_entities_selector/chain_entities_selector_item.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
 import { chainEntityTypeToProposalName } from 'identifiers';
 import type { ChainEntity } from 'models';
+import { CWText } from '../component_kit/cw_text';
 
 interface ChainEntitiesSelectorItemProps {
   chainEntity: ChainEntity;
@@ -18,17 +19,17 @@ const ChainEntitiesSelectorItem = ({
     <div className="chain-entity" onClick={() => onClick(chainEntity)}>
       <div className="selected">{isSelected && <CWCheck />}</div>
       <div className="text">
-        <div className="chain-entity-text">
+        <CWText fontWeight="medium" noWrap>
           {chainEntityTypeToProposalName(chainEntity.type) +
             (chainEntity.typeId.startsWith('0x')
               ? ` ${chainEntity.typeId.slice(0, 6)}...`
               : ` #${chainEntity.typeId}`)}
-        </div>
-        <div className="chain-entity-subtext">
+        </CWText>
+        <CWText type="caption">
           {chainEntity.threadTitle !== 'undefined'
             ? decodeURIComponent(chainEntity.threadTitle)
             : 'No thread title'}
-        </div>
+        </CWText>
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_text.tsx
@@ -39,6 +39,7 @@ type TextStyleProps = {
   isCentered?: boolean;
   noWrap?: boolean; // parent must be flex container and have definite width for this to work
   type?: FontType;
+  truncate?: boolean;
 };
 
 type TextProps = TextStyleProps &
@@ -66,6 +67,7 @@ export const CWText = (props: TextProps) => {
     title,
     type = 'b1',
     fontWeight = getFontWeight(type),
+    truncate = false,
     ...otherProps
   } = props;
 
@@ -81,6 +83,7 @@ export const CWText = (props: TextProps) => {
           onClick: !!onClick,
           isCentered,
           className,
+          truncate,
         },
         ComponentType.Text
       )}

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
@@ -22,6 +22,18 @@ export const SnapshotProposalSelector = ({
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
+  const queryLength = searchTerm?.trim()?.length;
+
+  const getEmptyContentMessage = () => {
+    if (queryLength > 0 && queryLength < 5) {
+      return 'Query too short';
+    } else if (queryLength >= 5 && !searchTerm.length) {
+      return 'No snapshots found';
+    } else if (!snapshotProposalsToSet?.length) {
+      return 'No currently linked snapshots';
+    }
+  };
+
   useEffect(() => {
     if (allProposals.length === 0) {
       setLoading(true);
@@ -76,6 +88,10 @@ export const SnapshotProposalSelector = ({
     setSearchTerm(e.target.value);
   };
 
+  const EmptyComponent = () => (
+    <div className="empty-component">{getEmptyContentMessage()}</div>
+  );
+
   return (
     <div className="SnapshotProposalSelector">
       <CWTextInput
@@ -89,6 +105,7 @@ export const SnapshotProposalSelector = ({
       <QueryList
         loading={loading}
         options={proposals}
+        components={{ EmptyPlaceholder: EmptyComponent }}
         renderItem={renderItem}
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
@@ -79,7 +79,7 @@ export const SnapshotProposalSelector = ({
   return (
     <div className="SnapshotProposalSelector">
       <CWTextInput
-        placeholder="Search for an existing snapshot proposal..."
+        placeholder="Search for snapshot proposals"
         iconRightonClick={handleClearButtonClick}
         value={searchTerm}
         iconRight="close"

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
@@ -17,12 +17,14 @@ const SnapshotProposalSelectorItem = ({
   return (
     <div className="proposal-item" onClick={() => onClick(snapshot)}>
       <div className="selected">{isSelected && <CWCheck />}</div>
-        <CWText fontWeight="medium" title={snapshot.title}>
+      <div>
+        <CWText fontWeight="medium" noWrap title={snapshot.title}>
           {snapshot.title}
         </CWText>
         <CWText type="caption" title={snapshot.id}>
-          Hash: {smartTruncate(snapshot.id, 8, {position: 5})}
+          Hash: {smartTruncate(snapshot.id, 12, {position: 4})}
         </CWText>
+      </div>
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
@@ -17,9 +17,9 @@ const SnapshotProposalSelectorItem = ({
   return (
     <div className="proposal-item" onClick={() => onClick(snapshot)}>
       <div className="selected">{isSelected && <CWCheck />}</div>
-      <div>
-        <CWText fontWeight="medium" noWrap title={snapshot.title}>
-          {smartTruncate(snapshot.title, 35)}
+      <div className="text">
+        <CWText fontWeight="medium" truncate title={snapshot.title}>
+          {snapshot.title}
         </CWText>
         <CWText type="caption" title={snapshot.id}>
           Hash: {smartTruncate(snapshot.id, 12, {position: 4})}

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
@@ -1,6 +1,6 @@
-import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
 import React from 'react';
 import type { SnapshotProposal } from 'helpers/snapshot_utils';
+import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
 import { CWText } from '../component_kit/cw_text';
 import smartTruncate from 'smart-truncate';
 interface SnapshotProposalSelectorItemProps {
@@ -19,7 +19,7 @@ const SnapshotProposalSelectorItem = ({
       <div className="selected">{isSelected && <CWCheck />}</div>
       <div>
         <CWText fontWeight="medium" noWrap title={snapshot.title}>
-          {snapshot.title}
+          {smartTruncate(snapshot.title, 35)}
         </CWText>
         <CWText type="caption" title={snapshot.id}>
           Hash: {smartTruncate(snapshot.id, 12, {position: 4})}

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
@@ -1,7 +1,8 @@
 import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
 import React from 'react';
 import type { SnapshotProposal } from 'helpers/snapshot_utils';
-
+import { CWText } from '../component_kit/cw_text';
+import smartTruncate from 'smart-truncate';
 interface SnapshotProposalSelectorItemProps {
   snapshot: SnapshotProposal;
   isSelected: boolean;
@@ -16,14 +17,12 @@ const SnapshotProposalSelectorItem = ({
   return (
     <div className="proposal-item" onClick={() => onClick(snapshot)}>
       <div className="selected">{isSelected && <CWCheck />}</div>
-      <div className="text">
-        <div className="proposal-item-text" title={snapshot.title}>
+        <CWText fontWeight="medium" title={snapshot.title}>
           {snapshot.title}
-        </div>
-        <div className="proposal-item-subtext" title={snapshot.id}>
-          Hash: ${snapshot.id}
-        </div>
-      </div>
+        </CWText>
+        <CWText type="caption" title={snapshot.id}>
+          Hash: {smartTruncate(snapshot.id, 8, {position: 5})}
+        </CWText>
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -129,16 +129,16 @@ export const UpdateProposalStatusModal = ({
       <div className="compact-modal-body">
         {/* To fix the issue of the select list not being able to be clicked on*/}
         <SelectList
-          items={stages.map((stage) => ({
+          defaultValue={tempStage ? { value: tempStage, label: threadStageToLabel(tempStage) } : null}
+          placeholder="Select the stage"
+          isSearchable={false}
+          options={stages.map((stage) => ({
             value: stage,
             label: threadStageToLabel(stage),
           }))}
-          selectedItem={tempStage}
-          onSelectItem={setTempStage}
-          listItemProps={{
-              buttonType: 'text',
-          }}
-      />
+          className="StageSelector"
+          onChange={(option) => setTempStage(option.value)}
+        />
         {showSnapshot && (
           <SnapshotProposalSelector
             onSelect={handleSelectProposal}

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -127,7 +127,6 @@ export const UpdateProposalStatusModal = ({
         <CWIconButton iconName="close" onClick={() => onModalClose()} />
       </div>
       <div className="compact-modal-body">
-        {/* To fix the issue of the select list not being able to be clicked on*/}
         <SelectList
           defaultValue={tempStage ? { value: tempStage, label: threadStageToLabel(tempStage) } : null}
           placeholder="Select the stage"

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -6,6 +6,7 @@ import type { SnapshotProposal } from 'helpers/snapshot_utils';
 import 'modals/update_proposal_status_modal.scss';
 import type { ChainEntity, Thread } from 'models';
 import { ThreadStage } from 'models';
+import { SelectList } from '../components/component_kit/cw_select_list';
 
 import app from 'state';
 import { ChainEntitiesSelector } from '../components/chain_entities_selector';
@@ -126,18 +127,18 @@ export const UpdateProposalStatusModal = ({
         <CWIconButton iconName="close" onClick={() => onModalClose()} />
       </div>
       <div className="compact-modal-body">
-        {stages.length > 0 && (
-          <div className="stage-options">
-            {stages.map((targetStage) => (
-              <CWButton
-                key={targetStage}
-                iconLeft={tempStage === targetStage ? 'check' : undefined}
-                label={threadStageToLabel(targetStage)}
-                onClick={() => setTempStage(targetStage)}
-              />
-            ))}
-          </div>
-        )}
+        {/* To fix the issue of the select list not being able to be clicked on*/}
+        <SelectList
+          items={stages.map((stage) => ({
+            value: stage,
+            label: threadStageToLabel(stage),
+          }))}
+          selectedItem={tempStage}
+          onSelectItem={setTempStage}
+          listItemProps={{
+              buttonType: 'text',
+          }}
+      />
         {showSnapshot && (
           <SnapshotProposalSelector
             onSelect={handleSelectProposal}

--- a/packages/commonwealth/client/styles/components/chain_entities_selector.scss
+++ b/packages/commonwealth/client/styles/components/chain_entities_selector.scss
@@ -34,20 +34,10 @@
     }
 
     .text {
-      width: calc(100% - 50px);
-
-      .proposal-item-text {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .proposal-item-subtext {
-        color: $neutral-500;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
+      width: calc(100% - 50px);;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
   }
 }

--- a/packages/commonwealth/client/styles/components/chain_entities_selector.scss
+++ b/packages/commonwealth/client/styles/components/chain_entities_selector.scss
@@ -4,7 +4,6 @@
   border-radius: $border-radius-corners;
   border: 1px solid $neutral-100;
   height: 208px;
-  width: 552px;
   display: flex;
   flex-direction: column;
 

--- a/packages/commonwealth/client/styles/components/component_kit/cw_text.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_text.scss
@@ -136,4 +136,10 @@
     justify-content: center;
     text-align: center;
   }
+
+  &.truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/packages/commonwealth/client/styles/components/snapshot_proposal_selector.scss
+++ b/packages/commonwealth/client/styles/components/snapshot_proposal_selector.scss
@@ -17,6 +17,13 @@
     font-size: 14px;
     cursor: pointer;
 
+    .text {
+      width: calc(100% - 15%);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
     &:hover {
       background-color: $neutral-100;
     }
@@ -30,30 +37,6 @@
       svg {
         fill: $black;
         width: 18px;
-      }
-    }
-
-    .truncate-text {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 100%;
-    }
-
-    .text {
-      width: calc(100% - 50px);
-
-      .proposal-item-text {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .proposal-item-subtext {
-        color: $neutral-500;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
     }
   }

--- a/packages/commonwealth/client/styles/components/snapshot_proposal_selector.scss
+++ b/packages/commonwealth/client/styles/components/snapshot_proposal_selector.scss
@@ -4,7 +4,6 @@
   border-radius: $border-radius-corners;
   border: 1px solid $neutral-100;
   height: 208px;
-  width: 552px;
   display: flex;
   flex-direction: column;
 
@@ -32,6 +31,13 @@
         fill: $black;
         width: 18px;
       }
+    }
+
+    .truncate-text {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
     }
 
     .text {

--- a/packages/commonwealth/client/styles/modals/update_proposal_status_modal.scss
+++ b/packages/commonwealth/client/styles/modals/update_proposal_status_modal.scss
@@ -1,6 +1,12 @@
 @import '../shared';
 
 .UpdateProposalStatusModal {
+  width: 504px;
+
+  @include smallInclusive {
+    width: 100%;
+  }
+
   .compact-modal-body {
     display: flex;
     flex-direction: column;

--- a/packages/commonwealth/client/styles/modals/update_proposal_status_modal.scss
+++ b/packages/commonwealth/client/styles/modals/update_proposal_status_modal.scss
@@ -12,12 +12,6 @@
     flex-direction: column;
     gap: 16px;
 
-    .stage-options {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-
     .buttons-row {
       display: flex;
       gap: 8px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3175 

## Description of Changes
- Adjusted the UpdateProposalStatusModal width to fit all screen sizes.
- Adjusted and update Stage Selection to use `SelectList` instead of custom component
- Adds notifyError so that errors do not fail silently

## Test Plan
- Manually tested the UpdateProposalStatusModal on various screen sizes.
- Ensure that the UpdateProposalStatusModal maintains its responsiveness across various devices and browsers.

## Other Considerations

- Later: Worth Refactoring / Making Generic all those sidebar actions I.e Linking Threads
- [x] (actually works) Later: related to other react work, the thread detail does not automatically refresh, rather the user has to manually refresh. This was not addressed in this PR