### PR TITLE
fix: community icon toggle on desktop

### DIFF
--- a/packages/commonwealth/client/scripts/views/sublayout_header.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header.tsx
@@ -43,7 +43,7 @@ export const SublayoutHeader = ({
           }}
         />
         {isWindowSmallInclusive(window.innerWidth) && <CWDivider isVertical />}
-        {!app.sidebarToggled && app.activeChainId() && (
+        {(!isWindowSmallInclusive(window.innerWidth) || !app.sidebarToggled) && app.activeChainId() && (
           <CWCommunityAvatar size="large" community={app.chain.meta} />
         )}
         {onMobile && app.activeChainId() && (


### PR DESCRIPTION
Community icon should only be hidden on `app.sidebarToggled` if we're in a mobile layout.

Prevent the icon from disappearing and reappearing on desktop when a sidebar item is clicked

also @Miaplacidus

## Link to Issue
Closes: #3553 

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 