### PR TITLE
Fixed bug in navigate community

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/helpers.tsx
+++ b/packages/commonwealth/client/scripts/navigation/helpers.tsx
@@ -103,6 +103,9 @@ export const navigateToCommunity = ({
 }: NavigateToCommunityProps) => {
   const isExternalLink = chain !== app.customDomainId();
 
+  // When we navigate to another chain, remove all listeners initialized from old chain.
+  app.chainModuleReady.removeAllListeners();
+
   if (!app.isCustomDomain()) {
     navigate(path, {}, chain);
   } else {


### PR DESCRIPTION
### Note
This ticket doesn't fix the issue because it is already fixed in Ian's PR (more about that at the bottom).
Instead this ticket just fixes a console error that appears when you navigate communities

## Link to Issue
Closes: #4063

## Description of Changes
- Removes event listener so that console error isn't thrown

## Test Plan
- Ensured works correctly with Ian's PR merged in with this change.

## Other Considerations
I am not sure proper procedure, but Ian's PR: https://github.com/hicommonwealth/commonwealth/pull/4138 fixes the issue.

The issue was caused due to osmosis chain taking forever to load. Normally we defer chain, but since we navigate through the sidebar, the deferedChain: true was not being passed into the Layout component causing osmosis to hang (because its rpc gateway is bad).