### PR TITLE
Fix stats middleware (cw.path.called)

### DIFF
--- a/packages/commonwealth/server/middleware/methodNotAllowed.ts
+++ b/packages/commonwealth/server/middleware/methodNotAllowed.ts
@@ -13,7 +13,7 @@ const routesMethods: { [key: string]: string[] } = {};
 
 type ValidateThenHandle = [ValidationChain[], ...RequestHandler[]];
 
-// middleware for to capture route traffic and latency
+// middleware to capture route traffic and latency
 const statsMiddleware = (method: string, path: string) => (req, res, next) => {
   try {
     const routePattern = `${method.toUpperCase()} ${path}`;

--- a/packages/commonwealth/server/middleware/methodNotAllowed.ts
+++ b/packages/commonwealth/server/middleware/methodNotAllowed.ts
@@ -7,10 +7,31 @@ import {
 } from 'express';
 import { HttpMethod } from 'aws-sdk/clients/appmesh';
 import { ValidationChain } from 'express-validator';
+import { StatsDController } from '../../../common-common/src/statsd';
 
 const routesMethods: { [key: string]: string[] } = {};
 
 type ValidateThenHandle = [ValidationChain[], ...RequestHandler[]];
+
+// middleware for to capture route traffic and latency
+const statsMiddleware = (method: string, path: string) => (req, res, next) => {
+  try {
+    const routePattern = `${method.toUpperCase()} ${path}`;
+    StatsDController.get().increment('cw.path.called', {
+      path: routePattern,
+    });
+    const start = Date.now();
+    res.on('finish', () => {
+      const latency = Date.now() - start;
+      StatsDController.get().histogram(`cw.path.latency`, latency, {
+        path: routePattern,
+      });
+    });
+  } catch (err) {
+    console.error(err);
+  }
+  next();
+};
 
 /**
  * Use this function to register a route on a given Express Router. This function updates an object that stores the
@@ -28,8 +49,8 @@ export const registerRoute = (
   path: string,
   ...handlers: RequestHandler[] | ValidateThenHandle
 ) => {
-  router[method](path, ...handlers);
   const realPath = `/api${path}`;
+  router[method](path, statsMiddleware(method, realPath), ...handlers);
   if (!routesMethods[realPath]) routesMethods[realPath] = [];
   routesMethods[realPath].push(method.toUpperCase());
 };

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -3,7 +3,6 @@ import passport from 'passport';
 import type { Express } from 'express';
 
 import type { TokenBalanceCache } from 'token-balance-cache/src/index';
-import { StatsDController } from 'common-common/src/statsd';
 
 import domain from '../routes/domain';
 import { status } from '../routes/status';
@@ -219,20 +218,6 @@ function setupRouter(
   // ---
 
   const router = express.Router();
-
-  router.use((req, res, next) => {
-    StatsDController.get().increment('cw.path.called', {
-      path: req.path.slice(1),
-    });
-    const start = Date.now();
-    res.on('finish', () => {
-      const latency = Date.now() - start;
-      StatsDController.get().histogram(`cw.path.latency`, latency, {
-        path: req.path.slice(1),
-      });
-    });
-    next();
-  });
 
   // Updating the address
   registerRoute(

--- a/yarn.lock
+++ b/yarn.lock
@@ -25598,11 +25598,6 @@ typescript@^4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
 typescript@^5.0.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4587

## Description of Changes
- Moves the stats middleware to be injected via the `registerRoute` method
- The `cw.path.called` value is equal to the method + path pattern

Examples
```
POST /api/reactionsCounts
POST /api/getAddressProfile
POST /api/threads/:id/comments
GET /api/comments/:id/reactions
DELETE /api/reactions/:id
POST /api/writeUserSetting
GET /api/comments/:id/reactions
```

## Test Plan
- Navigate to the home page, confirm that routes aren't broken

## Deployment Plan
N/A

## Other Considerations
- The external routes don't apply the `registerRoute` approach, and won't be affected. If we want to capture analytics for those routes, I can create a new ticket to knock that out.