### PR TITLE
Fix thread page crash

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/quill/render_quill_delta.ts
+++ b/packages/commonwealth/client/scripts/views/components/quill/render_quill_delta.ts
@@ -310,10 +310,22 @@ export const renderQuillDelta = (
             const content = parent.children.map(renderChild);
             if (tag === 'li.checked') {
               content.unshift(
-                render(`input[type='checkbox'][disabled][checked]`, { key: iii })
+                render(`input`, {
+                  key: `input-${iii}`,
+                  type: 'checkbox',
+                  disabled: true,
+                  checked: true
+                }, null)
               );
             } else if (tag === 'li.unchecked') {
-              content.unshift(render(`input[type='checkbox'][disabled]`, { key: iii }));
+              content.unshift(
+                render(`input`, {
+                  key: `input-${iii}`,
+                  type: 'checkbox',
+                  disabled: true,
+                  checked: false
+                }, null)
+              );
             }
             const indent = parent.attributes.indent || 0;
 


### PR DESCRIPTION
Fixes the thread page crash that occurs if rendering richtext that contains a checkbox element.

## Link to Issue
Closes: #3218

## Description of Changes
- Fixes checkbox richtext quill rendering in thread body

## Test Plan
- Create a new thread, add checkbox in richtext mode, save– confirm that it renders without and error

## Deployment Plan
N/A

## Other Considerations
N/A