### PR TITLE
Updated chain cards to be link compatible

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_chain_event_row.tsx
@@ -24,16 +24,12 @@ export const UserDashboardChainEventRow = (
   const navigate = useCommonNavigate();
 
   return (
-    <div
+    <a
       className={getClasses<{ isLink?: boolean }>(
         { isLink: !!label.linkUrl },
         'UserDashboardChainEventRow'
       )}
-      onClick={() => {
-        if (label.linkUrl) {
-          navigate(label.linkUrl);
-        }
-      }}
+      {...(label.linkUrl && { href: label.linkUrl })}
     >
       <div className="chain-event-icon-container">
         <CWIcon
@@ -67,6 +63,6 @@ export const UserDashboardChainEventRow = (
           {label.label}
         </CWText>
       </div>
-    </div>
+    </a>
   );
 };

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_chain_event_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_chain_event_row.scss
@@ -5,6 +5,25 @@
   @include userDashboardRowStyles;
   gap: 24px;
   width: 100%;
+  color: unset !important;
+  text-decoration: none;
+
+  a {
+    color: unset !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: unset !important;
+    }
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: unset !important;
+    text-decoration: none;
+  }
 
   &.isLink {
     cursor: pointer;

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
@@ -47,6 +47,16 @@
   color: unset !important;
   text-decoration: none;
 
+  a {
+    color: unset !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: unset !important;
+    }
+  }
+
   &:hover,
   &:focus,
   &:active {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a followup of #4165 

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4100

## Description of Changes
- Add link container to chain cards in dashboard page

## Test Plan
- Hovering over activity cards should show urls in the bottom left, right clicking should show link options, command/ctrl click should open it in new tab

## Deployment Plan
N/A

## Other Considerations
N/A