### PR TITLE
Join then create thread

### DIFF
--- a/packages/commonwealth/client/scripts/views/Layout.context.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import { createContext } from 'react';
 
 type LayoutContextProps = {
   onRerender: () => void;
@@ -11,20 +11,3 @@ const initialValues = {
 };
 
 export const LayoutContext = createContext<LayoutContextProps>(initialValues);
-
-// export const LayoutContextProvider = ({ children }) => {
-//   const [renderKey, setRenderKey] = useState('');
-
-//   const onRerender = () => {
-//     console.log('onRerender');
-//     setRenderKey(Date.now().toString());
-//   };
-
-//   console.log('renderKey', renderKey);
-
-//   return (
-//     <LayoutContext.Provider value={{ onRerender, renderKey }}>
-//       {children}
-//     </LayoutContext.Provider>
-//   );
-// };

--- a/packages/commonwealth/client/scripts/views/Layout.context.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.context.tsx
@@ -1,13 +1,11 @@
 import { createContext } from 'react';
 
 type LayoutContextProps = {
-  onRerender: () => void;
-  renderKey?: string;
+  reRenderLayout: () => void;
 };
 
 const initialValues = {
-  onRerender: () => {},
-  renderKey: '',
+  reRenderLayout: () => {},
 };
 
 export const LayoutContext = createContext<LayoutContextProps>(initialValues);

--- a/packages/commonwealth/client/scripts/views/Layout.context.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.context.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useState } from 'react';
+
+type LayoutContextProps = {
+  onRerender: () => void;
+  renderKey?: string;
+};
+
+const initialValues = {
+  onRerender: () => {},
+  renderKey: '',
+};
+
+export const LayoutContext = createContext<LayoutContextProps>(initialValues);
+
+// export const LayoutContextProvider = ({ children }) => {
+//   const [renderKey, setRenderKey] = useState('');
+
+//   const onRerender = () => {
+//     console.log('onRerender');
+//     setRenderKey(Date.now().toString());
+//   };
+
+//   console.log('renderKey', renderKey);
+
+//   return (
+//     <LayoutContext.Provider value={{ onRerender, renderKey }}>
+//       {children}
+//     </LayoutContext.Provider>
+//   );
+// };

--- a/packages/commonwealth/client/scripts/views/Layout.context.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.context.tsx
@@ -1,11 +1,7 @@
 import { createContext } from 'react';
 
 type LayoutContextProps = {
-  reRenderLayout: () => void;
+  reRenderLayout?: () => void;
 };
 
-const initialValues = {
-  reRenderLayout: () => {},
-};
-
-export const LayoutContext = createContext<LayoutContextProps>(initialValues);
+export const LayoutContext = createContext<LayoutContextProps>(null);

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -16,6 +16,7 @@ import { useParams } from 'react-router-dom';
 import { ChainType } from 'common-common/src/types';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorPage from 'views/pages/error';
+import { LayoutContext, LayoutContextProvider } from './Layout.context';
 
 const LoadingLayout = () => {
   return (
@@ -224,9 +225,20 @@ export const LayoutWrapper = ({ Component, params }) => {
     deferChain: params.deferChain,
   });
 
+  const [renderKey, setRenderKey] = useState('');
+
+  const onRerender = () => {
+    console.log('onRerender');
+    setRenderKey(Date.now().toString());
+  };
+
+  console.log('renderKey', renderKey);
+
   return (
     <LayoutComp scope={scope} deferChain={deferChain}>
-      <Component {...routerParams} />
+      <LayoutContext.Provider value={{ renderKey, onRerender }}>
+        <Component {...routerParams} />
+      </LayoutContext.Provider>
     </LayoutComp>
   );
 };

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -16,7 +16,7 @@ import { useParams } from 'react-router-dom';
 import { ChainType } from 'common-common/src/types';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorPage from 'views/pages/error';
