### PR TITLE
Make gov requests non-blocking

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/adapter.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/adapter.ts
@@ -39,9 +39,9 @@ class Cosmos
   }
 
   public async initData() {
-    this.activeAddressHasToken(this.app.user?.activeAccount?.address);
     await this.governance.init(this.chain, this.accounts);
     await super.initData();
+    await this.activeAddressHasToken(this.app.user?.activeAccount?.address);
   }
 
   public async deinit(): Promise<void> {

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/adapter.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/adapter.ts
@@ -39,9 +39,9 @@ class Cosmos
   }
 
   public async initData() {
+    this.activeAddressHasToken(this.app.user?.activeAccount?.address);
     await this.governance.init(this.chain, this.accounts);
     await super.initData();
-    await this.activeAddressHasToken(this.app.user?.activeAccount?.address);
   }
 
   public async deinit(): Promise<void> {

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -85,9 +85,6 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
   }
 
   private _tmClient: Tendermint34Client;
-  private _isFetchingPoolParams: boolean;
-  private _isFetchingStakingParams: boolean;
-  private _isFetchingBlock: boolean;
 
   public async init(chain: ChainInfo, reset = false) {
     const url = `${window.location.origin}/cosmosAPI/${chain.id}`;
@@ -128,8 +125,6 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
   }
 
   private async fetchPoolParams(): Promise<void> {
-    if (this._isFetchingPoolParams) return;
-    this._isFetchingPoolParams = true;
     try {
       const {
         pool: { bondedTokens },
@@ -137,14 +132,10 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       this._staked = this.coins(new BN(bondedTokens));
     } catch (e) {
       console.error('Error fetching pool params: ', e);
-    } finally {
-      this._isFetchingPoolParams = false;
     }
   }
 
   private async fetchBlock(): Promise<void> {
-    if (this._isFetchingBlock) return;
-    this._isFetchingBlock = true;
     try {
       const { block } = await this._tmClient.block();
       const height = +block.header.height;
@@ -156,16 +147,12 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       this.app.chain.block.lastTime = time;
       this.app.chain.block.height = height;
       this.app.chain.networkStatus = ApiStatus.Connected;
-      this._isFetchingBlock = false;
     } catch (e) {
       console.error('Error fetching block: ', e);
-      this._isFetchingBlock = false;
     }
   }
 
   private async fetchStakingParams(): Promise<void> {
-    if (this._isFetchingStakingParams) return;
-    this._isFetchingStakingParams = true;
     try {
       const {
         params: { bondDenom },
@@ -174,7 +161,6 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       this._isFetchingStakingParams = false;
     } catch (e) {
       console.error('Error fetching staking params: ', e);
-      this._isFetchingStakingParams = false;
     }
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -119,9 +119,11 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       }
     }
 
-    await this.fetchPoolParams();
-    await this.fetchBlock(); // Poll for new block immediately
-    await this.fetchStakingParams();
+    await Promise.all([
+      this.fetchPoolParams(),
+      this.fetchBlock(), // Poll for new block immediately
+      this.fetchStakingParams(),
+    ]);
   }
 
   private async fetchPoolParams(): Promise<void> {
@@ -158,7 +160,6 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
         params: { bondDenom },
       } = await this._api.staking.params();
       this._denom = bondDenom;
-      this._isFetchingStakingParams = false;
     } catch (e) {
       console.error('Error fetching staking params: ', e);
     }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -122,9 +122,9 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       }
     }
 
-    this.fetchPoolParams();
-    this.fetchStakingParams();
-    this.fetchBlock(); // Poll for new block immediately
+    await this.fetchPoolParams();
+    await this.fetchBlock(); // Poll for new block immediately
+    await this.fetchStakingParams();
   }
 
   private async fetchPoolParams(): Promise<void> {

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
@@ -50,45 +50,10 @@ class CosmosGovernanceV1 extends ProposalModule<
   ): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
-    try {
-      // query chain-wide params
-      const { deposit_params } = await this._Chain.lcd.cosmos.gov.v1.params({
-        paramsType: 'deposit',
-      });
-      const { tally_params } = await this._Chain.lcd.cosmos.gov.v1.params({
-        paramsType: 'tallying',
-      });
-      const { voting_params } = await this._Chain.lcd.cosmos.gov.v1.params({
-        paramsType: 'voting',
-      });
-      this._votingPeriodS = +voting_params.voting_period.replace('s', '');
-      this._yesThreshold = +tally_params?.threshold;
-      this._vetoThreshold = +tally_params?.veto_threshold;
-      this._maxDepositPeriodS = +deposit_params?.max_deposit_period.replace(
-        's',
-        ''
-      );
-
-      // TODO: support off-denom deposits
-      const depositCoins = deposit_params?.min_deposit.find(
-        ({ denom }) => denom === this._Chain.denom
-      );
-      if (depositCoins) {
-        this._minDeposit = new CosmosToken(
-          depositCoins.denom,
-          new BN(depositCoins.amount)
-        );
-      } else {
-        console.error(
-          'Gov minDeposit in wrong denom:',
-          deposit_params?.min_deposit
-        );
-        this._minDeposit = new CosmosToken(this._Chain.denom, 0);
-      }
-      console.log(this._minDeposit);
-    } catch (e) {
-      console.error(e);
-    }
+    // query chain-wide params
+    this.fetchDepositParams();
+    this.fetchTallyThresholds();
+    this.fetchVotingPeriod();
 
     // query existing proposals
     await this._initProposals();
