### PR TITLE
Refresh user dashboard feed section after login

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -10,6 +10,7 @@ import { CWTab, CWTabBar } from '../../components/component_kit/cw_tabs';
 import { Feed } from '../../components/feed';
 import { DashboardCommunitiesPreview } from './dashboard_communities_preview';
 import { fetchActivity } from './helpers';
+import useUserLoggedIn from 'hooks/useUserLoggedIn';
 
 export enum DashboardViews {
   ForYou = 'For You',
@@ -23,6 +24,7 @@ type UserDashboardProps = {
 
 const UserDashboard = (props: UserDashboardProps) => {
   const { type } = props;
+  const {isLoggedIn} = useUserLoggedIn();
 
   const [activePage, setActivePage] = React.useState<DashboardViews>(
     DashboardViews.Global
@@ -64,7 +66,7 @@ const UserDashboard = (props: UserDashboardProps) => {
   }, [activePage, subpage]);
 
   return (
-    <div ref={setScrollElement} className="UserDashboard">
+    <div ref={setScrollElement} className="UserDashboard" key={isLoggedIn + ''}>
       <div className="dashboard-column">
         <div className="dashboard-header">
           <CWTabBar>

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -24,7 +24,7 @@ type UserDashboardProps = {
 
 const UserDashboard = (props: UserDashboardProps) => {
   const { type } = props;
-  const {isLoggedIn} = useUserLoggedIn();
+  const { isLoggedIn } = useUserLoggedIn();
 
   const [activePage, setActivePage] = React.useState<DashboardViews>(
     DashboardViews.Global
@@ -66,7 +66,7 @@ const UserDashboard = (props: UserDashboardProps) => {
   }, [activePage, subpage]);
 
   return (
-    <div ref={setScrollElement} className="UserDashboard" key={isLoggedIn + ''}>
+    <div ref={setScrollElement} className="UserDashboard" key={`${isLoggedIn}`}>
       <div className="dashboard-column">
         <div className="dashboard-header">
           <CWTabBar>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/3946

## Description of Changes
Refreshes the user dashboard feed sections after login

## Test Plan
1. Go to the /dashboard page
2. Logout then login
3. Verify that the feed sections get updated

## Deployment Plan
When a user logouts on `/dashboard/for-you`, it redirects to `/dashboard/global` which seems like a bad UX. I asked a question for this [here](https://github.com/hicommonwealth/commonwealth/issues/3946#issuecomment-1618732475), awaiting how to move forward here. @CowMuon @jnaviask 


**Update:**
Got the reply [here](https://github.com/hicommonwealth/commonwealth/issues/3946#issuecomment-1629612670) which suggested the same implementation as in the pr. PR is ready for review

## Other Considerations
N/A