### PR TITLE
Edit searchThreadTitles fn parameter to input value, instead of last state value

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
@@ -48,13 +48,14 @@ export const ThreadSelector = ({
     const inputTimeoutRef = setTimeout(async () => {
       if (target.value?.trim().length > 4) {
         setLoading(true);
+        const inputValue = target.value;
         const params: SearchParams = {
           chainScope: app.activeChainId(),
           pageSize: 20,
         };
 
         app.search
-          .searchThreadTitles(searchTerm, params)
+          .searchThreadTitles(inputValue, params)
           .then((results) => {
             setSearchResults(results);
             setLoading(false);

--- a/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
@@ -48,7 +48,7 @@ export const ThreadSelector = ({
     const inputTimeoutRef = setTimeout(async () => {
       if (target.value?.trim().length > 4) {
         setLoading(true);
-        const inputValue = target.value;
+        const inputValue = target.value.trim();
         const params: SearchParams = {
           chainScope: app.activeChainId(),
           pageSize: 20,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3533 

## Description of Changes
- Edit function parameter to most recent input value, instead of current state value. The correct input value will only be set to state on next ThreadSelector component render. This was causing the searchThreadTitles function fetching results without the most recent input value.

## Test Plan
- Tested with input type events: _insertText_, _deleteContentBackward_ and _insertFromPaste_
