### PR TITLE
Fix failing Cosmos CI tests

### DIFF
--- a/packages/commonwealth/server-test.ts
+++ b/packages/commonwealth/server-test.ts
@@ -113,7 +113,7 @@ const resetServer = (debug = false): Promise<void> => {
           'Ropsten Testnet',
           '3',
         ],
-        ['https://rpc-juno.itastakers.com', 'Juno', null, BalanceType.Cosmos],
+        ['https://rpc-juno.ecostake.com', 'Juno', null, BalanceType.Cosmos],
         [
           'https://cosmos-devnet.herokuapp.com/rpc',
           'Cosmos SDK v0.46.11 devnet',

--- a/packages/commonwealth/server/migrations/20230807200112-update-juno-rpc.js
+++ b/packages/commonwealth/server/migrations/20230807200112-update-juno-rpc.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "ChainNodes"
+      SET url = 'https://rpc-juno.ecostake.com'
+      WHERE url = 'https://rpc-juno.itastakers.com';
+      `,
+      { raw: true }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "ChainNodes"
+      SET url = 'https://rpc-juno.itastakers.com'
+      WHERE url = 'https://rpc-juno.ecostake.com';
+      `,
+      { raw: true }
+    );
+  },
+};

--- a/packages/commonwealth/test/devnet/cosmos/proposal-tx-v1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposal-tx-v1beta1.spec.ts
@@ -167,30 +167,4 @@ describe('Cosmos Governance v1beta1 util Tests', () => {
       });
     });
   });
-  // Disabled for CI. Fails often in CI because heroku devnet resets periodically
-  describe.skip('getCompletedProposals', () => {
-    it('should fetch completed proposals (csdk-beta)', async () => {
-      const id = 'csdk-beta';
-      const tmClient = await getTMClient(
-        `http://localhost:8080/cosmosAPI/${id}`
-      );
-      const rpc = await getRPCClient(tmClient);
-      const proposals = await getCompletedProposalsV1Beta1(rpc);
-      // if below fails, make a proposal in csdk-beta UI and run again after 10 minutes.
-      // Somstimes the remote node crashes and restarts.
-      expect(
-        proposals.length,
-        'If this fails, make a proposal in csdk-beta UI and run tests again after 10 minutes.'
-      ).to.be.greaterThan(0);
-
-      proposals.forEach((proposal) => {
-        expect(proposal.state.completed).to.eq(true);
-        expect(proposal.state.status).to.be.oneOf([
-          'Passed',
-          'Rejected',
-          'Failed',
-        ]);
-      });
-    });
-  });
 });

--- a/packages/commonwealth/test/devnet/cosmos/proposal-tx-v1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposal-tx-v1beta1.spec.ts
@@ -167,7 +167,8 @@ describe('Cosmos Governance v1beta1 util Tests', () => {
       });
     });
   });
-  describe('getCompletedProposals', () => {
+  // Disabled for CI. Fails often in CI because heroku devnet resets periodically
+  describe.skip('getCompletedProposals', () => {
     it('should fetch completed proposals (csdk-beta)', async () => {
       const id = 'csdk-beta';
       const tmClient = await getTMClient(

--- a/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
+++ b/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
@@ -16,6 +16,8 @@ import {
   cosmosRPCKey,
 } from 'server/util/cosmosCache';
 
+const v1beta1ChainId = 'juno';
+
 function verifyNoCacheResponse(res) {
   expect(res.body).to.not.be.null;
   expect(res).to.have.status(200);
@@ -49,7 +51,7 @@ describe('Cosmos Cache', () => {
   describe('cosmosAPI', () => {
     async function makeRPCRequest(
       body,
-      path = '/cosmosAPI/juno',
+      path = `/cosmosAPI/${v1beta1ChainId}`,
       headers = {
         'content-type': 'text/plain;charset=UTF-8',
         'accept-language': 'en-US,en;q=0.9',
@@ -67,7 +69,7 @@ describe('Cosmos Cache', () => {
 
     function rpcTestKeyAndDuration(body, expectedKey, expectedDuration) {
       const request = {
-        originalUrl: '/cosmosAPI/juno',
+        originalUrl: `/cosmosAPI/${v1beta1ChainId}`,
       };
       const key = cosmosRPCKey(request, body);
       const duration = cosmosRPCDuration(body);
@@ -81,7 +83,7 @@ describe('Cosmos Cache', () => {
       expectedDuration: number
     ) => {
       const request = {
-        originalUrl: '/cosmosAPI/juno',
+        originalUrl: `/cosmosAPI/${v1beta1ChainId}`,
       };
       const params = {
         path: '/cosmos.gov.v1beta1.Query/Proposals',
@@ -95,7 +97,7 @@ describe('Cosmos Cache', () => {
         params: params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
 
       const key = cosmosRPCKey(request, body);
       expect(key).to.be.equal(expectedKey);
@@ -150,8 +152,7 @@ describe('Cosmos Cache', () => {
         },
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey =
-        '/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Proposal","data":"08b502","prove":false}';
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Proposal","data":"08b502","prove":false}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 7);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -169,7 +170,7 @@ describe('Cosmos Cache', () => {
         params: params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_{"path":"/cosmos.gov.v1beta1.Query/Votes","data":"08b502","prove":false}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Votes","data":"08b502","prove":false}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -187,7 +188,7 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_${params.path}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${params.path}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -205,7 +206,9 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_${JSON.stringify(params)}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${JSON.stringify(
+        params
+      )}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -223,7 +226,7 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_${params.path}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${params.path}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -236,7 +239,7 @@ describe('Cosmos Cache', () => {
         params: {},
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/juno_${bodyString}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${bodyString}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -250,7 +253,7 @@ describe('Cosmos Cache', () => {
       };
       const bodyString = JSON.stringify(body);
 
-      const expectedKey = `/cosmosAPI/juno_${bodyString}`;
+      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${bodyString}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4725 

## Description of Changes
- Deletes test for csdk-beta, which relies on unreliable state.
- Updates failing node for juno in migration and testServer.ts file

## Test Plan
- Devnet CI tests should pass
- Integration CI tests pass

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 