### PR TITLE
Fix: can't join second community after login

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/header/login_selector.tsx
@@ -520,7 +520,7 @@ export const LoginSelector = () => {
                 if (
                   sameBaseAddressesRemoveDuplicates.length === 0 ||
                   app.chain?.meta?.id === 'injective' ||
-                  (app.user.activeAccount.address.slice(0, 3) === 'inj' &&
+                  (app.user.activeAccount?.address?.slice(0, 3) === 'inj' &&
                     app.chain?.meta.id !== 'injective')
                 ) {
                   setIsLoginModalOpen(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3930

## Description of Changes
- Adds null check on activeAccount address
- Fixes ability to join community after login.

## Test Plan
- CA (click around) tested on local and frack:
  - Log into homepage with keplr (observed w keplr and magic login)
  - go to /juno
  - click "Join"
  - expect successful join


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 