### PR TITLE
Interop cleanup

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -7,7 +7,6 @@ import { notifyError } from 'controllers/app/notifications';
 import { isSameAccount } from 'helpers';
 import $ from 'jquery';
 
-import { redraw } from 'mithrilInterop';
 import moment from 'moment';
 import app from 'state';
 import Account from '../../models/Account';
@@ -35,7 +34,7 @@ export async function setActiveAccount(account: Account): Promise<void> {
   const role = app.roles.getRoleInCommunity({ account, chain });
 
   if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
-    app.chain.activeAddressHasToken(account.address).then(() => redraw());
+    await app.chain.activeAddressHasToken(account.address);
   }
 
   if (!role || role.is_user_default) {
@@ -123,7 +122,6 @@ export async function completeClientLogin(account: Account) {
     ) {
       app.user.setActiveAccounts(app.user.activeAccounts.concat([account]));
     }
-    redraw();
   } catch (e) {
     console.trace(e);
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -13,13 +13,16 @@ import BN from 'bn.js';
 import { ChainNetwork, WalletId } from 'common-common/src/types';
 
 import { CosmosToken } from 'controllers/chain/cosmos/types';
-import { redraw } from 'mithrilInterop';
 import moment from 'moment';
 import type { IApp } from 'state';
 import { ApiStatus } from 'state';
 import { LCD } from 'chain-events/src/chains/cosmos/types';
 import ChainInfo from '../../../models/ChainInfo';
-import { IChainModule, ITXData, ITXModalData } from '../../../models/interfaces';
+import {
+  IChainModule,
+  ITXData,
+  ITXModalData,
+} from '../../../models/interfaces';
 import WebWalletController from '../../app/web_wallets';
 import type KeplrWebWalletController from '../../app/webWallets/keplr_web_wallet';
 import type CosmosAccount from './account';
@@ -123,7 +126,6 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
     this.app.chain.block.height = height;
 
     this.app.chain.networkStatus = ApiStatus.Connected;
-    redraw();
   }
 
   public async deinit(): Promise<void> {

--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/chain.ts
@@ -2,7 +2,6 @@
 
 import { EthereumCoin } from 'adapters/chain/ethereum/types';
 
-import { redraw } from 'mithrilInterop';
 import moment from 'moment';
 import type { IApp } from 'state';
 import { ApiStatus } from 'state';
@@ -104,7 +103,6 @@ class EthereumChain implements IChainModule<EthereumCoin, EthereumAccount> {
       }
       this.app.chain.block.duration = totalDuration / nHeadersForBlocktime;
       console.log(`Computed block duration: ${this.app.chain.block.duration}`);
-      redraw();
     }
     return this._api;
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/near/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/near/chain.ts
@@ -21,7 +21,6 @@ import type { IChainModule, ITXModalData } from '../../../models/interfaces';
 import type { NearAccount, NearAccounts } from './account';
 import type { NearSputnikConfig, NearSputnikPolicy } from './sputnik/types';
 import { isGroupRole } from './sputnik/types';
