### PR TITLE
v1 view proposal - handle undefined thread properties

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -134,6 +134,17 @@ export class CosmosProposalV1 extends Proposal<
   }
 
   public async init() {
+    await this.fetchVoteInfo();
+
+    if (!this.initialized) {
+      this._initialized = true;
+    }
+    if (this.data.state.completed) {
+      super.complete(this._Governance.store);
+    }
+  }
+
+  private async fetchVoteInfo() {
     const lcd = this._Chain.lcd;
     const proposalId = longify(this.data.identifier);
     // only fetch voter data if active
@@ -182,15 +193,11 @@ export class CosmosProposalV1 extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTallyV1(tallyResp?.tally);
         }
+
+        this.isFetched.emit('redraw');
       } catch (err) {
         console.error(`Cosmos query failed: ${err.message}`);
       }
-    }
-    if (!this.initialized) {
-      this._initialized = true;
-    }
-    if (this.data.state.completed) {
-      super.complete(this._Governance.store);
     }
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
@@ -15,7 +15,12 @@ import type {
 
 import moment from 'moment';
 import { ITXModalData, IVote } from '../../../../../models/interfaces';
-import { ProposalEndTime, ProposalStatus, VotingType, VotingUnit } from '../../../../../models/types';
+import {
+  ProposalEndTime,
+  ProposalStatus,
+  VotingType,
+  VotingUnit,
+} from '../../../../../models/types';
 import { DepositVote } from '../../../../../models/votes';
 import Proposal from '../../../../../models/Proposal';
 import CosmosAccount from '../../account';
@@ -143,6 +148,17 @@ export class CosmosProposal extends Proposal<
   }
 
   public async init() {
+    await this.fetchVoteInfo();
+
+    if (!this.initialized) {
+      this._initialized = true;
+    }
+    if (this.data.state.completed) {
+      super.complete(this._Governance.store);
+    }
+  }
+
+  private async fetchVoteInfo() {
     const api = this._Chain.api;
     // only fetch voter data if active
     if (!this.data.state.completed) {
@@ -190,15 +206,10 @@ export class CosmosProposal extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTally(tallyResp?.tally);
         }
+        this.isFetched.emit('redraw');
       } catch (err) {
         console.error(`Cosmos query failed: ${err.message}`);
       }
-    }
-    if (!this.initialized) {
-      this._initialized = true;
-    }
-    if (this.data.state.completed) {
-      super.complete(this._Governance.store);
     }
   }
 

--- a/packages/commonwealth/client/scripts/models/Proposal.ts
+++ b/packages/commonwealth/client/scripts/models/Proposal.ts
@@ -12,6 +12,7 @@ import type {
   VotingType,
   VotingUnit,
 } from './types';
+import { EventEmitter } from 'events';
 
 abstract class Proposal<
   ApiT,
@@ -57,6 +58,8 @@ abstract class Proposal<
   public abstract get endTime(): ProposalEndTime;
 
   public abstract get isPassing(): ProposalStatus;
+
+  public isFetched = new EventEmitter();
 
   // display
   public abstract get support(): Coin | number;

