### PR TITLE
Hide join button when already in community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -301,7 +301,7 @@ export const LoginSelector = () => {
 
   useEffect(() => {
     setIsJoined(!!app.user.activeAccount);
-  }, []);
+  }, [app.user.activeAccount]);
 
   const leftMenuProps = usePopover();
   const rightMenuProps = usePopover();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3501

## Description of Changes
- Now updating state whenever active account changes

## Test Plan
- Go to a community you are a part of
- The join button should not be in header

## Deployment Plan
N/A

## Other Considerations
N/A