-import { redraw } from 'mithrilInterop';
 
 export interface IDaoInfo {
   contractId: string;
@@ -116,10 +115,8 @@ class NearChain implements IChainModule<NearToken, NearAccount> {
 
       // handle chain-related updates
       this._chainId = this._nodeStatus.chain_id;
-      const {
-        latest_block_time,
-        latest_block_height,
-      } = this._nodeStatus.sync_info;
+      const { latest_block_time, latest_block_height } =
+        this._nodeStatus.sync_info;
 
       // update block heights and times
       this.app.chain.block.lastTime = moment(latest_block_time);
@@ -132,13 +129,11 @@ class NearChain implements IChainModule<NearToken, NearAccount> {
         +latest_block_time - prevBlock.header.timestamp;
       if (this.app.chain.networkStatus !== ApiStatus.Connected) {
         this.app.chain.networkStatus = ApiStatus.Connected;
-        redraw();
       }
     } catch (e) {
       if (this.app.chain.networkStatus !== ApiStatus.Disconnected) {
         console.error(`failed to query NEAR status: ${JSON.stringify(e)}`);
         this.app.chain.networkStatus = ApiStatus.Disconnected;
-        redraw();
       }
     }
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/solana/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/solana/chain.ts
@@ -1,7 +1,6 @@
 import type * as solw3 from '@solana/web3.js';
 import BN from 'bn.js';
 
-import { redraw } from 'mithrilInterop';
 import moment from 'moment';
 import type { IApp } from 'state';
 import { ApiStatus } from 'state';
@@ -59,7 +58,6 @@ export default class SolanaChain
     );
     this.app.chain.block.lastTime = moment(); // approx hack to get current slot timestamp
     this.app.chain.networkStatus = ApiStatus.Connected;
-    redraw();
   }
 
   public async deinit() {

--- a/packages/commonwealth/client/scripts/controllers/chain/substrate/shared.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/substrate/shared.ts
@@ -1,4 +1,3 @@
-import { redraw } from 'mithrilInterop';
 import type { SubmittableResult } from '@polkadot/api';
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
 import type {
@@ -11,10 +10,8 @@ import type { u128 } from '@polkadot/types';
 
 import type { Compact } from '@polkadot/types/codec';
 import type {
-  ActiveEraInfo,
   Call,
   DispatchError,
-  EraIndex,
   SessionIndex,
 } from '@polkadot/types/interfaces';
 import type { CallFunction, InterfaceTypes } from '@polkadot/types/types';
@@ -154,7 +151,6 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
         this.app.chain.networkError = null;
         this._suppressAPIDisconnectErrors = false;
         this._connectTime = 0;
-        redraw();
       }
     };
     const disconnectedCb = () => {
@@ -169,7 +165,6 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
         setTimeout(() => {
           this._suppressAPIDisconnectErrors = false;
         }, CONNECT_TIMEOUT);
-        redraw();
       }
     };
     const errorCb = (err) => {
@@ -193,9 +188,7 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
           console.log('chain connection timed out!');
           provider.disconnect();
           this._timedOut = true;
-          redraw();
         }, CONNECT_TIMEOUT);
-        redraw();
       }
     };
 
@@ -349,9 +342,6 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
     this._totalbalance = this.coins(totalbalance);
     this._existentialdeposit = this.coins(existentialdeposit);
     this._sudoKey = sudokey ? sudokey.toString() : undefined;
-
-    // redraw
-    redraw();
     this._metadataInitialized = true;
   }
 
@@ -432,7 +422,6 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
             }
           }
         });
-        redraw();
       }
     );
     this._eventsInitialized = true;
@@ -548,7 +537,6 @@ class SubstrateChain implements IChainModule<SubstrateCoin, SubstrateAccount> {
             } else {
               notifyError(err.toString());
             }
-            redraw();
             events.emit(TransactionStatus.Error.toString(), {
               err: err.toString(),
             });

--- a/packages/commonwealth/client/scripts/controllers/server/communities.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/communities.ts
@@ -1,7 +1,6 @@
 import $ from 'jquery';
 import app from 'state';
 
