### PR TITLE
Reactify view proposal page.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
@@ -95,6 +95,24 @@ class CosmosGovernanceV1 extends ProposalModule<
     this._initialized = true;
   }
 
+  public async getProposal(proposalId: number): Promise<CosmosProposalV1> {
+    const existingProposal = this.store.getByIdentifier(proposalId);
+    if (existingProposal) {
+      return existingProposal;
+    }
+    const { proposal } = await this._Chain.lcd.cosmos.gov.v1.proposal({
+      proposalId: numberToLong(proposalId),
+    });
+    const cosmosProp = new CosmosProposalV1(
+      this._Chain,
+      this._Accounts,
+      this,
+      propToIProposal(proposal)
+    );
+    await cosmosProp.init();
+    return cosmosProp;
+  }
+
   private async _initProposals(proposalId?: number): Promise<void> {
     let cosmosProposals: CosmosProposalV1[] = [];
     try {

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -80,6 +80,22 @@ class CosmosGovernance extends ProposalModule<
     this._initialized = true;
   }
 
+  public async getProposal(proposalId: number): Promise<CosmosProposal> {
+    const existingProposal = this.store.getByIdentifier(proposalId);
+    if (existingProposal) {
+      return existingProposal;
+    }
+    const { proposal } = await this._Chain.api.gov.proposal(proposalId);
+    const cosmosProp = new CosmosProposal(
+      this._Chain,
+      this._Accounts,
+      this,
+      msgToIProposal(proposal)
+    );
+    await cosmosProp.init();
+    return cosmosProp;
+  }
+
   private async _initProposals(proposalId?: number): Promise<void> {
     let cosmosProposals: CosmosProposal[];
     if (!proposalId) {

--- a/packages/commonwealth/client/scripts/controllers/chain/substrate/democracy_referendum.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/substrate/democracy_referendum.ts
@@ -333,9 +333,8 @@ export class SubstrateDemocracyReferendum extends Proposal<
     }
 
     console.log(
-      'could not find:',
-      this.hash,
-      chain.democracyProposals?.store.getAll().map((c) => c.hash)
+      'could not find matching proposal or motion for referendum: ',
+      this.identifier
     );
     return undefined;
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/substrate/shared.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/substrate/shared.ts
@@ -265,7 +265,8 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
   }
 
   // load existing events and subscribe to future via client node connection
-  public initChainEntities(): Promise<void> {
+  public async initChainEntities(): Promise<void> {
+    await this._app.chainEntities.refresh(this.app.chain.id);
     const subscriber = new SubstrateEvents.Subscriber(this.api);
     const processor = new SubstrateEvents.Processor(this.api);
     return this._app.chainEntities.subscribeEntities(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3701 
Closes: #3704 
Closes: #3683

## Description of Changes
- Reactified the ViewProposal page (incl: removing unused logic around prefetching etc).
- Fixed substrate init flow (regression from #3623).

## Test Plan
- Verify proposals on Edgeware, Osmosis, dYdX, and auroradao.sputnik-dao.near load both directly and from the proposals page.
- Verify the proposals, referenda, tips, and treasury pages load correctly on Edgeware, both from sidebar and when landed on directly (sidebar may be broken still!).
