### PR TITLE
Fix: quick-switcher does not render redirect route

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -220,7 +220,6 @@ export const selectChain = async (
 // Initializes a selected chain. Requires `app.chain` to be defined and valid
 // and not already initialized.
 export const initChain = async (): Promise<void> => {
-  console.log('* INITCHAIN!!!');
   if (!app.chain || !app.chain.meta || app.chain.loaded) {
     return;
   }

--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -220,6 +220,7 @@ export const selectChain = async (
 // Initializes a selected chain. Requires `app.chain` to be defined and valid
 // and not already initialized.
 export const initChain = async (): Promise<void> => {
+  console.log('* INITCHAIN!!!');
   if (!app.chain || !app.chain.meta || app.chain.loaded) {
     return;
   }

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -93,19 +93,10 @@ const LayoutComponent = ({
   // redirected to the expected page (usually /discussions).
   // We want to avoid chain loading until the redirect is complete, and we have access to the deferChain flag.
   // This is mainly observable with the quick-switcher.
-  console.log('* app.chain.id', app.chain?.id);
-  console.log('* app.isCustomDomain()', app.isCustomDomain());
-  console.log('* app.customDomainId()', app.customDomainId());
-  console.log('* pathname', pathname);
-  console.log('* pathScope', pathScope);
+
   const isChainSelectDone = !!app.chain?.id && pathScope === app.chain.id;
   const isCommunityHomePathBeforeRedirect =
     isChainSelectDone && !app.isCustomDomain() && pathname === pathScope;
-  console.log('* isChainSelectDone', isChainSelectDone);
-  console.log(
-    '* isCommunityHomePathBeforeRedirect',
-    isCommunityHomePathBeforeRedirect
-  );
 
   // IFB 3: If the user has navigated to an ethereum address directly,
   // init a new token chain immediately

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -89,11 +89,23 @@ const LayoutComponent = ({
   const location = useLocation();
   const pathname = location.pathname.replaceAll('/', ''); // if it is community home page, it will match the chain id.
   const pathScope = routerParams?.scope?.toString() || app.customDomainId();
-  // isCommunityHomePathBeforeRedirect catches a case where the community home page is loaded before it gets
+  // isCommunityHomePathBeforeRedirect catches a case where the community home URL is loaded before it gets
   // redirected to the expected page (usually /discussions).
   // We want to avoid chain loading until the redirect is complete, and we have access to the deferChain flag.
   // This is mainly observable with the quick-switcher.
-  const isCommunityHomePathBeforeRedirect = pathname === pathScope;
+  console.log('* app.chain.id', app.chain?.id);
+  console.log('* app.isCustomDomain()', app.isCustomDomain());
+  console.log('* app.customDomainId()', app.customDomainId());
+  console.log('* pathname', pathname);
+  console.log('* pathScope', pathScope);
+  const isChainSelectDone = !!app.chain?.id && pathScope === app.chain.id;
+  const isCommunityHomePathBeforeRedirect =
+    isChainSelectDone && !app.isCustomDomain() && pathname === pathScope;
+  console.log('* isChainSelectDone', isChainSelectDone);
+  console.log(
+    '* isCommunityHomePathBeforeRedirect',
+    isCommunityHomePathBeforeRedirect
+  );
 
   // IFB 3: If the user has navigated to an ethereum address directly,
   // init a new token chain immediately
@@ -119,6 +131,7 @@ const LayoutComponent = ({
     !!selectedScope &&
     isChainDeferred &&
     !shouldDeferChain &&
+    isChainSelectDone &&
     !isCommunityHomePathBeforeRedirect;
 
   // IFB 7: If scope is not defined (and we are not on a custom domain),
@@ -145,8 +158,10 @@ const LayoutComponent = ({
         if (
           !shouldDeferChain &&
           response &&
+          isChainSelectDone &&
           !isCommunityHomePathBeforeRedirect
         ) {
+          console.log('IFB 5');
           await initChain();
         }
         setIsLoading(false);
@@ -162,6 +177,7 @@ const LayoutComponent = ({
     (async () => {
       // IFB 6
       if (shouldLoadDeferredChain) {
+        console.log('IFB 6');
         setIsLoading(true);
         setIsChainDeferred(false);
         await initChain();

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -89,12 +89,14 @@ const LayoutComponent = ({
   const location = useLocation();
   const pathname = location.pathname.replaceAll('/', ''); // if it is community home page, it will match the chain id.
   const pathScope = routerParams?.scope?.toString() || app.customDomainId();
+
+  // isChainSelectDone makes sure the selected chain matches the chain in the URL scope or custom domain.
+  const isChainSelectDone = !!app.chain?.id && pathScope === app.chain.id;
+
   // isCommunityHomePathBeforeRedirect catches a case where the community home URL is loaded before it gets
   // redirected to the expected page (usually /discussions).
   // We want to avoid chain loading until the redirect is complete, and we have access to the deferChain flag.
   // This is mainly observable with the quick-switcher.
-
-  const isChainSelectDone = !!app.chain?.id && pathScope === app.chain.id;
   const isCommunityHomePathBeforeRedirect =
     isChainSelectDone && !app.isCustomDomain() && pathname === pathScope;
 
@@ -152,7 +154,6 @@ const LayoutComponent = ({
           isChainSelectDone &&
           !isCommunityHomePathBeforeRedirect
         ) {
-          console.log('IFB 5');
           await initChain();
         }
         setIsLoading(false);
@@ -168,7 +169,6 @@ const LayoutComponent = ({
     (async () => {
       // IFB 6
       if (shouldLoadDeferredChain) {
-        console.log('IFB 6');
         setIsLoading(true);
         setIsChainDeferred(false);
         await initChain();

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { NavigateOptions } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { NavigateOptions, useParams } from 'react-router-dom';
 
 import app from 'state';
 import { PageLoading } from './loading';
@@ -8,10 +8,17 @@ import { useCommonNavigate } from 'navigation/helpers';
 import { featureFlags } from 'helpers/feature-flags';
 
 export default function DiscussionsRedirect() {
+  const routerParams = useParams();
   const navigate = useCommonNavigate();
+  const [isRedirected, setIsRedirected] = useState(false);
 
   useEffect(() => {
-    if (!app.chain) return;
+    if (!isRedirected) {
+      navigate('/', { replace: true }, routerParams.scope);
+      setIsRedirected(true);
+    }
+
+    if (!app.chain || isRedirected) return;
 
     const { defaultPage, defaultOverview, hasHomepage } = app.chain.meta;
     let view;
@@ -39,7 +46,7 @@ export default function DiscussionsRedirect() {
       default:
         navigate('/discussions', dontAddHistory);
     }
-  }, [navigate]);
+  }, [navigate, isRedirected, app.chain, routerParams.scope]);
 
   return <PageLoading />;
 }

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -46,7 +46,7 @@ export default function DiscussionsRedirect() {
       default:
         navigate('/discussions', dontAddHistory);
     }
-  }, [navigate, isRedirected, app.chain, routerParams.scope]);
+  }, [navigate, isRedirected, app?.chain, routerParams.scope]);
 
   return <PageLoading />;
 }

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -46,7 +46,7 @@ export default function DiscussionsRedirect() {
       default:
         navigate('/discussions', dontAddHistory);
     }
-  }, [navigate, isRedirected, app?.chain, routerParams.scope]);
+  }, [navigate, isRedirected, routerParams.scope]);
 
   return <PageLoading />;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4064 

## Description of Changes
There were two issues happening here:
1. The redirect from quick-switcher was updating the url before the Redirect route was rendered, so the redirect wasn't happening.
2. Since the redirect didn't happen, the flag to deferChain was not forwarded, and the chain data got loaded.

This fixes both of those problems.
1. Use a hack to re-trigger the render in the case of a redirect
2. Check for case before allowing initChain:
    -  flash of community home path before `deferChain` is detectable by Layout.tsx.

## Test Plan
- ran proposals.spec.ts E2E tests
- CA (click around) tested on local:
  - Join with magic link
  - Join redacted-cartel
  - join Osmosis
  - Quick switch to redacted-cartel
  - Quick switch to Osmosis
  - Expect: 
      - overview page loads quickly
      - no calls to `osmosis` rpc in network tab
      - /proposals loads like normal
  - Quick switch to redacted-cartel
  - Go directly to http://localhost:8080/osmosis/proposal/522-liquid-staked-token-incentive-category
      - Expect proposal page to load correctly 
  - Also tested with custom domain 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 