-import { redraw } from 'mithrilInterop';
 import StarredCommunity from '../../models/StarredCommunity';
 
 class CommunitiesController {
@@ -43,7 +42,6 @@ class CommunitiesController {
             app.user.removeStarredCommunity(star);
           }
           resolve();
-          redraw();
         })
         .catch(() => {
           reject();

--- a/packages/commonwealth/client/scripts/controllers/server/notifications.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/notifications.ts
@@ -2,7 +2,6 @@
 import { EventEmitter } from 'events';
 import $ from 'jquery';
 
-import { redraw } from 'mithrilInterop';
 import NotificationSubscription, { modelFromServer } from 'models/NotificationSubscription';
 
 import app from 'state';

--- a/packages/commonwealth/client/scripts/controllers/server/polls.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/polls.ts
@@ -4,7 +4,6 @@ import Poll from '../../models/Poll';
 import Vote from '../../models/Vote';
 import moment from 'moment';
 import app from 'state';
-import { redraw } from 'mithrilInterop';
 
 import PollStore from 'stores/PollStore';
 
@@ -125,9 +124,8 @@ class PollsController {
         chain_id: app.activeChainId(),
         jwt: app.user.jwt,
       },
-      success: (response) => {
+      success: () => {
         this._store.remove(this._store.getById(pollId));
-        redraw();
       },
       error: (err) => {
         console.log('Failed to delete poll');

--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -8,7 +8,6 @@ import { modelFromServer as modelReactionFromServer } from 'controllers/server/r
 import $ from 'jquery';
 /* eslint-disable no-restricted-syntax */
 
-import { redraw } from 'mithrilInterop';
 import Attachment from '../../models/Attachment';
 import type ChainEntity from '../../models/ChainEntity';
 import type MinimumProfile from '../../models/MinimumProfile';
@@ -412,7 +411,6 @@ class ThreadsController {
           this._listingStore.remove(proposal);
           this._overviewStore.remove(proposal);
           this.numTotalThreads -= 1;
-          redraw();
           resolve(result);
         })
         .catch((e) => {

--- a/packages/commonwealth/client/scripts/helpers/DEPRECATED_ReactRender.ts
+++ b/packages/commonwealth/client/scripts/helpers/DEPRECATED_ReactRender.ts
@@ -1,0 +1,59 @@
+import React, { createElement } from 'react';
+
+// This is legacy code from mithril interop layer. This method should
+// not be used anymore in new functionalities. We want to
+// gracefully get rid of it from the codebase
+export const render = (
+  tag: string | React.ComponentType,
+  attrs: any = {},
+  ...children: any[]
+) => {
+  let className = attrs?.className;
+
+  // check if selector uses classes (.) and convert to props, as
+  // Mithril supports e.g. `.User.etc` tags while React does not
+  if (typeof tag === 'string' && tag.includes('.')) {
+    const [selector, ...classes] = tag.split('.');
+
+    if (className) {
+      className = `${className} ${classes.join(' ')}`;
+    } else {
+      className = classes.join(' ');
+    }
+
+    // replace pure class selector (e.g. .User) with div (e.g. div.User)
+    tag = selector || 'div';
+  }
+
+  // handle children without attrs => corresponds to `m(tag, children)`
+  if (Array.isArray(attrs) || typeof attrs !== 'object') {
+    children = attrs;
+    attrs = { className };
+  } else {
+    attrs = { ...attrs };
+  }
+
+  // ensure vnode.className exists
+  attrs.className = className;
+
+  // react forbids <img> and <br> tags to have children
+  if (tag === 'img' || tag == 'br') {
+    return createElement(tag, attrs);
+  }
+
+  // ensure vnode.children exists as mithril expects
+  attrs.children = children;
+
+  return createElement(tag, attrs, ...children);
+};
+
+// corresponds to Mithril's `m.trust()` call, which is used to render inner HTML directly
+render.trust = (html: string, wrapper?: string) => {
+  if (wrapper) {
+    return createElement(wrapper, {
+      dangerouslySetInnerHTML: { __html: html },
+    });
+  } else {
+    return createElement('div', { dangerouslySetInnerHTML: { __html: html } });
+  }
+};

--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -2,7 +2,6 @@ import app, { ApiStatus } from 'state';
 import { ChainBase, ChainNetwork, ChainType } from 'common-common/src/types';
 import { updateActiveAddresses } from 'controllers/app/login';
 import $ from 'jquery';
-import { redraw } from 'mithrilInterop';
 import type { NavigateFunction } from 'react-router-dom';
 import ChainInfo from '../models/ChainInfo';
 import NodeInfo from '../models/NodeInfo';
@@ -53,7 +52,6 @@ export const selectChain = async (
   await deinitChainOrCommunity();
   app.chainPreloading = true;
   document.title = `Commonwealth – ${chain.name}`;
-  setTimeout(() => redraw()); // redraw to show API status indicator
 
   // Import top-level chain adapter lazily, to facilitate code split.
   let newChain;
@@ -216,9 +214,6 @@ export const selectChain = async (
     });
   }
 
-  // Redraw with not-yet-loaded chain and return true to indicate
-  // initialization has finalized.
-  redraw();
   return true;
 };
 
@@ -244,9 +239,6 @@ export const initChain = async (): Promise<void> => {
 
   // Instantiate (again) to create chain-specific Account<> objects
   await updateActiveAddresses(chain);
-
-  // Finish redraw to remove loading dialog
-  redraw();
 };
 
 export const initNewTokenChain = async (

--- a/packages/commonwealth/client/scripts/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/helpers/index.ts
@@ -1,5 +1,4 @@
 import type { ClassComponent } from 'mithrilInterop';
-import { render } from 'mithrilInterop';
 import BigNumber from 'bignumber.js';
 import { ChainBase, ChainNetwork } from 'common-common/src/types';
 import moment from 'moment';
@@ -8,6 +7,7 @@ import type { Coin } from 'adapters/currency';
 import Account from '../models/Account';
 import IChainAdapter from '../models/IChainAdapter';
 import { ThreadStage } from '../models/types';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 
 export async function sleep(msec) {
   return new Promise((resolve) => setTimeout(resolve, msec));

--- a/packages/commonwealth/client/scripts/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/helpers/index.ts
@@ -1,4 +1,3 @@
-import type { ClassComponent } from 'mithrilInterop';
 import BigNumber from 'bignumber.js';
 import { ChainBase, ChainNetwork } from 'common-common/src/types';
 import moment from 'moment';
@@ -8,6 +7,7 @@ import Account from '../models/Account';
 import IChainAdapter from '../models/IChainAdapter';
 import { ThreadStage } from '../models/types';
 import { render } from 'helpers/DEPRECATED_ReactRender';
+import { NavigateOptions, To } from 'react-router';
 
 export async function sleep(msec) {
   return new Promise((resolve) => setTimeout(resolve, msec));
@@ -83,7 +83,11 @@ export function link(
   selector: string,
   target: string,
   children,
-  setRoute: ClassComponent['setRoute'],
+  setRoute: (
+    url: To,
+    options?: NavigateOptions,
+    prefix?: null | string
+  ) => void,
   extraAttrs?: object,
   saveScrollPositionAs?: string,
   beforeRouteSet?: () => void,

--- a/packages/commonwealth/client/scripts/helpers/injectGoogleTagManagerScript.ts
+++ b/packages/commonwealth/client/scripts/helpers/injectGoogleTagManagerScript.ts
@@ -1,4 +1,4 @@
-import { render } from 'mithrilInterop';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 
 const injectGoogleTagManagerScript = () => {
   const script = document.createElement('noscript');

--- a/packages/commonwealth/client/scripts/mithrilInterop/index.ts
+++ b/packages/commonwealth/client/scripts/mithrilInterop/index.ts
@@ -9,73 +9,16 @@
  */
 
 import type { FunctionComponent, ReactNode } from 'react';
-import { createElement, Component as ReactComponent } from 'react';
+import { Component as ReactComponent } from 'react';
 import type {
   NavigateFunction,
   Location,
   NavigateOptions,
 } from 'react-router-dom';
-import { createRoot } from 'react-dom/client';
 import { getScopePrefix } from 'navigation/helpers';
 
 // corresponds to Mithril's "Children" type -- RARELY USED
 export type Children = ReactNode | ReactNode[];
-
-// corresponds to Mithril's `m()` call
-export const render = (
-  tag: string | React.ComponentType,
-  attrs: any = {},
-  ...children: any[]
-) => {
-  let className = attrs?.className;
-
-  // check if selector uses classes (.) and convert to props, as
-  // Mithril supports e.g. `.User.etc` tags while React does not
-  if (typeof tag === 'string' && tag.includes('.')) {
-    const [selector, ...classes] = tag.split('.');
-
-    if (className) {
-      className = `${className} ${classes.join(' ')}`;
-    } else {
-      className = classes.join(' ');
-    }
-
-    // replace pure class selector (e.g. .User) with div (e.g. div.User)
-    tag = selector || 'div';
-  }
-
-  // handle children without attrs => corresponds to `m(tag, children)`
-  if (Array.isArray(attrs) || typeof attrs !== 'object') {
-    children = attrs;
-    attrs = { className };
-  } else {
-    attrs = { ...attrs };
-  }
-
-  // ensure vnode.className exists
-  attrs.className = className;
-
-  // react forbids <img> and <br> tags to have children
-  if (tag === 'img' || tag == 'br') {
-    return createElement(tag, attrs);
-  }
-
-  // ensure vnode.children exists as mithril expects
-  attrs.children = children;
-
-  return createElement(tag, attrs, ...children);
-};
-
-// corresponds to Mithril's `m.trust()` call, which is used to render inner HTML directly
-render.trust = (html: string, wrapper?: string) => {
-  if (wrapper) {
-    return createElement(wrapper, {
-      dangerouslySetInnerHTML: { __html: html },
-    });
-  } else {
-    return createElement('div', { dangerouslySetInnerHTML: { __html: html } });
-  }
-};
 
 // Mithril component type, maps to FC
 export type Component<Props = unknown> = FunctionComponent<Props>;
@@ -207,14 +150,4 @@ export function redraw(sync = false, component?: any) {
   } else {
     // console.trace('no-op redraw called!');
   }
-}
-
-// m.mount() shim
-export function rootMount(element: Element, component?: any | null) {
-  return createRoot(element).render(component);
-}
-
-// m.render() shim
-export function rootRender(el: Element, vnodes: Children) {
-  return rootMount(el, render('div', {}, vnodes));
 }

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -1,4 +1,4 @@
-import { render } from 'mithrilInterop';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 import $ from 'jquery';
 import type { RegisteredTypes } from '@polkadot/types/types';
 import app from 'state';

--- a/packages/commonwealth/client/scripts/models/MinimumProfile.ts
+++ b/packages/commonwealth/client/scripts/models/MinimumProfile.ts
@@ -1,4 +1,4 @@
-import { render } from 'mithrilInterop';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 import jdenticon from 'jdenticon';
 
 import {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 
-import { redraw } from 'mithrilInterop';
-
 import 'components/component_kit/cw_sidebar_menu.scss';
 
 import app from 'state';
@@ -93,7 +91,6 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
                 e.stopPropagation();
                 await app.communities.setStarred(item.id);
                 setIsStarred((prevState) => !prevState);
-                redraw();
               }}
             />
           </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
 import app from 'state';
 import $ from 'jquery';
 import { ChainBase } from 'common-common/src/types';
@@ -299,8 +298,6 @@ export const CWWalletsList = (props: WalletsListProps) => {
     );
 
     await wallet.reset();
-
-    redraw();
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -5,7 +5,6 @@ import { initAppState } from 'state';
 import { ChainBase, ChainNetwork, WalletId } from 'common-common/src/types';
 import { addressSwapper } from 'utils';
 import $ from 'jquery';
-import { redraw } from 'mithrilInterop';
 
 import _ from 'lodash';
 
@@ -120,7 +119,6 @@ export const LoginSelectorMenuLeft = ({
                 onClick={async () => {
                   await setActiveAccount(account);
                   setSelectedAddress(account.address);
-                  redraw();
                 }}
               >
                 <UserBlock
@@ -225,7 +223,6 @@ export const LoginSelectorMenuRight = ({
                 ? toggleDarkMode(false, setIsDarkModeOn)
                 : toggleDarkMode(true, setIsDarkModeOn);
               e.stopPropagation();
-              redraw();
             }}
           />
           <div className="login-darkmode-label">
@@ -481,7 +478,6 @@ export const LoginSelector = () => {
         if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
           await app.chain.activeAddressHasToken(app.user.activeAccount.address);
         }
-        redraw();
       } catch (err) {
         console.error(err);
       }

--- a/packages/commonwealth/client/scripts/views/components/proposals/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/proposals/helpers.ts
@@ -1,5 +1,3 @@
-import { redraw } from 'mithrilInterop';
-
 import { formatCoin } from 'adapters/currency';
 import { CompoundTypes } from 'chain-events/src/types';
 import { notifyError } from 'controllers/app/notifications';
@@ -51,16 +49,13 @@ export const getBalance = (proposal: AnyProposal, vote: IVote<any>) => {
       if (vote instanceof AaveProposalVote) {
         balance = vote.power;
         balancesCache[vote.account.address] = vote.format();
-        redraw();
       } else if (vote instanceof CompoundProposalVote) {
         balance = formatCoin(app.chain.chain.coins(vote.power), true);
         balancesCache[vote.account.address] = balance;
-        redraw();
       } else {
         vote.account.balance.then((b) => {
           balance = b;
           balancesCache[vote.account.address] = formatCoin(b, true);
-          redraw();
         });
         balance = '--';
       }
@@ -84,7 +79,6 @@ export const cancelProposal = (
       .cancelTx()
       .then(() => {
         onModalClose();
-        redraw();
       })
       .catch((err) => {
         onModalClose();
@@ -95,7 +89,6 @@ export const cancelProposal = (
       .cancelTx()
       .then(() => {
         onModalClose();
-        redraw();
       })
       .catch((err) => {
         onModalClose();

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/render_quill_delta.ts
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/render_quill_delta.ts
@@ -1,4 +1,4 @@
-import { render } from 'mithrilInterop';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 
 import { loadScript } from 'helpers';
 import { preprocessQuillDeltaForRendering } from '../../../../../shared/utils';
@@ -152,7 +152,7 @@ export const renderQuillDelta = (
           })
         );
       })
-    : consolidateOrderedLists(groups).map((group, i) => {
+    : consolidateOrderedLists(groups).map((group) => {
         const renderChild = (child, ii) => {
           // handle images
           if (child.insert?.image) {
@@ -389,7 +389,7 @@ export const renderQuillDelta = (
               render(
                 getGroupTag(_group),
                 { key: `extra-${iii}` },
-                temp.pop().map(({ tag, content, key }, index) => {
+                temp.pop().map(({ tag, content }, index) => {
                   return render(tag, { key: index }, content);
                 })
               )
@@ -399,7 +399,7 @@ export const renderQuillDelta = (
           return render(
             getGroupTag(_group),
             { key: ii },
-            temp[0].map(({ tag, content, key }, index) => {
+            temp[0].map(({ tag, content }, index) => {
               return render(tag, { key: index }, content);
             })
           );

--- a/packages/commonwealth/client/scripts/views/components/reaction_button/comment_reaction_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/reaction_button/comment_reaction_button.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
-
 import 'components/reaction_button/comment_reaction_button.scss';
 import TopicGateCheck from 'controllers/chain/ethereum/gatedTopic';
 
@@ -68,8 +66,6 @@ export const CommentReactionButton = (props: CommentReactionButtonProps) => {
         );
 
         setIsLoading(false);
-
-        redraw();
       });
   };
 
@@ -87,8 +83,6 @@ export const CommentReactionButton = (props: CommentReactionButtonProps) => {
         ]);
 
         setIsLoading(false);
-
-        redraw();
       });
   };
 
@@ -126,7 +120,7 @@ export const CommentReactionButton = (props: CommentReactionButtonProps) => {
             content={
               <div className="reaction-button-tooltip-contents">
                 {getDisplayedReactorsForPopup({
-                  reactors: reactors.map(r => r.Address.address),
+                  reactors: reactors.map((r) => r.Address.address),
                 })}
               </div>
             }

--- a/packages/commonwealth/client/scripts/views/components/user/anonymous_user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/anonymous_user.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from 'mithrilInterop';
+import { render } from 'helpers/DEPRECATED_ReactRender';
 import jdenticon from 'jdenticon';
 
 import 'components/user/user.scss';

--- a/packages/commonwealth/client/scripts/views/layout.tsx
+++ b/packages/commonwealth/client/scripts/views/layout.tsx
@@ -1,16 +1,10 @@
 import React, { Suspense, useState } from 'react';
 
-// import type { ClassComponentRouter } from 'mithrilInterop';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
 
 import 'layout.scss';
 
-import {
-  deinitChainOrCommunity,
-  initChain,
-  initNewTokenChain,
-  selectChain,
-} from 'helpers/chain';
+import { deinitChainOrCommunity, initChain, selectChain } from 'helpers/chain';
 
 import app from 'state';
 import { PageNotFound } from 'views/pages/404';

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
 import { ChainBase, ChainNetwork, ProposalType } from 'common-common/src/types';
 // import { mixpanelBrowserTrack } from 'helpers/mixpanel_browser_util';
 // import { MixpanelCommunityCreationEvent } from 'analytics/types';
@@ -259,7 +258,6 @@ export const CreateContentSidebar = () => {
             app.sidebarToggled = false;
             app.sidebarMenu = 'default';
             app.sidebarRedraw.emit('redraw');
-            redraw();
           }, 200);
         },
       }}

--- a/packages/commonwealth/client/scripts/views/modals/canvas_verify_data_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/canvas_verify_data_modal.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import $ from 'jquery';
-import { redraw } from 'mithrilInterop';
 import type { Action, Session } from '@canvas-js/interfaces';
 
-import app from 'state';
 import { CWButton } from '../components/component_kit/cw_button';
 import { verify } from '../../helpers/canvas';
 
@@ -35,15 +33,13 @@ const CanvasVerifyDataModal = (props: CanvasVerifyDataModalProps) => {
 
       verify({ session })
         .then((result) => setVerifiedSession(result))
-        .catch((err) => console.error('Could not verify session:', err))
-        .finally(() => redraw());
+        .catch((err) => console.error('Could not verify session:', err));
       verify({
         action,
         actionSignerAddress: session.payload.sessionAddress,
       })
         .then((result) => setVerifiedAction(result))
-        .catch((err) => console.error('Could not verify action:', err))
-        .finally(() => redraw());
+        .catch((err) => console.error('Could not verify action:', err));
     });
   }, []);
 

--- a/packages/commonwealth/client/scripts/views/modals/confirm_snapshot_vote_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/confirm_snapshot_vote_modal.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
-
 import { notifyError } from 'controllers/app/notifications';
 import type { SnapshotProposal, SnapshotSpace } from 'helpers/snapshot_utils';
 import { castVote } from 'helpers/snapshot_utils';
 import { formatNumberShort } from 'adapters/currency';
-// import { MixpanelSnapshotEvents } from 'analytics/types';
 
 import 'modals/confirm_snapshot_vote_modal.scss';
 

--- a/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/feedback_modal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
 import $ from 'jquery';
 
 import 'modals/feedback_modal.scss';
@@ -56,13 +55,11 @@ export const FeedbackModal = (props: FeedbackModalProps) => {
                 setIsSending(false);
                 setStatus('success');
                 setMessage('Sent successfully!');
-                redraw();
               },
               (err) => {
                 setIsSending(false);
                 setStatus('failure');
                 setMessage(err.responseJSON?.error || err.responseText);
-                redraw();
               }
             );
           }}

--- a/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/login_modal.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import _ from 'lodash';
 import app, { initAppState } from 'state';
 import { ChainBase } from 'common-common/src/types';
-import { ClassComponent, redraw } from 'mithrilInterop';
+import { ClassComponent } from 'mithrilInterop';
 import type { ResultNode } from 'mithrilInterop';
 
 import {
@@ -186,7 +186,6 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
           }
           if (onSuccess) onSuccess();
         }
-        redraw();
       } else {
         // log in as the new user
         await initAppState(false);
@@ -207,7 +206,6 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
           }
           if (onSuccess) onSuccess();
         }
-        redraw();
       }
     };
 
@@ -322,13 +320,11 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
         }
       }
       this.bodyType = 'welcome';
