### PR TITLE
Spam fixes for threads and comments

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/comments/toggleCommentSpamStatus.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/toggleCommentSpamStatus.ts
@@ -9,20 +9,26 @@ interface ToggleCommentSpamStatusProps {
   chainId: string;
   commentId: number;
   isSpam: boolean;
+  address: string;
 }
 
 const toggleCommentSpamStatus = async ({
   chainId,
   commentId,
   isSpam,
+  address,
 }: ToggleCommentSpamStatusProps) => {
   const method = isSpam ? 'put' : 'delete';
-  return await axios[method](`${app.serverUrl()}/comments/${commentId}/spam`, {
-    data: {
-      jwt: app.user.jwt,
-      chain_id: chainId,
-    } as any,
-  });
+  const body = {
+    jwt: app.user.jwt,
+    chain_id: chainId,
+    address: address,
+    author_chain: chainId,
+  };
+  return await axios[method](
+    `${app.serverUrl()}/comments/${commentId}/spam`,
+    isSpam ? body : ({ data: { ...body } } as any)
+  );
 };
 
 interface UseToggleCommentSpamStatusMutationProps {

--- a/packages/commonwealth/client/scripts/state/api/threads/toggleSpam.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/toggleSpam.ts
@@ -7,19 +7,21 @@ interface ToggleThreadSpamProps {
   chainId: string;
   threadId: number;
   isSpam: boolean;
+  address: string;
 }
 
 const toggleThreadSpam = async ({
   chainId,
   threadId,
   isSpam,
+  address,
 }: ToggleThreadSpamProps) => {
-  const method = isSpam ? 'put' : 'delete';
-  return await axios[method](`${app.serverUrl()}/threads/${threadId}/spam`, {
-    data: {
-      jwt: app.user.jwt,
-      chain_id: chainId,
-    } as any,
+  return await axios.patch(`${app.serverUrl()}/threads/${threadId}`, {
+    author_chain: chainId,
+    chain: chainId,
+    address: address,
+    jwt: app.user.jwt,
+    spam: isSpam,
   });
 };
 
@@ -36,7 +38,7 @@ const useToggleThreadSpamMutation = ({
     mutationFn: toggleThreadSpam,
     onSuccess: async (response) => {
       updateThreadInAllCaches(chainId, threadId, {
-        markedAsSpamAt: response.data.result.markedAsSpamAt,
+        markedAsSpamAt: response.data.result.marked_as_spam_at,
       });
       return response.data.result;
     },

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -383,8 +383,9 @@ export const CommentTree = ({
             try {
               await toggleCommentSpamStatus({
                 commentId: comment.id,
-                isSpam: !!comment.markedAsSpamAt,
+                isSpam: !comment.markedAsSpamAt,
                 chainId: app.activeChainId(),
+                address: app.user.activeAccount.address,
               });
             } catch (err) {
               console.log(err);

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -170,6 +170,7 @@ export const AdminActions = ({
                 chainId: app.activeChainId(),
                 threadId: thread.id,
                 isSpam: isSpam,
+                address: app.user?.activeAccount?.address,
               })
                 .then((t: Thread | any) => onSpamToggle && onSpamToggle(t))
                 .catch(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4765

## Description of Changes
We were using incorrect API params/config in frontend for spamming/unspamming a comment/thread.

- Updated axios API config for thread spam API
- Now using updated unified threads API for threads spam feature 
- Updated axios API config for comments spam API

## "How We Fixed It"
By updating API params/config in frontend

## Test Plan
- With an admin account, mark a thread as spam and unspam it -> verify both spam/unspam work
- With an admin account, mark a thread comment as spam and unspam it -> verify both spam/unspam work

## Deployment Plan
N/A

## Other Considerations
N/A