### PR TITLE
Fixed 429 error response from CI github checkout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -116,6 +118,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
We are getting rate limited on our git checkouts, see:
https://github.com/hicommonwealth/commonwealth/actions/runs/4863687471/jobs/8671727412

## Description of Changes
- Adds token to checkout github action

## Test Plan
- Runs through CI