### PR TITLE
Allow Super Admins to update admins in any community

### DIFF
--- a/packages/commonwealth/server/routes/upgradeMember.ts
+++ b/packages/commonwealth/server/routes/upgradeMember.ts
@@ -49,7 +49,7 @@ const upgradeMember = async (
     },
   });
 
-  if (!adminAddress) {
+  if (!adminAddress && !req.user.isAdmin) {
     return next(new AppError(Errors.MustBeAdmin));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22032,6 +22032,11 @@ react-inspector@^6.0.0:
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.1.tgz#1a37f0165d9df81ee804d63259eaaeabe841287d"
   integrity sha512-cxKSeFTf7jpSSVddm66sKdolG90qURAX3g1roTeaN6x0YEbtWc8JpmFN9+yIqLNH2uEkYerWLtJZIXRIFuBKrg==
 
+react-intersection-observer@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz#f68363a1ff292323c0808201b58134307a1626d0"
+  integrity sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==
+
 react-is@18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4635 

## Description of Changes
- Route change to let super admins update user permissions status in any community. 

## Test Plan
- Get super admin powers, try to upgrade a user to an admin in a community you are not also an existing admin of. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 