### PR TITLE
Remove filtering of non-featured in sidebar topics.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
@@ -21,7 +21,6 @@ export const TopicSelector = ({
   onChange,
 }: TopicSelectorProps) => {
   const options = topics
-    .filter((topic) => topic.featuredInSidebar)
     .sort((a, b) => a.order - b.order)
     .map(topicToOption);
 


### PR DESCRIPTION
## Link to Issue
Closes: #3607 

## Description of Changes
- Removing a filter line that had been added during the React migration, after confirming that allowing posting in non-featured topics is expected behavior per @zakhap.

## Test Plan
- Verified locally.
