### PR TITLE
Increase base font size slightly

### DIFF
--- a/packages/commonwealth/client/styles/mixins/text.scss
+++ b/packages/commonwealth/client/styles/mixins/text.scss
@@ -7,14 +7,14 @@
 @mixin b1 {
   font-family: $font-family-neue-haas-unica;
   font-size: 16px;
-  letter-spacing: 0.02em;
-  line-height: 24px;
+  letter-spacing: 0.01em;
+  line-height: 1.45;
 }
 
 @mixin b2 {
   font-family: $font-family-neue-haas-unica;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 15.25px;
+  line-height: 1.5;
 
   &.bold,
   &.italic {


### PR DESCRIPTION
For readability, per conversation with Jessica and Meesh

- Increases proposal body font size slightly
- Increases b1 CWText font size slightly to match (this is in the discussions subheader, e.g. on Redacted Cartel: "This section is for the community to discuss how to manage the community treasury and spending on contributor grants, community initiatives, liquidity mining and other programs.")

<img width="884" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/1273926/d3ff425a-0f16-4084-9b48-2dc419ab5ac0">
<img width="876" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/1273926/6fa04575-e025-42d0-b9b3-ce1d25fac5e6">



## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 