-      redraw();
     };
 
     // Handle branching logic for linking an account
     const linkExistingAccountCallback = async () => {
       this.bodyType = 'selectPrevious';
-      redraw();
     };
 
     // Handle signature and validation logic for linking an account
@@ -379,7 +375,6 @@ export class LoginModal extends ClassComponent<LoginModalAttrs> {
           vnode.attrs.onModalClose();
         }
         if (onSuccess) onSuccess();
-        redraw();
       } catch (e) {
         console.log(e);
         notifyError('Failed to save profile info');

--- a/packages/commonwealth/client/scripts/views/modals/select_address_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/select_address_modal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
 import $ from 'jquery';
 
 import 'modals/select_address_modal.scss';
@@ -52,7 +51,6 @@ export const SelectAddressModal = (props: SelectAddressModalProps) => {
       })
       .then(() => {
         setIsLoading(false);
-        redraw();
         setSelectedIndex(null);
         // select the address, and close the form
         notifySuccess(
@@ -63,13 +61,11 @@ export const SelectAddressModal = (props: SelectAddressModalProps) => {
           )}`
         );
         setActiveAccount(account).then(() => {
-          redraw();
           $(e.target).trigger('modalexit');
         });
       })
       .catch((err: any) => {
         setIsLoading(false);
-        redraw();
         notifyError(err.responseJSON.error);
       });
   };

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -1,6 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
 import { notifySuccess } from 'controllers/app/notifications';
-import { redraw } from 'mithrilInterop';
 import type NotificationSubscription from '../../../models/NotificationSubscription';
 import type Thread from '../../../models/Thread';
 import moment from 'moment';
@@ -45,7 +44,7 @@ export const handleToggleSubscription = async (
   commentSubscription: NotificationSubscription,
   reactionSubscription: NotificationSubscription,
   isSubscribed: boolean,
-  setIsSubscribed?: Dispatch<SetStateAction<boolean>>,
+  setIsSubscribed?: Dispatch<SetStateAction<boolean>>
 ) => {
   if (!commentSubscription || !reactionSubscription) {
     await Promise.all([
@@ -73,8 +72,6 @@ export const handleToggleSubscription = async (
     notifySuccess('Subscribed!');
   }
   if (setIsSubscribed) setIsSubscribed(!isSubscribed);
-
-  redraw();
 };
 
 export const getCommentSubscription = (thread: Thread) => {
@@ -95,7 +92,7 @@ export const getReactionSubscription = (thread: Thread) => {
 
 export const getThreadSubScriptionMenuItem = (
   thread: Thread,
-  setIsSubscribed: Dispatch<SetStateAction<boolean>>,
+  setIsSubscribed: Dispatch<SetStateAction<boolean>>
 ): PopoverMenuItem => {
   const commentSubscription = getCommentSubscription(thread);
   const reactionSubscription = getReactionSubscription(thread);
@@ -110,9 +107,8 @@ export const getThreadSubScriptionMenuItem = (
         getCommentSubscription(thread),
         getReactionSubscription(thread),
         isSubscribed,
-        setIsSubscribed,
+        setIsSubscribed
       );
-      redraw();
     },
     label: isSubscribed ? 'Unsubscribe' : 'Subscribe',
     iconLeft: isSubscribed ? 'unsubscribe' : 'bell',

--- a/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/thread_preview_menu.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import React from 'react';
 
-import { redraw } from 'mithrilInterop';
 import type Thread from '../../../models/Thread';
 import app from 'state';
 import { PopoverMenu } from '../../components/component_kit/cw_popover/cw_popover_menu';
@@ -89,7 +88,6 @@ export const ThreadPreviewMenu = ({
                           threadId: thread.id,
                           action: ThreadActionType.Pinning,
                         });
-                        redraw();
                       });
                     },
                     label: thread.pinned ? 'Unpin thread' : 'Pin thread',

--- a/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_near_login.tsx
@@ -3,7 +3,6 @@ import type { Chain } from '@canvas-js/interfaces';
 import { constructCanvasMessage } from 'adapters/shared';
 import { initAppState } from 'state';
 import BN from 'bn.js';
-import { redraw } from 'mithrilInterop';
 import { ChainBase, WalletId } from 'common-common/src/types';
 import {
   completeClientLogin,
@@ -69,13 +68,10 @@ const FinishNearLogin = () => {
   const navigate = useCommonNavigate();
   const [searchParams] = useSearchParams();
   const [validating, setValidating] = React.useState<boolean>(false);
-  const [validationCompleted, setValidationCompleted] = React.useState<boolean>(
-    false
-  );
-  const [
-    validatedAccount,
-    setValidatedAccount,
-  ] = React.useState<NearAccount | null>(null);
+  const [validationCompleted, setValidationCompleted] =
+    React.useState<boolean>(false);
+  const [validatedAccount, setValidatedAccount] =
+    React.useState<NearAccount | null>(null);
   const [validationError, setValidationError] = React.useState<string>('');
   const [isNewAccount, setIsNewAccount] = React.useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
@@ -289,13 +285,11 @@ const FinishNearLogin = () => {
       validate(wallet).then(() => {
         setValidationCompleted(true);
         setValidating(false);
-        redraw();
       });
     } else {
       setValidationError('Sign-in failed.');
       setValidating(false);
       setValidationCompleted(true);
-      redraw();
     }
   } else {
     // validation in progress

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/helpers.ts
@@ -1,6 +1,3 @@
-import $ from 'jquery';
-
-import { redraw } from 'mithrilInterop';
 import app from 'state';
 import { AccessLevel } from '../../../../../shared/permissions';
 import { ChainCategoryType } from 'common-common/src/types';
@@ -35,7 +32,6 @@ export const setChainCategories = async (
           app.config.chainCategoryMap[newMap.chain] = newMap.tags;
         }
         resolve();
-        redraw();
       })
       .catch(() => {
         reject();

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -26,7 +26,6 @@ import {
 import { bundleSubs } from './helpers';
 import { useCommonNavigate } from 'navigation/helpers';
 import useForceRerender from 'hooks/useForceRerender';
-import { redraw } from 'mithrilInterop';
 import { NotificationCategories } from 'common-common/src/types';
 
 const emailIntervalFrequencyMap = {

--- a/packages/commonwealth/client/scripts/views/pages/web3login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/web3login.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { link } from 'helpers';
 
-import { redraw } from 'mithrilInterop';
 import $ from 'jquery';
 
 import 'pages/web3login.scss';
@@ -64,8 +63,6 @@ const Web3LoginPage = () => {
       }
     } catch (e) {
       setErrorMsg(e.responseJSON.error);
-
-      redraw();
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3818 &  #3812 

## Description of Changes
- removed `redraw()` from the codebase
- moved `render()` from interop to helper function

## Test Plan
- no changes in the app

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- created followup ticket https://github.com/hicommonwealth/commonwealth/issues/3836