### PR TITLE
use Correct chainId for new accounts

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -279,7 +279,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
           // Can't call authSession now, since chain.base is unknown, so we wait till action
           setCachedWalletSignature(signature);
           setCachedTimestamp(timestamp);
-          setCachedChainId(walletToUse.getChainId());
+          setCachedChainId(chainId);
           walletProps.onSuccess?.();
         } catch (e) {
           console.log(e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3919 

## Description of Changes
- Uses correct chainId based on what canvas message signs for on new account creation 

## Test Plan
- create a new keplr account, confirm login works
- log into injective, confirm login works
