### PR TITLE
Quill Editor Link Overflow Fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -235,48 +235,51 @@ const ReactQuillEditor = ({
               setIsPreviewVisible={setIsPreviewVisible}
               isDisabled={isDisabled}
             />
-            <ReactQuill
-              ref={editorRef}
-              className={clsx('QuillEditor', className, {
-                markdownEnabled: isMarkdownEnabled,
-              })}
-              placeholder={placeholder}
-              tabIndex={tabIndex}
-              theme="snow"
-              value={contentDelta}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
-              onChange={handleChange}
-              onChangeSelection={(selection: RangeStatic) => {
-                if (!selection) {
-                  return;
-                }
-                lastSelectionRef.current = selection;
-              }}
-              formats={isMarkdownEnabled ? [] : undefined}
-              modules={{
-                toolbar: {
-                  container: `#${toolbarId}`,
-                  handlers: isMarkdownEnabled
-                    ? markdownToolbarHandlers
+            <div data-text-editor="name">
+              <ReactQuill
+                ref={editorRef}
+                className={clsx('QuillEditor', className, {
+                  markdownEnabled: isMarkdownEnabled,
+                })}
+                placeholder={placeholder}
+                tabIndex={tabIndex}
+                theme="snow"
+                bounds={`[data-text-editor="name"]`}
+                value={contentDelta}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                onChange={handleChange}
+                onChangeSelection={(selection: RangeStatic) => {
+                  if (!selection) {
+                    return;
+                  }
+                  lastSelectionRef.current = selection;
+                }}
+                formats={isMarkdownEnabled ? [] : undefined}
+                modules={{
+                  toolbar: {
+                    container: `#${toolbarId}`,
+                    handlers: isMarkdownEnabled
+                      ? markdownToolbarHandlers
+                      : undefined,
+                  },
+                  imageDropAndPaste: {
+                    handler: handleImageDropAndPaste,
+                  },
+                  clipboard: {
+                    matchers: clipboardMatchers,
+                  },
+                  mention,
+                  magicUrl: !isMarkdownEnabled,
+                  keyboard: isMarkdownEnabled
+                    ? markdownKeyboardShortcuts
                     : undefined,
-                },
-                imageDropAndPaste: {
-                  handler: handleImageDropAndPaste,
-                },
-                clipboard: {
-                  matchers: clipboardMatchers,
-                },
-                mention,
-                magicUrl: !isMarkdownEnabled,
-                keyboard: isMarkdownEnabled
-                  ? markdownKeyboardShortcuts
-                  : undefined,
-                imageUploader: {
-                  upload: handleImageUploader,
-                },
-              }}
-            />
+                  imageUploader: {
+                    upload: handleImageUploader,
+                  },
+                }}
+              />
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4453 

## Description of Changes
- Added to bounds to react quill editor to prevent overflow of link popup. 

## Test Plan
- Create a thread, add a link in Quill Delta mode, and the link insertion popup should not overflow the left bound of the editor. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 