### PR TITLE
Add defer chain on discussions redirect.

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
@@ -272,6 +272,7 @@ const commonDomainsRoutes = () => [
     path="/:scope"
     element={withLayout(DiscussionsRedirectPage, {
       scoped: true,
+      deferChain: true,
     })}
   />,
   ...(featureFlags.communityHomepage

--- a/packages/commonwealth/client/scripts/navigation/customDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/customDomainRoutes.tsx
@@ -71,7 +71,10 @@ const customDomainRoutes = () => {
   return [
     <Route
       path="/"
-      element={withLayout(DiscussionsRedirectPage, { scoped: true })}
+      element={withLayout(DiscussionsRedirectPage, {
+        scoped: true,
+        deferChain: true,
+      })}
     />,
     <Route
       path="/createCommunity"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes
- Ensures the main discussion page accessed via root (i.e. `/` or `/osmosis`) does not load chain data unnecessarily.