### PR TITLE
Support for Zapier Webhooks

### DIFF
--- a/packages/commonwealth/server/webhookNotifier.ts
+++ b/packages/commonwealth/server/webhookNotifier.ts
@@ -369,6 +369,18 @@ const send = async (models, content: WebhookContent) => {
                   ],
                 },
               };
+        } else if (url.indexOf('zapier') !== -1 && !isChainEvent) {
+          webhookData = JSON.stringify({
+            event: notificationCategory,
+            author: {
+              name: actor,
+              url: actorAccountLink,
+              icon_url: actorAvatarUrl,
+            },
+            title: notificationTitlePrefix + actedOn,
+            url: actedOnLink,
+            content: notificationExcerpt,
+          });
         } else {
           // TODO: other formats unimplemented
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3366 

## Description of Changes
- Adds support for handling zapier webhooks in the manage community page.

The webhooks will emit an event with a json blob corresponding to this schema:
`{
  "type": "object",
  "properties": {
    "event": {
      "type": "string"
    },
    "author": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string"
        },
        "url": {
          "type": "string",
          "format": "uri"
        },
        "icon_url": {
          "type": "string",
          "format": "uri"
        }
      },
      "required": ["name", "url", "icon_url"]
    },
    "title": {
      "type": "string"
    },
    "url": {
      "type": "string",
      "format": "uri"
    },
    "content": {
      "type": "string"
    }
  },
  "required": ["event", "author", "title", "url", "content"]
}
`

This should be published somewhere or shared with the communities who want to use it. 

## Test Plan
- Tested locally by adding a zapier webhook endpoint and sending messages to it.
- 
## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 