### PR TITLE
Add localhost to psql scripts.

### DIFF
--- a/packages/chain-events/scripts/load-db.sh
+++ b/packages/chain-events/scripts/load-db.sh
@@ -12,4 +12,4 @@ if [ "$1" ]; then
   DUMP_NAME=$1
 fi
 
-psql -d commonwealth_chain_events -U commonwealth -f "$DUMP_NAME";
+psql -h localhost -d commonwealth_chain_events -U commonwealth -f "$DUMP_NAME";

--- a/packages/chain-events/scripts/reset-db.sh
+++ b/packages/chain-events/scripts/reset-db.sh
@@ -9,4 +9,4 @@ load-env-var '.env';
 
 
 
-psql -d postgres -U commonwealth -c 'DROP DATABASE commonwealth_chain_events WITH (FORCE);' && npx sequelize db:create
+psql -h localhost -d postgres -U commonwealth -c 'DROP DATABASE commonwealth_chain_events WITH (FORCE);' && npx sequelize db:create

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -45,7 +45,7 @@
     "datadog-db-setup": "chmod u+x scripts/setup-datadog-postgres.sh && ./scripts/setup-datadog-postgres.sh",
     "reset-db": "chmod u+x scripts/reset-db.sh && ./scripts/reset-db.sh",
     "load-db": "chmod u+x scripts/load-db.sh && ./scripts/load-db.sh",
-    "load-db-local": "psql -d commonwealth -U commonwealth -W -f local_save.dump",
+    "load-db-local": "psql -h localhost -d commonwealth -U commonwealth -W -f local_save.dump",
     "migrate-db": "npx sequelize db:migrate",
     "db-all": "yarn reset-db && yarn load-db && yarn migrate-db",
     "migrate-db-down": "npx sequelize db:migrate:undo",

--- a/packages/commonwealth/scripts/load-db.sh
+++ b/packages/commonwealth/scripts/load-db.sh
@@ -18,12 +18,12 @@ if [ "$1" ]; then
   DUMP_NAME=$1
 fi
 
-psql -d commonwealth -U commonwealth -f "$DUMP_NAME";
+psql -h localhost -d commonwealth -U commonwealth -f "$DUMP_NAME";
 
 if [ "$ETH_ALCHEMY_API_KEY" ]
 then
   ETH_ALCHEMY_URL="eth-mainnet.g.alchemy.com/v2"
-  psql -d commonwealth -U commonwealth -c "UPDATE \"ChainNodes\" SET url = 'https://$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY', alt_wallet_url = 'https://$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY' WHERE eth_chain_id = 1;"
+  psql -h localhost -d commonwealth -U commonwealth -c "UPDATE \"ChainNodes\" SET url = 'https://$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY', alt_wallet_url = 'https://$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY' WHERE eth_chain_id = 1;"
 else
   echo "You don't have the correct env var set so the Alchemy API urls were not updated"
 fi

--- a/packages/commonwealth/scripts/reset-db.sh
+++ b/packages/commonwealth/scripts/reset-db.sh
@@ -13,4 +13,4 @@ else
   PGPASSWORD="${PGPASSWORD}"
 fi
 
-psql -d postgres -U commonwealth -c 'DROP DATABASE commonwealth WITH (FORCE);'; npx sequelize db:create
+psql -h localhost -d postgres -U commonwealth -c 'DROP DATABASE commonwealth WITH (FORCE);'; npx sequelize db:create


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
N/A

## Description of Changes
Postgres 14 broke this week on archlinux, so I went about setting up a docker image to run postgres 14 instead, as 15 requires an upgrade path. In doing so, I learned that the psql command requires a `-h localhost` to connect locally. I added this command on all psql-related scripts.

## Test Plan
- Verified that `yarn reset-db`, `yarn load-db`, and `yarn migrate-db` work as expected.

## Deployment Plan
Does not affect production code.