### PR TITLE
Add rerender for DiscussionsPage whenever an action event is triggered

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -49,7 +49,7 @@ rendered on the listing—and receiving the next page worth of threads (typicall
 
 When a user navigates to a proposal page that has not been fetched through these bulk calls,
 the proposal component calls the controller fetchThread fn, which fetches an individual thread
-by an id, then returns it after addinig it to threads.store. These threads are *not* added
+by an id, then returns it after adding it to threads.store. These threads are *not* added
 to the listingStore, since they do not belong in the listing component, and their presence
 would break the listingStore's careful chronology.
 
@@ -416,6 +416,7 @@ class ThreadsController {
         // Post edits propagate to all thread stores
         this._store.update(result);
         this._listingStore.add(result);
+        app.threadUpdateEmitter.emit('threadUpdated', {});
         return result;
       },
       error: (err) => {

--- a/packages/commonwealth/client/scripts/controllers/server/topics.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/topics.ts
@@ -101,6 +101,7 @@ class TopicsController {
         this._store.remove(this._store.getById(result.id));
       }
       this._store.add(result);
+      app.threadUpdateEmitter.emit('threadUpdated', { threadId, topicId });
       return result;
     } catch (err) {
       console.log('Failed to update topic');

--- a/packages/commonwealth/client/scripts/state.ts
+++ b/packages/commonwealth/client/scripts/state.ts
@@ -66,6 +66,7 @@ export interface IApp {
   threadReactions: ThreadReactionsController;
   reactionCounts: ReactionCountsController;
   polls: PollsController;
+  threadUpdateEmitter: EventEmitter;
 
   // Search
   search: SearchController;
@@ -161,6 +162,7 @@ const app: IApp = {
   threadReactions: new ThreadReactionsController(),
   reactionCounts: new ReactionCountsController(),
   polls: new PollsController(),
+  threadUpdateEmitter: new EventEmitter(),
 
   // Community
   communities: new CommunitiesController(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3066 

## Description of Changes
- Adds rerender of DiscussionsPage component whenever actions such as topic or stage change are triggered

## Test Plan
- Logged as admin, create a thread and add a topic T1. Filter the discussions by topic T1. Click the 3 dots icon, change topic to T2, save changes => thread should disappear from the list
- Create a thread and add a topic X. Go to /discussions and update status to stage S1. Filter discussions by stage S1. Click the 3 dots icon, change status/stage to S2, save changes => thread should disappear from the list 

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->