### PR TITLE
null check on tx_params for CAT

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
@@ -224,6 +224,7 @@ const ViewTemplatePage = () => {
   const formatTransactionParams = () => {
     const { tx_template } = json;
     const txObject = {};
+    if (!tx_template.tx_params) return {};
     Object.keys(tx_template.tx_params).map((key) => {
       const arg = tx_template.tx_params[key];
       if (arg.startsWith('$')) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4051 

## Description of Changes
- creates empty object for tx encoding when not using tx_params template field 

## Test Plan
- Create action w/o tx_params and ensure metamask populates 
