### PR TITLE
Ensure cosmos proposals do not try to render outside of cosmos pages.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -245,9 +245,9 @@ const ProposalsPage = () => {
     (inactiveDemocracyProposals || [])
       .map((proposal, i) => <ProposalCard key={i} proposal={proposal} />)
       .concat(
-        inactiveCosmosProposals.map((proposal, i) => (
+        inactiveCosmosProposals?.length ? inactiveCosmosProposals.map((proposal, i) => (
           <ProposalCard key={i} proposal={proposal} />
-        ))
+        )) : []
       )
       .concat(
         (inactiveCompoundProposals || []).map((proposal, i) => (


### PR DESCRIPTION
## Link to Issue
Regression from #3564 

## Description of Changes
- /dydx/proposals was broken, due to changes in proposal loading hook.

## Test Plan
- Verified error was not shown post-fix.