### PR TITLE
Remove offchain prefix

### DIFF
--- a/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
+++ b/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
@@ -84,7 +84,7 @@ module.exports = {
 
       // Threads
       await renameIndex('offchain_threads_author_id', 'thread_author_id');
-      await renameIndex('Threads', 'offchain_threads_chain', 'threads_chain');
+      await renameIndex('offchain_threads_chain', 'threads_chain');
       await renameIndex(
         'offchain_threads_chain_created_at',
         'threads_chain_created_at'

--- a/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
+++ b/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
@@ -1,0 +1,133 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      const renameIndex = async (oldIndexName, newIndexName) => {
+        await queryInterface.sequelize.query(
+          `
+              ALTER INDEX "${oldIndexName}" RENAME TO "${newIndexName}";
+          `,
+          { transaction: t }
+        );
+      };
+
+      const renameConstraint = async (tableName, oldName, newName) => {
+        await queryInterface.sequelize.query(
+          `
+              ALTER TABLE "${tableName}"
+                  RENAME CONSTRAINT "${oldName}" TO "${newName}";
+          `,
+          { transaction: t }
+        );
+      };
+
+      // Comments
+      await queryInterface.removeIndex(
+        'Comments',
+        'offchain_comments_address_id',
+        { transaction: t }
+      );
+      await queryInterface.removeIndex(
+        'Comments',
+        'offchain_comments_chain_object_id',
+        { transaction: t }
+      );
+      await queryInterface.removeIndex('Comments', 'offchain_comments_id', {
+        transaction: t,
+      });
+      await renameIndex(
+        'offchain_comments_chain_created_at',
+        'comments_chain_created_at'
+      );
+      await renameIndex(
+        'offchain_comments_chain_updated_at',
+        'comments_chain_updated_at'
+      );
+
+      // Reactions
+      // no this index name is not a bug it's just cutoff in the db
+      await renameIndex(
+        'offchain_reactions_chain_address_id_thread_id_proposal_id_comme',
+        'reactions_chain_address_id_thread_id_proposal_id_comment_id'
+      );
+      await renameIndex(
+        'offchain_reactions_address_id',
+        'reactions_address_id'
+      );
+      await renameIndex(
+        'offchain_reactions_chain_comment_id',
+        'reactions_chain_comment_id'
+      );
+      await renameIndex(
+        'offchain_reactions_chain_thread_id',
+        'reactions_chain_thread_id'
+      );
+      await renameConstraint(
+        'Reactions',
+        'OffchainReactions_comment_id_fkey',
+        'Reactions_comment_id_fkey'
+      );
+      await renameConstraint(
+        'Reactions',
+        'OffchainReactions_thread_id_fkey',
+        'Reactions_thread_id_fkey'
+      );
+      await renameConstraint(
+        'Reactions',
+        'OffchainReactions_pkey',
+        'Reactions_pkey'
+      );
+      await queryInterface.removeIndex('Reactions', 'offchain_reactions_id', {
+        transaction: t,
+      });
+
+      // Threads
+      await renameIndex('offchain_threads_author_id', 'thread_author_id');
+      await renameIndex('Threads', 'offchain_threads_chain', 'threads_chain');
+      await renameIndex(
+        'offchain_threads_chain_created_at',
+        'threads_chain_created_at'
+      );
+      await renameIndex(
+        'offchain_threads_chain_pinned',
+        'threads_chain_pinned'
+      );
+      await renameIndex(
+        'offchain_threads_chain_updated_at',
+        'threads_chain_updated_at'
+      );
+      await renameIndex('offchain_threads_created_at', 'threads_created_at');
+      await renameIndex('offchain_threads_updated_at', 'threads_updated_at');
+      await renameIndex('OffchainThreads_search', 'threads_search');
+      await renameConstraint('Threads', 'OffchainThreads_pkey', 'Threads_pkey');
+      await renameConstraint(
+        'Threads',
+        'OffchainThreads_author_id_fkey',
+        'Threads_author_id_fkey'
+      );
+
+      // Topics
+      await renameConstraint(
+        'Topics',
+        'OffchainThreadCategories_pkey',
+        'Topics_pkey'
+      );
+      await renameConstraint(
+        'Topics',
+        'OffchainTopics_rule_id_fkey',
+        'Topics_rule_id_fkey'
+      );
+
+      // Votes
+      await renameConstraint('Votes', 'OffchainVotes_pkey', 'Votes_pkey');
+      await renameConstraint(
+        'Votes',
+        'OffchainVotes_poll_id_fkey',
+        'Votes_poll_id_fkey'
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
+++ b/packages/commonwealth/server/migrations/20230518155338-remove-offchain-prefix.js
@@ -8,7 +8,7 @@ module.exports = {
           `
               ALTER INDEX "${oldIndexName}" RENAME TO "${newIndexName}";
           `,
-          { transaction: t }
+          { transaction: t, logging: console.log }
         );
       };
 
@@ -18,7 +18,7 @@ module.exports = {
               ALTER TABLE "${tableName}"
                   RENAME CONSTRAINT "${oldName}" TO "${newName}";
           `,
-          { transaction: t }
+          { transaction: t, logging: console.log }
         );
       };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
- Removes the `offchain` prefix from all indexes, foreign keys, and primary keys.
- Drops the following columns which are duplicates and contained the `offchain` prefix:
  - `Comments.offchain_comments_address_id` -> existing index `Comments.comments_address_id` used instead.
  - `Comments.offchain_comments_chain_object_id` -> existing index `Comments.comments_chain_object_id` used instead.
  - `Comments.offchain_comments_id` -> existing primary key index `Comments.Comments_pkey` used instead.
  - `Reactions.offchain_reactions_id` -> existing primary key index `Reactions.Reactions_pkey` used instead (renamed from `Reactions.OffchainReactions_pkey`).

## Test Plan
- CI passing
- Deploy to Frack/Frick
- Locally running migration

## Deployment Plan


## Other Considerations
- Migration speed: 0.072s
### Database Lock Analysis
The migration contains 3 different operations that each acquire a different lock.
- Renaming an index requires `SHARE UPDATE EXCLUSIVE` lock.
  - This lock type does not block SELECT, UPDATE, DELETE, or INSERT queries.
- Renaming a constraint requires an `ACCESS EXCLUSIVE` lock.
  - This is the most restrictive table lock and will block all access to the table. That said, renaming is a very fast operation so as long as the transaction finishes in a timely manner this should not block queries for a significant amount of time.
- Dropping an index the standard way also requires an `ACCESS EXCLUSIVE` lock but by using `CONCURRENTLY` we can avoid this super restrictive lock. The downside to this is that the concurrent drop index command cannot be within a transaction.

All of this info was pulled from the [Explicit Lock Docs][1], [Alter Index Docs][2], [Drop Index Docs][3], and the [Alter Table Docs][4].

[1]: https://www.postgresql.org/docs/13/explicit-locking.html
[2]: https://www.postgresql.org/docs/13/sql-alterindex.html
[3]: https://www.postgresql.org/docs/13/sql-dropindex.html
[4]: https://www.postgresql.org/docs/13/sql-altertable.html

