### PR TITLE
Cosmos linking additions

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/utils.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/utils.ts
@@ -1,10 +1,13 @@
 import { CosmosProposal } from './v1beta1/proposal-v1beta1';
 import CosmosGovernance from './v1beta1/governance-v1beta1';
 import type Cosmos from '../adapter';
-import { getCompletedProposalsV1 } from './v1/utils-v1';
+import { getActiveProposalsV1, getCompletedProposalsV1 } from './v1/utils-v1';
 import { CosmosProposalV1 } from './v1/proposal-v1';
 import CosmosGovernanceV1 from './v1/governance-v1';
-import { getCompletedProposalsV1Beta1 } from './v1beta1/utils-v1beta1';
+import {
+  getActiveProposalsV1Beta1,
+  getCompletedProposalsV1Beta1,
+} from './v1beta1/utils-v1beta1';
 
 // -- Gov methods for all Cosmos SDK versions as of 0.46.11: --
 
@@ -29,6 +32,36 @@ export const getCompletedProposals = async (
     );
   } else {
     const v1Beta1Proposals = await getCompletedProposalsV1Beta1(chain.api);
+    cosmosProposals = v1Beta1Proposals.map(
+      (p) =>
+        new CosmosProposal(chain, accounts, governance as CosmosGovernance, p)
+    );
+  }
+  Promise.all(cosmosProposals.map((p) => p.init()));
+  return cosmosProposals;
+};
+
+/* This can be used for v1 or v1beta1 */
+export const getActiveProposals = async (
+  cosmosChain: Cosmos
+): Promise<CosmosProposal[]> => {
+  const { chain, accounts, governance, meta } = cosmosChain;
+  const isV1 = meta.cosmosGovernanceVersion === 'v1';
+  let cosmosProposals = [];
+
+  if (isV1) {
+    const v1Proposals = await getActiveProposalsV1(chain.lcd);
+    cosmosProposals = v1Proposals.map(
+      (p) =>
+        new CosmosProposalV1(
+          chain,
+          accounts,
+          governance as CosmosGovernanceV1,
+          p
+        )
+    );
+  } else {
+    const v1Beta1Proposals = await getActiveProposalsV1Beta1(chain.api);
     cosmosProposals = v1Beta1Proposals.map(
       (p) =>
         new CosmosProposal(chain, accounts, governance as CosmosGovernance, p)

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState, Dispatch, SetStateAction } from 'react';
+import _ from 'lodash';
+import { IApp } from 'state';
+
+import { ChainBase } from 'common-common/src/types';
+import Cosmos from 'controllers/chain/cosmos/adapter';
+import { getActiveProposals } from 'controllers/chain/cosmos/gov/utils';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+
+type UseStateSetter<T> = Dispatch<SetStateAction<T>>;
+
+interface Response {
+  activeCosmosProposals: CosmosProposal[];
+}
+
+interface Props {
+  app: IApp;
+  setIsLoading: UseStateSetter<boolean>;
+  isLoading: boolean;
+}
+
+export const useGetActiveCosmosProposals = ({
+  app,
+  setIsLoading,
+  isLoading,
+}: Props): Response => {
+  const [activeCosmosProposals, setActiveCosmosProposals] = useState<
+    CosmosProposal[]
+  >([]);
+
+  const hasFetchedDataRef = useRef(false);
+
+  useEffect(() => {
+    const getProposals = async () => {
+      if (!hasFetchedDataRef.current) {
+        hasFetchedDataRef.current = true;
+        const cosmos = app.chain as Cosmos;
+        const storedProposals =
+          cosmos.governance.store.getAll() as CosmosProposal[];
+        const activeProposals = storedProposals.filter((p) => !p.completed);
+        if (activeProposals?.length) {
+          setActiveCosmosProposals(activeProposals);
+        } else {
+          setIsLoading(true);
+          const proposals = await getActiveProposals(cosmos);
+          setActiveCosmosProposals(proposals);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    const initApiThenFetch = async () => {
+      await app.chain.initApi();
+      await getProposals();
+    };
+
+    if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
+      if (app.chain?.apiInitialized) {
+        getProposals();
+      } else {
+        initApiThenFetch();
+      }
+    }
+  }, [app.chain?.apiInitialized]);
+
+  return {
+    activeCosmosProposals,
+  };
+};

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState, Dispatch, SetStateAction } from 'react';
-import _ from 'lodash';
 import { IApp } from 'state';
 
 import { ChainBase } from 'common-common/src/types';

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -49,12 +49,17 @@ export const useGetCompletedCosmosProposals = ({
       }
     };
 
-    if (
-      app.chain?.apiInitialized &&
-      app.chain?.base === ChainBase.CosmosSDK &&
-      !isLoading
-    ) {
-      getProposals();
+    const initApiThenFetch = async () => {
+      await app.chain.initApi();
+      await getProposals();
+    };
+
+    if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
+      if (app.chain?.apiInitialized) {
+        getProposals();
+      } else {
+        initApiThenFetch();
+      }
     }
   }, [app.chain?.apiInitialized]);
 

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState, Dispatch, SetStateAction } from 'react';
-import _ from 'lodash';
 import { IApp } from 'state';
 
 import { ChainBase } from 'common-common/src/types';

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -103,7 +103,6 @@ export const ProposalSelector = ({
         iconRight="close"
         onInput={handleInputChange}
       />
-
       <QueryList
         loading={loadingActive}
         options={entities}

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -28,10 +28,11 @@ export const ProposalSelector = ({
 }: ProposalSelectorProps) => {
   const [loadingCompleted, setCompletedLoading] = useState(false);
   const [loadingActive, setActiveLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const { activeCosmosProposals } = useGetActiveCosmosProposals({
     app,
-    setIsLoading: setActiveLoading,
+    setIsLoading: setLoading,
     isLoading: loadingActive,
   });
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
@@ -103,11 +104,7 @@ export const ProposalSelector = ({
         iconRight="close"
         onInput={handleInputChange}
       />
-      <QueryList
-        loading={loadingActive}
-        options={entities}
-        renderItem={renderItem}
-      />
+      <QueryList loading={loading} options={entities} renderItem={renderItem} />
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import 'components/chain_entities_selector.scss';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+
+import app from 'state';
+import { CWTextInput } from 'views/components/component_kit/cw_text_input';
+import { QueryList } from 'views/components/component_kit/cw_query_list';
+import { useGetCompletedCosmosProposals } from 'hooks/cosmos/useGetCompletedCosmosProposals';
+import {ProposalSelectorItem} from 'views/components/cosmos_proposal_selector/cosmos_proposal_selector_item'
+import { CWText } from '../component_kit/cw_text';
+
+const filterProposals = (ce: CosmosProposal, searchTerm: string) => {
+    return (
+      ce.identifier.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
+      ce.title?.toString().toLowerCase().includes(searchTerm.toLowerCase())
+    );
+};
+
+type ProposalSelectorProps = {
+    proposalsToSet: Array<Pick<CosmosProposal, 'identifier'>>;
+    onSelect: ({ identifier }: { identifier: string }) => void;
+};
+
+export const ProposalSelector = ({
+    onSelect,
+    proposalsToSet,
+  }: ProposalSelectorProps) => {
+    const [loading, setLoading] = useState(false);
+    const [searchTerm, setSearchTerm] = useState('');
+    const { completedCosmosProposals } = useGetCompletedCosmosProposals({
+        app,
+        setIsLoading: setLoading,
+        isLoading: loading,
+    });
+
+    const queryLength = searchTerm?.trim()?.length;
+    const getEmptyContentMessage = () => {
+        if (queryLength > 0 && queryLength < 5) {
+          return 'Query too short';
+        } else if (queryLength >= 5 && !searchTerm.length) {
+          return 'No proposals found';
+        } else if (!completedCosmosProposals?.length) {
+          return 'No currently linked proposals';
+        }
+      };
+    
+    const handleClearButtonClick = () => {
+        setSearchTerm('');
+      };
+    
+    const handleInputChange = (e) => {
+    setSearchTerm(e.target.value);
+    };
+
+    const entities = useMemo(
+    () =>
+        completedCosmosProposals
+        .filter((el) => filterProposals(el, searchTerm)),
+    [completedCosmosProposals, searchTerm]
+    );
+    
+    const renderItem = useCallback(
+        (i: number, proposal: CosmosProposal) => {
+          const isSelected = !!proposalsToSet.find(
+            (el) => String(el.identifier) === proposal.identifier
+          );
+          
+          return (
+            <ProposalSelectorItem
+              proposal={proposal}
+              isSelected={isSelected}
+              onClick={(ce) => onSelect({ identifier: ce.identifier })}
+            />
+          );
+        },
+        [onSelect, proposalsToSet]
+      );
+
+      if (!app.chain || !app.activeChainId()) {
+        return;
+      }
+      console.log(entities)
+      console.log(renderItem)
+
+      const EmptyComponent = () => (
+        <div className="empty-component">{getEmptyContentMessage()}</div>
+      );
+
+      return (
+        <div className="ProposalSelector">
+          <CWTextInput
+            placeholder="Search for an existing proposal..."
+            iconRightonClick={handleClearButtonClick}
+            value={searchTerm}
+            iconRight="close"
+            onInput={handleInputChange}
+          />
+
+          <QueryList loading={loading} options={entities} components={{ EmptyPlaceholder: EmptyComponent }} renderItem={renderItem} />
+        </div>
+    );
+  }

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -18,8 +18,8 @@ const filterProposals = (ce: CosmosProposal, searchTerm: string) => {
 };
 
 type ProposalSelectorProps = {
-  proposalsToSet: Array<Pick<CosmosProposal, 'identifier'>>;
-  onSelect: ({ identifier }: { identifier: string }) => void;
+  proposalsToSet: Array<Pick<CosmosProposal, 'identifier' | 'title'>>;
+  onSelect: ({ identifier }: { identifier: string; title: string }) => void;
 };
 
 export const ProposalSelector = ({
@@ -28,7 +28,7 @@ export const ProposalSelector = ({
 }: ProposalSelectorProps) => {
   const [loadingCompleted, setCompletedLoading] = useState(false);
   const [loadingActive, setActiveLoading] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const { activeCosmosProposals } = useGetActiveCosmosProposals({
     app,
@@ -40,6 +40,10 @@ export const ProposalSelector = ({
     setIsLoading: setCompletedLoading,
     isLoading: loadingCompleted,
   });
+
+  useEffect(() => {
+    setLoading(!(activeCosmosProposals.length > 0));
+  }, [activeCosmosProposals]);
 
   const queryLength = searchTerm?.trim()?.length;
   const getEmptyContentMessage = () => {
@@ -80,7 +84,9 @@ export const ProposalSelector = ({
         <ProposalSelectorItem
           proposal={proposal}
           isSelected={isSelected}
-          onClick={(ce) => onSelect({ identifier: ce.identifier })}
+          onClick={(ce) =>
+            onSelect({ identifier: ce.identifier, title: ce.title })
+          }
         />
       );
     },

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -7,8 +7,8 @@ import app from 'state';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
 import { useGetCompletedCosmosProposals } from 'hooks/cosmos/useGetCompletedCosmosProposals';
-import {ProposalSelectorItem} from 'views/components/cosmos_proposal_selector/cosmos_proposal_selector_item'
-import { CWText } from '../component_kit/cw_text';
+import {ProposalSelectorItem} from 'views/components/cosmos_proposal_selector/cosmos_proposal_selector_item';
+
 
 const filterProposals = (ce: CosmosProposal, searchTerm: string) => {
     return (
@@ -56,6 +56,7 @@ export const ProposalSelector = ({
     const entities = useMemo(
     () =>
         completedCosmosProposals
+        .sort((a, b) => parseInt(b.identifier) - parseInt(a.identifier))
         .filter((el) => filterProposals(el, searchTerm)),
     [completedCosmosProposals, searchTerm]
     );
@@ -80,15 +81,14 @@ export const ProposalSelector = ({
       if (!app.chain || !app.activeChainId()) {
         return;
       }
-      console.log(entities)
-      console.log(renderItem)
+
 
       const EmptyComponent = () => (
         <div className="empty-component">{getEmptyContentMessage()}</div>
       );
 
       return (
-        <div className="ProposalSelector">
+        <div className="ChainEntitiesSelector">
           <CWTextInput
             placeholder="Search for an existing proposal..."
             iconRightonClick={handleClearButtonClick}
@@ -97,7 +97,7 @@ export const ProposalSelector = ({
             onInput={handleInputChange}
           />
 
-          <QueryList loading={loading} options={entities} components={{ EmptyPlaceholder: EmptyComponent }} renderItem={renderItem} />
+          <QueryList loading={loading} options={entities} renderItem={renderItem} />
         </div>
     );
   }

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector.tsx
@@ -7,97 +7,108 @@ import app from 'state';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
 import { useGetCompletedCosmosProposals } from 'hooks/cosmos/useGetCompletedCosmosProposals';
-import {ProposalSelectorItem} from 'views/components/cosmos_proposal_selector/cosmos_proposal_selector_item';
-
+import { useGetActiveCosmosProposals } from 'hooks/cosmos/useGetActiveCosmosProposals';
+import { ProposalSelectorItem } from 'views/components/cosmos_proposal_selector/cosmos_proposal_selector_item';
 
 const filterProposals = (ce: CosmosProposal, searchTerm: string) => {
-    return (
-      ce.identifier.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
-      ce.title?.toString().toLowerCase().includes(searchTerm.toLowerCase())
-    );
+  return (
+    ce.identifier.toString().toLowerCase().includes(searchTerm.toLowerCase()) ||
+    ce.title?.toString().toLowerCase().includes(searchTerm.toLowerCase())
+  );
 };
 
 type ProposalSelectorProps = {
-    proposalsToSet: Array<Pick<CosmosProposal, 'identifier'>>;
-    onSelect: ({ identifier }: { identifier: string }) => void;
+  proposalsToSet: Array<Pick<CosmosProposal, 'identifier'>>;
+  onSelect: ({ identifier }: { identifier: string }) => void;
 };
 
 export const ProposalSelector = ({
-    onSelect,
-    proposalsToSet,
-  }: ProposalSelectorProps) => {
-    const [loading, setLoading] = useState(false);
-    const [searchTerm, setSearchTerm] = useState('');
-    const { completedCosmosProposals } = useGetCompletedCosmosProposals({
-        app,
-        setIsLoading: setLoading,
-        isLoading: loading,
-    });
+  onSelect,
+  proposalsToSet,
+}: ProposalSelectorProps) => {
+  const [loadingCompleted, setCompletedLoading] = useState(false);
+  const [loadingActive, setActiveLoading] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const { activeCosmosProposals } = useGetActiveCosmosProposals({
+    app,
+    setIsLoading: setActiveLoading,
+    isLoading: loadingActive,
+  });
+  const { completedCosmosProposals } = useGetCompletedCosmosProposals({
+    app,
+    setIsLoading: setCompletedLoading,
+    isLoading: loadingCompleted,
+  });
 
-    const queryLength = searchTerm?.trim()?.length;
-    const getEmptyContentMessage = () => {
-        if (queryLength > 0 && queryLength < 5) {
-          return 'Query too short';
-        } else if (queryLength >= 5 && !searchTerm.length) {
-          return 'No proposals found';
-        } else if (!completedCosmosProposals?.length) {
-          return 'No currently linked proposals';
-        }
-      };
-    
-    const handleClearButtonClick = () => {
-        setSearchTerm('');
-      };
-    
-    const handleInputChange = (e) => {
+  const queryLength = searchTerm?.trim()?.length;
+  const getEmptyContentMessage = () => {
+    if (queryLength > 0 && queryLength < 5) {
+      return 'Query too short';
+    } else if (queryLength >= 5 && !searchTerm.length) {
+      return 'No proposals found';
+    } else if (!completedCosmosProposals?.length) {
+      return 'No currently linked proposals';
+    }
+  };
+
+  const handleClearButtonClick = () => {
+    setSearchTerm('');
+  };
+
+  const handleInputChange = (e) => {
     setSearchTerm(e.target.value);
-    };
+  };
 
-    const entities = useMemo(
-    () =>
-        completedCosmosProposals
-        .sort((a, b) => parseInt(b.identifier) - parseInt(a.identifier))
-        .filter((el) => filterProposals(el, searchTerm)),
-    [completedCosmosProposals, searchTerm]
-    );
-    
-    const renderItem = useCallback(
-        (i: number, proposal: CosmosProposal) => {
-          const isSelected = !!proposalsToSet.find(
-            (el) => String(el.identifier) === proposal.identifier
-          );
-          
-          return (
-            <ProposalSelectorItem
-              proposal={proposal}
-              isSelected={isSelected}
-              onClick={(ce) => onSelect({ identifier: ce.identifier })}
-            />
-          );
-        },
-        [onSelect, proposalsToSet]
-      );
+  const entities = useMemo(() => {
+    const allProposals = [
+      ...activeCosmosProposals,
+      ...completedCosmosProposals,
+    ];
+    return allProposals
+      .sort((a, b) => parseInt(b.identifier) - parseInt(a.identifier))
+      .filter((el) => filterProposals(el, searchTerm));
+  }, [activeCosmosProposals, completedCosmosProposals, searchTerm]);
 
-      if (!app.chain || !app.activeChainId()) {
-        return;
-      }
-
-
-      const EmptyComponent = () => (
-        <div className="empty-component">{getEmptyContentMessage()}</div>
+  const renderItem = useCallback(
+    (i: number, proposal: CosmosProposal) => {
+      const isSelected = !!proposalsToSet.find(
+        (el) => String(el.identifier) === proposal.identifier
       );
 
       return (
-        <div className="ChainEntitiesSelector">
-          <CWTextInput
-            placeholder="Search for an existing proposal..."
-            iconRightonClick={handleClearButtonClick}
-            value={searchTerm}
-            iconRight="close"
-            onInput={handleInputChange}
-          />
+        <ProposalSelectorItem
+          proposal={proposal}
+          isSelected={isSelected}
+          onClick={(ce) => onSelect({ identifier: ce.identifier })}
+        />
+      );
+    },
+    [onSelect, proposalsToSet]
+  );
 
-          <QueryList loading={loading} options={entities} renderItem={renderItem} />
-        </div>
-    );
+  if (!app.chain || !app.activeChainId()) {
+    return;
   }
+
+  const EmptyComponent = () => (
+    <div className="empty-component">{getEmptyContentMessage()}</div>
+  );
+
+  return (
+    <div className="ChainEntitiesSelector">
+      <CWTextInput
+        placeholder="Search for an existing proposal..."
+        iconRightonClick={handleClearButtonClick}
+        value={searchTerm}
+        iconRight="close"
+        onInput={handleInputChange}
+      />
+
+      <QueryList
+        loading={loadingActive}
+        options={entities}
+        renderItem={renderItem}
+      />
+    </div>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
@@ -19,7 +19,7 @@ interface ProposalSelectorItemProps {
         <div className="selected">{isSelected && <CWCheck />}</div>
         <div className="text">
           <CWText fontWeight="medium" truncate noWrap>
-            `${proposal.title} #${proposal.identifier}`
+            '`${proposal.title} #${proposal.identifier}`'
           </CWText>
           <CWText type="caption" truncate>
             {proposal.threadTitle !== 'undefined'

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
@@ -19,11 +19,11 @@ interface ProposalSelectorItemProps {
         <div className="selected">{isSelected && <CWCheck />}</div>
         <div className="text">
           <CWText fontWeight="medium" truncate noWrap>
-            '`${proposal.title} #${proposal.identifier}`'
+             #{proposal.identifier} {proposal.title}
           </CWText>
           <CWText type="caption" truncate>
-            {proposal.threadTitle !== 'undefined'
-              ? decodeURIComponent(proposal.threadTitle)
+            {proposal.status.toString() !== 'undefined'
+              ? proposal.status.toString()
               : 'No thread title'}
           </CWText>
         </div>

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+import { CWText } from '../component_kit/cw_text';
+
+interface ProposalSelectorItemProps {
+    proposal: CosmosProposal;
+    isSelected: boolean;
+    onClick: (proposal: CosmosProposal) => void;
+  }
+  
+  const ProposalSelectorItem = ({
+    onClick,
+    proposal,
+    isSelected,
+  }: ProposalSelectorItemProps) => {
+    return (
+      <div className="chain-entity" onClick={() => onClick(proposal)}>
+        <div className="selected">{isSelected && <CWCheck />}</div>
+        <div className="text">
+          <CWText fontWeight="medium" truncate noWrap>
+            `${proposal.title} #${proposal.identifier}`
+          </CWText>
+          <CWText type="caption" truncate>
+            {proposal.threadTitle !== 'undefined'
+              ? decodeURIComponent(proposal.threadTitle)
+              : 'No thread title'}
+          </CWText>
+        </div>
+      </div>
+    );
+  };
+  
+  export { ProposalSelectorItem };

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/cosmos_proposal_selector_item.tsx
@@ -4,31 +4,34 @@ import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1
 import { CWText } from '../component_kit/cw_text';
 
 interface ProposalSelectorItemProps {
-    proposal: CosmosProposal;
-    isSelected: boolean;
-    onClick: (proposal: CosmosProposal) => void;
-  }
-  
-  const ProposalSelectorItem = ({
-    onClick,
-    proposal,
-    isSelected,
-  }: ProposalSelectorItemProps) => {
-    return (
-      <div className="chain-entity" onClick={() => onClick(proposal)}>
-        <div className="selected">{isSelected && <CWCheck />}</div>
-        <div className="text">
-          <CWText fontWeight="medium" truncate noWrap>
-             #{proposal.identifier} {proposal.title}
-          </CWText>
-          <CWText type="caption" truncate>
-            {proposal.status.toString() !== 'undefined'
-              ? proposal.status.toString()
-              : 'No thread title'}
-          </CWText>
-        </div>
+  proposal: CosmosProposal;
+  isSelected: boolean;
+  onClick: (proposal: CosmosProposal) => void;
+}
+
+const ProposalSelectorItem = ({
+  onClick,
+  proposal,
+  isSelected,
+}: ProposalSelectorItemProps) => {
+  return (
+    <div className="chain-entity" onClick={() => onClick(proposal)}>
+      <div className="selected">{isSelected && <CWCheck />}</div>
+      <div className="text">
+        <CWText fontWeight="medium" truncate noWrap>
+          #{proposal.identifier} {proposal.title}
+        </CWText>
+        <CWText type="caption" truncate>
+          {proposal.status.toString() !== 'undefined'
+            ? proposal.status
+                .toString()
+                .replace(/([A-Z])/g, ' $1')
+                .trim()
+            : 'No thread title'}
+        </CWText>
       </div>
-    );
-  };
-  
-  export { ProposalSelectorItem };
+    </div>
+  );
+};
+
+export { ProposalSelectorItem };

--- a/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/cosmos_proposal_selector/index.tsx
@@ -1,0 +1,4 @@
+import { ProposalSelector } from './cosmos_proposal_selector';
+import { ProposalSelectorItem } from './cosmos_proposal_selector_item';
+
+export { ProposalSelector, ProposalSelectorItem };

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -17,7 +17,7 @@ import { Link, LinkSource } from 'models/Thread';
 import { filterLinks, getAddedAndDeleted } from 'helpers/threads';
 import { ProposalSelector } from '../components/cosmos_proposal_selector';
 import { CosmosProposal } from '/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
-import Cosmos from 'client/scripts/controllers/chain/cosmos/adapter';
+import CosmosChain from 'controllers/chain/cosmos/chain';
 
 const getInitialSnapshots = (thread: Thread) =>
   filterLinks(thread.links, LinkSource.Snapshot).map((l) => ({
@@ -31,7 +31,7 @@ const getInitialProposals = (thread: Thread) =>
     title: l.title,
   }));
 
-const getInitialCosmosProposals = (thread: Thread) => 
+const getInitialCosmosProposals = (thread: Thread) =>
   filterLinks(thread.links, LinkSource.Proposal).map((l) => ({
     identifier: l.identifier,
     title: l.title,
@@ -199,7 +199,6 @@ export const UpdateProposalStatusModal = ({
       throw new Error('Failed to update linked proposals');
     }
 
-
     onChangeHandler?.(tempStage, links);
     onModalClose();
   };
@@ -235,16 +234,20 @@ export const UpdateProposalStatusModal = ({
     setVotingStage();
   };
 
-  const handleSelectCosmosProposal = (proposal: {identifier: string}) => {
+  const handleSelectCosmosProposal = (proposal: { identifier: string }) => {
     const isSelected = tempCosmosProposals.find(
       ({ identifier }) => proposal.identifier === String(identifier)
     );
     const updatedProposals = isSelected
-      ? tempCosmosProposals.filter(({ identifier }) => proposal.identifier !== String(identifier))
+      ? tempCosmosProposals.filter(
+          ({ identifier }) => proposal.identifier !== String(identifier)
+        )
       : [...tempCosmosProposals, proposal];
-    setTempCosmosProposals(updatedProposals)
-    setVotingStage();  
-  }
+    setTempCosmosProposals(updatedProposals);
+    setVotingStage();
+  };
+
+  console.log('app.chain', app.chain);
   return (
     <div className="UpdateProposalStatusModal">
       <div className="compact-modal-title">
@@ -279,7 +282,7 @@ export const UpdateProposalStatusModal = ({
             proposalsToSet={tempProposals}
           />
         )}
-        {true && (
+        {app.chain.chain instanceof CosmosChain && (
           <ProposalSelector
             onSelect={handleSelectCosmosProposal}
             proposalsToSet={tempCosmosProposals}

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -75,6 +75,9 @@ export const UpdateProposalStatusModal = ({
       ]
     : parseCustomStages(customStages);
   const showSnapshot = !!app.chain.meta.snapshot?.length;
+  const isCosmos = app.chain?.chain instanceof CosmosChain;
+  const showChainEvents =
+    !isCosmos && app.chainEntities.store.get(thread.chain).length > 0;
 
   const handleSaveChanges = async () => {
     // set stage
@@ -247,7 +250,6 @@ export const UpdateProposalStatusModal = ({
     setVotingStage();
   };
 
-  console.log('app.chain', app.chain);
   return (
     <div className="UpdateProposalStatusModal">
       <div className="compact-modal-title">
@@ -276,13 +278,13 @@ export const UpdateProposalStatusModal = ({
             snapshotProposalsToSet={tempSnapshotProposals}
           />
         )}
-        {app.chainEntities.store.get(thread.chain).length > 0 && (
+        {showChainEvents && (
           <ChainEntitiesSelector
             onSelect={handleSelectChainEntity}
             proposalsToSet={tempProposals}
           />
         )}
-        {app.chain.chain instanceof CosmosChain && (
+        {isCosmos && (
           <ProposalSelector
             onSelect={handleSelectCosmosProposal}
             proposalsToSet={tempCosmosProposals}

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -17,7 +17,7 @@ import { Link, LinkSource } from 'models/Thread';
 import { filterLinks, getAddedAndDeleted } from 'helpers/threads';
 import { ProposalSelector } from '../components/cosmos_proposal_selector';
 import { CosmosProposal } from '/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
-import CosmosChain from 'controllers/chain/cosmos/chain';
+import { ChainBase } from 'common-common/src/types';
 
 const getInitialSnapshots = (thread: Thread) =>
   filterLinks(thread.links, LinkSource.Snapshot).map((l) => ({
@@ -75,7 +75,7 @@ export const UpdateProposalStatusModal = ({
       ]
     : parseCustomStages(customStages);
   const showSnapshot = !!app.chain.meta.snapshot?.length;
-  const isCosmos = app.chain?.chain instanceof CosmosChain;
+  const isCosmos = app.chain.base === ChainBase.CosmosSDK;
   const showChainEvents =
     !isCosmos && app.chainEntities.store.get(thread.chain).length > 0;
 

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -33,7 +33,7 @@ const getInitialProposals = (thread: Thread) =>
 
 const getInitialCosmosProposals = (thread: Thread) => 
   filterLinks(thread.links, LinkSource.Proposal).map((l) => ({
-    identifier: l.identifier.split('/')[1],
+    identifier: l.identifier,
     title: l.title,
   }));
 
@@ -57,7 +57,7 @@ export const UpdateProposalStatusModal = ({
   >(getInitialProposals(thread));
   const [tempCosmosProposals, setTempCosmosProposals] = useState<
     Array<Pick<CosmosProposal, 'identifier'>>
-  >((app.chain as Cosmos).governance.store.getAll() as CosmosProposal[]);
+  >(getInitialCosmosProposals(thread));
 
   if (!app.chain?.meta) {
     return;
@@ -176,7 +176,7 @@ export const UpdateProposalStatusModal = ({
           threadId: thread.id,
           links: toAdd.map(({ identifier }) => ({
             source: LinkSource.Proposal,
-            identifier: String("proposal/" + identifier),
+            identifier: identifier,
           })),
         });
 
@@ -188,7 +188,7 @@ export const UpdateProposalStatusModal = ({
           threadId: thread.id,
           links: toDelete.map(({ identifier }) => ({
             source: LinkSource.Proposal,
-            identifier: String("proposal/" + identifier),
+            identifier: String(identifier),
           })),
         });
 
@@ -245,7 +245,6 @@ export const UpdateProposalStatusModal = ({
     setTempCosmosProposals(updatedProposals)
     setVotingStage();  
   }
-  
   return (
     <div className="UpdateProposalStatusModal">
       <div className="compact-modal-title">
@@ -274,7 +273,7 @@ export const UpdateProposalStatusModal = ({
             snapshotProposalsToSet={tempSnapshotProposals}
           />
         )}
-        {app.chainEntities && (
+        {app.chainEntities.store.get(thread.chain).length > 0 && (
           <ChainEntitiesSelector
             onSelect={handleSelectChainEntity}
             proposalsToSet={tempProposals}

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -56,7 +56,7 @@ export const UpdateProposalStatusModal = ({
     Array<Pick<ChainEntity, 'typeId' | 'title'>>
   >(getInitialProposals(thread));
   const [tempCosmosProposals, setTempCosmosProposals] = useState<
-    Array<Pick<CosmosProposal, 'identifier'>>
+    Array<Pick<CosmosProposal, 'identifier' | 'title'>>
   >(getInitialCosmosProposals(thread));
 
   if (!app.chain?.meta) {
@@ -173,13 +173,14 @@ export const UpdateProposalStatusModal = ({
         getInitialCosmosProposals(thread),
         'identifier'
       );
-
+      console.log(toAdd[0]);
       if (toAdd.length > 0) {
         const updatedThread = await app.threads.addLinks({
           threadId: thread.id,
-          links: toAdd.map(({ identifier }) => ({
+          links: toAdd.map(({ identifier, title }) => ({
             source: LinkSource.Proposal,
             identifier: identifier,
+            title: title,
           })),
         });
 
@@ -237,7 +238,10 @@ export const UpdateProposalStatusModal = ({
     setVotingStage();
   };
 
-  const handleSelectCosmosProposal = (proposal: { identifier: string }) => {
+  const handleSelectCosmosProposal = (proposal: {
+    identifier: string;
+    title: string;
+  }) => {
     const isSelected = tempCosmosProposals.find(
       ({ identifier }) => proposal.identifier === String(identifier)
     );

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -173,7 +173,6 @@ export const UpdateProposalStatusModal = ({
         getInitialCosmosProposals(thread),
         'identifier'
       );
-      console.log(toAdd[0]);
       if (toAdd.length > 0) {
         const updatedThread = await app.threads.addLinks({
           threadId: thread.id,

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -24,6 +24,7 @@ import { filterLinks } from 'helpers/threads';
 
 type LinkedProposalProps = {
   thread: Thread;
+  title: string;
   ceType: ChainEntity['type'];
   ceTypeId: ChainEntity['typeId'];
   ceCompleted?: ChainEntity['completed'];
@@ -31,6 +32,7 @@ type LinkedProposalProps = {
 
 const LinkedProposal = ({
   thread,
+  title,
   ceType,
   ceTypeId,
   ceCompleted,
@@ -43,7 +45,7 @@ const LinkedProposal = ({
 
   return (
     <a href={threadLink}>
-      {`${chainEntityTypeToProposalName(ceType)} #${ceTypeId} ${
+      {`${title ?? chainEntityTypeToProposalName(ceType)} #${ceTypeId} ${
         ceCompleted ? ' (Completed)' : ''
       }`}
     </a>
@@ -127,6 +129,7 @@ export const LinkedProposalsCard = ({
                           <LinkedProposal
                             key={l.identifier}
                             thread={thread}
+                            title={l.title}
                             ceType={'proposal' as IChainEntityKind}
                             ceTypeId={l.identifier}
                           />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3674 

## Description of Changes
- Adds `ProposalSelector` component to `update_proposal_status_modal.tsx` to replace `chainEntitySelector` for cosmos proposals
- unique cosmos link builder
- Changes to pull cosmos proposals through to the modal

## Test Plan
- Ensure expected cosmos proposals render in modal
- Select proposal and ensure links appear on thread
- delete links 


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- There was an issue with clicking the link to the proposal and 'Proposal Not Found' which was determined to be out of scope for this PR