### PR TITLE
Discord Bot Image Handling

### DIFF
--- a/packages/common-common/src/types.ts
+++ b/packages/common-common/src/types.ts
@@ -167,6 +167,7 @@ export interface IDiscordMessage {
   channel_id: string;
   parent_channel_id: string;
   guild_id: string;
+  imageUrls?: string[];
 }
 export type HttpMethod =
   | 'get'

--- a/packages/discord-bot/discord-consumer/discordConsumer.ts
+++ b/packages/discord-bot/discord-consumer/discordConsumer.ts
@@ -49,7 +49,10 @@ async function consumeMessages() {
           title: encodeURIComponent(parsedMessage.title),
           body: encodeURIComponent(
             `[Go to Discord post](https://discord.com/channels/${parsedMessage.guild_id}/${parsedMessage.channel_id}) \n\n` +
-              parsedMessage.content
+              parsedMessage.content +
+              parsedMessage.imageUrls
+                .map((url) => `\n\n![image](${url})`)
+                .join('')
           ),
           stage: 'discussion',
           kind: 'discussion',

--- a/packages/discord-bot/discord-listener/discordListener.ts
+++ b/packages/discord-bot/discord-listener/discordListener.ts
@@ -18,6 +18,18 @@ log.info(
   )} GB`
 );
 
+const getImageUrls = (message: Message) => {
+  const attachments = [...message.attachments.values()];
+
+  return attachments
+    .filter((attachment) => {
+      return attachment.contentType.startsWith('image');
+    })
+    .map((attachment) => {
+      return attachment.url;
+    });
+};
+
 const client = new Client({
   intents: [
     IntentsBitField.Flags.Guilds,
@@ -64,7 +76,8 @@ client.on('messageCreate', async (message: Message) => {
       message_id: message.id,
       channel_id: message.channelId,
       parent_channel_id: parent_id,
-      guild_id: message.guildId
+      guild_id: message.guildId,
+      imageUrls: getImageUrls(message),
     };
 
     if (!message.nonce) new_message.title = channel.name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4614 

## Description of Changes
- Allows Discord Bot to post images in CW threads from images attached to Discord Forum threads. 

## Test Plan
- Connect the bot, create a forum thread with images attached. These images should populate in the CW forum post. 

## Deployment Plan
<!--- Omit if unneeded -->
1. Need to ensure the discord listener and consumer both are rebuilt and deployed when this goes live. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 