### PR TITLE
Added link containers for activity cards in dashboard page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row.tsx
@@ -58,14 +58,12 @@ export const UserDashboardRow = (props: UserDashboardRowProps) => {
   const path = getProposalUrlPath(root_type, thread_id, false, chain_id);
 
   return (
-    <div
+    <a
       className={getClasses<{ isLink?: boolean }>(
         { isLink: !!path },
         'UserDashboardRow'
       )}
-      onClick={() => {
-        navigate(path);
-      }}
+      href={path}
     >
       <UserDashboardRowTop activityData={notification} category={categoryId} />
       <UserDashboardRowBottom
@@ -75,6 +73,6 @@ export const UserDashboardRow = (props: UserDashboardRowProps) => {
         commentCount={commentCount}
         commenters={commenters}
       />
-    </div>
+    </a>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
@@ -74,7 +74,13 @@ export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
           <CWAvatarGroup profiles={commenters} chainId={chainId} />
         </div>
       </div>
-      <div className="actions" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="actions"
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+      >
         <PopoverMenu
           menuItems={[
             {

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
@@ -44,6 +44,15 @@
   flex-direction: column;
   min-width: 100%;
   max-width: 0;
+  color: unset !important;
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: unset !important;
+    text-decoration: none;
+  }
 
   &.isLink {
     cursor: pointer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4100

## Description of Changes
- Added links to activity rows in the dashboard page

## Test Plan
- Hovering over activity cards should show urls in the bottom left, right clicking should show link options, command/ctrl click should open it in new tab

## Deployment Plan
N/A

## Other Considerations
N/A