### PR TITLE
don't wait for profiles to load to show discussion threads

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -415,13 +415,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     return <PageNotFound />;
   }
 
-  if (
-    !app.newProfiles.allLoaded() &&
-    !prefetch[threadId]?.['profilesFinished']
-  ) {
-    return <PageLoading />;
-  }
-
   if (!thread) {
     return <PageLoading />;
   }


### PR DESCRIPTION
This eliminates a flash when displaying discussions, and allows discussion content to be shown earlier

Should be safe to show the page before profiles have all loaded since the Avatar/Profile components do that check internally

I might sort of be a code owner on this since I did some of the View Thread Page porting to React, but if there's anyone else who worked on that, they should see it too

## Link to Issue
Closes: n/a

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 