### PR TITLE
Tab Bar showing on threads without links fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -14,7 +14,6 @@ import { CWIconButton } from './cw_icon_button';
 import { CWIcon } from './cw_icons/cw_icon';
 import { CWTab, CWTabBar } from './cw_tabs';
 import { CWText } from './cw_text';
-import { isWindowMediumSmallInclusive } from './helpers';
 import { ComponentType } from './types';
 
 export type ContentPageSidebarItem = {
@@ -72,36 +71,9 @@ export const CWContentPage = (props: ContentPageProps) => {
     showTabs = false,
   } = props;
 
-  const [viewType, setViewType] = React.useState<'sidebarView' | 'tabsView'>(
-    isWindowMediumSmallInclusive(window.innerWidth)
-      ? 'tabsView'
-      : !showSidebar
-      ? 'tabsView'
-      : 'sidebarView'
-  );
   const [tabSelected, setTabSelected] = React.useState<number>(0);
-
   const createdOrEditedDate = lastEdited ? lastEdited : createdAt;
   const createdOrEditedText = lastEdited ? 'Edited' : 'Published';
-
-  React.useEffect(() => {
-    const onResize = () => {
-      setViewType(
-        isWindowMediumSmallInclusive(window.innerWidth)
-          ? 'tabsView'
-          : !showSidebar
-          ? 'tabsView'
-          : 'sidebarView'
-      );
-    };
-
-    window.addEventListener('resize', onResize);
-
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const mainBody = (
     <div className="main-body-container">
@@ -157,20 +129,19 @@ export const CWContentPage = (props: ContentPageProps) => {
 
   return (
     <div className={ComponentType.ContentPage}>
-      <div
-        className={`sidebar-view ${viewType !== 'sidebarView' ? 'hidden' : ''}`}
-      >
-        {mainBody}
-        {showSidebar && (
-          <div className="sidebar">
-            {sidebarComponents?.map((c) => (
-              <React.Fragment key={c.label}>{c.item}</React.Fragment>
-            ))}
-          </div>
-        )}
-      </div>
-      <div className={`tabs-view ${viewType !== 'tabsView' ? 'hidden' : ''}`}>
-        {showTabs && (
+      {!showTabs ? (
+        <div className="sidebar-view">
+          {mainBody}
+          {showSidebar && (
+            <div className="sidebar">
+              {sidebarComponents?.map((c) => (
+                <React.Fragment key={c.label}>{c.item}</React.Fragment>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="tabs-view">
           <CWTabBar>
             <CWTab
               label={contentBodyLabel}
@@ -190,19 +161,18 @@ export const CWContentPage = (props: ContentPageProps) => {
               />
             ))}
           </CWTabBar>
-        )}
-
-        {tabSelected === 0 && mainBody}
-        {sidebarComponents?.length >= 1 &&
-          tabSelected === 1 &&
-          sidebarComponents[0].item}
-        {sidebarComponents?.length >= 2 &&
-          tabSelected === 2 &&
-          sidebarComponents[1].item}
-        {sidebarComponents?.length === 3 &&
-          tabSelected === 3 &&
-          sidebarComponents[2].item}
-      </div>
+          {tabSelected === 0 && mainBody}
+          {sidebarComponents?.length >= 1 &&
+            tabSelected === 1 &&
+            sidebarComponents[0].item}
+          {sidebarComponents?.length >= 2 &&
+            tabSelected === 2 &&
+            sidebarComponents[1].item}
+          {sidebarComponents?.length === 3 &&
+            tabSelected === 3 &&
+            sidebarComponents[2].item}
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -48,6 +48,7 @@ type ContentPageProps = {
   subHeader?: React.ReactNode;
   viewCount?: number;
   displayNewTag?: boolean;
+  hideTabs?: boolean;
 };
 
 export const CWContentPage = (props: ContentPageProps) => {
@@ -68,6 +69,7 @@ export const CWContentPage = (props: ContentPageProps) => {
     title,
     viewCount,
     displayNewTag,
+    hideTabs = false,
   } = props;
 
   const [viewType, setViewType] = React.useState<'sidebarView' | 'tabsView'>(
@@ -168,25 +170,28 @@ export const CWContentPage = (props: ContentPageProps) => {
         )}
       </div>
       <div className={`tabs-view ${viewType !== 'tabsView' ? 'hidden' : ''}`}>
-        <CWTabBar>
-          <CWTab
-            label={contentBodyLabel}
-            onClick={() => {
-              setTabSelected(0);
-            }}
-            isSelected={tabSelected === 0}
-          />
-          {sidebarComponents?.map((item, i) => (
+        {!hideTabs && (
+          <CWTabBar>
             <CWTab
-              key={item.label}
-              label={item.label}
+              label={contentBodyLabel}
               onClick={() => {
-                setTabSelected(i + 1);
+                setTabSelected(0);
               }}
-              isSelected={tabSelected === i + 1}
+              isSelected={tabSelected === 0}
             />
-          ))}
-        </CWTabBar>
+            {sidebarComponents?.map((item, i) => (
+              <CWTab
+                key={item.label}
+                label={item.label}
+                onClick={() => {
+                  setTabSelected(i + 1);
+                }}
+                isSelected={tabSelected === i + 1}
+              />
+            ))}
+          </CWTabBar>
+        )}
+
         {tabSelected === 0 && mainBody}
         {sidebarComponents?.length >= 1 &&
           tabSelected === 1 &&

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -48,7 +48,7 @@ type ContentPageProps = {
   subHeader?: React.ReactNode;
   viewCount?: number;
   displayNewTag?: boolean;
-  hideTabs?: boolean;
+  showTabs?: boolean;
 };
 
 export const CWContentPage = (props: ContentPageProps) => {
@@ -69,7 +69,7 @@ export const CWContentPage = (props: ContentPageProps) => {
     title,
     viewCount,
     displayNewTag,
-    hideTabs = false,
+    showTabs = false,
   } = props;
 
   const [viewType, setViewType] = React.useState<'sidebarView' | 'tabsView'>(
@@ -170,7 +170,7 @@ export const CWContentPage = (props: ContentPageProps) => {
         )}
       </div>
       <div className={`tabs-view ${viewType !== 'tabsView' ? 'hidden' : ''}`}>
-        {!hideTabs && (
+        {showTabs && (
           <CWTabBar>
             <CWTab
               label={contentBodyLabel}

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -117,6 +117,7 @@ const ViewProposalPage = ({
   const onModalClose = () => {
     setVotingModalOpen(false);
   };
+
   return (
     <Sublayout
     //  title={headerTitle}

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -725,9 +725,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           !(
             showLinkedProposalOptions ||
             showLinkedThreadOptions ||
-            isAuthor ||
-            polls?.length > 0 ||
-            isAdminOrMod
+            polls?.length > 0
           )
         }
         contentBodyLabel="Thread"

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -721,6 +721,15 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   return (
     <Sublayout>
       <CWContentPage
+        hideTabs={
+          !(
+            showLinkedProposalOptions ||
+            showLinkedThreadOptions ||
+            isAuthor ||
+            polls?.length > 0 ||
+            isAdminOrMod
+          )
+        }
         contentBodyLabel="Thread"
         showSidebar={
           showLinkedProposalOptions ||

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -54,6 +54,11 @@ import { extractDomain, isDefaultStage } from 'helpers';
 import ExternalLink from 'views/components/ExternalLink';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
+import useBrowserWindow from 'hooks/useBrowserWindow';
+import {
+  breakpointFnValidator,
+  isWindowMediumSmallInclusive,
+} from '../../components/component_kit/helpers';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -91,6 +96,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const [isChangeTopicModalOpen, setIsChangeTopicModalOpen] = useState(false);
   const [isEditCollaboratorsModalOpen, setIsEditCollaboratorsModalOpen] =
     useState(false);
+  const [isCollapsedSize, setIsCollapsedSize] = useState(false);
 
   const threadId = identifier.split('-')[0];
   const threadDoesNotMatch =
@@ -100,6 +106,18 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     setIsGloballyEditing(false);
     setIsEditingBody(false);
   };
+
+  useBrowserWindow({
+    onResize: () =>
+      breakpointFnValidator(
+        isCollapsedSize,
+        (state: boolean) => {
+          setIsCollapsedSize(state);
+        },
+        isWindowMediumSmallInclusive
+      ),
+    resizeListenerUpdateDeps: [isCollapsedSize],
+  });
 
   useBrowserAnalyticsTrack({
     payload: { event: MixpanelPageViewEvent.THREAD_PAGE_VIEW },
@@ -718,14 +736,13 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const isStageDefault = isDefaultStage(thread.stage);
 
+  const tabsShouldBePresent =
+    showLinkedProposalOptions || showLinkedThreadOptions || polls?.length > 0;
+
   return (
     <Sublayout>
       <CWContentPage
-        showTabs={
-          showLinkedProposalOptions ||
-          showLinkedThreadOptions ||
-          polls?.length > 0
-        }
+        showTabs={isCollapsedSize && tabsShouldBePresent}
         contentBodyLabel="Thread"
         showSidebar={
           showLinkedProposalOptions ||

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -721,12 +721,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   return (
     <Sublayout>
       <CWContentPage
-        hideTabs={
-          !(
-            showLinkedProposalOptions ||
-            showLinkedThreadOptions ||
-            polls?.length > 0
-          )
+        showTabs={
+          showLinkedProposalOptions ||
+          showLinkedThreadOptions ||
+          polls?.length > 0
         }
         contentBodyLabel="Thread"
         showSidebar={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4074 

## Description of Changes
- Tab bar was showing on threads even when no polls/linked proposals were present, creating redundant UI. This fix ensures that if no polls or linked proposals are present and the thread viewer is not the author/admin, the tab bar won't be present. 

## Test Plan
- Tested locally. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 