### PR TITLE
Linked Proposals collapsing into info tab on mobile view

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -65,7 +65,6 @@ export const CWContentPage = (props: ContentPageProps) => {
     viewCount,
   } = props;
 
-  // @REACT TODO: this needs to be aware of which view to default to
   const [viewType, setViewType] = React.useState<'sidebarView' | 'tabsView'>(
     isWindowMediumSmallInclusive(window.innerWidth) && showSidebar
       ? 'tabsView'

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -67,7 +67,9 @@ export const CWContentPage = (props: ContentPageProps) => {
 
   // @REACT TODO: this needs to be aware of which view to default to
   const [viewType, setViewType] = React.useState<'sidebarView' | 'tabsView'>(
-    'sidebarView'
+    isWindowMediumSmallInclusive(window.innerWidth) && showSidebar
+      ? 'tabsView'
+      : 'sidebarView'
   );
   const [tabSelected, setTabSelected] = React.useState<number>(0);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3843 

## Description of Changes
- Quick fix to ensure linked proposals section collapsed into the info tab when initially rendering in mobile view. 

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 