### PR TITLE
Add archived filter to bulk threads route

### DIFF
--- a/packages/commonwealth/server/routes/threads/get_threads_handler.ts
+++ b/packages/commonwealth/server/routes/threads/get_threads_handler.ts
@@ -38,6 +38,7 @@ type BulkThreadsRequestQuery = {
   orderBy?: string;
   from_date?: string;
   to_date?: string;
+  archived?: string;
 };
 type GetThreadsResponse = any;
 
@@ -79,7 +80,12 @@ export const getThreadsHandler = async (
       orderBy,
       from_date,
       to_date,
+      archived,
     } = req.query as BulkThreadsRequestQuery;
+
+    if (!chain && req.query.chain !== ALL_CHAINS) {
+      throw new AppError(Errors.NoChains);
+    }
 
     const bulkThreads = await controllers.threads.getBulkThreads({
       chain,
@@ -91,6 +97,7 @@ export const getThreadsHandler = async (
       orderBy,
       fromDate: from_date,
       toDate: to_date,
+      archived: archived === 'true',
     });
     return success(res, bulkThreads);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4710

## Description of Changes
- Updates bulk threads route to allow filtering by archived: `GET /threads?bulk=true&archived=true…`
- Allows query param`chain=all_chains` to allow querying across all chains

## Test Plan
(For these API calls, I recommend to use the Chrome dev tools, run the app and find an authenticated network request, then "copy as cURL" so that it includes the cookies data. Then you can paste into Postman to auto-populate everything including cookie data. You can then duplicate the request and change the method/URL.)

- Through Postman or HTTP client– archive a few threads: `PUT http://localhost:8080/api/threads/XXX/archive`
- Make request to fetch all archived threads across all chains: `GET http://localhost:8080/api/threads?bulk=true&chain=all_chains&archived=true`– confirm that all threads you archived show up.

## Deployment Plan
N/A

## Other Considerations
N/A