### PR TITLE
Mark as read does not work in notifications

### DIFF
--- a/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/notifications_menu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
@@ -21,6 +21,7 @@ import { byDescendingCreationDate } from 'helpers';
 
 export const NotificationsMenu = () => {
   const navigate = useCommonNavigate();
+  const [allRead, setAllRead] = useState<boolean>(false);
 
   const discussionNotifications =
     app.user.notifications.discussionNotifications;
@@ -43,7 +44,7 @@ export const NotificationsMenu = () => {
             }
             data={mostRecentFirst}
             itemContent={(i, data) => (
-              <NotificationRow key={i} notification={data} />
+              <NotificationRow key={i} notification={data} allRead={allRead} />
             )}
           />
         ) : (
@@ -70,6 +71,7 @@ export const NotificationsMenu = () => {
             if (mostRecentFirst.length < 1) return;
 
             app.user.notifications.markAsRead(mostRecentFirst);
+            setAllRead(true);
           }}
         />
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
@@ -6,7 +6,6 @@ import 'pages/notifications/index.scss';
 import app from 'state';
 import Sublayout from 'views/sublayout';
 import PageError from 'views/pages/error';
-import { PageLoading } from 'views/pages/loading';
 import { NotificationRow } from './notification_row';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWText } from '../../components/component_kit/cw_text';

