### PR TITLE
Fix `yarn lint-branch` CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Fetch history
+        run: git fetch --unshallow
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,20 +92,10 @@ jobs:
     name: Code Quality checks
     runs-on: ubuntu-latest
     steps:
-      - name: Custom checkout
-        run: |
-          # Clone repository without history
-          git clone --no-checkout https://github.com/${{ github.repository }} .
-          
-          # Fetch base branch and PR branch
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
-          
-          # Checkout PR branch
-          git checkout ${{ github.head_ref }}
-
-      - name: Fetch history
-        run: git fetch --unshallow
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,8 +92,17 @@ jobs:
     name: Code Quality checks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Custom checkout
+        run: |
+          # Clone repository without history
+          git clone --no-checkout https://github.com/${{ github.repository }} .
+          
+          # Fetch base branch and PR branch
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+          git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
+          
+          # Checkout PR branch
+          git checkout ${{ github.head_ref }}
 
       - name: Fetch history
         run: git fetch --unshallow
@@ -114,6 +123,8 @@ jobs:
         run: yarn --ignore-engines
 
       - name: Run linter
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
         run: yarn lint-branch
 
       - name: Typecheck

--- a/packages/chain-events/services/app/routes/entities.ts
+++ b/packages/chain-events/services/app/routes/entities.ts
@@ -42,7 +42,6 @@ const entities: any = async (
     entityFindOptions.where.completed = true;
   }
 
-  // test CI lint file change
   try {
     const fetchedEntities = await models.ChainEntity.findAll(entityFindOptions);
     return res.json({

--- a/packages/chain-events/services/app/routes/entities.ts
+++ b/packages/chain-events/services/app/routes/entities.ts
@@ -42,6 +42,7 @@ const entities: any = async (
     entityFindOptions.where.completed = true;
   }
 
+  // test CI lint file change
   try {
     const fetchedEntities = await models.ChainEntity.findAll(entityFindOptions);
     return res.json({

--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -1,8 +1,10 @@
 # The base branch is provided by GitHub Actions. If it's not set, default to "master".
 BASE_BRANCH=${GITHUB_BASE_REF:-master}
 
-# Fetch the base branch
-git fetch origin $BASE_BRANCH
+# Fetch the base branch only if this script is running in GitHub Actions
+if [ -n "$GITHUB_BASE_REF" ]; then
+    git fetch origin $BASE_BRANCH
+fi
 
 # Get a list of changed .ts files
 LINES=$(git diff origin/$BASE_BRANCH...HEAD --name-only --diff-filter=d | grep \\.ts)

--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -1,4 +1,11 @@
-LINES=$(git diff master... --name-only --diff-filter=d | grep \\.ts)
+# The base branch is provided by GitHub Actions. If it's not set, default to "master".
+BASE_BRANCH=${GITHUB_BASE_REF:-master}
+
+# Fetch the base branch
+git fetch origin $BASE_BRANCH
+
+# Get a list of changed .ts files
+LINES=$(git diff origin/$BASE_BRANCH...HEAD --name-only --diff-filter=d | grep \\.ts)
 
 if [ -z "$LINES" ]
 then

--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -2,8 +2,11 @@
 BASE_BRANCH=${GITHUB_BASE_REF:-master}
 
 # Fetch the base branch only if this script is running in GitHub Actions
+# and the base branch hasn't been fetched yet
 if [ -n "$GITHUB_BASE_REF" ]; then
-    git fetch origin $BASE_BRANCH
+    if ! git show-ref --quiet refs/remotes/origin/$BASE_BRANCH; then
+        git fetch origin $BASE_BRANCH
+    fi
 fi
 
 # Get a list of changed .ts files


### PR DESCRIPTION
## Description
- Adds `fetch-depth: 0` which checks out the entire repo (necessary for specific branch linting)
- Edits the lint-branch script so that line differences are determined by comparing the PR branch with the target base branch rather than the master branch. This ensures we are only linting what needs to be linted at all times.