### PR TITLE
Remove stale bundle report commands

### DIFF
--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -39,7 +39,6 @@
     "send-notification-digest-emails": "SEND_EMAILS=true ts-node --project tsconfig.json server.ts",
     "migrate-server": "heroku run npx sequelize db:migrate --debug",
     "start-ci": "FETCH_INTERVAL_MS=500 ts-node --project tsconfig.json server.ts",
-    "profile": "NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack/webpack.dev.config.js --json --profile > webpack-stats.json",
     "psql": "chmod u+x scripts/start-psql.sh && ./scripts/start-psql.sh",
     "dump-db": "pg_dump $(heroku config:get CW_READ_DB -a commonwealth-beta) --verbose --exclude-table-data=\"public.\\\"Subscriptions\\\"\" --exclude-table-data=\"public.\\\"Sessions\\\"\" --exclude-table-data=\"public.\\\"LoginTokens\\\"\" --exclude-table-data=\"public.\\\"Notifications\\\"\" --exclude-table-data=\"public.\\\"SocialAccounts\\\"\" --exclude-table-data=\"public.\\\"Webhooks\\\"\" --exclude-table-data=\"public.\\\"NotificationsRead\\\"\" --no-privileges --no-owner -f latest.dump",
     "datadog-db-setup": "chmod u+x scripts/setup-datadog-postgres.sh && ./scripts/setup-datadog-postgres.sh",

--- a/packages/commonwealth/stats.sh
+++ b/packages/commonwealth/stats.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# Generates and visualizes webpack module sizes
-webpack --json --mode=development --config webpack/webpack.prod.config.js > stats.json
-yarn webpack-bundle-analyzer stats.json


### PR DESCRIPTION
Removes: ./stats.sh, `yarn profile` command in packages/commonwealth

What worked for me instead:
- in webpack/webpack.prod.config.js, set generateStatsFile to true, analyzerMode: 'enabled'
- then run yarn bundle-report

## Link to Issue
n/a

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 