### PR TITLE
Update thread list on rapidly changing thread topics

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -188,7 +188,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
           }
 
           if (finalThreads.length >= 20) {
-            setThreads(sortPinned(sortByFeaturedFilter(foundThreadsForChain)));
+            setThreads(sortPinned(sortByFeaturedFilter(finalThreads)));
             setInitializing(false);
             return;
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4254

## Description of Changes
There was a silly mistake, a wrong variable used (that set threads from state) by me during some last work on the `DiscussionPage` that caused this bug originally, now quickly changing topic from the sidebar did fix it when the layout wasn't refactored since it was a complete remount but after the layout refactor this bug became more visible. 

Now used the correct variable to set threads

## Test Plan
Quickly change topics from the sidebar in any community, the thread list should not get stuck while updating.

## Deployment Plan
N/A

## Other Considerations
N/A