### PR TITLE
Truncate search results

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_renderer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_renderer.tsx
@@ -4,12 +4,15 @@ import { MarkdownFormattedText } from './markdown_formatted_text';
 import { DeltaStatic } from 'quill';
 import { SerializableDeltaStatic, getTextFromDelta } from './utils';
 
+export const SEARCH_PREVIEW_HEIGHT = 70;
+
 export type QuillRendererProps = {
   doc: string;
   hideFormatting?: boolean;
   openLinksInNewTab?: boolean;
   searchTerm?: string;
   cutoffLines?: number;
+  containerClass?: string;
 };
 
 type RichTextDocInfo = { format: 'richtext'; content: DeltaStatic };
@@ -23,6 +26,7 @@ export const QuillRenderer = ({
   searchTerm,
   hideFormatting,
   cutoffLines,
+  containerClass,
 }: QuillRendererProps) => {
   const docInfo: DocInfo = useMemo(() => {
     let decodedText: string;
@@ -62,26 +66,40 @@ export const QuillRenderer = ({
     }
   }, [doc]);
 
-  switch (docInfo.format) {
-    case 'richtext':
-      return (
-        <QuillFormattedText
-          hideFormatting={hideFormatting}
-          doc={docInfo.content}
-          searchTerm={searchTerm}
-          cutoffLines={cutoffLines}
-        />
-      );
-    case 'markdown':
-      return (
-        <MarkdownFormattedText
-          hideFormatting={hideFormatting}
-          doc={docInfo.content}
-          searchTerm={searchTerm}
-          cutoffLines={cutoffLines}
-        />
-      );
-    default:
-      return <>N/A</>;
+  const renderedDoc = useMemo(() => {
+    switch (docInfo.format) {
+      case 'richtext':
+        return (
+          <QuillFormattedText
+            hideFormatting={hideFormatting}
+            doc={docInfo.content}
+            searchTerm={searchTerm}
+            cutoffLines={cutoffLines}
+          />
+        );
+      case 'markdown':
+        return (
+          <MarkdownFormattedText
+            hideFormatting={hideFormatting}
+            doc={docInfo.content}
+            searchTerm={searchTerm}
+            cutoffLines={cutoffLines}
+          />
+        );
+      default:
+        return <>N/A</>;
+    }
+  }, [
+    cutoffLines,
+    hideFormatting,
+    searchTerm,
+    docInfo.content,
+    docInfo.format,
+  ]);
+
+  if (containerClass) {
+    return <div className={containerClass}>{renderedDoc}</div>;
   }
+
+  return renderedDoc;
 };

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_renderer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_renderer.tsx
@@ -4,8 +4,6 @@ import { MarkdownFormattedText } from './markdown_formatted_text';
 import { DeltaStatic } from 'quill';
 import { SerializableDeltaStatic, getTextFromDelta } from './utils';
 
-export const SEARCH_PREVIEW_HEIGHT = 70;
-
 export type QuillRendererProps = {
   doc: string;
   hideFormatting?: boolean;

--- a/packages/commonwealth/client/scripts/views/pages/search/search_bar_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/search_bar_components.tsx
@@ -97,6 +97,7 @@ export const SearchBarThreadPreviewRow = (props: SearchBarPreviewRowProps) => {
           hideFormatting={true}
           doc={content}
           searchTerm={searchTerm}
+          containerClass="SearchQuillRenderer"
         />
       </CWText>
     </div>
@@ -129,6 +130,7 @@ export const SearchBarCommentPreviewRow = (props: SearchBarPreviewRowProps) => {
           hideFormatting={true}
           doc={content}
           searchTerm={searchTerm}
+          containerClass="SearchQuillRenderer"
         />
       </CWText>
     </div>

--- a/packages/commonwealth/client/styles/pages/search/search_bar_components.scss
+++ b/packages/commonwealth/client/styles/pages/search/search_bar_components.scss
@@ -83,3 +83,8 @@
 .SearchBarMemberPreviewRow {
   @include everyRowStyles;
 }
+
+.SearchQuillRenderer {
+  max-height: 60px;
+  overflow-y: hidden;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3775

## Description of Changes
- Truncates height of search bar results

## Test Plan
- Search for "osmosis" without submitting– confirm that all thread and comment previews show 3 lines at most

## Deployment Plan
N/A

## Other Considerations
- Truncation currently only applies to **search bar** results, not the **search page** results. Let me know if it should be applied to the page as well.
- Although the `cutoffLines` prop exists on the quill renderer, it works based on explicit line breaks, not visual line breaks, so we need to set the container height limit to guarantee visual consistency.