--- a/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
@@ -22,6 +22,7 @@ import {
 import { ProposalTag } from './ProposalTag';
 import { useCommonNavigate } from 'navigation/helpers';
 import { useProposalMetadata } from 'hooks/cosmos/useProposalMetadata';
+import useForceRerender from 'hooks/useForceRerender';
 
 type ProposalCardProps = {
   injectedContent?: React.ReactNode;
@@ -35,6 +36,7 @@ export const ProposalCard = ({
   const navigate = useCommonNavigate();
   const [title, setTitle] = useState(proposal.title);
   const { metadata } = useProposalMetadata({ app, proposal });
+  const forceRerender = useForceRerender();
 
   const secondaryTagText = getSecondaryTagText(proposal);
 
@@ -50,6 +52,14 @@ export const ProposalCard = ({
       });
     }
   }, [proposal]);
+
+  useEffect(() => {
+    proposal?.isFetched.once('redraw', forceRerender);
+
+    return () => {
+      proposal?.isFetched.removeAllListeners();
+    };
+  }, [proposal, forceRerender]);
 
   return (
     <CWCard

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -119,17 +119,18 @@ export const CWContentPage = ({
           <ThreadAuthorAndPublishInfo
             showSplitDotIndicator={true}
             isNew={!!displayNewTag}
-            isLocked={thread.readOnly}
-            {...(thread.lockedAt && {
+            isLocked={thread?.readOnly}
+            {...(thread?.lockedAt && {
               lockedAt: thread.lockedAt.toISOString(),
             })}
-            {...(thread.updatedAt && {
+            {...(thread?.updatedAt && {
               lastUpdated: thread.updatedAt.toISOString(),
             })}
             authorInfo={
+              author &&
               new AddressInfo(
                 null,
-                author.address,
+                author?.address,
                 typeof author.chain === 'string'
                   ? author.chain
                   : author.chain.id,
@@ -155,10 +156,10 @@ export const CWContentPage = ({
       {body &&
         body(
           <ThreadOptions
-            canVote={!thread.readOnly}
-            canComment={!thread.readOnly}
+            canVote={!thread?.readOnly}
+            canComment={!thread?.readOnly}
             thread={thread}
-            totalComments={thread.numberOfComments}
+            totalComments={thread?.numberOfComments}
             onLockToggle={onLockToggle}
             onSpamToggle={onSpamToggle}
             onDelete={onDelete}

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -59,19 +59,25 @@ const ProposalsPage = () => {
 
   useEffect(() => {
     app.chainAdapterReady.on('ready', () => setLoading(false));
-    app.chainModuleReady.on('ready', () => setSubstrateLoading(false));
 
     return () => {
       app.chainAdapterReady.off('ready', () => {
         setLoading(false);
         app.chainAdapterReady.removeAllListeners();
       });
+    };
+  }, [setLoading]);
+
+  useEffect(() => {
+    app.chainModuleReady.on('ready', () => setSubstrateLoading(false));
+
+    return () => {
       app.chainModuleReady.off('ready', () => {
         setSubstrateLoading(false);
         app.chainModuleReady.removeAllListeners();
       });
     };
-  }, [setLoading, setSubstrateLoading]);
+  }, [setSubstrateLoading]);
 
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { ChainBase } from 'common-common/src/types';
 import Cosmos from 'controllers/chain/cosmos/adapter';
 import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
@@ -43,6 +43,7 @@ const ViewProposalPage = ({
   const forceRerender = useForceRerender();
   useInitChainIfNeeded(app);
 
+  const hasFetchedProposalRef = useRef(false);
   const [proposal, setProposal] = useState<AnyProposal>(undefined);
   const [type, setType] = useState(typeProp);
   const [votingModalOpen, setVotingModalOpen] = useState(false);
@@ -56,6 +57,9 @@ const ViewProposalPage = ({
 
   useNecessaryEffect(() => {
     const afterAdapterLoaded = async () => {
+      if (hasFetchedProposalRef.current) return;
+      hasFetchedProposalRef.current = true;
+
       if (!type) {
         setType(chainToProposalSlug(app.chain.meta));
       }

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -55,6 +55,14 @@ const ViewProposalPage = ({
     if (metadata?.title) forceRerender();
   }, [metadata?.title, forceRerender]);
 
+  useEffect(() => {
+    proposal?.isFetched.once('redraw', forceRerender);
+
+    return () => {
+      proposal?.isFetched.removeAllListeners();
+    };
+  }, [proposal, forceRerender]);
+
   useNecessaryEffect(() => {
     const afterAdapterLoaded = async () => {
       if (hasFetchedProposalRef.current) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4181 
Closes: #4343 

## Description of Changes
- Adds null checks for possibly undefined `thread` or `author` in cw_content_page
- Adds `useRef` in view_proposal fetch to avoid overwriting proposal that is already fully loaded.

## Test Plan
- ensure env var `COSMOS_GOV_V1=kyve` is set
- ran proposals.spec.ts E2E tests locally
- CA (click around) tested on local and frack:
  - http://localhost:8080/kyve/proposal/7
  - CA to another community's /proposals page (reset chain)
  - CA back to kyve
  - create a discussion, link to Proposal 7, click on link
  - expect proposal page to load with metadata in all cases (content doesn't show for 5 - 7 otherwise)
