### PR TITLE
Fixed initial bundle size regression

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -43,7 +43,6 @@ import {
   MixpanelLoginEvent,
   MixpanelLoginPayload,
 } from '../../../shared/analytics/types';
-import { MockMetaMaskProvider } from 'helpers/mockMetaMaskUtil';
 
 type IuseWalletProps = {
   initialBody?: LoginActiveStep;
@@ -65,9 +64,8 @@ const useWallets = (walletProps: IuseWalletProps) => {
   const [email, setEmail] = useState<string>();
   const [wallets, setWallets] = useState<Array<IWebWallet<any>>>();
   const [selectedWallet, setSelectedWallet] = useState<IWebWallet<any>>();
-  const [selectedLinkingWallet, setSelectedLinkingWallet] = useState<
-    IWebWallet<any>
-  >();
+  const [selectedLinkingWallet, setSelectedLinkingWallet] =
+    useState<IWebWallet<any>>();
   const [cachedWalletSignature, setCachedWalletSignature] = useState<string>();
   const [cachedTimestamp, setCachedTimestamp] = useState<number>();
   const [cachedChainId, setCachedChainId] = useState<string | number>();
@@ -108,10 +106,12 @@ const useWallets = (walletProps: IuseWalletProps) => {
 
   useEffect(() => {
     if (process.env.ETH_RPC === 'e2e-test') {
-      window['ethereum'] = new MockMetaMaskProvider(
-        'https://eth-mainnet.g.alchemy.com/v2/pZsX6R3wGdnwhUJHlVmKg4QqsiS32Qm4',
-        '0x09187906d2ff8848c20050df632152b5b27d816ec62acd41d4498feb522ac5c3'
-      );
+      import('../helpers/mockMetaMaskUtil').then((f) => {
+        window['ethereum'] = new f.MockMetaMaskProvider(
+          'https://eth-mainnet.g.alchemy.com/v2/pZsX6R3wGdnwhUJHlVmKg4QqsiS32Qm4',
+          '0x09187906d2ff8848c20050df632152b5b27d816ec62acd41d4498feb522ac5c3'
+        );
+      });
     }
 
     // Determine if in a community
@@ -281,11 +281,8 @@ const useWallets = (walletProps: IuseWalletProps) => {
     // Handle Logged in and joining community of different chain base
     if (isInCommunityPage && app.isLoggedIn()) {
       const timestamp = +new Date();
-      const {
-        signature,
-        chainId,
-        sessionPayload,
-      } = await signSessionWithAccount(walletToUse, account, timestamp);
+      const { signature, chainId, sessionPayload } =
+        await signSessionWithAccount(walletToUse, account, timestamp);
       await account.validate(signature, timestamp, chainId);
       app.sessions.authSession(
         app.chain.base,
@@ -321,11 +318,8 @@ const useWallets = (walletProps: IuseWalletProps) => {
     if (!newlyCreated && !linking) {
       try {
         const timestamp = +new Date();
-        const {
-          signature,
-          sessionPayload,
-          chainId,
-        } = await signSessionWithAccount(walletToUse, account, timestamp);
+        const { signature, sessionPayload, chainId } =
+          await signSessionWithAccount(walletToUse, account, timestamp);
         await account.validate(signature, timestamp, chainId);
         // Can't call authSession now, since chain.base is unknown, so we wait till action
         await onLogInWithAccount(account, true);
@@ -396,14 +390,12 @@ const useWallets = (walletProps: IuseWalletProps) => {
   const onPerformLinking = async () => {
     try {
       const secondaryTimestamp = +new Date();
-      const {
-        signature: secondarySignature,
-        chainId: secondaryChainId,
-      } = await signSessionWithAccount(
-        selectedLinkingWallet,
-        secondaryLinkAccount,
-        secondaryTimestamp
-      );
+      const { signature: secondarySignature, chainId: secondaryChainId } =
+        await signSessionWithAccount(
+          selectedLinkingWallet,
+          secondaryLinkAccount,
+          secondaryTimestamp
+        );
       await secondaryLinkAccount.validate(
         secondarySignature,
         secondaryTimestamp,
@@ -531,16 +523,14 @@ const useWallets = (walletProps: IuseWalletProps) => {
       const chainIdentifier = app.chain?.id || wallet.defaultNetwork;
       const validationBlockInfo =
         wallet.getRecentBlock && (await wallet.getRecentBlock(chainIdentifier));
-      const {
-        account: signingAccount,
-        newlyCreated,
-      } = await createUserWithAddress(
-        selectedAddress,
-        wallet.name,
-        chainIdentifier,
-        sessionPublicAddress,
-        validationBlockInfo
-      );
+      const { account: signingAccount, newlyCreated } =
+        await createUserWithAddress(
+          selectedAddress,
+          wallet.name,
+          chainIdentifier,
+          sessionPublicAddress,
+          validationBlockInfo
+        );
 
       if (isMobile) {
         setSignerAccount(signingAccount);

--- a/packages/commonwealth/test/e2e/landing.spec.ts
+++ b/packages/commonwealth/test/e2e/landing.spec.ts
@@ -97,9 +97,9 @@ test.describe('Commonwealth Homepage - Links', () => {
 
   test('Test Login', async ({ page }) => {
     await page.goto('http://localhost:8080/');
-    await page.getByText('Login').click();
-    await page.waitForSelector('.LoginDesktop');
-    await page.getByText('Metamask').click();
+
+    await login(page);
+
     await page.waitForSelector('.new-or-returning');
     await page.getByText('New Account').click();
     await page.getByText('Finish').click();
@@ -108,3 +108,19 @@ test.describe('Commonwealth Homepage - Links', () => {
     expect(element).toBeTruthy();
   });
 });
+
+// Since we lazily import web3 in order to inject metamask into the window, it might not be available right away.
+// This allows us to wait until it becomes available by re-clicking the login button until it shows up.
+export async function login(page) {
+  await page.getByText('Login').click();
+  await page.waitForSelector('.LoginDesktop');
+
+  let metaMaskIcon = await page.$$("text='Metamask'");
+  do {
+    await page.mouse.click(0, 0);
+    await page.getByText('Login').click();
+    metaMaskIcon = await page.$$("text='Metamask'");
+  } while (metaMaskIcon.length === 0);
+
+  await page.getByText('Metamask').click();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4277

## Description of Changes
- Added lazy import to web3 usage for e2e tests
- Fixed our existing e2e login test (Lazy import adds race condition to login, so we need to await until the bundle is loaded).
- Adds a test in order to prevent us from accidentally including more bundles in our initial bundles.

## Test Plan
- Made sure no login regressions locally
- Ran on CI

For test guard rail:
- Ran with the fix reverted, asserted the test failed.
- Ran with the fix included, assert that the test passed.