### PR TITLE
Fix: magic login when bech32 prefix not supported

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -309,9 +309,14 @@ export async function loginWithMagicLink(email: string) {
   });
 
   if (isCosmos) {
-    chainAddress = await magic.cosmos.changeAddress(
-      app.chain.meta.bech32Prefix
-    );
+    const bech32Prefix = app.chain.meta.bech32Prefix;
+    try {
+      chainAddress = await magic.cosmos.changeAddress(bech32Prefix);
+    } catch (err) {
+      console.error(
+        `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`
+      );
+    }
   }
 
   const didToken = await magic.auth.loginWithMagicLink({ email });

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -308,6 +308,7 @@ export async function loginWithMagicLink(email: string) {
       : null,
   });
 
+  // Not every chain prefix will succeed, so Magic defaults to osmo... as the Cosmos prefix
   if (isCosmos) {
     const bech32Prefix = app.chain.meta.bech32Prefix;
     try {

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -34,6 +34,7 @@
     "test-consumer": "ts-mocha --project tsconfig.json test/systemTests/consumer.test.ts --timeout 20000",
     "test-scripts": "ts-mocha --project tsconfig.json test/integration/enforceDataConsistency.spec.ts",
     "start": "ts-node-dev --max-old-space-size=4096 --respawn --transpile-only --project tsconfig.json server.ts",
+    "start:debug": "ts-node-dev --inspect-brk --max-old-space-size=4096 --respawn --transpile-only --project tsconfig.json server.ts",
     "start-consumer": "ts-node --project ./tsconfig.consumer.json server/CommonwealthConsumer/CommonwealthConsumer.ts run-as-script",
     "start-prerender": "ts-node --project tsconfig.json server/scripts/runPrerenderService.ts",
     "start-all": "concurrently -p '{name}' -c red,green -n app,consumer 'yarn start' 'yarn start-consumer'",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -34,7 +34,6 @@
     "test-consumer": "ts-mocha --project tsconfig.json test/systemTests/consumer.test.ts --timeout 20000",
     "test-scripts": "ts-mocha --project tsconfig.json test/integration/enforceDataConsistency.spec.ts",
     "start": "ts-node-dev --max-old-space-size=4096 --respawn --transpile-only --project tsconfig.json server.ts",
-    "start:debug": "ts-node-dev --inspect-brk --max-old-space-size=4096 --respawn --transpile-only --project tsconfig.json server.ts",
     "start-consumer": "ts-node --project ./tsconfig.consumer.json server/CommonwealthConsumer/CommonwealthConsumer.ts run-as-script",
     "start-prerender": "ts-node --project tsconfig.json server/scripts/runPrerenderService.ts",
     "start-all": "concurrently -p '{name}' -c red,green -n app,consumer 'yarn start' 'yarn start-consumer'",

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -221,44 +221,6 @@ export function initMagicAuth(models: DB) {
           ssoToken.updated_at = new Date();
           await ssoToken.save();
           console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
-          const addressExistsForChain = existingUser.Addresses?.some(
-            (a) => a.chain === chain.id
-          );
-
-          if (registrationChainAddress && !addressExistsForChain) {
-            // insert an address for their selected chain if it doesn't exist
-            await sequelize.transaction(async (t) => {
-              const [newRegistrationChainAddress, created] =
-                await models.Address.findOrCreate({
-                  where: {
-                    address: registrationChainAddress,
-                    chain: registrationChain.id,
-                    user_id: existingUser.id,
-                    profile_id: (existingUser.Profiles[0] as ProfileAttributes)
-                      .id,
-                    wallet_id: WalletId.Magic,
-                  },
-                  defaults: {
-                    verification_token: 'MAGIC',
-                    verification_token_expires: null,
-                    verified: new Date(),
-                    last_active: new Date(),
-                  },
-                  transaction: t,
-                });
-              if (created) {
-                await createRole(
-                  models,
-                  newRegistrationChainAddress.id,
-                  registrationChain.id,
-                  'member',
-                  false,
-                  t
-                );
-              }
-            });
-          }
-
           return cb(null, existingUser);
         } else {
           // migrate to magic if email already exists

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -221,8 +221,11 @@ export function initMagicAuth(models: DB) {
           ssoToken.updated_at = new Date();
           await ssoToken.save();
           console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
+          const addressExistsForChain = existingUser.Addresses?.some(
+            (a) => a.chain === chain.id
+          );
 
-          if (registrationChainAddress) {
+          if (registrationChainAddress && !addressExistsForChain) {
             // insert an address for their selected chain if it doesn't exist
             await sequelize.transaction(async (t) => {
               const [newRegistrationChainAddress, created] =

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -221,6 +221,49 @@ export function initMagicAuth(models: DB) {
           ssoToken.updated_at = new Date();
           await ssoToken.save();
           console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
+
+          const addressExistsForChain = existingUser.Addresses?.some(
+            (a) =>
+              a.chain === chain.id ||
+              (chain.base === 'cosmos' &&
+                (a.address.startsWith('cosmos') ||
+                  a.address.startsWith('osmo')))
+          );
+
+          if (registrationChainAddress && !addressExistsForChain) {
+            // insert an address for their selected chain if it doesn't exist
+            await sequelize.transaction(async (t) => {
+              const [newRegistrationChainAddress, created] =
+                await models.Address.findOrCreate({
+                  where: {
+                    address: registrationChainAddress,
+                    chain: registrationChain.id,
+                    user_id: existingUser.id,
+                    profile_id: (existingUser.Profiles[0] as ProfileAttributes)
+                      .id,
+                    wallet_id: WalletId.Magic,
+                  },
+                  defaults: {
+                    verification_token: 'MAGIC',
+                    verification_token_expires: null,
+                    verified: new Date(),
+                    last_active: new Date(),
+                  },
+                  transaction: t,
+                });
+              if (created) {
+                await createRole(
+                  models,
+                  newRegistrationChainAddress.id,
+                  registrationChain.id,
+                  'member',
+                  false,
+                  t
+                );
+              }
+            });
+          }
+
           return cb(null, existingUser);
         } else {
           // migrate to magic if email already exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3948

## Description of Changes
- Adds try/catch for magic.changeAddress. This sometimes fails for new chains like sei
- In this case, `osmo` is used for the prefix. This is sufficient for Cosmos login and discussion.

## Test Plan
- CA (click around) tested on local:
    - Log in to /sei with keplr
    - log out
    - log in to /sei with new email
    - expect successful login and ability to post thread.
    - expect an osmo... address in profile.


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- If we tackle TXs with magic login later, we will need to make sure the chain prefix matches (or notify user)