### PR TITLE
Adds Drag and Drop Hover State to QuillEditor

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -44,9 +44,6 @@ export const useImageDropAndPaste = ({
           imageType = 'image/png';
         }
 
-        const selectedIndex =
-          editor.getSelection()?.index || editor.getLength() || 0;
-
         // filter out ops that contain a base64 image
         const opsWithoutBase64Images: DeltaOperation[] = (
           editor.getContents() || []
@@ -72,11 +69,40 @@ export const useImageDropAndPaste = ({
           app.user.jwt
         );
 
+        const selectedIndex: number = editor.getSelection()?.index;
+        const text: string = editor.getText();
+        const blankEditor: boolean = editor.getLength() === 1;
+        const isEndOfLine: boolean = text[selectedIndex].endsWith('\n');
+        var middleOfText: boolean = false;
+
+        // adds line break to insert image above or below text
+        if (!blankEditor) {
+          var lineBreak: string = '\n';
+          if (text[selectedIndex - 1] && text[selectedIndex]) {
+            lineBreak = '\n\n';
+            middleOfText = true;
+          }
+
+          editor.setText(
+            text
+              .slice(0, selectedIndex)
+              .concat(lineBreak)
+              .concat(text.slice(selectedIndex))
+          );
+        } else {
+          editor.setText('\n'.concat(text));
+        }
+
+        const destinationIndex: number =
+          (isEndOfLine && !blankEditor) || middleOfText
+            ? selectedIndex + 1
+            : selectedIndex;
+
         // insert image op at the selected index
         if (isMarkdownEnabled) {
-          editor.insertText(selectedIndex, `![image](${uploadedFileUrl})`);
+          editor.insertText(destinationIndex, `![image](${uploadedFileUrl})`);
         } else {
-          editor.insertEmbed(selectedIndex, 'image', uploadedFileUrl);
+          editor.insertEmbed(destinationIndex, 'image', uploadedFileUrl);
         }
         setContentDelta({
           ...editor.getContents(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4037 

## Description of Changes
- Adds dashed 4, 4 pattern when hovering editor
- Adds placement when image dropped to text

## Test Plan
- dropping image on blank editor
- dropping image on beginning of line
- dropping image on end of line
- dropping image in the middle of line of text