### PR TITLE
Switch Rollbar environment to `ROLLBAR_ENV`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,8 @@
 name: CI
+
+env:
+  ROLLBAR_ENV: 'GitHubCI'
+
 on: [push]
 
 jobs:
@@ -137,14 +141,14 @@ jobs:
 
       - name: Run linter
         run: yarn lint-all
-        
+
       - name: Start EVM Testnet
         run: |
           /usr/bin/docker pull trufflesuite/ganache;
           network_name=$(docker inspect -f '{{.HostConfig.NetworkMode}}' ${{ job.services.evm_test_app.id }})
           echo "Network name: $network_name"
           /usr/bin/docker run -d --name chain --network $network_name --network-alias chain -p 8545:8545 -e GITHUB_ACTIONS=true -e CI=true trufflesuite/ganache --fork --miner.blockTime 12 --wallet.unlockedAccounts 0xF977814e90dA44bFA03b6295A0616a897441aceC --wallet.unlockedAccounts 0xfA9b5f7fDc8AB34AAf3099889475d47febF830D7 --wallet.unlockedAccounts 0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8;
-          
+
       - name: Run Token Balance Cache Unit Tests
         run: yarn --cwd packages/token-balance-cache test
 
@@ -161,6 +165,6 @@ jobs:
 
       - name: Typecheck
         run: yarn --cwd packages/commonwealth check-types
-      
+
       - name: Stop EVM Chain
         run: docker stop chain

--- a/packages/chain-events/services/ChainEventsConsumer/chainEventsConsumer.ts
+++ b/packages/chain-events/services/ChainEventsConsumer/chainEventsConsumer.ts
@@ -11,7 +11,7 @@ import Rollbar from 'rollbar';
 import { SubstrateTypes } from 'chain-events/src/types';
 
 import models from '../database/database';
-import { RABBITMQ_URI, ROLLBAR_SERVER_TOKEN } from '../config';
+import {RABBITMQ_URI, ROLLBAR_ENV, ROLLBAR_SERVER_TOKEN} from '../config';
 
 import EventStorageHandler from './ChainEventHandlers/storage';
 import NotificationsHandler from './ChainEventHandlers/notification';
