### PR TITLE
Cosmos cache TTL updates

### DIFF
--- a/packages/commonwealth/server/util/cosmosCache.ts
+++ b/packages/commonwealth/server/util/cosmosCache.ts
@@ -5,19 +5,17 @@ const defaultCacheDuration = 60 * 10; // 10 minutes
 
 export function calcCosmosRPCCacheKeyDuration(req, res, next) {
   const body = parseReqBody(req);
-  const params = JSON.stringify(body?.params);
-  const method = body?.method;
 
   // cosmosRPCDuration and cosmosRPCKey are defined below
   // TX Response: do not cache and call next()
-  req.cacheDuration = cosmosRPCDuration(body, method, params);
+  req.cacheDuration = cosmosRPCDuration(body);
   if (req.cacheDuration === null) return next();
   req.cacheKey = cosmosRPCKey(req, body);
 
   return next();
 }
 
-export function calcCosmosLCDCacheKeyDuration(req, res, next) {
+export function cosmosLCDDuration(req) {
   // Matches ProposalStatus from common-common/src/cosmos-ts/src/codegen/cosmos/gov/v1/gov.ts
   const activeProposalCodes = [1, 2]; // ['DepositPeriod', 'VotingPeriod']
   const completedProposalCodes = [3, 4, 5]; // ['Passed', 'Rejected', 'Failed']
@@ -27,68 +25,68 @@ export function calcCosmosLCDCacheKeyDuration(req, res, next) {
 
   if (proposalStatus) {
     if (activeProposalCodes.some((c) => c === +proposalStatus)) {
-      // ACTIVE PROPOSALS: short cache
-      duration = oneBlock;
+      // ACTIVE PROPOSALS: 5 minute cache
+      duration = 60 * 5;
     } else if (completedProposalCodes.some((c) => c === +proposalStatus)) {
       // COMPLETED PROPOSALS: cache 15 minutes
       duration = 60 * 15;
     }
-    // specific proposal request:
-  } else if (url.includes('/proposals/')) {
-    // LIVE VOTES/TALLY/DEPOSITS: 5 minutes
-    duration = 60 * 5;
-  } else if (url.includes('/params/')) {
-    // PARAMS: cache long term (1 day)
-    duration = 60 * 60 * 24;
+  } else if (/\/proposals\/\d+\/(votes|tally|deposits)/.test(url)) {
+    // live proposal voting data: cache 6 seconds
+    duration = oneBlock;
+  } else if (/\/proposals\/(\d+)$/.test(url)) {
+    // specific proposal request: long-term cache (1 week)
+    duration = 60 * 60 * 24 * 7;
+  } else if (url?.includes('/params/')) {
+    // PARAMS: cache long term (5 days)
+    duration = 60 * 60 * 24 * 5;
   }
+  return duration;
+}
 
+export function calcCosmosLCDCacheKeyDuration(req, res, next) {
+  const duration = cosmosLCDDuration(req);
   req.cacheDuration = duration;
   req.cacheKey = req.originalUrl;
-
   return next();
 }
 
-const cosmosRPCDuration = (body, method, params) => {
+export const cosmosRPCDuration = (body) => {
   let duration = defaultCacheDuration;
-  // RPC specific codes from cosmJS requests
-  const activeCodes = ['0801', '0802']; // ['DepositPerion', 'VotingPeriod']
-  const completedCodes = [
-    '0803', // 'Passed'
-    '0804', // 'Rejected'
-    '0805', // 'Failed'
-    '0803220a0a080000000000000087', // 'Passed - Osmosis'
-    '0803220a0a080000000000000100', // 'Passed - Osmosis'
-    '0803220a0a080000000000000189', // 'Passed - Osmosis'
-  ];
 
-  if (/^(tx)/.test(method)) {
+  if (/^(tx)/.test(body?.method)) {
     // TX Response: do not cache
     return null;
-  } else if (/(block|status)/.test(method)) {
+  } else if (/(block|status)/.test(body?.method)) {
     // BLOCK CHECK: short cache
     duration = oneBlock;
-  } else if (/Query\/(Votes|TallyResult|Deposits)/.test(params)) {
-    // LIVE DATA: 5 minutes
-    duration = 60 * 5;
-  } else if (/Query\/(Params|Pool)/.test(params)) {
-    // chain PARAMS: cache long-term (1 day)
-    duration = 60 * 60 * 24;
-  } else if (activeCodes.some((c) => c === body?.params?.data)) {
-    // ACTIVE PROPOSALS: short cache
+  } else if (/Query\/(Proposal)$/.test(body?.params?.path)) {
+    // Individual Proposal: cache long-term (1 week)
+    duration = 60 * 60 * 24 * 7;
+  } else if (/Query\/(Votes|TallyResult|Deposits)/.test(body?.params?.path)) {
+    // LIVE DATA: 6 seconds
     duration = oneBlock;
-  } else if (completedCodes.some((c) => c === body?.params?.data)) {
-    // COMPLETED PROPOSALS: cache 15 minutes
+  } else if (/Query\/(Params|Pool)/.test(body?.params?.path)) {
+    // chain PARAMS: cache long-term (5 days)
+    duration = 60 * 60 * 24 * 5;
+  } else if (/(0801|0802)/.test(body?.params?.data)) {
+    // ACTIVE PROPOSALS: 5 minutes
+    // RPC specific codes from cosmJS requests:
+    // 0801 = 'DepositPeriod', 0802 = 'VotingPeriod'
+    duration = 60 * 5;
+  } else if (/(0803|0804|0805)/.test(body?.params?.data)) {
+    // COMPLETED PROPOSALS: 15 minutes
+    // 0803 = 'Passed', 0804 = 'Rejected', 0805 = 'Failed'
     duration = 60 * 15;
   }
-
   return duration;
 };
 
-const cosmosRPCKey = (req, body) => {
+export const cosmosRPCKey = (req, body) => {
   const params = body?.params;
   let identifier = JSON.stringify(params);
 
-  if (/Query\/(Params|Pool)/.test(identifier)) {
+  if (/Query\/(Params|Pool)/.test(params?.path) && params?.data === '') {
     // chain PARAMS: need to leave off ID to cache long-term
     identifier = params.path;
   }

--- a/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
+++ b/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
@@ -10,7 +10,11 @@ import { RedisNamespaces } from 'common-common/src/types';
 import { cacheDecorator } from 'common-common/src/cacheDecorator';
 import app, { resetDatabase } from '../../../server-test';
 import { connectToRedis } from '../../util/redisUtils';
-import { delay } from '../../util/delayUtils';
+import {
+  cosmosLCDDuration,
+  cosmosRPCDuration,
+  cosmosRPCKey,
+} from 'server/util/cosmosCache';
 
 function verifyNoCacheResponse(res) {
   expect(res.body).to.not.be.null;
@@ -61,123 +65,288 @@ describe('Cosmos Cache', () => {
       await verifyCacheResponse(key, res2, res1);
     }
 
-    const rpcProposalsCacheExpectedTest = async (proposalStatus: string) => {
-      const params = `{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
-      const body = `{"jsonrpc":"2.0","id":382288611593,"method":"abci_query","params":${params}}`;
-      const key = `/cosmosAPI/juno_${params}`;
-      await rpcTestIsCached(body, key);
-    };
+    function rpcTestKeyAndDuration(body, expectedKey, expectedDuration) {
+      const request = {
+        originalUrl: '/cosmosAPI/juno',
+      };
+      const key = cosmosRPCKey(request, body);
+      const duration = cosmosRPCDuration(body);
 
+      expect(key).to.be.equal(expectedKey);
+      expect(duration).to.be.equal(expectedDuration);
+    }
+
+    const rpcProposalsCacheExpectedTest = async (
+      proposalStatus: string,
+      expectedDuration: number
+    ) => {
+      const request = {
+        originalUrl: '/cosmosAPI/juno',
+      };
+      const params = {
+        path: '/cosmos.gov.v1beta1.Query/Proposals',
+        data: proposalStatus,
+        prove: false,
+      };
+      const body = {
+        jsonrpc: '2.0',
+        id: 382288611593,
+        method: 'abci_query',
+        params: params,
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
+
+      const key = cosmosRPCKey(request, body);
+      expect(key).to.be.equal(expectedKey);
+
+      const duration = cosmosRPCDuration(body);
+      expect(duration).to.be.equal(expectedDuration);
+
+      await rpcTestIsCached(bodyString, expectedKey);
+    };
     it('should cache passed proposals', async () => {
-      await rpcProposalsCacheExpectedTest('0803');
+      await rpcProposalsCacheExpectedTest('0803', 60 * 15);
     });
-    it('should cache passed proposals (Osmosis case - 0803220a0a080000000000000087)', async () => {
-      await rpcProposalsCacheExpectedTest('0803220a0a080000000000000087');
+    it('should cache passed proposals (paginated request - 0803220a0a080000000000000087)', async () => {
+      await rpcProposalsCacheExpectedTest(
+        '0803220a0a080000000000000087',
+        60 * 15
+      );
     });
-    it('should cache passed proposals (Osmosis case - 0803220a0a080000000000000100)', async () => {
-      await rpcProposalsCacheExpectedTest('0803220a0a080000000000000100');
+    it('should cache passed proposals (paginated request - 0803220a0a080000000000000100)', async () => {
+      await rpcProposalsCacheExpectedTest(
+        '0803220a0a080000000000000100',
+        60 * 15
+      );
     });
-    it('should cache passed proposals (Osmosis case - 0803220a0a080000000000000189)', async () => {
-      await rpcProposalsCacheExpectedTest('0803220a0a080000000000000189');
+    it('should cache passed proposals (paginated request - 0803220a0a080000000000000189)', async () => {
+      await rpcProposalsCacheExpectedTest(
+        '0803220a0a080000000000000189',
+        60 * 15
+      );
     });
     it('should cache rejected proposals', async () => {
-      await rpcProposalsCacheExpectedTest('0804');
+      await rpcProposalsCacheExpectedTest('0804', 60 * 15);
     });
     it('should cache failed proposals', async () => {
-      await rpcProposalsCacheExpectedTest('0805');
+      await rpcProposalsCacheExpectedTest('0805', 60 * 15);
     });
     it('should cache deposit period proposals', async () => {
-      await rpcProposalsCacheExpectedTest('0801');
-    });
-    it('should cache voting period proposals for short period', async () => {
-      const statusCode = '0802';
-      const body = `{"jsonrpc":"2.0","id":382288611593,"method":"abci_query","params":{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${statusCode}","prove":false}}`;
-      await rpcProposalsCacheExpectedTest(statusCode);
-
-      console.log('waiting 7 seconds');
-      // wait 7 seconds then expect cached request to be expired
-      await delay(7000);
-      const res3 = await makeRPCRequest(body);
-
-      expect(res3).to.have.status(200);
-      expect(res3).to.not.have.header('X-Cache', 'HIT');
-    });
-    it('should cache params requests', async () => {
-      const body =
-        '{"jsonrpc":"2.0","id":533311223528,"method":"abci_query","params":{"path":"/cosmos.staking.v1beta1.Query/Params","data":"","prove":false}}';
-      const key = '/cosmosAPI/juno_/cosmos.staking.v1beta1.Query/Params';
-      await rpcTestIsCached(body, key);
-    });
-    it('should cache pool requests', async () => {
-      const body =
-        '{"jsonrpc":"2.0","id":411681968672,"method":"abci_query","params":{"path":"/cosmos.staking.v1beta1.Query/Pool","data":"","prove":false}}';
-      const key = '/cosmosAPI/juno_/cosmos.staking.v1beta1.Query/Pool';
-      await rpcTestIsCached(body, key);
-    });
-    it('should cache status requests', async () => {
-      const body =
-        '{"jsonrpc":"2.0","id":599352122315,"method":"status","params":{}}';
-      const key =
-        '/cosmosAPI/juno_{"jsonrpc":"2.0","id":599352122315,"method":"status","params":{}}';
-      await rpcTestIsCached(body, key);
-    });
-  });
-  describe('cosmosLCD', () => {
-    const lcdProposalsCacheExpectedTest = async (proposalStatus: string) => {
-      const query = `/cosmosLCD/csdk/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
-      const res1 = await chai.request(app).get(query);
-      await verifyNoCacheResponse(res1);
-
-      const res2 = await chai.request(app).get(query);
-      await verifyCacheResponse(query, res2, res1);
-    };
-
-    const lcdParamsCacheExpectedTest = async (param: string) => {
-      const query = `/cosmosLCD/csdk/cosmos/gov/v1/params/${param}`;
-      const res1 = await chai.request(app).get(query);
-      await verifyNoCacheResponse(res1);
-
-      const res2 = await await chai.request(app).get(query);
-      await verifyCacheResponse(query, res2, res1);
-    };
-
-    it('should cache deposit period proposals for a short period', async () => {
-      const statusCode = '1';
-      const query = `/cosmosLCD/csdk/cosmos/gov/v1/proposals?proposal_status=${statusCode}&voter=&depositor=`;
-      await lcdProposalsCacheExpectedTest(statusCode);
-
-      console.log('waiting 7 seconds');
-      // wait 7 seconds then expect cached request to be expired
-      await delay(7000);
-
-      const res3 = await chai
-        .request(app)
-        .get(query)
-        .set('accept', 'application/json, text/plain, */*');
-
-      expect(res3).to.have.status(200);
-      expect(res3).to.not.have.header('X-Cache', 'HIT');
+      await rpcProposalsCacheExpectedTest('0801', 60 * 5);
     });
     it('should cache voting period proposals', async () => {
-      await lcdProposalsCacheExpectedTest('2');
+      await rpcProposalsCacheExpectedTest('0802', 60 * 5);
+    });
+    it('should cache an individual proposal', async () => {
+      const body = {
+        jsonrpc: '2.0',
+        id: 695367312169,
+        method: 'abci_query',
+        params: {
+          path: '/cosmos.gov.v1beta1.Query/Proposal',
+          data: '08b502',
+          prove: false,
+        },
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey =
+        '/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Proposal","data":"08b502","prove":false}';
+
+      rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 7);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache individual proposal votes', async () => {
+      const params = {
+        path: '/cosmos.gov.v1beta1.Query/Votes',
+        data: '08b502',
+        prove: false,
+      };
+      const body = {
+        jsonrpc: '2.0',
+        id: 382288611593,
+        method: 'abci_query',
+        params: params,
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Votes","data":"08b502","prove":false}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 6);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache chain params requests', async () => {
+      const params = {
+        path: '/cosmos.staking.v1beta1.Query/Params',
+        data: '',
+        prove: false,
+      };
+      const body = {
+        jsonrpc: '2.0',
+        id: 533311223528,
+        method: 'abci_query',
+        params,
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_${params.path}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache chain params requests with specific parameter', async () => {
+      const params = {
+        path: '/cosmos.staking.v1beta1.Query/Params',
+        data: '0a076465706f736974',
+        prove: false,
+      };
+      const body = {
+        jsonrpc: '2.0',
+        id: 533311223528,
+        method: 'abci_query',
+        params,
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_${JSON.stringify(params)}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache pool requests', async () => {
+      const params = {
+        path: '/cosmos.staking.v1beta1.Query/Pool',
+        data: '',
+        prove: false,
+      };
+      const body = {
+        jsonrpc: '2.0',
+        id: 411681968672,
+        method: 'abci_query',
+        params,
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_${params.path}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache status requests', async () => {
+      const body = {
+        jsonrpc: '2.0',
+        id: 927661494768,
+        method: 'status',
+        params: {},
+      };
+      const bodyString = JSON.stringify(body);
+      const expectedKey = `/cosmosAPI/juno_${bodyString}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 6);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+    it('should cache block requests', async () => {
+      const body = {
+        jsonrpc: '2.0',
+        id: 559422771321,
+        method: 'block',
+        params: {},
+      };
+      const bodyString = JSON.stringify(body);
+
+      const expectedKey = `/cosmosAPI/juno_${bodyString}`;
+
+      rpcTestKeyAndDuration(body, expectedKey, 6);
+      await rpcTestIsCached(bodyString, expectedKey);
+    });
+  });
+
+  describe('cosmosLCD', () => {
+    const lcdProposalsCacheExpectedTest = async (
+      proposalStatus: string,
+      expectedDuration: number
+    ) => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
+      lcdTestDuration(expectedDuration, url, {
+        proposal_status: proposalStatus,
+      });
+      await lcdTestIsCached(url);
+    };
+
+    const lcdParamsCacheExpectedTest = async (
+      param: string,
+      expectedDuration: number
+    ) => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/params/${param}`;
+      lcdTestDuration(expectedDuration, url);
+      await lcdTestIsCached(url);
+    };
+
+    async function lcdTestIsCached(url) {
+      const res1 = await chai.request(app).get(url);
+      await verifyNoCacheResponse(res1);
+
+      const res2 = await await chai.request(app).get(url);
+      await verifyCacheResponse(url, res2, res1);
+    }
+
+    function lcdTestDuration(
+      expectedDuration: number,
+      url: string,
+      query?: any
+    ) {
+      const request = {
+        originalUrl: url,
+        url,
+        query,
+      };
+      const duration = cosmosLCDDuration(request);
+      expect(duration).to.be.equal(expectedDuration);
+    }
+
+    it('should cache an individual proposal', async () => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1`;
+
+      lcdTestDuration(60 * 60 * 24 * 7, url);
+      await lcdTestIsCached(url);
+    });
+    it("should cache an individual proposal's live votes", async () => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/votes`;
+
+      lcdTestDuration(6, url);
+      await lcdTestIsCached(url);
+    });
+    it("should cache an individual proposal's live tally", async () => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/tally`;
+
+      lcdTestDuration(6, url);
+      await lcdTestIsCached(url);
+    });
+    it("should cache an individual proposal's live deposits", async () => {
+      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/deposits`;
+
+      lcdTestDuration(6, url);
+      await lcdTestIsCached(url);
+    });
+    it('should cache deposit period proposals', async () => {
+      await lcdProposalsCacheExpectedTest('1', 60 * 5);
+    });
+    it('should cache voting period proposals', async () => {
+      await lcdProposalsCacheExpectedTest('2', 60 * 5);
     });
     it('should cache passed proposals', async () => {
-      await lcdProposalsCacheExpectedTest('3');
+      await lcdProposalsCacheExpectedTest('3', 60 * 15);
     });
     it('should cache rejected proposals', async () => {
-      await lcdProposalsCacheExpectedTest('4');
+      await lcdProposalsCacheExpectedTest('4', 60 * 15);
     });
     it('should cache failed proposals', async () => {
-      await lcdProposalsCacheExpectedTest('5');
+      await lcdProposalsCacheExpectedTest('5', 60 * 15);
     });
     it('should cache deposit params requests', async () => {
-      await lcdParamsCacheExpectedTest('deposit');
+      await lcdParamsCacheExpectedTest('deposit', 60 * 60 * 24 * 5);
     });
     it('should cache tallying params requests', async () => {
-      await lcdParamsCacheExpectedTest('tallying');
+      await lcdParamsCacheExpectedTest('tallying', 60 * 60 * 24 * 5);
     });
     it('should cache voting params requests', async () => {
-      await lcdParamsCacheExpectedTest('voting');
+      await lcdParamsCacheExpectedTest('voting', 60 * 60 * 24 * 5);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4495  
Closes: #4496 

## Description of Changes
- Updates some caching TTL rules and fixes some mistakes
- Long-term caching for individual proposal requests. This data never changes so we can always use cache.
- Fixes: requests for /proposal/votes, /proposal/tally, /proposal/deposit, /proposal/id all have same cache key (which caused #4496) 
- Adds tests to verify cache keys and durations

## Test Plan
- ran proposals.spec.ts E2E tests locally
- Updated cosmosCache.spec.ts tests
- Make sure redis is running and `REDIS_URL=redis://localhost:6379`
- CA (click around) tested on local and frack:
  - Osmosis and Kyve
  - Tested live proposals with http://localhost:8080/csdk and http://localhost:8080/csdk-beta to make sure `proposal/id` and `proposal/id/votes`  (tally, deposits) are on separate cache TTLs.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 