### PR TITLE
Remove `NotificationsRead.id`

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/notifications.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/notifications.ts
@@ -2,7 +2,9 @@
 import { EventEmitter } from 'events';
 import $ from 'jquery';
 
-import NotificationSubscription, { modelFromServer } from 'models/NotificationSubscription';
+import NotificationSubscription, {
+  modelFromServer,
+} from 'models/NotificationSubscription';
 
 import app from 'state';
 
@@ -46,9 +48,6 @@ class NotificationsController {
   // these are the chains that chain-events has active listeners for (used to detemine what chains are shown on the
   // notification settings page
   private _chainEventSubscribedChainIds: string[] = [];
-
-  private _maxChainEventNotificationId: number = Number.POSITIVE_INFINITY;
-  private _maxDiscussionNotificationId: number = Number.POSITIVE_INFINITY;
 
   private _numPages = 0;
   private _numUnread = 0;
@@ -309,9 +308,6 @@ class NotificationsController {
       ? { chain_filter: app.activeChainId(), maxId: undefined }
       : { chain_filter: undefined, maxId: undefined };
 
-    if (this._maxChainEventNotificationId !== Number.POSITIVE_INFINITY)
-      options.maxId = this._maxChainEventNotificationId;
-
     return post('/viewChainEventNotifications', options, (result) => {
       this._numPages = result.numPages;
       this._numUnread = result.numUnread;
@@ -327,9 +323,6 @@ class NotificationsController {
     const options: NotifOptions = app.isCustomDomain()
       ? { chain_filter: app.activeChainId(), maxId: undefined }
       : { chain_filter: undefined, maxId: undefined };
-
-    if (this._maxDiscussionNotificationId !== Number.POSITIVE_INFINITY)
-      options.maxId = this._maxDiscussionNotificationId;
 
     return post('/viewDiscussionNotifications', options, (result) => {
       this._numPages = result.numPages;
@@ -356,20 +349,9 @@ class NotificationsController {
         if (subscription.category === 'chain-event') {
           if (!this._chainEventStore.getById(notification.id))
             this._chainEventStore.add(notification);
-          // the minimum id is the new max id for next page
-          if (notificationsReadJSON.id < this._maxChainEventNotificationId) {
-            this._maxChainEventNotificationId = notificationsReadJSON.id;
-            if (notificationsReadJSON.id === 1)
-              this._maxChainEventNotificationId = 0;
-          }
         } else {
           if (!this._discussionStore.getById(notification.id))
             this._discussionStore.add(notification);
-          if (notificationsReadJSON.id < this._maxDiscussionNotificationId) {
-            this._maxDiscussionNotificationId = notificationsReadJSON.id;
-            if (notificationsReadJSON.id === 1)
-              this._maxDiscussionNotificationId = 0;
-          }
         }
       }
       if (subscription.category === 'chain-event') ceSubs.push(subscription);

--- a/packages/commonwealth/server/migrations/20230803225000-rm-nr-id.js
+++ b/packages/commonwealth/server/migrations/20230803225000-rm-nr-id.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Notifications', 'id');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Notifications', 'id', {
+      type: Sequelize.INTEGER,
+    });
+  },
+};

--- a/packages/commonwealth/server/migrations/20230803225000-rm-nr-id.js
+++ b/packages/commonwealth/server/migrations/20230803225000-rm-nr-id.js
@@ -2,11 +2,11 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.removeColumn('Notifications', 'id');
+    await queryInterface.removeColumn('NotificationsRead', 'id');
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('Notifications', 'id', {
+    await queryInterface.addColumn('NotificationsRead', 'id', {
       type: Sequelize.INTEGER,
     });
   },

--- a/packages/commonwealth/server/models/notifications_read.ts
+++ b/packages/commonwealth/server/models/notifications_read.ts
@@ -26,7 +26,6 @@ export default (
   const NotificationsRead = <NotificationsReadModelStatic>sequelize.define(
     'NotificationsRead',
     {
-      id: { type: dataTypes.INTEGER },
       subscription_id: { type: dataTypes.INTEGER, primaryKey: true },
       notification_id: { type: dataTypes.INTEGER, primaryKey: true },
       is_read: {

--- a/packages/commonwealth/server/models/notifications_read.ts
+++ b/packages/commonwealth/server/models/notifications_read.ts
@@ -5,7 +5,6 @@ import type { SubscriptionAttributes } from './subscription';
 import type { ModelInstance, ModelStatic } from './types';
 
 export type NotificationsReadAttributes = {
-  id: number;
   subscription_id: number;
   notification_id: number;
   is_read: boolean;

--- a/packages/commonwealth/server/routes/viewNotifications.ts
+++ b/packages/commonwealth/server/routes/viewNotifications.ts
@@ -83,7 +83,7 @@ export default async (
     where: {
       [Op.and]: whereAndOptions,
     },
-    order: [['id', 'DESC']],
+    order: [['notification_id', 'DESC']],
     limit: MAX_NOTIF,
     raw: true,
     nest: true,

--- a/packages/commonwealth/server/routes/viewNotifications.ts
+++ b/packages/commonwealth/server/routes/viewNotifications.ts
@@ -60,30 +60,12 @@ export default async (
     },
   });
 
-  let maxId;
-  // if maxId is not provided that means this is the first request so load the first 100
-  // TODO: if this is too slow create a table keeping track of maxId for each user and query that instead
-  //  (increment the counters in emitNotifications)
-  // TODO: or better yet create onUpdate and onDelete triggers to update the counters
-  // TODO: should this always run so we can return number of unread or things like that?
-  const numNr = (<any>await models.NotificationsRead.findOne({
-    attributes: [<any>models.sequelize.fn('MAX', models.sequelize.col('id'))],
-    where: { user_id: req.user.id },
-    raw: true,
-  })).max;
-
-  if (!req.body.maxId || req.body.maxId === 0) maxId = numNr;
-  else maxId = req.body.maxId;
-
-  const whereAndOptions: any = [
-    { user_id: req.user.id },
-    { id: { [Op.lte]: maxId } },
-  ];
+  const whereAndOptions: any = [{ user_id: req.user.id }];
 
   if (req.body.unread_only) whereAndOptions.push({ is_read: false });
 
   // TODO: write raw query so that all subscriptions are included
-  const notificationsReadPromise = models.NotificationsRead.findAll({
+  const notificationsRead = await models.NotificationsRead.findAll({
     include: [
       {
         model: models.Subscription,
@@ -106,21 +88,6 @@ export default async (
     raw: true,
     nest: true,
   });
-
-  // NOTE: Zak commenting this out (and promise below). getting more enriched subscriptions in /viewSubscriptions
-  // const subscriptionsPromise = models.Subscription.findAll({
-  //   where: {
-  //     subscriber_id: req.user.id,
-  //   },
-  // });
-
-  const [
-    notificationsRead,
-    // allSubscriptions
-  ] = await Promise.all([
-    notificationsReadPromise,
-    // subscriptionsPromise,
-  ]);
 
   const subscriptionsObj = {};
 
@@ -160,7 +127,6 @@ export default async (
 
     // push the NotificationsRead + Notifications data to the NotificationsRead array for each subscription
     subscriptionsObj[nr.subscription_id].NotificationsReads.push({
-      id: nr.id,
       is_read: nr.is_read,
       notification_id: nr.notification_id,
       subscription_id: nr.subscription_id,
@@ -193,6 +159,6 @@ export default async (
 
   return res.json({
     status: 'Success',
-    result: { subscriptions, numNotifications: numNr, numUnread },
+    result: { subscriptions, numUnread },
   });
 };

--- a/packages/commonwealth/server/routes/viewNotifications.ts
+++ b/packages/commonwealth/server/routes/viewNotifications.ts
@@ -114,7 +114,6 @@ export default async (
     if (nr.Notification.chain_event_id) {
       chainEvent = JSON.parse(nr.Notification.notification_data);
     }
-
     // creates an object for each subscription for which we have a NotificationsRead instance.
     // this object will store all the NotificationsRead, Notification, and ChainEvent instances associated with
     // a specific subscription

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -47,7 +47,7 @@ export default class DatabaseCleaner {
     this._redisCache = redisCache;
     this._oneRunMax = oneRunMax;
 
-    if (!hourToRun) {
+    if (!hourToRun && hourToRun !== 0) {
       this.log.warn(`No hourToRun given. The cleaner will not run.`);
       this._rollbar?.warn(`No hourToRun given. The cleaner will not run.`);
       return;

--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -164,7 +164,7 @@ export default async function emitNotifications(
     console.trace(e);
   }
 
-  let query = `INSERT INTO "NotificationsRead" (notification_id, subscription_id, is_read, user_id, id) VALUES `;
+  let query = `INSERT INTO "NotificationsRead" (notification_id, subscription_id, is_read, user_id) VALUES `;
   const replacements = [];
   for (const subscription of subscriptions) {
     if (subscription.subscriber_id) {
@@ -176,7 +176,7 @@ export default async function emitNotifications(
           (notification_data as any).chain_id,
         subscriber: `${subscription.subscriber_id}`,
       });
-      query += `(?, ?, ?, ?, (SELECT COALESCE(MAX(id), 0) + 1 FROM "NotificationsRead" WHERE user_id = ?)), `;
+      query += `(?, ?, ?, ?), `;
       replacements.push(
         notification.id,
         subscription.id,

--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -197,7 +197,6 @@ export default async function emitNotifications(
     await models.sequelize.query(query, {
       replacements,
       type: QueryTypes.INSERT,
-      logging: console.error,
     });
   }
 

--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -181,7 +181,6 @@ export default async function emitNotifications(
         notification.id,
         subscription.id,
         false,
-        subscription.subscriber_id,
         subscription.subscriber_id
       );
     } else {
@@ -198,6 +197,7 @@ export default async function emitNotifications(
     await models.sequelize.query(query, {
       replacements,
       type: QueryTypes.INSERT,
+      logging: console.error,
     });
   }
 

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -12,7 +12,7 @@ import { REDIS_URL } from '../../server/config';
 chai.use(chaiHttp);
 const { expect } = chai;
 
-describe.only('DatabaseCleaner Tests', () => {
+describe('DatabaseCleaner Tests', () => {
   let mockRedis: sinon.SinonStubbedInstance<RedisCache>;
 
   before('Reset database', async () => {

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -22,7 +22,7 @@ describe.only('DatabaseCleaner Tests', () => {
   describe('Tests when the cleaner runs', () => {
     let clock: sinon.SinonFakeTimers;
 
-    before(function () {
+    beforeEach(function () {
       const now = new Date();
       now.setUTCHours(8);
       now.setUTCMinutes(0);
@@ -32,7 +32,7 @@ describe.only('DatabaseCleaner Tests', () => {
       clock = sinon.useFakeTimers(now);
     });
 
-    after(function () {
+    afterEach(function () {
       clock.restore();
     });
 
@@ -152,13 +152,13 @@ describe.only('DatabaseCleaner Tests', () => {
       const eightyEightDaysAgo = new Date(now);
       eightyEightDaysAgo.setUTCDate(now.getUTCDate() - 88);
 
-      const ninetyTwoDaysAgo = new Date(now);
-      ninetyTwoDaysAgo.setUTCDate(now.getUTCDate() - 92);
+      const hundredDaysAgo = new Date(now);
+      hundredDaysAgo.setUTCDate(now.getUTCDate() - 100);
 
       // create old notification
       await models.Notification.create({
         notification_data: 'testing',
-        created_at: ninetyTwoDaysAgo,
+        created_at: hundredDaysAgo,
         chain_id: 'ethereum',
         category_id: 'new-thread-creation',
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3438

## Description of Changes
- Removed the `id` column of `NotificaitonsRead` in migration and Sequelize model
- Refactored `viewNotifications` so it doesn't use the id (removed maxId and pagination)
- Removed pagination from the notifications controller on the client since we have no UI for pagination and we simply limit notifications to the last 50. Pagination should be reintroduced further down the line with V2.
- Fixed an edge case where the database cleaner fails to run with the given hour is 0 i.e. midnight UTC.

## Test Plan
- Load the main user dashboard and notifications dropdown.
- Create a thread and a comment with one account and view the notifications on another account (if subscribed).
- Can run through: [Notifications QA][1]

## Deployment Plan
<!--- Omit if unneeded -->
Normal deployment to CW.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Migration is extremely fast (0.007s locally) since it is just a simple column drop.
- `emitNotifications` is hugely faster. `stargatetoken` community has the most users subscribed to new threads so I tested creating a new thread in `stargatetoken` before and after this change. Before the change, the fannout query took 67 seconds and after the change it took 300ms.
- Since NR removal is still several PRs (and thus sprints) away, this PR provides temporary relief to speed up `emitNotifications`.

[1]: https://github.com/hicommonwealth/commonwealth/wiki/Notifications-QA