### PR TITLE
Sequelize: unnecessary calls from named getter of included model

### DIFF
--- a/packages/commonwealth/server/routes/getAddressProfile.ts
+++ b/packages/commonwealth/server/routes/getAddressProfile.ts
@@ -69,7 +69,7 @@ const getAddressProfile = async (
       return next(new AppError(Errors.InvalidAddress));
     }
 
-    const profile = await address.getProfile();
+    const profile = await address.Profile;
 
     return res.json({
       status: 'Success',
@@ -116,9 +116,7 @@ const getAddressProfile = async (
       addrObjs = addrObjs.flat();
     }
 
-    const profiles = await Promise.all(
-      addrObjs.map((addr) => addr.getProfile())
-    );
+    const profiles = addrObjs.map((addr) => addr?.Profile);
 
     return res.json({
       status: 'Success',

--- a/packages/commonwealth/server/webhookNotifier.ts
+++ b/packages/commonwealth/server/webhookNotifier.ts
@@ -130,7 +130,7 @@ const send = async (models, content: WebhookContent) => {
       },
       include: [models.Profile],
     });
-    profile = await address.getProfile();
+    profile = await address.Profile;
   } catch (err) {
     // pass nothing if no matching address is found
   }

--- a/packages/commonwealth/server/webhookNotifier.ts
+++ b/packages/commonwealth/server/webhookNotifier.ts
@@ -130,7 +130,7 @@ const send = async (models, content: WebhookContent) => {
       },
       include: [models.Profile],
     });
-    profile = await address.Profile;
+    profile = await address.getProfile();
   } catch (err) {
     // pass nothing if no matching address is found
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 
- Sequelize "get<model>" syntax making extra calls to database for included model

## Description of Changes
- use Object reference instead of getter to fix the issue

- We fetch Addresses with Profiles included,
- followed by profile call to each address again

Look at screenshot.

Same could be true in other places in codebase

## Test Plan
- Analyzed results
- Click around testing

<img width="1360" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/4791635/2d2698df-cc93-40b4-9919-6b851424a920">