@@ -138,6 +103,61 @@ class CosmosGovernanceV1 extends ProposalModule<
       Promise.all(cosmosProposals?.map((p) => p.init()));
     } catch (error) {
       console.error('Error fetching proposals: ', error);
+    }
+  }
+
+  private async fetchDepositParams(): Promise<void> {
+    try {
+      const { deposit_params } = await this._Chain.lcd.cosmos.gov.v1.params({
+        paramsType: 'deposit',
+      });
+      this._maxDepositPeriodS = +deposit_params?.max_deposit_period.replace(
+        's',
+        ''
+      );
+
+      // TODO: support off-denom deposits
+      const depositCoins = deposit_params?.min_deposit.find(
+        ({ denom }) => denom === this._Chain.denom
+      );
+      if (depositCoins) {
+        this._minDeposit = new CosmosToken(
+          depositCoins.denom,
+          new BN(depositCoins.amount)
+        );
+      } else {
+        console.error(
+          'Gov minDeposit in wrong denom:',
+          deposit_params?.min_deposit
+        );
+        this._minDeposit = new CosmosToken(this._Chain.denom, 0);
+      }
+      console.log(this._minDeposit);
+    } catch (e) {
+      console.error('Error fetching deposit params', e);
+    }
+  }
+
+  private async fetchTallyThresholds(): Promise<void> {
+    try {
+      const { tally_params } = await this._Chain.lcd.cosmos.gov.v1.params({
+        paramsType: 'tallying',
+      });
+      this._yesThreshold = +tally_params?.threshold;
+      this._vetoThreshold = +tally_params?.veto_threshold;
+    } catch (e) {
+      console.error('Error fetching tally params', e);
+    }
+  }
+
+  private async fetchVotingPeriod(): Promise<void> {
+    try {
+      const { voting_params } = await this._Chain.lcd.cosmos.gov.v1.params({
+        paramsType: 'voting',
+      });
+      this._votingPeriodS = +voting_params.voting_period.replace('s', '');
+    } catch (e) {
+      console.error('Error fetching voting params', e);
     }
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
@@ -50,13 +50,12 @@ class CosmosGovernanceV1 extends ProposalModule<
   ): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
-    // query chain-wide params
-    await this.fetchDepositParams();
-    await this.fetchTallyThresholds();
-    await this.fetchVotingPeriod();
-
-    // query existing proposals
-    await this._initProposals();
+    Promise.all([
+      this.fetchDepositParams(),
+      this.fetchTallyThresholds(),
+      this.fetchVotingPeriod(),
+      this._initProposals(),
+    ]);
     this._initialized = true;
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
@@ -51,9 +51,9 @@ class CosmosGovernanceV1 extends ProposalModule<
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
     // query chain-wide params
