### PR TITLE
Fixed notifications bug by migrating root_id field to thread_id

### DIFF
--- a/packages/commonwealth/server/migrations/20230405143032-notifications-root-id-migration.js
+++ b/packages/commonwealth/server/migrations/20230405143032-notifications-root-id-migration.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // for SET, we have
+    await queryInterface.sequelize.query(`
+        UPDATE "Notifications"
+        SET notification_data = notification_data::jsonb - 'root_id' || -- remove the root_id entry
+         jsonb_build_object('thread_id', -- build the thread_id entry
+         CASE 
+             WHEN notification_data::jsonb->>'root_id' like 'discussion_%' -- If it has discussion prefix
+             THEN substring(notification_data::jsonb->>'root_id' from 'discussion_(.*)') -- remove the discussion prefix
+             ELSE notification_data::jsonb->>'root_id' -- otherwise no discussion prefix, get thread_id portion
+         END)
+        WHERE notification_data::jsonb ? 'root_id'; -- only apply to jsons with root_id key
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+        UPDATE "Notifications"
+        SET notification_data = notification_data::jsonb - 'thread_id' ||
+        jsonb_build_object('root_id', 'discussion_'::text || (notification_data::jsonb->>'thread_id')::text)
+        WHERE notification_data::jsonb ? 'thread_id';
+    `);
+  }
+};

--- a/packages/commonwealth/server/routes/createComment.ts
+++ b/packages/commonwealth/server/routes/createComment.ts
@@ -323,7 +323,7 @@ const createComment = async (
   emitNotifications(
     models,
     NotificationCategories.NewComment,
-    thread_id,
+    `discussion_${thread_id}`,
     {
       created_at: new Date(),
       thread_id: thread_id,

--- a/packages/commonwealth/server/scripts/emailDigest.ts
+++ b/packages/commonwealth/server/scripts/emailDigest.ts
@@ -56,7 +56,7 @@ export const getTopThreads = async (
         t.created_at AS created_at
       FROM 
         "Threads" t
-        LEFT JOIN "Comments" c ON t.id = CAST(substring(c.root_id from '[0-9]+$') AS INTEGER)
+        LEFT JOIN "Comments" c ON t.id = c.thread_id
         LEFT JOIN "Reactions" r ON t.id = r.thread_id
         INNER JOIN "Addresses" a ON t.address_id = a.id
       WHERE 
@@ -131,7 +131,7 @@ const getCommunityActivityScore = async (
           0.3 * COUNT(DISTINCT r.id) AS activity_score
         FROM 
           "Threads" t
-          LEFT JOIN "Comments" c ON t.id = CAST(substring(c.root_id from '[0-9]+$') AS INTEGER)
+          LEFT JOIN "Comments" c ON t.id = c.thread_id
           LEFT JOIN "Reactions" r ON t.id = r.thread_id
         WHERE 
           t.chain='${communityId}' AND

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -71,10 +71,10 @@ export const requiresTypeSlug = (type: ProposalType): boolean => {
 };
 
 /* eslint-disable */
-export const getThreadUrl = (proposal, comment?) => {
-  const aId = proposal.chain;
-  const tId = proposal.type_id || proposal.id;
-  const tTitle = proposal.title ? `-${slugify(proposal.title)}` : '';
+export const getThreadUrl = (type, thread, comment?) => {
+  const aId = thread.chain;
+  const tId = thread.type_id || thread.id;
+  const tTitle = thread.title ? `-${slugify(thread.title)}` : '';
   const cId = comment ? `?comment=${comment.id}` : '';
 
   return process.env.NODE_ENV === 'production'

--- a/packages/commonwealth/test/integration/api/external/dbEntityHooks.spec.ts
+++ b/packages/commonwealth/test/integration/api/external/dbEntityHooks.spec.ts
@@ -273,7 +273,7 @@ beforeEach(async () => {
               chain: 'cmntest',
               address_id: -1,
               text: '',
-              thread_id: 'discussion_-1',
+              thread_id: '-1',
               plaintext: '',
             },
           })
@@ -292,7 +292,7 @@ beforeEach(async () => {
                 chain: 'cmntest',
                 address_id: -2,
                 text: '',
-                thread_id: 'discussion_-2',
+                thread_id: '-2',
                 plaintext: '',
               },
             })

--- a/packages/commonwealth/test/integration/api/subscriptions.spec.ts
+++ b/packages/commonwealth/test/integration/api/subscriptions.spec.ts
@@ -157,7 +157,7 @@ describe.skip('Subscriptions Tests', () => {
         address: loggedInAddr,
         jwt: jwtToken,
         text: 'cw4eva',
-        thread_id: `discussion_${res1.result.id}`,
+        thread_id: res1.result.id,
       });
       const object_id = `comment-${res.result.id}`;
       const is_active = true;
@@ -191,7 +191,7 @@ describe.skip('Subscriptions Tests', () => {
         address: loggedInAddr,
         jwt: jwtToken,
         text: 'hi',
-        thread_id: `discussion_${res.result.id}`,
+        thread_id: res.result.id,
       });
       const object_id = `comment-${res.result.id}`;
       const is_active = true;

--- a/packages/commonwealth/test/util/fixtures/markdownComment.ts
+++ b/packages/commonwealth/test/util/fixtures/markdownComment.ts
@@ -4,7 +4,7 @@ export const markdownComment = {
   community: '',
   address: 'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
   parent_id: '',
-  thread_id: 'discussion_3',
+  thread_id: '3',
   text: '%23%20markdown%20comment%0A%3E%20test%0A%0A',
   versionHistory:
     '{"timestamp":"2020-03-21T01:40:40.456Z","body":"# markdown comment\\n> test\\n\\n"}',

--- a/packages/commonwealth/test/util/fixtures/richTextComment.ts
+++ b/packages/commonwealth/test/util/fixtures/richTextComment.ts
@@ -4,7 +4,7 @@ module.exports = {
   community: '',
   address: 'ik52qFh92pboSctWPSFKtQwGEpypzz2m6D5ZRP8AYxqjHpM',
   parent_id: '',
-  thread_id: 'discussion_3',
+  thread_id: '3',
   text:
     '%7B%22ops%22%3A%5B%7B%22insert%22%3A%22Rich%20text%20comment%22%7D%2C%7B%22attributes%22%3A%7B%22header%22%3' +
     'A2%7D%2C%22insert%22%3A%22%5Cn%22%7D%2C%7B%22attributes%22%3A%7B%22bold%22%3Atrue%7D%2C%22insert%22%3A%22test%2' +


### PR DESCRIPTION
I see two ways to fix the Notification problem, revert or migrate. Either we revert all the Notifications.notification_data.thread_id to root_id, or we just fully go through with converting notifications to use thread_id as well. I have taken the migrate approach, but the migration script down sequence will be used if we decide on taking the revert approach.

Note that object_id still needs the discussion prefix because we need to distinguish threads from other types of notifications.

## Link to Issue
Closes: #3354

## Description of Changes
- Create migration script to turn Notifications.notification_data.thread_id -> Notifications.notification_data.root_id
- Fixed incorrect setting of object_id in some emitNotifications calls.
- Fixed error with notification not pointing to correct thread url

## Test Plan
- [x] CA (click around) tested on local 
- [x] CA (click around) tested on frick
