### PR TITLE
Database Cleaner Updates

### DIFF
--- a/packages/common-common/src/redisCache.ts
+++ b/packages/common-common/src/redisCache.ts
@@ -7,7 +7,6 @@ import {
 import type { RedisNamespaces } from './types';
 import type Rollbar from 'rollbar';
 import { factory, formatFilename } from 'common-common/src/logging';
-import { SetOptions } from 'sequelize';
 
 const log = factory.getLogger(formatFilename(__filename));
 

--- a/packages/common-common/src/redisCache.ts
+++ b/packages/common-common/src/redisCache.ts
@@ -164,8 +164,8 @@ export class RedisCache {
       return false;
     }
 
-    // redis returns 'Ok' on successful write but if nothing is updated e.g. NX true then it returns null
-    return res === 'Ok';
+    // redis returns 'OK' on successful write but if nothing is updated e.g. NX true then it returns null
+    return res === 'OK';
   }
 
   public async getKey(

--- a/packages/common-common/src/types.ts
+++ b/packages/common-common/src/types.ts
@@ -136,6 +136,7 @@ export enum RedisNamespaces {
   Function_Response = 'function_response',
   Global_Response = 'global_response',
   Test_Redis = 'test_redis',
+  Database_Cleaner = 'database_cleaner',
 }
 
 export interface ISnapshotNotification {

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -43,7 +43,7 @@
     "psql": "chmod u+x scripts/start-psql.sh && ./scripts/start-psql.sh",
     "dump-db": "pg_dump $(heroku config:get CW_READ_DB -a commonwealth-beta) --verbose --exclude-table-data=\"public.\\\"Subscriptions\\\"\" --exclude-table-data=\"public.\\\"Sessions\\\"\" --exclude-table-data=\"public.\\\"DiscussionDrafts\\\"\" --exclude-table-data=\"public.\\\"LoginTokens\\\"\" --exclude-table-data=\"public.\\\"Notifications\\\"\" --exclude-table-data=\"public.\\\"SocialAccounts\\\"\" --exclude-table-data=\"public.\\\"Webhooks\\\"\" --exclude-table-data=\"public.\\\"NotificationsRead\\\"\" --no-privileges --no-owner -f latest.dump",
     "datadog-db-setup": "chmod u+x scripts/setup-datadog-postgres.sh && ./scripts/setup-datadog-postgres.sh",
-    "clean-db": "ts-node --project tsconfig.json server/util/databaseCleaner.ts",
+    "clean-db": "ts-node --project tsconfig.json server/scripts/cleanDb.ts",
     "reset-db": "chmod u+x scripts/reset-db.sh && ./scripts/reset-db.sh",
     "load-db": "chmod u+x scripts/load-db.sh && ./scripts/load-db.sh",
     "load-db-local": "psql -h localhost -d commonwealth -U commonwealth -W -f local_save.dump",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -43,6 +43,7 @@
     "psql": "chmod u+x scripts/start-psql.sh && ./scripts/start-psql.sh",
     "dump-db": "pg_dump $(heroku config:get CW_READ_DB -a commonwealth-beta) --verbose --exclude-table-data=\"public.\\\"Subscriptions\\\"\" --exclude-table-data=\"public.\\\"Sessions\\\"\" --exclude-table-data=\"public.\\\"DiscussionDrafts\\\"\" --exclude-table-data=\"public.\\\"LoginTokens\\\"\" --exclude-table-data=\"public.\\\"Notifications\\\"\" --exclude-table-data=\"public.\\\"SocialAccounts\\\"\" --exclude-table-data=\"public.\\\"Webhooks\\\"\" --exclude-table-data=\"public.\\\"NotificationsRead\\\"\" --no-privileges --no-owner -f latest.dump",
     "datadog-db-setup": "chmod u+x scripts/setup-datadog-postgres.sh && ./scripts/setup-datadog-postgres.sh",
+    "clean-db": "ts-node --project tsconfig.json server/util/databaseCleaner.ts",
     "reset-db": "chmod u+x scripts/reset-db.sh && ./scripts/reset-db.sh",
     "load-db": "chmod u+x scripts/load-db.sh && ./scripts/load-db.sh",
     "load-db-local": "psql -h localhost -d commonwealth -U commonwealth -W -f local_save.dump",

--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -52,9 +52,7 @@ import devWebpackConfig from './webpack/webpack.dev.config.js';
 import prodWebpackConfig from './webpack/webpack.prod.config.js';
 import * as v8 from 'v8';
 import { factory, formatFilename } from 'common-common/src/logging';
-import DatabaseCleaner, {
-  databaseCleaner,
-} from './server/util/databaseCleaner';
+import { databaseCleaner } from './server/util/databaseCleaner';
 import { RedisCache } from 'common-common/src/redisCache';
 
 const log = factory.getLogger(formatFilename(__filename));

--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -25,9 +25,11 @@ import setupErrorHandlers from '../common-common/src/scripts/setupErrorHandlers'
 import {
   DATABASE_CLEAN_HOUR,
   RABBITMQ_URI,
+  REDIS_URL,
   ROLLBAR_ENV,
   ROLLBAR_SERVER_TOKEN,
   SESSION_SECRET,
+  VULTR_IP,
 } from './server/config';
 import models from './server/database';
 import DatabaseValidationService from './server/middleware/databaseValidationService';
@@ -50,7 +52,10 @@ import devWebpackConfig from './webpack/webpack.dev.config.js';
 import prodWebpackConfig from './webpack/webpack.prod.config.js';
 import * as v8 from 'v8';
 import { factory, formatFilename } from 'common-common/src/logging';
-import DatabaseCleaner from './server/util/databaseCleaner';
+import DatabaseCleaner, {
+  databaseCleaner,
+} from './server/util/databaseCleaner';
+import { RedisCache } from 'common-common/src/redisCache';
 
 const log = factory.getLogger(formatFilename(__filename));
 // set up express async error handling hack
@@ -261,6 +266,9 @@ async function main() {
     // TODO: this requires an immediate response if in production
   }
 
+  const redisCache = new RedisCache();
+  await redisCache.init(REDIS_URL, VULTR_IP);
+
   if (!NO_TOKEN_BALANCE_CACHE) await tokenBalanceCache.start();
   const banCache = new BanCache(models);
   const globalActivityCache = new GlobalActivityCache(models);
@@ -295,12 +303,13 @@ async function main() {
 
   setupErrorHandlers(app, rollbar);
 
-  setupServer(app, rollbar, models, rabbitMQController);
+  setupServer(app, rollbar, models, rabbitMQController, redisCache);
 
   // database clean-up jobs (should be run after the API so, we don't affect start-up time
-  const databaseCleaner = new DatabaseCleaner(
+  databaseCleaner.initLoop(
     models,
     Number(DATABASE_CLEAN_HOUR),
+    redisCache,
     rollbar
   );
 }

--- a/packages/commonwealth/server/scripts/cleanDb.ts
+++ b/packages/commonwealth/server/scripts/cleanDb.ts
@@ -1,0 +1,14 @@
+import { factory, formatFilename } from 'common-common/src/logging';
+import { databaseCleaner } from 'commonwealth/server/util/databaseCleaner';
+import models from '../database';
+
+const log = factory.getLogger(formatFilename(__filename));
+databaseCleaner.init(models);
+databaseCleaner
+  .executeQueries()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    log.error(`Failed to clean the database.`, err);
+  });

--- a/packages/commonwealth/server/scripts/setupServer.ts
+++ b/packages/commonwealth/server/scripts/setupServer.ts
@@ -7,6 +7,8 @@ import { PORT } from '../config';
 import type { DB } from '../models';
 import { setupWebSocketServer } from '../socket';
 import { factory, formatFilename } from 'common-common/src/logging';
+import { RedisCache } from 'common-common/src/redisCache';
+import { cacheDecorator } from 'common-common/src/cacheDecorator';
 
 const log = factory.getLogger(formatFilename(__filename));
 
@@ -14,11 +16,13 @@ const setupServer = (
   app: Express,
   rollbar: Rollbar,
   models: DB,
-  rabbitMQController: RabbitMQController
+  rabbitMQController: RabbitMQController,
+  redisCache: RedisCache
 ) => {
   app.set('port', PORT);
   const server = http.createServer(app);
   setupWebSocketServer(server, rollbar, models, rabbitMQController);
+  cacheDecorator.setCache(redisCache);
 
   const onError = (error) => {
     if (error.syscall !== 'listen') {

--- a/packages/commonwealth/server/socket/index.ts
+++ b/packages/commonwealth/server/socket/index.ts
@@ -3,8 +3,7 @@ import { createAdapter } from '@socket.io/redis-adapter';
 import { factory, formatFilename } from 'common-common/src/logging';
 import type { RabbitMQController } from 'common-common/src/rabbitmq';
 import { RascalSubscriptions } from 'common-common/src/rabbitmq/types';
-import { RedisCache, redisRetryStrategy } from 'common-common/src/redisCache';
-import { cacheDecorator } from 'common-common/src/cacheDecorator';
+import { redisRetryStrategy } from 'common-common/src/redisCache';
 import { StatsDController } from 'common-common/src/statsd';
 import type * as http from 'http';
 import * as jwt from 'jsonwebtoken';
@@ -194,12 +193,6 @@ export async function setupWebSocketServer(
 
   // provide the redis connection instances to the socket.io adapters
   await io.adapter(<any>createAdapter(pubClient, subClient));
-
-  const redisCache = new RedisCache();
-  console.log('Initializing Redis Cache for WebSockets...');
-  await redisCache.init(REDIS_URL, VULTR_IP);
-  console.log('Redis Cache initialized!');
-  cacheDecorator.setCache(redisCache);
 
   const chainEventsNamespace = createNamespace(
     io,

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -2,6 +2,10 @@ import type { DB } from '../models';
 import { factory, formatFilename } from 'common-common/src/logging';
 import { QueryTypes } from 'sequelize';
 import Rollbar from 'rollbar';
+import { RedisCache } from 'common-common/src/redisCache';
+import { v4 as uuidv4 } from 'uuid';
+import { RedisNamespaces } from 'common-common/src/types';
+import models from '../database';
 
 /**
  * This class hosts a series of 'cleaner' functions that delete unnecessary data from the database. The class schedules
@@ -10,26 +14,39 @@ import Rollbar from 'rollbar';
  */
 export default class DatabaseCleaner {
   private readonly log = factory.getLogger(formatFilename(__filename));
-  private readonly _models: DB;
-  private readonly _rollbar?: Rollbar;
-  private readonly _timeToRun: Date;
+  private _models: DB;
+  private _redisCache: RedisCache;
+  private _rollbar?: Rollbar;
+  private _timeToRun: Date;
   private _completed = false;
+  private _oneRunMax = false;
   private _timeoutID;
+  private lockName = 'cw_database_cleaner_locker';
+  // lock times out in 2 hours
+  private lockTimeoutSeconds = 7200;
+
+  public init(models: DB, rollbar?: Rollbar) {
+    this._models = models;
+    this._rollbar = rollbar;
+  }
 
   /**
    * @param models An instance of the DB containing the sequelize instance and all the models.
    * @param hourToRun A number in [0, 24) indicating the hour in which to run the cleaner. Uses UTC!
+   * @param redisCache An instance of RedisCache used for locking a key that ensures only 1 dbCleaner is running.
    * @param rollbar A rollbar instance to report errors
    * @param oneRunMax If set to true the database clean will only occur once and will not be re-scheduled
    */
-  constructor(
+  public async initLoop(
     models: DB,
     hourToRun: number,
+    redisCache: RedisCache,
     rollbar?: Rollbar,
     oneRunMax = false
   ) {
-    this._models = models;
-    this._rollbar = rollbar;
+    this.init(models, rollbar);
+    this._redisCache = redisCache;
+    this._oneRunMax = oneRunMax;
 
     if (!hourToRun) {
       this.log.warn(`No hourToRun given. The cleaner will not run.`);
@@ -53,39 +70,54 @@ export default class DatabaseCleaner {
     this._timeToRun.setUTCMinutes(0);
     this._timeToRun.setUTCMilliseconds(0);
 
-    this._timeoutID = setTimeout(
-      this.start.bind(this),
-      this.getTimeout(),
-      oneRunMax
-    );
+    this._timeoutID = setTimeout(this.startLoop.bind(this), this.getTimeout());
 
     this.log.info(
       `The current date is ${now.toString()}. The cleaner will run on ${this._timeToRun.toString()}`
     );
   }
 
-  public async start(oneRunMax = false) {
+  public async startLoop() {
+    // the lock will automatically time out so there is no need to unlock it
+    const lockAcquired = await this.acquireLock();
+
+    if (lockAcquired === false) {
+      this.log.info('Unable to acquire lock. Skipping clean-up...');
+    } else {
+      await this.executeQueries();
+    }
+
+    this._completed = true;
+    if (!this._oneRunMax) {
+      this._timeoutID = setTimeout(
+        this.startLoop.bind(this),
+        this.getTimeout()
+      );
+    }
+  }
+
+  public async executeQueries() {
+    if (!this._models) {
+      this.log.error(`Must initialize the cleaner before executing queries`);
+      return;
+    }
     this.log.info('Database clean-up starting...');
 
     try {
-      await this.cleanNotifications(oneRunMax);
+      await this.cleanNotifications(this._oneRunMax);
     } catch (e) {
       this.log.error('Failed to clean notifications', e);
       this._rollbar?.error('Failed to clean notifications', e);
     }
 
     try {
-      await this.cleanSubscriptions(oneRunMax);
+      await this.cleanSubscriptions(this._oneRunMax);
     } catch (e) {
       this.log.error('Failed to clean subscriptions', e);
       this._rollbar?.error('Failed to clean subscriptions', e);
     }
 
-    this._completed = true;
     this.log.info('Database clean-up finished.');
-    if (!oneRunMax) {
-      this._timeoutID = setTimeout(this.start.bind(this), this.getTimeout());
-    }
   }
 
   /**
@@ -266,6 +298,17 @@ export default class DatabaseCleaner {
     }
   }
 
+  private async acquireLock() {
+    // the lock will automatically time out so there is no need to unlock it
+    return await this._redisCache.setKey(
+      RedisNamespaces.Database_Cleaner,
+      this.lockName,
+      uuidv4(),
+      this.lockTimeoutSeconds,
+      true
+    );
+  }
+
   public get timeToRun() {
     return this._timeToRun;
   }
@@ -277,4 +320,14 @@ export default class DatabaseCleaner {
   public get timeoutID() {
     return this._timeoutID;
   }
+}
+
+export const databaseCleaner = new DatabaseCleaner();
+
+if (require.main === module) {
+  const log = factory.getLogger(formatFilename(__filename));
+  databaseCleaner.init(models);
+  databaseCleaner.executeQueries().catch((err) => {
+    log.error(`Failed to clean the database.`, err);
+  });
 }

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -21,8 +21,8 @@ export default class DatabaseCleaner {
   private _oneRunMax = false;
   private _timeoutID;
   private _lockName = 'cw_database_cleaner_locker';
-  // lock times out in 2 hours
-  private _lockTimeoutSeconds = 7200;
+  // lock times out in 12 hours
+  private _lockTimeoutSeconds = 43200;
 
   public init(models: DB, rollbar?: Rollbar) {
     this._models = models;

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -36,7 +36,7 @@ export default class DatabaseCleaner {
    * @param rollbar A rollbar instance to report errors
    * @param oneRunMax If set to true the database clean will only occur once and will not be re-scheduled
    */
-  public async initLoop(
+  public initLoop(
     models: DB,
     hourToRun: number,
     redisCache: RedisCache,

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -5,7 +5,6 @@ import Rollbar from 'rollbar';
 import { RedisCache } from 'common-common/src/redisCache';
 import { v4 as uuidv4 } from 'uuid';
 import { RedisNamespaces } from 'common-common/src/types';
-import models from '../database';
 
 /**
  * This class hosts a series of 'cleaner' functions that delete unnecessary data from the database. The class schedules
@@ -323,11 +322,3 @@ export default class DatabaseCleaner {
 }
 
 export const databaseCleaner = new DatabaseCleaner();
-
-if (require.main === module) {
-  const log = factory.getLogger(formatFilename(__filename));
-  databaseCleaner.init(models);
-  databaseCleaner.executeQueries().catch((err) => {
-    log.error(`Failed to clean the database.`, err);
-  });
-}

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -20,9 +20,9 @@ export default class DatabaseCleaner {
   private _completed = false;
   private _oneRunMax = false;
   private _timeoutID;
-  private lockName = 'cw_database_cleaner_locker';
+  private _lockName = 'cw_database_cleaner_locker';
   // lock times out in 2 hours
-  private lockTimeoutSeconds = 7200;
+  private _lockTimeoutSeconds = 7200;
 
   public init(models: DB, rollbar?: Rollbar) {
     this._models = models;
@@ -301,9 +301,9 @@ export default class DatabaseCleaner {
     // the lock will automatically time out so there is no need to unlock it
     return await this._redisCache.setKey(
       RedisNamespaces.Database_Cleaner,
-      this.lockName,
+      this._lockName,
       uuidv4(),
-      this.lockTimeoutSeconds,
+      this._lockTimeoutSeconds,
       true
     );
   }

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -6,11 +6,15 @@ import models from '../../server/database';
 import sinon from 'sinon';
 import { NotificationCategories } from 'common-common/src/types';
 import { QueryTypes } from 'sequelize';
+import { RedisCache } from 'common-common/src/redisCache';
+import { REDIS_URL } from '../../server/config';
 
 chai.use(chaiHttp);
 const { expect } = chai;
 
-describe('DatabaseCleaner Tests', () => {
+describe.only('DatabaseCleaner Tests', () => {
+  let mockRedis: sinon.SinonStubbedInstance<RedisCache>;
+
   before('Reset database', async () => {
     await resetDatabase();
   });
@@ -32,16 +36,28 @@ describe('DatabaseCleaner Tests', () => {
       clock.restore();
     });
 
+    beforeEach(() => {
+      mockRedis = sinon.createStubInstance(RedisCache);
+      mockRedis.setKey.resolves(true);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('should not run if started before the correct hour', () => {
       const now = new Date();
       // set cleaner to run at 10 AM UTC
       console.log('input time to run', now.toString(), now.getUTCHours() + 4);
-      const dbCleaner = new DatabaseCleaner(
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(
         models,
         now.getUTCHours() + 4,
+        mockRedis,
         undefined,
         true
       );
+
       expect(dbCleaner.timeoutID).to.not.be.undefined;
       clearTimeout(dbCleaner.timeoutID);
       expect(dbCleaner.timeToRun.getTime()).to.be.equal(
@@ -52,12 +68,10 @@ describe('DatabaseCleaner Tests', () => {
 
     it('should run exactly once (immediately) if started in the correct hour', () => {
       const now = new Date();
-      const dbCleaner = new DatabaseCleaner(
-        models,
-        now.getUTCHours(),
-        undefined,
-        true
-      );
+      now.setUTCMinutes(0);
+      now.setUTCMilliseconds(0);
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(models, now.getUTCHours(), mockRedis, undefined, true);
       expect(dbCleaner.timeoutID).to.not.be.undefined;
       clearTimeout(dbCleaner.timeoutID);
       expect(dbCleaner.timeToRun.getUTCHours()).to.be.equal(now.getUTCHours());
@@ -66,9 +80,11 @@ describe('DatabaseCleaner Tests', () => {
 
     it('should not run if started after the correct hour', () => {
       const now = new Date();
-      const dbCleaner = new DatabaseCleaner(
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(
         models,
         now.getUTCHours() - 4,
+        mockRedis,
         undefined,
         true
       );
@@ -76,26 +92,32 @@ describe('DatabaseCleaner Tests', () => {
       clearTimeout(dbCleaner.timeoutID);
       now.setUTCDate(now.getUTCDate() + 1);
       now.setUTCHours(now.getUTCHours() - 4);
+      now.setUTCMinutes(0);
+      now.setUTCMilliseconds(0);
       expect(dbCleaner.timeToRun.getTime()).to.be.equal(now.getTime());
       expect(dbCleaner.completed).to.be.false;
     });
 
     it('should not run if an hour to run is not provided', () => {
-      const dbCleaner = new DatabaseCleaner(models, NaN, undefined, true);
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(models, NaN, mockRedis, undefined, true);
       expect(dbCleaner.timeToRun).to.be.undefined;
       expect(dbCleaner.timeoutID).to.be.undefined;
     });
 
     it('should not run if the hour provided is invalid', () => {
-      let dbCleaner = new DatabaseCleaner(models, 24, undefined, true);
+      let dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(models, 24, mockRedis, undefined, true);
       expect(dbCleaner.timeToRun).to.be.undefined;
       expect(dbCleaner.timeoutID).to.be.undefined;
 
-      dbCleaner = new DatabaseCleaner(models, 25, undefined, true);
+      dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(models, 25, mockRedis, undefined, true);
       expect(dbCleaner.timeToRun).to.be.undefined;
       expect(dbCleaner.timeoutID).to.be.undefined;
 
-      dbCleaner = new DatabaseCleaner(models, -1, undefined, true);
+      dbCleaner = new DatabaseCleaner();
+      dbCleaner.initLoop(models, -1, mockRedis, undefined, true);
       expect(dbCleaner.timeToRun).to.be.undefined;
       expect(dbCleaner.timeoutID).to.be.undefined;
     });
@@ -149,27 +171,9 @@ describe('DatabaseCleaner Tests', () => {
         category_id: 'new-thread-creation',
       });
 
-      const dbCleaner = new DatabaseCleaner(
-        models,
-        now.getUTCHours() + 2,
-        undefined,
-        true
-      );
-      clock.runAll();
-
-      const waitForStart = new Promise((resolve) => {
-        const intervalId = setInterval(() => {
-          if (dbCleaner.completed === true) {
-            clearInterval(intervalId);
-            resolve(null);
-          } else {
-            console.log(
-              'Waiting on cleaner to finish executing the start method...'
-            );
-          }
-        }, 100);
-      });
-      await waitForStart;
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.init(models);
+      await dbCleaner.executeQueries();
 
       const notifs = await models.Notification.findAll();
       expect(notifs.length).to.equal(1);
@@ -226,27 +230,9 @@ describe('DatabaseCleaner Tests', () => {
         immediate_email: false,
       });
 
-      const dbCleaner = new DatabaseCleaner(
-        models,
-        now.getHours() + 2,
-        undefined,
-        true
-      );
-      clock.runAll();
-
-      const waitForStart = new Promise((resolve) => {
-        const intervalId = setInterval(() => {
-          if (dbCleaner.completed === true) {
-            clearInterval(intervalId);
-            resolve(null);
-          } else {
-            console.log(
-              'Waiting on cleaner to finish executing the start method...'
-            );
-          }
-        }, 100);
-      });
-      await waitForStart;
+      const dbCleaner = new DatabaseCleaner();
+      dbCleaner.init(models);
+      await dbCleaner.executeQueries();
 
       const subs = await models.Subscription.findAll();
       let newUserSub;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Might close: #4589 
Closes: #4590 

## Description of Changes
- Adds the `clean-db` yarn command which triggers a run of the database cleaner.
- Switched to a singleton pattern which means there is now a new `initLoop` function which starts the timeout loop.
- Added a Redis-based lock, ensuring only a single database cleaner runs at any moment. The lock automatically times out so you don't have to unlock.

## Test Plan
This test plan is useful locally only if you have a full database dump with notifications
- Run the following queries and save the results: 
    `SELECT id, created_at FROM "Notifications" ORDER BY created_at LIMIT 10;`
    ```
      WITH user_ids_to_delete as MATERIALIZED (
          SELECT U.id, U.updated_at
          FROM "Users" U
          WHERE U.updated_at < NOW() - interval '12 months'
          ORDER BY U.updated_at
      ) SELECT S.id
      FROM "Subscriptions" S
               JOIN user_ids_to_delete UD ON UD.id = S.subscriber_id
      ORDER BY UD.updated_at
      LIMIT 10;
    ```
- Run `yarn clean-db`
- Leave it running for some time (at least until all old notifications have been cleared).
- Run the same queries as above and compare the results. The `created_at` dates returned should be more recent than the first time you ran the query. This indicates the database cleaner is running queries to delete old notifications and subscriptions.



## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 