-import { LayoutContext, LayoutContextProvider } from './Layout.context';
+import { LayoutContext } from './Layout.context';
 
 const LoadingLayout = () => {
   return (

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -218,6 +218,7 @@ const LayoutComponent = ({
 export const LayoutWrapper = ({ Component, params }) => {
   const routerParams = useParams();
   const LayoutComp = withRouter(LayoutComponent);
+  const [, setRenderKey] = useState({});
 
   const pathScope = routerParams?.scope?.toString() || app.customDomainId();
   const scope = params.scoped ? pathScope : null;
@@ -225,18 +226,14 @@ export const LayoutWrapper = ({ Component, params }) => {
     deferChain: params.deferChain,
   });
 
-  const [renderKey, setRenderKey] = useState('');
-
-  const onRerender = () => {
-    console.log('onRerender');
-    setRenderKey(Date.now().toString());
+  const reRenderLayout = () => {
+    // a simple state update to trigger children to re-render
+    setRenderKey({});
   };
-
-  console.log('renderKey', renderKey);
 
   return (
     <LayoutComp scope={scope} deferChain={deferChain}>
-      <LayoutContext.Provider value={{ renderKey, onRerender }}>
+      <LayoutContext.Provider value={{ reRenderLayout }}>
         <Component {...routerParams} />
       </LayoutContext.Provider>
     </LayoutComp>

--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import 'SublayoutHeader.scss';
 
@@ -26,7 +26,6 @@ export const SublayoutHeader = ({
 }: SublayoutHeaderProps) => {
   const navigate = useCommonNavigate();
   const { isLoggedIn } = useUserLoggedIn();
-  const [contentKey, setContentKey] = useState('');
 
   return (
     <div className="SublayoutHeader">
@@ -79,11 +78,11 @@ export const SublayoutHeader = ({
           />
         </div>
         <div className="DesktopMenuContainer">
-          <CreateContentPopover key={contentKey} />
+          <CreateContentPopover />
           <HelpMenuPopover />
           {isLoggedIn && !onMobile && <NotificationsMenuPopover />}
         </div>
-        <LoginSelector onJoinSuccess={() => setContentKey('joined')} />
+        <LoginSelector />
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -307,6 +307,12 @@ export const LoginSelector = () => {
     setIsJoined(!!app.user.activeAccount);
   }, [app.user.activeAccount]);
 
+  const onJoinSuccess = () => {
+    console.log('onJoinSuccess');
+    setIsJoined(true);
+    onRerender();
+  };
+
   const leftMenuProps = usePopover();
   const rightMenuProps = usePopover();
 
@@ -328,7 +334,12 @@ export const LoginSelector = () => {
         </div>
         <Modal
           content={
-            <LoginModal onModalClose={() => setIsLoginModalOpen(false)} />
+            <LoginModal
+              onModalClose={() => {
+                setIsLoginModalOpen(false);
+                onRerender();
+              }}
+            />
           }
           isFullScreen={isWindowMediumSmallInclusive(window.innerWidth)}
           onClose={() => setIsLoginModalOpen(false)}
@@ -482,7 +493,7 @@ export const LoginSelector = () => {
         if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
           await app.chain.activeAddressHasToken(app.user.activeAccount.address);
         }
-        onRerender();
+        onJoinSuccess();
       } catch (err) {
         console.error(err);
       }
@@ -522,7 +533,6 @@ export const LoginSelector = () => {
                     setIsTOSModalOpen(true);
                   } else {
                     await performJoinCommunityLinking();
-                    setIsJoined(true);
                   }
                 }
               }}
@@ -607,7 +617,7 @@ export const LoginSelector = () => {
             onAccept={async () => {
               await performJoinCommunityLinking();
               setIsTOSModalOpen(false);
-              setIsJoined(true);
+              onJoinSuccess();
             }}
             onModalClose={() => setIsTOSModalOpen(false)}
           />
@@ -618,7 +628,7 @@ export const LoginSelector = () => {
       <Modal
         content={
           <LoginModal
-            onSuccess={() => setIsJoined(true)}
+            onSuccess={onJoinSuccess}
             onModalClose={() => setIsLoginModalOpen(false)}
           />
         }

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 
 import { initAppState } from 'state';
@@ -18,6 +18,7 @@ import { isSameAccount, pluralize } from 'helpers';
 import { setDarkMode } from 'helpers/darkMode';
 
 import app from 'state';
+import { LayoutContext } from 'views/Layout.context';
 import { User } from 'views/components/user/user';
 import { LoginModal } from 'views/modals/login_modal';
 import { FeedbackModal } from 'views/modals/feedback_modal';
@@ -292,11 +293,7 @@ const TOSModal = ({ onModalClose, onAccept }: TOSModalProps) => {
   );
 };
 
-type LoginSelectorProps = {
-  onJoinSuccess: () => void;
-};
-
-export const LoginSelector = ({ onJoinSuccess }: LoginSelectorProps) => {
+export const LoginSelector = () => {
   const forceRerender = useForceRerender();
   const [profileLoadComplete, setProfileLoadComplete] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
@@ -304,6 +301,7 @@ export const LoginSelector = ({ onJoinSuccess }: LoginSelectorProps) => {
     useState(false);
   const [isTOSModalOpen, setIsTOSModalOpen] = useState(false);
   const [isJoined, setIsJoined] = useState(false);
+  const { onRerender } = useContext(LayoutContext);
 
   useEffect(() => {
     setIsJoined(!!app.user.activeAccount);
@@ -484,7 +482,7 @@ export const LoginSelector = ({ onJoinSuccess }: LoginSelectorProps) => {
         if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
           await app.chain.activeAddressHasToken(app.user.activeAccount.address);
         }
-        onJoinSuccess(); // this triggers a state update from the parent to update the sibling component
+        onRerender();
       } catch (err) {
         console.error(err);
       }

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -301,16 +301,15 @@ export const LoginSelector = () => {
     useState(false);
   const [isTOSModalOpen, setIsTOSModalOpen] = useState(false);
   const [isJoined, setIsJoined] = useState(false);
-  const { onRerender } = useContext(LayoutContext);
+  const { reRenderLayout } = useContext(LayoutContext);
 
   useEffect(() => {
     setIsJoined(!!app.user.activeAccount);
   }, [app.user.activeAccount]);
 
   const onJoinSuccess = () => {
-    console.log('onJoinSuccess');
     setIsJoined(true);
-    onRerender();
+    reRenderLayout();
   };
 
   const leftMenuProps = usePopover();
@@ -337,7 +336,7 @@ export const LoginSelector = () => {
             <LoginModal
               onModalClose={() => {
                 setIsLoginModalOpen(false);
-                onRerender();
+                reRenderLayout();
               }}
             />
           }

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import type Thread from '../../../models/Thread';
 import type Topic from '../../../models/Topic';

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import type Thread from '../../../models/Thread';
 import type Topic from '../../../models/Topic';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3711 

## Description of Changes
- Adds `LayoutContext` and `reRenderLayout` 
- call reRenderLayout on modal-close (after login) and after join success

## Test Plan
- Expect "Create thread" button to be enabled immediately after login or join new community

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This copies the forceRerender method, but uses Context instead of a hook. I found that this helped with cases that `useForceRerender` didn't work on. We may want a follow-up ticket to consolidate one forceRerender.