### PR TITLE
Fixed profile-id-refactor breaking on react

### DIFF
--- a/packages/commonwealth/server/migrations/20230330164706-root-id-refactor.js
+++ b/packages/commonwealth/server/migrations/20230330164706-root-id-refactor.js
@@ -115,9 +115,6 @@ module.exports = {
               chain: c.chain,
               read_only: true,
               stage: 'discussion',
-              canvas_action: null,
-              canvas_hash: null,
-              canvas_session: null,
               // set the dates to a year back so they dont spam chain's home page
               created_at: new Date(
                 new Date().setFullYear(new Date().getFullYear() - 1)


### PR DESCRIPTION
The profile-id-refactor assumed that the canvas migration had ran in the database. This was not caught locally because my db-dump was performed after the canvas migration (so the migration had already went through).

## Link to Issue
Closes: #TODO

## Description of Changes
- Remove inserting canvas fields in thread.
