### PR TITLE
Reverted migrating the roll-token bucket to CDN

### DIFF
--- a/packages/commonwealth/server/migrations/20230712170109-undo-tokens-cdn-migration.js
+++ b/packages/commonwealth/server/migrations/20230712170109-undo-tokens-cdn-migration.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `UPDATE "Tokens" SET icon_url = 
+     regexp_replace("icon_url", 'https://assets.commonwealth.im/(.*)', 'https://roll-token.s3.amazonaws.com/\\1')`
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `UPDATE "Tokens" SET icon_url = 
+     regexp_replace("icon_url", 'https://roll-token.s3.amazonaws.com/\\1', 'https://assets.commonwealth.im/(.*)')`
+    );
+  },
+};


### PR DESCRIPTION
## Link to Issue
Hotfix

## Description of Changes
- Adds migration script to revert changes to Tokens table

## Test Plan
- Ran db-all, made sure that a few new urls in Tokens table point to the correct image.