### PR TITLE
Sort comments by recency

### DIFF
--- a/packages/commonwealth/client/scripts/models/types.ts
+++ b/packages/commonwealth/client/scripts/models/types.ts
@@ -37,6 +37,11 @@ export enum ThreadFeaturedFilterTypes {
   MostComments = 'mostComments',
 }
 
+export enum CommentsFeaturedFilterTypes {
+  Newest = 'newest',
+  Oldest = 'oldest',
+}
+
 export enum ThreadTimelineFilterTypes {
   AllTime = 'allTime',
   ThisWeek = 'thisWeek',

--- a/packages/commonwealth/client/scripts/views/components/Select/Option.scss
+++ b/packages/commonwealth/client/scripts/views/components/Select/Option.scss
@@ -11,12 +11,19 @@
     flex-direction: row;
     text-overflow: ellipsis;
     height: auto !important;
-    padding: 10px 12px !important;
     border-radius: $border-radius-md  !important;
     font-size: 14px !important;
     min-height: 40px;
     line-height: 20px;
     letter-spacing: 1%;
+
+    &.size-default {
+        padding: 10px 12px !important;
+    }
+
+    &.size-compact {
+        padding: 6px 12px !important;
+    }
 
     &:hover,
     &:active {

--- a/packages/commonwealth/client/scripts/views/components/Select/Option.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Select/Option.tsx
@@ -5,6 +5,7 @@ import { getClasses } from '../component_kit/helpers';
 import './Option.scss';
 
 export type OptionProps = {
+  size?: 'default' | 'compact',
   iconLeft?: IconName;
   iconRight?: ReactNode;
   isSelected: boolean;
@@ -13,6 +14,7 @@ export type OptionProps = {
 };
 
 export const Option = ({
+  size = 'default',
   iconRight,
   isSelected,
   label,
@@ -23,7 +25,7 @@ export const Option = ({
     <div
       className={getClasses<{ isSelected: boolean }>(
         { isSelected },
-        'select-option'
+        `select-option ${`size-${size}`}`
       )}
       onClick={onClick}
     >

--- a/packages/commonwealth/client/scripts/views/components/Select/Select.scss
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.scss
@@ -6,7 +6,6 @@
     min-width: 144px;
     max-width: max(24ch, 264px);
     text-overflow: ellipsis;
-    padding: 10px 16px !important;
     border-radius: $border-radius-md  !important;
     cursor: pointer;
     height: auto !important;
@@ -17,6 +16,14 @@
     margin: 0;
     line-height: 20px;
     color: $neutral-800  !important;
+    
+    &.size-default {
+        padding: 10px 16px !important;
+    }
+
+    &.size-compact {
+        padding: 6px 16px !important;
+    }
 
     &:hover {
         border-color: $primary-600  !important;

--- a/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
@@ -9,6 +9,7 @@ import { Option } from './Option';
 import './Select.scss';
 
 export type SelectProps = {
+  size?: 'default' | 'compact',
   placeholder?: string;
   selected: string;
   onSelect?: (
@@ -19,8 +20,8 @@ export type SelectProps = {
   onOpen?: () => {};
   onClose?: () => {};
   options:
-    | string[]
-    | { id: string | number; value: any; label: string; iconLeft?: IconName }[];
+  | string[]
+  | { id: string | number; value: any; label: string; iconLeft?: IconName }[];
   canEditOption?: boolean;
   onOptionEdit?: (
     v: string | { id: string | number; value: any; label: string }
@@ -29,6 +30,7 @@ export type SelectProps = {
 };
 
 export const Select = ({
+  size = 'default',
   options,
   selected,
   onClose,
@@ -55,7 +57,7 @@ export const Select = ({
       {/* needs to be div instead of fragment so listener can work */}
       <div>
         <CWButton
-          className={`Select ${popoverProps.anchorEl ? 'active' : ''}`}
+          className={`Select ${popoverProps.anchorEl ? 'active' : ''} ${`size-${size}`}`}
           {...(selectedOption &&
             selectedOption.iconLeft && { iconLeft: selectedOption.iconLeft })}
           iconRight={popoverProps.anchorEl ? 'carotUp' : 'carotDown'}
@@ -80,6 +82,7 @@ export const Select = ({
                 return (
                   <Option
                     key={i}
+                    size={size}
                     label={label}
                     onClick={(e) => {
                       e.preventDefault();

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -680,6 +680,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           <div className='comments-filter-row'>
             <Select
               key={commentSortType}
+              size='compact'
               selected={commentSortType}
               onSelect={(item: any) => {
                 setCommentSortType(item.value)

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -27,9 +27,10 @@ import Comment from '../../../models/Comment';
 import Poll from '../../../models/Poll';
 import { Link, LinkSource, Thread } from '../../../models/Thread';
 import Topic from '../../../models/Topic';
-import { ThreadStage } from '../../../models/types';
+import { CommentsFeaturedFilterTypes, ThreadStage } from '../../../models/types';
 import Permissions from '../../../utils/Permissions';
 import { CreateComment } from '../../components/Comments/CreateComment';
+import { Select } from '../../components/Select';
 import { CWCheckbox } from '../../components/component_kit/cw_checkbox';
 import type { SidebarComponents } from '../../components/component_kit/cw_content_page';
 import { CWContentPage } from '../../components/component_kit/cw_content_page';
@@ -84,6 +85,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const [initializedPolls, setInitializedPolls] = useState(false);
   const [isCollapsedSize, setIsCollapsedSize] = useState(false);
   const [includeSpamThreads, setIncludeSpamThreads] = useState<boolean>(false);
+  const [commentSortType, setCommentSortType] = useState<
+    CommentsFeaturedFilterTypes
+  >(CommentsFeaturedFilterTypes.Newest);
 
   const threadId = identifier.split('-')[0];
   const threadDoesNotMatch =
@@ -507,7 +511,11 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const tabsShouldBePresent =
     showLinkedProposalOptions || showLinkedThreadOptions || polls?.length > 0;
 
-  console.log('comments => ', comments);
+  const sortedComments = [...comments].sort((a, b) =>
+    commentSortType === CommentsFeaturedFilterTypes.Oldest ?
+      moment(a.createdAt).diff(moment(b.createdAt)) :
+      moment(b.createdAt).diff(moment(a.createdAt))
+  )
 
   return (
     <CWContentPage
@@ -669,16 +677,39 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       )}
       comments={
         <>
-          {comments.length > 0 && (
-            <CWCheckbox
-              className="ml-auto"
-              checked={includeSpamThreads}
-              label="Include comments flagged as spam"
-              onChange={(e) => setIncludeSpamThreads(e.target.checked)}
+          <div className='comments-filter-row'>
+            <Select
+              key={commentSortType}
+              selected={commentSortType}
+              onSelect={(item: any) => {
+                setCommentSortType(item.value)
+              }}
+              options={[
+                {
+                  id: 1,
+                  value: CommentsFeaturedFilterTypes.Newest,
+                  label: 'Newest',
+                  iconLeft: 'sparkle',
+                },
+                {
+                  id: 2,
+                  value: CommentsFeaturedFilterTypes.Oldest,
+                  label: 'Oldest',
+                  iconLeft: 'clockCounterClockwise',
+                },
+              ]}
             />
-          )}
+            {comments.length > 0 && (
+              <CWCheckbox
+                className="ml-auto"
+                checked={includeSpamThreads}
+                label="Include comments flagged as spam"
+                onChange={(e) => setIncludeSpamThreads(e.target.checked)}
+              />
+            )}
+          </div>
           <CommentsTree
-            comments={comments}
+            comments={sortedComments}
             includeSpams={includeSpamThreads}
             thread={thread}
             setIsGloballyEditing={setIsGloballyEditing}
@@ -690,65 +721,65 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
         [
           ...(showLinkedProposalOptions || showLinkedThreadOptions
             ? [
-                {
-                  label: 'Links',
-                  item: (
-                    <div className="cards-column">
-                      {showLinkedProposalOptions && (
-                        <LinkedProposalsCard
-                          onChangeHandler={handleLinkedProposalChange}
-                          thread={thread}
-                          showAddProposalButton={isAuthor || isAdminOrMod}
-                        />
-                      )}
-                      {showLinkedThreadOptions && (
-                        <LinkedThreadsCard
-                          thread={thread}
-                          allowLinking={isAuthor || isAdminOrMod}
-                          onChangeHandler={handleLinkedThreadChange}
-                        />
-                      )}
-                    </div>
-                  ),
-                },
-              ]
+              {
+                label: 'Links',
+                item: (
+                  <div className="cards-column">
+                    {showLinkedProposalOptions && (
+                      <LinkedProposalsCard
+                        onChangeHandler={handleLinkedProposalChange}
+                        thread={thread}
+                        showAddProposalButton={isAuthor || isAdminOrMod}
+                      />
+                    )}
+                    {showLinkedThreadOptions && (
+                      <LinkedThreadsCard
+                        thread={thread}
+                        allowLinking={isAuthor || isAdminOrMod}
+                        onChangeHandler={handleLinkedThreadChange}
+                      />
+                    )}
+                  </div>
+                ),
+              },
+            ]
             : []),
           ...(polls?.length > 0 ||
-          (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
+            (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
             ? [
-                {
-                  label: 'Polls',
-                  item: (
-                    <div className="cards-column">
-                      {[
-                        ...new Map(
-                          polls?.map((poll) => [poll.id, poll])
-                        ).values(),
-                      ].map((poll: Poll) => {
-                        return (
-                          <ThreadPollCard
-                            poll={poll}
-                            key={poll.id}
-                            onVote={() => setInitializedPolls(false)}
-                            showDeleteButton={isAuthor || isAdmin}
-                            onDelete={() => {
-                              setInitializedPolls(false);
-                            }}
-                          />
-                        );
-                      })}
-                      {isAuthor &&
-                        (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
-                          <ThreadPollEditorCard
-                            thread={thread}
-                            threadAlreadyHasPolling={!polls?.length}
-                            onPollCreate={() => setInitializedPolls(false)}
-                          />
-                        )}
-                    </div>
-                  ),
-                },
-              ]
+              {
+                label: 'Polls',
+                item: (
+                  <div className="cards-column">
+                    {[
+                      ...new Map(
+                        polls?.map((poll) => [poll.id, poll])
+                      ).values(),
+                    ].map((poll: Poll) => {
+                      return (
+                        <ThreadPollCard
+                          poll={poll}
+                          key={poll.id}
+                          onVote={() => setInitializedPolls(false)}
+                          showDeleteButton={isAuthor || isAdmin}
+                          onDelete={() => {
+                            setInitializedPolls(false);
+                          }}
+                        />
+                      );
+                    })}
+                    {isAuthor &&
+                      (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
+                        <ThreadPollEditorCard
+                          thread={thread}
+                          threadAlreadyHasPolling={!polls?.length}
+                          onPollCreate={() => setInitializedPolls(false)}
+                        />
+                      )}
+                  </div>
+                ),
+              },
+            ]
             : []),
         ] as SidebarComponents
       }

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -702,7 +702,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             />
             {comments.length > 0 && (
               <CWCheckbox
-                className="ml-auto"
                 checked={includeSpamThreads}
                 label="Include comments flagged as spam"
                 onChange={(e) => setIncludeSpamThreads(e.target.checked)}

--- a/packages/commonwealth/client/styles/pages/view_thread/index.scss
+++ b/packages/commonwealth/client/styles/pages/view_thread/index.scss
@@ -51,8 +51,26 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
 
   .CommentsTree {
     margin-left: auto;
   }
+
+  .Checkbox {
+    margin-left: auto !important;
+  }
+}
+
+@include extraSmall {  
+  .comments-filter-row {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+
+    .Checkbox {
+      margin-left: 0 !important;
+    }
+  }
+
 }

--- a/packages/commonwealth/client/styles/pages/view_thread/index.scss
+++ b/packages/commonwealth/client/styles/pages/view_thread/index.scss
@@ -46,3 +46,13 @@
   flex-direction: column;
   gap: 16px;
 }
+
+.comments-filter-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .CommentsTree {
+    margin-left: auto;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4170

## Description of Changes
Added a filter in view threads page to sort comments by oldest or newest first.

## Test Plan
- Go to any thread details page that has some comments (view thread page)
- Try using the sort filter for comments - validate that when 'newest' is selected it should show newest comments first and when 'oldest' is selected it should show oldest comments first.

## Deployment Plan
N/A

## Other Considerations
The `/viewComments` api does not have any kind of pagination and will return all comments for the queried thread (we had an issue before that broke the prod server, that had a similar reason). I think we should update this endpoint to support pagination, and on frontend we can add a 'load more' button or infinite loader to load more comments as the user scrolls.

If we go this route then I would incline towards the load more button as its the popular option in many other sites and most users might already by used to it, but this is just an opinion i could be wrong tho.