### PR TITLE
Fix sidebar z-index

### DIFF
--- a/packages/commonwealth/client/styles/components/sidebar/index.scss
+++ b/packages/commonwealth/client/styles/components/sidebar/index.scss
@@ -81,7 +81,7 @@
   .ExploreCommunitiesSidebar {
     // display: block;
     position: absolute;
-    z-index: 1000;
+    z-index: 70;
 
     animation: slidein 0.2s ease-in-out;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4503

## Description of Changes
Updated sidebar z-index from `1000` to `70`

## Test Plan
- Logout
- Go to any community
- Open the sidebar
- Now open the login login
- Verify that the sidebar is below the login modal (or the login modal overlay covers the sidebar)

## Deployment Plan
N/A

## Other Considerations
N/A