### PR TITLE
Makes Electron Desktop App be draggable

### DIFF
--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -126,3 +126,7 @@ pre {
   height: 100vh;
   width: 100%;
 }
+
+html.todesktop .header {
+  -webkit-app-region: drag;
+}


### PR DESCRIPTION
Right now if you use the pre-alpha ToDesktop App. The screen stays fixed on screen. Following instructions [here](https://www.todesktop.com/docs/recipes/make-a-transparent-titlebar-draggable), this fixes the issue.

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 