### PR TITLE
Fixed sidebar toggle

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -31,7 +31,7 @@ const setAdminToggleTree = (path: string, toggle: boolean) => {
     }
   }
 
-  currentTree[split[split.length - 1]] = toggle;
+  currentTree[split[split.length - 1]] = !toggle;
 
   const newTree = currentTree;
 

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -29,7 +29,7 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
       return;
     }
   }
-  currentTree[split[split.length - 1]] = toggle;
+  currentTree[split[split.length - 1]] = !toggle;
   const newTree = currentTree;
   localStorage[`${app.activeChainId()}-discussions-toggle-tree`] =
     JSON.stringify(newTree);

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -36,7 +36,7 @@ function setGovernanceToggleTree(path: string, toggle: boolean) {
     }
   }
 
-  currentTree[split[split.length - 1]] = toggle;
+  currentTree[split[split.length - 1]] = !toggle;
 
   const newTree = currentTree;
 

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
@@ -173,7 +173,7 @@ export const SidebarSectionGroup = (props: SidebarSectionAttrs) => {
 
     setToggled(!toggled);
 
-    localStorage.setItem(`${sectionName}-toggled`, (!!toggled).toString());
+    localStorage.setItem(`${sectionName}-toggled`, (!toggled).toString());
 
     if (toggled) {
       setHoverColor('none');


### PR DESCRIPTION
Sidebar was not adhering to local storage state between page refreshes.

## Link to Issue
Closes: #3257

## Description of Changes
- Fixed minor logical issue in sidebar components

## Test Plan
- CA (click around) tested on local
