### PR TITLE
Get current chain address from keplr when TBC

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/wallet.ts
+++ b/packages/commonwealth/client/scripts/helpers/wallet.ts
@@ -1,6 +1,7 @@
 import IWebWallet from '../models/IWebWallet';
 import Near from '../controllers/chain/near/adapter';
 import axios from 'axios';
+import Account from 'models/Account';
 
 const getAddressFromWallet = (wallet: IWebWallet<any>) => {
   const selectedAddress = (() => {
@@ -67,4 +68,24 @@ const loginToNear = async (activeChain: Near, isCustomDomain: boolean) => {
   });
 };
 
-export { getAddressFromWallet, loginToAxie, loginToNear };
+/**
+  Returns bech32 address for the currently selected chain.
+  In Cosmos, we can check the native chain by selecting the correct address from Keplr,
+  even if using a different cosmos chain to log in.
+*/
+const getAddressForChainFromKeplr = async (
+  account: Account
+): Promise<string> => {
+  const cosm = await import('@cosmjs/stargate');
+  const client = await cosm.StargateClient.connect(account.chain.ChainNode.url);
+  const chainId = await client.getChainId();
+  const accountForChain = await window.keplr.getKey(chainId);
+  return accountForChain?.bech32Address;
+};
+
+export {
+  getAddressFromWallet,
+  loginToAxie,
+  loginToNear,
+  getAddressForChainFromKeplr,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4299 

## Description of Changes
- use cosmjs to get current chain network ID
- use keplr to get address for selected community (using network ID), even if logged in with other cosmos account

## Test Plan
- Use a keplr account with EVMOS tokens on evmos chain
- Log into /osmosis - keplr will use your osmosis address
- go to /evmos
- expect tokenBalance query to return the correct number of EVMOS tokens (in micro denom) from your Evmos address

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This uses Keplr to fetch the user's appropriate address. So we can query their other chain account, even if they never log into CW with that address. 
- Any security concerns?
