### PR TITLE
Show thread options menu to community admin/moderators on thread details page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -553,6 +553,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       canUpdateThread={
         isLoggedIn &&
         (Permissions.isSiteAdmin() ||
+          Permissions.isCommunityAdmin() ||
+          Permissions.isCommunityModerator() ||
           Permissions.isThreadAuthor(thread) ||
           Permissions.isThreadCollaborator(thread))
       }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4487

## Description of Changes
Fixed the permission check conditions in the thread view page to match the ones already in the thread list page

https://github.com/hicommonwealth/commonwealth/blob/2aa94be415f8c37815bd55d845d2cc1164979baa/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/Card/index.tsx#L63-L68

## Test Plan
Visit `/discussions` and `/discussions/{any thread}` and verify the thread 3-dots menu/button is visible with these account types
- Site admin
- Community Admin
- Community Moderator
- Thread Author (the user who created the thread)
- Thread Collaborator (thread author must assign a collaborator first for this to work)

## Deployment Plan
N/A

## Other Considerations
N/A