### PR TITLE
Create a Polygon whitelabeled create community form + Fix Adjacent Bugs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_dropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_dropdown.tsx
@@ -44,6 +44,7 @@ export const CWDropdown = ({
         }}
         label={label}
         onClick={() => {
+          if (disabled) return;
           setShowDropdown(!showDropdown);
         }}
         disabled={disabled}

--- a/packages/commonwealth/client/scripts/views/pages/create_community/chain_input_rows.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/chain_input_rows.tsx
@@ -156,7 +156,7 @@ export const ethChainRows = (
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    onSelectHandler(options[0]);
+    onSelectHandler(options[6]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -165,8 +165,9 @@ export const ethChainRows = (
       <CWDropdown
         label="Chain"
         options={options}
-        initialValue={options[0]}
+        initialValue={options[6]}
         onSelect={(o) => onSelectHandler(o)}
+        disabled={!!props.disabled}
       />
       {state.chainString === 'Custom' && (
         <InputRow
@@ -202,7 +203,7 @@ export const ethChainRows = (
         />
       )}
       <InputRow
-        title="Address"
+        title="Token Contract Address"
         value={state.address}
         placeholder="0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
         onChangeHandler={(v) => {

--- a/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
@@ -16,6 +16,7 @@ import { SplTokenForm } from './spl_token_form';
 import { SputnikForm } from './sputnik_form';
 import { StarterCommunityForm } from './starter_community_form';
 import { SubstrateForm } from './substrate_form';
+import { PolygonForm } from './polygon_form';
 
 export enum CommunityType {
   StarterCommunity = 'Starter Community',
@@ -26,6 +27,7 @@ export enum CommunityType {
   Cosmos = 'Cosmos',
   EthDao = 'Compound/Aave',
   SplToken = 'Solana Token',
+  Polygon = 'Polygon',
   AbiFactory = 'Abi Factory',
 }
 
@@ -105,6 +107,8 @@ const CreateCommunity = () => {
         return (
           <EthDaoForm ethChains={ethChains} ethChainNames={ethChainNames} />
         );
+      case CommunityType.Polygon:
+          return <PolygonForm ethChains={ethChains} ethChainNames={ethChainNames} />;
       case CommunityType.SplToken:
         return <SplTokenForm />;
       default:

--- a/packages/commonwealth/client/scripts/views/pages/create_community/polygon_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/polygon_form.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from 'react';
+import { isAddress } from 'web3-utils';
+import { providers } from 'ethers';
+import $ from 'jquery';
+
+import 'pages/create_community.scss';
+
+import app from 'state';
+import { initAppState } from 'state';
+import { IERC20Metadata__factory } from 'common-common/src/eth/types';
+import { ChainBase, ChainNetwork, ChainType } from 'common-common/src/types';
+import { notifyError } from 'controllers/app/notifications';
+import { slugify, slugifyPreserveDashes } from 'utils';
+import { IdRow, InputRow } from 'views/components/metadata_rows';
+import { linkExistingAddressToChainOrCommunity } from '../../../controllers/app/login';
+import { CWButton } from '../../components/component_kit/cw_button';
+import { CWValidationText } from '../../components/component_kit/cw_validation_text';
+import { defaultChainRows, ethChainRows } from './chain_input_rows';
+import type { EthChainFormState } from './types';
+import { useCommonNavigate } from 'navigation/helpers';
+import {
+  useChainFormIdFields,
+  useChainFormDefaultFields,
+  useChainFormState,
+  useEthChainFormFields,
+} from './hooks';
+
+export const PolygonForm = (props: EthChainFormState) => {
+  const { ethChainNames, ethChains } = props;
+
+  const [, setDecimals] = useState(18);
+
+  const { id, setId, name, setName, symbol, setSymbol } =
+    useChainFormIdFields();
+
+  const chainFormDefaultFields = useChainFormDefaultFields();
+
+  const chainFormState = useChainFormState();
+
+  const ethChainFormFields = useEthChainFormFields();
+
+  const navigate = useCommonNavigate();
+
+  useEffect(() => {
+    ethChainFormFields.setChainString('Ethereum Mainnet');
+    ethChainFormFields.setNodeUrl(ethChains[1].url);
+  }, []);
+
+  const validAddress = isAddress(ethChainFormFields.address);
+
+  const updateTokenForum = async () => {
+    if (!ethChainFormFields.address || !ethChainFormFields.ethChainId) {
+      return;
+    }
+
+    chainFormState.setStatus(undefined);
+    chainFormState.setMessage('');
+    chainFormState.setLoading(true);
+
+    const args = {
+      address: ethChainFormFields.address,
+      chain_id: ethChainFormFields.ethChainId,
+      url: ethChainFormFields.nodeUrl,
+    };
+
+    try {
+      console.log('Querying backend for token data');
+
+      const res = await $.get(`${app.serverUrl()}/getTokenForum`, args);
+
+      if (res.status === 'Success') {
+        if (res?.token?.name) {
+          setName(res.token.name || '');
+          setId(res.token.id && slugify(res.token.id));
+          setSymbol(res.token.symbol || '');
+          setDecimals(+res.token.decimals);
+          chainFormDefaultFields.setIconUrl(res.token.icon_url || '');
+
+          if (chainFormDefaultFields.iconUrl.startsWith('/')) {
+            chainFormDefaultFields.setIconUrl(
+              `https://commonwealth.im${chainFormDefaultFields.iconUrl}`
+            );
+          }
+
+          chainFormDefaultFields.setDescription(res.token.description || '');
+          chainFormDefaultFields.setWebsite(res.token.website || '');
+          chainFormDefaultFields.setDiscord(res.token.discord || '');
+          chainFormDefaultFields.setElement(res.token.element || '');
+          chainFormDefaultFields.setTelegram(res.token.telegram || '');
+          chainFormDefaultFields.setGithub(res.token.github || '');
+          chainFormState.setStatus('success');
+          chainFormState.setMessage('Success!');
+        } else {
+          // attempt to query ERC20Detailed token info from chain
+          console.log('Querying chain for ERC info');
+
+          const Web3 = (await import('web3')).default;
+          const provider =
+            args.url.slice(0, 4) == 'http'
+              ? new Web3.providers.HttpProvider(args.url)
+              : new Web3.providers.WebsocketProvider(args.url);
+
+          try {
+            const ethersProvider = new providers.Web3Provider(provider);
+
+            const contract = IERC20Metadata__factory.connect(
+              args.address,
+              ethersProvider
+            );
+
+            const contractName = await contract.name();
+            const contractSymbol = await contract.symbol();
+            const contractDecimals = await contract.decimals();
+
+            setName(contractName || '');
+            setId(contractName);
+            setSymbol(contractSymbol || '');
+            setDecimals(contractDecimals);
+            chainFormState.setStatus('success');
+            chainFormState.setMessage('Success!');
+          } catch (e) {
+            setName('');
+            setId('');
+            setSymbol('');
+            chainFormState.setStatus('failure');
+            chainFormState.setMessage(
+              'Verified token but could not load metadata.'
+            );
+          }
+
+          chainFormDefaultFields.setIconUrl('');
+          chainFormDefaultFields.setDescription('');
+          chainFormDefaultFields.setWebsite('');
+          chainFormDefaultFields.setDiscord('');
+          chainFormDefaultFields.setElement('');
+          chainFormDefaultFields.setTelegram('');
+          chainFormDefaultFields.setGithub('');
+          if (provider instanceof Web3.providers.WebsocketProvider)
+            provider.disconnect(1000, 'finished');
+        }
+
+        chainFormState.setLoaded(true);
+      } else {
+        chainFormState.setStatus('failure');
+        chainFormState.setMessage(
+          res.message || 'Failed to load Token Information'
+        );
+      }
+    } catch (err) {
+      chainFormState.setStatus('failure');
+      chainFormState.setMessage(
+        err.responseJSON?.error || 'Failed to load Token Information'
+      );
+    }
+    chainFormState.setLoading(false);
+  };
+
+  console.log(chainFormState.saving || (!validAddress && !!ethChainFormFields.address ) || chainFormState.loading);
+  console.log(chainFormState.saving, (!validAddress && !!ethChainFormFields.address ), chainFormState.loading)
+  return (
+    <div className="CreateCommunityForm">
+      {ethChainRows(
+        { ethChainNames, ethChains, disabled: true },
+        { ...ethChainFormFields, ...chainFormState }
+      )}
+      <CWButton
+        label="Populate fields"
+        disabled={
+          chainFormState.saving ||
+          !validAddress ||
+          !ethChainFormFields.ethChainId ||
+          chainFormState.loading
+        }
+        onClick={async () => {
+          await updateTokenForum();
+        }}
+      />
+      {chainFormState.message && (
+        <CWValidationText
+          message={chainFormState.message}
+          status={chainFormState.status}
+        />
+      )}
+      <InputRow
+        title="Name"
+        value={name}
+        onChangeHandler={(v) => {
+          setName(v);
+          setId(slugifyPreserveDashes(v));
+        }}
+      />
+      <IdRow id={id} />
+      <InputRow
+        title="Symbol"
+        value={symbol}
+        placeholder="XYZ"
+        onChangeHandler={(v) => {
+          setSymbol(v);
+        }}
+      />
+      {defaultChainRows(chainFormDefaultFields)}
+      <CWButton
+        label="Save changes"
+        disabled={
+          chainFormState.saving ||
+          (!validAddress && !!ethChainFormFields.address ) ||
+          chainFormState.loading ||
+          id.length < 1
+        }
+        onClick={async () => {
+          chainFormState.setSaving(true);
+
+          try {
+            const res = await $.post(`${app.serverUrl()}/createChain`, {
+              alt_wallet_url: ethChainFormFields.altWalletUrl,
+              base: ChainBase.Ethereum,
+              id: id,
+              name: name,
+              address: ethChainFormFields.address,
+              chain_string: ethChainFormFields.chainString,
+              eth_chain_id: ethChainFormFields.ethChainId,
+              icon_url: chainFormDefaultFields.iconUrl,
+              jwt: app.user.jwt,
+              network: ChainNetwork.ERC20,
+              node_url: ethChainFormFields.nodeUrl,
+              type: validAddress ? ChainType.Token : ChainType.Offchain,
+              default_symbol: symbol,
+              // ...form, <-- not typed so I don't know what's needed
+            });
+
+            if (res.result.admin_address) {
+              await linkExistingAddressToChainOrCommunity(
+                res.result.admin_address,
+                res.result.role.chain_id,
+                res.result.role.chain_id
+              );
+            }
+
+            await initAppState(false);
+
+            navigate(`/${res.result.chain?.id}`);
+          } catch (err) {
+            notifyError(
+              err.responseJSON?.error || 'Creating new ERC20 community failed'
+            );
+          } finally {
+            chainFormState.setSaving(false);
+          }
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/create_community/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/types.ts
@@ -70,6 +70,7 @@ export type EthChainNamesType = { [id: number]: string };
 export type EthChainFormState = {
   ethChains: EthChainsType;
   ethChainNames: EthChainNamesType;
+  disabled?: boolean;
 };
 
 export type EthChainFormStateSetters = {

--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -133,7 +133,8 @@ const createChain = async (
     return next(new AppError(Errors.NoBase));
   }
 
-  if ((await getFileSizeBytes(req.body.icon_url)) / 1024 > MAX_IMAGE_SIZE_KB) {
+  if (req.body.icon_url &&
+    (await getFileSizeBytes(req.body.icon_url)) / 1024 > MAX_IMAGE_SIZE_KB) {
     throw new AppError(Errors.ImageTooLarge);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR creates adds another form to our Create Community options. It is specifically for creating/onboarding Polygon communities, at the request of Growth Team.
The form does not let users select a different chain base and does not _require_ an erc20 token address. 

This PR also removes the requirement of `icon_url` from the `/createChain` route.


## Link to Issue
Closes: #4388 and #4387

## Description of Changes
- Adds another form to the create community page, hardcodes Polygon as the chain base without a hard requirement for including an erc20 token address. 
- Fixes bug in CWDropdown where even if disabled, it was still interact-able. 
- Removes requirement for `icon_url` in `/createChain`.

## Test Plan
- Using the new Polygon community creation form, create both:
  - a community **without** an erc20 token address.
  - a community **with** an erc20 token address.
- Using any of the forms, you should be able to create a community without providing an icon or icon_url.
- Using the new Polygon community creation form, confirm that the disabled Chain base selection dropdown does not open upon interaction/click. 