### PR TITLE
Fixed ViewCount bug from root_id refactor as well as merge mistakes

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/profile/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/index.tsx
@@ -52,7 +52,7 @@ export default class ProfileComponent extends ClassComponent<NewProfileAttrs> {
       const commentsWithAssociatedThread = comments.map((c) => {
         const thread = result.commentThreads.find(
           (t) =>
-            t.id === parseInt(c.rootProposal.replace('discussion_', ''), 10)
+            t.id === parseInt(c.threadId, 10)
         );
         return { ...c, thread };
       });

--- a/packages/commonwealth/server/routes/bulkThreads.ts
+++ b/packages/commonwealth/server/routes/bulkThreads.ts
@@ -101,10 +101,7 @@ const bulkThreads = async (
       return next(new ServerError('Could not fetch threads'));
     }
 
-    const thread_ids = [];
     threads = preprocessedThreads.map((t) => {
-      const thread_id = `discussion_${t.thread_id}`;
-      thread_ids.push(thread_id);
       const collaborators = JSON.parse(t.collaborators[0]).address?.length
         ? t.collaborators.map((c) => JSON.parse(c))
         : [];

--- a/packages/commonwealth/server/routes/viewUserActivity.ts
+++ b/packages/commonwealth/server/routes/viewUserActivity.ts
@@ -19,7 +19,7 @@ export default async (
 
   const query = `
     SELECT nt.thread_id, nts.created_at as last_activity, nts.notification_data, nts.category_id,
-      MAX(ovc.view_count) as view_count,
+      MAX(thr.view_count) as view_count,
       COUNT(DISTINCT oc.id) AS comment_count,
       COUNT(DISTINCT tr.id) + COUNT(DISTINCT cr.id) AS reaction_count
     FROM
@@ -38,8 +38,7 @@ export default async (
           ) nnn
       ) nt
     INNER JOIN "Notifications" nts ON nt.mx_not_id = nts.id
-    LEFT JOIN "ViewCounts" ovc ON nt.thread_id = CAST(ovc.object_id AS VARCHAR)
-    LEFT JOIN "Comments" oc ON 'discussion_'||CAST(nt.thread_id AS VARCHAR) = oc.thread_id
+    LEFT JOIN "Comments" oc ON nt.thread_id = CAST(oc.thread_id AS VARCHAR)
       --TODO: eval execution path with alternate aggregations
     LEFT JOIN "Reactions" tr ON nt.thread_id = CAST(tr.thread_id AS VARCHAR)
     LEFT JOIN "Reactions" cr ON oc.id = cr.comment_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes
- viewUserActivity was failing due to missing it in the root_id refactor
- a newProfiles change was merged in that made it incompatible with root_id refactor, fixed this as well.

## Test Plan
- CA (click around) tested on local