### PR TITLE
Fix thread update for chains that dont required snapshot

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -32,7 +32,12 @@ export const UpdateProposalStatusModal = ({
   const [tempStage, setTempStage] = useState<ThreadStage>(thread.stage);
   const [tempSnapshotProposals, setTempSnapshotProposals] = useState<
     Array<SnapshotProposal>
-  >([{ id: thread.snapshotProposal } as SnapshotProposal]);
+  >(
+    [
+      thread.snapshotProposal &&
+        ({ id: thread.snapshotProposal } as SnapshotProposal),
+    ].filter(Boolean)
+  );
   const [tempChainEntities, setTempChainEntities] = useState<
     Array<ChainEntity>
   >(thread.chainEntities || []);
@@ -76,10 +81,12 @@ export const UpdateProposalStatusModal = ({
         threadId: thread.id,
         entities: tempChainEntities,
       });
-      await app.threads.setLinkedSnapshotProposal({
-        threadId: thread.id,
-        snapshotProposal: tempSnapshotProposals[0]?.id,
-      });
+      if (tempSnapshotProposals.length > 0 && tempSnapshotProposals[0]?.id) {
+        await app.threads.setLinkedSnapshotProposal({
+          threadId: thread.id,
+          snapshotProposal: tempSnapshotProposals[0]?.id,
+        });
+      }
     } catch (err) {
       console.log('Failed to update linked proposals');
       throw new Error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3538

## Description of Changes
Some chains dont require snapshot to be enabled. Threads proposal status updates was not working on these chains as the frontend was sending a nullish snapshot id to api on `/updateThreadLinkedSnapshotProposal` which would mean that the chain has no snapshot requirement, but the api controller would query it and if it got 0 results would throw the error. 

With new changes the frontend will only send req to `/updateThreadLinkedSnapshotProposal` when the thread/chain actually has snapshot support

## Test Plan
- Visit a chain that does not require snapshot
- Create a thread
- Update the thread status
- Verify that it updates correctly and there are no errors

## Deployment Plan
N/A

## Other Considerations
N/A