### PR TITLE
Clean up getThreadUrl usage to fix invalid notification links.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
@@ -133,11 +133,7 @@ const getNotificationFields = (category, data: IPostNotificationData) => {
     chain: chain_id,
   };
 
-  const args = comment_id
-    ? [root_type, pseudoProposal, { id: comment_id }]
-    : [root_type, pseudoProposal];
-
-  const path = (getThreadUrl as any)(...args);
+  const path = getThreadUrl(pseudoProposal, comment_id);
 
   const pageJump = comment_id
     ? () => jumpHighlightNotification(comment_id)
@@ -259,14 +255,10 @@ export const getBatchNotificationFields = (
     chain: chain_id,
   };
 
-  const args = comment_id
-    ? [pseudoProposal, { id: comment_id }]
-    : [pseudoProposal, undefined];
-
   const path =
     category === NotificationCategories.NewThread
-      ? (getCommunityUrl as any)(chain_id)
-      : (getThreadUrl as any)(...args);
+      ? getCommunityUrl(chain_id)
+      : getThreadUrl(pseudoProposal, comment_id);
 
   const pageJump = comment_id
     ? () => jumpHighlightNotification(comment_id)

--- a/packages/commonwealth/server/routes/createComment.ts
+++ b/packages/commonwealth/server/routes/createComment.ts
@@ -270,7 +270,7 @@ const createComment = async (
   const cwUrl =
     typeof thread === 'string'
       ? getThreadUrlWithoutObject(finalComment.chain, thread, finalComment)
-      : getThreadUrl(thread, finalComment);
+      : getThreadUrl(thread, finalComment?.id);
   const root_title = typeof thread === 'string' ? '' : thread.title || '';
 
   // auto-subscribe comment author to reactions & child comments

--- a/packages/commonwealth/server/routes/createReaction.ts
+++ b/packages/commonwealth/server/routes/createReaction.ts
@@ -192,11 +192,11 @@ const createReaction = async (
     proposal = await models.Thread.findOne({
       where: { id },
     });
-    cwUrl = getThreadUrl(proposal, comment);
+    cwUrl = getThreadUrl(proposal, comment?.id);
   } else if (thread_id) {
     proposal = await models.Thread.findByPk(Number(thread_id));
     if (!proposal) return next(new AppError(Errors.NoProposalMatch));
-    cwUrl = getThreadUrl(proposal, comment);
+    cwUrl = getThreadUrl(proposal, comment?.id);
     root_type = 'discussion';
   }
 

--- a/packages/commonwealth/server/routes/editComment.ts
+++ b/packages/commonwealth/server/routes/editComment.ts
@@ -119,7 +119,7 @@ const editComment = async (
     const cwUrl =
       typeof proposal === 'string'
         ? getThreadUrlWithoutObject(comment.chain, proposal, finalComment)
-        : getThreadUrl(proposal, comment);
+        : getThreadUrl(proposal, comment?.id);
     const root_title = typeof proposal === 'string' ? '' : proposal.title || '';
 
     // dispatch notifications to subscribers of the comment/thread

--- a/packages/commonwealth/shared/notificationFormatter.ts
+++ b/packages/commonwealth/shared/notificationFormatter.ts
@@ -110,10 +110,10 @@ export const getForumNotificationCopy = async (
     title: root_title,
     chain: chain_id,
   };
-  const proposalUrlArgs = comment_id
-    ? [pseudoProposal, { id: comment_id }]
-    : [pseudoProposal];
-  const proposalPath = (getThreadUrl as any)(...proposalUrlArgs);
+  const proposalPath = getThreadUrl(
+    pseudoProposal,
+    comment_id,
+  );
   return [
     emailSubjectLine,
     authorName,

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -71,11 +71,16 @@ export const requiresTypeSlug = (type: ProposalType): boolean => {
 };
 
 /* eslint-disable */
-export const getThreadUrl = (thread, comment?) => {
+export const getThreadUrl = (thread: {
+  chain: string;
+  type_id?: string | number;
+  id?: string | number;
+  title?: string;
+}, comment?: string | number): string => {
   const aId = thread.chain;
   const tId = thread.type_id || thread.id;
   const tTitle = thread.title ? `-${slugify(thread.title)}` : '';
-  const cId = comment ? `?comment=${comment.id}` : '';
+  const cId = comment ? `?comment=${comment}` : '';
 
   return process.env.NODE_ENV === 'production'
     ? `https://commonwealth.im/${aId}/discussion/${tId}${tTitle.toLowerCase()}${cId}`
@@ -96,7 +101,7 @@ export const getThreadUrlWithoutObject = (
     : `http://localhost:8080/${aId}/discussion/${tId}${cId}`;
 };
 
-export const getCommunityUrl = (community) => {
+export const getCommunityUrl = (community: string): string => {
   return process.env.NODE_ENV === 'production'
     ? `https://commonwealth.im/${community}`
     : `http://localhost:8080/${community}`;


### PR DESCRIPTION
## Link to Issue
Closes: #3833 

## Description of Changes
- Simplified usage of getThreadUrl and getCommunityUrl (added types, removed unnecessary `any` casting).
- Fixed bug caused by passing incorrect arguments to `getThreadUrl`, leftover from root_id migration.

## Test Plan
- Confirm new thread, new comment, new reaction links from notifications popover or page work as expected.
