### PR TITLE
Fixed avatar not being full circle on discussion page

### DIFF
--- a/packages/commonwealth/client/styles/components/user/user.scss
+++ b/packages/commonwealth/client/styles/components/user/user.scss
@@ -3,7 +3,6 @@
 @mixin bareAvatar {
   position: relative;
   display: inline-block;
-  margin: -3px 0;
   margin-right: 8px;
   background: $white;
   border-radius: $border-radius-round;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3624 

## Description of Changes
- Changed css in order to fix author avatar circle on discussion page

## Test Plan
- CA (click around) tested on local

## Other Considerations
Looked previously like:
<img width="777" alt="Screenshot 2023-05-01 at 10 12 27 AM" src="https://user-images.githubusercontent.com/14794654/235494659-90ad2908-8f6e-4ad9-a94e-9e3a7f15663c.png">

Looks now like:
<img width="819" alt="Screenshot 2023-05-01 at 10 12 04 AM" src="https://user-images.githubusercontent.com/14794654/235494617-7ca74643-1784-44d0-ae7d-53ac5519430a.png">

Gap between author and main body a little off, should I also reduce gap in between author and main-body in order to compensate for this change? For example:
<img width="828" alt="Screenshot 2023-05-01 at 10 13 36 AM" src="https://user-images.githubusercontent.com/14794654/235494809-e673768f-85e9-4e4e-80f0-36c0c7aa3d34.png">
