### PR TITLE
Add quill image upload toolbar button

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useDraft.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useDraft.tsx
@@ -1,11 +1,17 @@
 const KEY_VERSION = 'v2'; // update this for breaking changes
 const PREFIX = `cw-draft-${KEY_VERSION}`;
 
+const MAX_DRAFT_SIZE = 1024 * 1024 * 4;
+
 export function useDraft<T>(key: string) {
   const fullKey = `${PREFIX}-${key}`;
 
   const saveDraft = (data: T) => {
-    localStorage.setItem(fullKey, JSON.stringify(data));
+    const draft = JSON.stringify(data);
+    if (draft.length > MAX_DRAFT_SIZE) {
+      return;
+    }
+    localStorage.setItem(fullKey, draft);
   };
 
   const restoreDraft = (): T | null => {

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { RangeStatic } from 'quill';
 import ReactQuill, { Quill } from 'react-quill';
 import MagicUrl from 'quill-magic-url';
+import ImageUploader from 'quill-image-uploader';
 
 import { SerializableDeltaStatic } from './utils';
 import { getTextFromDelta } from './utils';
@@ -22,8 +23,10 @@ import { useClipboardMatchers } from './use_clipboard_matchers';
 import { useImageDropAndPaste } from './use_image_drop_and_paste';
 import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
 import { useMarkdownShortcuts } from './use_markdown_shortcuts';
+import { useImageUploader } from './use_image_uploader';
 
 Quill.register('modules/magicUrl', MagicUrl);
+Quill.register('modules/imageUploader', ImageUploader);
 
 type ReactQuillEditorProps = {
   className?: string;
@@ -63,12 +66,20 @@ const ReactQuillEditor = ({
   // handle clipboard behavior
   const { clipboardMatchers } = useClipboardMatchers();
 
-  // handle image upload
+  // handle image upload for drag and drop
   const { handleImageDropAndPaste } = useImageDropAndPaste({
     editorRef,
+    setContentDelta,
     setIsUploading,
     isMarkdownEnabled,
+  });
+
+  // handle image upload for image toolbar button
+  const { handleImageUploader } = useImageUploader({
+    editorRef,
     setContentDelta,
+    setIsUploading,
+    isMarkdownEnabled,
   });
 
   // handle custom toolbar behavior for markdown
@@ -261,6 +272,9 @@ const ReactQuillEditor = ({
               keyboard: isMarkdownEnabled
                 ? markdownKeyboardShortcuts
                 : undefined,
+              imageUploader: {
+                upload: handleImageUploader,
+              },
             }}
           />
         </>

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -23,6 +23,7 @@ export const CustomQuillToolbar = ({ toolbarId }: CustomQuillToolbarProps) => (
     <button className="ql-link"></button>
     <button className="ql-code-block"></button>
     <button className="ql-blockquote"></button>
+    <button className="ql-image"></button>
     <button className="ql-list" value="ordered" />
     <button className="ql-list" value="bullet" />
     <button className="ql-list" value="check" />

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -4,9 +4,12 @@ import { DeltaOperation, DeltaStatic } from 'quill';
 import imageDropAndPaste from 'quill-image-drop-and-paste';
 
 import app from 'state';
-import { SerializableDeltaStatic, base64ToFile, uploadFileToS3 } from './utils';
-
-const VALID_IMAGE_TYPES = ['jpeg', 'gif', 'png'];
+import {
+  SerializableDeltaStatic,
+  VALID_IMAGE_TYPES,
+  base64ToFile,
+  uploadFileToS3,
+} from './utils';
 
 Quill.register('modules/imageDropAndPaste', imageDropAndPaste);
 

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_uploader.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+import { SerializableDeltaStatic, uploadFileToS3 } from './utils';
+import { DeltaStatic } from 'quill';
+
+import app from 'state';
+
+type UseImageUploaderProps = {
+  editorRef: MutableRefObject<ReactQuill>;
+  setIsUploading: (value: boolean) => void;
+  isMarkdownEnabled: boolean;
+  setContentDelta: (value: DeltaStatic) => void;
+};
+
+export const useImageUploader = ({
+  editorRef,
+  setIsUploading,
+  isMarkdownEnabled,
+  setContentDelta,
+}: UseImageUploaderProps) => {
+  const handleImageUploader = useCallback(
+    async (file: File) => {
+      const editor = editorRef.current?.editor;
+
+      try {
+        if (!editor) {
+          throw new Error('editor is not set');
+        }
+
+        setIsUploading(true);
+
+        editor.disable();
+
+        const selectedIndex =
+          editor.getSelection()?.index || editor.getLength() || 0;
+
+        const uploadedFileUrl = await uploadFileToS3(
+          file,
+          app.serverUrl(),
+          app.user.jwt
+        );
+
+        // insert image op at the selected index
+        if (isMarkdownEnabled) {
+          // for some reason, must prefix with 3 spaces or else text will be truncated
+          editor.insertText(selectedIndex, `   ![image](${uploadedFileUrl})`);
+        } else {
+          editor.insertEmbed(selectedIndex, 'image', uploadedFileUrl);
+        }
+        setContentDelta({
+          ...editor.getContents(),
+          ___isMarkdown: isMarkdownEnabled,
+        } as SerializableDeltaStatic); // sync state with editor content
+
+        return uploadedFileUrl;
+      } catch (err) {
+        console.error(err);
+      } finally {
+        editor.enable();
+        setIsUploading(false);
+      }
+    },
+    [editorRef, isMarkdownEnabled, setContentDelta, setIsUploading]
+  );
+
+  return { handleImageUploader };
+};

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_uploader.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, MutableRefObject } from 'react';
 import { SerializableDeltaStatic, uploadFileToS3 } from './utils';
 import { DeltaStatic } from 'quill';
+import ReactQuill from 'react-quill';
 
 import app from 'state';
 

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import type { DeltaStatic } from 'quill';
 
+export const VALID_IMAGE_TYPES = ['jpeg', 'gif', 'png'];
+
 // createDeltaFromText returns a new DeltaStatic object from a string
 export const createDeltaFromText = (
   str: string,

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -175,3 +175,7 @@
     }
   }
 }
+
+.image-uploading {
+  display: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3698

## Description of Changes
- Adds button to quill toolbar to trigger upload dialog
- Limits draft per-entry save size to 4MB to prevent hitting local storage size limit (there are temporary spikes in draft size due to base64 image encoding, which is immediately converted to a URL– the URL version of the draft will still be saved if under 4MB)

## Test Plan
- With any quill editor, click the image icon– confirm that upload dialog appears and you can upload an image
- Perform the above step in both richtext and markdown mode
- [Regression Check] Perform drag and drop of an image– confirm it uploads as expected

## Deployment Plan
N/A

## Other Considerations
N/A