### PR TITLE
Make 'General' topic featured in the sidebar by default

### DIFF
--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -393,6 +393,7 @@ const createChain = async (
   await models.Topic.create({
     chain_id: chain.id,
     name: 'General',
+    featured_in_sidebar: true,
   });
 
   // try to make admin one of the user's addresses


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3554 

## Changes
- while creating a general topic (during chain creation), I set `featured_in_sidebar` to `true`

https://user-images.githubusercontent.com/14819225/234042719-543eaff7-beab-423f-9cdd-1bd84b2b2f2d.mp4



## Test Plan
- create community
- try to create topic
- `general` should be visible in the dropdown

