### PR TITLE
Style fixes

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/thread_components.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import 'pages/view_proposal/proposal_header_links.scss';
+import 'pages/view_thread/thread_components.scss';
 
 import app from 'state';
 import {
@@ -39,18 +40,6 @@ export const ThreadAuthor = (props: ThreadComponentProps) => {
       {thread.collaborators?.length > 0 && (
         <>
           <CWText type="caption">and</CWText>
-          <Popover
-            content={
-              <div className="collaborators">
-                {thread.collaborators.map(({ address, chain }) => {
-                  return (
-                    <User user={new AddressInfo(null, address, chain, null)} />
-                  );
-                })}
-              </div>
-            }
-            {...popoverProps}
-          />
           <CWText
             type="caption"
             className="trigger-text"
@@ -58,6 +47,22 @@ export const ThreadAuthor = (props: ThreadComponentProps) => {
             onMouseLeave={popoverProps.handleInteraction}
           >
             {pluralize(thread.collaborators?.length, 'other')}
+            <Popover
+              content={
+                <div className="collaborators">
+                  {thread.collaborators.map(({ address, chain }) => {
+                    return (
+                      <User
+                        linkify
+                        key={address}
+                        user={new AddressInfo(null, address, chain, null)}
+                      />
+                    );
+                  })}
+                </div>
+              }
+              {...popoverProps}
+            />
           </CWText>
         </>
       )}

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -194,7 +194,6 @@
 
     li::before {
       width: 1.4em;
-      padding-right: 10px;
       position: relative;
       padding-right: 11px;
     }
@@ -298,7 +297,6 @@
 // mixin for collapsing large text blocks to <200px in height
 @mixin collapsible {
   &.collapsed {
-    white-space: nowrap;
     overflow: hidden;
     display: block;
     text-overflow: ellipsis;

--- a/packages/commonwealth/client/styles/pages/view_thread/thread_components.scss
+++ b/packages/commonwealth/client/styles/pages/view_thread/thread_components.scss
@@ -29,4 +29,7 @@
   border-radius: $border-radius-corners;
   box-shadow: $elevation-1;
   padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3179 
Closes: #3417 

## Description of Changes
- for #3179 - there was missing import for CSS and the popover was placed in wrong place 

![image](https://user-images.githubusercontent.com/14819225/232821994-984673bf-d036-4989-a4e8-6da27f0317a6.png)

- for #3417 - there were wrong styles for page wrapper when the thread had to be trimmed

https://user-images.githubusercontent.com/14819225/232822588-423d960e-3cc8-4603-95eb-7448f2c84f3e.mp4




## Test Plan
- for #3179 - go to the thread with multiple collaborators and hover over the 'other'
- for #3417 - go to the thread which has long body and it is trimmed, then resize the window
