### PR TITLE
Community spend proposal

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
@@ -18,12 +18,13 @@ import {
 import { longify } from '@cosmjs/stargate/build/queries/utils';
 
 import type {
+  CoinObject,
   CosmosProposalState,
   CosmosProposalType,
-  CosmosToken,
   ICosmosProposal,
   ICosmosProposalTally,
 } from 'controllers/chain/cosmos/types';
+import { CosmosToken } from 'controllers/chain/cosmos/types';
 import { CosmosApiType } from '../../chain';
 
 /* -- v1beta1-specific methods: -- */
@@ -151,12 +152,17 @@ export const msgToIProposal = (p: Proposal): ICosmosProposal | null => {
   );
   let type: CosmosProposalType = 'text';
   let spendRecipient: string;
-  let spendAmount: string;
+  let spendAmount: CoinObject[];
   if (isCommunitySpend) {
     const spend = CommunityPoolSpendProposal.decode(content.value);
     type = 'communitySpend';
     spendRecipient = spend.recipient;
-    spendAmount = spend?.amount[0]?.amount;
+    spendAmount = [
+      new CosmosToken(
+        spend.amount[0].denom.toUpperCase(),
+        spend.amount[0].amount
+      ).toCoinObject(),
+    ];
   }
   return {
     identifier: p.proposalId.toString(),

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/types.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/types.ts
@@ -18,13 +18,18 @@ export class CosmosToken extends Coin {
     return +this;
   }
 
-  public toCoinObject() {
+  public toCoinObject(): CoinObject {
     return {
       denom: this.denom,
       amount: this.toString(),
     };
   }
 }
+
+export type CoinObject = {
+  denom: string;
+  amount: string;
+};
 
 export type CosmosProposalType =
   | 'text'
@@ -64,7 +69,7 @@ export interface ICosmosProposal extends IIdentifiable {
   messages?: any[]; // v1 only
   proposer: string;
   spendRecipient?: string;
-  spendAmount?: string;
+  spendAmount?: CoinObject[];
   submitTime: moment.Moment;
   depositEndTime: moment.Moment;
   votingStartTime: moment.Moment;

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/types.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/types.ts
@@ -26,7 +26,11 @@ export class CosmosToken extends Coin {
   }
 }
 
-export type CosmosProposalType = 'text' | 'upgrade' | 'parameter';
+export type CosmosProposalType =
+  | 'text'
+  | 'upgrade'
+  | 'parameter'
+  | 'communitySpend';
 export type CosmosVoteChoice = 'Yes' | 'No' | 'NoWithVeto' | 'Abstain';
 export type CosmosProposalState =
   | 'Unspecified'
@@ -59,6 +63,8 @@ export interface ICosmosProposal extends IIdentifiable {
   description: string;
   messages?: any[]; // v1 only
   proposer: string;
+  spendRecipient?: string;
+  spendAmount?: string;
   submitTime: moment.Moment;
   depositEndTime: moment.Moment;
   votingStartTime: moment.Moment;

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
@@ -38,10 +38,11 @@ export const CosmosProposalForm = () => {
       <CWLabel label="Proposal Type" />
       <CWRadioGroup
         name="cosmos-proposal-type"
-        onChange={(value) => {
+        onChange={(e) => {
+          const value = e.target.value as 'textProposal' | 'communitySpend';
           setCosmosProposalType(value);
         }}
-        toggledOption="textProposal"
+        toggledOption={cosmosProposalType}
         options={[
           { label: 'Text Proposal', value: 'textProposal' },
           { label: 'Community Spend', value: 'communitySpend' },

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { ChainBase } from 'common-common/src/types';
 import Cosmos from 'controllers/chain/cosmos/adapter';
 import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
 import { SubstrateTreasuryTip } from 'controllers/chain/substrate/treasury_tip';
 import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
 import useNecessaryEffect from 'hooks/useNecessaryEffect';
@@ -166,6 +167,16 @@ const ViewProposalPage = ({
           {proposal.data?.messages && (
             <JSONDisplay data={proposal.data.messages} title="Messages" />
           )}
+          {proposal instanceof CosmosProposal &&
+            proposal.data.type === 'communitySpend' && (
+              <JSONDisplay
+                data={{
+                  recipient: proposal.data?.spendRecipient,
+                  amount: proposal.data?.spendAmount,
+                }}
+                title="Community Spend Proposal"
+              />
+            )}
           <VotingResults proposal={proposal} />
           <VotingActions
             onModalClose={onModalClose}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4732 

## Description of Changes
- Fixes broken toggle on Cosmos proposal form
- Displays Community Spend Proposal details on view_proposal page

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- toggle wasn't wired up correctly. Now setting proposal type correctly
- Added simple way to display on-chain Community Spend details

## Test Plan
- CA (click around) tested on local
  - Using shared devnet address
      - v1beta1: http://localhost:8080/csdk-beta/new/proposal -> toggle Community Spend
      - Create Community Spend Proposal. Sign in keplr and expect this view in View Proposal screen:
      
<img width="1013" alt="Screenshot 2023-08-08 at 12 39 42 PM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/16b9c34b-3170-4892-832f-c6c7ac849d11">

- Repeat for v1: http://localhost:8080/csdk/new/proposal , expect:

<img width="1012" alt="Screenshot 2023-08-08 at 12 41 53 PM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/30bcd585-5b6d-4e8c-a521-f325c795bdb2">


- Regression-tested csdk (v1) and csdk-beta (v1beta1) for text proposals

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This enables basic Community Spend proposal TXs, but does not address the Ledger issue. That is a separate ticket: #4731 
- We may want to consider a community option to disable this feature, to avoid s p a m proposals