### PR TITLE
Fixed reaction count on comments

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/reactionCounts.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/reactionCounts.ts
@@ -1,5 +1,6 @@
 /* eslint-disable dot-notation */
 import { notifyError } from 'controllers/app/notifications';
+import { EventEmitter } from 'events';
 import proposalIdToEntity from 'helpers/proposalIdToEntity';
 /* eslint-disable no-restricted-syntax */
 import $ from 'jquery';
@@ -30,6 +31,7 @@ export const modelFromServer = (reactionCount) => {
 
 // TODO: Graham 4/24/22: File + class needs to be named ReactionCounts (plural) following convention
 class ReactionCountController {
+  public isFetched = new EventEmitter();
   private _store: ReactionCountsStore = new ReactionCountsStore();
   public get store() {
     return this._store;

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -6,6 +6,8 @@ import TopicGateCheck from 'controllers/chain/ethereum/gatedTopic';
 import app from 'state';
 import type ChainInfo from '../../../models/ChainInfo';
 import type Comment from '../../../models/Comment';
+import reactionCount from '../../../models/ReactionCount';
+import ReactionCount from '../../../models/ReactionCount';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import { CWTooltip } from '../component_kit/cw_popover/cw_tooltip';
 import { CWText } from '../component_kit/cw_text';
@@ -31,8 +33,20 @@ export const CommentReactionButton = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [reactors, setReactors] = useState<Array<any>>([]);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [reactionCounts, setReactionCounts] = useState<ReactionCount<any>>();
 
-  const reactionCounts = app.reactionCounts.store.getByPost(comment);
+  useEffect(() => {
+    const redrawFunction = () => {
+      setReactionCounts(app.reactionCounts.store.getByPost(comment));
+    };
+
+    app.reactionCounts.isFetched.on('redraw', redrawFunction);
+
+    return () => {
+      app.reactionCounts.isFetched.off('redraw', redrawFunction);
+    };
+  });
+
   const { likes = 0, hasReacted } = reactionCounts || {};
 
   // token balance check if needed
@@ -66,6 +80,7 @@ export const CommentReactionButton = ({
           reactors.filter(({ Address }) => Address.address !== userAddress)
         );
 
+        setReactionCounts(app.reactionCounts.store.getByPost(comment));
         setIsLoading(false);
       });
   };
@@ -83,6 +98,7 @@ export const CommentReactionButton = ({
           },
         ]);
 
+        setReactionCounts(app.reactionCounts.store.getByPost(comment));
         setIsLoading(false);
       });
   };

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -6,7 +6,6 @@ import TopicGateCheck from 'controllers/chain/ethereum/gatedTopic';
 import app from 'state';
 import type ChainInfo from '../../../models/ChainInfo';
 import type Comment from '../../../models/Comment';
-import reactionCount from '../../../models/ReactionCount';
 import ReactionCount from '../../../models/ReactionCount';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import { CWTooltip } from '../component_kit/cw_popover/cw_tooltip';
@@ -36,7 +35,11 @@ export const CommentReactionButton = ({
   const [reactionCounts, setReactionCounts] = useState<ReactionCount<any>>();
 
   useEffect(() => {
-    const redrawFunction = () => {
+    const redrawFunction = (comment_id) => {
+      if (comment_id !== comment.id) {
+        return;
+      }
+
       setReactionCounts(app.reactionCounts.store.getByPost(comment));
     };
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -279,6 +279,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             app.reactionCounts.store.add(
               modelReactionCountFromServer({ ...rc, id })
             );
+
+            app.reactionCounts.isFetched.emit('redraw');
           }
         })
         .catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -280,7 +280,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
               modelReactionCountFromServer({ ...rc, id })
             );
 
-            app.reactionCounts.isFetched.emit('redraw');
+            app.reactionCounts.isFetched.emit('redraw', rc.comment_id);
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Link to Issue
Closes: #4186 

## Description of Changes
- change CommentReactionButton so it updates on getCommentsReaction via EventEmitter.

## Test Plan
- Created a thread with multiple comments, like/disliked them, refreshed page.

## Other Considerations
I guess this would be a good candidate for using Zustand. I know Marcin is out, so I am not sure if we want to go this route (since it might be better if he could review it to make sure we are all on board with the structure). Anyways if we want to still go ahead and use Zustand, let me know in the comments, and I will convert this PR.