@@ -39,7 +39,7 @@ export async function setupChainEventConsumer(): Promise<ServiceConsumer> {
   if (ROLLBAR_SERVER_TOKEN) {
     rollbar = new Rollbar({
       accessToken: ROLLBAR_SERVER_TOKEN,
-      environment: process.env.NODE_ENV,
+      environment: ROLLBAR_ENV,
       captureUncaught: true,
       captureUnhandledRejections: true,
     });

--- a/packages/chain-events/services/ChainSubscriber/chainSubscriber.ts
+++ b/packages/chain-events/services/ChainSubscriber/chainSubscriber.ts
@@ -20,7 +20,7 @@ import {
   RABBITMQ_URI,
   REPEAT_TIME,
   ROLLBAR_SERVER_TOKEN,
-  CHAIN_SUBSCRIBER_INDEX,
+  CHAIN_SUBSCRIBER_INDEX, ROLLBAR_ENV,
 } from '../config';
 
 import {
@@ -229,7 +229,7 @@ export async function chainEventsSubscriberInitializer(): Promise<{
   if (ROLLBAR_SERVER_TOKEN) {
     rollbar = new Rollbar({
       accessToken: ROLLBAR_SERVER_TOKEN,
-      environment: process.env.NODE_ENV,
+      environment: ROLLBAR_ENV,
       captureUncaught: true,
       captureUnhandledRejections: true,
     });

--- a/packages/chain-events/services/config.ts
+++ b/packages/chain-events/services/config.ts
@@ -37,6 +37,8 @@ export const RABBITMQ_API_URI = (() => {
 
 export const ROLLBAR_SERVER_TOKEN = process.env.ROLLBAR_SERVER_TOKEN;
 
+export const ROLLBAR_ENV = process.env.ROLLBAR_ENV || 'local';
+
 // ----------------- ChainSubscriber specific var ------------------------
 export const CHAIN_SUBSCRIBER_INDEX = process.env.CHAIN_SUBSCRIBER_INDEX
   ? Number(process.env.CHAIN_SUBSCRIBER_INDEX)

--- a/packages/commonwealth/server-test.ts
+++ b/packages/commonwealth/server-test.ts
@@ -19,7 +19,7 @@ import favicon from 'serve-favicon';
 import setupAPI from './server/routing/router'; // performance note: this takes 15 seconds
 import { TokenBalanceCache } from 'token-balance-cache/src/index';
 
-import { ROLLBAR_SERVER_TOKEN, SESSION_SECRET } from './server/config';
+import {ROLLBAR_ENV, ROLLBAR_SERVER_TOKEN, SESSION_SECRET} from './server/config';
 import models from './server/database';
 import DatabaseValidationService from './server/middleware/databaseValidationService';
 import setupPassport from './server/passport';
@@ -425,7 +425,7 @@ setupCosmosProxy(app, models);
 
 const rollbar = new Rollbar({
   accessToken: ROLLBAR_SERVER_TOKEN,
-  environment: process.env.NODE_ENV,
+  environment: ROLLBAR_ENV,
   captureUncaught: true,
   captureUnhandledRejections: true,
 });

--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -23,7 +23,7 @@ import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import setupErrorHandlers from '../common-common/src/scripts/setupErrorHandlers';
 import {
-  RABBITMQ_URI,
+  RABBITMQ_URI, ROLLBAR_ENV,
   ROLLBAR_SERVER_TOKEN,
   SESSION_SECRET,
 } from './server/config';
@@ -230,7 +230,7 @@ async function main() {
 
   const rollbar = new Rollbar({
     accessToken: ROLLBAR_SERVER_TOKEN,
-    environment: process.env.NODE_ENV,
+    environment: ROLLBAR_ENV,
     captureUncaught: true,
     captureUnhandledRejections: true,
   });

--- a/packages/commonwealth/server/CommonwealthConsumer/CommonwealthConsumer.ts
+++ b/packages/commonwealth/server/CommonwealthConsumer/CommonwealthConsumer.ts
@@ -8,7 +8,7 @@ import type { BrokerConfig } from 'rascal';
 import { factory, formatFilename } from 'common-common/src/logging';
 import { RascalSubscriptions } from 'common-common/src/rabbitmq/types';
 import Rollbar from 'rollbar';
-import { RABBITMQ_URI, ROLLBAR_SERVER_TOKEN } from '../config';
+import {RABBITMQ_URI, ROLLBAR_ENV, ROLLBAR_SERVER_TOKEN} from '../config';
 import models from '../database';
 import { processChainEntityCUD } from './messageProcessors/chainEntityCUDQueue';
 import { processChainEventNotificationsCUD } from './messageProcessors/chainEventNotificationsCUDQueue';
@@ -19,7 +19,7 @@ const log = factory.getLogger(formatFilename(__filename));
 export async function setupCommonwealthConsumer(): Promise<ServiceConsumer> {
   const rollbar = new Rollbar({
     accessToken: ROLLBAR_SERVER_TOKEN,
-    environment: process.env.NODE_ENV,
+    environment: ROLLBAR_ENV,
     captureUncaught: true,
     captureUnhandledRejections: true,
   });

--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -32,6 +32,8 @@ export const ADDRESS_TOKEN_EXPIRES_IN = 10;
 
 export const ROLLBAR_SERVER_TOKEN = process.env.ROLLBAR_SERVER_TOKEN;
 
+export const ROLLBAR_ENV = process.env.ROLLBAR_ENV || 'local';
+
 export const SLACK_FEEDBACK_WEBHOOK = process.env.SLACK_FEEDBACK_WEBHOOK;
 
 export const SLACK_WEBHOOKS = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3726

## Description of Changes
- Creates the ROLLBAR_ENV config variable. ROLLBAR_ENV defaults to 'local' if undefined.
- Replaced `process.env.NODE_ENV` with `ROLLBAR_ENV` when initializing Rollbar.

## Test Plan
- Set the `ROLLBAR_ENV` locally in `.env` file and generate errors. The errors should be reported under the matching environment on Rollbar.

## Deployment Plan
<!--- Omit if unneeded -->
1. Set `ROLLBAR_ENV` in all Heroku environments.
1. Deploy to chain-events
2. Deploy to commonwealthapp

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->