### PR TITLE
Fix thread view "cannot read properties of null"

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -114,7 +114,7 @@ export const LinkedProposalsCard = ({
   }, [initialSnapshotLinks]);
 
   const showSnapshot =
-    initialSnapshotLinks.length > 0 && snapshotProposalsLoaded;
+    snapshot && initialSnapshotLinks.length > 0 && snapshotProposalsLoaded;
 
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3951 

## Description of Changes
- Fixes error on thread page caused by attempting to display linked snapshot before it was loaded. 

## Test Plan
- tested locally

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 