### PR TITLE
Default stage fix

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/helpers/index.ts
@@ -32,10 +32,18 @@ export function parseCustomStages(str) {
   // Parse customStages into a `string[]` and then cast to ThreadStage[]
   // If parsing fails, return an empty array.
   let arr;
+  const default_stages = [
+    ThreadStage.Discussion,
+    ThreadStage.ProposalInReview,
+    ThreadStage.Voting,
+    ThreadStage.Passed,
+    ThreadStage.Failed,
+  ];
   try {
-    arr = Array.from(JSON.parse(str));
+    const stages = JSON.parse(str);
+    arr = Array.isArray(stages) ? Array.from(stages) : default_stages;
   } catch (e) {
-    return [];
+    return default_stages;
   }
   return arr
     .map((s) => s?.toString())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3753

## Description of Changes
- Adds a fallback to default stages when custom_stage column contains non-stage data
- Fixes this in multiple areas. Thread creation and modal

## Test Plan
- Check modal for any community. Always includes stage options
- Check custom stage communities that have real stages set in db and ensured they still populate

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- As mentioned in the ticket there is a bigger data issue causing this where the custom_stages column contains non-null, non array values for default stage communities 