### PR TITLE
Show truncated cosmos address with prefix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -94,8 +94,9 @@ export const User = ({
     addrShort = formatAddressShort(
       user.address,
       typeof user.chain === 'string' ? user.chain : user.chain?.id,
-      false,
-      maxCharLength
+      true,
+      maxCharLength,
+      app.chain?.meta?.bech32Prefix
     );
 
     friendlyChainName = app.config.chains.getById(
@@ -319,7 +320,13 @@ export const User = ({
                   <>
                     {profile.name}
                     <div className="id-short">
-                      {formatAddressShort(profile.address, profile.chain)}
+                      {formatAddressShort(
+                        profile.address,
+                        profile.chain,
+                        true,
+                        maxCharLength,
+                        app.chain?.meta?.bech32Prefix
+                      )}
                     </div>
                   </>
                 )}
@@ -331,8 +338,9 @@ export const User = ({
               {formatAddressShort(
                 profile.address,
                 profile.chain,
-                false,
-                maxCharLength
+                true,
+                maxCharLength,
+                app.chain?.meta?.bech32Prefix
               )}
             </div>
           )}

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -197,20 +197,19 @@ export function formatAddressShort(
   address: string,
   chain?: string,
   includeEllipsis?: boolean,
-  maxCharLength?: number
+  maxCharLength?: number,
+  prefix?: string
 ) {
   if (!address) return;
   if (chain === 'near') {
     return `@${address}`;
-  } else if (
-    chain === 'straightedge' ||
-    chain === 'cosmoshub' ||
-    chain === 'osmosis' ||
-    chain === 'injective' ||
-    chain === 'injective-testnet' ||
-    chain === 'osmosis-local'
-  ) {
-    return `${address.slice(0, 9)}${includeEllipsis ? '…' : ''}`;
+  } else if (prefix && !maxCharLength) {
+    if (!includeEllipsis) return address;
+    const totalLength = address.length;
+    return `${address.slice(0, prefix.length + 3)}...${address.slice(
+      totalLength - 4,
+      totalLength
+    )}`;
   } else {
     return `${address.slice(0, maxCharLength || 5)}${
       includeEllipsis ? '…' : ''


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4398 

## Description of Changes
- Truncates address on vote result and popover: prefix + 3 chars + ... + last 4 chars:
<img width="353" alt="Screenshot 2023-07-17 at 2 14 08 PM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/2c935d80-683b-4ce8-a1fb-04db363f1b6c">



## Test Plan
- CA (click around) tested on local:
  - http://localhost:8080/osmosis/proposal/565-regular-incentive-adjustment-for-20230717
  - http://localhost:8080/quasar-finance/proposal/5
  
## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- There are other spots in the app (profile chips) where you just see "osmo1" for everybody. We may want to update these too, but maybe at a shorter length than the vote result.