### PR TITLE
Prevent Discord Webhooks on DiscoBot

### DIFF
--- a/packages/commonwealth/server/webhookNotifier.ts
+++ b/packages/commonwealth/server/webhookNotifier.ts
@@ -272,7 +272,10 @@ const send = async (models, content: WebhookContent) => {
               },
             ],
           });
-        } else if (url.indexOf('discord.com') !== -1) {
+        } else if (
+          url.indexOf('discord.com') !== -1 &&
+          actor !== 'Discord Bot'
+        ) {
           // discord webhook format (raw json, for application/json)
           webhookData = isChainEvent
             ? {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4612 

## Description of Changes
- Simple fix that prevents discord webhooks from firing if the content came from the discord bot.

## Test Plan
- Add discobot to a community and also add a discord webhook url, then make a post from discobot. There should be no webhook event sent to discord. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 