### PR TITLE
Enable create thread button on community join

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import 'SublayoutHeader.scss';
 
@@ -26,7 +26,6 @@ export const SublayoutHeader = ({
 }: SublayoutHeaderProps) => {
   const navigate = useCommonNavigate();
   const { isLoggedIn } = useUserLoggedIn();
-  const [contentKey, setContentKey] = useState('');
 
   return (
     <div className="SublayoutHeader">
@@ -79,11 +78,11 @@ export const SublayoutHeader = ({
           />
         </div>
         <div className="DesktopMenuContainer">
-          <CreateContentPopover key={contentKey} />
+          <CreateContentPopover />
           <HelpMenuPopover />
           {isLoggedIn && !onMobile && <NotificationsMenuPopover />}
         </div>
-        <LoginSelector onJoinSuccess={() => setContentKey('joined')} />
+        <LoginSelector />
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -58,7 +58,6 @@ type LoginSelectorMenuLeftAttrs = {
 };
 
 export const LoginSelectorMenuLeft = ({
-  activeAddressesWithRole,
   nAccountsWithoutRole,
 }: LoginSelectorMenuLeftAttrs) => {
   const navigate = useCommonNavigate();
@@ -292,11 +291,7 @@ const TOSModal = ({ onModalClose, onAccept }: TOSModalProps) => {
   );
 };
 
-type LoginSelectorProps = {
-  onJoinSuccess: () => void;
-};
-
-export const LoginSelector = ({ onJoinSuccess }: LoginSelectorProps) => {
+export const LoginSelector = () => {
   const forceRerender = useForceRerender();
   const [profileLoadComplete, setProfileLoadComplete] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
@@ -484,7 +479,6 @@ export const LoginSelector = ({ onJoinSuccess }: LoginSelectorProps) => {
         if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
           await app.chain.activeAddressHasToken(app.user.activeAccount.address);
         }
-        onJoinSuccess(); // this triggers a state update from the parent to update the sibling component
       } catch (err) {
         console.error(err);
       }

--- a/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/recent_threads_header.tsx
@@ -45,10 +45,12 @@ export const RecentThreadsHeader = ({
 
     window.addEventListener('resize', onResize);
     app.loginStateEmitter.on('redraw', forceRerender);
+    app.user.isFetched.on('redraw', forceRerender);
 
     return () => {
       window.removeEventListener('resize', onResize);
       app.loginStateEmitter.off('redraw', forceRerender);
+      app.user.isFetched.off('redraw', forceRerender);
     };
   }, [forceRerender]);
 

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -40,10 +40,12 @@ const OverviewPage = () => {
   useEffect(() => {
     app.threads.isFetched.on('redraw', forceRerender);
     app.loginStateEmitter.on('redraw', forceRerender);
+    app.user.isFetched.on('redraw', forceRerender);
 
     return () => {
       app.threads.isFetched.off('redraw', forceRerender);
       app.loginStateEmitter.off('redraw', forceRerender);
+      app.user.isFetched.off('redraw', forceRerender);
     };
   }, [forceRerender]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3711 
## Description of Changes
- We have event that is triggered on active account change
- I caught the event in the component and force rerender when it happens
- Reverted merged code that is not working


https://github.com/hicommonwealth/commonwealth/assets/14819225/c034654b-f373-4174-a1ba-7a2e44e1c74e



## Test Plan
- go to community page you are not part of 
- click join button
- create thread button should be enabled
