### PR TITLE
add dynamic voting delay + period to snapshot

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
+++ b/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
@@ -46,6 +46,13 @@ class GqlLazyLoader {
       symbol
       private
       network
+      validation {
+        params
+      }
+      voting {
+        period
+        delay
+      }
       filters {
         minScore
         onlyMembers
@@ -162,6 +169,15 @@ export interface SnapshotSpace {
   symbol: string;
   private: boolean;
   network: string;
+  validation: {
+    params: {
+      minScore: number;
+    };
+  };
+  voting: {
+    period: number;
+    delay: number;
+  };
   filters: {
     minScore: number;
     onlyMembers: boolean;

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/helpers.ts
@@ -45,8 +45,11 @@ const newThread = async (
 
   // Format form for proper validation
   delete form.range;
-  form.start = Math.floor(form.start / 1000);
-  form.end = Math.floor(form.end / 1000);
+  const delay = space.voting.delay ?? 0;
+  const period = space.voting.period ?? 432000; // 5 day default
+  const timestamp = Math.floor(Date.now() / 1e3);
+  form.start = timestamp + delay;
+  form.end = form.start + period;
 
   const proposalPayload = {
     space: space.id,
@@ -58,7 +61,7 @@ const newThread = async (
     end: form.end,
     snapshot: form.snapshot,
     network: '1', // TODO: unclear if this is always 1
-    timestamp: Math.floor(Date.now() / 1e3),
+    timestamp: timestamp,
     strategies: JSON.stringify({}),
     plugins: JSON.stringify({}),
     metadata: JSON.stringify({}),

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -217,27 +217,6 @@ export class NewSnapshotProposalPage extends ClassComponent<NewSnapshotProposalP
               m.redraw();
             }}
           />
-          <div class="date-range">
-            <CWLabel label="Date Range" />
-            <CWRadioGroup
-              name="period"
-              options={[{ value: '4d', label: '4-day' }]}
-              value={this.form.range}
-              toggledOption="4d"
-              onchange={(e: Event) => {
-                this.form.range = (e.target as any).value;
-                this.form.start = new Date().getTime();
-
-                switch (this.form.range) {
-                  case '4d':
-                    this.form.end = moment().add(4, 'days').toDate().getTime();
-                    break;
-                  default:
-                    break;
-                }
-              }}
-            />
-          </div>
           <QuillEditorComponent
             contentsDoc={this.form.body || ' '}
             oncreateBind={(state: QuillEditor) => {

--- a/packages/commonwealth/server/routes/subscription/createSubscription.ts
+++ b/packages/commonwealth/server/routes/subscription/createSubscription.ts
@@ -102,6 +102,5 @@ export default async (
     subscription.Chain = chain.toJSON();
   }
 
-
   return res.json({ status: 'Success', result: subscription });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3365 

## Description of Changes
- Dynamically sets voting start + end to work with any voting delay and period
- sets timestamp to base of the above calc

## Test Plan
- Using test community, copied 1inch and timelessfi vote/space configs and created proposals
- tested on a community with no set delay or period
