### PR TITLE
Hot-Fix: handle undefined title in slugify

### DIFF
--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -15,6 +15,8 @@ import type { RoleObject } from './types';
 export const slugify = (str: string): string => {
   // Remove any character that isn't a alphanumeric character or a
   // space, and then replace any sequence of spaces with dashes.
+  if (!str) return '';
+
   return str
     .toLowerCase()
     .trim()
@@ -49,12 +51,15 @@ export const requiresTypeSlug = (type: ProposalType): boolean => {
 };
 
 /* eslint-disable */
-export const getThreadUrl = (thread: {
-  chain: string;
-  type_id?: string | number;
-  id?: string | number;
-  title?: string;
-}, comment?: string | number): string => {
+export const getThreadUrl = (
+  thread: {
+    chain: string;
+    type_id?: string | number;
+    id?: string | number;
+    title?: string;
+  },
+  comment?: string | number
+): string => {
   const aId = thread.chain;
   const tId = thread.type_id || thread.id;
   const tTitle = thread.title ? `-${slugify(thread.title)}` : '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4181 

## Description of Changes
- If no proposal title, return empty string in slugify (handle null reference case)
- 

## Test Plan
- Ran proposals.spec E2E tests (fails without this change)
- CA (click around) tested on local and frack:
  - http://localhost:8080/kyve/proposal/6
  - http://localhost:8080/kyve/proposals  , click on proposal 5 or 6
  - check other proposals and communities

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This case happened because newer Kyve proposals are relying solely on IPFS-loaded metadata for title and content. We will handle loading this metadata in a #4184 .