### PR TITLE
Fixed roles shim diff

### DIFF
--- a/packages/commonwealth/server/util/roles.ts
+++ b/packages/commonwealth/server/util/roles.ts
@@ -198,7 +198,7 @@ export async function findOneRole(
       permissions
     );
   let communityRole: CommunityRoleAttributes;
-  if (communityRoles && communityRoles.length > 0) {
+  if (communityRoles) {
     // find the highest role
     communityRole = await getHighestRoleFromCommunityRoles(communityRoles);
   } else {


### PR DESCRIPTION
Somehow I added a check that should not have been in the shim. This check changed the output from the shim when no role is found.

## Link to Issue
Closes: #4225

## Description of Changes
- Minor conditional fix to the roles shim

## Test Plan
- Tried creating then deleting a poll, asserted worked.