### PR TITLE
Only call /threads when thread id is defined in threads page

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/getThreadsById.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/getThreadsById.ts
@@ -9,6 +9,7 @@ const THREAD_STALE_TIME = 5000; // 5 seconds
 interface GetThreadsByIdProps {
   chainId: string;
   ids: number[];
+  enabled?: boolean;
 }
 
 const getThreadsById = async ({ chainId, ids }: GetThreadsByIdProps) => {
@@ -28,7 +29,11 @@ const getThreadsById = async ({ chainId, ids }: GetThreadsByIdProps) => {
   return response.data.result.map((t) => new Thread(t));
 };
 
-const useGetThreadsByIdQuery = ({ chainId, ids }: GetThreadsByIdProps) => {
+const useGetThreadsByIdQuery = ({
+  chainId,
+  ids = [],
+  enabled,
+}: GetThreadsByIdProps) => {
   return useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
@@ -39,6 +44,7 @@ const useGetThreadsByIdQuery = ({ chainId, ids }: GetThreadsByIdProps) => {
     ],
     queryFn: () => getThreadsById({ chainId, ids }),
     staleTime: THREAD_STALE_TIME,
+    enabled: enabled,
   });
 };
 

--- a/packages/commonwealth/client/scripts/state/api/threads/getThreadsById.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/getThreadsById.ts
@@ -9,7 +9,7 @@ const THREAD_STALE_TIME = 5000; // 5 seconds
 interface GetThreadsByIdProps {
   chainId: string;
   ids: number[];
-  enabled?: boolean;
+  apiCallEnabled?: boolean;
 }
 
 const getThreadsById = async ({ chainId, ids }: GetThreadsByIdProps) => {
@@ -32,7 +32,7 @@ const getThreadsById = async ({ chainId, ids }: GetThreadsByIdProps) => {
 const useGetThreadsByIdQuery = ({
   chainId,
   ids = [],
-  enabled,
+  apiCallEnabled,
 }: GetThreadsByIdProps) => {
   return useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
@@ -44,7 +44,7 @@ const useGetThreadsByIdQuery = ({
     ],
     queryFn: () => getThreadsById({ chainId, ids }),
     staleTime: THREAD_STALE_TIME,
-    enabled: enabled,
+    enabled: apiCallEnabled,
   });
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -96,6 +96,18 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
+  const {
+    data,
+    error: fetchThreadError,
+    isLoading,
+  } = useGetThreadsByIdQuery({
+    chainId: app.activeChainId(),
+    ids: [+threadId].filter(Boolean),
+    enabled: !!threadId,
+  });
+
+  const thread = data?.[0];
+
   const { data: comments = [], error: fetchCommentsError } =
     useFetchCommentsQuery({
       chainId: app.activeChainId(),
@@ -106,19 +118,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     chainId: app.activeChainId(),
     threadId: parseInt(threadId),
   });
-
-  const {
-    data,
-    error: fetchThreadError,
-    isLoading,
-  } = useGetThreadsByIdQuery({
-    chainId: app.activeChainId(),
-    ids: [+threadId],
-  });
-
-  const thread = data?.[0];
-  const threadDoesNotMatch =
-    +thread?.identifier !== +threadId || thread?.slug !== ProposalType.Thread;
 
   useEffect(() => {
     if (fetchCommentsError) notifyError('Failed to load comments');
@@ -531,79 +530,79 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           [
             ...(showLinkedProposalOptions || showLinkedThreadOptions
               ? [
-                {
-                  label: 'Links',
-                  item: (
-                    <div className="cards-column">
-                      {showLinkedProposalOptions && (
-                        <LinkedProposalsCard
-                          thread={thread}
-                          showAddProposalButton={isAuthor || isAdminOrMod}
-                        />
-                      )}
-                      {showLinkedThreadOptions && (
-                        <LinkedThreadsCard
-                          thread={thread}
-                          allowLinking={isAuthor || isAdminOrMod}
-                        />
-                      )}
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Links',
+                    item: (
+                      <div className="cards-column">
+                        {showLinkedProposalOptions && (
+                          <LinkedProposalsCard
+                            thread={thread}
+                            showAddProposalButton={isAuthor || isAdminOrMod}
+                          />
+                        )}
+                        {showLinkedThreadOptions && (
+                          <LinkedThreadsCard
+                            thread={thread}
+                            allowLinking={isAuthor || isAdminOrMod}
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                ]
               : []),
             ...(canCreateSnapshotProposal && !hasSnapshotProposal
               ? [
-                {
-                  label: 'Snapshot',
-                  item: (
-                    <div className="cards-column">
-                      <SnapshotCreationCard
-                        thread={thread}
-                        allowSnapshotCreation={isAuthor || isAdminOrMod}
-                        onChangeHandler={handleNewSnapshotChange}
-                      />
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Snapshot',
+                    item: (
+                      <div className="cards-column">
+                        <SnapshotCreationCard
+                          thread={thread}
+                          allowSnapshotCreation={isAuthor || isAdminOrMod}
+                          onChangeHandler={handleNewSnapshotChange}
+                        />
+                      </div>
+                    ),
+                  },
+                ]
               : []),
             ...(polls?.length > 0 ||
-              (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
+            (isAuthor && (!app.chain?.meta?.adminOnlyPolling || isAdmin))
               ? [
-                {
-                  label: 'Polls',
-                  item: (
-                    <div className="cards-column">
-                      {[
-                        ...new Map(
-                          polls?.map((poll) => [poll.id, poll])
-                        ).values(),
-                      ].map((poll: Poll) => {
-                        return (
-                          <ThreadPollCard
-                            poll={poll}
-                            key={poll.id}
-                            onVote={() => setInitializedPolls(false)}
-                            showDeleteButton={isAuthor || isAdmin}
-                            onDelete={() => {
-                              setInitializedPolls(false);
-                            }}
-                          />
-                        );
-                      })}
-                      {isAuthor &&
-                        (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
-                          <ThreadPollEditorCard
-                            thread={thread}
-                            threadAlreadyHasPolling={!polls?.length}
-                            onPollCreate={() => setInitializedPolls(false)}
-                          />
-                        )}
-                    </div>
-                  ),
-                },
-              ]
+                  {
+                    label: 'Polls',
+                    item: (
+                      <div className="cards-column">
+                        {[
+                          ...new Map(
+                            polls?.map((poll) => [poll.id, poll])
+                          ).values(),
+                        ].map((poll: Poll) => {
+                          return (
+                            <ThreadPollCard
+                              poll={poll}
+                              key={poll.id}
+                              onVote={() => setInitializedPolls(false)}
+                              showDeleteButton={isAuthor || isAdmin}
+                              onDelete={() => {
+                                setInitializedPolls(false);
+                              }}
+                            />
+                          );
+                        })}
+                        {isAuthor &&
+                          (!app.chain?.meta?.adminOnlyPolling || isAdmin) && (
+                            <ThreadPollEditorCard
+                              thread={thread}
+                              threadAlreadyHasPolling={!polls?.length}
+                              onPollCreate={() => setInitializedPolls(false)}
+                            />
+                          )}
+                      </div>
+                    ),
+                  },
+                ]
               : []),
           ] as SidebarComponents
         }

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -103,7 +103,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   } = useGetThreadsByIdQuery({
     chainId: app.activeChainId(),
     ids: [+threadId].filter(Boolean),
-    enabled: !!threadId,
+    apiCallEnabled: !!threadId, // only call the api if we have thread id
   });
 
   const thread = data?.[0];

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
@@ -37,7 +37,7 @@ export const LinkedThreadsCard = ({
   const { data: linkedThreads, isLoading } = useGetThreadsByIdQuery({
     chainId: app.activeChainId(),
     ids: linkedThreadIds.map(Number),
-    enabled: linkedThreadIds.length > 0,
+    apiCallEnabled: linkedThreadIds.length > 0, // only call the api if we have thread id
   });
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_threads_card.tsx
@@ -37,6 +37,7 @@ export const LinkedThreadsCard = ({
   const { data: linkedThreads, isLoading } = useGetThreadsByIdQuery({
     chainId: app.activeChainId(),
     ids: linkedThreadIds.map(Number),
+    enabled: linkedThreadIds.length > 0,
   });
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4775

## Description of Changes
Now conditionally calling the /threads API in view threads page, only when thread id is defined

## "How We Fixed It"
Now conditionally calling the /threads API in view threads page, only when thread id is defined

## Test Plan
Load any view threads page on any community and in the network tab verify that there are no 400 calls for /threads

## Deployment Plan
N/A

## Other Considerations
N/A