### PR TITLE
isFetched eventEmitter on Proposal, listen in ProposalCard, view_proposal

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -134,6 +134,17 @@ export class CosmosProposalV1 extends Proposal<
   }
 
   public async init() {
+    await this.fetchVoteInfo();
+
+    if (!this.initialized) {
+      this._initialized = true;
+    }
+    if (this.data.state.completed) {
+      super.complete(this._Governance.store);
+    }
+  }
+
+  private async fetchVoteInfo() {
     const lcd = this._Chain.lcd;
     const proposalId = longify(this.data.identifier);
     // only fetch voter data if active
@@ -182,15 +193,11 @@ export class CosmosProposalV1 extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTallyV1(tallyResp?.tally);
         }
+
+        this.isFetched.emit('redraw');
       } catch (err) {
         console.error(`Cosmos query failed: ${err.message}`);
       }
-    }
-    if (!this.initialized) {
-      this._initialized = true;
-    }
-    if (this.data.state.completed) {
-      super.complete(this._Governance.store);
     }
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
@@ -15,7 +15,12 @@ import type {
 
 import moment from 'moment';
 import { ITXModalData, IVote } from '../../../../../models/interfaces';
-import { ProposalEndTime, ProposalStatus, VotingType, VotingUnit } from '../../../../../models/types';
+import {
+  ProposalEndTime,
+  ProposalStatus,
+  VotingType,
+  VotingUnit,
+} from '../../../../../models/types';
 import { DepositVote } from '../../../../../models/votes';
 import Proposal from '../../../../../models/Proposal';
 import CosmosAccount from '../../account';
@@ -143,6 +148,17 @@ export class CosmosProposal extends Proposal<
   }
 
   public async init() {
+    await this.fetchVoteInfo();
+
+    if (!this.initialized) {
+      this._initialized = true;
+    }
+    if (this.data.state.completed) {
+      super.complete(this._Governance.store);
+    }
+  }
+
+  private async fetchVoteInfo() {
     const api = this._Chain.api;
     // only fetch voter data if active
     if (!this.data.state.completed) {
@@ -190,15 +206,10 @@ export class CosmosProposal extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTally(tallyResp?.tally);
         }
+        this.isFetched.emit('redraw');
       } catch (err) {
         console.error(`Cosmos query failed: ${err.message}`);
       }
-    }
-    if (!this.initialized) {
-      this._initialized = true;
-    }
-    if (this.data.state.completed) {
-      super.complete(this._Governance.store);
     }
   }
 

--- a/packages/commonwealth/client/scripts/models/Proposal.ts
+++ b/packages/commonwealth/client/scripts/models/Proposal.ts
@@ -12,6 +12,7 @@ import type {
   VotingType,
   VotingUnit,
 } from './types';
+import { EventEmitter } from 'events';
 
 abstract class Proposal<
   ApiT,
@@ -57,6 +58,8 @@ abstract class Proposal<
   public abstract get endTime(): ProposalEndTime;
 
   public abstract get isPassing(): ProposalStatus;
+
+  public isFetched = new EventEmitter();
 
   // display
   public abstract get support(): Coin | number;

