### PR TITLE
3934 design system avatars

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
@@ -10,9 +10,10 @@ enum AvatarSizes {
   Lg = 36,
 
   // TODO: this is to account for sizing in user popover and avatar upload
-  Tmp1 = 32,
-  Tmp2 = 60, 
-  Tmp3 = 108
+  Tmp1 = 18,
+  Tmp2 = 32,
+  Tmp3 = 60,
+  Tmp4 = 108
 };
 
 interface AvatarProps {

--- a/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
@@ -4,9 +4,20 @@ import {
   CWJdenticon,
 } from 'views/components/component_kit/cw_avatar';
 
+enum AvatarSizes {
+  Sm = 16,
+  Med = 24,
+  Lg = 36,
+
+  // TODO: this is to account for sizing in user popover and avatar upload
+  Tmp1 = 32,
+  Tmp2 = 60, 
+  Tmp3 = 108
+};
+
 interface AvatarProps {
   url: string;
-  size?: number;
+  size?: AvatarSizes;
   address?: number;
 }
 

--- a/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Avatar/Avatar.tsx
@@ -7,13 +7,11 @@ import {
 enum AvatarSizes {
   Sm = 16,
   Med = 24,
-  Lg = 36,
+  Lg = 32,
 
-  // TODO: this is to account for sizing in user popover and avatar upload
-  Tmp1 = 18,
-  Tmp2 = 32,
-  Tmp3 = 60,
-  Tmp4 = 108
+  // TODO: this is to account for sizing in the avatar upload
+  Tmp1 = 60,
+  Tmp2 = 108
 };
 
 interface AvatarProps {

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -193,7 +193,7 @@ export const User = ({
     <div className="User avatar-only" key={profile?.address || '-'}>
       <Avatar
         url={profile?.avatarUrl}
-        size={24}
+        size={profile?.avatarUrl ? avatarSize : avatarSize - 4}
         address={profile?.id}
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -193,7 +193,7 @@ export const User = ({
     <div className="User avatar-only" key={profile?.address || '-'}>
       <Avatar
         url={profile?.avatarUrl}
-        size={profile?.avatarUrl ? avatarSize : avatarSize - 4}
+        size={24}
         address={profile?.id}
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -193,7 +193,7 @@ export const User = ({
     <div className="User avatar-only" key={profile?.address || '-'}>
       <Avatar
         url={profile?.avatarUrl}
-        size={profile?.avatarUrl ? avatarSize : avatarSize - 4}
+        size={16}
         address={profile?.id}
       />
     </div>
@@ -295,7 +295,7 @@ export const User = ({
           <div className="user-avatar">
             <Avatar
               url={profile?.avatarUrl}
-              size={profile?.avatarUrl ? 36 : 32}
+              size={32}
               address={profile?.id}
             />
           </div>

--- a/packages/commonwealth/client/styles/components/Profile/ProfileHeader.scss
+++ b/packages/commonwealth/client/styles/components/Profile/ProfileHeader.scss
@@ -30,6 +30,7 @@
       width: 160px;
       border-radius: 50%;
       object-fit: cover;
+      border: solid $neutral-50 2px;
     }
   }
 


### PR DESCRIPTION
Adds specific sizing to Avatar component and adds styling elements to profile page avatar. Does *not* modify all avatars present in the app (updating the sizing in this way results in poor design). 

## Link to Issue
Closes: #3934 

## Description of Changes
- adds sizing to Avatar component. 

## Test Plan
- view code changes