### PR TITLE
Fixed reaction button

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
@@ -290,8 +290,8 @@ export const getBatchNotificationFields = (
   };
 
   const args = comment_id
-    ? [root_type, pseudoProposal, { id: comment_id }]
-    : [root_type, pseudoProposal];
+    ? [pseudoProposal, { id: comment_id }]
+    : [pseudoProposal, undefined];
 
   const path =
     category === NotificationCategories.NewThread

--- a/packages/commonwealth/server/routes/addEditors.ts
+++ b/packages/commonwealth/server/routes/addEditors.ts
@@ -150,7 +150,7 @@ const addEditors = async (
         },
         {
           user: author.address,
-          url: getThreadUrl('discussion', thread),
+          url: getThreadUrl(thread),
           title: req.body.title,
           bodyUrl: req.body.url,
           chain: thread.chain,

--- a/packages/commonwealth/server/routes/createThread.ts
+++ b/packages/commonwealth/server/routes/createThread.ts
@@ -154,7 +154,7 @@ const dispatchHooks = async (
     {
       user: finalThread.Address.address,
       author_chain: finalThread.Address.chain,
-      url: getThreadUrl('discussion', finalThread),
+      url: getThreadUrl(finalThread),
       title: req.body.title,
       bodyUrl: req.body.url,
       chain: finalThread.chain,

--- a/packages/commonwealth/shared/notificationFormatter.ts
+++ b/packages/commonwealth/shared/notificationFormatter.ts
@@ -111,8 +111,8 @@ export const getForumNotificationCopy = async (
     chain: chain_id,
   };
   const proposalUrlArgs = comment_id
-    ? [root_type, pseudoProposal, { id: comment_id }]
-    : [root_type, pseudoProposal];
+    ? [pseudoProposal, { id: comment_id }]
+    : [pseudoProposal];
   const proposalPath = (getThreadUrl as any)(...proposalUrlArgs);
   return [
     emailSubjectLine,

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -71,7 +71,7 @@ export const requiresTypeSlug = (type: ProposalType): boolean => {
 };
 
 /* eslint-disable */
-export const getThreadUrl = (type, thread, comment?) => {
+export const getThreadUrl = (thread, comment?) => {
   const aId = thread.chain;
   const tId = thread.type_id || thread.id;
   const tTitle = thread.title ? `-${slugify(thread.title)}` : '';


### PR DESCRIPTION
## Link to Issue
Closes: #3602

## Description of Changes
- Refactored getThreadUrl so that it no longer needs type argument.
- Refactored calling functions so that they no longer pass in type parameter.

## Test Plan
- CA (click around) tested on local