### PR TITLE
Fixed new profile having null ids

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -303,6 +303,13 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
           );
         }
         await logInWithAccount(this.primaryAccount, false);
+        // Important: when we first create an account and verify it, the user id
+        // is initially null from api (reloading the page will update it), to correct
+        // it we need to get the id from api
+        await app.newProfiles.updateProfileForAccount(
+          this.primaryAccount.profile.address,
+          {}
+        );
       } catch (e) {
         console.log(e);
         notifyError('Failed to create account. Please try again.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3479

## Description of Changes
- Added logic to refresh profile data after creating a fresh account

## Test Plan
1. Clear browser cookies/data
2. Login with a wallet that was not used before
3. After signup, going to profile view and edit pages should work correctly without having null in url

## Deployment Plan
N/A

## Other Considerations
N/A