### PR TITLE
Template link display POC

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -27,10 +27,17 @@ export enum LinkSource {
   Template = 'template',
 }
 
+export enum LinkDisplay {
+  inline = 'inline',
+  sidebar = 'sidebar',
+  both = 'both',
+}
+
 export type Link = {
   source: LinkSource;
   identifier: string;
   title?: string;
+  display?: LinkDisplay;
 };
 
 export class Thread implements IUniqueId {

--- a/packages/commonwealth/client/scripts/views/modals/template_action_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/template_action_modal.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import 'modals/template_action_modal.scss';
 
 import app from 'state';
-import Thread, { Link, LinkSource } from '../../models/Thread';
+import Thread, { Link, LinkDisplay, LinkSource } from '../../models/Thread';
 import { filterLinks, getAddedAndDeleted } from '../../helpers/threads';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
 import { TemplateSelector } from '../components/template_action_selector';
@@ -12,6 +12,7 @@ import { CWButton } from '../components/component_kit/cw_button';
 type TemplateFormModalProps = {
   isOpen: boolean;
   thread: Thread; // Pass the thread content to the form
+  display: LinkDisplay;
   onSave: (link?: Link[]) => void;
   onClose: () => void;
 };
@@ -25,6 +26,7 @@ const getInitialTemplates = (thread: Thread) =>
 export const TemplateActionModal = ({
   isOpen,
   thread,
+  display,
   onSave,
   onClose,
 }: TemplateFormModalProps) => {
@@ -97,6 +99,7 @@ export const TemplateActionModal = ({
             source: LinkSource.Template,
             identifier: newIdentifier,
             title: title,
+            display: display,
           };
         });
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -25,7 +25,7 @@ import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 import NewProfilesController from '../../../controllers/server/newProfiles';
 import Comment from '../../../models/Comment';
 import Poll from '../../../models/Poll';
-import { Link, LinkSource, Thread } from '../../../models/Thread';
+import { Link, LinkDisplay, LinkSource, Thread } from '../../../models/Thread';
 import Topic from '../../../models/Topic';
 import {
   CommentsFeaturedFilterTypes,
@@ -95,7 +95,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     useState<CommentsFeaturedFilterTypes>(CommentsFeaturedFilterTypes.Newest);
   const [isReplying, setIsReplying] = useState(false);
   const [parentCommentId, setParentCommentId] = useState(null);
-  const [hideTemplate, setHideTemplate] = useState(false);
 
   const threadId = identifier.split('-')[0];
   const threadDoesNotMatch =
@@ -669,25 +668,14 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           ) : (
             <>
               <QuillRenderer doc={thread.body} cutoffLines={50} />
-              {showLinkedTemplateOptions && !hideTemplate && (
-                <ViewTemplateForm
-                  address={linkedTemplates[0]?.identifier.split('/')[1]}
-                  slug={linkedTemplates[0]?.identifier.split('/')[2]}
-                  setTemplateNickname={null}
-                />
-              )}
-              {hideTemplate ? (
-                <CWText
-                  type="buttonMini"
-                  onClick={() => setHideTemplate(false)}
-                >
-                  Show transaction template
-                </CWText>
-              ) : (
-                <CWText type="buttonMini" onClick={() => setHideTemplate(true)}>
-                  Hide transaction template
-                </CWText>
-              )}
+              {showLinkedTemplateOptions &&
+                linkedTemplates[0]?.display !== LinkDisplay.sidebar && (
+                  <ViewTemplateForm
+                    address={linkedTemplates[0]?.identifier.split('/')[1]}
+                    slug={linkedTemplates[0]?.identifier.split('/')[2]}
+                    setTemplateNickname={null}
+                  />
+                )}
               {thread.readOnly ? (
                 <>
                   {threadOptionsComp}
@@ -831,7 +819,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 },
               ]
             : []),
-          ...(showLinkedTemplateOptions && hideTemplate
+          ...(showLinkedTemplateOptions &&
+          linkedTemplates[0]?.display !== LinkDisplay.inline
             ? [
                 {
                   label: 'View Template',

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/template_action_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/template_action_card.tsx
@@ -1,22 +1,79 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWContentPageCard } from '../../components/component_kit/cw_content_page';
 import { TemplateActionModal } from '../../modals/template_action_modal'; // Import the new modal component
 
 import 'pages/view_thread/template_action_card.scss';
-import Thread, { Link } from 'client/scripts/models/Thread';
+import Thread, { Link, LinkDisplay, LinkSource } from 'models/Thread';
 import { Modal } from '../../components/component_kit/cw_modal';
+import {
+  CWDropdown,
+  DropdownItemType,
+} from '../../components/component_kit/cw_dropdown';
+import { filterLinks } from 'helpers/threads';
+import app from 'state';
 
 type TemplateActionCardProps = {
   thread: Thread; // Pass the thread content to the modal
   onChangeHandler: (links?: Link[]) => void;
 };
+const dropdownOptions: DropdownItemType[] = [
+  {
+    label: 'sidebar',
+    value: LinkDisplay.sidebar,
+  },
+  {
+    label: 'in-line',
+    value: LinkDisplay.inline,
+  },
+  {
+    label: 'inline and sidebar',
+    value: LinkDisplay.both,
+  },
+];
 
 export const TemplateActionCard = ({
   thread,
   onChangeHandler,
 }: TemplateActionCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedDisplay, setSelectedDisplay] = useState<DropdownItemType>(
+    dropdownOptions[0]
+  );
+  const [initialTemplates, setInitialTemplates] = useState<Link[]>([]);
+
+  useEffect(() => {
+    const initLinks = filterLinks(thread.links, LinkSource.Template);
+    setInitialTemplates(initLinks);
+    if (initLinks.length > 0) {
+      setSelectedDisplay(
+        dropdownOptions.find((o) => o.value === initLinks[0].display)
+      );
+    }
+  }, []);
+
+  const onDisplayChange = async (selected: DropdownItemType) => {
+    if (selected.value !== initialTemplates[0].display) {
+      await app.threads.deleteLinks({
+        threadId: thread.id,
+        links: initialTemplates,
+      });
+      const newThread = await app.threads.addLinks({
+        threadId: thread.id,
+        links: initialTemplates.map((t) => {
+          return {
+            identifier: t.identifier,
+            source: t.source,
+            title: t.title,
+            display: selected.value,
+          };
+        }),
+      });
+      const newLinks = newThread.links;
+      setInitialTemplates(filterLinks(newLinks, LinkSource.Template));
+      onChangeHandler(newLinks);
+    }
+  };
 
   return (
     <div>
@@ -29,6 +86,14 @@ export const TemplateActionCard = ({
               label="Add Template"
               onClick={() => setIsModalOpen(true)}
             />
+            {initialTemplates.length > 0 && (
+              <CWDropdown
+                label="Display Options"
+                options={dropdownOptions}
+                initialValue={selectedDisplay}
+                onSelect={(o) => onDisplayChange(o)}
+              />
+            )}
           </div>
         }
       />
@@ -37,6 +102,7 @@ export const TemplateActionCard = ({
           <TemplateActionModal
             isOpen={isModalOpen}
             thread={thread}
+            display={selectedDisplay.value as LinkDisplay}
             onSave={() => onChangeHandler}
             onClose={() => setIsModalOpen(false)}
           />

--- a/packages/commonwealth/client/styles/components/component_kit/cw_dropdown.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_dropdown.scss
@@ -9,9 +9,9 @@
     box-shadow: $elevation-3;
     margin-top: 5px;
     overflow: hidden;
-    position: absolute;
+    position: relative;
     width: 100%;
-    z-index: 1001;
+    z-index: 5000;
 
     .dropdown-item {
       align-items: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4560  

## Description of Changes
- Adds a display option to `Links` model with the following enum values
    - inline
    - sidebar
    - both
- adds a dropdown component to template card to select display
- allows new links to be set with display option as the current selected value
- Reactive updates to optimistically update UI

## Test Plan
- Add a template link
- select inline
- select both
- create a new link with both
- ensure expected placement of all above

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This only effects Template links as far as functionality although the display attribute will be added to all links for future use. Further discussion required as to what to do with other links re: display