### PR TITLE
Fix: existing user Magic login from dashboard

### DIFF
--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -224,8 +224,8 @@ export function initMagicAuth(models: DB) {
 
           const addressExistsForChain = existingUser.Addresses?.some(
             (a) =>
-              a.chain === chain.id ||
-              (chain.base === 'cosmos' &&
+              chain?.id === a.chain ||
+              (chain?.base === 'cosmos' &&
                 (a.address.startsWith('cosmos') ||
                   a.address.startsWith('osmo')))
           );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3965 

## Description of Changes
- Fix for case: existing user logging in from dashboard
- Adds null check to chain lookup 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - with fresh email, login with Magic to eth community or homepage
  -  log out
  - from http://localhost:8080/dashboard/global , Magic log in again with same email
  - expect login success

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 