### PR TITLE
Hotfix admin permissioning.

### DIFF
--- a/packages/commonwealth/server/util/linkingValidationHelper.ts
+++ b/packages/commonwealth/server/util/linkingValidationHelper.ts
@@ -35,7 +35,7 @@ export const isAuthorOrAdmin = async (
     const role = roles.find((r) => {
       return r.chain_id === chain;
     });
-    if (!role) return false;
+    return !!role;
   } else {
     return true;
   }


### PR DESCRIPTION
## Description of Changes
- `isAuthorOrAdmin` was returning false for admins/moderators who aren't authors. This fix ensures admins can properly perform admin functionality.

## Test Plan
- Verify admins can link on threads they didn't create.