### PR TITLE
[WIP] Use react query for api state with optimistic updates - research

### DIFF
--- a/packages/commonwealth/client/scripts/app.tsx
+++ b/packages/commonwealth/client/scripts/app.tsx
@@ -1,6 +1,9 @@
 import React, { StrictMode } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 import useInitApp from 'hooks/useInitApp';
 import { CWSpinner } from 'views/components/component_kit/cw_spinner';
@@ -20,8 +23,10 @@ const App = () => {
 
   return (
     <StrictMode>
-      <RouterProvider router={router(customDomain)} />
-      <ToastContainer />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router(customDomain)} />
+        <ToastContainer />
+      </QueryClientProvider>
     </StrictMode>
   );
 };

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -208,6 +208,7 @@ export function updateActiveUser(data) {
     app.user.setEmailInterval(data.emailInterval);
     app.user.setEmailVerified(data.emailVerified);
     app.user.setJWT(data.jwt);
+    localStorage.setItem('jwt', data.jwt);
 
     app.user.setAddresses(
       data.addresses.map(

--- a/packages/commonwealth/client/scripts/hooks/api/queryKeys.ts
+++ b/packages/commonwealth/client/scripts/hooks/api/queryKeys.ts
@@ -1,0 +1,6 @@
+const queryKeys = {
+  BULK_OFFCHAIN: (chainId) => `bulk-offchain-${chainId}`,
+  TOPICS_FOR_CHAIN: (chainId) => `${chainId}-topics`,
+};
+
+export default queryKeys;

--- a/packages/commonwealth/client/scripts/hooks/api/useChains.tsx
+++ b/packages/commonwealth/client/scripts/hooks/api/useChains.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Topic } from 'models';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import $ from 'jquery';
+import app from 'state';
+import queryKeys from './queryKeys';
+
+const useChains = () => {
+  // auth state to come from zustand, localstorage is just for demo purposes
+  const JWT = localStorage.getItem('jwt');
+
+  const queryClient = useQueryClient();
+  const [chainIdToFetch, setChainIdToFetch] = useState<string>();
+
+  const fetchBulkOffChainQuery = useQuery({
+    queryKey: [queryKeys.BULK_OFFCHAIN(chainIdToFetch)],
+    queryFn: async () => {
+      // api call
+      const [response] = await Promise.all([
+        $.get(`${app.serverUrl()}/bulkOffchain`, {
+          community: null,
+          chain: chainIdToFetch,
+          jwt: JWT,
+        }),
+      ]);
+
+      // process payload
+      const { topics } = response.result;
+
+      // set topics state (changes are propogated to all components that use the useTopics hook)
+      await queryClient.cancelQueries({
+        queryKey: [queryKeys.TOPICS_FOR_CHAIN(chainIdToFetch)],
+      });
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(chainIdToFetch)],
+        (t: []) => [...(t || []), ...topics].map((x) => new Topic(x))
+      );
+
+      // return cached response
+      return response;
+    },
+    enabled: !!chainIdToFetch,
+    staleTime: 60_000, // cache for 60 seconds, then auto refetch
+  });
+
+  return {
+    fetchBulkOffChainQuery: {
+      ...fetchBulkOffChainQuery,
+      fetchChainById: (chainId: string) => setChainIdToFetch(chainId),
+    },
+  };
+};
+
+export default useChains;

