### PR TITLE
update heroku random color name with our own alias

### DIFF
--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -39,7 +39,7 @@
     "start-ci": "FETCH_INTERVAL_MS=500 ts-node --project tsconfig.json server.ts",
     "profile": "NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack/webpack.dev.config.js --json --profile > webpack-stats.json",
     "psql": "chmod u+x scripts/start-psql.sh && ./scripts/start-psql.sh",
-    "dump-db": "pg_dump $(heroku config:get HEROKU_POSTGRESQL_RED_URL -a commonwealth-beta) --verbose --exclude-table-data=\"public.\\\"Subscriptions\\\"\" --exclude-table-data=\"public.\\\"Sessions\\\"\" --exclude-table-data=\"public.\\\"DiscussionDrafts\\\"\" --exclude-table-data=\"public.\\\"LoginTokens\\\"\" --exclude-table-data=\"public.\\\"Notifications\\\"\" --exclude-table-data=\"public.\\\"SocialAccounts\\\"\" --exclude-table-data=\"public.\\\"Webhooks\\\"\" --exclude-table-data=\"public.\\\"NotificationsRead\\\"\" --no-privileges --no-owner -f latest.dump",
+    "dump-db": "pg_dump $(heroku config:get CW_READ_DB -a commonwealth-beta) --verbose --exclude-table-data=\"public.\\\"Subscriptions\\\"\" --exclude-table-data=\"public.\\\"Sessions\\\"\" --exclude-table-data=\"public.\\\"DiscussionDrafts\\\"\" --exclude-table-data=\"public.\\\"LoginTokens\\\"\" --exclude-table-data=\"public.\\\"Notifications\\\"\" --exclude-table-data=\"public.\\\"SocialAccounts\\\"\" --exclude-table-data=\"public.\\\"Webhooks\\\"\" --exclude-table-data=\"public.\\\"NotificationsRead\\\"\" --no-privileges --no-owner -f latest.dump",
     "reset-db": "chmod u+x scripts/reset-db.sh && ./scripts/reset-db.sh",
     "load-db": "chmod u+x scripts/load-db.sh && ./scripts/load-db.sh",
     "load-db-local": "psql -d commonwealth -U commonwealth -W -f local_save.dump",
@@ -47,7 +47,7 @@
     "db-all": "yarn reset-db && yarn load-db && yarn migrate-db",
     "migrate-db-down": "npx sequelize db:migrate:undo",
     "create-migration": "npx sequelize migration:generate --name",
-    "dump-db-limit": "yarn run dump-db &&  psql $(heroku config:get HEROKU_POSTGRESQL_RED_URL -a commonwealth-beta) -a -f limited_dump.sql",
+    "dump-db-limit": "yarn run dump-db &&  psql $(heroku config:get CW_READ_DB -a commonwealth-beta) -a -f limited_dump.sql",
     "load-db-limit": "yarn run reset-db && yarn run load-db && psql -d commonwealth -U commonwealth -a -f limited_load.sql",
     "start-ios": "npx cap run ios",
     "open-ios": "NODE_ENV=mobile npx cap open ios",
@@ -63,7 +63,7 @@
     "gen-e2e": "npx playwright codegen",
     "test-e2e": "npx playwright test ./test/e2e/*",
     "wait-server": "chmod +x ./scripts/wait-server.sh && ./scripts/wait-server.sh",
-    "reset-frack-db": "heroku pg:copy commonwealth-beta::HEROKU_POSTGRESQL_RED_URL DATABASE_URL --app commonwealth-staging2 --confirm commonwealth-staging2"
+    "reset-frack-db": "heroku pg:copy commonwealth-beta::CW_READ_DB DATABASE_URL --app commonwealth-staging2 --confirm commonwealth-staging2"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3277

## Description of Changes
- Adds our own alias for follower DB instead of HEROKU generated random color name
- 

## Test Plan
- `yarn run dump-db` , `yarn run dump-db-limit` `yarn run reset-frack-db`

Try run- looking fine
<img width="966" alt="image" src="https://user-images.githubusercontent.com/4791635/229140518-5e8f817c-57c8-43fb-b8f6-1189fc2ab800.png">


## Deployment Plan
- [x] New follower is provisioned & deployed
- [ ] Need to delete old DB's
- [ ] Update Spreadsheet owners who are using reference 
- [ ] Reset Frack DB?

## Other Considerations
Added scenario here for future considerations
https://github.com/hicommonwealth/commonwealth/wiki/database#scenario-add-follower-db