### PR TITLE
Handle community links in sidebar - custom domain

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/helpers.tsx
+++ b/packages/commonwealth/client/scripts/navigation/helpers.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react-router-dom';
 import app from 'state';
 
+const PROD_URL = 'https://commonwealth.im';
+
 type NavigateWithParamsProps = {
   to: string | ((params: Record<string, string | undefined>) => string);
 };
@@ -76,6 +78,40 @@ const withRouter = (Component) => {
 
     return <Component {...props} router={{ location, navigate, params }} />;
   };
+};
+
+interface NavigateToCommunityProps {
+  navigate: (
+    url: To,
+    options?: NavigateOptions,
+    prefix?: null | string
+  ) => void;
+  path: string;
+  chain: string;
+}
+
+// This helper wraps the logic to properly navigate to community depending
+// on presence of custom domain vs common domain.
+// In case of custom domain, other community is opened in new tab and
+// current community is open without prefix.
+// In case of common domain, both other and current community are opened
+// in the same tab with proper prefix.
+export const navigateToCommunity = ({
+  navigate,
+  path,
+  chain,
+}: NavigateToCommunityProps) => {
+  const isExternalLink = chain !== app.customDomainId();
+
+  if (!app.isCustomDomain()) {
+    navigate(path, {}, chain);
+  } else {
+    if (isExternalLink) {
+      window.open(`${PROD_URL}/${chain}${path}`);
+    } else {
+      navigate(path);
+    }
+  }
 };
 
 export default withRouter;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -13,7 +13,7 @@ import { CWText } from './cw_text';
 import { getClasses } from './helpers';
 import type { MenuItem } from './types';
 import { ComponentType } from './types';
-import { useCommonNavigate } from 'navigation/helpers';
+import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 
 type CWSidebarMenuItemProps = {
   isStarred?: boolean;
@@ -65,7 +65,11 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
           app.sidebarToggled = false;
           app.sidebarMenu = 'default';
           app.sidebarRedraw.emit('redraw');
-          navigate(item.id ? `/${item.id}` : '/', {}, null);
+          navigateToCommunity({
+            navigate,
+            path: '/',
+            chain: item.id,
+          });
         }}
       >
         <CommunityLabel community={item} />

--- a/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_activity_row.tsx
@@ -6,7 +6,10 @@ import 'components/profile/profile_activity_row.scss';
 
 import app from 'state';
 import type Thread from 'client/scripts/models/Thread';
-import withRouter, { useCommonNavigate } from 'navigation/helpers';
+import withRouter, {
+  navigateToCommunity,
+  useCommonNavigate,
+} from 'navigation/helpers';
 import { CWText } from '../component_kit/cw_text';
 import { CWTag } from '../component_kit/cw_tag';
 import { renderQuillTextBody } from '../react_quill_editor/helpers';
@@ -17,8 +20,6 @@ import { CWIconButton } from '../component_kit/cw_icon_button';
 type ProfileActivityRowProps = {
   activity: CommentWithAssociatedThread | Thread;
 };
-
-const PROD_URL = 'https://commonwealth.im';
 
 const ProfileActivityRow = (props: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
@@ -45,30 +46,16 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
     <CWIconButton iconName="share" iconSize="small" onClick={onclick} />
   );
 
-  const handleClickLink = (path) => {
-    const isExternalLink = chain !== app.customDomainId();
-
-    if (!app.isCustomDomain()) {
-      navigate(path, {}, chain);
-    } else {
-      if (isExternalLink) {
-        window.open(`${PROD_URL}/${chain}${path}`);
-      } else {
-        navigate(path);
-      }
-    }
-  };
-
   return (
     <div className="ProfileActivityRow">
       <div className="chain-info">
-        <img src={iconUrl} />
+        <img src={iconUrl} alt="chain-logo" />
         <CWText fontWeight="semiBold" className="link">
           <a
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              handleClickLink(`/discussions`);
+              navigateToCommunity({ navigate, path: `/discussions`, chain });
             }}
           >
             {chain}
@@ -94,7 +81,11 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                handleClickLink(`/discussion/${id}`);
+                navigateToCommunity({
+                  navigate,
+                  path: `/discussion/${id}`,
+                  chain,
+                });
               }}
             >
               {title}
@@ -104,9 +95,11 @@ const ProfileActivityRow = (props: ProfileActivityRowProps) => {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                handleClickLink(
-                  `/discussion/${comment.thread?.id}?comment=${comment.id}`
-                );
+                navigateToCommunity({
+                  navigate,
+                  path: `/discussion/${comment.thread?.id}?comment=${comment.id}`,
+                  chain,
+                });
               }}
             >
               {decodedTitle}

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 
 import 'components/sidebar/sidebar_quick_switcher.scss';
 
-import { link } from 'helpers';
 import { ChainInfo } from 'models';
 
 import app from 'state';
 import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 import { CWDivider } from '../component_kit/cw_divider';
 import { CWIconButton } from '../component_kit/cw_icon_button';
-import { useCommonNavigate } from 'navigation/helpers';
+import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 
 export const SidebarQuickSwitcher = () => {
@@ -57,7 +56,9 @@ export const SidebarQuickSwitcher = () => {
             key={item.id}
             size="large"
             community={item}
-            onClick={link ? () => navigate(`/${item.id}`, {}, null) : undefined}
+            onClick={() =>
+              navigateToCommunity({ navigate, path: '', chain: item.id })
+            }
           />
         ))}
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3504 

## Description of Changes
- We already handled that case but only in new profile page, so I created helper function from that and used that in multiple places


https://user-images.githubusercontent.com/14819225/233064161-49ad8237-d7d3-42e9-aac6-f740d3c67a6c.mp4



## Test Plan
- In custom domain app, log in as a user that belongs to multiple communities
- In sidebar, click on community
- Current community should be open in the same tab, but other communities should be open in the new tab
