### PR TITLE
Fix Comment Box Resizing Bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -38,14 +38,13 @@ export const CreateComment = ({
   updatedCommentsCallback,
 }: CreateCommentProps) => {
   const { saveDraft, restoreDraft, clearDraft } = useDraft<DeltaStatic>(
-    `new-thread-comment-${rootThread.id}`
+    !parentCommentId
+      ? `new-thread-comment-${rootThread.id}`
+      : `new-comment-reply-${parentCommentId}`
   );
 
   // get restored draft on init
   const restoredDraft = useMemo(() => {
-    if (handleIsReplying) {
-      return createDeltaFromText('');
-    }
     return restoreDraft() || createDeltaFromText('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -125,16 +124,12 @@ export const CreateComment = ({
     setContentDelta(createDeltaFromText(''));
     if (handleIsReplying) {
       handleIsReplying(false);
-    } else {
-      clearDraft();
     }
+    clearDraft();
   };
 
   // on content updated, save draft
   useEffect(() => {
-    if (handleIsReplying) {
-      return;
-    }
     saveDraft(contentDelta);
   }, [handleIsReplying, saveDraft, contentDelta]);
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/index.tsx
@@ -27,6 +27,10 @@ type CommentsTreeAttrs = {
   setIsGloballyEditing?: (status: boolean) => void;
   updatedCommentsCallback: () => void;
   includeSpams: boolean;
+  isReplying: boolean;
+  setIsReplying: (status: boolean) => void;
+  parentCommentId: number;
+  setParentCommentId: (id: number) => void;
 };
 
 export const CommentsTree = ({
@@ -35,11 +39,13 @@ export const CommentsTree = ({
   setIsGloballyEditing,
   updatedCommentsCallback,
   includeSpams,
+  isReplying,
+  setIsReplying,
+  parentCommentId,
+  setParentCommentId,
 }: CommentsTreeAttrs) => {
   const [commentError] = useState(null);
   const [highlightedComment, setHighlightedComment] = useState(false);
-  const [isReplying, setIsReplying] = useState(false);
-  const [parentCommentId, setParentCommentId] = useState(null);
 
   const [edits, setEdits] = useState<{
     [commentId: number]: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4411 

## Description of Changes
- Fixes some state logic to prevent the content of the comment reply box from completely being overwritten when the page resizes, forcing a rerender because the tabs and sidebar become visible.

## Test Plan
- Start some replies to comments with the rich text editor, resize the screen, verify they have not vanished. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 