### PR TITLE
if user has no shared chain base, send to login flow

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -511,11 +511,15 @@ export const LoginSelector = () => {
             <CWButton
               buttonType="tertiary-black"
               onClick={async () => {
-                if (hasTermsOfService) {
-                  setIsTOSModalOpen(true);
+                if(sameBaseAddressesRemoveDuplicates.length === 0) {
+                  setIsLoginModalOpen(true)
                 } else {
-                  await performJoinCommunityLinking();
-                  setIsJoined(true);
+                  if (hasTermsOfService) {
+                    setIsTOSModalOpen(true);
+                  } else {
+                    await performJoinCommunityLinking();
+                    setIsJoined(true);
+                  }
                 }
               }}
               label={
@@ -606,6 +610,14 @@ export const LoginSelector = () => {
         }
         onClose={() => setIsTOSModalOpen(false)}
         open={isTOSModalOpen}
+      />
+      <Modal
+        content={
+          <LoginModal onModalClose={() => setIsLoginModalOpen(false)} />
+        }
+        isFullScreen={isWindowMediumSmallInclusive(window.innerWidth)}
+        onClose={() => setIsLoginModalOpen(false)}
+        open={isLoginModalOpen}
       />
     </>
   );


### PR DESCRIPTION
When the user does not have a shared chain base with the current community, they see a button that says `No [chain_name] Address` that, when clicked, sends them to the login flow.

## Link to Issue
Closes: #3555 

## Description of Changes
- clicking the 'No ... Address' button directs you to log in

## Test Plan
- click around locally and on dev
