### PR TITLE
Fix Slow Delete

### DIFF
--- a/packages/commonwealth/server/routes/deleteComment.ts
+++ b/packages/commonwealth/server/routes/deleteComment.ts
@@ -66,7 +66,7 @@ const deleteComment = async (
       }
     }
     // find and delete all associated subscriptions
-    await models.Subscription.destroy({
+    models.Subscription.destroy({
       where: {
         offchain_comment_id: comment.id,
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3523 

## Description of Changes
- One liner fix that changes deleteComment to an optimistic delete by not awaiting the deletions on Subscriptions. 

## Test Plan
- Tested on frick (it was not easy to reproduce the original bug locally)

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 