### PR TITLE
Show thread lock status without page reload

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -600,6 +600,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                     setRecentlyEdited(true);
                     notifySuccess(thread.readOnly ? 'Unlocked!' : 'Locked!');
                   });
+                setThread(
+                  new Thread({ ...thread, readOnly: !thread.readOnly })
+                );
               },
             },
           ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3500

## Description of Changes
- Updated state to reflect the thread lock/unlock status

## Test Plan
- Go to a thread details/view page (you must be admin of that thread)
- Try to lock the thread (it should display 'Commenting is disabled because this post has been locked.')
- Try to unlock the thread (it should display the full thread view)

## Deployment Plan
N/A

## Other Considerations
N/A