### PR TITLE
fix searchProfiles infinite loop on members page

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/search.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/search.ts
@@ -277,24 +277,19 @@ class SearchController {
     page?: number,
     includeRoles?: boolean
   ) => {
-    try {
-      const response = await axios.get(`${app.serverUrl()}/searchProfiles`, {
-        params: {
-          chain: chainScope,
-          search: searchTerm,
-          page_size: pageSize,
-          page,
-          include_roles: includeRoles,
-        },
-      });
-      if (response.data.status !== 'Success') {
-        throw new Error(`Got unsuccessful status: ${response.status}`);
-      }
-      return response.data.result;
-    } catch (e) {
-      console.error(e);
-      return { profiles: [] };
+    const response = await axios.get(`${app.serverUrl()}/searchProfiles`, {
+      params: {
+        chain: chainScope,
+        search: searchTerm,
+        page_size: pageSize,
+        page,
+        include_roles: includeRoles,
+      },
+    });
+    if (response.data.status !== 'Success') {
+      throw new Error(`Got unsuccessful status: ${response.status}`);
     }
+    return response.data.result;
   };
 
   private sortResults = (a, b) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4600

## Description of Changes
- Fixes searchProfiles infinite loop on members page
- On initial load, there are a few duplicate calls for page 1, but once the page 2 failure occurs, no more requests are made.
- All of this has been completely refactored and fixed on my pagination PR (#4508) which will be fixed up soon.

## Test Plan
- Confirm that the infinite loop doesn't occur anymore (but with slight duplication on first request)

## Deployment Plan
N/A

## Other Considerations
- Solution isn't the best, but since this code will soon be replaced, it's not worth investing more in it.