### PR TITLE
Comment Address switcher path

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/comments.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/comments.ts
@@ -150,7 +150,7 @@ class CommentsController {
       const res = await $.post(`${app.serverUrl()}/createComment`, {
         author_chain: app.user.activeAccount.chain.id,
         chain,
-        address,
+        address: app.user.activeAccount.address,
         parent_id: parentCommentId,
         chain_entity_id: chainEntity?.id,
         thread_id: threadId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4046 

## Description of Changes
- Adds same logic from `NewThreadForm` PR for comments 

## Test Plan
- connect 2 addresses 
- write a comment
- switch to other address w/o modifying text and ensure created comment is correct