--- a/packages/commonwealth/client/scripts/hooks/api/useTopics.tsx
+++ b/packages/commonwealth/client/scripts/hooks/api/useTopics.tsx
@@ -1,0 +1,294 @@
+import React, { useState } from 'react';
+import { Topic } from 'models';
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+import $ from 'jquery';
+import app from 'state';
+import queryKeys from './queryKeys';
+
+const useTopics = () => {
+  // auth state to come from zustand, localstorage is just for demo purposes
+  const JWT = localStorage.getItem('jwt');
+
+  const queryClient = useQueryClient();
+  const [topicsForChainId, setTopicsForChainId] = useState<string>();
+
+  const fetchTopicsQuery = useQuery({
+    queryKey: [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+    queryFn: async () => {
+      return queryClient.getQueryData([
+        queryKeys.TOPICS_FOR_CHAIN(topicsForChainId),
+      ]);
+    },
+    enabled: !!topicsForChainId,
+    staleTime: 60_000, // cache for 60 seconds
+  });
+
+  const addTopicQuery = useMutation({
+    onMutate: async ({
+      name,
+      description,
+      telegram,
+      featuredInSidebar,
+      featuredInNewPost,
+      tokenThreshold,
+      defaultOffchainTemplate,
+    }: {
+      name: string;
+      description: string;
+      telegram: string;
+      featuredInSidebar: boolean;
+      featuredInNewPost: boolean;
+      tokenThreshold: string;
+      defaultOffchainTemplate: string;
+    }) => {
+      // Cancel any outgoing refetches ,(so they don't overwrite
+      // our optimistic update)
+      await queryClient.cancelQueries({
+        queryKey: [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+      });
+
+      // fetch old topics from react query store
+      const oldTopics = queryClient.getQueryData([
+        queryKeys.TOPICS_FOR_CHAIN(topicsForChainId),
+      ]);
+
+      // update optimistic value
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          const updatedTopics = [...t];
+
+          const newTopic = new Topic({
+            id: -1, // -1 to indicate a new thread
+            name,
+            description,
+            telegram,
+            featured_in_new_post: featuredInNewPost,
+            featured_in_sidebar: featuredInSidebar,
+            token_threshold: tokenThreshold,
+            default_offchain_template: defaultOffchainTemplate,
+          });
+
+          return [...updatedTopics, newTopic];
+        }
+      );
+
+      return { oldTopics };
+    },
+    mutationFn: async ({
+      name,
+      description,
+      telegram,
+      featuredInSidebar,
+      featuredInNewPost,
+      tokenThreshold,
+      defaultOffchainTemplate,
+    }: {
+      name: string;
+      description: string;
+      telegram: string;
+      featuredInSidebar: boolean;
+      featuredInNewPost: boolean;
+      tokenThreshold: string;
+      defaultOffchainTemplate: string;
+    }) => {
+      const response = await $.post(`${app.serverUrl()}/createTopic`, {
+        chain: app.activeChainId(),
+        name,
+        description,
+        telegram,
+        featured_in_sidebar: featuredInSidebar,
+        featured_in_new_post: featuredInNewPost,
+        default_offchain_template: defaultOffchainTemplate,
+        token_threshold: tokenThreshold,
+        jwt: JWT,
+      });
+
+      const result = new Topic(response.result);
+
+      // update proper value
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          const foundIndex = t.findIndex((x) => x.id === -1);
+
+          t[foundIndex] = new Topic({
+            ...t[foundIndex],
+            ...response.result,
+          });
+
+          return [...t];
+        }
+      );
+
+      return result;
+    },
+    onError: (err: any, originalPayload, context) => {
+      // revert optimistic change
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          return context.oldTopics;
+        }
+      );
+
+      return err.responseJSON && err.responseJSON.error
+        ? err.responseJSON.error
+        : 'Failed to add topic';
+    },
+  });
+
+  const editTopicByIdQuery = useMutation({
+    onMutate: async ({
+      topic,
+      address,
+      featuredOrder,
+    }: {
+      topic: Topic;
+      address: string;
+      featuredOrder?: number;
+    }) => {
+      // Cancel any outgoing refetches ,(so they don't overwrite
+      // our optimistic update)
+      await queryClient.cancelQueries({
+        queryKey: [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+      });
+
+      // fetch old topics from react query store
+      const oldTopics = queryClient.getQueryData([
+        queryKeys.TOPICS_FOR_CHAIN(topicsForChainId),
+      ]);
+
+      // update optimistic value
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          const updatedTopics = [...t];
+
+          const foundIndex = updatedTopics.findIndex((x) => x.id === topic.id);
+
+          updatedTopics[foundIndex] = new Topic({
+            ...updatedTopics[foundIndex],
+            ...topic,
+          });
+
+          return [...updatedTopics];
+        }
+      );
+
+      return { oldTopics };
+    },
+    mutationFn: async ({
+      topic,
+      address,
+      featuredOrder,
+    }: {
+      topic: Topic;
+      address: string;
+      featuredOrder?: number;
+    }) => {
+      const response = await $.post(`${app.serverUrl()}/editTopic`, {
+        id: topic.id,
+        chain: topic.chainId,
+        name: topic.name,
+        description: topic.description,
+        telegram: topic.telegram,
+        featured_in_sidebar: topic.featuredInSidebar,
+        featured_in_new_post: topic.featuredInNewPost,
+        default_offchain_template: topic.defaultOffchainTemplate,
+        featured_order: featuredOrder,
+        address: address,
+        jwt: JWT,
+      });
+
+      const result = new Topic(response.result);
+
+      // update proper value
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          const foundIndex = t.findIndex((x) => x.id === topic.id);
+
+          t[foundIndex] = new Topic({
+            ...t[foundIndex],
+            ...response.result,
+          });
+
+          return [...t];
+        }
+      );
+
+      return result;
+    },
+    onError: (err: any, originalPayload, context) => {
+      // revert optimistic change
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          return context.oldTopics;
+        }
+      );
+
+      return err.responseJSON && err.responseJSON.error
+        ? err.responseJSON.error
+        : 'Failed to edit topic';
+    },
+  });
+
+  const removeTopicByIdQuery = useMutation({
+    onMutate: async ({ id, chainId }: { id: number; chainId: string }) => {
+      // Cancel any outgoing refetches ,(so they don't overwrite
+      // our optimistic update)
+      await queryClient.cancelQueries({
+        queryKey: [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+      });
+
+      // fetch old topics from react query store
+      const oldTopics = queryClient.getQueryData([
+        queryKeys.TOPICS_FOR_CHAIN(topicsForChainId),
+      ]);
+
+      // update optimistic value
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          return [...t].filter((x) => x.id !== id);
+        }
+      );
+
+      return { oldTopics };
+    },
+    mutationFn: async ({ id, chainId }: { id: number; chainId: string }) => {
+      await $.post(`${app.serverUrl()}/deleteTopic`, {
+        id: id,
+        chain: chainId,
+        jwt: JWT,
+      });
+    },
+    onError: (err: any, originalPayload, context) => {
+      // revert optimistic change
+      queryClient.setQueryData(
+        [queryKeys.TOPICS_FOR_CHAIN(topicsForChainId)],
+        (t: Topic[]) => {
+          return context.oldTopics;
+        }
+      );
+
+      return err.responseJSON && err.responseJSON.error
+        ? err.responseJSON.error
+        : 'Failed to remove topic';
+    },
+  });
+
+  return {
+    fetchTopicsQuery: {
+      ...fetchTopicsQuery,
+      fetchTopicsForChainId: (chainId: string) => setTopicsForChainId(chainId),
+    },
+    editTopicByIdQuery,
+    addTopicQuery,
+    removeTopicByIdQuery,
+  };
+};
+
+export default useTopics;