-    this.fetchDepositParams();
-    this.fetchTallyThresholds();
-    this.fetchVotingPeriod();
+    await this.fetchDepositParams();
+    await this.fetchTallyThresholds();
+    await this.fetchVotingPeriod();
 
     // query existing proposals
     await this._initProposals();

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/governance-v1.ts
@@ -50,7 +50,7 @@ class CosmosGovernanceV1 extends ProposalModule<
   ): Promise<void> {
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
-    Promise.all([
+    await Promise.all([
       this.fetchDepositParams(),
       this.fetchTallyThresholds(),
       this.fetchVotingPeriod(),

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -134,7 +134,7 @@ export class CosmosProposalV1 extends Proposal<
   }
 
   public async init() {
-    this.fetchVoteInfo();
+    await this.fetchVoteInfo();
 
     if (!this.initialized) {
       this._initialized = true;

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -134,7 +134,7 @@ export class CosmosProposalV1 extends Proposal<
   }
 
   public async init() {
-    await this.fetchVoteInfo();
+    this.fetchVoteInfo();
 
     if (!this.initialized) {
       this._initialized = true;
@@ -193,10 +193,10 @@ export class CosmosProposalV1 extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTallyV1(tallyResp?.tally);
         }
-
-        this.isFetched.emit('redraw');
       } catch (err) {
-        console.error(`Cosmos query failed: ${err.message}`);
+        console.error(`Cosmos vote query failed: ${err.message}`);
+      } finally {
+        this.isFetched.emit('redraw');
       }
     }
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/utils-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/utils-v1.ts
@@ -20,33 +20,38 @@ export const fetchProposalsByStatusV1 = async (
   lcd: LCD,
   status: ProposalStatus
 ): Promise<ProposalSDKType[]> => {
-  const { proposals: proposalsByStatus, pagination } =
-    await lcd.cosmos.gov.v1.proposals({
-      proposalStatus: status,
-      voter: '',
-      depositor: '',
-    });
-
-  let nextKey = pagination?.next_key;
-  while (nextKey?.length > 0) {
-    // console.log(nextKey);
-    const { proposals, pagination: nextPage } =
+  try {
+    const { proposals: proposalsByStatus, pagination } =
       await lcd.cosmos.gov.v1.proposals({
         proposalStatus: status,
         voter: '',
         depositor: '',
-        pagination: {
-          key: nextKey,
-          limit: null,
-          offset: null,
-          countTotal: true,
-          reverse: true,
-        },
       });
-    proposalsByStatus.push(...proposals);
-    nextKey = nextPage.next_key;
+
+    let nextKey = pagination?.next_key;
+    while (nextKey?.length > 0) {
+      // console.log(nextKey);
+      const { proposals, pagination: nextPage } =
+        await lcd.cosmos.gov.v1.proposals({
+          proposalStatus: status,
+          voter: '',
+          depositor: '',
+          pagination: {
+            key: nextKey,
+            limit: null,
+            offset: null,
+            countTotal: true,
+            reverse: true,
+          },
+        });
+      proposalsByStatus.push(...proposals);
+      nextKey = nextPage.next_key;
+    }
+    return proposalsByStatus;
+  } catch (e) {
+    console.error(`Error fetching proposal by status ${status}`, e);
+    return [];
   }
-  return proposalsByStatus;
 };
 
 export const getActiveProposalsV1 = async (

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -49,13 +49,12 @@ class CosmosGovernance extends ProposalModule<
     this._Chain = ChainInfo;
     this._Accounts = Accounts;
 
-    // query chain-wide params
-    await this.fetchDepositParams();
-    await this.fetchTallyThresholds();
-    await this.fetchVotingPeriod();
-
-    // query existing proposals
-    await this._initProposals();
+    await Promise.all([
+      this.fetchDepositParams(),
+      this.fetchTallyThresholds(),
+      this.fetchVotingPeriod(),
+      this._initProposals(),
+    ]);
     this._initialized = true;
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -18,7 +18,7 @@ import {
   msgToIProposal,
 } from './utils-v1beta1';
 
-/* AKA CosmosGovernance v1beta1 */
+/* CosmosGovernance v1beta1 */
 
 class CosmosGovernance extends ProposalModule<
   CosmosApiType,
@@ -50,72 +50,110 @@ class CosmosGovernance extends ProposalModule<
     this._Accounts = Accounts;
 
     // query chain-wide params
-    const { depositParams } = await this._Chain.api.gov.params('deposit');
-    const { tallyParams } = await this._Chain.api.gov.params('tallying');
-    const { votingParams } = await this._Chain.api.gov.params('voting');
-    this._votingPeriodS = votingParams.votingPeriod.seconds.toNumber();
-    this._yesThreshold = await asciiLiteralToDecimal(tallyParams.threshold);
-    this._vetoThreshold = await asciiLiteralToDecimal(
-      tallyParams.vetoThreshold
-    );
-    this._maxDepositPeriodS = depositParams.maxDepositPeriod.seconds.toNumber();
-
-    // TODO: support off-denom deposits
-    const depositCoins = depositParams.minDeposit.find(
-      ({ denom }) => denom === this._Chain.denom
-    );
-    if (depositCoins) {
-      this._minDeposit = new CosmosToken(
-        depositCoins.denom,
-        new BN(depositCoins.amount)
-      );
-    } else {
-      console.error('Gov minDeposit in wrong denom:', depositParams.minDeposit);
-      this._minDeposit = new CosmosToken(this._Chain.denom, 0);
-    }
-    console.log(this._minDeposit);
+    this.fetchDepositParams();
+    this.fetchTallyThresholds();
+    this.fetchVotingPeriod();
 
     // query existing proposals
     await this._initProposals();
     this._initialized = true;
   }
 
+  private async fetchDepositParams(): Promise<void> {
+    try {
+      const { depositParams } = await this._Chain.api.gov.params('deposit');
+      this._maxDepositPeriodS =
+        depositParams.maxDepositPeriod.seconds.toNumber();
+
+      // TODO: support off-denom deposits
+      const depositCoins = depositParams.minDeposit.find(
+        ({ denom }) => denom === this._Chain.denom
+      );
+      if (depositCoins) {
+        this._minDeposit = new CosmosToken(
+          depositCoins.denom,
+          new BN(depositCoins.amount)
+        );
+      } else {
+        console.error(
+          'Gov minDeposit in wrong denom:',
+          depositParams.minDeposit
+        );
+        this._minDeposit = new CosmosToken(this._Chain.denom, 0);
+      }
+      console.log('minDeposit: ', this._minDeposit);
+    } catch (e) {
+      console.error('Error fetching deposit params', e);
+    }
+  }
+
+  private async fetchTallyThresholds(): Promise<void> {
+    try {
+      const { tallyParams } = await this._Chain.api.gov.params('tallying');
+      this._yesThreshold = await asciiLiteralToDecimal(tallyParams.threshold);
+      this._vetoThreshold = await asciiLiteralToDecimal(
+        tallyParams.vetoThreshold
+      );
+    } catch (e) {
+      console.error('Error fetching tally params', e);
+    }
+  }
+
+  private async fetchVotingPeriod(): Promise<void> {
+    try {
+      const { votingParams } = await this._Chain.api.gov.params('voting');
+      this._votingPeriodS = votingParams.votingPeriod.seconds.toNumber();
+    } catch (e) {
+      console.error('Error fetching voting params', e);
+    }
+  }
+
   public async getProposal(proposalId: number): Promise<CosmosProposal> {
     const existingProposal = this.store.getByIdentifier(proposalId);
-    if (existingProposal) {
-      return existingProposal;
+    if (existingProposal) return existingProposal;
+
+    try {
+      const { proposal } = await this._Chain.api.gov.proposal(proposalId);
+      const cosmosProp = new CosmosProposal(
+        this._Chain,
+        this._Accounts,
+        this,
+        msgToIProposal(proposal)
+      );
+      await cosmosProp.init();
+      return cosmosProp;
+    } catch (e) {
+      console.error('Error fetching proposal', e);
     }
-    const { proposal } = await this._Chain.api.gov.proposal(proposalId);
-    const cosmosProp = new CosmosProposal(
-      this._Chain,
-      this._Accounts,
-      this,
-      msgToIProposal(proposal)
-    );
-    await cosmosProp.init();
-    return cosmosProp;
   }
 
   private async _initProposals(proposalId?: number): Promise<void> {
     let cosmosProposals: CosmosProposal[];
-    if (!proposalId) {
-      const activeProposals = await getActiveProposalsV1Beta1(this._Chain.api);
+    try {
+      if (!proposalId) {
+        const activeProposals = await getActiveProposalsV1Beta1(
+          this._Chain.api
+        );
 
-      cosmosProposals = activeProposals.map(
-        (p) => new CosmosProposal(this._Chain, this._Accounts, this, p)
-      );
-    } else {
-      const { proposal } = await this._Chain.api.gov.proposal(proposalId);
-      cosmosProposals = [
-        new CosmosProposal(
-          this._Chain,
-          this._Accounts,
-          this,
-          msgToIProposal(proposal)
-        ),
-      ];
+        cosmosProposals = activeProposals.map(
+          (p) => new CosmosProposal(this._Chain, this._Accounts, this, p)
+        );
+      } else {
+        const { proposal } = await this._Chain.api.gov.proposal(proposalId);
+        cosmosProposals = [
+          new CosmosProposal(
+            this._Chain,
+            this._Accounts,
+            this,
+            msgToIProposal(proposal)
+          ),
+        ];
+      }
+    } catch (e) {
+      console.error('Error fetching proposals: ', e);
+    } finally {
+      Promise.all(cosmosProposals.map((p) => p.init()));
     }
-    Promise.all(cosmosProposals.map((p) => p.init()));
   }
 
   public createTx(

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -55,7 +55,7 @@ class CosmosGovernance extends ProposalModule<
     await this.fetchVotingPeriod();
 
     // query existing proposals
-    await this._initProposals();
+    this._initProposals();
     this._initialized = true;
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -55,7 +55,7 @@ class CosmosGovernance extends ProposalModule<
     await this.fetchVotingPeriod();
 
     // query existing proposals
-    this._initProposals();
+    await this._initProposals();
     this._initialized = true;
   }
 

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/governance-v1beta1.ts
@@ -50,9 +50,9 @@ class CosmosGovernance extends ProposalModule<
     this._Accounts = Accounts;
 
     // query chain-wide params
-    this.fetchDepositParams();
-    this.fetchTallyThresholds();
-    this.fetchVotingPeriod();
+    await this.fetchDepositParams();
+    await this.fetchTallyThresholds();
+    await this.fetchVotingPeriod();
 
     // query existing proposals
     await this._initProposals();

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
@@ -130,6 +130,8 @@ export class CosmosProposal extends Proposal<
   private _Accounts: CosmosAccounts;
   private _Governance: CosmosGovernance;
 
+  private _isFetching: boolean;
+
   constructor(
     ChainInfo: CosmosChain,
     Accounts: CosmosAccounts,
@@ -148,7 +150,7 @@ export class CosmosProposal extends Proposal<
   }
 
   public async init() {
-    await this.fetchVoteInfo();
+    this.fetchVoteInfo();
 
     if (!this.initialized) {
       this._initialized = true;
@@ -159,6 +161,8 @@ export class CosmosProposal extends Proposal<
   }
 
   private async fetchVoteInfo() {
+    if (this._isFetching) return;
+    this._isFetching = true;
     const api = this._Chain.api;
     // only fetch voter data if active
     if (!this.data.state.completed) {
@@ -206,9 +210,11 @@ export class CosmosProposal extends Proposal<
         if (tallyResp?.tally) {
           this.data.state.tally = marshalTally(tallyResp?.tally);
         }
-        this.isFetched.emit('redraw');
       } catch (err) {
-        console.error(`Cosmos query failed: ${err.message}`);
+        console.error(`Votes query failed: ${err.message}`);
+      } finally {
+        this._isFetching = false;
+        this.isFetched.emit('redraw');
       }
     }
   }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
@@ -130,8 +130,6 @@ export class CosmosProposal extends Proposal<
   private _Accounts: CosmosAccounts;
   private _Governance: CosmosGovernance;
 
-  private _isFetching: boolean;
-
   constructor(
     ChainInfo: CosmosChain,
     Accounts: CosmosAccounts,
@@ -161,8 +159,6 @@ export class CosmosProposal extends Proposal<
   }
 
   private async fetchVoteInfo() {
-    if (this._isFetching) return;
-    this._isFetching = true;
     const api = this._Chain.api;
     // only fetch voter data if active
     if (!this.data.state.completed) {
@@ -213,7 +209,6 @@ export class CosmosProposal extends Proposal<
       } catch (err) {
         console.error(`Votes query failed: ${err.message}`);
       } finally {
-        this._isFetching = false;
         this.isFetched.emit('redraw');
       }
     }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1.ts
@@ -150,7 +150,7 @@ export class CosmosProposal extends Proposal<
   }
 
   public async init() {
-    this.fetchVoteInfo();
+    await this.fetchVoteInfo();
 
     if (!this.initialized) {
       this._initialized = true;

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
@@ -72,25 +72,27 @@ const fetchProposalsByStatus = async (
     return [];
   }
 
-  const { proposals: proposalsByStatus, pagination } = await api.gov.proposals(
-    status,
-    '',
-    ''
-  );
+  try {
+    const { proposals: proposalsByStatus, pagination } =
+      await api.gov.proposals(status, '', '');
 
-  let nextKey = pagination?.nextKey;
-  while (nextKey.length > 0) {
-    // console.log(nextKey);
-    const { proposals, pagination: nextPage } = await api.gov.proposals(
-      status,
-      '',
-      '',
-      nextKey
-    );
-    proposalsByStatus.push(...proposals);
-    nextKey = nextPage.nextKey;
+    let nextKey = pagination?.nextKey;
+    while (nextKey.length > 0) {
+      // console.log(nextKey);
+      const { proposals, pagination: nextPage } = await api.gov.proposals(
+        status,
+        '',
+        '',
+        nextKey
+      );
+      proposalsByStatus.push(...proposals);
+      nextKey = nextPage.nextKey;
+    }
+    return proposalsByStatus;
+  } catch (e) {
+    console.error(`Error fetching proposals by status ${status}`, e);
+    return [];
   }
-  return proposalsByStatus;
 };
 
 export const getActiveProposalsV1Beta1 = async (

--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -221,8 +221,11 @@ export const initChain = async (): Promise<void> => {
     await app.chain.initApi();
   }
 
+  if (!app.chain.loaded) {
+    await app.chain.initData();
+  }
+
   const chain = app.chain.meta;
-  await app.chain.initData();
 
   // Emit chain as updated
   app.chainAdapterReady.emit('ready');

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
@@ -37,7 +37,9 @@ export const useGetActiveCosmosProposals = ({
     const fetchProposals = async () => {
       if (isApiReady && !hasFetchedDataRef.current) {
         hasFetchedDataRef.current = true;
+        setIsLoading(true);
         const proposals = await getActiveProposals(cosmos);
+        setIsLoading(false);
         setActiveCosmosProposals(proposals);
       }
     };
@@ -51,16 +53,14 @@ export const useGetActiveCosmosProposals = ({
         setActiveCosmosProposals(activeProposals); // show whatever we have stored
         await fetchProposals(); // update if there are more from the API
       } else {
-        setIsLoading(true);
         await fetchProposals();
-        setIsLoading(false);
       }
     };
 
     if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
       getProposals();
     }
-  }, [isApiReady, app.chain, isLoading, setIsLoading]);
+  }, [isApiReady, app.chain, setIsLoading]);
 
   return {
     activeCosmosProposals,

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
@@ -15,14 +15,12 @@ interface Response {
 interface Props {
   app: IApp;
   setIsLoading: UseStateSetter<boolean>;
-  isLoading: boolean;
   isApiReady?: boolean;
 }
 
 export const useGetActiveCosmosProposals = ({
   app,
   setIsLoading,
-  isLoading,
   isApiReady,
 }: Props): Response => {
   const [activeCosmosProposals, setActiveCosmosProposals] = useState<
@@ -57,7 +55,7 @@ export const useGetActiveCosmosProposals = ({
       }
     };
 
-    if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
+    if (app.chain?.base === ChainBase.CosmosSDK) {
       getProposals();
     }
   }, [isApiReady, app.chain, setIsLoading]);

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetActiveCosmosProposals.tsx
@@ -60,7 +60,7 @@ export const useGetActiveCosmosProposals = ({
     if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
       getProposals();
     }
-  }, [isApiReady]);
+  }, [isApiReady, app.chain, isLoading, setIsLoading]);
 
   return {
     activeCosmosProposals,

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
@@ -36,14 +36,12 @@ export const useGetAllCosmosProposals = ({
   const { activeCosmosProposals } = useGetActiveCosmosProposals({
     app,
     setIsLoading: setIsLoadingActiveProposals,
-    isLoading: isLoadingActiveProposals,
     isApiReady,
   });
 
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,
     setIsLoading: setIsLoadingCompletedProposals,
-    isLoading: isLoadingCompletedProposals,
     isApiReady,
   });
 

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState, Dispatch, SetStateAction } from 'react';
+import { IApp } from 'state';
+
+import { ChainBase } from 'common-common/src/types';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+import { useGetCompletedCosmosProposals } from './useGetCompletedCosmosProposals';
+import { useGetActiveCosmosProposals } from './useGetActiveCosmosProposals';
+
+type UseStateSetter<T> = Dispatch<SetStateAction<T>>;
+
+interface Response {
+  activeCosmosProposals: CosmosProposal[];
+  completedCosmosProposals: CosmosProposal[];
+}
+
+interface Props {
+  app: IApp;
+  setIsLoadingActive?: UseStateSetter<boolean>;
+  setIsLoadingCompleted?: UseStateSetter<boolean>;
+  isLoadingActive?: boolean;
+  isLoadingCompleted?: boolean;
+  needToInitAPI?: boolean;
+}
+
+export const useGetAllCosmosProposals = ({
+  app,
+  setIsLoadingActive,
+  setIsLoadingCompleted,
+  isLoadingActive,
+  isLoadingCompleted,
+  needToInitAPI,
+}: Props): Response => {
+  const startedApiRef = useRef(false);
+  const [isApiReady, setIsApiReady] = useState(false);
+
+  const { activeCosmosProposals } = useGetActiveCosmosProposals({
+    app,
+    setIsLoading: setIsLoadingActive,
+    isLoading: isLoadingActive,
+    isApiReady,
+  });
+
+  const { completedCosmosProposals } = useGetCompletedCosmosProposals({
+    app,
+    setIsLoading: setIsLoadingCompleted,
+    isLoading: isLoadingCompleted,
+    isApiReady,
+  });
+
+  useEffect(() => {
+    const initApi = async () => {
+      startedApiRef.current = true;
+      await app.chain.initApi();
+      setIsApiReady(true);
+    };
+
+    if (
+      app.chain?.base === ChainBase.CosmosSDK &&
+      needToInitAPI &&
+      !startedApiRef.current
+    ) {
+      initApi();
+    }
+  }, [needToInitAPI]);
+
+  return {
+    activeCosmosProposals,
+    completedCosmosProposals,
+  };
+};

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
@@ -15,19 +15,19 @@ interface Response {
 
 interface Props {
   app: IApp;
-  setIsLoadingActive?: UseStateSetter<boolean>;
-  setIsLoadingCompleted?: UseStateSetter<boolean>;
-  isLoadingActive?: boolean;
-  isLoadingCompleted?: boolean;
+  setIsLoadingActiveProposals?: UseStateSetter<boolean>;
+  setIsLoadingCompletedProposals?: UseStateSetter<boolean>;
+  isLoadingActiveProposals?: boolean;
+  isLoadingCompletedProposals?: boolean;
   needToInitAPI?: boolean;
 }
 
 export const useGetAllCosmosProposals = ({
   app,
-  setIsLoadingActive,
-  setIsLoadingCompleted,
-  isLoadingActive,
-  isLoadingCompleted,
+  setIsLoadingActiveProposals,
+  setIsLoadingCompletedProposals,
+  isLoadingActiveProposals,
+  isLoadingCompletedProposals,
   needToInitAPI,
 }: Props): Response => {
   const startedApiRef = useRef(false);
@@ -35,15 +35,15 @@ export const useGetAllCosmosProposals = ({
 
   const { activeCosmosProposals } = useGetActiveCosmosProposals({
     app,
-    setIsLoading: setIsLoadingActive,
-    isLoading: isLoadingActive,
+    setIsLoading: setIsLoadingActiveProposals,
+    isLoading: isLoadingActiveProposals,
     isApiReady,
   });
 
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,
-    setIsLoading: setIsLoadingCompleted,
-    isLoading: isLoadingCompleted,
+    setIsLoading: setIsLoadingCompletedProposals,
+    isLoading: isLoadingCompletedProposals,
     isApiReady,
   });
 

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetAllCosmosProposals.tsx
@@ -61,7 +61,7 @@ export const useGetAllCosmosProposals = ({
     ) {
       initApi();
     }
-  }, [needToInitAPI]);
+  }, [needToInitAPI, app.chain]);
 
   return {
     activeCosmosProposals,

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -63,7 +63,7 @@ export const useGetCompletedCosmosProposals = ({
     if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
       getProposals();
     }
-  }, [isApiReady]);
+  }, [isApiReady, app.chain, isLoading, setIsLoading, setIsLoadingMore]);
 
   return {
     completedCosmosProposals,

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -38,7 +38,9 @@ export const useGetCompletedCosmosProposals = ({
     const fetchProposals = async () => {
       if (isApiReady && !hasFetchedDataRef.current) {
         hasFetchedDataRef.current = true;
+        setIsLoading(true);
         const proposals = await getCompletedProposals(cosmos);
+        setIsLoading(false);
         setCompletedCosmosProposals(proposals);
       }
     };
@@ -54,16 +56,14 @@ export const useGetCompletedCosmosProposals = ({
         await fetchProposals(); // update if there are more from the API
         if (setIsLoadingMore) setIsLoadingMore(false);
       } else {
-        setIsLoading(true);
         await fetchProposals();
-        setIsLoading(false);
       }
     };
 
     if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
       getProposals();
     }
-  }, [isApiReady, app.chain, isLoading, setIsLoading, setIsLoadingMore]);
+  }, [isApiReady, app.chain, setIsLoading, setIsLoadingMore]);
 
   return {
     completedCosmosProposals,

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -15,7 +15,6 @@ interface Response {
 interface Props {
   app: IApp;
   setIsLoading: UseStateSetter<boolean>;
-  isLoading: boolean;
   setIsLoadingMore?: UseStateSetter<boolean>;
   isApiReady?: boolean;
 }
@@ -23,7 +22,6 @@ interface Props {
 export const useGetCompletedCosmosProposals = ({
   app,
   setIsLoading,
-  isLoading,
   setIsLoadingMore,
   isApiReady,
 }: Props): Response => {
@@ -60,7 +58,7 @@ export const useGetCompletedCosmosProposals = ({
       }
     };
 
-    if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
+    if (app.chain?.base === ChainBase.CosmosSDK) {
       getProposals();
     }
   }, [isApiReady, app.chain, setIsLoading, setIsLoadingMore]);

--- a/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
+++ b/packages/commonwealth/client/scripts/hooks/cosmos/useGetCompletedCosmosProposals.tsx
@@ -17,6 +17,7 @@ interface Props {
   setIsLoading: UseStateSetter<boolean>;
   isLoading: boolean;
   setIsLoadingMore?: UseStateSetter<boolean>;
+  isApiReady?: boolean;
 }
 
 export const useGetCompletedCosmosProposals = ({
@@ -24,54 +25,45 @@ export const useGetCompletedCosmosProposals = ({
   setIsLoading,
   isLoading,
   setIsLoadingMore,
+  isApiReady,
 }: Props): Response => {
   const [completedCosmosProposals, setCompletedCosmosProposals] = useState<
     CosmosProposal[]
   >([]);
-
   const hasFetchedDataRef = useRef(false);
 
   useEffect(() => {
     const cosmos = app.chain as Cosmos;
 
-    const getAndSetProposals = async () => {
-      const proposals = await getCompletedProposals(cosmos);
-      setCompletedCosmosProposals(proposals);
+    const fetchProposals = async () => {
+      if (isApiReady && !hasFetchedDataRef.current) {
+        hasFetchedDataRef.current = true;
+        const proposals = await getCompletedProposals(cosmos);
+        setCompletedCosmosProposals(proposals);
+      }
     };
 
     const getProposals = async () => {
-      if (!hasFetchedDataRef.current) {
-        hasFetchedDataRef.current = true;
-        const storedProposals =
-          cosmos.governance.store.getAll() as CosmosProposal[];
-        const completedProposals = storedProposals.filter((p) => p.completed);
+      const storedProposals =
+        cosmos.governance.store.getAll() as CosmosProposal[];
+      const completedProposals = storedProposals.filter((p) => p.completed);
 
-        if (completedProposals?.length) {
-          if (setIsLoadingMore) setIsLoadingMore(true);
-          setCompletedCosmosProposals(completedProposals); // show whatever we have stored
-          await getAndSetProposals(); // update if there are more from the API
-          if (setIsLoadingMore) setIsLoadingMore(false);
-        } else {
-          setIsLoading(true);
-          await getAndSetProposals();
-          setIsLoading(false);
-        }
+      if (completedProposals?.length) {
+        if (setIsLoadingMore) setIsLoadingMore(true);
+        setCompletedCosmosProposals(completedProposals); // show whatever we have stored
+        await fetchProposals(); // update if there are more from the API
+        if (setIsLoadingMore) setIsLoadingMore(false);
+      } else {
+        setIsLoading(true);
+        await fetchProposals();
+        setIsLoading(false);
       }
-    };
-
-    const initApiThenFetch = async () => {
-      await app.chain.initApi();
-      await getProposals();
     };
 
     if (app.chain?.base === ChainBase.CosmosSDK && !isLoading) {
-      if (app.chain?.apiInitialized) {
-        getProposals();
-      } else {
-        initApiThenFetch();
-      }
+      getProposals();
     }
-  }, [app.chain?.apiInitialized]);
+  }, [isApiReady]);
 
   return {
     completedCosmosProposals,

--- a/packages/commonwealth/client/scripts/views/components/CosmosProposalSelector/CosmosProposalSelector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CosmosProposalSelector/CosmosProposalSelector.tsx
@@ -32,10 +32,10 @@ export const CosmosProposalSelector = ({
   const { activeCosmosProposals, completedCosmosProposals } =
     useGetAllCosmosProposals({
       app,
-      setIsLoadingActive: setActiveLoading,
-      setIsLoadingCompleted: setCompletedProposalsLoading,
-      isLoadingActive: loadingActive,
-      isLoadingCompleted: loadingCompletedProposals,
+      setIsLoadingActiveProposals: setActiveLoading,
+      setIsLoadingCompletedProposals: setCompletedProposalsLoading,
+      isLoadingActiveProposals: loadingActive,
+      isLoadingCompletedProposals: loadingCompletedProposals,
       needToInitAPI:
         !app.chain.apiInitialized &&
         app.chain.networkStatus !== ApiStatus.Connecting,

--- a/packages/commonwealth/client/scripts/views/components/CosmosProposalSelector/CosmosProposalSelector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CosmosProposalSelector/CosmosProposalSelector.tsx
@@ -3,12 +3,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import 'components/ChainEntitiesSelector.scss';
 import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
 
-import app from 'state';
+import app, { ApiStatus } from 'state';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
-import { useGetCompletedCosmosProposals } from 'hooks/cosmos/useGetCompletedCosmosProposals';
-import { useGetActiveCosmosProposals } from 'hooks/cosmos/useGetActiveCosmosProposals';
 import { CosmosProposalSelectorItem } from 'views/components/CosmosProposalSelector';
+import { useGetAllCosmosProposals } from 'hooks/cosmos/useGetAllCosmosProposals';
 
 const filterProposals = (ce: CosmosProposal, searchTerm: string) => {
   return (
@@ -30,16 +29,17 @@ export const CosmosProposalSelector = ({
     useState(false);
   const [loadingActive, setActiveLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
-  const { activeCosmosProposals } = useGetActiveCosmosProposals({
-    app,
-    setIsLoading: setActiveLoading,
-    isLoading: loadingActive,
-  });
-  const { completedCosmosProposals } = useGetCompletedCosmosProposals({
-    app,
-    setIsLoading: setCompletedProposalsLoading,
-    isLoading: loadingCompletedProposals,
-  });
+  const { activeCosmosProposals, completedCosmosProposals } =
+    useGetAllCosmosProposals({
+      app,
+      setIsLoadingActive: setActiveLoading,
+      setIsLoadingCompleted: setCompletedProposalsLoading,
+      isLoadingActive: loadingActive,
+      isLoadingCompleted: loadingCompletedProposals,
+      needToInitAPI:
+        !app.chain.apiInitialized &&
+        app.chain.networkStatus !== ApiStatus.Connecting,
+    });
 
   const handleClearButtonClick = () => {
     setSearchTerm('');

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -82,7 +82,6 @@ const ProposalsPage = () => {
   const { completedCosmosProposals } = useGetCompletedCosmosProposals({
     app,
     setIsLoading: setIsCosmosCompletedProposalsLoading,
-    isLoading: isCosmosCompletedProposalsLoading,
     setIsLoadingMore: setIsCosmosCompletedProposalsLoadingMore,
     isApiReady: app.chain?.apiInitialized,
   });

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -84,6 +84,7 @@ const ProposalsPage = () => {
     setIsLoading: setIsCosmosCompletedProposalsLoading,
     isLoading: isCosmosCompletedProposalsLoading,
     setIsLoadingMore: setIsCosmosCompletedProposalsLoadingMore,
+    isApiReady: app.chain?.apiInitialized,
   });
 
   if (isLoading) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4472 

## Description of Changes
- Adds error-handling to chain, gov, and proposal requests
- Refactors a lot of `init`code to make it non-blocking and more asynchronous
- Prevents duplicate chain inits and its requests
- Fixes a bug where chain API was getting initialized by custom hooks and page init at the same time.
    - This was likely the root cause of rate-limits, sometimes tripling requests. 

Before (master):
- 33 osmosis chain requests on http://localhost:8080/osmosis/proposals page
- 35 osmosis chain requests on Proposal link modal
- 4 "status" requests
<img width="513" alt="Screenshot 2023-07-13 at 1 18 07 AM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/156dff3e-cd90-4257-8323-3b688135d322">


**After**:
- **23** osmosis chain requests on http://localhost:8080/osmosis/proposals page
- **20** osmosis chain requests on Proposal link modal
- **1** "status" request


## Test Plan
- Ran proposals.spec.ts E2E tests locally
- CA (click around) tested on local:
  - v1beta1:
      - http://localhost:8080/osmosis/proposals (plus regen, juno)
      - http://localhost:8080/osmosis/proposal/555 or any proposal
      - http://localhost:8080/osmosis/discussions -> clear cache, create thread, link proposal -> expect same behavior with way fewer requests.
  - v1: 
      - http://localhost:8080/kyve/proposals 
      - (repeat thread link flow) for kyve
  - CI devnet tests


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- There will be a separate ticket for cache improvements. Combined with this PR, rate-limits should be much less common.