### PR TITLE
Added default placement for notification

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_popover/cw_popover.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_popover/cw_popover.tsx
@@ -52,7 +52,7 @@ export const Popover = (props: PopoverProps) => {
       id={id}
       open={open}
       anchorEl={anchorEl}
-      placement={placement}
+      placement={placement || 'bottom-start'}
       modifiers={[
         {
           name: 'preventOverflow',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3834

## Description of Changes
Added default anchor placement for notification popover.

## Test Plan
1. Reload the page
2. As soon as the header shows, click on the notification icon and verify that the anchor is placed right below it
3. Repeat step 2 as soon as the sidebar loads (in case of a community page)
4. When the full page is loaded, repeat step 2.

Verify that all the popover positions are the same

## Deployment Plan
N/A

## Other Considerations
N/A