--- a/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
@@ -22,6 +22,8 @@ import {
 import { ProposalTag } from './ProposalTag';
 import { useCommonNavigate } from 'navigation/helpers';
 import { useProposalMetadata } from 'hooks/cosmos/useProposalMetadata';
+import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
+import useForceRerender from 'hooks/useForceRerender';
 
 type ProposalCardProps = {
   injectedContent?: React.ReactNode;
@@ -35,6 +37,7 @@ export const ProposalCard = ({
   const navigate = useCommonNavigate();
   const [title, setTitle] = useState(proposal.title);
   const { metadata } = useProposalMetadata({ app, proposal });
+  const forceRerender = useForceRerender();
 
   const secondaryTagText = getSecondaryTagText(proposal);
 
@@ -50,6 +53,14 @@ export const ProposalCard = ({
       });
     }
   }, [proposal]);
+
+  useEffect(() => {
+    proposal?.isFetched.once('redraw', forceRerender);
+
+    return () => {
+      proposal?.isFetched.removeAllListeners();
+    };
+  }, [proposal, forceRerender]);
 
   return (
     <CWCard

--- a/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ProposalCard/ProposalCard.tsx
@@ -22,7 +22,6 @@ import {
 import { ProposalTag } from './ProposalTag';
 import { useCommonNavigate } from 'navigation/helpers';
 import { useProposalMetadata } from 'hooks/cosmos/useProposalMetadata';
-import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
 import useForceRerender from 'hooks/useForceRerender';
 
 type ProposalCardProps = {

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -59,19 +59,25 @@ const ProposalsPage = () => {
 
   useEffect(() => {
     app.chainAdapterReady.on('ready', () => setLoading(false));
-    app.chainModuleReady.on('ready', () => setSubstrateLoading(false));
 
     return () => {
       app.chainAdapterReady.off('ready', () => {
         setLoading(false);
         app.chainAdapterReady.removeAllListeners();
       });
+    };
+  }, [setLoading, app]);
+
+  useEffect(() => {
+    app.chainModuleReady.on('ready', () => setSubstrateLoading(false));
+
+    return () => {
       app.chainModuleReady.off('ready', () => {
         setSubstrateLoading(false);
         app.chainModuleReady.removeAllListeners();
       });
     };
-  }, [setLoading, setSubstrateLoading]);
+  }, [setSubstrateLoading, app]);
 
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -66,7 +66,7 @@ const ProposalsPage = () => {
         app.chainAdapterReady.removeAllListeners();
       });
     };
-  }, [setLoading, app]);
+  }, [setLoading]);
 
   useEffect(() => {
     app.chainModuleReady.on('ready', () => setSubstrateLoading(false));
@@ -77,7 +77,7 @@ const ProposalsPage = () => {
         app.chainModuleReady.removeAllListeners();
       });
     };
-  }, [setSubstrateLoading, app]);
+  }, [setSubstrateLoading]);
 
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -28,6 +28,7 @@ import type { LinkedSubstrateProposal } from './linked_proposals_embed';
 import { LinkedProposalsEmbed } from './linked_proposals_embed';
 import type { SubheaderProposalType } from './proposal_components';
 import { ProposalSubheader } from './proposal_components';
+import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
 
 type ViewProposalPageAttrs = {
   identifier: string;
@@ -54,6 +55,14 @@ const ViewProposalPage = ({
   useEffect(() => {
     if (metadata?.title) forceRerender();
   }, [metadata?.title, forceRerender]);
+
+  useEffect(() => {
+    proposal?.isFetched.once('redraw', forceRerender);
+
+    return () => {
+      proposal?.isFetched.removeAllListeners();
+    };
+  }, [proposal, forceRerender]);
 
   useNecessaryEffect(() => {
     const afterAdapterLoaded = async () => {
@@ -90,6 +99,7 @@ const ViewProposalPage = ({
       app.chainAdapterReady.on('ready', () => {
         setIsAdapterLoaded(true);
         afterAdapterLoaded();
+        // setTimeout(forceRerender, 5500);
       });
     } else {
       afterAdapterLoaded();

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -28,7 +28,6 @@ import type { LinkedSubstrateProposal } from './linked_proposals_embed';
 import { LinkedProposalsEmbed } from './linked_proposals_embed';
 import type { SubheaderProposalType } from './proposal_components';
 import { ProposalSubheader } from './proposal_components';
-import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
 
 type ViewProposalPageAttrs = {
   identifier: string;

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -99,7 +99,6 @@ const ViewProposalPage = ({
       app.chainAdapterReady.on('ready', () => {
         setIsAdapterLoaded(true);
         afterAdapterLoaded();
-        // setTimeout(forceRerender, 5500);
       });
     } else {
       afterAdapterLoaded();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4343 

## Description of Changes
- Trigger re-render when vote data is done loading
- /proposals ProposalCards update from "loading..." to status
- view proposal page updates votes and status

## Test Plan
- CA (click around) tested on local and frack:
  - V1: http://localhost:8080/kyve/proposal/7
      - expect status and votes to update async
  - http://localhost:8080/kyve/proposals
      - expect status to update async on active ProposalCards
  - v1beta1: same expectations for http://localhost:8080/chihuahua/proposals , http://localhost:8080/chihuahua/proposal/49
