### PR TITLE
Import function only to fix Substrate joining issue

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/substrate/account.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/substrate/account.ts
@@ -1,9 +1,6 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable consistent-return */
-import type {
-  AccountId,
-  Conviction,
-} from '@polkadot/types/interfaces';
+import type { AccountId, Conviction } from '@polkadot/types/interfaces';
 import type { Codec } from '@polkadot/types/types';
 import type { SubstrateCoin } from 'adapters/chain/substrate/types';
 
@@ -12,12 +9,11 @@ import { AccountsStore } from 'stores';
 import Account from '../../../models/Account';
 import { IAccountsModule } from '../../../models/interfaces';
 import SubstrateChain from './shared';
+import { decodeAddress } from '@polkadot/util-crypto';
 
 type Delegation = [AccountId, Conviction] & Codec;
 
 export class SubstrateAccount extends Account {
-  private polkadot;
-
   // GETTERS AND SETTERS
 
   // The total balance
@@ -137,8 +133,6 @@ class SubstrateAccounts
 
   private _Chain: SubstrateChain;
 
-  private polkadot;
-
   public get(address: string, keytype?: string) {
     if (keytype && keytype !== 'ed25519' && keytype !== 'sr25519') {
       throw new Error(`invalid keytype: ${keytype}`);
@@ -156,13 +150,13 @@ class SubstrateAccounts
   }
 
   public isZero(address: string) {
-    const decoded = this.polkadot.decodeAddress(address);
+    const decoded = decodeAddress(address);
     return decoded.every((v) => v === 0);
   }
 
   public fromAddress(address: string, isEd25519 = false): SubstrateAccount {
     try {
-      this.polkadot.decodeAddress(address); // try to decode address; this will produce an error if the address is invalid
+      decodeAddress(address); // try to decode address; this will produce an error if the address is invalid
     } catch (e) {
       console.error(`Decoded invalid address: ${address}`);
       return;
@@ -199,7 +193,6 @@ class SubstrateAccounts
   }
 
   public async init(ChainInfo: SubstrateChain): Promise<void> {
-    this.polkadot = await import('@polkadot/keyring');
     this._Chain = ChainInfo;
     this._initialized = true;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4401 
Closes: #3747

## Description of Changes
- Statically imports solely the `decodeAddress` function so it is available synchronously when loading discussions.

## Test Plan
- Use a new Polkadot account and join the edgeware community (you will need to navigate directly to discussions as the for-you page is broken #4396).
- Try posting a thread.
The join button should not appear after you have joined the community.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- @kurtisassad does the static import of the function import the entire `@polkadot/util-crypto` package or can webpack properly optimize so only the function and its dependencies are imported? I'm no Webpack wizard so help here would be appreciated.