### PR TITLE
Fix avatar url undefined crash.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
@@ -38,7 +38,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
         )}
       </div>
       <div className="profile-image">
-        {profile.avatarUrl ? (
+        {profile?.avatarUrl ? (
           <img src={profile.avatarUrl} />
         ) : (
           <img

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
@@ -37,7 +37,7 @@ export const CWAvatarGroup = (props: AvatarGroupProps) => {
     <div className="AvatarGroup">
       <div className="avatar-group-icons">
         {truncatedProfiles.map((profile, i) => {
-          if (profile.avatarUrl) {
+          if (profile?.avatarUrl) {
             return (
               <div className="avatar-group-icon" key={i}>
                 <CWAvatar avatarUrl={profile.avatarUrl} size={16} />

--- a/packages/commonwealth/client/scripts/views/modals/delete_address_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/delete_address_modal.tsx
@@ -73,7 +73,7 @@ export const DeleteAddressModal = (props: DeleteAddressModalAttrs) => {
           Address will be removed from the following linked profile.
         </CWText>
         <div className="profile">
-          {profile.avatarUrl ? (
+          {profile?.avatarUrl ? (
             <img src={profile.avatarUrl} />
           ) : (
             <img


### PR DESCRIPTION
## Description of Changes
- Fixes "Cannot read properties of null (reading 'avatarUrl')" on user dashboard page.
