### PR TITLE
Replace useEffect having api calls with useNecessaryEffect

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
@@ -1,23 +1,21 @@
-import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import { isEqual } from 'lodash';
-
 import 'modals/edit_collaborators_modal.scss';
-import NewProfilesController from '../../controllers/server/newProfiles';
-
-import type { IThreadCollaborator } from '../../models/Thread';
-import type Thread from '../../models/Thread';
+import React, { useState } from 'react';
 import type { RoleInstanceWithPermissionAttributes } from 'server/util/roles';
-
 import app from 'state';
-import { User } from '../components/user/user';
+import { useDebounce } from 'usehooks-ts';
+import NewProfilesController from '../../controllers/server/newProfiles';
+import type Thread from '../../models/Thread';
+import type { IThreadCollaborator } from '../../models/Thread';
 import { CWButton } from '../components/component_kit/cw_button';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
 import { CWLabel } from '../components/component_kit/cw_label';
 import { CWText } from '../components/component_kit/cw_text';
-import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { CWTextInput } from '../components/component_kit/cw_text_input';
-import { useDebounce } from 'usehooks-ts';
+import { User } from '../components/user/user';
 
 type EditCollaboratorsModalProps = {
   onModalClose: () => void;
@@ -40,7 +38,7 @@ export const EditCollaboratorsModal = ({
     Array<IThreadCollaborator>
   >(thread.collaborators);
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetchMembers = async () => {
       try {
         const response = await app.search.searchMentionableProfiles(

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
@@ -1,14 +1,14 @@
-import { notifyError } from 'controllers/app/notifications';
-import React, { useEffect, useState } from 'react';
-import app from 'state';
 import axios from 'axios';
-
+import { notifyError } from 'controllers/app/notifications';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import 'pages/AdminPanel.scss';
+import React, { useState } from 'react';
+import app from 'state';
+import { CWButton } from '../../components/component_kit/cw_button';
 import { CWSpinner } from '../../components/component_kit/cw_spinner';
 import { CWText } from '../../components/component_kit/cw_text';
-import { ValidationStatus } from '../../components/component_kit/cw_validation_text';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
-import { CWButton } from '../../components/component_kit/cw_button';
+import { ValidationStatus } from '../../components/component_kit/cw_validation_text';
 
 const Analytics = () => {
   const [initialized, setInitialized] = useState<boolean>(false);
@@ -60,7 +60,7 @@ const Analytics = () => {
       });
   };
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     // Fetch global analytics on load
     const fetchAnalytics = async () => {
       axios
@@ -80,15 +80,11 @@ const Analytics = () => {
         });
     };
 
-    const timerId = setTimeout(() => {
-      if (!initialized) {
-        fetchAnalytics().then(() => {
-          setInitialized(true);
-        });
-      }
-    });
-
-    return () => clearTimeout(timerId);
+    if (!initialized) {
+      fetchAnalytics().then(() => {
+        setInitialized(true);
+      });
+    }
   }, [initialized]);
 
   const validationFn = (value: string): [ValidationStatus, string] | [] => {

--- a/packages/commonwealth/client/scripts/views/pages/chain_entity_link_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/chain_entity_link_redirect.tsx
@@ -1,18 +1,22 @@
-import React, { useEffect } from 'react';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import { chainEntityTypeToProposalSlug } from 'identifiers';
+import { useCommonNavigate } from 'navigation/helpers';
+import React from 'react';
 import app from 'state';
 import { PageLoading } from './loading';
-import { useCommonNavigate } from 'navigation/helpers';
-import { chainEntityTypeToProposalSlug } from 'identifiers';
 
 type ChainEntityLinkRedirectProps = {
   identifier: string;
   scope: string;
 };
 
-export default function ChainEntityLinkRedirect({ identifier, scope }: ChainEntityLinkRedirectProps) {
+export default function ChainEntityLinkRedirect({
+  identifier,
+  scope,
+}: ChainEntityLinkRedirectProps) {
   const navigate = useCommonNavigate();
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetchChainEntityData = async () => {
       try {
         // 1. make query to chain events to get the specific entity data
@@ -23,7 +27,10 @@ export default function ChainEntityLinkRedirect({ identifier, scope }: ChainEnti
         const newLink = {
           source: 'proposal',
           title,
-          identifier: type === 'proposal' ? `${typeId}` : `${chainEntityTypeToProposalSlug(type)}/${typeId}`
+          identifier:
+            type === 'proposal'
+              ? `${typeId}`
+              : `${chainEntityTypeToProposalSlug(type)}/${typeId}`,
         };
 
         // 3. redirect
@@ -32,7 +39,7 @@ export default function ChainEntityLinkRedirect({ identifier, scope }: ChainEnti
         // TODO: show error page
         throw new Error('could not find entity');
       }
-    }
+    };
 
     fetchChainEntityData();
   }, [navigate]);

--- a/packages/commonwealth/client/scripts/views/pages/contracts/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/contracts/index.tsx
@@ -1,20 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import { notifyError } from 'controllers/app/notifications';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import Contract from 'models/Contract';
+import Template from 'models/Template';
+import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/contracts/contracts_page.scss';
+import React, { useState } from 'react';
 import app from 'state';
-import { PageLoading } from '../loading';
-import Sublayout from '../../Sublayout';
-import { CWText } from 'views/components/component_kit/cw_text';
 import { CWBreadcrumbs } from 'views/components/component_kit/cw_breadcrumbs';
 import { CWButton } from 'views/components/component_kit/cw_button';
-import { ContractCard } from './contract_card';
-import { useCommonNavigate } from 'navigation/helpers';
-import Contract from 'models/Contract';
+import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTab, CWTabBar } from '../../components/component_kit/cw_tabs';
-import Template from 'models/Template';
-
-import { notifyError } from 'controllers/app/notifications';
-import { TemplateDisplayTab } from './template_display_tab';
 import { openConfirmation } from '../../modals/confirmation_modal';
+import Sublayout from '../../Sublayout';
+import { PageLoading } from '../loading';
+import { ContractCard } from './contract_card';
+import { TemplateDisplayTab } from './template_display_tab';
 
 const ContractsPage = () => {
   const navigate = useCommonNavigate();
@@ -47,7 +47,7 @@ const ContractsPage = () => {
     }
   };
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     fetchTemplates();
   }, [contracts, setTemplates]);
 

--- a/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import $ from 'jquery';
-
 import 'pages/create_community.scss';
-
+import React, { useEffect, useState } from 'react';
 import app from 'state';
+import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 import { CWTab, CWTabBar } from '../../components/component_kit/cw_tabs';
 import { CWText } from '../../components/component_kit/cw_text';
 import Sublayout from '../../Sublayout';
@@ -11,13 +12,11 @@ import { CosmosForm } from './cosmos_form';
 import { ERC20Form } from './erc20_form';
 import { ERC721Form } from './erc721_form';
 import { EthDaoForm } from './eth_dao_form';
+import { useEthChainFormState } from './hooks';
 import { SplTokenForm } from './spl_token_form';
 import { SputnikForm } from './sputnik_form';
 import { StarterCommunityForm } from './starter_community_form';
 import { SubstrateForm } from './substrate_form';
-import { useEthChainFormState } from './hooks';
-import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
-import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 
 export enum CommunityType {
   StarterCommunity = 'Starter Community',
@@ -65,7 +64,7 @@ const CreateCommunity = () => {
     fetchEthChains();
   }, []);
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetchEthChainNames = async () => {
       const chains = await $.getJSON('https://chainid.network/chains.json');
 

--- a/packages/commonwealth/client/scripts/views/pages/finish_axie_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_axie_login.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import type { NavigateOptions, To } from 'react-router';
-import $ from 'jquery';
-
-import app from 'state';
-import { initAppState } from 'state';
 import { updateActiveAddresses } from 'controllers/app/login';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import $ from 'jquery';
+import { useCommonNavigate } from 'navigation/helpers';
+import React, { useState } from 'react';
+import type { NavigateOptions, To } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
+import app, { initAppState } from 'state';
 import { PageLoading } from 'views/pages/loading';
 import ErrorPage from './error';
-import { useCommonNavigate } from 'navigation/helpers';
-import { useSearchParams } from 'react-router-dom';
 
 // creates address, initializes account, and redirects to main page
 const validate = async (
@@ -49,7 +48,7 @@ const FinishAxieLogin = () => {
   const token = searchParams.get('token');
   const stateId = searchParams.get('stateId');
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     validate(token, stateId, 'axie-infinity', navigate).then((res) => {
       if (typeof res === 'string') {
         setError(res);

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/chain_metadata_rows.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/chain_metadata_rows.tsx
@@ -1,17 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { uuidv4 } from 'lib/util';
 import axios from 'axios';
-
-import 'pages/manage_community/chain_metadata_rows.scss';
-
-import app from 'state';
 import { ChainBase, DefaultPage } from 'common-common/src/types';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import { featureFlags } from 'helpers/feature-flags';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import { uuidv4 } from 'lib/util';
+import 'pages/manage_community/chain_metadata_rows.scss';
+import React, { useCallback, useState } from 'react';
+import app from 'state';
 import { InputRow, SelectRow, ToggleRow } from 'views/components/metadata_rows';
 import type ChainInfo from '../../../models/ChainInfo';
 import type RoleInfo from '../../../models/RoleInfo';
 import { AvatarUpload } from '../../components/Avatar';
-
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWDropdown } from '../../components/component_kit/cw_dropdown';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
@@ -21,7 +20,6 @@ import { CWText } from '../../components/component_kit/cw_text';
 import { CWToggle } from '../../components/component_kit/cw_toggle';
 import { setChainCategories, setSelectedTags } from './helpers';
 import { ManageRoles } from './manage_roles';
-import { featureFlags } from 'helpers/feature-flags';
 
 type ChainMetadataRowsProps = {
   admins: Array<RoleInfo>;
@@ -91,7 +89,7 @@ export const ChainMetadataRows = ({
     }
   }, [chain.id]);
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     if (discordBotConnected && !channelsLoaded) {
       getChannels();
     }

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/webhooks_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/webhooks_form.tsx
@@ -1,20 +1,18 @@
-import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
-import smartTruncate from 'smart-truncate';
-
-import 'pages/manage_community/webhooks_form.scss';
-
-import type Webhook from '../../../models/Webhook';
-
-import app from 'state';
 import { notifyError } from 'controllers/app/notifications';
 import { pluralize } from 'helpers';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import 'pages/manage_community/webhooks_form.scss';
+import React, { useMemo, useState } from 'react';
+import smartTruncate from 'smart-truncate';
+import app from 'state';
 import { WebhookSettingsModal } from 'views/modals/webhook_settings_modal';
+import type Webhook from '../../../models/Webhook';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
+import { Modal } from '../../components/component_kit/cw_modal';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
-import { Modal } from '../../components/component_kit/cw_modal';
 
 export const WebhooksForm = () => {
   const [webhookUrl, setWebhookUrl] = useState('');
@@ -28,7 +26,7 @@ export const WebhooksForm = () => {
     []
   );
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetch = async () => {
       try {
         const response = await axios.get(`${app.serverUrl()}/getWebhooks`, {

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposal_link_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposal_link_redirect.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
-import { PageLoading } from './loading';
-import { useCommonNavigate } from 'navigation/helpers';
 import { getProposal } from 'helpers/snapshot_utils';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import { useCommonNavigate } from 'navigation/helpers';
+import React from 'react';
+import { PageLoading } from './loading';
 
 type SnapshotProposalLinkRedirectProps = {
   identifier: string;
@@ -13,7 +14,7 @@ export default function SnapshotProposalLinkRedirect({
 }: SnapshotProposalLinkRedirectProps) {
   const navigate = useCommonNavigate();
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetchSnapshotData = async () => {
       try {
         // 1. make query to snapshot to get the specific proposal data

--- a/packages/commonwealth/client/scripts/views/pages/stats.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/stats.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import 'pages/stats.scss';
-
+import React, { useState } from 'react';
 import app from 'state';
 import ErrorPage from 'views/pages/error';
 import { PageLoading } from 'views/pages/loading';
@@ -93,7 +92,7 @@ const StatsPage = () => {
   const [totalData, setTotalData] = useState<TotalDataType>();
   const [error, setError] = useState('');
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const fetch = async () => {
       try {
         const response = await axios.get(`${app.serverUrl()}/communityStats`, {

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -1,20 +1,23 @@
-import React, { useState, useEffect, useRef } from 'react';
-
-import app from 'state';
-import Sublayout from 'views/Sublayout';
 import { ChainBase } from 'common-common/src/types';
+import Cosmos from 'controllers/chain/cosmos/adapter';
 import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
 import { SubstrateTreasuryTip } from 'controllers/chain/substrate/treasury_tip';
+import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import {
   chainToProposalSlug,
   getProposalUrlPath,
   idToProposal,
 } from 'identifiers';
-import type { AnyProposal } from '../../../models/types';
-
+import { useCommonNavigate } from 'navigation/helpers';
+import React, { useState } from 'react';
+import app from 'state';
 import { slugify } from 'utils';
 import { PageNotFound } from 'views/pages/404';
 import { PageLoading } from 'views/pages/loading';
+import Sublayout from 'views/Sublayout';
+import type { AnyProposal } from '../../../models/types';
+import { CollapsibleProposalBody } from '../../components/collapsible_body_text';
 import { CWContentPage } from '../../components/component_kit/cw_content_page';
 import { VotingActions } from '../../components/proposals/voting_actions';
 import { VotingResults } from '../../components/proposals/voting_results';
@@ -25,11 +28,6 @@ import type { LinkedSubstrateProposal } from './linked_proposals_embed';
 import { LinkedProposalsEmbed } from './linked_proposals_embed';
 import type { SubheaderProposalType } from './proposal_components';
 import { ProposalSubheader } from './proposal_components';
-import { CollapsibleProposalBody } from '../../components/collapsible_body_text';
-import useForceRerender from 'hooks/useForceRerender';
-import { useCommonNavigate } from 'navigation/helpers';
-import Cosmos from 'controllers/chain/cosmos/adapter';
-import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
 
 type ViewProposalPageAttrs = {
   identifier: string;
@@ -50,7 +48,7 @@ const ViewProposalPage = ({
   const [isAdapterLoaded, setIsAdapterLoaded] = useState(!!app.chain?.loaded);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     const afterAdapterLoaded = async () => {
       if (!type) {
         setType(chainToProposalSlug(app.chain.meta));

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_components.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState } from 'react';
-
-import app from 'state';
-
+import axios from 'axios';
 import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
 import CompoundProposal from 'controllers/chain/ethereum/compound/proposal';
-
+import { extractDomain } from 'helpers';
+import useForceRerender from 'hooks/useForceRerender';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import { LinkSource } from 'models/Thread';
 import 'pages/view_proposal/proposal_components.scss';
+import React, { useEffect, useState } from 'react';
+import app from 'state';
+import ExternalLink from 'views/components/ExternalLink';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWText } from '../../components/component_kit/cw_text';
 import {
@@ -14,11 +17,6 @@ import {
 } from '../../components/ProposalCard/helpers';
 import { cancelProposal } from '../../components/proposals/helpers';
 import { ThreadLink } from './proposal_header_links';
-import useForceRerender from 'hooks/useForceRerender';
-import ExternalLink from 'views/components/ExternalLink';
-import { extractDomain } from 'helpers';
-import axios from 'axios';
-import { LinkSource } from 'models/Thread';
 
 type BaseCancelButtonProps = {
   onModalClose?: () => void;
@@ -83,7 +81,7 @@ export const ProposalSubheader = (props: ProposalSubheaderProps) => {
     };
   }, [forceRerender]);
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     if (!linkedThreads) {
       axios
         .post(`${app.serverUrl()}/linking/getLinks`, {

--- a/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/index.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-
 import {
+  getPower,
+  getResults,
   Power,
   SnapshotProposal,
   SnapshotProposalVote,
@@ -8,8 +8,9 @@ import {
   VoteResults,
   VoteResultsData,
 } from 'helpers/snapshot_utils';
-import { getPower, getResults } from 'helpers/snapshot_utils';
-
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import { LinkSource } from 'models/Thread';
+import React, { useCallback, useMemo, useState } from 'react';
 import app from 'state';
 import Sublayout from 'views/Sublayout';
 import AddressInfo from '../../../models/AddressInfo';
@@ -19,13 +20,12 @@ import {
   ActiveProposalPill,
   ClosedProposalPill,
 } from '../../components/proposal_pills';
+import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
 import { User } from '../../components/user/user';
 import { PageLoading } from '../loading';
 import { SnapshotInformationCard } from './snapshot_information_card';
 import { SnapshotPollCardContainer } from './snapshot_poll_card_container';
 import { SnapshotVotesTable } from './snapshot_votes_table';
-import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
-import { LinkSource } from 'models/Thread';
 
 type ViewProposalPageProps = {
   identifier: string;
@@ -111,7 +111,7 @@ export const ViewProposalPage = ({
     [activeUserAddress]
   );
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     loadVotes(snapshotId, identifier).catch(console.error);
   }, [identifier, loadVotes, snapshotId]);
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -2,27 +2,34 @@ import { ProposalType } from 'common-common/src/types';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import TopicGateCheck from 'controllers/chain/ethereum/gatedTopic';
 import { modelFromServer as modelReactionCountFromServer } from 'controllers/server/reactionCounts';
+import { extractDomain, isDefaultStage } from 'helpers';
+import { filterLinks } from 'helpers/threads';
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
+import useBrowserWindow from 'hooks/useBrowserWindow';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
+import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { getProposalUrlPath } from 'identifiers';
 import $ from 'jquery';
-import NewProfilesController from '../../../controllers/server/newProfiles';
-import { ThreadStage } from '../../../models/types';
-
-import { Link, LinkSource, Thread } from '../../../models/Thread';
 import type { IThreadCollaborator } from 'models/Thread';
 import { useCommonNavigate } from 'navigation/helpers';
-
 import 'pages/view_thread/index.scss';
 import React, { useCallback, useEffect, useState } from 'react';
-
 import app from 'state';
 import { ContentType } from 'types';
 import { slugify } from 'utils';
+import ExternalLink from 'views/components/ExternalLink';
+import { openConfirmation } from 'views/modals/confirmation_modal';
 import { PageNotFound } from 'views/pages/404';
 import { PageLoading } from 'views/pages/loading';
 import Sublayout from 'views/Sublayout';
+import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
+import { ThreadActionType } from '../../../../../shared/types';
+import NewProfilesController from '../../../controllers/server/newProfiles';
 import Comment from '../../../models/Comment';
 import Poll from '../../../models/Poll';
+import { Link, LinkSource, Thread } from '../../../models/Thread';
 import Topic from '../../../models/Topic';
+import { ThreadStage } from '../../../models/types';
 import { CommentsTree } from '../../components/Comments/CommentsTree';
 import { CreateComment } from '../../components/Comments/CreateComment';
 import { clearEditingLocalStorage } from '../../components/Comments/helpers';
@@ -30,9 +37,15 @@ import type { SidebarComponents } from '../../components/component_kit/cw_conten
 import { CWContentPage } from '../../components/component_kit/cw_content_page';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { Modal } from '../../components/component_kit/cw_modal';
+import { PopoverMenuItem } from '../../components/component_kit/cw_popover/cw_popover_menu';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
+import {
+  breakpointFnValidator,
+  isWindowMediumSmallInclusive,
+} from '../../components/component_kit/helpers';
 import { ThreadReactionPreviewButtonSmall } from '../../components/ReactionButton/ThreadPreviewReactionButtonSmall';
+import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
 import { ChangeThreadTopicModal } from '../../modals/change_thread_topic_modal';
 import { EditCollaboratorsModal } from '../../modals/edit_collaborators_modal';
 import {
@@ -43,24 +56,9 @@ import {
 import { EditBody } from './edit_body';
 import { LinkedProposalsCard } from './linked_proposals_card';
 import { LinkedThreadsCard } from './linked_threads_card';
+import { LockMessage } from './lock_message';
 import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
 import { ThreadAuthor, ThreadStageComponent } from './thread_components';
-import useUserLoggedIn from 'hooks/useUserLoggedIn';
-import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
-import { PopoverMenuItem } from '../../components/component_kit/cw_popover/cw_popover_menu';
-import { openConfirmation } from 'views/modals/confirmation_modal';
-import { ThreadActionType } from '../../../../../shared/types';
-import { filterLinks } from 'helpers/threads';
-import { LockMessage } from './lock_message';
-import { extractDomain, isDefaultStage } from 'helpers';
-import ExternalLink from 'views/components/ExternalLink';
-import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
-import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
-import useBrowserWindow from 'hooks/useBrowserWindow';
-import {
-  breakpointFnValidator,
-  isWindowMediumSmallInclusive,
-} from '../../components/component_kit/helpers';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -168,140 +166,124 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     }
   }, [recentlyEdited]);
 
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      app.threads
-        .fetchThreadsFromId([+threadId])
-        .then((res) => {
-          const t = res[0];
-          if (t) {
-            const reactions = app.reactions.getByPost(t);
-            t.associatedReactions = reactions
-              .filter((r) => r.reaction === 'like')
-              .map((r) => {
-                return {
-                  id: r.id,
-                  type: 'like',
-                  address: r.author,
-                };
-              });
+  useNecessaryEffect(() => {
+    app.threads
+      .fetchThreadsFromId([+threadId])
+      .then((res) => {
+        const t = res[0];
+        if (t) {
+          const reactions = app.reactions.getByPost(t);
+          t.associatedReactions = reactions
+            .filter((r) => r.reaction === 'like')
+            .map((r) => {
+              return {
+                id: r.id,
+                type: 'like',
+                address: r.author,
+              };
+            });
 
-            setThread(t);
+          setThread(t);
+        }
+      })
+      .catch(() => {
+        notifyError('Thread not found');
+        setThreadFetchFailed(true);
+      });
+  }, [threadId]);
+
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load proposal
+    if (!prefetch[threadId]['threadReactionsStarted']) {
+      app.threads.fetchReactionsCount([thread]).then(() => {
+        setThread(thread);
+      });
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadId]: {
+          ...prevState[threadId],
+          threadReactionsStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, threadId]);
+
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    if (thread && identifier !== `${threadId}-${slugify(thread?.title)}`) {
+      const url = getProposalUrlPath(
+        thread.slug,
+        `${threadId}-${slugify(thread?.title)}${window.location.search}`,
+        true
+      );
+      navigate(url, { replace: true });
+    }
+  }, [identifier, navigate, thread, thread?.slug, thread?.title, threadId]);
+
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    if (!prefetch[threadId]['commentsStarted']) {
+      app.comments
+        .refresh(thread, app.activeChainId())
+        .then(async () => {
+          // fetch comments
+          const _comments = app.comments
+            .getByThread(thread)
+            .filter((c) => c.parentComment === null);
+          setComments(_comments);
+
+          // fetch reactions
+          const { result: reactionCounts } = await $.ajax({
+            type: 'POST',
+            url: `${app.serverUrl()}/reactionsCounts`,
+            headers: {
+              'content-type': 'application/json',
+            },
+            data: JSON.stringify({
+              proposal_ids: [threadId],
+              comment_ids: app.comments
+                .getByThread(thread)
+                .map((comment) => comment.id),
+              active_address: app.user.activeAccount?.address,
+            }),
+          });
+
+          // app.reactionCounts.deinit()
+          for (const rc of reactionCounts) {
+            const id = app.reactionCounts.store.getIdentifier({
+              threadId: rc.thread_id,
+              proposalId: rc.proposal_id,
+              commentId: rc.comment_id,
+            });
+
+            app.reactionCounts.store.add(
+              modelReactionCountFromServer({ ...rc, id })
+            );
           }
         })
         .catch(() => {
-          notifyError('Thread not found');
-          setThreadFetchFailed(true);
+          notifyError('Failed to load comments');
+          setComments([]);
         });
-    });
 
-    return () => clearTimeout(timerId);
-  }, [threadId]);
-
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
-
-      // load proposal
-      if (!prefetch[threadId]['threadReactionsStarted']) {
-        app.threads.fetchReactionsCount([thread]).then(() => {
-          setThread(thread);
-        });
-        setPrefetch((prevState) => ({
-          ...prevState,
-          [threadId]: {
-            ...prevState[threadId],
-            threadReactionsStarted: true,
-          },
-        }));
-      }
-    });
-
-    return () => clearTimeout(timerId);
-  }, [prefetch, thread, threadId]);
-
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
-
-      if (thread && identifier !== `${threadId}-${slugify(thread?.title)}`) {
-        const url = getProposalUrlPath(
-          thread.slug,
-          `${threadId}-${slugify(thread?.title)}${window.location.search}`,
-          true
-        );
-        navigate(url, { replace: true });
-      }
-    });
-
-    return () => clearTimeout(timerId);
-  }, [identifier, navigate, thread, thread?.slug, thread?.title, threadId]);
-
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
-
-      if (!prefetch[threadId]['commentsStarted']) {
-        app.comments
-          .refresh(thread, app.activeChainId())
-          .then(async () => {
-            // fetch comments
-            const _comments = app.comments
-              .getByThread(thread)
-              .filter((c) => c.parentComment === null);
-            setComments(_comments);
-
-            // fetch reactions
-            const { result: reactionCounts } = await $.ajax({
-              type: 'POST',
-              url: `${app.serverUrl()}/reactionsCounts`,
-              headers: {
-                'content-type': 'application/json',
-              },
-              data: JSON.stringify({
-                proposal_ids: [threadId],
-                comment_ids: app.comments
-                  .getByThread(thread)
-                  .map((comment) => comment.id),
-                active_address: app.user.activeAccount?.address,
-              }),
-            });
-
-            // app.reactionCounts.deinit()
-            for (const rc of reactionCounts) {
-              const id = app.reactionCounts.store.getIdentifier({
-                threadId: rc.thread_id,
-                proposalId: rc.proposal_id,
-                commentId: rc.comment_id,
-              });
-
-              app.reactionCounts.store.add(
-                modelReactionCountFromServer({ ...rc, id })
-              );
-            }
-          })
-          .catch(() => {
-            notifyError('Failed to load comments');
-            setComments([]);
-          });
-
-        setPrefetch((prevState) => ({
-          ...prevState,
-          [threadId]: {
-            ...prevState[threadId],
-            commentsStarted: true,
-          },
-        }));
-      }
-    });
-
-    return () => clearTimeout(timerId);
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadId]: {
+          ...prevState[threadId],
+          commentsStarted: true,
+        },
+      }));
+    }
   }, [prefetch, thread, threadId]);
 
   useEffect(() => {
@@ -318,118 +300,106 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     }
   }, [initializedPolls, thread?.id]);
 
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
 
-      // load polls
-      if (!prefetch[threadId]['pollsStarted']) {
-        app.polls
-          .fetchPolls(app.activeChainId(), thread?.id)
-          .then(() => {
-            setPolls(app.polls.getByThreadId(thread.id));
-          })
-          .catch(() => {
-            notifyError('Failed to load polls');
-            setPolls([]);
-          });
-
-        setPrefetch((prevState) => ({
-          ...prevState,
-          [threadId]: {
-            ...prevState[threadId],
-            pollsStarted: true,
-          },
-        }));
-      }
-    });
-
-    return () => clearTimeout(timerId);
-  }, [prefetch, thread, thread?.id, threadId]);
-
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
-
-      // load view count
-      if (!prefetch[threadId]['viewCountStarted']) {
-        $.post(`${app.serverUrl()}/viewCount`, {
-          chain: app.activeChainId(),
-          object_id: thread.id,
+    // load polls
+    if (!prefetch[threadId]['pollsStarted']) {
+      app.polls
+        .fetchPolls(app.activeChainId(), thread?.id)
+        .then(() => {
+          setPolls(app.polls.getByThreadId(thread.id));
         })
-          .then((response) => {
-            if (response.status !== 'Success') {
-              setViewCount(0);
-              throw new Error(`got unsuccessful status: ${response.status}`);
-            } else {
-              setViewCount(response.result.view_count);
-            }
-          })
-          .catch(() => {
-            setViewCount(0);
-            throw new Error('could not load view count');
-          });
+        .catch(() => {
+          notifyError('Failed to load polls');
+          setPolls([]);
+        });
 
-        setPrefetch((prevState) => ({
-          ...prevState,
-          [threadId]: {
-            ...prevState[threadId],
-            viewCountStarted: true,
-          },
-        }));
-      }
-    });
-
-    return () => clearTimeout(timerId);
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadId]: {
+          ...prevState[threadId],
+          pollsStarted: true,
+        },
+      }));
+    }
   }, [prefetch, thread, thread?.id, threadId]);
 
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!thread) {
-        return;
-      }
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
 
