### PR TITLE
Remove wallet connect session during logout

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -78,6 +78,8 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
   public async reset() {
     console.log('Attempting to reset WalletConnect');
     if (!this._provider) {
+      // Remove the object that stores the session (needed when refreshed page since initial connection established)
+      localStorage.removeItem('walletconnect');
       return;
     }
     await this._provider.wc.killSession();
@@ -119,6 +121,7 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
     await this.initAccountsChanged();
     this._enabled = true;
     this._enabling = false;
+    console.log('WalletConnect enabled');
     // } catch (error) {
     //   this._enabling = false;
     //   throw new Error(`Failed to enable WalletConnect: ${error.message}`);

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -36,6 +36,8 @@ import { Popover, usePopover } from '../component_kit/cw_popover/cw_popover';
 import { Modal } from '../component_kit/cw_modal';
 import { useCommonNavigate } from 'navigation/helpers';
 import useForceRerender from 'hooks/useForceRerender';
+import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/terra_walletconnect_web_wallet';
+import WalletConnectWebWalletController from 'controllers/app/webWallets/walletconnect_web_wallet';
 
 const CHAINBASE_SHORT = {
   [ChainBase.CosmosSDK]: 'Cosmos',
@@ -197,6 +199,22 @@ export const LoginSelectorMenuRight = ({
     localStorage.getItem('dark-mode-state') === 'on'
   );
 
+  const resetWalletConnectSession = async () => {
+    /**
+     * Imp to reset wc session on logout as subsequent login attempts fail
+     */
+    const chainbase = app.chain?.meta?.base;
+    const wallets = app.wallets.availableWallets(chainbase);
+
+    const wallet = wallets.find(
+      (w) =>
+        w instanceof WalletConnectWebWalletController ||
+        w instanceof TerraWalletConnectWebWalletController
+    );
+
+    await wallet.reset();
+  };
+
   return (
     <>
       <div className="LoginSelectorMenu right">
@@ -231,6 +249,8 @@ export const LoginSelectorMenuRight = ({
             $.get(`${app.serverUrl()}/logout`)
               .then(async () => {
                 await initAppState();
+                await resetWalletConnectSession();
+
                 notifySuccess('Logged out');
                 onLogout();
                 setDarkMode(false);

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
 import { initAppState } from 'state';
-import { ChainBase, ChainNetwork } from 'common-common/src/types';
+import { ChainBase, ChainNetwork, WalletId } from 'common-common/src/types';
 import { addressSwapper } from 'utils';
 import $ from 'jquery';
 import { redraw } from 'mithrilInterop';
@@ -36,8 +36,6 @@ import { Popover, usePopover } from '../component_kit/cw_popover/cw_popover';
 import { Modal } from '../component_kit/cw_modal';
 import { useCommonNavigate } from 'navigation/helpers';
 import useForceRerender from 'hooks/useForceRerender';
-import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/terra_walletconnect_web_wallet';
-import WalletConnectWebWalletController from 'controllers/app/webWallets/walletconnect_web_wallet';
 
 const CHAINBASE_SHORT = {
   [ChainBase.CosmosSDK]: 'Cosmos',
@@ -203,16 +201,8 @@ export const LoginSelectorMenuRight = ({
     /**
      * Imp to reset wc session on logout as subsequent login attempts fail
      */
-    const chainbase = app.chain?.meta?.base;
-    const wallets = app.wallets.availableWallets(chainbase);
-
-    const wallet = wallets.find(
-      (w) =>
-        w instanceof WalletConnectWebWalletController ||
-        w instanceof TerraWalletConnectWebWalletController
-    );
-
-    await wallet.reset();
+    const walletConnectWallet = app.wallets.getByName(WalletId.WalletConnect);
+    await walletConnectWallet.reset();
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3430

## Description of Changes
- Now removing WalletConnect session during logout (WalletConnect was adding a `walletconnect` localstorage key which prevents subsequent auth attempts)

**Tested and works with these wallets**
- 1inch
- Zerion
- Wallet 3
- Keyring pro

## Test Plan
- Clear browser cookies, local storage, session storage after pulling code (to remove old state)
- We should be able to login with WalletConnect enabled wallets (do try with multiple login/logout attempts)

## Deployment Plan
ATM, only removing session during logout. There could be potential side effects unknown right now

## Other Considerations
There are many wallet connect enabled wallets, some automated testing might be good (cant say what the implementation steps would be)