### PR TITLE
Fix Snapshot Notifications

### DIFF
--- a/packages/commonwealth/server/CommonwealthConsumer/messageProcessors/snapshotConsumer.ts
+++ b/packages/commonwealth/server/CommonwealthConsumer/messageProcessors/snapshotConsumer.ts
@@ -73,19 +73,6 @@ export async function processSnapshotMessage(
     });
   }
 
-  // Notifications
-  emitNotifications(
-    this.models,
-    NotificationCategories.SnapshotProposal,
-    snapshotNotificationData.space,
-    { eventType, ...snapshotNotificationData },
-    {
-      notificationCategory: eventType,
-      body: snapshotNotificationData.body,
-      title: snapshotNotificationData.title, // TODO: Decide on what we want for the webhook we emit
-    }
-  );
-
   try {
     if (space || proposal.space) {
       await this.models.SnapshotSpace.findOrCreate({
@@ -134,6 +121,21 @@ export async function processSnapshotMessage(
   this.log.info(
     `Found ${associatedCommunities.length} associated communities for snapshot space ${space} `
   );
+
+  if (associatedCommunities.length > 0) {
+    // Notifications
+    emitNotifications(
+      this.models,
+      NotificationCategories.SnapshotProposal,
+      snapshotNotificationData.space,
+      { eventType, ...snapshotNotificationData },
+      {
+        notificationCategory: eventType,
+        body: snapshotNotificationData.body,
+        title: snapshotNotificationData.title, // TODO: Decide on what we want for the webhook we emit
+      }
+    );
+  }
 
   for (const community of associatedCommunities) {
     const communityId = community.chain_id;

--- a/packages/commonwealth/server/migrations/20230814204849-delete-unused-snapshot-notif.js
+++ b/packages/commonwealth/server/migrations/20230814204849-delete-unused-snapshot-notif.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      WITH notif_id_to_keep as (SELECT DISTINCT notification_id
+                          FROM "NotificationsRead" NR
+                                   JOIN "Notifications" N ON N.id = NR.notification_id
+                          WHERE N.category_id = 'snapshot-proposal')
+      DELETE
+      FROM "Notifications"
+          WHERE id NOT IN (SELECT * FROM notif_id_to_keep) AND category_id = 'snapshot-proposal';
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4782 

## Description of Changes
- Created a migration to delete useless snapshot notifications.
- Fix snapshot notification emission so that notifications are only emitted if the snapshot event space has an associated CW community.

## Test Plan
- View your notifications (ensure `/viewDiscussionNotifications` and `/viewChainEventNotifications` return the appropriate notifications.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Migration takes 5.7 seconds on Frack.