### PR TITLE
add on delete cascade notifread to allow sub del

### DIFF
--- a/packages/commonwealth/server/migrations/20230621152651-subscription-ondelete-cascade.js
+++ b/packages/commonwealth/server/migrations/20230621152651-subscription-ondelete-cascade.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// TODO: update all null count columns by zero as default
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      let label = 'drop existing constraint';
+      console.log(label);
+      console.time(label);
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE "NotificationsRead" DROP CONSTRAINT "NotificationsRead_subscription_id_fkey";
+        `,
+        { raw: true, transaction: t, logging: console.log }
+      );
+      console.timeEnd(label);
+
+      label = 'Add delete cascade to subscription foreign key constraint';
+      console.log(label);
+      console.time(label);
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE "NotificationsRead" ADD CONSTRAINT "NotificationsRead_subscription_id_fkey" FOREIGN KEY (subscription_id) REFERENCES "Subscriptions"(id) ON DELETE CASCADE;
+        `,
+        { raw: true, transaction: t, logging: console.log }
+      );
+      console.timeEnd(label);
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/packages/commonwealth/server/migrations/20230621162651-subscription-ondelete-cascade.js
+++ b/packages/commonwealth/server/migrations/20230621162651-subscription-ondelete-cascade.js
@@ -20,7 +20,7 @@ module.exports = {
       console.time(label);
       await queryInterface.sequelize.query(
         `
-        ALTER TABLE "NotificationsRead" ADD CONSTRAINT "NotificationsRead_subscription_id_fkey" FOREIGN KEY (subscription_id) REFERENCES "Subscriptions"(id) ON DELETE CASCADE;
+        ALTER TABLE "NotificationsRead" ADD CONSTRAINT "NotificationsRead_subscription_id_fkey" FOREIGN KEY (subscription_id) REFERENCES "Subscriptions"(id) ON DELETE SET NULL;
         `,
         { raw: true, transaction: t, logging: console.log }
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4033

## Issue
- User unable to delete subs from 
https://commonwealth.im/notification-settings
`/deleteSubscription` returns status code 500

**Error:**
```
  name: 'SequelizeForeignKeyConstraintError',
  parent: error: update or delete on table "Subscriptions" violates foreign key constraint "NotificationsRead_subscription_id_fkey" on table "NotificationsRead"
```

## Description of Changes
- Add on Delete Cascade on DB side - to foreign key constraint on Notifications read


## Test Plan
- Testing on Frack
- measure migration script time

## Deployment Plan
1. merge to master



## Other Considerations
- NotificationsRead is huge table - on local migration script ran in 32s
- On Frack it ran in 16s
- NotificationsRead - rows would be deleted
- NotificationsRead - offset key not continuous
