### PR TITLE
Tree shake ethersproject

### DIFF
--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -87,12 +87,6 @@ module.exports = {
           name: 'bitcoin',
           chunks: 'all',
         },
-        ethereum: {
-          // this is made into an inital chunk
-          test: /[\\/]node_modules[\\/](@ethersproject)[\\/]/,
-          name: 'ethereum',
-          chunks: 'all',
-        },
         ethereumAsync: {
           // this is made into an async chunk (lazy loaded)
           test: /[\\/]node_modules[\\/](web3|@audius|ethers|web3-eth-accounts|@walletconnect|ethereumjs-abi)[\\/]/,
@@ -119,6 +113,11 @@ module.exports = {
           name: 'snapshot',
           chunks: 'all',
         },
+        // ethereum: {
+        //   test: /[\\/]node_modules[\\/](@ethersproject)[\\/]/,
+        //   name: 'ethereum',
+        //   chunks: 'all',
+        // },
         // near: {
         //   test: /[\\/]node_modules[\\/](near-api-js)[\\/]/,
         //   name: 'near',


### PR DESCRIPTION
@ethersproject can be codesplit (however is not being done so now, probably until client state is singelton-ified)

We save 100k gzipped by letting @ethersproject be treeshaken like the rest of the web3 packages.



## Link to Issue
Closes: #TODO

## Description of Changes
### After -> ~1,241 kbs gzipped loaded
<img width="1501" alt="Pasted image 20230602055635" src="https://github.com/hicommonwealth/commonwealth/assets/5334557/00c055b5-6a2b-4c17-8e51-f143f4780695">

<img width="998" alt="Pasted image 20230602055010" src="https://github.com/hicommonwealth/commonwealth/assets/5334557/f86e2fc0-d92b-4f27-a820-3e9eb5dbc7f3">

### Before -> ~1,319 kbs

<img width="729" alt="Pasted image 20230602055452" src="https://github.com/hicommonwealth/commonwealth/assets/5334557/77c8ed8c-1149-4411-b1ef-d687a4ac8b91">

<img width="1512" alt="Pasted image 20230602055439" src="https://github.com/hicommonwealth/commonwealth/assets/5334557/0a151211-694f-443c-9c9a-94620c103d96">


## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 