### PR TITLE
fix CSS for loading indicator

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -123,7 +123,7 @@
   }
 
   .LoadingIndicator {
-    position: relative;
+    position: absolute;
     left: 50%;
     top: calc(50% + 15px);
 


### PR DESCRIPTION
Fixes loading indicator position bug that was identified here: https://github.com/hicommonwealth/commonwealth/pull/4517

<img width="754" alt="CleanShot 2023-07-20 at 10 51 38@2x" src="https://github.com/hicommonwealth/commonwealth/assets/126922418/33bea953-0626-4132-94df-467057045265">
