### PR TITLE
make community avatar navigate to community

### DIFF
--- a/packages/commonwealth/client/scripts/views/sublayout_header.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header.tsx
@@ -47,7 +47,7 @@ export const SublayoutHeader = ({
           <CWCommunityAvatar
             size="large"
             community={app.chain.meta}
-             onClick={() => { navigate('/discussions'); }}
+            onClick={() => { navigate('/discussions'); }}
           />
         )}
         {onMobile && app.activeChainId() && (

--- a/packages/commonwealth/client/scripts/views/sublayout_header.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header.tsx
@@ -44,7 +44,11 @@ export const SublayoutHeader = ({
         />
         {isWindowSmallInclusive(window.innerWidth) && <CWDivider isVertical />}
         {!app.sidebarToggled && app.activeChainId() && (
-          <CWCommunityAvatar size="large" community={app.chain.meta} />
+          <CWCommunityAvatar
+            size="large"
+            community={app.chain.meta}
+             onClick={() => { navigate('/discussions'); }}
+          />
         )}
         {onMobile && app.activeChainId() && (
           <CWIconButton


### PR DESCRIPTION
This ensures users always have a way to return to the root of their community.

## Link to Issue
Closes: n/a

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 