### PR TITLE
Fix thread card link navigation on click of blank side of footer

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/Card/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/Card/index.tsx
@@ -8,7 +8,8 @@ import {
 } from 'identifiers';
 import { LinkSource } from 'models/Thread';
 import moment from 'moment';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { slugify } from 'utils';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import useBrowserWindow from '../../../../../hooks/useBrowserWindow';
@@ -18,14 +19,13 @@ import Permissions from '../../../../../utils/Permissions';
 import { CWTag } from '../../../../components/component_kit/cw_tag';
 import { CWText } from '../../../../components/component_kit/cw_text';
 import { getClasses } from '../../../../components/component_kit/helpers';
-import { isHot } from '../../helpers';
 import { isNewThread } from '../../NewThreadTag';
+import { isHot } from '../../helpers';
 import { AuthorAndPublishInfo } from '../AuthorAndPublishInfo';
 import { Options } from '../Options';
 import { AdminActionsProps } from '../Options/AdminActions';
 import { ReactionButton } from '../Options/ReactionButton';
 import './index.scss';
-import { Link } from 'react-router-dom';
 
 type CardProps = AdminActionsProps & {
   onBodyClick?: () => any;
@@ -138,11 +138,10 @@ export const Card = ({
                     label={`${chainEntityTypeToProposalShortName(
                       'proposal' as IChainEntityKind
                     )} 
-                        ${
-                          Number.isNaN(parseInt(link.identifier, 10))
-                            ? ''
-                            : ` #${link.identifier}`
-                        }`}
+                        ${Number.isNaN(parseInt(link.identifier, 10))
+                        ? ''
+                        : ` #${link.identifier}`
+                      }`}
                   />
                 ))}
             </div>
@@ -171,13 +170,7 @@ export const Card = ({
               {thread.plaintext}
             </CWText>
           </div>
-          <div
-            className="content-footer"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
+          <div className="content-footer">
             <Options
               totalComments={thread.numberOfComments}
               shareEndpoint={discussionLink}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/Options/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/Options/index.tsx
@@ -2,7 +2,6 @@ import Thread from 'models/Thread';
 import React, { useState } from 'react';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../../../components/component_kit/cw_text';
-import { ReactionButton } from './ReactionButton';
 import { SharePopover } from '../../../../components/share_popover';
 import {
   getCommentSubscription,
@@ -10,6 +9,7 @@ import {
   handleToggleSubscription,
 } from '../../helpers';
 import { AdminActions, AdminActionsProps } from './AdminActions';
+import { ReactionButton } from './ReactionButton';
 import './index.scss';
 
 type OptionsProps = AdminActionsProps & {
@@ -43,13 +43,19 @@ export const Options = ({
 }: OptionsProps) => {
   const [isSubscribed, setIsSubscribed] = useState(
     thread &&
-      getCommentSubscription(thread)?.isActive &&
-      getReactionSubscription(thread)?.isActive
+    getCommentSubscription(thread)?.isActive &&
+    getReactionSubscription(thread)?.isActive
   );
 
   return (
     <>
-      <div className="Options">
+      <div
+        className="Options"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
         {canVote && thread && <ReactionButton thread={thread} size="small" />}
 
         {canComment && totalComments >= 0 && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4379

## Description of Changes
Now clicking on the blank right side of footer in thread card will correctly redirect to view threads page

## Test Plan
1. Go to any community and select any discussions page. 
2. Click In the thread card footer on the right click, verify it correctly redirects to the view threads page


## Deployment Plan
N/A

## Other Considerations
N/A