### PR TITLE
update upvote button designs

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.scss
@@ -17,16 +17,6 @@
   max-height: 54px;
   outline: none;
 
-  &.has-reacted {
-    color: $primary-500;
-  }
-
-  &.disabled {
-    border-color: $neutral-50;
-    color: $neutral-500;
-    pointer-events: none;
-  }
-
   .reactions-container {
     display: flex;
     flex-direction: column;
@@ -50,5 +40,40 @@
         color: $primary-500;
       }
     }
+  }
+
+  &.has-reacted {
+    color: $primary-500;
+    border-color: $primary-500;
+  }
+
+  &.disabled {
+    border-color: $neutral-400;
+    background-color: $neutral-200;
+    pointer-events: none;
+
+    .reactions-container {
+      color: $neutral-400;
+
+      .reactions-count {
+        color: $neutral-400;
+      }
+    }
+  }
+
+  &:hover {
+    color: $primary-600;
+    border: 1px solid $primary-600;
+
+    .reactions-container {
+      .reactions-count {
+        color: $primary-600;
+      }
+    }
+
+  }
+
+  &:focus {
+    outline: none;
   }
 }


### PR DESCRIPTION
The designs for the upvote button have been updated. This card includes those updates. 
Note that we still need to make a decision as to whether the tooltip containing the list of users who have upvoted a card will remain or will be redesigned. A card for that is in the backlog (#4643) to be filled in with details. This card *does not* change the existing tooltip. 

## Link to Issue
Closes: #4483 

## Description of Changes
- adds new design changes

## Test Plan
- visit our [demo site](https://commonwealth-demo.herokuapp.com/)

## Other Considerations
- Follow up ticket: #4643 to be filled in by @meeshlin @zakhap 