### PR TITLE
migration to delete offchainprofiles table

### DIFF
--- a/packages/commonwealth/server/migrations/20230327185728-remove-offchain-profiles-table.js
+++ b/packages/commonwealth/server/migrations/20230327185728-remove-offchain-profiles-table.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.dropTable('OffchainProfiles');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
- Deletes offchainprofiles table (not needed now that new profiles are merged). Needed in order to fix the deleteChain route (will be in another PR).

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 