### PR TITLE
Fixed communityStats Page

### DIFF
--- a/packages/commonwealth/server/routes/communityStats.ts
+++ b/packages/commonwealth/server/routes/communityStats.ts
@@ -47,7 +47,7 @@ ORDER BY seq.date DESC;`,
       }
     );
   };
-  const roles = await newObjectsQuery('"Roles"', 'chain_id');
+  const roles = await newObjectsQuery('"Addresses"', 'chain');
   const threads = await newObjectsQuery('"Threads"', 'chain');
   const comments = await newObjectsQuery('"Comments"', 'chain');
 
@@ -61,7 +61,7 @@ ORDER BY seq.date DESC;`,
       }
     );
   };
-  const totalRoles = await totalObjectsQuery('"Roles"', 'chain_id');
+  const totalRoles = await totalObjectsQuery('"Addresses"', 'chain');
   const totalThreads = await totalObjectsQuery('"Threads"', 'chain');
   const totalComments = await totalObjectsQuery('"Comments"', 'chain');
 


### PR DESCRIPTION
Community stats page was referencing the Roles table which we had deleted.

## Link to Issue
Closes: #TODO

## Description of Changes
- Changes communityStats to get total number of Addresses instead of roles

## Test Plan
- Changed role to admin, checked dydx/communityStats to ensure it works correctly.