### PR TITLE
Fix edit bio page null bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
@@ -109,6 +109,10 @@ export const serializeDelta = (delta: DeltaStatic): string => {
 // parseDelta converts a string to a delta object for state
 export const deserializeDelta = (str: string): DeltaStatic => {
   try {
+    if (typeof str !== 'string') {
+      // empty richtext delta
+      return createDeltaFromText('', false);
+    }
     // is richtext delta object
     const delta: DeltaStatic = JSON.parse(str);
     if (!delta.ops) {

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
@@ -9,7 +9,7 @@ export const createDeltaFromText = (
   return {
     ops: [
       {
-        insert: str,
+        insert: str || '',
       },
     ],
     ___isMarkdown: !!isMarkdown,

--- a/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
+++ b/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
@@ -18,6 +18,18 @@ describe('react quill editor unit tests', () => {
       assert.deepEqual(result, expectedDelta)
     })
 
+    it('should convert text to delta (richtext) – bad input case', () => {
+      const text = null
+      const expectedDelta = {
+        ops: [
+          { insert: '' }
+        ],
+        ___isMarkdown: false
+      } as any as SerializableDeltaStatic
+      const result = createDeltaFromText(text)
+      assert.deepEqual(result, expectedDelta)
+    })
+
     it('should convert text to delta (markdown)', () => {
       const text = 'hello'
       const expectedDelta = {
@@ -123,6 +135,18 @@ describe('react quill editor unit tests', () => {
       const expectedOutput = {
         ops: [
           { insert: 'hello' }
+        ],
+        ___isMarkdown: true
+      } as SerializableDeltaStatic
+      const result = deserializeDelta(original)
+      assert.deepEqual(result, expectedOutput)
+    })
+
+    it('should deserialize at string (markdown) to DeltaStatic - bad input case', () => {
+      const original = null
+      const expectedOutput = {
+        ops: [
+          { insert: '' }
         ],
         ___isMarkdown: true
       } as SerializableDeltaStatic

--- a/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
+++ b/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
@@ -118,7 +118,7 @@ describe('react quill editor unit tests', () => {
 
   describe('deserializeDelta', () => {
 
-    it('should deserialize at string (richtext) to DeltaStatic', () => {
+    it('should deserialize a string (richtext) to DeltaStatic', () => {
       const original = '{"ops":[{"insert":"hello"}],"___isMarkdown":false}'
       const expectedOutput = {
         ops: [
@@ -130,23 +130,24 @@ describe('react quill editor unit tests', () => {
       assert.deepEqual(result, expectedOutput)
     })
 
-    it('should deserialize at string (markdown) to DeltaStatic', () => {
-      const original = 'hello'
+    it('should deserialize a string (richtext) to DeltaStatic - bad input case', () => {
+      // bad input should return an empty richtext delta
+      const original = null
       const expectedOutput = {
         ops: [
-          { insert: 'hello' }
+          { insert: '' }
         ],
-        ___isMarkdown: true
+        ___isMarkdown: false
       } as SerializableDeltaStatic
       const result = deserializeDelta(original)
       assert.deepEqual(result, expectedOutput)
     })
 
-    it('should deserialize at string (markdown) to DeltaStatic - bad input case', () => {
-      const original = null
+    it('should deserialize a string (markdown) to DeltaStatic', () => {
+      const original = 'hello'
       const expectedOutput = {
         ops: [
-          { insert: '' }
+          { insert: 'hello' }
         ],
         ___isMarkdown: true
       } as SerializableDeltaStatic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: N/A

## Description of Changes
- Makes quill functions more resilient to bad inputs

## Test Plan
- Create new account
- Go to profile edit page, confirm the page renders without error

## Deployment Plan
N/A

## Other Considerations
The root issue is of typing. The value passed to `deserializeDelta(str: string)` was a null/undefined value as `any`, so the type checker doesn't reject it. Since the value originates from an API call, the only bulletproof solution would be to have runtime type validation on the frontend, or shared types between API and FE.

Nonetheless, this PR fixes the issue at it pertains to the quill editor.