### PR TITLE
Fix user dashboard avatar group crash.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
@@ -20,7 +20,10 @@ export const CWAvatarGroup = (props: AvatarGroupProps) => {
 
   if (!profiles || profiles?.filter((p) => !!p).length === 0) return;
 
-  const truncatedProfiles = profiles.filter((p) => !!p).slice(0, 4).reverse();
+  const truncatedProfiles = profiles
+    .filter((p) => !!p)
+    .slice(0, 4)
+    .reverse();
 
   const count = profiles.length - 4;
   let countText;
@@ -48,11 +51,15 @@ export const CWAvatarGroup = (props: AvatarGroupProps) => {
               return addr.chain == chainId;
             });
 
-            return (
-              <div className="avatar-group-icon" key={i}>
-                <CWJdenticon address={address.address} size={16} />
-              </div>
-            );
+            // some old posts are broken = have no address in the specified community.
+            // if so, we omit their icon as a quick fix.
+            if (address) {
+              return (
+                <div className="avatar-group-icon" key={i}>
+                  <CWJdenticon address={address.address} size={16} />
+                </div>
+              );
+            }
           }
         })}
       </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_avatar_group.tsx
@@ -18,10 +18,11 @@ type AvatarGroupProps = {
 export const CWAvatarGroup = (props: AvatarGroupProps) => {
   const { profiles, chainId } = props;
 
-  if (!profiles || profiles?.filter((p) => !!p).length === 0) return;
+  if (!profiles || profiles?.filter((p) => !!p && p.Addresses).length === 0)
+    return;
 
   const truncatedProfiles = profiles
-    .filter((p) => !!p)
+    .filter((p) => !!p && p.Addresses)
     .slice(0, 4)
     .reverse();
 
@@ -52,14 +53,15 @@ export const CWAvatarGroup = (props: AvatarGroupProps) => {
             });
 
             // some old posts are broken = have no address in the specified community.
-            // if so, we omit their icon as a quick fix.
-            if (address) {
-              return (
-                <div className="avatar-group-icon" key={i}>
-                  <CWJdenticon address={address.address} size={16} />
-                </div>
-              );
-            }
+            // if so, we display an arbitrary icon based on their non-chain address.
+            const displayAddress =
+              address?.address || profile.Addresses[0].address;
+
+            return (
+              <div className="avatar-group-icon" key={i}>
+                <CWJdenticon address={displayAddress} size={16} />
+              </div>
+            );
           }
         })}
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4477 

## Description of Changes
- Fixes rare user dashboard crash involving posts from addresses outside the community.

## Test Plan
- Reproduced issue locally by dumping beta DB + notifications.
- Ensured dashboard page does not crash post-changes.
- Difficult to reliably test because it involves broken ownership contract. 
