### PR TITLE
Fix search tabs

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/search/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/index.tsx
@@ -39,7 +39,8 @@ const SearchPage = () => {
         'tab'
       ] as SearchScope) || SearchScope.Threads
     );
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   const setActiveTab = (newTab: SearchScope) => {
     navigate(`/search?${searchQuery.toUrlParams()}&tab=${newTab}`, {
@@ -139,9 +140,9 @@ const SearchPage = () => {
   const resultCount =
     tabScopedListing.length >= 10
       ? `${tabScopedListing.length}+ ${pluralize(
-          2,
-          activeTab.toLowerCase()
-        ).replace('2 ', '')}`
+        2,
+        activeTab.toLowerCase()
+      ).replace('2 ', '')}`
       : pluralize(tabScopedListing.length, activeTab.toLowerCase());
 
   const getCaptionScope = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: Not ticketed

## Description of Changes
The search functionality was broken, couldn't switch b/w these tabs
<img width="553" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/64243f02-e583-4b49-92f8-4686371249f5">

@rbennettcw identified the bug while working on pagination rework, the change was simple so made a PR.

## Test Plan
Go to any search page, tabs switching should work

## Deployment Plan
N/A

## Other Considerations
N/A