### PR TITLE
Removed unjoined communities from explore sidebar

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/explore_sidebar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/explore_sidebar.tsx
@@ -32,8 +32,6 @@ export const ExploreCommunitiesSidebar = () => {
     (c) => isInCommunity(c) && !app.communities.isStarred(c.id)
   );
 
-  const unjoinedCommunities = allCommunities.filter((c) => !isInCommunity(c));
-
   const communityList: MenuItem[] = [
     ...(app.isLoggedIn()
       ? [
@@ -53,15 +51,8 @@ export const ExploreCommunitiesSidebar = () => {
           ...(starredCommunities.length === 0 && joinedCommunities.length === 0
             ? [{ type: 'default', label: 'None' } as MenuItem]
             : []),
-          { type: 'header', label: 'Other communities' } as MenuItem,
         ]
       : []),
-    ...(unjoinedCommunities.map((c: ChainInfo) => {
-      return {
-        community: c,
-        type: 'community',
-      };
-    }) as MenuItem[]),
   ];
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3344 

## Description of Changes
- Simple removal of unjoined communities from explore sidebar

![image](https://user-images.githubusercontent.com/30223098/230687257-1c75ff4c-ba16-4487-b5fb-2048db9382a3.png)



## Test Plan
- CA (click around) tested on local: on sidebar click on 'compass' icon => the only communities that will appear are the ones the user has joined and/or starred

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
