### PR TITLE
Fix error handling on discord channel fetch

### DIFF
--- a/packages/commonwealth/server/routes/getDiscordChannels.ts
+++ b/packages/commonwealth/server/routes/getDiscordChannels.ts
@@ -9,7 +9,7 @@ enum SetDiscordBotConfigErrors {
   NoChain = 'Must supply a chain ID',
   NotAdmin = 'Not an admin',
   CommonbotConnected = 'Discord is already connected to another Commonwealth community',
-  Error = 'Could not set discord bot config',
+  Error = 'Could not get discord bot config',
   TokenExpired = 'Token expired',
 }
 
@@ -47,6 +47,14 @@ const getDiscordChannels = async (
       chain_id,
     },
   });
+
+  if (!configEntry) {
+    return success(res, {
+      channels: [],
+      forumChannels: [],
+      selectedChannel: null,
+    });
+  }
 
   const url = `https://discord.com/api/v10/guilds/${configEntry.guild_id}/channels`;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4621 

## Description of Changes
- Stops unnecessary error from being thrown in admin page on communities that don't have a connected discobot.

## Test Plan
- Visit community that doesn't have a bot connected, view server logs. Should have no errors.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 