-      // load profiles
-      if (!prefetch[threadId]['profilesStarted']) {
-        NewProfilesController.Instance.getProfile(
-          thread.authorChain,
-          thread.author
-        );
-
-        comments.forEach((comment) => {
-          NewProfilesController.Instance.getProfile(
-            comment.authorChain,
-            comment.author
-          );
-        });
-
-        NewProfilesController.Instance.isFetched.on('redraw', () => {
-          if (!prefetch[threadId]?.['profilesFinished']) {
-            setPrefetch((prevState) => ({
-              ...prevState,
-              [threadId]: {
-                ...prevState[threadId],
-                profilesFinished: true,
-              },
-            }));
+    // load view count
+    if (!prefetch[threadId]['viewCountStarted']) {
+      $.post(`${app.serverUrl()}/viewCount`, {
+        chain: app.activeChainId(),
+        object_id: thread.id,
+      })
+        .then((response) => {
+          if (response.status !== 'Success') {
+            setViewCount(0);
+            throw new Error(`got unsuccessful status: ${response.status}`);
+          } else {
+            setViewCount(response.result.view_count);
           }
+        })
+        .catch(() => {
+          setViewCount(0);
+          throw new Error('could not load view count');
         });
 
-        setPrefetch((prevState) => ({
-          ...prevState,
-          [threadId]: {
-            ...prevState[threadId],
-            profilesStarted: true,
-          },
-        }));
-      }
-    });
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadId]: {
+          ...prevState[threadId],
+          viewCountStarted: true,
+        },
+      }));
+    }
+  }, [prefetch, thread, thread?.id, threadId]);
 
