### PR TITLE
Deleted Thread page fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -92,6 +92,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     useState<CommentsFeaturedFilterTypes>(CommentsFeaturedFilterTypes.Newest);
   const [isReplying, setIsReplying] = useState(false);
   const [parentCommentId, setParentCommentId] = useState(null);
+  const [threadFetchCompleted, setThreadFetchCompleted] = useState(false);
 
   const threadId = identifier.split('-')[0];
   const threadDoesNotMatch =
@@ -190,10 +191,12 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
           setThread(t);
         }
+        setThreadFetchCompleted(true);
       })
       .catch(() => {
         notifyError('Thread not found');
         setThreadFetchFailed(true);
+        setThreadFetchCompleted(true);
       });
   }, [threadId]);
 
@@ -452,6 +455,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   // load app controller
   if (!app.threads.initialized) {
     return <PageLoading />;
+  }
+
+  if (!thread && threadFetchCompleted) {
+    return <PageNotFound />;
   }
 
   if (threadFetchFailed) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4476 

## Description of Changes
- Displays the page not found screen on delete thread pages instead of infinite cow bobber

## Test Plan
- Create a thread, save it's url, delete the thread, return to the url. Should see our 404 page. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 