### PR TITLE
add 5mins caching to CE entities events

### DIFF
--- a/packages/commonwealth/server/util/entitiesProxy.ts
+++ b/packages/commonwealth/server/util/entitiesProxy.ts
@@ -3,6 +3,22 @@ import type { Express } from 'express';
 import url from 'url';
 
 import { CE_URL } from '../config';
+import { cacheDecorator } from 'common-common/src/cacheDecorator';
+import { lookupKeyDurationInReq } from 'common-common/src/cacheKeyUtils';
+
+async function calcCeProxyCacheKeyDuration(
+  ceEndpoint: 'entities' | 'events',
+  req,
+  res,
+  next
+) {
+  const search = url.parse(req.url).search;
+  const ceUrl = `${CE_URL}/${ceEndpoint}${search}`;
+
+  req.cacheKey = ceUrl;
+  req.cacheDuration = 60 * 5; // 5 minutes
+  next();
+}
 
 async function ceProxy(ceEndpoint: 'entities' | 'events', req, res) {
   try {
@@ -21,8 +37,18 @@ async function ceProxy(ceEndpoint: 'entities' | 'events', req, res) {
 
 function setupCEProxy(app: Express) {
   // using bodyParser here because cosmjs generates text/plain type headers
-  app.get('/api/ce/entities', ceProxy.bind(null, 'entities'));
-  app.get('/api/ce/events', ceProxy.bind(null, 'events'));
+  app.get(
+    '/api/ce/entities',
+    calcCeProxyCacheKeyDuration.bind(null, 'entities'),
+    cacheDecorator.cacheMiddleware(60 * 5, lookupKeyDurationInReq),
+    ceProxy.bind(null, 'entities')
+  );
+  app.get(
+    '/api/ce/events',
+    calcCeProxyCacheKeyDuration.bind(null, 'events'),
+    cacheDecorator.cacheMiddleware(60 * 5, lookupKeyDurationInReq),
+    ceProxy.bind(null, 'events')
+  );
 }
 
 export default setupCEProxy;


### PR DESCRIPTION

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4090

## Description of Changes
- caching /api/ce/entities & /api/ce/events for 5mins
Sample Key:
`route_response_https://chain-events.herokuapp.com/api/entities?chain=osmosis`

## Test Plan
- Unit tested the `FIXME()` call.

## Deployment Plan
1. merge to master

## Other Considerations
- is it ok to to cache this stream for 5mins ? 