### PR TITLE
Update quill editor styles for height expansion

### DIFF
--- a/packages/commonwealth/client/styles/components/new_thread_form.scss
+++ b/packages/commonwealth/client/styles/components/new_thread_form.scss
@@ -77,11 +77,6 @@
         }
       }
 
-      .QuillEditor {
-        height: 280px;
-        margin-bottom: 40px;
-      }
-
       .buttons-row {
         display: flex;
         gap: 8px;

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -1,8 +1,14 @@
 @import '../../shared';
 
 .QuillEditorWrapper {
+  .ql-container {
+    min-height: 212px;
+    max-height: 512px;
+    overflow-y: scroll;
+  }
+
   .ql-editor {
-    min-height: 180px;
+    min-height: 212px;
   }
 
   .custom-buttons {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3614

## Description of Changes
- Allows dynamic height for quill editor, with min and max height constraints

## Test Plan
- In the New Thread or New Comment quill editor, add text lines until the editor begins to expand– it should expand until a limit is reached, then stop expanding and become scrollable

## Deployment Plan
N/A

## Other Considerations
- While the requirement specifically calls out the New Thread and New Comment instances of the editor, the same behavior is applied globally to all instances of the editor, including create/update topic + reply comment.