### PR TITLE
Removed UI option for admin to be able to ban themselves

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -183,6 +183,10 @@ export const User = ({
     }
   };
 
+  const isSelfSelected = app.user.addresses
+    .map((a) => a.address)
+    .includes(account?.address);
+
   const userFinal = avatarOnly ? (
     <div className="User avatar-only" key={profile?.address || '-'}>
       <Avatar
@@ -331,7 +335,7 @@ export const User = ({
           )}
           {getRoleTags()}
           {/* If Admin Allow Banning */}
-          {loggedInUserIsAdmin && (
+          {loggedInUserIsAdmin && !isSelfSelected && (
             <div className="ban-wrapper">
               <CWButton
                 onClick={() => {


### PR DESCRIPTION
## Link to Issue
Closes: #3577

## Description of Changes
- Adds check on ban tooltip to check whether the selected address exists within the users active addresses.

## Test Plan
- Made admin user, checked to make sure that hover tooltip does not contain ban user
- Hovered over other user, checked to make sure that ban tooltip still exists, and that it works.