### PR TITLE
Snapshot Validation Fix (React)

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
+++ b/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
@@ -46,6 +46,13 @@ class GqlLazyLoader {
       symbol
       private
       network
+      validation {
+        params
+      }
+      voting {
+        period
+        delay
+      }
       filters {
         minScore
         onlyMembers
@@ -162,6 +169,15 @@ export interface SnapshotSpace {
   symbol: string;
   private: boolean;
   network: string;
+  validation: {
+    params: {
+      minScore: number;
+    };
+  };
+  voting: {
+    period: number;
+    delay: number;
+  };
   filters: {
     minScore: number;
     onlyMembers: boolean;

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/helpers.ts
@@ -39,8 +39,11 @@ export const createNewProposal = async (
   form.metadata.strategies = space.strategies;
 
   // Format form for proper validation
-  form.start = Math.floor(form.start / 1000);
-  form.end = Math.floor(form.end / 1000);
+  const delay = space.voting.delay ?? 0;
+  const period = space.voting.period ?? 432000; // 5 day default
+  const timestamp = Math.floor(Date.now() / 1e3);
+  form.start = timestamp + delay;
+  form.end = form.start + period;
 
   const proposalPayload = {
     space: space.id,
@@ -52,7 +55,7 @@ export const createNewProposal = async (
     end: form.end,
     snapshot: form.snapshot,
     network: '1', // TODO: unclear if this is always 1
-    timestamp: Math.floor(Date.now() / 1e3),
+    timestamp: timestamp,
     strategies: JSON.stringify({}),
     plugins: JSON.stringify({}),
     metadata: JSON.stringify({}),

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -150,19 +150,19 @@ export const NewSnapshotProposalPageComponent = ({
       (member) => member.toLowerCase() === author.address.toLowerCase()
     );
 
-  const hasMinScore = userScore >= space.filters?.minScore;
+  const minScoreFromSpace =
+    space.validation?.params.minScore ?? space.filters?.minScore; // Fall back to filters
+
+  const hasMinScore = userScore >= minScoreFromSpace;
 
   const showScoreWarning =
-    space.filters?.minScore > 0 &&
-    !hasMinScore &&
-    !isMember &&
-    userScore !== null;
+    minScoreFromSpace > 0 && !hasMinScore && !isMember && userScore !== null;
 
   const isValid =
     !!space &&
     (!space.filters?.onlyMembers || (space.filters?.onlyMembers && isMember)) &&
-    (space.filters?.minScore === 0 ||
-      (space.filters?.minScore > 0 && userScore > space.filters?.minScore) ||
+    (minScoreFromSpace === 0 ||
+      (minScoreFromSpace > 0 && userScore > minScoreFromSpace) ||
       isMember);
 
   return (
@@ -237,29 +237,6 @@ export const NewSnapshotProposalPageComponent = ({
             });
           }}
         />
-        <div className="date-range">
-          <CWLabel label="Date Range" />
-          <CWRadioGroup
-            name="period"
-            options={[{ value: '4d', label: '4-day' }]}
-            toggledOption="4d"
-            onChange={(e: FormEvent<HTMLInputElement>) => {
-              const values: Partial<ThreadForm> = {
-                range: e.currentTarget.value,
-                start: new Date().getTime(),
-              };
-
-              if (form.range === '4d') {
-                form.end = moment().add(4, 'days').toDate().getTime();
-              }
-
-              setForm({
-                ...form,
-                ...values,
-              });
-            }}
-          />
-        </div>
         <ReactQuillEditor
           contentDelta={contentDelta}
           setContentDelta={setContentDelta}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3236 

## Description of Changes
- Two distinct changes (the former was the reported bug, the latter a bug uncovered while sleuthing)
- Fix to handle dynamic date ranges (voting delay period) on proposal creation. This was previously hardcoded and caused a failure when the space had a different date range than the hardcoded value.
-Changes our validation for whether a user can post a proposal to the correct field in the snapshot space object. Snapshot introduced a new field in the space object at some point, but not all spaces have migrated their settings to this new schema, so our code now correctly handles both old and new space configurations.

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 