### PR TITLE
Fix incorrect reaction removal on details page

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/threads.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/threads.ts
@@ -18,7 +18,7 @@ import type ChainEntity from '../../models/ChainEntity';
 import type MinimumProfile from '../../models/MinimumProfile';
 import NotificationSubscription from '../../models/NotificationSubscription';
 import Poll from '../../models/Poll';
-import Thread, { AssociatedReaction } from '../../models/Thread';
+import Thread from '../../models/Thread';
 import Topic from '../../models/Topic';
 import {
   ThreadFeaturedFilterTypes,
@@ -69,20 +69,6 @@ class ThreadsController {
   private readonly _listingStore: RecentListingStore;
   private readonly _overviewStore: ProposalStore<Thread>;
   public isFetched = new EventEmitter();
-  private _threadIdToReactions: Map<number, AssociatedReaction[]> = new Map<
-    number,
-    AssociatedReaction[]
-  >();
-
-  public refreshReactionsFromThreads(threads: Thread[]) {
-    threads.forEach((t) => {
-      this._threadIdToReactions.set(t.id, t.associatedReactions);
-    });
-  }
-
-  public get threadIdToReactions() {
-    return this._threadIdToReactions;
-  }
 
   private constructor() {
     this._store = new ProposalStore<Thread>();
@@ -169,8 +155,8 @@ class ThreadsController {
         app.comments.reactionsStore.add(modelReactionFromServer(reaction));
       }
       reactionIds = reactions.map((r) => r.id);
-      reactionType = reactions.map((r) => r.type);
-      addressesReacted = reactions.map((r) => r.address);
+      reactionType = reactions.map((r) => r?.type || r?.reaction);
+      addressesReacted = reactions.map((r) => r?.address || r?.Address?.address);
     }
 
     let versionHistoryProcessed;
@@ -507,8 +493,7 @@ class ThreadsController {
   public async setArchived(threadId: number, isArchived: boolean) {
     return new Promise((resolve, reject) => {
       $.post(
-        `${app.serverUrl()}/threads/${threadId}/${
-          !isArchived ? 'archive' : 'unarchive'
+        `${app.serverUrl()}/threads/${threadId}/${!isArchived ? 'archive' : 'unarchive'
         }`,
         {
           jwt: app.user.jwt,
@@ -765,10 +750,13 @@ class ThreadsController {
         ...((foundThread || {}) as any),
         ...((thread || {}) as any),
       });
-      finalThread.associatedReactions =
-        thread.associatedReactions.length > 0
-          ? thread.associatedReactions
-          : foundThread?.associatedReactions || [];
+      finalThread.associatedReactions = [
+        ...(
+          thread.associatedReactions.length > 0
+            ? thread.associatedReactions
+            : foundThread?.associatedReactions || []
+        )
+      ];
       finalThread.numberOfComments =
         rawThread?.numberOfComments || foundThread?.numberOfComments || 0;
       this._store.update(finalThread);
@@ -933,8 +921,6 @@ class ThreadsController {
     const modeledThreads: Thread[] = threads.map((t) => {
       return this.modelFromServer(t);
     });
-
-    this.refreshReactionsFromThreads(modeledThreads)
 
     modeledThreads.forEach((thread) => {
       try {

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -42,24 +42,8 @@ const useCreateThreadReactionMutation = () => {
   return useMutation({
     mutationFn: createReaction,
     onSuccess: async (response) => {
-      const reaction = response.data.result
-      const formattedReaction = {
-        id: reaction.id + '',
-        type: reaction.reaction,
-        address: reaction.Address.address
-      }
-
-      // TODO: this state below would be stored in threads react query state when we migrate the
-      // whole thread controller from current state to react query
-      const existingReactions = app.threads.threadIdToReactions.get(reaction.thread_id)
-      if (!existingReactions) {
-        app.threads.threadIdToReactions.set(reaction.thread_id, [formattedReaction]);
-      } else {
-        app.threads.threadIdToReactions.set(reaction.thread_id, [
-          ...existingReactions,
-          formattedReaction
-        ]);
-      }
+      // TODO: when we migrate the reactionCounts store proper to react query
+      // then we will have to update the react query state here
     },
   });
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -41,16 +41,8 @@ const useDeleteThreadReactionMutation = () => {
   return useMutation({
     mutationFn: deleteReaction,
     onSuccess: async (response) => {
-      // TODO: this state below would be stored in threads react query state when we migrate the
-      // whole thread controller from current state to react query
-      const reaction = response.data.result
-
-      app.threads.threadIdToReactions.set(
-        reaction.thread_id,
-        [...(app.threads.threadIdToReactions
-          .get(reaction.thread_id)
-          ?.filter((r) => r.id !== reaction.reaction_id + '') || [])]
-      );
+      // TODO: when we migrate the reactionCounts store proper to react query
+      // then we will have to update the react query state here
     }
   });
 };

--- a/packages/commonwealth/client/scripts/stores/Store.ts
+++ b/packages/commonwealth/client/scripts/stores/Store.ts
@@ -17,7 +17,7 @@ abstract class Store<T> {
         ? this._store.splice(options.pushToIndex, 0, item)
         : this._store.push(item);
     } else {
-      this._store[index] = item;
+      this._store[index] = {...item};
     }
 
     return this;

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -180,20 +180,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       .fetchThreadsFromId([+threadId])
       .then((res) => {
         const t = res[0];
-        if (t) {
-          const reactions = app.comments.getReactionByPost(t);
-          t.associatedReactions = reactions
-            .filter((r) => r.reaction === 'like')
-            .map((r) => {
-              return {
-                id: r.id,
-                type: 'like',
-                address: r.author,
-              };
-            });
-
-          setThread(t);
-        }
+        if (t) setThread(t);
         setThreadFetchCompleted(true);
       })
       .catch(() => {
@@ -757,65 +744,65 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           [
             ...(showLinkedProposalOptions || showLinkedThreadOptions
               ? [
-                  {
-                    label: 'Links',
-                    item: (
-                      <div className="cards-column">
-                        {showLinkedProposalOptions && (
-                          <LinkedProposalsCard
-                            onChangeHandler={handleLinkedProposalChange}
-                            thread={thread}
-                            showAddProposalButton={isAuthor || isAdminOrMod}
-                          />
-                        )}
-                        {showLinkedThreadOptions && (
-                          <LinkedThreadsCard
-                            thread={thread}
-                            allowLinking={isAuthor || isAdminOrMod}
-                            onChangeHandler={handleLinkedThreadChange}
-                          />
-                        )}
-                      </div>
-                    ),
-                  },
-                ]
+                {
+                  label: 'Links',
+                  item: (
+                    <div className="cards-column">
+                      {showLinkedProposalOptions && (
+                        <LinkedProposalsCard
+                          onChangeHandler={handleLinkedProposalChange}
+                          thread={thread}
+                          showAddProposalButton={isAuthor || isAdminOrMod}
+                        />
+                      )}
+                      {showLinkedThreadOptions && (
+                        <LinkedThreadsCard
+                          thread={thread}
+                          allowLinking={isAuthor || isAdminOrMod}
+                          onChangeHandler={handleLinkedThreadChange}
+                        />
+                      )}
+                    </div>
+                  ),
+                },
+              ]
               : []),
             ...(polls?.length > 0 ||
-            (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
+              (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
               ? [
-                  {
-                    label: 'Polls',
-                    item: (
-                      <div className="cards-column">
-                        {[
-                          ...new Map(
-                            polls?.map((poll) => [poll.id, poll])
-                          ).values(),
-                        ].map((poll: Poll) => {
-                          return (
-                            <ThreadPollCard
-                              poll={poll}
-                              key={poll.id}
-                              onVote={() => setInitializedPolls(false)}
-                              showDeleteButton={isAuthor || isAdmin}
-                              onDelete={() => {
-                                setInitializedPolls(false);
-                              }}
-                            />
-                          );
-                        })}
-                        {isAuthor &&
-                          (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
-                            <ThreadPollEditorCard
-                              thread={thread}
-                              threadAlreadyHasPolling={!polls?.length}
-                              onPollCreate={() => setInitializedPolls(false)}
-                            />
-                          )}
-                      </div>
-                    ),
-                  },
-                ]
+                {
+                  label: 'Polls',
+                  item: (
+                    <div className="cards-column">
+                      {[
+                        ...new Map(
+                          polls?.map((poll) => [poll.id, poll])
+                        ).values(),
+                      ].map((poll: Poll) => {
+                        return (
+                          <ThreadPollCard
+                            poll={poll}
+                            key={poll.id}
+                            onVote={() => setInitializedPolls(false)}
+                            showDeleteButton={isAuthor || isAdmin}
+                            onDelete={() => {
+                              setInitializedPolls(false);
+                            }}
+                          />
+                        );
+                      })}
+                      {isAuthor &&
+                        (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
+                          <ThreadPollEditorCard
+                            thread={thread}
+                            threadAlreadyHasPolling={!polls?.length}
+                            onPollCreate={() => setInitializedPolls(false)}
+                          />
+                        )}
+                    </div>
+                  ),
+                },
+              ]
               : []),
           ] as SidebarComponents
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4556

## Description of Changes
Now updates the thread reaction state properly. Also removed some unused state.


https://github.com/hicommonwealth/commonwealth/assets/51641047/d2692af0-ffec-475e-8cfa-d01b1e056891



## Test Plan

1. React to a thread from the topic view.
2. Click into the thread and un-react.
3. Click back onto the topic via the sidebar.
4. Click back into the thread -- you will see the reaction is still showing inside the thread.
5. Clicking to un-react again causes an error (invalid state)

## Deployment Plan
N/A

## Other Considerations
N/A
