### PR TITLE
Add bg color to mobile login

### DIFF
--- a/packages/commonwealth/client/styles/pages/login/login_mobile.scss
+++ b/packages/commonwealth/client/styles/pages/login/login_mobile.scss
@@ -61,14 +61,17 @@
 
 .LoginMobile {
   @include mediumSmallInclusive {
+    background-color: #342e37;
     background-image: url('/static/img/login-background-mediumsmall.png');
   }
 
   @include small {
+    background-color: #342e37;
     background-image: url('/static/img/login-background-small.png');
   }
 
   @include extraSmall {
+    background-color: #342e37;
     background-image: url('/static/img/login-background-extrasmall.png');
   }
 


### PR DESCRIPTION
This prevents the screen from flashing white when opening the mobile login interface

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 