### PR TITLE
Fix login modal in not-yet-joined community.

### DIFF
--- a/packages/commonwealth/server/util/createAddressHelper.ts
+++ b/packages/commonwealth/server/util/createAddressHelper.ts
@@ -196,9 +196,10 @@ export async function createAddressHelper(
         isCustomDomain: null,
       });
 
-      const isNewlyCreatedAddress = existingAddressOnOtherChain ? false : true;
-
-      return { ...newObj.toJSON(), newly_created: isNewlyCreatedAddress };
+      return {
+        ...newObj.toJSON(),
+        newly_created: !existingAddressOnOtherChain,
+      };
     } catch (e) {
       return next(e);
     }

--- a/packages/commonwealth/server/util/createAddressHelper.ts
+++ b/packages/commonwealth/server/util/createAddressHelper.ts
@@ -11,6 +11,7 @@ import type { DB } from '../models';
 import { addressSwapper } from '../../shared/utils';
 import { Errors } from '../routes/createAddress';
 import { serverAnalyticsTrack } from '../../shared/analytics/server-track';
+import { Op } from 'sequelize';
 
 type CreateAddressReq = {
   address: string;
@@ -93,6 +94,12 @@ export async function createAddressHelper(
       where: { chain: req.chain, address: encodedAddress },
     }
   );
+
+  const existingAddressOnOtherChain = await models.Address.scope(
+    'withPrivateData'
+  ).findOne({
+    where: { chain: { [Op.ne]: req.chain }, address: encodedAddress },
+  });
 
   if (existingAddress) {
     // address already exists on another user, only take ownership if
@@ -189,7 +196,9 @@ export async function createAddressHelper(
         isCustomDomain: null,
       });
 
-      return { ...newObj.toJSON(), newly_created: true };
+      const isNewlyCreatedAddress = existingAddressOnOtherChain ? false : true;
+
+      return { ...newObj.toJSON(), newly_created: isNewlyCreatedAddress };
     } catch (e) {
       return next(e);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4540 

## Description of Changes
- Ensures that if a user already has an address on the site/another community on the site, and then tries to log in with that address on a community page where they _aren't_ a member, the UI will not prompt them to "create new" or "link account".

## Test Plan
- Log into community 1 with address X. Then log out, visit community 2 (same chain base) and attempt to login with address X again. Should just log the user in without any intermediate modal steps. 
 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 