### PR TITLE
Fix regression in community admin/mod thread update menu access.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -521,6 +521,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const canUpdateThread =
     isLoggedIn &&
     (Permissions.isSiteAdmin() ||
+      Permissions.isCommunityAdmin() ||
+      Permissions.isCommunityModerator() ||
       Permissions.isThreadAuthor(thread) ||
       Permissions.isThreadCollaborator(thread) ||
       (fromDiscordBot && isAdmin));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4743 

## Description of Changes
- Re-adds correct check for mod/admin permissions in View Thread Page triple dot menu visibility.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
No logical issues, just a product regression that occurred in #4488 -- resolved by simply re-adding the correct permission check.

## Test Plan
- Confirm expected behavior (as community admin/mod, attempt to update a thread from within the view thread page).

