### PR TITLE
Fix Sort/Filter on Thread Listing Page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -140,6 +140,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   // setup initial threads
   useEffect(() => {
     const timerId = setTimeout(() => {
+      setInitializing(true);
       // always reset pagination on page change
       app.threads.resetPagination();
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -223,7 +223,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     });
 
     return () => clearTimeout(timerId);
-  }, [stageName, topicName]);
+  }, [stageName, topicName, featuredFilter, dateRange]);
 
   const loadMore = useCallback(async () => {
     const response = await app.threads.loadNextPage({


### PR DESCRIPTION
## NB: This PR merges 2 workstreams and title has been updated accordingly: 
- Fix Thread Sort
- Fix Topic Switcher Race Condition

**Note also that means adding additional Test Plan below and much more complication in general, which is exactly the reason we don't, as a rule, do this. (However in this case, it was a deliberate decision, and one time exception.)** 

##  Issues Resolved
Closes: #4279 https://github.com/hicommonwealth/commonwealth/issues/4254
Closes #4254 https://github.com/hicommonwealth/commonwealth/issues/4254

## Description of Changes
- fixes thread refresh bug that causes threads not to load when filters are applied. 
- kills 2 birds with 1 stone

## Testing

### Test Plan: 4279
- on any community, go through the discussion page and apply each filter. Threads should update correctly, or be resorted if a sort is applied. 


### Test Plan: 4264
_Given that we have mergedf 4264 in here,_ **we also need to merge the test plans.** 
- Go to a community with minimum 1500-2000 threads for a topic (the more the better), select some topics and scroll to load a decent amount of topics > 500
- Slowly switch between multiple topics from the sidebar (make sure the topics have a lot of threads) - this will make sure we save those threads in local state
- Now rapidly switch b/w the same topics, this time the topics from the state will be used.
- Verify the thread list section on the page, it should not get stuck. If it takes time a placeholder bobber will be shown in place of thread cards.

## Deployment Plan
4279:  Mark to confirm on beta that the sort is applying correctly.
4264: Mark (Growth) to confirm on Beta it does the thing. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 