### PR TITLE
Subpage Routes for Create Community

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -96,6 +96,10 @@ const CommonDomainRoutes = () => [
     element={withLayout(CreateCommunityPage, { type: 'common' })}
   />,
   <Route
+    path="/createCommunity/:type"
+    element={withLayout(CreateCommunityPage, { type: 'common' })}
+  />,
+  <Route
     path="/whyCommonwealth"
     element={withLayout(WhyCommonwealthPage, {
       type: 'common',

--- a/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/index.tsx
@@ -17,6 +17,8 @@ import { SputnikForm } from './sputnik_form';
 import { StarterCommunityForm } from './starter_community_form';
 import { SubstrateForm } from './substrate_form';
 import { PolygonForm } from './polygon_form';
+import { useCommonNavigate } from 'navigation/helpers';
+import { CWSpinner } from '../../components/component_kit/cw_spinner';
 
 export enum CommunityType {
   StarterCommunity = 'Starter Community',
@@ -38,12 +40,69 @@ const ADMIN_ONLY_TABS = [
   CommunityType.SputnikDao,
 ];
 
-const CreateCommunity = () => {
+type CreateCommunityProps = {
+  type?: string;
+};
+
+const getFormType = (type: string) => {
+  switch (type) {
+    case 'starter':
+      return CommunityType.StarterCommunity;
+    case 'erc20':
+      return CommunityType.Erc20Community;
+    case 'erc721':
+      return CommunityType.Erc721Community;
+    case 'sputnik':
+      return CommunityType.SputnikDao;
+    case 'substrate':
+      return CommunityType.SubstrateCommunity;
+    case 'cosmos':
+      return CommunityType.Cosmos;
+    case 'ethdao':
+      return CommunityType.EthDao;
+    case 'polygon':
+      return CommunityType.Polygon;
+    case 'solana':
+      return CommunityType.SplToken;
+    default:
+      return CommunityType.StarterCommunity;
+  }
+};
+
+const getTypeUrl = (type: CommunityType): string => {
+  switch (type) {
+    case CommunityType.StarterCommunity:
+      return 'starter';
+    case CommunityType.Erc20Community:
+      return 'erc20';
+    case CommunityType.Erc721Community:
+      return 'erc721';
+    case CommunityType.SputnikDao:
+      return 'sputnik';
+    case CommunityType.SubstrateCommunity:
+      return 'substrate';
+    case CommunityType.Cosmos:
+      return 'cosmos';
+    case CommunityType.EthDao:
+      return 'ethdao';
+    case CommunityType.Polygon:
+      return 'polygon';
+    case CommunityType.SplToken:
+      return 'solana';
+    default:
+      return 'starter';
+  }
+};
+
+const CreateCommunity = (props: CreateCommunityProps) => {
+  const { type } = props;
+
   const [currentForm, setCurrentForm] = useState<CommunityType>(
-    CommunityType.StarterCommunity
+    getFormType(type)
   );
   const { ethChains, setEthChains, ethChainNames, setEthChainNames } =
     useEthChainFormState();
+  const navigate = useCommonNavigate();
 
   useBrowserAnalyticsTrack({
     payload: {
@@ -86,33 +145,35 @@ const CreateCommunity = () => {
   }, [ethChains]);
 
   const getCurrentForm = () => {
-    switch (currentForm) {
-      case CommunityType.StarterCommunity:
+    switch (type) {
+      case 'starter':
         return <StarterCommunityForm />;
-      case CommunityType.Erc20Community:
+      case 'erc20':
         return (
           <ERC20Form ethChains={ethChains} ethChainNames={ethChainNames} />
         );
-      case CommunityType.Erc721Community:
+      case 'erc721':
         return (
           <ERC721Form ethChains={ethChains} ethChainNames={ethChainNames} />
         );
-      case CommunityType.SputnikDao:
+      case 'sputnik':
         return <SputnikForm />;
-      case CommunityType.SubstrateCommunity:
+      case 'substrate':
         return <SubstrateForm />;
-      case CommunityType.Cosmos:
+      case 'cosmos':
         return <CosmosForm />;
-      case CommunityType.EthDao:
+      case 'ethdao':
         return (
           <EthDaoForm ethChains={ethChains} ethChainNames={ethChainNames} />
         );
-      case CommunityType.Polygon:
-          return <PolygonForm ethChains={ethChains} ethChainNames={ethChainNames} />;
-      case CommunityType.SplToken:
+      case 'polygon':
+        return (
+          <PolygonForm ethChains={ethChains} ethChainNames={ethChainNames} />
+        );
+      case 'solana':
         return <SplTokenForm />;
       default:
-        throw new Error(`Invalid community type: ${currentForm}`);
+        return <StarterCommunityForm />;
     }
   };
 
@@ -137,12 +198,19 @@ const CreateCommunity = () => {
                 isSelected={currentForm === t}
                 onClick={() => {
                   setCurrentForm(t);
+                  navigate(`/createCommunity/${getTypeUrl(t)}`);
                 }}
               />
             );
           })}
       </CWTabBar>
-      {getCurrentForm()}
+      {Object.keys(ethChainNames).length !== 0 ? (
+        getCurrentForm()
+      ) : (
+        <div className="SpinnerContainer">
+          <CWSpinner />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/commonwealth/client/styles/pages/create_community.scss
+++ b/packages/commonwealth/client/styles/pages/create_community.scss
@@ -9,6 +9,13 @@
   padding: 24px;
   width: 100%;
 
+  .SpinnerContainer {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .CreateCommunityForm {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4533 

## Description of Changes
- Adds subpage routes for individual parts of the create community page. 

## Test Plan
- Visit create community page, click between tabs. Refresh, and should stay on the current tab due to the route name. 
 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 