### PR TITLE
Fix page break on view threads page due to undefined topic id

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -69,7 +69,8 @@ export const CreateComment = ({
   const activeTopic = rootThread instanceof Thread ? rootThread?.topic : null;
 
   useEffect(() => {
-    setTokenPostingThreshold(app.chain.getTopicThreshold(activeTopic.id));
+    activeTopic?.id &&
+      setTokenPostingThreshold(app.chain.getTopicThreshold(activeTopic?.id));
   }, [activeTopic]);
 
   useEffect(() => {
@@ -130,7 +131,7 @@ export const CreateComment = ({
     }
   };
 
-  const userFailsThreshold = app.chain.isGatedTopic(activeTopic.id);
+  const userFailsThreshold = app.chain.isGatedTopic(activeTopic?.id);
   const isAdmin = Permissions.isCommunityAdmin();
   const disabled =
     editorValue.length === 0 ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: No ticket

## Description of Changes
Some old threads i.e https://commonwealth.im/ethereum/discussion/429-great-ui, caused the page to break. This was due to some undefined topic id (which had some delay in getting data). Now added optional chaining, which would access obj property when defined.

## Test Plan
Visiting https://commonwealth.im/ethereum/discussion/429-great-ui or any other old thread should not break the page. On local env, you can test with http://localhost:8080/ethereum/discussion/429-great-ui

## Deployment Plan
N/A

## Other Considerations
N/A