### PR TITLE
Proposal -> Thread Links

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ChainEntitiesSelector/ChainEntitiesSelectorItem.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ChainEntitiesSelector/ChainEntitiesSelectorItem.tsx
@@ -25,11 +25,6 @@ const ChainEntitiesSelectorItem = ({
               ? ` ${chainEntity.typeId.slice(0, 6)}...`
               : ` #${chainEntity.typeId}`)}
         </CWText>
-        <CWText type="caption" truncate>
-          {chainEntity.threadTitle !== 'undefined'
-            ? decodeURIComponent(chainEntity.threadTitle)
-            : 'No thread title'}
-        </CWText>
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
@@ -106,33 +106,6 @@ export const ProposalCard = ({
           {getStatusText(proposal)}
         </CWText>
       ) : null}
-      {proposal.threadId && (
-        <CWText type="caption" className="proposal-thread-link-text">
-          <a
-            href={getProposalUrlPath(
-              ProposalType.Thread,
-              `${proposal.threadId}`
-            )}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-
-              localStorage[`${app.activeChainId()}-proposals-scrollY`] =
-                window.scrollY;
-
-              navigate(
-                getProposalUrlPath(
-                  ProposalType.Thread,
-                  `${proposal.threadId}`,
-                  true
-                )
-              );
-            }}
-          >
-            {proposal.threadTitle ? proposal.threadTitle : 'Go to thread'}
-          </a>
-        </CWText>
-      )}
     </CWCard>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_components.tsx
@@ -74,7 +74,6 @@ export const ProposalSubheader = (props: ProposalSubheaderProps) => {
   const { onModalClose, proposal, toggleVotingModal, votingModalOpen } = props;
   const forceRerender = useForceRerender();
   const [linkedThreads, setLinkedThreads] = useState(null);
-  console.log(linkedThreads);
 
   useEffect(() => {
     app.proposalEmitter.on('redraw', forceRerender);

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
@@ -24,7 +24,7 @@ const threadLinkButton = (threadId: string, title: string, chain: string) => {
 
   return (
     <div className="HeaderLink">
-      <Link to={path}>Go to Thread: {title}</Link>
+      <Link to={path}>{title ? decodeURIComponent(title) : 'Go to thread'}</Link>
       <CWIcon iconName="externalLink" iconSize="small" />
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
 import 'pages/view_proposal/proposal_header_links.scss';
@@ -9,24 +9,32 @@ import type { AnyProposal } from '../../../models/types';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 
 type ProposalHeaderLinkProps = {
-  proposal: AnyProposal;
+  threads: any[];
+  chain: string;
 };
 
 // "Go to discussion"
-export const ThreadLink = ({ proposal }: ProposalHeaderLinkProps) => {
+const threadLinkButton = (threadId: string, title: string, chain: string) => {
   const path = getProposalUrlPath(
     ProposalType.Thread,
-    `${proposal.threadId}`,
+    `${threadId}`,
     false,
-    proposal['chain']
+    chain
   );
 
   return (
     <div className="HeaderLink">
-      <Link to={path}>Go to discussion</Link>
+      <Link to={path}>Go to Thread: {title}</Link>
       <CWIcon iconName="externalLink" iconSize="small" />
     </div>
   );
+};
+export const ThreadLink = ({ threads, chain }: ProposalHeaderLinkProps) => {
+  const components: JSX.Element[] = [];
+  threads.forEach((t) =>
+    components.push(threadLinkButton(t.id, t.title, chain))
+  );
+  return <React.Fragment>{components}</React.Fragment>;
 };
 
 type SnapshotThreadLinkProps = {

--- a/packages/commonwealth/server/routes/linking/addThreadLinks.ts
+++ b/packages/commonwealth/server/routes/linking/addThreadLinks.ts
@@ -36,7 +36,7 @@ const addThreadLink = async (
     thread.address_id,
     thread.chain
   );
-  if (!isAuth) return next(new AppError(Errors.NotAdminOrOwner));
+  if (!isAuth && !req.user.isAdmin) return next(new AppError(Errors.NotAdminOrOwner));
 
   if (thread.links) {
     const filteredLinks = links.filter((link) => {

--- a/packages/commonwealth/server/routes/updateThreadStage.ts
+++ b/packages/commonwealth/server/routes/updateThreadStage.ts
@@ -36,7 +36,7 @@ const updateThreadStage = async (
     const userOwnedAddressIds = (await req.user.getAddresses())
       .filter((addr) => !!addr.verified)
       .map((addr) => addr.id);
-    if (!userOwnedAddressIds.includes(thread.address_id)) {
+    if (!userOwnedAddressIds.includes(thread.address_id) && !req.user.isAdmin) {
       // is not author
       const roles = await findAllRoles(
         models,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4094 

## Description of Changes
- Add functionality to pull all linked threads to the proposal page and replicated the old 'Go to Discussion' button across multiple links 
<img width="679" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/36428666/27bb2b27-5520-419c-9b0f-9d08c1e677f3">
- Removes thread title from CE Selector
- Removes Go to Thread from proposal cards on Proposals 

## Test Plan
- Create a thread(Osmosis is easy for this process) 
- Link a proposal 
- repeat on another thread
- go to proposal and ensure both links work to created/linked threads on view proposal page
