### PR TITLE
Fix substrate communities joining

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -49,7 +49,7 @@ export const selectChain = async (chain?: ChainInfo): Promise<boolean> => {
 
   // Import top-level chain adapter lazily, to facilitate code split.
   let newChain;
-  let initApi; // required for NEAR
+  let initApi; // required for NEAR and substrate
 
   if (chain.base === ChainBase.Substrate) {
     const Substrate = (
@@ -60,6 +60,7 @@ export const selectChain = async (chain?: ChainInfo): Promise<boolean> => {
       )
     ).default;
     newChain = new Substrate(chain, app);
+    initApi = true;
   } else if (chain.base === ChainBase.CosmosSDK) {
     const Cosmos = (
       await import(
@@ -192,7 +193,7 @@ export const selectChain = async (chain?: ChainInfo): Promise<boolean> => {
   }
 
   if (initApi) {
-    await app.chain.initApi(); // required for loading NearAccounts
+    await app.chain.initApi(); // required for loading NearAccounts and SubstrateAccounts
   }
 
   app.chainPreloading = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4401

## Description of Changes
We were not calling the `init` method on the [substrate/account.ts](https://github.com/hicommonwealth/commonwealth/blob/645c1157f4ecee28369e4181ca04a3b9518b2814/packages/commonwealth/client/scripts/controllers/chain/substrate/account.ts#L201-L206), which caused the `this.polkadot` in the same file to be `undefined` and users were not able to login/signup.

Now switched the `initApi` bool to `true` for substrate chains which calls the substrate/account.ts init() in its method chain.

## Test Plan
- Login with polkadot 
- Go to any substrate based community (i.e edgeware, kusama)
- Join the community
- Refresh the page,  verify you are still a member of the community i.e no join button
- Post a thread, verify it works.

## Deployment Plan
N/A

## Other Considerations
With the implemented change substrate based communities may get a little slow, video attached for reference

https://github.com/hicommonwealth/commonwealth/assets/51641047/b74e3444-6028-410e-999f-297751ada449


