### PR TITLE
Fix createCommunity avatar upload state handling.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/create_community/chain_input_rows.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/chain_input_rows.tsx
@@ -52,16 +52,16 @@ export const defaultChainRows = <T extends UseChainFormDefaultFieldsHookType>(
         <AvatarUpload
           scope="community"
           uploadStartedCallback={() => {
-            state.uploadInProgress = true;
+            state.setUploadInProgress(true);
           }}
           uploadCompleteCallback={(files) => {
             files.forEach((f) => {
               if (!f.uploadURL) return;
               const url = f.uploadURL.replace(/\?.*/, '');
-              state.iconUrl = url;
+              state.setIconUrl(url);
             });
 
-            state.uploadInProgress = false;
+            state.setUploadInProgress(false);
           }}
         />
       </div>
@@ -170,7 +170,7 @@ export const ethChainRows = (
             state.setNodeUrl('');
             state.setAltWalletUrl('');
           }
-          state.loaded = false;
+          state.setLoaded(false);
 
           // mixpanelBrowserTrack({
           //   event: MixpanelCommunityCreationEvent.CHAIN_SELECTED,


### PR DESCRIPTION
## Link to Issue
Closes: #3605

## Description of Changes
- Changes createCommunity page to use setState instead of equals assignment.

## Test Plan
- Verified locally.
- Merge + have BD confirm on QA.
- Would be awesome to have support for an e2e test on the create community flow, however we need a hook to get us into a logged in state to use the form properly, so, not pursuing that route.