### PR TITLE
Remove jobs link e2e test.

### DIFF
--- a/packages/commonwealth/test/e2e/landing.spec.ts
+++ b/packages/commonwealth/test/e2e/landing.spec.ts
@@ -81,17 +81,6 @@ test.describe('Commonwealth Homepage - Links', () => {
     await newPage.waitForURL(`https://blog.commonwealth.im`);
   });
 
-  test('Check Jobs button', async ({ page, context }) => {
-    const jobs = await page.locator('.footer-link', { hasText: 'Jobs' });
-
-    const pagePromise = context.waitForEvent('page');
-
-    await jobs.click();
-
-    const newPage = await pagePromise;
-    await newPage.waitForURL(`https://angel.co/company/commonwealth-labs/jobs`);
-  });
-
   test('Check Terms button', async ({ page }) => {
     const terms = await page.locator('.footer-link', { hasText: 'Terms' });
     expect(terms).toBeTruthy();


### PR DESCRIPTION
## Description of Changes

E2E tests currently failing, because the jobs link in the footer was updated. The e2e test verifies that the jobs link goes to a specific URL, which does not test any necessary functionality where we expect regressions, but breaks testing if the link changes.

The test also used the link URL to fetch the element, which is really bad practice -- we should locate the element specifically and then validate the URL, because currently the test failure is a timeout rather than a direct throw.
