### PR TITLE
Show skeleton loader in overview page when loading data

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -22,7 +22,7 @@ const OverviewPage = () => {
   const { isWindowExtraSmall } = useBrowserWindow({});
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
-  const { data: recentlyActiveThreads } = useFetchThreadsQuery({
+  const { data: recentlyActiveThreads, isLoading } = useFetchThreadsQuery({
     queryType: 'active',
     chainId: app.activeChainId(),
     topicsPerThread: 3,
@@ -127,7 +127,7 @@ const OverviewPage = () => {
       </div>
       <CWDivider />
       {topicSummaryRows.map((row, i) => (
-        <TopicSummaryRow {...row} key={i} />
+        <TopicSummaryRow {...row} key={i} isLoading={isLoading} />
       ))}
     </div>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4785

## Description of Changes
Much of the groundwork for this PR was done in #4295 but was not usable then, now added the switches/props to show the loader properly

## "How We Fixed It"
By using react component parameters

## Test Plan
- Visit any overview page
- Verify that it shows skeleton until it loads data 

## Deployment Plan
N/A

## Other Considerations
N/A