### PR TITLE
Handle cross community link in custom domain

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
@@ -18,6 +18,8 @@ type ProfileActivityRowProps = {
   activity: CommentWithAssociatedThread | Thread;
 };
 
+const PROD_URL = 'https://commonwealth.im';
+
 const ProfileActivityRow = (props: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
   const { activity } = props;
@@ -43,6 +45,20 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
     <CWIconButton iconName="share" iconSize="small" onClick={onclick} />
   );
 
+  const handleClickLink = (path) => {
+    const isExternalLink = chain !== app.customDomainId();
+
+    if (!app.isCustomDomain()) {
+      navigate(path, {}, chain);
+    } else {
+      if (isExternalLink) {
+        window.open(`${PROD_URL}/${chain}${path}`);
+      } else {
+        navigate(path);
+      }
+    }
+  };
+
   return (
     <div className="ProfileActivityRow">
       <div className="chain-info">
@@ -52,7 +68,7 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              navigate(`/${chain}/discussions`);
+              handleClickLink(`/discussions`);
             }}
           >
             {chain}
@@ -78,7 +94,7 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                navigate(`/${chain}/discussion/${id}`);
+                handleClickLink(`/discussion/${id}`);
               }}
             >
               {title}
@@ -88,8 +104,8 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                navigate(
-                  `/${chain}/discussion/${comment.thread?.id}?comment=${comment.id}`
+                handleClickLink(
+                  `/discussion/${comment.thread?.id}?comment=${comment.id}`
                 );
               }}
             >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3219 

## Description of Changes
- Our router is different depending if we are in custom domain or not (`commonDomainsRoutes` vs `customDomainRoutes` files are loaded). Thus, being in custom domain we are not able to redirect to `/:scope/something` simply because scoped route does not exist in the custom domain router 
- Solution is that link to other community has to be open in new tab 
- Link to the current community will be still opened in the same tab


https://user-images.githubusercontent.com/14819225/230089305-2e2b87a1-1af7-4757-901b-19fc37854475.mp4



## Test Plan
- tested locally on custom domain

