### PR TITLE
Remove CE loading on discussions page.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
@@ -78,7 +78,7 @@ class RecentActivityController {
 
     const [response] = await Promise.all([
       $.get(`${app.serverUrl()}/activeThreads`, params),
-      app.chainEntities.refresh(params.chain),
+      // app.chainEntities.refresh(params.chain),
     ]);
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful: ${response.status}`);

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -740,7 +740,7 @@ class ThreadsController {
     // fetch threads and refresh entities so we can join them together
     const [response] = await Promise.all([
       $.get(`${app.serverUrl()}/bulkThreads`, params),
-      app.chainEntities.getRawEntities(chain),
+      // app.chainEntities.getRawEntities(chain),
     ]);
     if (response.status !== 'Success') {
       throw new Error(`Unsuccessful refresh status: ${response.status}`);

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -45,8 +45,8 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
   public async initServer(): Promise<boolean> {
     clearLocalStorage();
     console.log(`Starting ${this.meta.name}`);
-    const [, response] = await Promise.all([
-      this.app.chainEntities.refresh(this.meta.id),
+    const [response] = await Promise.all([
+      // this.app.chainEntities.refresh(this.meta.id),
       $.get(`${this.app.serverUrl()}/bulkOffchain`, {
         chain: this.id,
         community: null,

--- a/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/commonDomainRoutes.tsx
@@ -249,6 +249,7 @@ const commonDomainsRoutes = () => [
     path="/:scope/discussion/:identifier"
     element={withLayout(ViewThreadPage, {
       scoped: true,
+      deferChain: true,
     })}
   />,
   <Route
@@ -348,6 +349,7 @@ const commonDomainsRoutes = () => [
     path="/:scope/manage"
     element={withLayout(ManageCommunityPage, {
       scoped: true,
+      deferChain: true,
     })}
   />,
   <Route path="/manage" element={withLayout(ManageCommunityPage, {})} />,

--- a/packages/commonwealth/client/scripts/navigation/customDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/customDomainRoutes.tsx
@@ -195,6 +195,7 @@ const customDomainRoutes = () => {
       path="/discussion/:identifier"
       element={withLayout(ViewThreadPage, {
         scoped: true,
+        deferChain: true,
       })}
     />,
     <Route
@@ -268,7 +269,10 @@ const customDomainRoutes = () => {
     // TREASURY END
 
     // ADMIN
-    <Route path="/manage" element={withLayout(ManageCommunityPage, {})} />,
+    <Route path="/manage" element={withLayout(ManageCommunityPage, {
+      scoped: true,
+      deferChain: true,
+    })} />,
     <Route
       path="/analytics"
       element={withLayout(AnalyticsPage, {

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -113,6 +113,7 @@ export const LinkedProposalsCard = ({
                           <LinkedProposal
                             thread={thread}
                             chainEntity={chainEntity}
+                            key={chainEntity.id}
                           />
                         );
                       })}


### PR DESCRIPTION
## Description of Changes
- Discussions page does not depend on chain events being loaded in any way. This PR defers chain event loading until the data is needed. In other words, we remove the /entities and /getEntityMeta from the _mandatory_ init flow, saving us significant time.

## Test Plan
- Visited proposals pages depending on chain entities to ensure they load (/dydx/proposals).
- Visited various threads which had links to ensure the links still loaded.
- Tested feeds that rely on chain events.
- Tested linking proposals to threads.