### PR TITLE
Mark thread/comment as spam

### DIFF
--- a/packages/commonwealth/server/migrations/20230525191624-add-is-spam-threads-comments.js
+++ b/packages/commonwealth/server/migrations/20230525191624-add-is-spam-threads-comments.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'Threads',
+        'marked_as_spam_at',
+        {
+          type: Sequelize.DATE,
+          allowNull: true,
+        },
+        { transaction }
+      );
+
+      await queryInterface.addColumn(
+        'Comments',
+        'marked_as_spam_at',
+        {
+          type: Sequelize.DATE,
+          allowNull: true,
+        },
+        { transaction }
+      );
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('Threads', 'marked_as_spam_at', {
+        transaction
+      });
+
+      await queryInterface.removeColumn('Comments', 'marked_as_spam_at', {
+        transaction
+      });
+    })
+  }
+};

--- a/packages/commonwealth/server/models/comment.ts
+++ b/packages/commonwealth/server/models/comment.ts
@@ -23,6 +23,7 @@ export type CommentAttributes = {
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
+  marked_as_spam_at?: Date;
 
   // associations
   Chain?: ChainAttributes;
@@ -61,6 +62,7 @@ export default (
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },
       deleted_at: { type: dataTypes.DATE, allowNull: true },
+      marked_as_spam_at: { type: dataTypes.DATE, allowNull: true },
     },
     {
       timestamps: true,

--- a/packages/commonwealth/server/models/thread.ts
+++ b/packages/commonwealth/server/models/thread.ts
@@ -49,6 +49,7 @@ export type ThreadAttributes = {
   last_edited?: Date;
   deleted_at?: Date;
   last_commented_on?: Date;
+  marked_as_spam_at?: Date;
 
   // associations
   Chain?: ChainAttributes;
@@ -120,6 +121,7 @@ export default (
       last_edited: { type: dataTypes.DATE, allowNull: true },
       deleted_at: { type: dataTypes.DATE, allowNull: true },
       last_commented_on: { type: dataTypes.DATE, allowNull: true },
+      marked_as_spam_at: { type: dataTypes.DATE, allowNull: true },
     },
     {
       timestamps: true,

--- a/packages/commonwealth/server/routes/spam/markCommentAsSpam.ts
+++ b/packages/commonwealth/server/routes/spam/markCommentAsSpam.ts
@@ -1,0 +1,51 @@
+import { AppError } from 'common-common/src/errors';
+import type { NextFunction, Request, Response } from 'express';
+import type { DB } from '../../models';
+import { Op, Sequelize } from 'sequelize';
+import { success } from '../../types';
+
+export const Errors = {
+  InvalidCommentId: 'Comment ID invalid',
+  NotLoggedIn: 'Not logged in',
+  CommentNotFound: 'Could not find Comment',
+};
+
+export default async (
+  models: DB,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const commentId = req.params.id;
+  if (!commentId) {
+    return next(new AppError(Errors.InvalidCommentId));
+  }
+
+  if (!req.user) {
+    return next(new AppError(Errors.NotLoggedIn));
+  }
+
+  const userAddressIds = (await req.user.getAddresses())
+    .filter((addr) => !!addr.verified)
+    .map((addr) => addr.id);
+
+  const [affectedCount] = await models.Comment.update(
+    {
+      marked_as_spam_at: Sequelize.literal('CURRENT_TIMESTAMP'),
+    },
+    {
+      where: {
+        id: commentId,
+        address_id: {
+          [Op.in]: userAddressIds,
+        },
+      },
+    }
+  );
+
+  if (affectedCount === 0) {
+    return next(new AppError(Errors.CommentNotFound));
+  }
+
+  return success(res, {});
+};

--- a/packages/commonwealth/server/routes/spam/markThreadAsSpam.ts
+++ b/packages/commonwealth/server/routes/spam/markThreadAsSpam.ts
@@ -1,0 +1,51 @@
+import { AppError } from 'common-common/src/errors';
+import type { NextFunction, Request, Response } from 'express';
+import type { DB } from '../../models';
+import { Op, Sequelize } from 'sequelize';
+import { success } from '../../types';
+
+export const Errors = {
+  InvalidThreadId: 'Thread ID invalid',
+  NotLoggedIn: 'Not logged in',
+  ThreadNotFound: 'Could not find Thread',
+};
+
+export default async (
+  models: DB,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const threadId = req.params.id;
+  if (!threadId) {
+    return next(new AppError(Errors.InvalidThreadId));
+  }
+
+  if (!req.user) {
+    return next(new AppError(Errors.NotLoggedIn));
+  }
+
+  const userAddressIds = (await req.user.getAddresses())
+    .filter((addr) => !!addr.verified)
+    .map((addr) => addr.id);
+
+  const [affectedCount] = await models.Thread.update(
+    {
+      marked_as_spam_at: Sequelize.literal('CURRENT_TIMESTAMP'),
+    },
+    {
+      where: {
+        id: threadId,
+        address_id: {
+          [Op.in]: userAddressIds,
+        },
+      },
+    }
+  );
+
+  if (affectedCount === 0) {
+    return next(new AppError(Errors.ThreadNotFound));
+  }
+
+  return success(res, {});
+};

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -182,6 +182,8 @@ import * as controllers from '../controller';
 import addThreadLink from '../routes/linking/addThreadLinks';
 import deleteThreadLinks from '../routes/linking/deleteThreadLinks';
 import getLinks from '../routes/linking/getLinks';
+import markThreadAsSpam from '../routes/spam/markThreadAsSpam';
+import markCommentAsSpam from '../routes/spam/markCommentAsSpam';
 
 function setupRouter(
   endpoint: string,
@@ -957,6 +959,19 @@ function setupRouter(
     getLinks.bind(this, models)
   );
 
+  // spam
+  router.post(
+    '/threads/:id/mark-as-spam',
+    passport.authenticate('jwt', { session: false }),
+    markThreadAsSpam.bind(this, models)
+  );
+
+  router.post(
+    '/comments/:id/mark-as-spam',
+    passport.authenticate('jwt', { session: false }),
+    markCommentAsSpam.bind(this, models)
+  );
+
   // login
   router.post('/login', startEmailLogin.bind(this, models));
   router.get('/finishLogin', finishEmailLogin.bind(this, models));
@@ -1004,12 +1019,9 @@ function setupRouter(
     startOAuthLogin.bind(this, models, 'discord')
   );
 
-  router.post(
-    '/auth/magic',
-    passport.authenticate('magic'), (req, res) => {
-      return res.json({ status: 'Success', result: req.user.toJSON() });
-    }
-  );
+  router.post('/auth/magic', passport.authenticate('magic'), (req, res) => {
+    return res.json({ status: 'Success', result: req.user.toJSON() });
+  });
 
   router.post('/auth/sso', startSsoLogin.bind(this, models));
   router.post(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3976

## Description of Changes
- Adds migration + routes for marking threads/comments as spam

## Test Plan
- Run migrations locally
- Request `POST http://localhost:8080/api/threads/AAA/mark-as-spam` where `AAA` is a valid thread ID– confirm that the response body is an updated thread with `marked_as_spam_at` timestamp set
- Do the same for `POST http://localhost:8080/api/comments/BBB/mark-as-spam` where `BBB` is a valid comment ID

## Deployment Plan
- Must run migration

## Other Considerations
N/A