### PR DESCRIPTION
## PR should not be merged


### Tickets
https://github.com/hicommonwealth/commonwealth/issues/3709


### Purpose
Test and propose react query (RQ) implementation to replace existing state logic. This is just a research/demo implementation of how the final outcome might look like.

### Why React Query (RQ)
With any state solution, most of what we do is store api responses. Even in the app currently more than half of what we do is store api responses.

RQ handles both the api/http layer and the state/cache layer. RQ has options for state/cache/auto-retries/auto-refresh and more out of the box along with optimistic updates and rollbacks.

### Suggested Design for RQ implementation
We could potentially add RQ in our react components but that would soon clutter up our components, the logic would be all over the place.

I believe custom react hooks would be a good option to encapsulate and abstract away all of the data fetching + caching/state related things.

We could follow this approach

- Use hooks for every api resource with RQ implementation ex: `/threads` -> `useThreads`, `/topics`  -> `/useTopics`.
- For 1-off api resources make a hooks that can categorise them ex: `/status`, `/domain` can go in a `useBootstrap` hook (apologies for the bad naming).
- Read data from hooks (will be auto refreshed when cache changes)
- Define params for auto retries / cache refresh etc in the hooks
- Optimistic updates and rollbacks will be handled by RQ in custom hooks + RQ will provide api status indicators `isLoading`, `error`, `data` etc.

So essentially our react component will only have the UI level logic + the glue logic for these custom hooks.



### Where RQ won't work
For UI level state we would need to have some kind of a standalone solution. There is a potential solution in https://github.com/hicommonwealth/commonwealth/pull/3731 for using zustand.   



