### PR TITLE
Fix create thread button

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
@@ -17,6 +17,7 @@ import { TopicsMenu } from './topics_menu';
 import { useCommonNavigate } from 'navigation/helpers';
 import { Modal } from 'views/components/component_kit/cw_modal';
 import { EditTopicModal } from 'views/modals/edit_topic_modal';
+import useForceRerender from 'hooks/useForceRerender';
 
 type RecentThreadsHeaderProps = {
   stage: string;
@@ -31,6 +32,7 @@ export const RecentThreadsHeader = ({
 }: RecentThreadsHeaderProps) => {
   const navigate = useCommonNavigate();
   const [topicSelectedToEdit, setTopicSelectedToEdit] = useState<Topic>(null);
+  const forceRerender = useForceRerender();
 
   const [windowIsExtraSmall, setWindowIsExtraSmall] = useState(
     isWindowExtraSmall(window.innerWidth)
@@ -42,11 +44,13 @@ export const RecentThreadsHeader = ({
     };
 
     window.addEventListener('resize', onResize);
+    app.loginStateEmitter.on('redraw', forceRerender);
 
     return () => {
       window.removeEventListener('resize', onResize);
+      app.loginStateEmitter.off('redraw', forceRerender);
     };
-  }, []);
+  }, [forceRerender]);
 
   const { stagesEnabled, customStages } = app.chain?.meta || {};
 
@@ -98,6 +102,7 @@ export const RecentThreadsHeader = ({
                   onClick={() => {
                     navigate('/new/discussion');
                   }}
+                  disabled={!app.user.activeAccount}
                 />
               ) : (
                 <CWButton
@@ -107,6 +112,7 @@ export const RecentThreadsHeader = ({
                   onClick={() => {
                     navigate('/new/discussion');
                   }}
+                  disabled={!app.user.activeAccount}
                 />
               )}
             </div>

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -37,12 +37,14 @@ const OverviewPage = () => {
   }, []);
 
   useEffect(() => {
-    app.threads.isFetched.on('redraw', () => forceRerender());
+    app.threads.isFetched.on('redraw', forceRerender);
+    app.loginStateEmitter.on('redraw', forceRerender);
 
     return () => {
-      app.threads.isFetched.off('redraw', () => forceRerender());
+      app.threads.isFetched.off('redraw', forceRerender);
+      app.loginStateEmitter.off('redraw', forceRerender);
     };
-  }, []);
+  }, [forceRerender]);
 
   const allMonthlyThreads = app.threads.overviewStore.getAll();
   const allPinnedThreads = app.threads.listingStore.getThreads({

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -10,7 +10,6 @@ import { Footer } from './footer';
 import { SublayoutBanners } from './sublayout_banners';
 import { SublayoutHeader } from './sublayout_header';
 import useForceRerender from 'hooks/useForceRerender';
-import { setDarkMode } from '../helpers';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -30,12 +29,12 @@ const Sublayout = ({
   );
 
   useEffect(() => {
-    app.sidebarRedraw.on('redraw', () => forceRerender());
+    app.sidebarRedraw.on('redraw', forceRerender);
 
     return () => {
-      app.sidebarRedraw.off('redraw', () => forceRerender());
+      app.sidebarRedraw.off('redraw', forceRerender);
     };
-  });
+  }, [forceRerender]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3401 

## Description of Changes
- we did not rerender in this particular case 
- added handler to rerender when login/logout is performed 
- added this behaviour both to `overview` and `all`

## Test Plan
- go to overall page
- login / logout
- observe `Create Thread` button
