### PR TITLE
hide join button once user has joined community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -613,7 +613,10 @@ export const LoginSelector = () => {
       />
       <Modal
         content={
-          <LoginModal onModalClose={() => setIsLoginModalOpen(false)} />
+          <LoginModal
+            onSuccess={() => setIsJoined(true)}
+            onModalClose={() => setIsLoginModalOpen(false)}
+          />
         }
         isFullScreen={isWindowMediumSmallInclusive(window.innerWidth)}
         onClose={() => setIsLoginModalOpen(false)}


### PR DESCRIPTION
## Link to Issue
Closes: #3649 

## Description of Changes
- sets user as joined once they have added the correct chain to their profile

## Test Plan
- navigate to a community page for which you don't share a chain (you should see 'No [chain] address' where the 'Join' button usually is). Click it and go through the login flow. When that is complete, neither a 'No [chain] address' nor a 'Join' button should be present in the header  
