### PR TITLE
Long Topic Name Overflow Bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Select/Select.scss
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.scss
@@ -1,84 +1,91 @@
 @import '../../../../styles/shared';
 
 .Select {
-    display: flex;
-    justify-content: space-between;
-    min-width: 144px;
-    max-width: max(24ch, 264px);
-    text-overflow: ellipsis;
-    cursor: pointer;
-    height: auto !important;
-    background-color: $white;
+  display: flex;
+  justify-content: space-between;
+  min-width: 144px;
+  max-width: max(24ch, 264px);
+  text-overflow: ellipsis;
+  cursor: pointer;
+  height: auto !important;
+  background-color: $white;
+  font-size: 14px !important;
+  border: 1px solid transparent !important;
+  border-radius: $border-radius-md !important;
+  box-shadow: 0 0 0 1px $neutral-200 inset;
+  margin: 0;
+  line-height: 20px;
+  color: $neutral-800 !important;
+
+  &.size-default {
+    padding: 10px 16px !important;
+  }
+
+  &.size-compact {
+    padding: 6px 16px !important;
+  }
+
+  &:hover {
+    border: 1px solid $primary-600 !important;
+  }
+
+  &:active {
+    border: 1px solid $primary-500 !important;
+    box-shadow: 0px 0px 0px 3px $primary-100 !important;
+  }
+
+  .button-text {
+    margin-right: auto;
+    color: $neutral-800 !important;
     font-size: 14px !important;
-    border: 1px solid transparent !important;
-    border-radius: $border-radius-md  !important;
-    box-shadow: 0 0 0 1px $neutral-200 inset;
-    margin: 0;
     line-height: 20px;
-    color: $neutral-800  !important;
-    
-    &.size-default {
-        padding: 10px 16px !important;
-    }
+    letter-spacing: 1%;
+    font-weight: 400;
+    margin-top: 3px;
+  }
 
-    &.size-compact {
-        padding: 6px 16px !important;
-    }
-
-    &:hover {
-        border: 1px solid $primary-600  !important;
-    }
-
-    &:active {
-        border: 1px solid $primary-500  !important;
-        box-shadow: 0px 0px 0px 3px $primary-100 !important;
-    }
-
-    .button-text {
-        margin-right: auto;
-        color: $neutral-800  !important;
-        font-size: 14px !important;
-        line-height: 20px;
-        letter-spacing: 1%;
-        font-weight: 400;
-        margin-top: 3px;
-    }
-
-    &.active {
-        border: 1px solid $primary-500  !important;
-        box-shadow: 0px 0px 0px 3px $primary-100 !important;
-    }
+  &.active {
+    border: 1px solid $primary-500 !important;
+    box-shadow: 0px 0px 0px 3px $primary-100 !important;
+  }
 }
 
 .Select-Options-Wrapper {
-    min-width: 224px;
-    max-width: 320px;
+  min-width: 224px;
+  max-width: 320px;
+  text-overflow: ellipsis;
+  padding: 8px 1px !important;
+  background-color: $white;
+  border-radius: $border-radius-md !important;
+  overflow-y: auto;
+  max-height: 336px;
+  margin-top: 4px;
+  font-size: 14px !important;
+  border: 1px solid $neutral-200 !important;
+  box-shadow: $elevation-6;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  scrollbar-gutter: stable both-edges;
+
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 7px;
+    background-color: rgba(0, 0, 0, 0.5);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+  }
+
+  p {
     text-overflow: ellipsis;
-    padding: 8px 1px !important;
-    background-color: $white;
-    border-radius: $border-radius-md  !important;
-    overflow-y: auto;
-    max-height: 336px;
-    margin-top: 4px;
-    font-size: 14px !important;
-    border: 1px solid $neutral-200  !important;
-    box-shadow: $elevation-6;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    scrollbar-gutter: stable both-edges;
-
-    &::-webkit-scrollbar {
-        -webkit-appearance: none;
-        width: 7px;
-    }
-
-    &::-webkit-scrollbar-track {
-        background-color: transparent;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        border-radius: 7px;
-        background-color: rgba(0, 0, 0, .5);
-        -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
-    }
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4456 

## Description of Changes
- Prevents overflow on topic names in the selector dropdown which was stopping admins from editing names. 

## Test Plan
- Create a long (more than 150px ish) topic name, and see dropdown. Edit button should be present.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 