### PR TITLE
Fix error when no member search results

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/search.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/search.ts
@@ -291,7 +291,7 @@ class SearchController {
       return response.result;
     } catch (e) {
       console.error(e);
-      return [];
+      return { profiles: [] };
     }
   };
 

--- a/packages/commonwealth/client/scripts/views/pages/search/search_bar.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/search_bar.tsx
@@ -97,8 +97,8 @@ export const SearchBar = () => {
       setSearchResults(results);
       app.search.addToHistory(searchQuery);
     } catch (err) {
+      console.error(err);
       setSearchResults({});
-
       notifyError(
         err.responseJSON?.error || err.responseText || err.toString()
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4028

## Description of Changes
- Fixes search bar error when no members results are returned

## Test Plan
- Go to the dydx community, search for "delegator"– confirm that the search behaves correctly and doesn't show any members

## Deployment Plan
N/A

## Other Considerations
N/A