### PR TITLE
Fix deleted thread skeleton loading issue

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -399,20 +399,20 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     return <PageNotFound />;
   }
 
-  if (!app.chain?.meta || !app.threads.initialized || !thread) {
-    return <CWContentPage showSkeleton isWindowMedium={isWindowMedium} />;
+  if (!thread && threadFetchCompleted) {
+    return <PageNotFound />;
   }
 
   if (typeof identifier !== 'string') {
     return <PageNotFound />;
   }
 
-  if (!thread && threadFetchCompleted) {
+  if (threadFetchFailed) {
     return <PageNotFound />;
   }
 
-  if (threadFetchFailed) {
-    return <PageNotFound />;
+  if (!app.chain?.meta || !app.threads.initialized || !thread) {
+    return <CWContentPage showSkeleton isWindowMedium={isWindowMedium} />;
   }
 
   // Original posters have full editorial control, while added collaborators


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4720 

## Description of Changes
- Ensures that a deleted thread page will display the "page not visible" error layout instead of the skeleton loader. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Simple issue with the order of conditional displays in the component that was introduced with the skeleton loader recently. 

## Test Plan
- Create a thread, delete it, and visit it's url. You should see the page not visible content appear. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 