### PR TITLE
Fix unit test for delete comment

### DIFF
--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -743,10 +743,13 @@ describe('ServerCommentsController', () => {
 
   describe('#deleteComment', () => {
     it('should delete a comment', async () => {
+      let didDestroy = false;
       const db = {
         Comment: {
           findOne: async () => ({
-            destroy: async () => ({}),
+            destroy: async () => {
+              didDestroy = true;
+            },
           }),
         },
         Subscription: {
@@ -776,6 +779,7 @@ describe('ServerCommentsController', () => {
         chain: chain as any,
         commentId,
       });
+      expect(didDestroy).to.be.true;
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the unit test for deleting a comment– to confirm that the comment is destroyed.