### PR TITLE
Quill: markdown controls + shortcuts

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -5,17 +5,13 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { DeltaOperation, RangeStatic } from 'quill';
-import imageDropAndPaste from 'quill-image-drop-and-paste';
+import type { RangeStatic } from 'quill';
 import ReactQuill, { Quill } from 'react-quill';
-import QuillMention from 'quill-mention';
 import MagicUrl from 'quill-magic-url';
-import moment from 'moment';
 
 import { SerializableDeltaStatic } from './utils';
-import { base64ToFile, getTextFromDelta, uploadFileToS3 } from './utils';
+import { getTextFromDelta } from './utils';
 
-import app from 'state';
 import { CWText } from '../component_kit/cw_text';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import { PreviewModal } from '../../modals/preview_modal';
@@ -25,15 +21,12 @@ import 'components/react_quill/react_quill_editor.scss';
 import 'react-quill/dist/quill.snow.css';
 import { nextTick } from 'process';
 
-import { MinimumProfile } from 'models';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { LoadingIndicator } from './loading_indicator';
+import { useMention } from './use_mention';
+import { useClipboardMatchers } from './use_clipboard_matchers';
+import { useImageDropAndPaste } from './use_image_drop_and_paste';
 
-const VALID_IMAGE_TYPES = ['jpeg', 'gif', 'png'];
-
-const Delta = Quill.import('delta');
-Quill.register('modules/imageDropAndPaste', imageDropAndPaste);
-Quill.register('modules/mention', QuillMention);
 Quill.register('modules/magicUrl', MagicUrl);
 
 type ReactQuillEditorProps = {
@@ -62,6 +55,19 @@ const ReactQuillEditor = ({
   // ref is used to prevent rerenders when selection
   // is changed, since rerenders bug out the editor
   const lastSelectionRef = useRef<RangeStatic | null>(null);
+  const { mention } = useMention({
+    editorRef,
+    lastSelectionRef,
+  });
+
+  const { clipboardMatchers } = useClipboardMatchers();
+
+  const { handleImageDropAndPaste } = useImageDropAndPaste({
+    editorRef,
+    setIsUploading,
+    isMarkdownEnabled,
+    setContentDelta,
+  });
 
   // refreshQuillComponent unmounts and remounts the
   // React Quill component, as this is the only way
@@ -80,72 +86,6 @@ const ReactQuillEditor = ({
       ___isMarkdown: isMarkdownEnabled,
     } as SerializableDeltaStatic);
   };
-
-  // must be memoized or else infinite loop
-  const handleImageDropAndPaste = useCallback(
-    async (imageDataUrl, imageType) => {
-      const editor = editorRef.current?.editor;
-
-      try {
-        if (!editor) {
-          throw new Error('editor is not set');
-        }
-
-        setIsUploading(true);
-
-        editor.disable();
-
-        if (!imageType) {
-          imageType = 'image/png';
-        }
-
-        const selectedIndex =
-          editor.getSelection()?.index || editor.getLength() || 0;
-
-        // filter out ops that contain a base64 image
-        const opsWithoutBase64Images: DeltaOperation[] = (
-          editor.getContents() || []
-        ).filter((op) => {
-          for (const opImageType of VALID_IMAGE_TYPES) {
-            const base64Prefix = `data:image/${opImageType};base64`;
-            if (op.insert?.image?.startsWith(base64Prefix)) {
-              return false;
-            }
-          }
-          return true;
-        });
-        setContentDelta({
-          ops: opsWithoutBase64Images,
-          ___isMarkdown: isMarkdownEnabled,
-        } as SerializableDeltaStatic);
-
-        const file = base64ToFile(imageDataUrl, imageType);
-
-        const uploadedFileUrl = await uploadFileToS3(
-          file,
-          app.serverUrl(),
-          app.user.jwt
-        );
-
-        // insert image op at the selected index
-        if (isMarkdownEnabled) {
-          editor.insertText(selectedIndex, `![image](${uploadedFileUrl})`);
-        } else {
-          editor.insertEmbed(selectedIndex, 'image', uploadedFileUrl);
-        }
-        setContentDelta({
-          ...editor.getContents(),
-          ___isMarkdown: isMarkdownEnabled,
-        } as SerializableDeltaStatic); // sync state with editor content
-      } catch (err) {
-        console.error(err);
-      } finally {
-        editor.enable();
-        setIsUploading(false);
-      }
-    },
-    [editorRef, isMarkdownEnabled, setContentDelta]
-  );
 
   const handleToggleMarkdown = () => {
     const editor = editorRef.current?.getEditor();
@@ -195,166 +135,18 @@ const ReactQuillEditor = ({
     setIsPreviewVisible(false);
   };
 
-  // must be memoized or else infinite loop
-  const clipboardMatchers = useMemo(() => {
-    return [
-      [
-        Node.ELEMENT_NODE,
-        (node, delta) => {
-          return delta.compose(
-            new Delta().retain(delta.length(), {
-              header: false,
-              align: false,
-              color: false,
-              background: false,
-            })
-          );
-        },
-      ],
-    ];
-  }, []);
-
   // if markdown is disabled, hide toolbar buttons
   const toolbar = useMemo(() => {
     if (isMarkdownEnabled) {
       return [];
     }
+    // ref: https://quilljs.com/docs/modules/toolbar/
     return ([[{ header: 1 }, { header: 2 }]] as any).concat([
       ['bold', 'italic', 'strike'],
       ['link', 'code-block', 'blockquote'],
       [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
     ]);
   }, [isMarkdownEnabled]);
-
-  const selectMention = useCallback(
-    (item: QuillMention) => {
-      const editor = editorRef.current?.getEditor();
-      if (!editor) {
-        return;
-      }
-      if (item.link === '#' && item.name === '') return;
-      const text = editor.getText();
-      const lastSelection = lastSelectionRef.current;
-      if (!lastSelection) {
-        return;
-      }
-      const cursorIdx = lastSelection.index;
-      const mentionLength =
-        text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
-      const beforeText = text.slice(0, cursorIdx - mentionLength);
-      const afterText = text.slice(cursorIdx).replace(/\n$/, '');
-      const delta = new Delta()
-        .retain(beforeText.length)
-        .delete(mentionLength)
-        .insert(`@${item.name}`, { link: item.link });
-      if (!afterText.startsWith(' ')) delta.insert(' ');
-      editor.updateContents(delta);
-      editor.setSelection(
-        editor.getLength() -
-          afterText.length -
-          (afterText.startsWith(' ') ? 0 : 1),
-        0
-      );
-    },
-    [lastSelectionRef]
-  );
-
-  const mention = useMemo(() => {
-    return {
-      allowedChars: /^[A-Za-z0-9\sÅÄÖåäö\-_.]*$/,
-      mentionDenotationChars: ['@'],
-      dataAttributes: ['name', 'link', 'component'],
-      renderItem: (item) => item.component,
-      onSelect: selectMention,
-      source: async (
-        searchTerm: string,
-        renderList: (
-          formattedMatches: QuillMention,
-          searchTerm: string
-        ) => null,
-        mentionChar: string
-      ) => {
-        if (mentionChar !== '@') return;
-
-        let formattedMatches = [];
-        if (searchTerm.length === 0) {
-          const node = document.createElement('div');
-          const tip = document.createElement('span');
-          tip.innerText = 'Type to tag a member';
-          node.appendChild(tip);
-          formattedMatches = [
-            {
-              link: '#',
-              name: '',
-              component: node.outerHTML,
-            },
-          ];
-        } else if (searchTerm.length > 0) {
-          const members = await app.search.searchMentionableAddresses(
-            searchTerm,
-            {
-              pageSize: 10,
-              chainScope: app.activeChainId(),
-            }
-          );
-          formattedMatches = members.map((addr) => {
-            const profile = app.newProfiles.getProfile(
-              addr.chain,
-              addr.address
-            );
-            const node = document.createElement('div');
-
-            let avatar;
-            if (profile.avatarUrl) {
-              avatar = document.createElement('img');
-              (avatar as HTMLImageElement).src = profile.avatarUrl;
-              avatar.className = 'ql-mention-avatar';
-              node.appendChild(avatar);
-            } else {
-              avatar = document.createElement('div');
-              avatar.className = 'ql-mention-avatar';
-              avatar.innerHTML = MinimumProfile.getSVGAvatar(addr.address, 20);
-            }
-
-            const nameSpan = document.createElement('span');
-            nameSpan.innerText = addr.name;
-            nameSpan.className = 'ql-mention-name';
-
-            const addrSpan = document.createElement('span');
-            addrSpan.innerText =
-              addr.chain === 'near'
-                ? addr.address
-                : `${addr.address.slice(0, 6)}...`;
-            addrSpan.className = 'ql-mention-addr';
-
-            const lastActiveSpan = document.createElement('span');
-            lastActiveSpan.innerText = profile.lastActive
-              ? `Last active ${moment(profile.lastActive).fromNow()}`
-              : null;
-            lastActiveSpan.className = 'ql-mention-la';
-
-            const textWrap = document.createElement('div');
-            textWrap.className = 'ql-mention-text-wrap';
-
-            node.appendChild(avatar);
-            textWrap.appendChild(nameSpan);
-            textWrap.appendChild(addrSpan);
-            textWrap.appendChild(lastActiveSpan);
-            node.appendChild(textWrap);
-
-            return {
-              link: `/profile/id/${addr.profile_id}`,
-              name: addr.name,
-              component: node.outerHTML,
-            };
-          });
-        }
-        renderList(formattedMatches, searchTerm);
-      },
-      isolateChar: true,
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // when markdown state is changed, add markdown metadata to delta ops
   // and refresh quill component

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -47,7 +47,6 @@ export const useMarkdownToolbarHandlers = ({
       if (!selection) {
         return;
       }
-      // TODO: remove leading/trailing spaces from selection?
       const text = editor.getText(selection.index, selection.length);
       editor.deleteText(selection.index, selection.length);
       editor.insertText(

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -152,11 +152,12 @@ export const useMarkdownToolbarHandlers = ({
       const text = editor.getText(selection.index, selection.length);
       console.log(text);
       const newText = text.split('\n').reduce((acc, line) => {
-        if (line.length === 0) {
+        // remove empty lines
+        if (line.trim().length === 0) {
           return acc;
         }
+        // don't add prefix if already has it
         if (line.startsWith(prefix)) {
-          // already has prefix
           return acc + `${line.trim()}\n`;
         }
         return acc + `${prefix} ${line}\n`;

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -1,5 +1,12 @@
-import React, { MutableRefObject, useCallback, useMemo } from 'react';
+import React, { MutableRefObject, useMemo } from 'react';
 import ReactQuill from 'react-quill';
+import { SerializableDeltaStatic } from './utils';
+
+const LIST_ITEM_PREFIX = {
+  ordered: '1.',
+  bullet: '-',
+  check: '- [ ]',
+};
 
 type CustomQuillToolbarProps = {
   toolbarId: string;
@@ -41,11 +48,16 @@ export const useMarkdownToolbarHandlers = ({
         return;
       }
       // TODO: remove leading/trailing spaces from selection?
-      const start = selection.index;
-      const end = start + selection.length;
-      editor.insertText(end, markdownChars);
-      editor.insertText(start, markdownChars);
-      setContentDelta(editor.getContents());
+      const text = editor.getText(selection.index, selection.length);
+      editor.deleteText(selection.index, selection.length);
+      editor.insertText(
+        selection.index,
+        `${markdownChars}${text.trim()}${markdownChars}`
+      );
+      setContentDelta({
+        ...editor.getContents(),
+        ___isMarkdown: true,
+      } as SerializableDeltaStatic);
     };
   };
 
@@ -63,7 +75,10 @@ export const useMarkdownToolbarHandlers = ({
       const prefix = start === 0 ? '' : '\n';
       const hashChar = headerValue === '2' ? '##' : '#';
       editor.insertText(start, `${prefix}${hashChar} `);
-      setContentDelta(editor.getContents());
+      setContentDelta({
+        ...editor.getContents(),
+        ___isMarkdown: true,
+      } as SerializableDeltaStatic);
     };
   };
 
@@ -93,12 +108,15 @@ export const useMarkdownToolbarHandlers = ({
       const linkMarkdown = `[${linkText}](${linkUrl})`;
       editor.deleteText(selection.index, selection.length);
       editor.insertText(selection.index, linkMarkdown);
-      setContentDelta(editor.getContents());
+      setContentDelta({
+        ...editor.getContents(),
+        ___isMarkdown: true,
+      } as SerializableDeltaStatic);
     };
   };
 
   const createBlockquoteHandler = () => {
-    return (headerValue: string) => {
+    return () => {
       const editor = editorRef?.current?.getEditor();
       if (!editor) {
         return;
@@ -110,7 +128,45 @@ export const useMarkdownToolbarHandlers = ({
       const start = selection.index;
       const prefix = start === 0 ? '' : '\n';
       editor.insertText(start, `${prefix}> `);
-      setContentDelta(editor.getContents());
+      setContentDelta({
+        ...editor.getContents(),
+        ___isMarkdown: true,
+      } as SerializableDeltaStatic);
+    };
+  };
+
+  const createListHandler = () => {
+    return (value: string) => {
+      const editor = editorRef?.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      const selection = editor.getSelection();
+      if (!selection) {
+        return;
+      }
+      const prefix = LIST_ITEM_PREFIX[value];
+      if (!prefix) {
+        throw new Error(`could not get prefix for value: ${value}`);
+      }
+      const text = editor.getText(selection.index, selection.length);
+      console.log(text);
+      const newText = text.split('\n').reduce((acc, line) => {
+        if (line.length === 0) {
+          return acc;
+        }
+        if (line.startsWith(prefix)) {
+          // already has prefix
+          return acc + `${line.trim()}\n`;
+        }
+        return acc + `${prefix} ${line}\n`;
+      }, '');
+      editor.deleteText(selection.index, selection.length);
+      editor.insertText(selection.index, newText);
+      setContentDelta({
+        ...editor.getContents(),
+        ___isMarkdown: true,
+      } as SerializableDeltaStatic);
     };
   };
 
@@ -124,6 +180,7 @@ export const useMarkdownToolbarHandlers = ({
       header: createHeaderHandler(),
       link: createLinkHandler(),
       blockquote: createBlockquoteHandler(),
+      list: createListHandler(),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -1,0 +1,131 @@
+import React, { MutableRefObject, useCallback, useMemo } from 'react';
+import ReactQuill from 'react-quill';
+
+type CustomQuillToolbarProps = {
+  toolbarId: string;
+};
+
+export const CustomQuillToolbar = ({ toolbarId }: CustomQuillToolbarProps) => (
+  <div id={toolbarId}>
+    <button className="ql-header" value={1} />
+    <button className="ql-header" value={2} />
+    <button className="ql-bold"></button>
+    <button className="ql-italic"></button>
+    <button className="ql-strike"></button>
+    <button className="ql-link"></button>
+    <button className="ql-code-block"></button>
+    <button className="ql-blockquote"></button>
+    <button className="ql-list" value="ordered" />
+    <button className="ql-list" value="bullet" />
+    <button className="ql-list" value="check" />
+  </div>
+);
+
+type UseMarkdownToolbarHandlersProps = {
+  editorRef: MutableRefObject<ReactQuill>;
+  setContentDelta: (value: DeltaStatic) => void;
+};
+
+export const useMarkdownToolbarHandlers = ({
+  editorRef,
+  setContentDelta,
+}: UseMarkdownToolbarHandlersProps) => {
+  const createHandler = (markdownChars: string) => {
+    return () => {
+      const editor = editorRef?.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      const selection = editor.getSelection();
+      if (!selection) {
+        return;
+      }
+      // TODO: remove leading/trailing spaces from selection?
+      const start = selection.index;
+      const end = start + selection.length;
+      editor.insertText(end, markdownChars);
+      editor.insertText(start, markdownChars);
+      setContentDelta(editor.getContents());
+    };
+  };
+
+  const createHeaderHandler = () => {
+    return (headerValue: string) => {
+      const editor = editorRef?.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      const selection = editor.getSelection();
+      if (!selection) {
+        return;
+      }
+      const start = selection.index;
+      const prefix = start === 0 ? '' : '\n';
+      const hashChar = headerValue === '2' ? '##' : '#';
+      editor.insertText(start, `${prefix}${hashChar} `);
+      setContentDelta(editor.getContents());
+    };
+  };
+
+  const createLinkHandler = () => {
+    return () => {
+      const editor = editorRef?.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      const selection = editor.getSelection();
+      if (!selection) {
+        return;
+      }
+      let linkUrl =
+        selection.length === 0
+          ? prompt('Enter link URL:')
+          : editor.getText(selection.index, selection.length);
+      if (!linkUrl.startsWith('https://')) {
+        if (linkUrl.startsWith('http://')) {
+          // convert HTTP to HTTPS
+          linkUrl = `https://${linkUrl.substring('http://'.length)}`;
+        } else {
+          linkUrl = `https://${linkUrl}`;
+        }
+      }
+      const linkText = prompt('Enter link text:');
+      const linkMarkdown = `[${linkText}](${linkUrl})`;
+      editor.deleteText(selection.index, selection.length);
+      editor.insertText(selection.index, linkMarkdown);
+      setContentDelta(editor.getContents());
+    };
+  };
+
+  const createBlockquoteHandler = () => {
+    return (headerValue: string) => {
+      const editor = editorRef?.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      const selection = editor.getSelection();
+      if (!selection) {
+        return;
+      }
+      const start = selection.index;
+      const prefix = start === 0 ? '' : '\n';
+      editor.insertText(start, `${prefix}> `);
+      setContentDelta(editor.getContents());
+    };
+  };
+
+  const handlers = useMemo(() => {
+    return {
+      bold: createHandler('**'),
+      italic: createHandler('_'),
+      strike: createHandler('~~'),
+      code: createHandler('`'),
+      'code-block': createHandler('\n```\n'),
+      header: createHeaderHandler(),
+      link: createLinkHandler(),
+      blockquote: createBlockquoteHandler(),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return handlers;
+};

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -1,6 +1,7 @@
 import React, { MutableRefObject, useMemo } from 'react';
 import ReactQuill from 'react-quill';
 import { SerializableDeltaStatic } from './utils';
+import { DeltaStatic } from 'quill';
 
 const LIST_ITEM_PREFIX = {
   ordered: '1.',

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -91,10 +91,11 @@ export const useMarkdownToolbarHandlers = ({
       if (!selection) {
         return;
       }
-      let linkUrl =
+      const linkText =
         selection.length === 0
-          ? prompt('Enter link URL:')
+          ? prompt('Enter link text:')
           : editor.getText(selection.index, selection.length);
+      let linkUrl = prompt('Enter link URL:');
       if (!linkUrl.startsWith('https://')) {
         if (linkUrl.startsWith('http://')) {
           // convert HTTP to HTTPS
@@ -103,7 +104,6 @@ export const useMarkdownToolbarHandlers = ({
           linkUrl = `https://${linkUrl}`;
         }
       }
-      const linkText = prompt('Enter link text:');
       const linkMarkdown = `[${linkText}](${linkUrl})`;
       editor.deleteText(selection.index, selection.length);
       editor.insertText(selection.index, linkMarkdown);

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -150,7 +150,6 @@ export const useMarkdownToolbarHandlers = ({
         throw new Error(`could not get prefix for value: ${value}`);
       }
       const text = editor.getText(selection.index, selection.length);
-      console.log(text);
       const newText = text.split('\n').reduce((acc, line) => {
         // remove empty lines
         if (line.trim().length === 0) {

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_clipboard_matchers.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_clipboard_matchers.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { Quill } from 'react-quill';
+
+const Delta = Quill.import('delta');
+
+export const useClipboardMatchers = () => {
+  // must be memoized or else infinite loop
+  const clipboardMatchers = useMemo(() => {
+    return [
+      [
+        Node.ELEMENT_NODE,
+        (node, delta) => {
+          return delta.compose(
+            new Delta().retain(delta.length(), {
+              header: false,
+              align: false,
+              color: false,
+              background: false,
+            })
+          );
+        },
+      ],
+    ];
+  }, []);
+
+  return { clipboardMatchers };
+};

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -1,0 +1,93 @@
+import { MutableRefObject, useCallback } from 'react';
+import ReactQuill, { Quill } from 'react-quill';
+import { DeltaOperation, DeltaStatic } from 'quill';
+import imageDropAndPaste from 'quill-image-drop-and-paste';
+
+import app from 'state';
+import { SerializableDeltaStatic, base64ToFile, uploadFileToS3 } from './utils';
+
+const VALID_IMAGE_TYPES = ['jpeg', 'gif', 'png'];
+
+Quill.register('modules/imageDropAndPaste', imageDropAndPaste);
+
+type UseImageDropAndPasteProps = {
+  editorRef: MutableRefObject<ReactQuill>;
+  setIsUploading: (value: boolean) => void;
+  isMarkdownEnabled: boolean;
+  setContentDelta: (value: DeltaStatic) => void;
+};
+
+export const useImageDropAndPaste = ({
+  editorRef,
+  setIsUploading,
+  isMarkdownEnabled,
+  setContentDelta,
+}: UseImageDropAndPasteProps) => {
+  // must be memoized or else infinite loop
+  const handleImageDropAndPaste = useCallback(
+    async (imageDataUrl, imageType) => {
+      const editor = editorRef.current?.editor;
+
+      try {
+        if (!editor) {
+          throw new Error('editor is not set');
+        }
+
+        setIsUploading(true);
+
+        editor.disable();
+
+        if (!imageType) {
+          imageType = 'image/png';
+        }
+
+        const selectedIndex =
+          editor.getSelection()?.index || editor.getLength() || 0;
+
+        // filter out ops that contain a base64 image
+        const opsWithoutBase64Images: DeltaOperation[] = (
+          editor.getContents() || []
+        ).filter((op) => {
+          for (const opImageType of VALID_IMAGE_TYPES) {
+            const base64Prefix = `data:image/${opImageType};base64`;
+            if (op.insert?.image?.startsWith(base64Prefix)) {
+              return false;
+            }
+          }
+          return true;
+        });
+        setContentDelta({
+          ops: opsWithoutBase64Images,
+          ___isMarkdown: isMarkdownEnabled,
+        } as SerializableDeltaStatic);
+
+        const file = base64ToFile(imageDataUrl, imageType);
+
+        const uploadedFileUrl = await uploadFileToS3(
+          file,
+          app.serverUrl(),
+          app.user.jwt
+        );
+
+        // insert image op at the selected index
+        if (isMarkdownEnabled) {
+          editor.insertText(selectedIndex, `![image](${uploadedFileUrl})`);
+        } else {
+          editor.insertEmbed(selectedIndex, 'image', uploadedFileUrl);
+        }
+        setContentDelta({
+          ...editor.getContents(),
+          ___isMarkdown: isMarkdownEnabled,
+        } as SerializableDeltaStatic); // sync state with editor content
+      } catch (err) {
+        console.error(err);
+      } finally {
+        editor.enable();
+        setIsUploading(false);
+      }
+    },
+    [editorRef, isMarkdownEnabled, setContentDelta]
+  );
+
+  return { handleImageDropAndPaste };
+};

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -86,7 +86,7 @@ export const useImageDropAndPaste = ({
         setIsUploading(false);
       }
     },
-    [editorRef, isMarkdownEnabled, setContentDelta]
+    [editorRef, isMarkdownEnabled, setContentDelta, setIsUploading]
   );
 
   return { handleImageDropAndPaste };

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
@@ -1,6 +1,7 @@
 import { DeltaStatic } from 'quill';
 import { MutableRefObject, useMemo } from 'react';
 import ReactQuill from 'react-quill';
+import { SerializableDeltaStatic } from './utils';
 
 type UseMarkdownShortcutsProps = {
   editorRef: MutableRefObject<ReactQuill>;

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
@@ -25,11 +25,12 @@ export const useMarkdownShortcuts = ({
           if (!selection) {
             return;
           }
-          // TODO: remove leading/trailing spaces from selection?
-          const start = selection.index;
-          const end = start + selection.length;
-          editor.insertText(end, markdownChars);
-          editor.insertText(start, markdownChars);
+          const text = editor.getText(selection.index, selection.length);
+          editor.deleteText(selection.index, selection.length);
+          editor.insertText(
+            selection.index,
+            `${markdownChars}${text.trim()}${markdownChars}`
+          );
           setContentDelta({
             ...editor.getContents(),
             ___isMarkdown: true,

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
@@ -1,0 +1,47 @@
+import { DeltaStatic } from 'quill';
+import { MutableRefObject, useMemo } from 'react';
+import ReactQuill from 'react-quill';
+
+type UseMarkdownShortcutsProps = {
+  editorRef: MutableRefObject<ReactQuill>;
+  setContentDelta: (value: DeltaStatic) => void;
+};
+
+export const useMarkdownShortcuts = ({
+  editorRef,
+  setContentDelta,
+}: UseMarkdownShortcutsProps) => {
+  const keyboard = useMemo(() => {
+    const createBinding = (keyboardKey: string, markdownChars: string) => {
+      return {
+        key: keyboardKey,
+        shortKey: true,
+        handler: () => {
+          const editor = editorRef?.current?.getEditor();
+          if (!editor) {
+            return;
+          }
+          const selection = editor.getSelection();
+          if (!selection) {
+            return;
+          }
+          // TODO: remove leading/trailing spaces from selection?
+          const start = selection.index;
+          const end = start + selection.length;
+          editor.insertText(end, markdownChars);
+          editor.insertText(start, markdownChars);
+          setContentDelta(editor.getContents());
+        },
+      };
+    };
+
+    return {
+      bindings: {
+        bold: createBinding('b', '**'),
+        italic: createBinding('i', '_'),
+      },
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return keyboard;
+};

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_markdown_shortcuts.tsx
@@ -30,7 +30,10 @@ export const useMarkdownShortcuts = ({
           const end = start + selection.length;
           editor.insertText(end, markdownChars);
           editor.insertText(start, markdownChars);
-          setContentDelta(editor.getContents());
+          setContentDelta({
+            ...editor.getContents(),
+            ___isMarkdown: true,
+          } as SerializableDeltaStatic);
         },
       };
     };

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_mention.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_mention.tsx
@@ -1,0 +1,153 @@
+import { MinimumProfile } from 'models';
+import { RangeStatic } from 'quill';
+import { MutableRefObject, useCallback, useMemo } from 'react';
+import ReactQuill, { Quill } from 'react-quill';
+import moment from 'moment';
+import QuillMention from 'quill-mention';
+
+import app from 'state';
+
+const Delta = Quill.import('delta');
+Quill.register('modules/mention', QuillMention);
+
+type UseMentionProps = {
+  editorRef: MutableRefObject<ReactQuill>;
+  lastSelectionRef: MutableRefObject<RangeStatic | null>;
+};
+
+export const useMention = ({
+  editorRef,
+  lastSelectionRef,
+}: UseMentionProps) => {
+  const selectMention = useCallback(
+    (item: QuillMention) => {
+      const editor = editorRef.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+      if (item.link === '#' && item.name === '') return;
+      const text = editor.getText();
+      const lastSelection = lastSelectionRef.current;
+      if (!lastSelection) {
+        return;
+      }
+      const cursorIdx = lastSelection.index;
+      const mentionLength =
+        text.slice(0, cursorIdx).split('').reverse().indexOf('@') + 1;
+      const beforeText = text.slice(0, cursorIdx - mentionLength);
+      const afterText = text.slice(cursorIdx).replace(/\n$/, '');
+      const delta = new Delta()
+        .retain(beforeText.length)
+        .delete(mentionLength)
+        .insert(`@${item.name}`, { link: item.link });
+      if (!afterText.startsWith(' ')) delta.insert(' ');
+      editor.updateContents(delta);
+      editor.setSelection(
+        editor.getLength() -
+          afterText.length -
+          (afterText.startsWith(' ') ? 0 : 1),
+        0
+      );
+    },
+    [lastSelectionRef]
+  );
+
+  const mention = useMemo(() => {
+    return {
+      allowedChars: /^[A-Za-z0-9\sÅÄÖåäö\-_.]*$/,
+      mentionDenotationChars: ['@'],
+      dataAttributes: ['name', 'link', 'component'],
+      renderItem: (item) => item.component,
+      onSelect: selectMention,
+      source: async (
+        searchTerm: string,
+        renderList: (
+          formattedMatches: QuillMention,
+          searchTerm: string
+        ) => null,
+        mentionChar: string
+      ) => {
+        if (mentionChar !== '@') return;
+
+        let formattedMatches = [];
+        if (searchTerm.length === 0) {
+          const node = document.createElement('div');
+          const tip = document.createElement('span');
+          tip.innerText = 'Type to tag a member';
+          node.appendChild(tip);
+          formattedMatches = [
+            {
+              link: '#',
+              name: '',
+              component: node.outerHTML,
+            },
+          ];
+        } else if (searchTerm.length > 0) {
+          const members = await app.search.searchMentionableAddresses(
+            searchTerm,
+            {
+              pageSize: 10,
+              chainScope: app.activeChainId(),
+            }
+          );
+          formattedMatches = members.map((addr) => {
+            const profile = app.newProfiles.getProfile(
+              addr.chain,
+              addr.address
+            );
+            const node = document.createElement('div');
+
+            let avatar;
+            if (profile.avatarUrl) {
+              avatar = document.createElement('img');
+              (avatar as HTMLImageElement).src = profile.avatarUrl;
+              avatar.className = 'ql-mention-avatar';
+              node.appendChild(avatar);
+            } else {
+              avatar = document.createElement('div');
+              avatar.className = 'ql-mention-avatar';
+              avatar.innerHTML = MinimumProfile.getSVGAvatar(addr.address, 20);
+            }
+
+            const nameSpan = document.createElement('span');
+            nameSpan.innerText = addr.name;
+            nameSpan.className = 'ql-mention-name';
+
+            const addrSpan = document.createElement('span');
+            addrSpan.innerText =
+              addr.chain === 'near'
+                ? addr.address
+                : `${addr.address.slice(0, 6)}...`;
+            addrSpan.className = 'ql-mention-addr';
+
+            const lastActiveSpan = document.createElement('span');
+            lastActiveSpan.innerText = profile.lastActive
+              ? `Last active ${moment(profile.lastActive).fromNow()}`
+              : null;
+            lastActiveSpan.className = 'ql-mention-la';
+
+            const textWrap = document.createElement('div');
+            textWrap.className = 'ql-mention-text-wrap';
+
+            node.appendChild(avatar);
+            textWrap.appendChild(nameSpan);
+            textWrap.appendChild(addrSpan);
+            textWrap.appendChild(lastActiveSpan);
+            node.appendChild(textWrap);
+
+            return {
+              link: `/profile/id/${addr.profile_id}`,
+              name: addr.name,
+              component: node.outerHTML,
+            };
+          });
+        }
+        renderList(formattedMatches, searchTerm);
+      },
+      isolateChar: true,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { mention };
+};

--- a/packages/commonwealth/client/styles/modals/preview_modal.scss
+++ b/packages/commonwealth/client/styles/modals/preview_modal.scss
@@ -2,6 +2,7 @@
 
 .PreviewModal {
   max-height: 95vh;
+  max-width: 70vw;
   overflow-y: scroll;
 
   .compact-modal-title {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3549 

## Description of Changes
- Splits out quill modules into separate hooks to make the `ReactQuillEditor` component more maintainable
- Updates toolbar so that controls remain the same in richtext and markdown mode, but use different behavior for each mode– richtext mode applies direct formatting, while markdown mode applies markdown syntax
- Adds markdown keyboard shortcuts for bold and italic (all other formatting done via toolbar)

## Test Plan
- Using any quill editor, switch to markdown mode, go through all toolbar options– confirm that markdown syntax is applied correctly
- In markdown mode, use the keyboard shortcuts CMD + B for bold and CMD + I for italic– confirm that markdown syntax is applied correctly
- (Regression check): Perform the same previous steps in richtext mode– confirm no regressions

## Deployment Plan
N/A

## Other Considerations
- Further UX improvements might be worth splitting out into an additional "polish" ticket, since we'll start to see increased code complexity as we handle edge cases.