### PR TITLE
Set verified date when existing address is used for rejoining community

### DIFF
--- a/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToChain.ts
@@ -128,6 +128,7 @@ const linkExistingAddressToChain = async (
       existingAddress.verification_token_expires = verificationTokenExpires;
       existingAddress.last_active = new Date();
       existingAddress.name = originalAddress.name;
+      existingAddress.verified = originalAddress.verified;
       const updatedObj = await existingAddress.save();
       addressId = updatedObj.id;
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3581

## Description of Changes
Users were not able to rejoin the community after leaving, this was because we were not setting the `verified` date in the `/linkExistingAddressToChain` api when an address was rejoining a community. With new changes we are setting the `verified` date

## Test Plan
1. Join any community: ex /ethereum
2. Go to edit profile -> leave the community just joined
3. Try to join the same community again: ex /ethereum
4. It should work successfully

## Deployment Plan
N/A

## Other Considerations
Not really sure why we were not setting verified on the existing address when it was re-linking. Maybe that was on purpose, just to confirm @jnaviask?