### PR TITLE
[WIP] React x Zustand - research

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/gatedTopic.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/gatedTopic.ts
@@ -1,12 +1,12 @@
 import BN from 'bn.js';
 import { ITokenAdapter } from 'models';
 import app from 'state';
-import { vanillaStore } from 'stores/zustand';
+import { appStore } from 'stores/zustand';
 
 export default class TopicGateCheck {
   public static isGatedTopic(topicName: string): boolean {
     if (ITokenAdapter.instanceOf(app.chain) && topicName) {
-      const tokenPostingThreshold: BN = vanillaStore
+      const tokenPostingThreshold: BN = appStore
         .getState()
         .getByName(topicName, app.activeChainId())?.tokenThreshold;
       return (
@@ -19,7 +19,7 @@ export default class TopicGateCheck {
 
   public static getTopicThreshold(topicName: string): BN {
     if (ITokenAdapter.instanceOf(app.chain) && topicName) {
-      return vanillaStore.getState().getByName(topicName, app.activeChainId())
+      return appStore.getState().getByName(topicName, app.activeChainId())
         ?.tokenThreshold;
     }
     return new BN('0', 10);

--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/gatedTopic.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/gatedTopic.ts
@@ -1,14 +1,14 @@
 import BN from 'bn.js';
 import { ITokenAdapter } from 'models';
 import app from 'state';
+import { vanillaStore } from 'stores/zustand';
 
 export default class TopicGateCheck {
   public static isGatedTopic(topicName: string): boolean {
     if (ITokenAdapter.instanceOf(app.chain) && topicName) {
-      const tokenPostingThreshold: BN = app.topics.getByName(
-        topicName,
-        app.activeChainId()
-      )?.tokenThreshold;
+      const tokenPostingThreshold: BN = vanillaStore
+        .getState()
+        .getByName(topicName, app.activeChainId())?.tokenThreshold;
       return (
         tokenPostingThreshold &&
         tokenPostingThreshold.gt(app.chain.tokenBalance)
@@ -19,7 +19,7 @@ export default class TopicGateCheck {
 
   public static getTopicThreshold(topicName: string): BN {
     if (ITokenAdapter.instanceOf(app.chain) && topicName) {
-      return app.topics.getByName(topicName, app.activeChainId())
+      return vanillaStore.getState().getByName(topicName, app.activeChainId())
         ?.tokenThreshold;
     }
     return new BN('0', 10);

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -197,7 +197,6 @@ class ThreadsController {
     let topicFromStore = null;
     if (topic?.id) {
       topicFromStore = vanillaStore.getState().getByIdentifier(topic.id);
-      // topicFromStore = app.topics.store.getById(topic.id);
     }
 
     let decodedTitle;
@@ -702,7 +701,6 @@ class ThreadsController {
         ? this.listingStore.getCutoffDate(options).toISOString()
         : moment().toISOString(),
     };
-    // const topicId = app.topics.getByName(topicName, chain)?.id;
     const topicId = vanillaStore.getState().getByName(topicName, chain)?.id;
 
     if (topicId) params['topic_id'] = topicId;

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -25,7 +25,7 @@ import { orderDiscussionsbyLastComment } from 'views/pages/discussions/helpers';
 import { EventEmitter } from 'events';
 import { Link, LinkSource } from 'server/models/thread';
 import axios from 'axios';
-import { vanillaStore } from 'stores/zustand';
+import { appStore } from 'stores/zustand';
 
 export const INITIAL_PAGE_SIZE = 10;
 export const DEFAULT_PAGE_SIZE = 20;
@@ -196,7 +196,7 @@ class ThreadsController {
 
     let topicFromStore = null;
     if (topic?.id) {
-      topicFromStore = vanillaStore.getState().getByIdentifier(topic.id);
+      topicFromStore = appStore.getState().getByIdentifier(topic.id);
     }
 
     let decodedTitle;
@@ -701,7 +701,7 @@ class ThreadsController {
         ? this.listingStore.getCutoffDate(options).toISOString()
         : moment().toISOString(),
     };
-    const topicId = vanillaStore.getState().getByName(topicName, chain)?.id;
+    const topicId = appStore.getState().getByName(topicName, chain)?.id;
 
     if (topicId) params['topic_id'] = topicId;
     if (stageName) params['stage'] = stageName;

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -25,6 +25,7 @@ import { orderDiscussionsbyLastComment } from 'views/pages/discussions/helpers';
 import { EventEmitter } from 'events';
 import { Link, LinkSource } from 'server/models/thread';
 import axios from 'axios';
+import { vanillaStore } from 'stores/zustand';
 
 export const INITIAL_PAGE_SIZE = 10;
 export const DEFAULT_PAGE_SIZE = 20;
@@ -195,7 +196,8 @@ class ThreadsController {
 
     let topicFromStore = null;
     if (topic?.id) {
-      topicFromStore = app.topics.store.getById(topic.id);
+      topicFromStore = vanillaStore.getState().getByIdentifier(topic.id);
+      // topicFromStore = app.topics.store.getById(topic.id);
     }
 
     let decodedTitle;
@@ -700,7 +702,8 @@ class ThreadsController {
         ? this.listingStore.getCutoffDate(options).toISOString()
         : moment().toISOString(),
     };
-    const topicId = app.topics.getByName(topicName, chain)?.id;
+    // const topicId = app.topics.getByName(topicName, chain)?.id;
+    const topicId = vanillaStore.getState().getByName(topicName, chain)?.id;
 
     if (topicId) params['topic_id'] = topicId;
     if (stageName) params['stage'] = stageName;

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -10,7 +10,7 @@ import type { Account, ProposalModule } from '.';
 import { setDarkMode } from '../helpers';
 import type ChainInfo from './ChainInfo';
 import type { IAccountsModule, IBlockInfo, IChainModule } from './interfaces';
-import { vanillaStore } from 'stores/zustand';
+import { appStore } from 'stores/zustand';
 
 // Extended by a chain's main implementation. Responsible for module
 // initialization. Saved as `app.chain` in the global object store.
@@ -81,7 +81,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
       contractsWithTemplatesData,
       communityRoles,
     } = response.result;
-    vanillaStore.getState().initialize(topics);
+    appStore.getState().initialize(topics);
     this.app.threads.initialize(pinnedThreads, numVotingThreads, true);
     this.meta.setAdmins(admins);
     this.app.recentActivity.setMostActiveUsers(activeUsers);

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -81,7 +81,6 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
       contractsWithTemplatesData,
       communityRoles,
     } = response.result;
-    // this.app.topics.initialize(topics, true);
     vanillaStore.getState().initialize(topics);
     this.app.threads.initialize(pinnedThreads, numVotingThreads, true);
     this.meta.setAdmins(admins);

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -2,7 +2,6 @@ import type { Coin } from 'adapters/currency';
 import type { ChainBase } from 'common-common/src/types';
 import $ from 'jquery';
 
-import { redraw } from 'mithrilInterop';
 import moment from 'moment';
 import type { IApp } from 'state';
 import { ApiStatus } from 'state';
@@ -11,6 +10,7 @@ import type { Account, ProposalModule } from '.';
 import { setDarkMode } from '../helpers';
 import type ChainInfo from './ChainInfo';
 import type { IAccountsModule, IBlockInfo, IChainModule } from './interfaces';
+import { vanillaStore } from 'stores/zustand';
 
 // Extended by a chain's main implementation. Responsible for module
 // initialization. Saved as `app.chain` in the global object store.
@@ -81,7 +81,8 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
       contractsWithTemplatesData,
       communityRoles,
     } = response.result;
-    this.app.topics.initialize(topics, true);
+    // this.app.topics.initialize(topics, true);
+    vanillaStore.getState().initialize(topics);
     this.app.threads.initialize(pinnedThreads, numVotingThreads, true);
     this.meta.setAdmins(admins);
     this.app.recentActivity.setMostActiveUsers(activeUsers);

--- a/packages/commonwealth/client/scripts/stores/zustand/index.ts
+++ b/packages/commonwealth/client/scripts/stores/zustand/index.ts
@@ -3,10 +3,12 @@ import { createStore } from 'zustand/vanilla';
 
 import createTopicsSlice, { TopicsSlice } from './topics';
 
-export const vanillaStore = createStore<TopicsSlice>((...args) => ({
+// appStore can be imported and used outside the React context
+export const appStore = createStore<TopicsSlice>((...args) => ({
   ...createTopicsSlice(...args),
 }));
 
-const useAppStore = create(vanillaStore);
+// useAppStore can be imported and used only inside the React functional components
+const useAppStore = create(appStore);
 
 export default useAppStore;

--- a/packages/commonwealth/client/scripts/stores/zustand/index.ts
+++ b/packages/commonwealth/client/scripts/stores/zustand/index.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import { createStore } from 'zustand/vanilla';
+
+import createTopicsSlice, { TopicsSlice } from './topics';
+
+export const vanillaStore = createStore<TopicsSlice>((...args) => ({
+  ...createTopicsSlice(...args),
+}));
+
+const useAppStore = create(vanillaStore);
+
+export default useAppStore;

--- a/packages/commonwealth/client/scripts/stores/zustand/sidebar.ts
+++ b/packages/commonwealth/client/scripts/stores/zustand/sidebar.ts
@@ -1,0 +1,27 @@
+import { create, StateCreator } from 'zustand';
+import { SidebarMenuName } from 'views/components/sidebar';
+import { createStore } from 'zustand/vanilla';
+
+export interface SidebarSlice {
+  menuName: SidebarMenuName;
+  toggled: boolean;
+  toggle: (val: boolean) => void;
+  setMenu: (menuName: SidebarMenuName) => void;
+}
+
+const createSidebarSlice: StateCreator<SidebarSlice, [], [], SidebarSlice> = (
+  set,
+) => ({
+  menuName: 'default',
+  toggled: false,
+  toggle: (val) => set(() => ({ toggled: val })),
+  setMenu: (menuName) => set(() => ({ menuName })),
+});
+
+export const sidebarStore = createStore<SidebarSlice>((...args) => ({
+  ...createSidebarSlice(...args),
+}));
+
+const useSidebarStore = create(sidebarStore);
+
+export default useSidebarStore;

--- a/packages/commonwealth/client/scripts/stores/zustand/topics.ts
+++ b/packages/commonwealth/client/scripts/stores/zustand/topics.ts
@@ -33,10 +33,6 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
   get
 ) => ({
   topics: [],
-  initialize: (initialTopics) => {
-    const initializedTopics = initialTopics.map((t) => new Topic(t));
-    set({ topics: initializedTopics });
-  },
   getByIdentifier: (identifier: number) =>
     get().topics.find((t) => t.id === identifier),
   getByCommunity: (communityId: string) =>
@@ -45,6 +41,10 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
     get()
       .getByCommunity(communityId)
       .find((t) => t.name === name),
+  initialize: (initialTopics) => {
+    const initializedTopics = initialTopics.map((t) => new Topic(t));
+    set({ topics: initializedTopics });
+  },
   addTopic: async (
     name: string,
     description: string,
@@ -65,6 +65,7 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
       jwt: app.user.jwt,
       token_threshold: tokenThreshold,
     });
+
     const result = new Topic(response.result);
 
     set((prev) => ({ topics: [...prev.topics, result] }));
@@ -84,12 +85,14 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
       jwt: app.user.jwt,
     });
     const result = new Topic(response.result);
+
     const updatedTopics = get().topics.map((t) => {
       if (t.id === result.id) {
         return result;
       }
       return t;
     });
+
     set({ topics: updatedTopics });
   },
   removeTopic: async (topic: Partial<Topic>) => {
@@ -98,7 +101,9 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
       chain: topic.chainId,
       jwt: app.user.jwt,
     });
+
     const updatedTopics = get().topics.filter((t) => t.id !== topic.id);
+
     set({ topics: updatedTopics });
   },
   updateTopic: async (
@@ -113,14 +118,18 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
       topic_name: topicName,
       address: app.user.activeAccount.address,
     });
+
     const result = new Topic(response.result);
+
     const updatedTopics = get().topics.map((t) => {
       if (t.id === result.id) {
         return result;
       }
       return t;
     });
+
     set({ topics: updatedTopics });
+
     return result;
   },
   updateFeaturedOrder: async (featuredTopics: Topic[]) => {
@@ -141,6 +150,7 @@ const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
       }
       return topic;
     });
+
     set({ topics: updatedTopics });
   },
 });

--- a/packages/commonwealth/client/scripts/stores/zustand/topics.ts
+++ b/packages/commonwealth/client/scripts/stores/zustand/topics.ts
@@ -1,0 +1,100 @@
+import { StateCreator } from 'zustand';
+import { Topic } from '../../models';
+import $ from 'jquery';
+import app from 'state';
+
+export interface TopicsSlice {
+  topics: Topic[];
+  initialize: (initialTopics: any) => void;
+  getByIdentifier: (identifier: number) => Topic | undefined;
+  getByCommunity: (communityId: string) => Topic[];
+  getByName: (name: string, communityId: string) => Topic | undefined;
+  addTopic: (
+    name: string,
+    description: string,
+    telegram: string,
+    featuredInSidebar: boolean,
+    featuredInNewPost: boolean,
+    tokenThreshold: string,
+    defaultOffchainTemplate: string
+  ) => void;
+  editTopic: (topic: Topic, featuredOrder?: number) => void;
+  removeTopic: (topic: Topic) => void;
+}
+
+const createTopicsSlice: StateCreator<TopicsSlice, [], [], TopicsSlice> = (
+  set,
+  get
+) => ({
+  topics: [],
+  initialize: (initialTopics) => {
+    const initializedTopics = initialTopics.map((t) => new Topic(t));
+    set({ topics: initializedTopics });
+  },
+  getByIdentifier: (identifier: number) =>
+    get().topics.find((t) => t.id === identifier),
+  getByCommunity: (communityId: string) =>
+    get().topics.filter((t) => t.chainId === communityId),
+  getByName: (name: string, communityId: string) =>
+    get()
+      .getByCommunity(communityId)
+      .find((t) => t.name === name),
+  addTopic: async (
+    name: string,
+    description: string,
+    telegram: string,
+    featuredInSidebar: boolean,
+    featuredInNewPost: boolean,
+    tokenThreshold: string,
+    defaultOffchainTemplate: string
+  ) => {
+    const response = await $.post(`${app.serverUrl()}/createTopic`, {
+      chain: app.activeChainId(),
+      name,
+      description,
+      telegram,
+      featured_in_sidebar: featuredInSidebar,
+      featured_in_new_post: featuredInNewPost,
+      default_offchain_template: defaultOffchainTemplate,
+      jwt: app.user.jwt,
+      token_threshold: tokenThreshold,
+    });
+    const result = new Topic(response.result);
+
+    set((prev) => ({ topics: [...prev.topics, result] }));
+  },
+  editTopic: async (topic: Topic, featuredOrder?: number) => {
+    const response = await $.post(`${app.serverUrl()}/editTopic`, {
+      id: topic.id,
+      chain: topic.chainId,
+      name: topic.name,
+      description: topic.description,
+      telegram: topic.telegram,
+      featured_in_sidebar: topic.featuredInSidebar,
+      featured_in_new_post: topic.featuredInNewPost,
+      default_offchain_template: topic.defaultOffchainTemplate,
+      featured_order: featuredOrder,
+      address: app.user.activeAccount.address,
+      jwt: app.user.jwt,
+    });
+    const result = new Topic(response.result);
+    const updatedTopics = get().topics.map((t) => {
+      if (t.id === result.id) {
+        return result;
+      }
+      return t;
+    });
+    set({ topics: updatedTopics });
+  },
+  removeTopic: async (topic: Partial<Topic>) => {
+    await $.post(`${app.serverUrl()}/deleteTopic`, {
+      id: topic.id,
+      chain: topic.chainId,
+      jwt: app.user.jwt,
+    });
+    const updatedTopics = get().topics.filter((t) => t.id !== topic.id);
+    set({ topics: updatedTopics });
+  },
+});
+
+export default createTopicsSlice;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -14,6 +14,7 @@ import { getClasses } from './helpers';
 import type { MenuItem } from './types';
 import { ComponentType } from './types';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 type CWSidebarMenuItemProps = {
   isStarred?: boolean;
@@ -22,6 +23,10 @@ type CWSidebarMenuItemProps = {
 export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
   const navigate = useCommonNavigate();
   const [isStarred, setIsStarred] = useState<boolean>(!!props.isStarred);
+  const [toggleSidebar, setMenuName] = useSidebarStore((s) => [
+    s.toggle,
+    s.setMenu,
+  ]);
 
   if (props.type === 'default') {
     const { disabled, iconLeft, iconRight, isSecondary, label, onClick } =
@@ -62,9 +67,8 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          app.sidebarToggled = false;
-          app.sidebarMenu = 'default';
-          app.sidebarRedraw.emit('redraw');
+          toggleSidebar(false);
+          setMenuName('default');
           navigateToCommunity({
             navigate,
             path: '/',
@@ -112,6 +116,10 @@ type SidebarMenuProps = {
 export const CWSidebarMenu = (props: SidebarMenuProps) => {
   const { className, menuHeader, menuItems } = props;
   const navigate = useCommonNavigate();
+  const [toggleSidebar, setMenuName] = useSidebarStore((s) => [
+    s.toggle,
+    s.setMenu,
+  ]);
 
   return (
     <div
@@ -158,9 +166,8 @@ export const CWSidebarMenu = (props: SidebarMenuProps) => {
             label: 'Explore communities',
             iconLeft: 'compass',
             onClick: () => {
-              app.sidebarToggled = false;
-              app.sidebarMenu = 'default';
-              app.sidebarRedraw.emit('redraw');
+              toggleSidebar(false);
+              setMenuName('default');
               navigate('/communities', {}, null);
             },
           },
@@ -169,9 +176,8 @@ export const CWSidebarMenu = (props: SidebarMenuProps) => {
             label: 'Notification settings',
             iconLeft: 'person',
             onClick: () => {
-              app.sidebarToggled = false;
-              app.sidebarMenu = 'default';
-              app.sidebarRedraw.emit('redraw');
+              toggleSidebar(false);
+              setMenuName('default');
               navigate('/notification-settings');
             },
           } as MenuItem,

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/helpers/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/helpers/helpers.ts
@@ -5,7 +5,7 @@ import app from 'state';
 import type { NewThreadFormType } from '../types';
 import { NewThreadErrors } from '../types';
 import { notifyError } from 'controllers/app/notifications';
-import { vanillaStore } from 'stores/zustand';
+import { appStore } from 'stores/zustand';
 
 export const checkNewThreadErrors = (
   { threadTitle, threadKind, threadTopic, threadUrl }: NewThreadFormType,
@@ -31,7 +31,7 @@ export const updateTopicList = (
   chain: IChainAdapter<any, any>
 ) => {
   try {
-    const topicNames = vanillaStore
+    const topicNames = appStore
       .getState()
       .getByCommunity(chain.id)
       .map((t) => t.name);

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/helpers/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/helpers/helpers.ts
@@ -5,6 +5,7 @@ import app from 'state';
 import type { NewThreadFormType } from '../types';
 import { NewThreadErrors } from '../types';
 import { notifyError } from 'controllers/app/notifications';
+import { vanillaStore } from 'stores/zustand';
 
 export const checkNewThreadErrors = (
   { threadTitle, threadKind, threadTopic, threadUrl }: NewThreadFormType,
@@ -30,7 +31,11 @@ export const updateTopicList = (
   chain: IChainAdapter<any, any>
 ) => {
   try {
-    const topicNames = app.topics.getByCommunity(chain.id).map((t) => t.name);
+    const topicNames = vanillaStore
+      .getState()
+      .getByCommunity(chain.id)
+      .map((t) => t.name);
+
     if (!topicNames.includes(topic.name)) {
       app.topics.store.add(topic);
     }

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
@@ -34,7 +34,6 @@ export const NewThreadForm = () => {
   const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
 
   const chainId = app.chain.id;
-  // const hasTopics = !!app.topics.getByCommunity(chainId).length;
   const hasTopics = getByCommunity(chainId).length;
   const author = app.user.activeAccount;
   const { authorName } = useAuthorName();

--- a/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
+++ b/packages/commonwealth/client/scripts/views/components/new_thread_form/new_thread_form.tsx
@@ -27,17 +27,20 @@ import {
   getTextFromDelta,
   serializeDelta,
 } from '../react_quill_editor/utils';
+import useAppStore from 'stores/zustand';
 
 export const NewThreadForm = () => {
   const navigate = useCommonNavigate();
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
 
   const chainId = app.chain.id;
-  const hasTopics = !!app.topics.getByCommunity(chainId).length;
+  // const hasTopics = !!app.topics.getByCommunity(chainId).length;
+  const hasTopics = getByCommunity(chainId).length;
   const author = app.user.activeAccount;
   const { authorName } = useAuthorName();
   const isAdmin = app.roles.isAdminOfEntity({ chain: chainId });
 
-  const topicsForSelector = app.topics?.getByCommunity(chainId)?.filter((t) => {
+  const topicsForSelector = getByCommunity(chainId)?.filter((t) => {
     return (
       isAdmin ||
       t.tokenThreshold.isZero() ||

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -16,6 +16,7 @@ import type {
   ToggleTree,
 } from './types';
 import { useCommonNavigate } from 'navigation/helpers';
+import useAppStore from 'stores/zustand';
 
 function setDiscussionsToggleTree(path: string, toggle: boolean) {
   let currentTree = JSON.parse(
@@ -37,6 +38,7 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
 
 export const DiscussionSection = () => {
   const navigate = useCommonNavigate();
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
 
   // Conditional Render Details +
   const onAllDiscussionPage = (p) => {
@@ -86,8 +88,7 @@ export const DiscussionSection = () => {
   const onSputnikDaosPage = (p) =>
     p.startsWith(`/${app.activeChainId()}/sputnik-daos`);
 
-  const topics = app.topics.store
-    .getByCommunity(app.activeChainId())
+  const topics = getByCommunity(app.activeChainId())
     .filter((t) => t.featuredInSidebar)
     .sort((a, b) => a.name.localeCompare(b.name))
     .sort((a, b) => a.order - b.order);

--- a/packages/commonwealth/client/scripts/views/components/sidebar/explore_sidebar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/explore_sidebar.tsx
@@ -6,8 +6,13 @@ import { ChainInfo } from 'models';
 import app from 'state';
 import { CWSidebarMenu } from '../component_kit/cw_sidebar_menu';
 import type { MenuItem } from '../component_kit/types';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 export const ExploreCommunitiesSidebar = () => {
+  const [toggleSidebar, setMenuName] = useSidebarStore((s) => [
+    s.toggle,
+    s.setMenu,
+  ]);
   const allCommunities = app.config.chains
     .getAll()
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -66,9 +71,8 @@ export const ExploreCommunitiesSidebar = () => {
           );
           sidebar[0].classList.add('onremove');
           setTimeout(() => {
-            app.sidebarToggled = false;
-            app.sidebarMenu = 'default';
-            app.sidebarRedraw.emit('redraw');
+            setMenuName('default');
+            toggleSidebar(false);
           }, 200);
         },
       }}

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -17,6 +17,7 @@ import { CWText } from '../component_kit/cw_text';
 import { useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { featureFlags } from 'helpers/feature-flags';
+import useSidebarStore from "stores/zustand/sidebar";
 
 export type SidebarMenuName =
   | 'default'
@@ -27,7 +28,7 @@ export const Sidebar = () => {
   const navigate = useCommonNavigate();
   const { pathname } = useLocation();
   const { isLoggedIn } = useUserLoggedIn();
-
+  const [sidebarMenu] = useSidebarStore((s) => [s.menuName]);
   const onHomeRoute = pathname === `/${app.activeChainId()}/feed`;
 
   const isAdmin =
@@ -45,7 +46,7 @@ export const Sidebar = () => {
 
   return (
     <div className="Sidebar">
-      {app.sidebarMenu === 'default' && (
+      {sidebarMenu === 'default' && (
         <div className="sidebar-default-menu">
           <SidebarQuickSwitcher />
           {app.chain && (
@@ -82,8 +83,8 @@ export const Sidebar = () => {
           )}
         </div>
       )}
-      {app.sidebarMenu === 'createContent' && <CreateContentSidebar />}
-      {app.sidebarMenu === 'exploreCommunities' && (
+      {sidebarMenu === 'createContent' && <CreateContentSidebar />}
+      {sidebarMenu === 'exploreCommunities' && (
         <ExploreCommunitiesSidebar />
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -10,11 +10,12 @@ import { CWDivider } from '../component_kit/cw_divider';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 export const SidebarQuickSwitcher = () => {
   const navigate = useCommonNavigate();
   const { isLoggedIn } = useUserLoggedIn();
-
+  const [setMenuName] = useSidebarStore((s) => [s.setMenu]);
   const allCommunities = app.config.chains
     .getAll()
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -35,8 +36,7 @@ export const SidebarQuickSwitcher = () => {
             iconName="plusCircle"
             iconButtonTheme="black"
             onClick={() => {
-              app.sidebarMenu = 'createContent';
-              app.sidebarRedraw.emit('redraw');
+              setMenuName('createContent');
             }}
           />
         )}
@@ -44,8 +44,7 @@ export const SidebarQuickSwitcher = () => {
           iconName="compass"
           iconButtonTheme="black"
           onClick={() => {
-            app.sidebarMenu = 'exploreCommunities';
-            app.sidebarRedraw.emit('redraw');
+            setMenuName('exploreCommunities');
           }}
         />
       </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import 'components/sidebar/sidebar_section.scss';
 
 import { isNotUndefined } from 'helpers/typeGuards';
-import app from 'state';
 import { CWIcon } from '../component_kit/cw_icons/cw_icon';
 import { CWText } from '../component_kit/cw_text';
 import type {
@@ -11,6 +10,7 @@ import type {
   SidebarSectionAttrs,
   SubSectionAttrs,
 } from './types';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 const SubSection = (props: SubSectionAttrs) => {
   const { isActive, isUpdated, isVisible, onClick, rightIcon, rowIcon, title } =
@@ -61,6 +61,11 @@ const SubSectionGroup = (props: SectionGroupAttrs) => {
     title,
   } = props;
 
+  const [toggleSidebar, sidebarToggled] = useSidebarStore((s) => [
+    s.toggle,
+    s.toggled,
+  ]);
+
   const [toggled, setToggled] = React.useState<boolean>(
     hasDefaultToggle || localStorage.getItem(`${title}-toggled`) === 'true'
   );
@@ -74,10 +79,7 @@ const SubSectionGroup = (props: SectionGroupAttrs) => {
     if (containsChildren) {
       setToggled(!toggled);
     }
-
-    app.sidebarToggled = !app.sidebarToggled;
-    app.sidebarRedraw.emit('redraw');
-
+    toggleSidebar(!sidebarToggled);
     onClick(e, toggled);
   };
 

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -14,13 +14,13 @@ import { CWMobileMenu } from '../components/component_kit/cw_mobile_menu';
 import { CWSidebarMenu } from '../components/component_kit/cw_sidebar_menu';
 import { useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
-import { vanillaStore } from 'stores/zustand';
+import { appStore } from 'stores/zustand';
 
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
     app.user.activeAccount && !!app.chain?.meta.snapshot.length;
 
-  const topics = vanillaStore
+  const topics = appStore
     .getState()
     .getByCommunity(app.activeChainId())
     .reduce(

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -15,6 +15,7 @@ import { CWSidebarMenu } from '../components/component_kit/cw_sidebar_menu';
 import { useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { appStore } from 'stores/zustand';
+import useSidebarStore, { sidebarStore } from 'stores/zustand/sidebar';
 
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
@@ -182,9 +183,9 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
         //   isCustomDomain: app.isCustomDomain(),
         //   communityType: null,
         // });
-        app.sidebarToggled = false;
-        app.sidebarMenu = 'default';
-        app.sidebarRedraw.emit('redraw');
+
+        sidebarStore.getState().setMenu('default');
+        sidebarStore.getState().toggle(false);
         navigate('/createCommunity', {}, null);
       },
     },
@@ -199,9 +200,8 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
         //   isCustomDomain: app.isCustomDomain(),
         //   communityType: null,
         // });
-        app.sidebarToggled = false;
-        app.sidebarMenu = 'default';
-        app.sidebarRedraw.emit('redraw');
+        sidebarStore.getState().setMenu('default');
+        sidebarStore.getState().toggle(false);
 
         window.open(
           `https://discord.com/oauth2/authorize?client_id=${
@@ -246,6 +246,10 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
 
 export const CreateContentSidebar = () => {
   const navigate = useCommonNavigate();
+  const [toggleSidebar, setMenuName] = useSidebarStore((s) => [
+    s.toggle,
+    s.setMenu,
+  ]);
 
   return (
     <CWSidebarMenu
@@ -258,9 +262,8 @@ export const CreateContentSidebar = () => {
           );
           sidebar[0].classList.add('onremove');
           setTimeout(() => {
-            app.sidebarToggled = false;
-            app.sidebarMenu = 'default';
-            app.sidebarRedraw.emit('redraw');
+            setMenuName('default');
+            toggleSidebar(false);
             redraw();
           }, 200);
         },

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -14,12 +14,14 @@ import { CWMobileMenu } from '../components/component_kit/cw_mobile_menu';
 import { CWSidebarMenu } from '../components/component_kit/cw_sidebar_menu';
 import { useCommonNavigate } from 'navigation/helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
+import { vanillaStore } from 'stores/zustand';
 
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
     app.user.activeAccount && !!app.chain?.meta.snapshot.length;
 
-  const topics = app.topics
+  const topics = vanillaStore
+    .getState()
     .getByCommunity(app.activeChainId())
     .reduce(
       (acc, current) => (current.featuredInNewPost ? [...acc, current] : acc),

--- a/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
@@ -7,6 +7,7 @@ import app from 'state';
 import { CWButton } from '../components/component_kit/cw_button';
 import { TopicSelector } from '../components/topic_selector';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
+import useAppStore from 'stores/zustand';
 
 type ChangeTopicModalProps = {
   onChangeHandler: (topic: Topic) => void;
@@ -20,7 +21,8 @@ export const ChangeTopicModal = ({
   thread,
 }: ChangeTopicModalProps) => {
   const [activeTopic, setActiveTopic] = useState<Topic>(thread.topic);
-  const topics = app.topics.getByCommunity(app.activeChainId());
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+  const topics = getByCommunity(app.activeChainId());
 
   const handleSaveChanges = async () => {
     try {

--- a/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_topic_modal.tsx
@@ -21,12 +21,15 @@ export const ChangeTopicModal = ({
   thread,
 }: ChangeTopicModalProps) => {
   const [activeTopic, setActiveTopic] = useState<Topic>(thread.topic);
-  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+  const [getByCommunity, updateTopic] = useAppStore((s) => [
+    s.getByCommunity,
+    s.updateTopic,
+  ]);
   const topics = getByCommunity(app.activeChainId());
 
   const handleSaveChanges = async () => {
     try {
-      const topic: Topic = await app.topics.update(
+      const topic = await updateTopic(
         thread.id,
         activeTopic.name,
         activeTopic.id

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -89,7 +89,6 @@ export const EditTopicModal = ({
     };
 
     try {
-      // await app.topics.edit(new Topic(topicInfo));
       await editTopic(new Topic(topicInfo));
       navigate(`/discussions/${encodeURI(name.toString().trim())}`);
     } catch (err) {
@@ -114,7 +113,6 @@ export const EditTopicModal = ({
               chainId: app.activeChainId(),
             };
 
-            // await app.topics.remove(topicInfo);
             await removeTopic(topicInfo as Topic);
             await navigate('/');
           },

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -23,6 +23,7 @@ import {
   serializeDelta,
 } from '../components/react_quill_editor/utils';
 import { openConfirmation } from 'views/modals/confirmation_modal';
+import useAppStore from 'stores/zustand';
 
 type EditTopicModalProps = {
   onModalClose: () => void;
@@ -41,6 +42,10 @@ export const EditTopicModal = ({
     id,
     name: nameProp,
   } = topic;
+  const [editTopic, removeTopic] = useAppStore((s) => [
+    s.editTopic,
+    s.removeTopic,
+  ]);
 
   const navigate = useCommonNavigate();
 
@@ -84,7 +89,8 @@ export const EditTopicModal = ({
     };
 
     try {
-      await app.topics.edit(new Topic(topicInfo));
+      // await app.topics.edit(new Topic(topicInfo));
+      await editTopic(new Topic(topicInfo));
       navigate(`/discussions/${encodeURI(name.toString().trim())}`);
     } catch (err) {
       setErrorMsg(err.message || err);
@@ -108,9 +114,9 @@ export const EditTopicModal = ({
               chainId: app.activeChainId(),
             };
 
-            await app.topics.remove(topicInfo);
-
-            navigate('/');
+            // await app.topics.remove(topicInfo);
+            await removeTopic(topicInfo as Topic);
+            await navigate('/');
           },
         },
         {

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_thresholds_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_thresholds_modal.tsx
@@ -11,14 +11,16 @@ import { TokenDecimalInput } from 'views/components/token_decimal_input';
 import { CWButton } from '../components/component_kit/cw_button';
 import { CWText } from '../components/component_kit/cw_text';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
+import useAppStore from 'stores/zustand';
 
 type EditTopicThresholdsRowProps = {
   topic: Topic;
 };
 
 const EditTopicThresholdsRow = (props: EditTopicThresholdsRowProps) => {
-  const [newTokenThresholdInWei, setNewTokenThresholdInWei] =
-    React.useState<string>();
+  const [newTokenThresholdInWei, setNewTokenThresholdInWei] = React.useState<
+    string
+  >();
 
   const { topic } = props;
 
@@ -73,6 +75,8 @@ type EditTopicThresholdsModalProps = {
 export const EditTopicThresholdsModal = (
   props: EditTopicThresholdsModalProps
 ) => {
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+
   if (
     !app.user.isSiteAdmin &&
     !app.roles.isAdminOfEntity({ chain: app.activeChainId() })
@@ -80,7 +84,7 @@ export const EditTopicThresholdsModal = (
     return null;
   }
 
-  const topics = app.topics.getByCommunity(app.activeChainId());
+  const topics = getByCommunity(app.activeChainId());
 
   return (
     <div className="EditTopicThresholdsModal">

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -38,10 +38,12 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
   );
   const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const [description, setDescription] = React.useState<string>('');
-  const [featuredInNewPost, setFeaturedInNewPost] =
-    React.useState<boolean>(false);
-  const [featuredInSidebar, setFeaturedInSidebar] =
-    React.useState<boolean>(false);
+  const [featuredInNewPost, setFeaturedInNewPost] = React.useState<boolean>(
+    false
+  );
+  const [featuredInSidebar, setFeaturedInSidebar] = React.useState<boolean>(
+    false
+  );
   const [name, setName] = React.useState<string>('');
   const [tokenThreshold, setTokenThreshold] = React.useState<string>('0');
 
@@ -167,16 +169,6 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
             e.preventDefault();
 
             try {
-              // await app.topics.add(
-              //   name,
-              //   description,
-              //   null,
-              //   featuredInSidebar,
-              //   featuredInNewPost,
-              //   tokenThreshold || '0',
-              //   serializeDelta(contentDelta)
-              // );
-
               await addTopic(
                 name,
                 description,

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -21,6 +21,7 @@ import {
   ReactQuillEditor,
 } from '../components/react_quill_editor';
 import { serializeDelta } from '../components/react_quill_editor/utils';
+import useAppStore from 'stores/zustand';
 
 type NewTopicModalProps = {
   onModalClose: () => void;
@@ -45,6 +46,8 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
   const [tokenThreshold, setTokenThreshold] = React.useState<string>('0');
 
   const editorText = getTextFromDelta(contentDelta);
+
+  const [addTopic] = useAppStore((s) => [s.addTopic]);
 
   useEffect(() => {
     if (!name || !name.trim()) {
@@ -164,7 +167,17 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
             e.preventDefault();
 
             try {
-              await app.topics.add(
+              // await app.topics.add(
+              //   name,
+              //   description,
+              //   null,
+              //   featuredInSidebar,
+              //   featuredInNewPost,
+              //   tokenThreshold || '0',
+              //   serializeDelta(contentDelta)
+              // );
+
+              await addTopic(
                 name,
                 description,
                 null,

--- a/packages/commonwealth/client/scripts/views/modals/order_topics_modal/order_topics_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/order_topics_modal/order_topics_modal.tsx
@@ -35,7 +35,10 @@ const getSortedTopics = (topics: Topic[]): Topic[] => {
 };
 
 export const OrderTopicsModal = ({ onModalClose }: OrderTopicsModalProps) => {
-  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+  const [getByCommunity, updateFeaturedOrder] = useAppStore((s) => [
+    s.getByCommunity,
+    s.updateFeaturedOrder,
+  ]);
 
   const [topics, setTopics] = useState<Topic[]>(() =>
     getSortedTopics(getByCommunity(app.activeChainId()))
@@ -43,9 +46,8 @@ export const OrderTopicsModal = ({ onModalClose }: OrderTopicsModalProps) => {
 
   const handleSave = async () => {
     try {
-      await app.topics.updateFeaturedOrder(topics);
+      await updateFeaturedOrder(topics);
       onModalClose();
-      app.sidebarRedraw.emit('redraw');
       app.threads.isFetched.emit('redraw');
     } catch (err) {
       notifyError('Failed to update order');

--- a/packages/commonwealth/client/scripts/views/modals/order_topics_modal/order_topics_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/order_topics_modal/order_topics_modal.tsx
@@ -10,14 +10,14 @@ import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 
 import DraggableTopicsList from './draggable_topics_list';
 import { CWText } from '../../components/component_kit/cw_text';
+import useAppStore from 'stores/zustand';
 
 type OrderTopicsModalProps = {
   onModalClose: () => void;
 };
 
-const getSortedTopics = (): Topic[] => {
-  const topics = app.topics.store
-    .getByCommunity(app.chain.id)
+const getSortedTopics = (topics: Topic[]): Topic[] => {
+  topics
     .filter((topic) => topic.featuredInSidebar)
     .map((topic) => ({ ...topic } as Topic));
 
@@ -35,7 +35,11 @@ const getSortedTopics = (): Topic[] => {
 };
 
 export const OrderTopicsModal = ({ onModalClose }: OrderTopicsModalProps) => {
-  const [topics, setTopics] = useState<Topic[]>(() => getSortedTopics());
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+
+  const [topics, setTopics] = useState<Topic[]>(() =>
+    getSortedTopics(getByCommunity(app.activeChainId()))
+  );
 
   const handleSave = async () => {
     try {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
@@ -18,6 +18,7 @@ import { useCommonNavigate } from 'navigation/helpers';
 import { Modal } from 'views/components/component_kit/cw_modal';
 import { EditTopicModal } from 'views/modals/edit_topic_modal';
 import useForceRerender from 'hooks/useForceRerender';
+import useAppStore from 'stores/zustand';
 
 type RecentThreadsHeaderProps = {
   stage: string;
@@ -38,6 +39,8 @@ export const RecentThreadsHeader = ({
     isWindowExtraSmall(window.innerWidth)
   );
 
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
+
   useEffect(() => {
     const onResize = () => {
       setWindowIsExtraSmall(isWindowExtraSmall(window.innerWidth));
@@ -54,7 +57,7 @@ export const RecentThreadsHeader = ({
 
   const { stagesEnabled, customStages } = app.chain?.meta || {};
 
-  const topics = app.topics.getByCommunity(app.activeChainId());
+  const topics = getByCommunity(app.activeChainId());
 
   const featuredTopics = topics
     .filter((t) => t.featuredInSidebar)

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -15,6 +15,7 @@ import { PageLoading } from '../loading';
 import { TopicSummaryRow } from './topic_summary_row';
 import { useCommonNavigate } from 'navigation/helpers';
 import useForceRerender from 'hooks/useForceRerender';
+import useAppStore from 'stores/zustand';
 
 const OverviewPage = () => {
   const navigate = useCommonNavigate();
@@ -23,6 +24,8 @@ const OverviewPage = () => {
   const [windowIsExtraSmall, setWindowIsExtraSmall] = useState(
     isWindowExtraSmall(window.innerWidth)
   );
+
+  const [getByCommunity] = useAppStore((s) => [s.getByCommunity]);
 
   useEffect(() => {
     const onResize = () => {
@@ -51,7 +54,7 @@ const OverviewPage = () => {
     pinned: true,
   });
 
-  const topics = app.topics.getByCommunity(app.activeChainId());
+  const topics = getByCommunity(app.activeChainId());
 
   const anyTopicsFeatured = topics.some((t) => t.featuredInSidebar);
 

--- a/packages/commonwealth/client/scripts/views/sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout.tsx
@@ -10,6 +10,7 @@ import { Footer } from './footer';
 import { SublayoutBanners } from './sublayout_banners';
 import { SublayoutHeader } from './sublayout_header';
 import useForceRerender from 'hooks/useForceRerender';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -23,6 +24,7 @@ const Sublayout = ({
   hideSearch,
   onScroll,
 }: SublayoutProps) => {
+  const [sidebarToggled] = useSidebarStore((s) => [s.toggled]);
   const forceRerender = useForceRerender();
   const [isWindowSmall, setIsWindowSmall] = useState(
     isWindowSmallInclusive(window.innerWidth)
@@ -58,7 +60,7 @@ const Sublayout = ({
   const chain = app.chain ? app.chain.meta : null;
   const terms = app.chain ? chain.terms : null;
   const banner = app.chain ? chain.communityBanner : null;
-  const showSidebar = app.sidebarToggled || !isWindowSmall;
+  const showSidebar = sidebarToggled || !isWindowSmall;
 
   return (
     <div className="Sublayout">

--- a/packages/commonwealth/client/scripts/views/sublayout_header.tsx
+++ b/packages/commonwealth/client/scripts/views/sublayout_header.tsx
@@ -14,6 +14,7 @@ import { SearchBar } from './pages/search/search_bar';
 import { useCommonNavigate } from 'navigation/helpers';
 import { HelpMenuPopover } from 'views/menus/help_menu';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
+import useSidebarStore from 'stores/zustand/sidebar';
 
 type SublayoutHeaderProps = {
   hideSearch?: boolean;
@@ -26,6 +27,10 @@ export const SublayoutHeader = ({
 }: SublayoutHeaderProps) => {
   const navigate = useCommonNavigate();
   const { isLoggedIn } = useUserLoggedIn();
+  const [sidebarToggled, toggleSidebar] = useSidebarStore((s) => [
+    s.toggled,
+    s.toggle,
+  ]);
 
   return (
     <div className="SublayoutHeader">
@@ -43,7 +48,7 @@ export const SublayoutHeader = ({
           }}
         />
         {isWindowSmallInclusive(window.innerWidth) && <CWDivider isVertical />}
-        {(!isWindowSmallInclusive(window.innerWidth) || !app.sidebarToggled) && app.activeChainId() && (
+        {(!isWindowSmallInclusive(window.innerWidth) || !sidebarToggled) && app.activeChainId() && (
           <CWCommunityAvatar
             size="large"
             community={app.chain.meta}
@@ -53,10 +58,9 @@ export const SublayoutHeader = ({
         {onMobile && app.activeChainId() && (
           <CWIconButton
             iconButtonTheme="black"
-            iconName={app.sidebarToggled ? 'sidebarCollapse' : 'sidebarExpand'}
+            iconName={sidebarToggled ? 'sidebarCollapse' : 'sidebarExpand'}
             onClick={() => {
-              app.sidebarToggled = !app.sidebarToggled;
-              app.sidebarRedraw.emit('redraw');
+              toggleSidebar(!sidebarToggled);
             }}
           />
         )}
@@ -68,9 +72,8 @@ export const SublayoutHeader = ({
             iconName="dotsVertical"
             iconButtonTheme="black"
             onClick={() => {
-              app.sidebarToggled = false;
+              toggleSidebar(false);
               app.mobileMenu = app.mobileMenu ? null : 'MainMenu';
-              app.sidebarRedraw.emit('redraw');
             }}
           />
         </div>

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -274,7 +274,8 @@
     "webpack-dev-middleware": "^5.3.3",
     "webpack-hot-middleware": "^2.25.2",
     "webpack-merge": "^5.8.0",
-    "ws": "^7.4.6"
+    "ws": "^7.4.6",
+    "zustand": "^4.3.7"
   },
   "devDependencies": {
     "@aave/aave-token": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5834,6 +5834,14 @@ array-back@^2.0.0:
   dependencies:
     typical "^2.6.1"
 
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
+
 array-find@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz"
@@ -7473,7 +7481,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x, clone@^2.0.0, clone@^2.1.1:
+clone@2.x, clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
@@ -8593,6 +8601,30 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
+deep-equal@^2.0.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.1.tgz#c72ab22f3a7d3503a4ca87dde976fe9978816739"
+  integrity sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.0"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.0"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-equal@^2.0.3:
   version "2.0.5"
   resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz"
@@ -8715,6 +8747,14 @@ define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
   integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
+define-properties@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
+  integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
@@ -9514,7 +9554,7 @@ es-get-iterator@^1.1.1:
     is-string "^1.0.5"
     isarray "^2.0.5"
 
-es-get-iterator@^1.1.2:
+es-get-iterator@^1.1.2, es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
   integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
@@ -11471,7 +11511,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -12811,7 +12851,7 @@ is-arguments@^1.1.1:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-array-buffer@^3.0.1:
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
   integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
@@ -12902,6 +12942,13 @@ is-core-module@^2.10.0, is-core-module@^2.5.0, is-core-module@^2.7.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.11.0, is-core-module@^2.9.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
   dependencies:
     has "^1.0.3"
 
@@ -13653,7 +13700,12 @@ js-sha256@^0.9.0:
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
   integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
-js-sha3@0.5.7, js-sha3@0.8.0, js-sha3@^0.5.7, js-sha3@^0.8.0:
+js-sha3@0.5.7, js-sha3@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==
+
+js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -16417,6 +16469,11 @@ param-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+parchment@2.0.0-dev.2:
+  version "2.0.0-dev.2"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-2.0.0-dev.2.tgz#9d6fe57b3721317bd1c481ea38ffa9b287d496b8"
+  integrity sha512-4fgRny4pPISoML08Zp7poi52Dff3E2G1ORTi2D/acJ/RiROdDAMDB6VcQNfBcmehrX5Wixp6dxh6JjLyE5yUNQ==
+
 parchment@^1.1.2, parchment@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz"
@@ -16627,7 +16684,7 @@ path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -18000,6 +18057,15 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+quill-delta@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-4.2.1.tgz#ad4f191cdf3be5079c5dc3991b9603a5cc0db69a"
+  integrity sha512-Y2nksOj6Q+4hizre8n0dml76vLNGK4/y86EoI1d7rv6EL1bx7DPDYRmqQMPu1UqFQO/uQuVHQ3fOmm4ZSzWrfA==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.2.0"
+
 quill-delta@^3.6.2:
   version "3.6.3"
   resolved "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz"
@@ -18046,7 +18112,7 @@ quill-mention@^2.2.7:
   dependencies:
     quill "^1.3.4"
 
-quill@^1.3.4, quill@^1.3.6, quill@^1.3.7, quill@^2.0.0-dev.4:
+quill@^1.3.4, quill@^1.3.6, quill@^1.3.7:
   version "1.3.7"
   resolved "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz"
   integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
@@ -18057,6 +18123,18 @@ quill@^1.3.4, quill@^1.3.6, quill@^1.3.7, quill@^2.0.0-dev.4:
     extend "^3.0.2"
     parchment "^1.1.4"
     quill-delta "^3.6.2"
+
+quill@^2.0.0-dev.4:
+  version "2.0.0-dev.4"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-2.0.0-dev.4.tgz#130e38efe7a16b3766d767d750c8aacc038945e7"
+  integrity sha512-9WmMVCEIhf3lDdhzl+i+GBDeDl0BFi65waC4Im8Y4HudEJ9kEEb1lciAz9A8pcDmLMjiMbvz84lNt/U5OBS8Vg==
+  dependencies:
+    clone "^2.1.2"
+    deep-equal "^2.0.2"
+    eventemitter3 "^4.0.0"
+    extend "^3.0.2"
+    parchment "2.0.0-dev.2"
+    quill-delta "4.2.1"
 
 raf-schd@^4.0.2:
   version "4.0.3"
@@ -18494,6 +18572,15 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
+regexp.prototype.flags@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
+
 regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -18687,13 +18774,38 @@ resolve-url@^0.2.1:
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@1.17.0, resolve@^1.0.0, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0, resolve@^2.0.0-next.4:
+resolve@1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.0.0, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+resolve@^1.22.0:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -20414,6 +20526,11 @@ supports-hyperlinks@^2.3.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz"
@@ -21653,6 +21770,11 @@ use-memo-one@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
   integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
+
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"
@@ -23116,3 +23238,10 @@ zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zustand@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.7.tgz#501b1f0393a7f1d103332e45ab574be5747fedce"
+  integrity sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
# Goal
This PR should not be merged. The main purpose of this PR is to explore the possibilities offered by 
[Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction) as a tool for state management. Due to time constraints, this is not a comprehensive research, but sufficient enough to have first impressions of the library.

# Why Zustand
- Redux is not taken into account. 
- Initially we thought of Recoil. However, Recoil does not have a stable version, in addition, its probably not going to be maintained any longer. 
- A good alternative to Recoil is Jotai. After a brief research, however, it turns out that Jotai can only be used in function components using a hook. In my opinion, this disfavors the tool, as our current state is spread between react class and function components, controllers and stores (typescript classes), and other javascript methods. The transition to a new state management approach will be a multi-stage process, so the new tool must allow us to use the current state and incrementally introduce the new one. 
- Zustand is a simple yet powerful tool. It allows you to both create one large store and several smaller ones. Importantly, it can be operated both from react and outside its context, keeping it synchronized.

# What has been done in this PR
The idea was to transfer a piece of logic from the current flow to the zustand world. I decided to use topics for this because it's small, uncomplicated, and allows reading, updating, and writing data to the server. 

## Topics slice as a part of one big store
As I mentioned earlier, zustand allows you to create several small stores (they call them slices). They can function in separation, but it is also possible to combine them into one large store. So I created `createTopicsSlice` first. Translating to our current system, this is a combination of both controller and store. From the component level, you can both read the state and modify it through defined actions. These actions can modify the state, but they can also be asynchronous actions that communicate with the server and then modify the application state. Zustand is not opinionated, so it would be necessary to create rules as to the naming and architecture of the store, so as not to confuse store-only modifying actions with actions that make HTTP requests.

In this case, I copied the logic from topic controller to topic slice, but in case we decided to go this way, it would be more appropriate to follow the approach of creating new stores from scratch, taking into account reactive aspects, rather than copying the current logic. 

In zustand/index.ts TopicSlice is used as a part of a larger store. With createStore we create a store, which can then be used in a non-react context. In turn, with `create` we create an instance of the store, which can be used in react components. 

Video below shows different actions related to topics - they all work!

https://user-images.githubusercontent.com/14819225/236399535-1d0469d9-e7d1-4c0e-81da-c20590159309.mp4

## Sidebar slice as a separate small store


I still wanted to check additionally how the issue of having multiple smaller stores could be solved. I decided that a good example here would be a sidebar, which does not communicate with the server - it is only responsible for the visual layer of the application. 

It turned out to be very simple. You create a slice similar to topics. The only difference is that you don't combine this store with others, you just leave it as standalone. Again, it can be exported in two different ways, so it can be used both in react components and outside react context.

We can get rid of `app.sidebarRedraw.emit('redraw');` because now components are aware of changes and rerender automatically. As you can see on the video below, sidebar works the same way as before.

https://user-images.githubusercontent.com/14819225/236398130-b0bf097c-5fa3-4d84-a18f-e7c6e65c1bc5.mp4


## Other considerations
- zustand allows you to add different kinds of middlewares e.g. [immer](https://docs.pmnd.rs/zustand/integrations/immer-middleware) - to update the state more transparently, or to maintain a [persistent state](https://docs.pmnd.rs/zustand/integrations/persisting-store-data) in localStorage
- It looks like zustand is a good solution for our situation. However, it is worth considering another configuration that uses a caching layer e.g. React-query. Then we wouldn't have to save all the data retrieved from the API to a local store. Depending on the results of the work in task #3709 , we have two solutions
1. using zustand as the only state management - saving responses from the server to the state and synchronizing it every time the server state changes
2. using zustand only as state management for UI layer (sidebar, modals, popups etc.) while react-query as caching layer/store for data coming from backend

