### PR TITLE
Convert discobot rmq exchange to topic

### DIFF
--- a/packages/common-common/src/rabbitmq/rabbitMQConfig.ts
+++ b/packages/common-common/src/rabbitmq/rabbitMQConfig.ts
@@ -82,7 +82,7 @@ export function getRabbitMQConfig(rabbitmq_uri: string): Rascal.BrokerConfig {
             ...exchangeConfig,
           },
           [RascalExchanges.SnapshotListener]: {
-            type: 'fanout',
+            type: 'topic',
             ...exchangeConfig,
           },
           [RascalExchanges.DeadLetter]: {
@@ -133,7 +133,7 @@ export function getRabbitMQConfig(rabbitmq_uri: string): Rascal.BrokerConfig {
           },
           [RascalQueues.DiscordListener]: {
             ...queueConfig,
-          }
+          },
         },
         bindings: {
           [RascalBindings.ChainEvents]: {
@@ -182,8 +182,8 @@ export function getRabbitMQConfig(rabbitmq_uri: string): Rascal.BrokerConfig {
             source: RascalExchanges.SnapshotListener,
             destination: RascalQueues.DiscordListener,
             destinationType: 'queue',
-            bindingKey: RascalRoutingKeys.DiscordListener
-          }
+            bindingKey: RascalRoutingKeys.DiscordListener,
+          },
         },
         publications: {
           [RascalPublications.ChainEvents]: {
@@ -250,7 +250,7 @@ export function getRabbitMQConfig(rabbitmq_uri: string): Rascal.BrokerConfig {
           [RascalSubscriptions.DiscordListener]: {
             queue: RascalQueues.DiscordListener,
             ...subscriptionConfig,
-          }
+          },
         },
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4610 

## Description of Changes
- Change snapshot exchange(shared by discobot per spec) to topic from fanout

## Test Plan
- start rmq
- Start discobot listener + app and test fucntionality(no random messages should be processed)

## Deployment Plan
1. Turn off produces that push to queues that use the exchange. 
2. Wait some time for in-flight messages to be processed. 
3. Delete the exchange from RMQ dashboard (might have to delete dependent queues I don't remember - if it lets you delete the exchange without deleting the queues then should be fine otherwise just delete the queues too). 
4. Deploy and the exchange will be recreated. 