### PR TITLE
Show threads count per topic on the overview page

### DIFF
--- a/packages/commonwealth/client/scripts/models/Topic.ts
+++ b/packages/commonwealth/client/scripts/models/Topic.ts
@@ -10,6 +10,7 @@ class Topic {
   public readonly featuredInNewPost?: boolean;
   public order?: number;
   public readonly defaultOffchainTemplate?: string;
+  public totalThreads?: number;
 
   private _tokenThreshold?: BN;
   public get tokenThreshold() {
@@ -31,6 +32,7 @@ class Topic {
     order,
     default_offchain_template,
     token_threshold,
+    total_threads,
   }: {
     name: string;
     id: number;
@@ -42,6 +44,7 @@ class Topic {
     order?: number;
     default_offchain_template?: string;
     token_threshold?: BN | string | number;
+    total_threads: number;
   }) {
     this.name = name;
     this.id = id;
@@ -55,6 +58,7 @@ class Topic {
     if (token_threshold !== undefined) {
       this._tokenThreshold = new BN(token_threshold);
     }
+    this.totalThreads = total_threads || 0;
   }
 }
 

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -81,6 +81,7 @@ export const EditTopicModal = ({
       default_offchain_template: featuredInNewPost
         ? serializeDelta(contentDelta)
         : null,
+      total_threads: topic.totalThreads || 0,
     };
 
     try {

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -70,7 +70,6 @@ const OverviewPage = () => {
   const topicSummaryRows: Array<{
     monthlyThreads: Array<Thread>;
     pinnedThreads: Array<Thread>;
-    allThreadsCount: number;
     topic: Topic;
   }> = topicsSorted.map((topic) => {
     const monthlyThreads = allMonthlyThreads.filter(
@@ -79,15 +78,11 @@ const OverviewPage = () => {
     const pinnedThreads = allPinnedThreads.filter(
       (thread) => topic?.id && thread.topic?.id && topic.id === thread.topic.id
     );
-    const allThreadsCount = allThreads.filter(
-      (thread) => topic?.id && thread.topic?.id && topic.id === thread.topic.id
-    ).length;
 
     return {
       monthlyThreads,
       pinnedThreads,
       topic,
-      allThreadsCount: allThreadsCount,
     };
   });
 

--- a/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/topic_summary_row.tsx
@@ -23,7 +23,6 @@ import { CWTag } from 'views/components/component_kit/cw_tag';
 type TopicSummaryRowProps = {
   monthlyThreads: Array<Thread>;
   pinnedThreads: Array<Thread>;
-  allThreadsCount: number;
   topic: Topic;
 };
 
@@ -31,7 +30,6 @@ export const TopicSummaryRow = ({
   monthlyThreads,
   pinnedThreads,
   topic,
-  allThreadsCount,
 }: TopicSummaryRowProps) => {
   const navigate = useCommonNavigate();
 
@@ -65,7 +63,7 @@ export const TopicSummaryRow = ({
             fontWeight="medium"
             className="threads-count-text"
           >
-            {allThreadsCount} Threads
+            {topic.totalThreads || 0} Threads
           </CWText>
         </div>
         {topic.description && <CWText type="b2">{topic.description}</CWText>}

--- a/packages/commonwealth/server/routes/bulkOffchain.ts
+++ b/packages/commonwealth/server/routes/bulkOffchain.ts
@@ -61,9 +61,19 @@ const bulkOffchain = async (models: DB, req: Request, res: Response) => {
     >
   >Promise.all([
     // topics
-    models.Topic.findAll({
-      where: { chain_id: chain.id },
-    }),
+    models.sequelize.query(
+      `SELECT 
+        *,
+        (
+          SELECT COUNT(*)::int FROM "Threads" 
+          WHERE chain = :chain_id AND topic_id = t.id AND deleted_at IS NULL 
+        ) as total_threads
+      FROM "Topics" t WHERE chain_id = :chain_id AND deleted_at IS NULL`,
+      {
+        replacements: { chain_id: chain.id },
+        type: QueryTypes.SELECT,
+      }
+    ),
 
     // admins
     findAllRoles(
@@ -234,7 +244,7 @@ const bulkOffchain = async (models: DB, req: Request, res: Response) => {
   return res.json({
     status: 'Success',
     result: {
-      topics: topics.map((t) => t.toJSON()),
+      topics: topics,
       numVotingThreads,
       numTotalThreads,
       admins: admins.map((a) => a.toJSON()),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3750

## Description of Changes
- The `/bulkOffChain` api now returns a new `total_threads` key per topic for the topics array which we use on the overview page to show total threads count for the topic row.

## Test Plan
- Visit the /overview page for a community, note the thread count for the topic.
- Now visit the topic/discussion page for that topic and scroll to load all threads for that topic (a bit tedious but counting the threads here should match the total thread count noted earlier, console logs can also be used for a more hands on approach)

## Deployment Plan
N/A 

## Other Considerations
This pr only addresses the concern to show the correct thread count per topic on the overview page on load. Adding/deleting a new thread or updating thread topic wont update the count here (unless we do a page reload). Also adding/deleting a topic wont update thread count on the overview page (unless we do a page reload).

@jnaviask Please let me know if we want to update thread count per topic in state based on these actions above. Btw there is also a ticket to address thread count per topic on thread create/update/delete https://github.com/hicommonwealth/commonwealth/issues/3608