--- a/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import 'pages/notifications/index.scss';
@@ -15,6 +15,8 @@ const NotificationsPage = () => {
   if (!app.isLoggedIn()) {
     return <PageError message="This page requires you to be logged in." />;
   }
+
+  const [allRead, setAllRead] = useState<boolean>(false);
 
   const discussionNotifications =
     app.user.notifications.discussionNotifications;
@@ -34,6 +36,7 @@ const NotificationsPage = () => {
             onClick={(e) => {
               e.preventDefault();
               app.user.notifications.markAsRead(mostRecentFirst);
+              setAllRead(true);
             }}
           />
           <CWButton
@@ -57,7 +60,12 @@ const NotificationsPage = () => {
               style={{ height: '400px' }}
               data={mostRecentFirst}
               itemContent={(i, data) => (
-                <NotificationRow key={i} notification={data} onListPage />
+                <NotificationRow
+                  key={i}
+                  notification={data}
+                  onListPage
+                  allRead={allRead}
+                />
               )}
             />
           ) : (

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import type { Notification } from 'models';
 import { NotificationCategories } from 'common-common/src/types';
@@ -12,16 +12,19 @@ import {
 export type NotificationRowProps = {
   notification: Notification;
   onListPage?: boolean;
+  allRead: boolean;
 };
 
 export const NotificationRow = (props: NotificationRowProps) => {
-  const { notification, onListPage } = props;
+  const { notification, onListPage, allRead } = props;
 
   const [markingRead, setMarkingRead] = React.useState<boolean>(false);
 
   const handleSetMarkingRead = (isMarkingRead: boolean) => {
     setMarkingRead(isMarkingRead);
   };
+
+  useEffect(() => setMarkingRead(allRead), [allRead]);
 
   const { category } = notification.subscription;
 
@@ -38,6 +41,7 @@ export const NotificationRow = (props: NotificationRowProps) => {
         notification={notification}
         handleSetMarkingRead={handleSetMarkingRead}
         markingRead={markingRead}
+        allRead={allRead}
       />
     );
   } else {
@@ -46,6 +50,7 @@ export const NotificationRow = (props: NotificationRowProps) => {
         notification={notification}
         handleSetMarkingRead={handleSetMarkingRead}
         markingRead={markingRead}
+        allRead={allRead}
       />
     );
   }

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
@@ -64,9 +64,7 @@ export const ChainEventNotificationRow = (props: NotificationRowProps) => {
   return (
     <div
       className={
-        !notification.isRead
-          ? 'NotificationRow NewNotificationRow'
-          : 'NotificationRow'
+        !notification.isRead ? 'NotificationRow unread' : 'NotificationRow'
       }
       onClick={() => navigate(`/notifications?id=${notification.id}`)}
     >
@@ -133,9 +131,7 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
 
   return (
     <div
-      className={
-        !isRead ? 'NotificationRow NewNotificationRow' : 'NotificationRow'
-      }
+      className={!isRead ? 'NotificationRow unread' : 'NotificationRow'}
       onClick={() => navigate(path.replace(/ /g, '%20'))}
     >
       {authorInfo.length === 1 ? (
@@ -229,9 +225,7 @@ export const SnapshotNotificationRow = (
 
   return (
     <div
-      className={
-        !isRead ? 'NotificationRow NewNotificationRow' : 'NotificationRow'
-      }
+      className={!isRead ? 'NotificationRow unread' : 'NotificationRow'}
       onClick={() =>
         navigate(`/snapshot/${notificationData.space}/${notificationData.id}`)
       }

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
@@ -93,10 +93,11 @@ export const ChainEventNotificationRow = (props: NotificationRowProps) => {
 type ExtendedNotificationRowProps = NotificationRowProps & {
   handleSetMarkingRead: (isMarkingRead: boolean) => void;
   markingRead: boolean;
+  allRead: boolean;
 };
 
 export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
-  const { handleSetMarkingRead, markingRead, notification } = props;
+  const { handleSetMarkingRead, markingRead, notification, allRead } = props;
   const [isRead, setIsRead] = useState<boolean>(notification.isRead);
 
   const { category } = notification.subscription;
@@ -131,7 +132,9 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
 
   return (
     <div
-      className={!isRead ? 'NotificationRow unread' : 'NotificationRow'}
+      className={
+        !isRead && !allRead ? 'NotificationRow unread' : 'NotificationRow'
+      }
       onClick={() => navigate(path.replace(/ /g, '%20'))}
     >
       {authorInfo.length === 1 ? (
@@ -166,7 +169,7 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
           <div className="comment-body-created">
             {moment(createdAt).fromNow()}
           </div>
-          {!isRead && (
+          {!isRead && !allRead && (
             <div
               className="comment-body-mark-as-read"
               onClick={(e) => {
@@ -198,7 +201,7 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
 export const SnapshotNotificationRow = (
   props: ExtendedNotificationRowProps
 ) => {
-  const { handleSetMarkingRead, markingRead, notification } = props;
+  const { handleSetMarkingRead, markingRead, notification, allRead } = props;
   const [isRead, setIsRead] = useState<boolean>(notification.isRead);
   const navigate = useNavigate();
 
@@ -225,7 +228,9 @@ export const SnapshotNotificationRow = (
 
   return (
     <div
-      className={!isRead ? 'NotificationRow unread' : 'NotificationRow'}
+      className={
+        !isRead && !allRead ? 'NotificationRow unread' : 'NotificationRow'
+      }
       onClick={() =>
         navigate(`/snapshot/${notificationData.space}/${notificationData.id}`)
       }

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import moment from 'moment';
 
 import 'pages/notifications/notification_row.scss';
@@ -63,7 +63,11 @@ export const ChainEventNotificationRow = (props: NotificationRowProps) => {
 
   return (
     <div
-      className="NotificationRow"
+      className={
+        !notification.isRead
+          ? 'NotificationRow NewNotificationRow'
+          : 'NotificationRow'
+      }
       onClick={() => navigate(`/notifications?id=${notification.id}`)}
     >
       <div className="comment-body">
@@ -95,6 +99,7 @@ type ExtendedNotificationRowProps = NotificationRowProps & {
 
 export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
   const { handleSetMarkingRead, markingRead, notification } = props;
+  const [isRead, setIsRead] = useState<boolean>(notification.isRead);
 
   const { category } = notification.subscription;
 
@@ -128,7 +133,9 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
 
   return (
     <div
-      className="NotificationRow"
+      className={
+        !isRead ? 'NotificationRow NewNotificationRow' : 'NotificationRow'
+      }
       onClick={() => navigate(path.replace(/ /g, '%20'))}
     >
       {authorInfo.length === 1 ? (
@@ -163,7 +170,7 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
           <div className="comment-body-created">
             {moment(createdAt).fromNow()}
           </div>
-          {!notification.isRead && (
+          {!isRead && (
             <div
               className="comment-body-mark-as-read"
               onClick={(e) => {
@@ -175,6 +182,7 @@ export const DefaultNotificationRow = (props: ExtendedNotificationRowProps) => {
                 app.user.notifications
                   .markAsRead([notification])
                   ?.then(() => {
+                    setIsRead(true);
                     handleSetMarkingRead(false);
                   })
                   .catch(() => {
@@ -195,6 +203,7 @@ export const SnapshotNotificationRow = (
   props: ExtendedNotificationRowProps
 ) => {
   const { handleSetMarkingRead, markingRead, notification } = props;
+  const [isRead, setIsRead] = useState<boolean>(notification.isRead);
   const navigate = useNavigate();
 
   const notificationData = JSON.parse(notification.data);
@@ -220,7 +229,9 @@ export const SnapshotNotificationRow = (
 
   return (
     <div
-      className="NotificationRow"
+      className={
+        !isRead ? 'NotificationRow NewNotificationRow' : 'NotificationRow'
+      }
       onClick={() =>
         navigate(`/snapshot/${notificationData.space}/${notificationData.id}`)
       }
@@ -229,7 +240,7 @@ export const SnapshotNotificationRow = (
         <div className="comment-body-title">{header}</div>
         <div className="comment-body-excerpt">{body}</div>
         <div className="comment-body-bottom-wrap">
-          {!notification.isRead && (
+          {!isRead && (
             <div
               className="comment-body-mark-as-read"
               onClick={(e) => {
@@ -241,6 +252,7 @@ export const SnapshotNotificationRow = (
                 app.user.notifications
                   .markAsRead([notification])
                   ?.then(() => {
+                    setIsRead(true);
                     handleSetMarkingRead(false);
                   })
                   .catch(() => {

--- a/packages/commonwealth/client/styles/pages/notifications/notification_row.scss
+++ b/packages/commonwealth/client/styles/pages/notifications/notification_row.scss
@@ -11,12 +11,13 @@
   text-decoration: none !important;
   color: $black !important;
 
-  &:hover {
-    background: $neutral-200;
-  }
-
   &.unread {
     background: $yellow-100;
+    border-bottom: 1px solid $neutral-300;
+  }
+
+  &:hover {
+    background: $neutral-50;
   }
 
   > .User {
@@ -87,9 +88,4 @@
   .comment-body-mark-as-read:hover {
     color: $primary-600;
   }
-}
-
-.NewNotificationRow {
-  background: $neutral-50;
-  border-bottom: 1px solid $neutral-300;
 }

--- a/packages/commonwealth/client/styles/pages/notifications/notification_row.scss
+++ b/packages/commonwealth/client/styles/pages/notifications/notification_row.scss
@@ -1,7 +1,6 @@
 @import '../../shared';
 
 .NotificationRow {
-  border-bottom: 1px solid $neutral-100;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -13,7 +12,7 @@
   color: $black !important;
 
   &:hover {
-    background: $neutral-50;
+    background: $neutral-200;
   }
 
   &.unread {
@@ -81,11 +80,16 @@
 
   .comment-body-mark-as-read {
     display: inline;
-    color: $neutral-500;
+    color: $primary-300;
     margin-left: 8px;
   }
 
   .comment-body-mark-as-read:hover {
     color: $primary-600;
   }
+}
+
+.NewNotificationRow {
+  background: $neutral-50;
+  border-bottom: 1px solid $neutral-300;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3136 

## Description of Changes
- Edits style for new notifications (those unread)
- Mark as read working "real time"

![image](https://user-images.githubusercontent.com/30223098/229234596-3a09439c-b11d-4737-bcf3-8341408e077d.png)

![image](https://user-images.githubusercontent.com/30223098/229234769-6db32ad9-5196-466e-af9a-1ddeb7979a54.png)


## Test Plan
- CA (click around) tested on local
- Design QA to see if it looks nice
- To help see notifications:
1. Log in with an account, make comments on thread (or like it)
2. Developer tools > Empty cache and force reload
3. Log in with account that will receive notifications

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->