### PR TITLE
Removed AbridgedThread from models/index.ts

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/recent_activity.ts
@@ -1,8 +1,9 @@
 import $ from 'jquery';
 import type { Thread, Topic } from 'models';
-import { AbridgedThread, MinimumProfile as Profile } from 'models';
 import moment from 'moment';
 import app from 'state';
+import AbridgedThread from '../../models/AbridgedThread';
+import { MinimumProfile } from '../../models/index';
 
 export interface IAbridgedThreadFromServer {
   id: number;
@@ -60,7 +61,7 @@ class RecentActivityController {
     this._activeUsers = users.map((user) => {
       const { count } = user;
       const { chain, address, name, id, avatarUrl, lastActive } = user.info;
-      const info = new Profile(address, chain);
+      const info = new MinimumProfile(address, chain);
       info.initialize(name, address, avatarUrl, id, chain, lastActive);
       return { info, count };
     });

--- a/packages/commonwealth/client/scripts/controllers/server/comments.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/comments.ts
@@ -2,12 +2,14 @@ import { notifyError } from 'controllers/app/notifications';
 import { modelFromServer as modelReactionFromServer } from 'controllers/server/reactions';
 import $ from 'jquery';
 import _ from 'lodash';
-import type { IUniqueId, AbridgedThread } from 'models';
-import { Attachment, Comment } from 'models';
 import moment from 'moment';
 
 import app from 'state';
 import { CommentsStore } from 'stores';
+import AbridgedThread from '../../models/AbridgedThread';
+import Attachment from '../../models/Attachment';
+import Comment from '../../models/Comment';
+import { IUniqueId } from '../../models/index';
 import type Thread from '../../models/Thread';
 import { updateLastVisited } from '../app/login';
 

--- a/packages/commonwealth/client/scripts/controllers/server/reactions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/reactions.ts
@@ -1,7 +1,9 @@
-import type { AbridgedThread, AnyProposal } from 'models';
-import { Comment, Reaction, Thread } from 'models';
-
 import { ReactionStore } from 'stores';
+import AbridgedThread from '../../models/AbridgedThread';
+import Comment from '../../models/Comment';
+import { AnyProposal } from '../../models/index';
+import Reaction from '../../models/Reaction';
+import Thread from '../../models/Thread';
 
 export const modelFromServer = (reaction) => {
   return new Reaction({

--- a/packages/commonwealth/client/scripts/models/index.ts
+++ b/packages/commonwealth/client/scripts/models/index.ts
@@ -1,4 +1,3 @@
-export { default as AbridgedThread } from './AbridgedThread';
 export { default as Account } from './Account';
 export { default as AddressInfo } from './AddressInfo';
 export { default as BlockInfo } from './BlockInfo';
@@ -29,7 +28,6 @@ export { AccessLevel } from 'permissions';
 export { default as SearchQuery } from './SearchQuery';
 export { default as SearchResult } from './SearchResult';
 export { default as SocialAccount } from './SocialAccount';
-export { default as StorageModule } from './StorageModule';
 export { default as ChainEvent } from './ChainEvent';
 export { default as ChainEntity } from './ChainEntity';
 export { default as StarredCommunity } from './StarredCommunity';

--- a/packages/commonwealth/client/scripts/stores/ActivityStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ActivityStore.ts
@@ -1,5 +1,5 @@
-import type { AbridgedThread } from 'models';
-import { AddressInfo } from 'models';
+import type AbridgedThread from '../models/AbridgedThread';
+import AddressInfo from '../models/AddressInfo';
 import app from 'state';
 import { byAscendingCreationDate } from '../helpers';
 

--- a/packages/commonwealth/client/scripts/stores/CommentsStore.ts
+++ b/packages/commonwealth/client/scripts/stores/CommentsStore.ts
@@ -1,6 +1,6 @@
 import { byAscendingCreationDate } from '../helpers';
-import type { AbridgedThread } from '../models';
-import type { Comment } from '../models';
+import AbridgedThread from '../models/AbridgedThread';
+import Comment from '../models/Comment';
 import type Thread from '../models/Thread';
 import IdStore from './IdStore';
 

--- a/packages/commonwealth/client/scripts/stores/ReactionCountsStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ReactionCountsStore.ts
@@ -1,7 +1,11 @@
-import type { AnyProposal, Reaction } from 'models';
-import { AbridgedThread, Comment, Proposal, Thread } from 'models';
 import type ReactionCount from 'models/ReactionCount';
 import IdStore from 'stores/IdStore';
+import AbridgedThread from '../models/AbridgedThread';
+import Comment from '../models/Comment';
+import { AnyProposal } from '../models/index';
+import Proposal from '../models/Proposal';
+import Reaction from '../models/Reaction';
+import Thread from '../models/Thread';
 
 class ReactionCountsStore extends IdStore<ReactionCount<any>> {
   private _storeRC: { [identifier: string]: ReactionCount<any> } = {};

--- a/packages/commonwealth/client/scripts/stores/ReactionStore.ts
+++ b/packages/commonwealth/client/scripts/stores/ReactionStore.ts
@@ -1,6 +1,10 @@
 import { byAscendingCreationDate } from '../helpers';
 import type { AnyProposal } from '../models';
-import { AbridgedThread, Comment, Proposal, Reaction, Thread } from '../models';
+import AbridgedThread from '../models/AbridgedThread';
+import Comment from '../models/Comment';
+import Proposal from '../models/Proposal';
+import Reaction from '../models/Reaction';
+import Thread from '../models/Thread';
 import IdStore from './IdStore';
 
 class ReactionStore extends IdStore<Reaction> {


### PR DESCRIPTION
I will start removing imports from models/index.ts and replacing them with imports to the original exporting class.

## Link to Issue
Closes: #3467 

## Description of Changes
- Removes AbdrigedThreads export from models/index.ts
- Replaces import usages with models/AbridgedThreads
- Replaces imports of files touched with parent imports (to avoid needing to review the same file multiple times).

## Test Plan
- started the app, made sure homepage runs.