### PR TITLE
Always use server-side Cosmos address.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -2,7 +2,7 @@
  * @file Manages logged-in user accounts and local storage.
  */
 import { initAppState } from 'state';
-import { ChainBase, WalletId } from 'common-common/src/types';
+import { WalletId } from 'common-common/src/types';
 import { notifyError } from 'controllers/app/notifications';
 import { isSameAccount } from 'helpers';
 import $ from 'jquery';

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -316,7 +316,7 @@ export async function loginWithMagicLink(email: string) {
     extensions: [
       new CosmosExtension({
         // default to Osmosis URL
-        rpcUrl: app.chain.meta?.node?.url || app.config.chains.getById('osmosis').node.url,
+        rpcUrl: app.chain?.meta?.node?.url || app.config.chains.getById('osmosis').node.url,
       }),
     ]
   });

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -312,29 +312,14 @@ export async function unlinkLogin(account: AddressInfo) {
 
 export async function loginWithMagicLink(email: string) {
   const { Magic } = await import('magic-sdk');
-  let chainAddress;
-  const isCosmos = app?.chain?.meta?.base === ChainBase.CosmosSDK;
   const magic = new Magic(process.env.MAGIC_PUBLISHABLE_KEY, {
-    extensions: isCosmos
-      ? [
-          new CosmosExtension({
-            rpcUrl: app.chain.meta?.node?.url,
-          }),
-        ]
-      : null,
+    extensions: [
+      new CosmosExtension({
+        // default to Osmosis URL
+        rpcUrl: app.chain.meta?.node?.url || app.config.chains.getById('osmosis').node.url,
+      }),
+    ]
   });
-
-  // Not every chain prefix will succeed, so Magic defaults to osmo... as the Cosmos prefix
-  if (isCosmos) {
-    const bech32Prefix = app.chain.meta.bech32Prefix;
-    try {
-      chainAddress = await magic.cosmos.changeAddress(bech32Prefix);
-    } catch (err) {
-      console.error(
-        `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`
-      );
-    }
-  }
 
   const didToken = await magic.auth.loginWithMagicLink({ email });
   const response = await $.post({
@@ -348,7 +333,6 @@ export async function loginWithMagicLink(email: string) {
     data: {
       // send chain/community to request
       chain: app.activeChainId(),
-      address: chainAddress,
     },
   });
   if (response.status === 'Success') {

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -1,8 +1,8 @@
-import type { MagicUserMetadata } from '@magic-sdk/admin';
+import { MagicUserMetadata, MagicWallet, WalletType } from '@magic-sdk/admin';
 import { Magic } from '@magic-sdk/admin';
 
 import { AppError, ServerError } from 'common-common/src/errors';
-import { NotificationCategories, WalletId } from 'common-common/src/types';
+import { ChainBase, NotificationCategories, WalletId } from 'common-common/src/types';
 import passport from 'passport';
 import { Strategy as MagicStrategy } from 'passport-magic';
 import { MAGIC_API_KEY, MAGIC_SUPPORTED_BASES } from '../config';
@@ -13,6 +13,7 @@ import type { ProfileAttributes } from '../models/profile';
 
 import '../types';
 import { createRole } from '../util/roles';
+import { ChainAttributes } from '../models/chain';
 
 export function initMagicAuth(models: DB) {
   // allow magic login if configured with key
@@ -22,17 +23,20 @@ export function initMagicAuth(models: DB) {
     passport.use(
       new MagicStrategy({ passReqToCallback: true }, async (req, user, cb) => {
         // determine login location
-        let chain, error, registrationChainAddress;
+        let chain, error;
         if (req.body.chain || req.body.community) {
           [chain, error] = await validateChain(models, req.body);
           if (error) return cb(error);
         }
 
-        if (req.body.address) {
-          registrationChainAddress = req.body.address;
-        }
+        // grab cosmos address for registration
+        const cosmosMetadata = await magic.users.getMetadataByIssuerAndWallet(
+          user.issuer,
+          WalletType.COSMOS
+        );
+        const registrationChainAddress = (cosmosMetadata?.wallets[0] as any)?.public_address;
 
-        const registrationChain = chain;
+        const registrationChain: ChainAttributes = chain;
 
         // fetch user data from magic backend
         let userMetadata: MagicUserMetadata;
@@ -90,10 +94,13 @@ export function initMagicAuth(models: DB) {
             );
 
             // create a default Eth address
+            const ethereumChain = registrationChain.base === ChainBase.Ethereum
+              ? registrationChain.id
+              : 'ethereum';
             const newDefaultAddress = await models.Address.create(
               {
                 address: ethAddress,
-                chain: 'ethereum',
+                chain: ethereumChain,
                 verification_token: 'MAGIC',
                 verification_token_expires: null,
                 verified: new Date(), // trust addresses from magic
@@ -108,7 +115,7 @@ export function initMagicAuth(models: DB) {
             await createRole(
               models,
               newDefaultAddress.id,
-              'ethereum',
+              ethereumChain,
               'member',
               false,
               t
@@ -116,10 +123,13 @@ export function initMagicAuth(models: DB) {
 
             if (registrationChainAddress) {
               // create an address on their selected chain
+              const cosmosChain = registrationChain.base === ChainBase.CosmosSDK
+                ? registrationChain.id
+                : 'osmosis';
               const newRegistrationChainAddress = await models.Address.create(
                 {
                   address: registrationChainAddress,
-                  chain: registrationChain.id,
+                  chain: cosmosChain,
                   verification_token: 'MAGIC',
                   verification_token_expires: null,
                   verified: new Date(), // trust addresses from magic
@@ -133,7 +143,7 @@ export function initMagicAuth(models: DB) {
               await createRole(
                 models,
                 newRegistrationChainAddress.id,
-                registrationChain.id,
+                cosmosChain,
                 'member',
                 false,
                 t
@@ -236,11 +246,12 @@ export function initMagicAuth(models: DB) {
               const [newRegistrationChainAddress, created] =
                 await models.Address.findOrCreate({
                   where: {
-                    address: registrationChainAddress,
+                    address: registrationChain.base === ChainBase.CosmosSDK
+                      ? registrationChainAddress
+                      : userMetadata.publicAddress,
                     chain: registrationChain.id,
                     user_id: existingUser.id,
-                    profile_id: (existingUser.Profiles[0] as ProfileAttributes)
-                      .id,
+                    profile_id: (existingUser.Profiles[0] as ProfileAttributes).id,
                     wallet_id: WalletId.Magic,
                   },
                   defaults: {
@@ -294,8 +305,7 @@ export function initMagicAuth(models: DB) {
                   verified: new Date(), // trust addresses from magic
                   last_active: new Date(),
                   user_id: existingUser.id,
-                  profile_id: (existingUser.Profiles[0] as ProfileAttributes)
-                    .id,
+                  profile_id: (existingUser.Profiles[0] as ProfileAttributes).id,
                   wallet_id: WalletId.Magic,
                 },
                 { transaction: t }

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -232,15 +232,7 @@ export function initMagicAuth(models: DB) {
           await ssoToken.save();
           console.log(`Found existing user: ${JSON.stringify(existingUser)}`);
 
-          const addressExistsForChain = existingUser.Addresses?.some(
-            (a) =>
-              chain?.id === a.chain ||
-              (chain?.base === 'cosmos' &&
-                (a.address.startsWith('cosmos') ||
-                  a.address.startsWith('osmo')))
-          );
-
-          if (registrationChainAddress && !addressExistsForChain) {
+          if (registrationChainAddress) {
             // insert an address for their selected chain if it doesn't exist
             await sequelize.transaction(async (t) => {
               const [newRegistrationChainAddress, created] =
@@ -251,10 +243,10 @@ export function initMagicAuth(models: DB) {
                       : userMetadata.publicAddress,
                     chain: registrationChain.id,
                     user_id: existingUser.id,
-                    profile_id: (existingUser.Profiles[0] as ProfileAttributes).id,
                     wallet_id: WalletId.Magic,
                   },
                   defaults: {
+                    profile_id: (existingUser.Profiles[0] as ProfileAttributes).id,
                     verification_token: 'MAGIC',
                     verification_token_expires: null,
                     verified: new Date(),

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -27,6 +27,9 @@ export function initMagicAuth(models: DB) {
         if (req.body.chain || req.body.community) {
           [chain, error] = await validateChain(models, req.body);
           if (error) return cb(error);
+        } else {
+          // default to Osmosis as secondary chain
+          chain = await models.Chain.findOne({ where: { id: 'osmosis' }});
         }
 
         // grab cosmos address for registration

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -1,4 +1,4 @@
-import { MagicUserMetadata, MagicWallet, WalletType } from '@magic-sdk/admin';
+import { MagicUserMetadata, WalletType } from '@magic-sdk/admin';
 import { Magic } from '@magic-sdk/admin';
 
 import { AppError, ServerError } from 'common-common/src/errors';


### PR DESCRIPTION
## Description of Changes
- Derive cosmos address from server metadata instead of client.

## Test Plan
- Login on a Cosmos community via an EXISTING magic link account.
- Login on a Cosmos community with a NEW magic link account.
- Login on an Ethereum community with an EXISTING magic link account.
- Login on an Ethereum community with a NEW magic link account.
- Login on the user dashboard or homepage with an EXISTING magic link account.
- Login on the user dashboard or homepage with a NEW magic link account.