-    return () => clearTimeout(timerId);
+  useNecessaryEffect(() => {
+    if (!thread) {
+      return;
+    }
+
+    // load profiles
+    if (!prefetch[threadId]['profilesStarted']) {
+      NewProfilesController.Instance.getProfile(
+        thread.authorChain,
+        thread.author
+      );
+
+      comments.forEach((comment) => {
+        NewProfilesController.Instance.getProfile(
+          comment.authorChain,
+          comment.author
+        );
+      });
+
+      NewProfilesController.Instance.isFetched.on('redraw', () => {
+        if (!prefetch[threadId]?.['profilesFinished']) {
+          setPrefetch((prevState) => ({
+            ...prevState,
+            [threadId]: {
+              ...prevState[threadId],
+              profilesFinished: true,
+            },
+          }));
+        }
+      });
+
+      setPrefetch((prevState) => ({
+        ...prevState,
+        [threadId]: {
+          ...prevState[threadId],
+          profilesStarted: true,
+        },
+      }));
+    }
   }, [
     comments,
     prefetch,

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
@@ -1,20 +1,18 @@
-import React, { useEffect, useMemo, useState } from 'react';
-
+import { filterLinks } from 'helpers/threads';
+import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import { getProposalUrlPath } from 'identifiers';
-import type Thread from '../../../models/Thread';
-
 import 'pages/view_thread/linked_threads_card.scss';
-
+import React, { useMemo, useState } from 'react';
 import app from 'state';
+import { CWSpinner } from 'views/components/component_kit/cw_spinner';
 import { slugify } from '../../../../../shared/utils';
+import type Thread from '../../../models/Thread';
+import { LinkSource } from '../../../models/Thread';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWContentPageCard } from '../../components/component_kit/cw_content_page';
+import { Modal } from '../../components/component_kit/cw_modal';
 import { CWText } from '../../components/component_kit/cw_text';
 import { LinkedThreadModal } from '../../modals/linked_thread_modal';
-import { Modal } from '../../components/component_kit/cw_modal';
-import { CWSpinner } from 'views/components/component_kit/cw_spinner';
-import { LinkSource } from '../../../models/Thread';
-import { filterLinks } from 'helpers/threads';
 
 type LinkedThreadsCardProps = {
   thread: Thread;
@@ -39,7 +37,7 @@ export const LinkedThreadsCard = ({
     [thread.links]
   );
 
-  useEffect(() => {
+  useNecessaryEffect(() => {
     if (linkedThreadIds.length > 0) {
       app.threads
         .fetchThreadsFromId(linkedThreadIds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4176

## Description of Changes
We were doing api calls inside useEffect that had multiple dependencies, any of those changing dependencies caused the useEffect to run which triggered an unnecessary api call. We made a custom hook `useNecessaryEffect` that utilizes a set/clear timeout pattern to only trigger useEffect callback when needed. The pr changes all instance of useEffect that has an api call with useNecessaryEffect

## Test Plan
Api calls inside the update useEffect (now useNecessaryEffect) should work correctly

## Deployment Plan
N/A

## Other Considerations
N/A