### PR TITLE
Add debounce to page level loader (cow-bobber)

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_spinner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_spinner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import 'components/component_kit/cw_spinner.scss';
 import { CWIcon } from './cw_icons/cw_icon';
@@ -8,14 +8,33 @@ import { ComponentType } from './types';
 
 type SpinnerProps = {
   size?: IconSize;
+  shouldDebounce?: boolean;
+  debounceMilliseconds?: number;
 };
 
 export const CWSpinner = (props: SpinnerProps) => {
-  const { size = 'xl' } = props;
+  const {
+    size = 'xl',
+    shouldDebounce = false,
+    debounceMilliseconds = 300, // default 300ms
+  } = props;
 
-  return (
+  const [showSpinner, setShowSpinner] = useState<boolean>(!shouldDebounce);
+
+  useEffect(() => {
+    let timer;
+    if (shouldDebounce) {
+      timer = setTimeout(() => setShowSpinner(true), debounceMilliseconds);
+    }
+
+    return () => shouldDebounce && clearTimeout(timer);
+  });
+
+  return showSpinner ? (
     <div className={ComponentType.Spinner}>
       <CWIcon iconName="cow" iconSize={size} />
     </div>
+  ) : (
+    <></>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -213,7 +213,7 @@ const EditProfileComponent = () => {
     return (
       <div className="EditProfile full-height">
         <div className="loading-spinner">
-          <CWSpinner />
+          <CWSpinner shouldDebounce />
         </div>
       </div>
     );

--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -58,7 +58,7 @@ export const Feed = ({
     getData();
   }, []);
 
-  if (loading) return <CWSpinner />;
+  if (loading) return <CWSpinner shouldDebounce />;
 
   if (error) {
     return <PageNotFound message="There was an error rendering the feed." />;

--- a/packages/commonwealth/client/scripts/views/components/profile/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/index.tsx
@@ -95,7 +95,7 @@ const ProfileComponent = (props: ProfileProps) => {
     return (
       <div className="Profile loading">
         <div className="loading-spinner">
-          <CWSpinner />
+          <CWSpinner shouldDebounce />
         </div>
       </div>
     );

--- a/packages/commonwealth/client/scripts/views/pages/loading.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/loading.tsx
@@ -17,7 +17,11 @@ export const PageLoading = (props: PageLoadingProps) => {
     <Sublayout hideSearch>
       <div className="LoadingPage">
         <div className="inner-content">
-          <CWSpinner size="xl" />
+          <CWSpinner
+            size="xl"
+            shouldDebounce={!message}
+            debounceMilliseconds={500}
+          />
           <CWText>{message}</CWText>
         </div>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3386

## Description of Changes
- The loader (cow-bobber) now debounces on page level loaders (when the app is loading, or any page level loading action)

## Test Plan
- Site should build without errors
- The loader (cow-bobber) should not flicker when loading any page of the app.