### PR TITLE
Allow Admins to delete Discobot threads + comments

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -6,7 +6,7 @@ import {
   useDeleteCommentMutation,
   useEditCommentMutation,
   useFetchCommentsQuery,
-  useToggleCommentSpamStatusMutation
+  useToggleCommentSpamStatusMutation,
 } from 'state/api/comments';
 import { ContentType } from 'types';
 import { openConfirmation } from 'views/modals/confirmation_modal';
@@ -57,23 +57,24 @@ export const CommentTree = ({
 
   const { data: allComments = [] } = useFetchCommentsQuery({
     chainId: app.activeChainId(),
-    threadId: parseInt(`${thread.id}`)
-  })
+    threadId: parseInt(`${thread.id}`),
+  });
 
   const { mutateAsync: deleteComment } = useDeleteCommentMutation({
     chainId: app.activeChainId(),
-    threadId: thread.id
-  })
+    threadId: thread.id,
+  });
 
   const { mutateAsync: editComment } = useEditCommentMutation({
     chainId: app.activeChainId(),
-    threadId: thread.id
-  })
+    threadId: thread.id,
+  });
 
-  const { mutateAsync: toggleCommentSpamStatus } = useToggleCommentSpamStatusMutation({
-    chainId: app.activeChainId(),
-    threadId: thread.id
-  })
+  const { mutateAsync: toggleCommentSpamStatus } =
+    useToggleCommentSpamStatusMutation({
+      chainId: app.activeChainId(),
+      threadId: thread.id,
+    });
 
   const [edits, setEdits] = useState<{
     [commentId: number]: {
@@ -91,8 +92,7 @@ export const CommentTree = ({
     Permissions.isCommunityAdmin() ||
     Permissions.isCommunityModerator();
 
-  const isLocked =
-    fromDiscordBot || !!(thread instanceof Thread && thread.readOnly);
+  const isLocked = !!(thread instanceof Thread && thread.readOnly);
 
   useEffect(() => {
     if (comments?.length > 0 && !highlightedComment) {
@@ -133,7 +133,9 @@ export const CommentTree = ({
           break;
         }
 
-        const grandchildren = allComments.filter(c => c.threadId === thread.id && c.parentComment === comment.id)
+        const grandchildren = allComments.filter(
+          (c) => c.threadId === thread.id && c.parentComment === comment.id
+        );
 
         for (let j = 0; j < grandchildren.length; j++) {
           const grandchild = grandchildren[j];
@@ -165,8 +167,8 @@ export const CommentTree = ({
                 commentId: comment.id,
                 canvasHash: comment.canvas_hash,
                 chainId: app.activeChainId(),
-                address: app.user.activeAccount.address
-              })
+                address: app.user.activeAccount.address,
+              });
             } catch (e) {
               console.log(e);
               notifyError('Failed to delete comment.');
@@ -305,8 +307,8 @@ export const CommentTree = ({
           threadId: thread.id,
           parentCommentId: comment.parentComment,
           chainId: app.activeChainId(),
-          address: app.user.activeAccount.address
-        })
+          address: app.user.activeAccount.address,
+        });
         setEdits((p) => ({
           ...p,
           [comment.id]: {
@@ -377,7 +379,7 @@ export const CommentTree = ({
                 commentId: comment.id,
                 isSpam: !!comment.markedAsSpamAt,
                 chainId: app.activeChainId(),
-              })
+              });
             } catch (err) {
               console.log(err);
             }
@@ -397,7 +399,9 @@ export const CommentTree = ({
     return comments_
       .filter((x) => (includeSpams ? true : !x.markedAsSpamAt))
       .map((comment: CommentType<any>) => {
-        const children = allComments.filter(c => c.threadId === thread.id && c.parentComment === comment.id)
+        const children = allComments.filter(
+          (c) => c.threadId === thread.id && c.parentComment === comment.id
+        );
 
         if (isLivingCommentTree(comment, children)) {
           const isCommentAuthor =
@@ -405,7 +409,12 @@ export const CommentTree = ({
 
           const isLast = threadLevel === 8;
 
-          const replyBtnVisible = !!(!isLast && !isLocked && isLoggedIn);
+          const replyBtnVisible = !!(
+            !isLast &&
+            !isLocked &&
+            !fromDiscordBot &&
+            isLoggedIn
+          );
 
           return (
             <React.Fragment key={comment.id + '' + comment.markedAsSpamAt}>
@@ -421,9 +430,9 @@ export const CommentTree = ({
                             isReplying &&
                             i === threadLevel - 1 &&
                             parentCommentId === comment.id
-                            ? 'replying'
-                            : ''
-                            }`}
+                              ? 'replying'
+                              : ''
+                          }`}
                         />
                       ))}
                   </div>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -90,9 +90,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const [initializedPolls, setInitializedPolls] = useState(false);
   const [isCollapsedSize, setIsCollapsedSize] = useState(false);
   const [includeSpamThreads, setIncludeSpamThreads] = useState<boolean>(false);
-  const [commentSortType, setCommentSortType] = useState<
-    CommentsFeaturedFilterTypes
-  >(CommentsFeaturedFilterTypes.Newest);
+  const [commentSortType, setCommentSortType] =
+    useState<CommentsFeaturedFilterTypes>(CommentsFeaturedFilterTypes.Newest);
   const [isReplying, setIsReplying] = useState(false);
   const [parentCommentId, setParentCommentId] = useState<number>(null);
   const [threadFetchCompleted, setThreadFetchCompleted] = useState(false);
@@ -101,14 +100,15 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const threadDoesNotMatch =
     +thread?.identifier !== +threadId || thread?.slug !== ProposalType.Thread;
 
-  const { data: comments = [], error: fetchCommentsError } = useFetchCommentsQuery({
-    chainId: app.activeChainId(),
-    threadId: parseInt(`${threadId}`)
-  })
+  const { data: comments = [], error: fetchCommentsError } =
+    useFetchCommentsQuery({
+      chainId: app.activeChainId(),
+      threadId: parseInt(`${threadId}`),
+    });
 
   useEffect(() => {
     if (fetchCommentsError) notifyError('Failed to load comments');
-  }, [fetchCommentsError])
+  }, [fetchCommentsError]);
 
   const cancelEditing = () => {
     setIsGloballyEditing(false);
@@ -225,9 +225,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     if (comments.length > 0 && thread && thread.id) {
       fetchReactionCounts({
         proposalIds: [`${thread.id}`],
-        commentIds: comments.map(c => `${c.id}`),
+        commentIds: comments.map((c) => `${c.id}`),
         address: app.user.activeAccount?.address,
-      }).then(reactionCounts => {
+      }).then((reactionCounts) => {
         for (const rc of reactionCounts) {
           const id = app.threads.reactionCountsStore.getIdentifier({
             threadId: rc.thread_id,
@@ -241,7 +241,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
           app.threads.isReactionFetched.emit('redraw', rc.comment_id);
         }
-      })
+      });
     }
   }, [thread, threadId, comments]);
 
@@ -391,7 +391,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     }
   }, [comments, thread, threadId]);
 
-
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
@@ -439,7 +438,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const showLinkedThreadOptions =
     linkedThreads.length > 0 || isAuthor || isAdminOrMod;
 
-  const hasSnapshotProposal = thread.links.find(x => x.source === 'snapshot')
+  const hasSnapshotProposal = thread.links.find((x) => x.source === 'snapshot');
 
   const canComment =
     !!hasJoinedCommunity ||
@@ -504,11 +503,13 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const tabsShouldBePresent =
     showLinkedProposalOptions || showLinkedThreadOptions || polls?.length > 0;
 
-  const sortedComments = [...comments].filter(c => !c.parentComment).sort((a, b) =>
-    commentSortType === CommentsFeaturedFilterTypes.Oldest
-      ? moment(a.createdAt).diff(moment(b.createdAt))
-      : moment(b.createdAt).diff(moment(a.createdAt))
-  )
+  const sortedComments = [...comments]
+    .filter((c) => !c.parentComment)
+    .sort((a, b) =>
+      commentSortType === CommentsFeaturedFilterTypes.Oldest
+        ? moment(a.createdAt).diff(moment(b.createdAt))
+        : moment(b.createdAt).diff(moment(a.createdAt))
+    );
 
   const showBanner = !hasJoinedCommunity && isBannerVisible;
   const fromDiscordBot =
@@ -516,6 +517,13 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const showLocked =
     (thread.readOnly && !thread.markedAsSpamAt) || fromDiscordBot;
+
+  const canUpdateThread =
+    isLoggedIn &&
+    (Permissions.isSiteAdmin() ||
+      Permissions.isThreadAuthor(thread) ||
+      Permissions.isThreadCollaborator(thread) ||
+      (fromDiscordBot && isAdmin));
 
   return (
     <>
@@ -548,12 +556,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
         updatedAt={thread.updatedAt}
         lastEdited={thread.lastEdited}
         viewCount={viewCount}
-        canUpdateThread={
-          isLoggedIn &&
-          (Permissions.isSiteAdmin() ||
-            Permissions.isThreadAuthor(thread) ||
-            Permissions.isThreadCollaborator(thread))
-        }
+        canUpdateThread={canUpdateThread}
         displayNewTag={true}
         stageLabel={!isStageDefault && thread.stage}
         subHeader={
@@ -740,81 +743,81 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           [
             ...(showLinkedProposalOptions || showLinkedThreadOptions
               ? [
-                {
-                  label: 'Links',
-                  item: (
-                    <div className="cards-column">
-                      {showLinkedProposalOptions && (
-                        <LinkedProposalsCard
-                          onChangeHandler={handleLinkedProposalChange}
-                          thread={thread}
-                          showAddProposalButton={isAuthor || isAdminOrMod}
-                        />
-                      )}
-                      {showLinkedThreadOptions && (
-                        <LinkedThreadsCard
-                          thread={thread}
-                          allowLinking={isAuthor || isAdminOrMod}
-                          onChangeHandler={handleLinkedThreadChange}
-                        />
-                      )}
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Links',
+                    item: (
+                      <div className="cards-column">
+                        {showLinkedProposalOptions && (
+                          <LinkedProposalsCard
+                            onChangeHandler={handleLinkedProposalChange}
+                            thread={thread}
+                            showAddProposalButton={isAuthor || isAdminOrMod}
+                          />
+                        )}
+                        {showLinkedThreadOptions && (
+                          <LinkedThreadsCard
+                            thread={thread}
+                            allowLinking={isAuthor || isAdminOrMod}
+                            onChangeHandler={handleLinkedThreadChange}
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                ]
               : []),
             ...(canCreateSnapshotProposal && !hasSnapshotProposal
               ? [
-                {
-                  label: 'Snapshot',
-                  item: (
-                    <div className="cards-column">
-                      <SnapshotCreationCard
-                        thread={thread}
-                        allowSnapshotCreation={isAuthor || isAdminOrMod}
-                        onChangeHandler={handleNewSnapshotChange}
-                      />
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Snapshot',
+                    item: (
+                      <div className="cards-column">
+                        <SnapshotCreationCard
+                          thread={thread}
+                          allowSnapshotCreation={isAuthor || isAdminOrMod}
+                          onChangeHandler={handleNewSnapshotChange}
+                        />
+                      </div>
+                    ),
+                  },
+                ]
               : []),
             ...(polls?.length > 0 ||
-              (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
+            (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
               ? [
-                {
-                  label: 'Polls',
-                  item: (
-                    <div className="cards-column">
-                      {[
-                        ...new Map(
-                          polls?.map((poll) => [poll.id, poll])
-                        ).values(),
-                      ].map((poll: Poll) => {
-                        return (
-                          <ThreadPollCard
-                            poll={poll}
-                            key={poll.id}
-                            onVote={() => setInitializedPolls(false)}
-                            showDeleteButton={isAuthor || isAdmin}
-                            onDelete={() => {
-                              setInitializedPolls(false);
-                            }}
-                          />
-                        );
-                      })}
-                      {isAuthor &&
-                        (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
-                          <ThreadPollEditorCard
-                            thread={thread}
-                            threadAlreadyHasPolling={!polls?.length}
-                            onPollCreate={() => setInitializedPolls(false)}
-                          />
-                        )}
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Polls',
+                    item: (
+                      <div className="cards-column">
+                        {[
+                          ...new Map(
+                            polls?.map((poll) => [poll.id, poll])
+                          ).values(),
+                        ].map((poll: Poll) => {
+                          return (
+                            <ThreadPollCard
+                              poll={poll}
+                              key={poll.id}
+                              onVote={() => setInitializedPolls(false)}
+                              showDeleteButton={isAuthor || isAdmin}
+                              onDelete={() => {
+                                setInitializedPolls(false);
+                              }}
+                            />
+                          );
+                        })}
+                        {isAuthor &&
+                          (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
+                            <ThreadPollEditorCard
+                              thread={thread}
+                              threadAlreadyHasPolling={!polls?.length}
+                              onPollCreate={() => setInitializedPolls(false)}
+                            />
+                          )}
+                      </div>
+                    ),
+                  },
+                ]
               : []),
           ] as SidebarComponents
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4655 

## Description of Changes
- Allows community admins to delete posts made by the discobot using the standard 3 dot menu. A requested fast follow. 

## Test Plan
- Visit a discobot post in a community where you are an admin. You should see the three dot menu, and have the ability to delete the posts. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 