### PR TITLE
Handle chunk error

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/error.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/error.tsx
@@ -2,20 +2,45 @@ import React from 'react';
 
 import Sublayout from 'views/sublayout';
 import { CWEmptyState } from '../components/component_kit/cw_empty_state';
+import { openConfirmation } from 'views/modals/confirmation_modal';
 
 type ErrorPageProps = { title?: any; message?: string };
 
-const ErrorPage = (props: ErrorPageProps) => {
-  const { message } = props;
+const ErrorPage = ({ message }: ErrorPageProps) => {
+  const chunkLoadingErrRe = /^Uncaught SyntaxError: Unexpected token/;
+
+  const isChunkLoadingError = () => {
+    if (typeof message === 'string' && chunkLoadingErrRe.test(message)) {
+      openConfirmation({
+        title: 'Info',
+        description: (
+          <>
+            A new version of the application has been released. Please refresh
+            the page.
+          </>
+        ),
+        buttons: [
+          {
+            label: 'Refresh',
+            buttonType: 'mini-black',
+            onClick: () => window.location.reload(),
+          },
+        ],
+      });
+    }
+
+    return null;
+  };
 
   return (
-    <Sublayout
-    // title={title}
-    >
-      <CWEmptyState
-        iconName="cautionTriangle"
-        content={message || 'An error occurred while loading this page.'}
-      />
+    <Sublayout>
+      <>
+        {isChunkLoadingError()}
+        <CWEmptyState
+          iconName="cautionTriangle"
+          content={message || 'An error occurred while loading this page.'}
+        />
+      </>
     </Sublayout>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3582 

## Description of Changes
- We have error boundry that is fired up when something is broken. Used that component to detect if chunk error is there. If it is, display modal that confirms reload.


https://user-images.githubusercontent.com/14819225/234338213-1978038f-befa-4c29-8c12-1826a1ffd0a0.mp4


## Test Plan
- in local dev the only way I was able to test it was to throw error deliberately from the component
- it would be good to test it on frick/stage before the deployment  but I am not sure what are exactly repro steps