### PR TITLE
WIP: fix remove child node error

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/profile/profile_activity_content.tsx
+++ b/packages/commonwealth/client/scripts/views/components/profile/profile_activity_content.tsx
@@ -35,13 +35,13 @@ const ProfileActivityContent = (props: ProfileActivityContentProps) => {
       );
     }
     return (
-      <>
+      <div>
         {threads
           .sort((a, b) => +b.createdAt - +a.createdAt)
           .map((thread, i) => (
             <NewProfileActivityRow key={i} activity={thread} />
           ))}
-      </>
+      </div>
     );
   }
 
@@ -64,11 +64,11 @@ const ProfileActivityContent = (props: ProfileActivityContentProps) => {
   }
 
   return (
-    <>
+    <div>
       {allActivities.map((activity, i) => {
         return <NewProfileActivityRow key={i} activity={activity} />;
       })}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
When on the user profile page, navigating between 'All Activity' and 'Threads' results in a 'Failed to execute removeChild on node. The node to be removed is not a child of this node' error. This may be due to the use of fragments as opposed to proper elements like divs, since a fragment would not have a parent relationship with its contents. 

I am unable to replicate the error locally, so I'm passing this on to anyone who is seeing the error locally to confirm that the proposed fix does, indeed, solve our problem. 

## Link to Issue
Potentially Closes: #3619 

## Description of Changes
- Replaces React fragments with divs

## Test Plan
1. replicate error on local machine (start by reverting the divs to fragments
2. note if error stops appearing after fragments are changed back to divs
