### PR TITLE
Clean up Layout component inline docs, first pass

### DIFF
--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -17,21 +17,14 @@ type LayoutAttrs = {
   Component: ReactNode | any;
   scoped?: boolean;
   type:
-    | 'community' // community specific layout with header, commonwealth sidebar and community sidebar - used for cw community owned pages
-    | 'common' // common wealth layout with header and commonwealth sidebar - used for cw self owned pages
-    | 'blank'; //  a blank layout with just the layout styles
+    | 'community' // Community-scoped layout with a header, CW sidebar, & community sidebar.
+    | 'common' // Generic layout with header and CW sidebar, used for non-community-scoped pages.
+    | 'blank'; //  Blank layout using Layout.scss styles
 };
 
-/**
- * Handles the app init flow and branch cases
- * --
- * Each logic block is marked with a IFS=Init-Flow-Step comment
- * with a number indicating the order in which they occur
- * Important:
- * - IBS 3 is omitted
- */
+// For complete documentation, see the App-Initialization-Flow.md wiki entry.
 const LayoutComponent = ({
-  Component, // the component to render
+  Component, // Child component being rendered
   scoped = false,
   type = 'community',
 }: LayoutAttrs) => {
@@ -44,28 +37,18 @@ const LayoutComponent = ({
 
   const scopeMatchesChain = app.config.chains.getById(selectedScope);
 
-  // IFB 5: If scope is different from app.activeChainId() at render
-  // time (and we are not loading another community at the same time,
-  // via this.loadingScope), set this.loadingScope to the provided scope,
-  // and then call selectChain, passing deferChain through. If deferChain
-  // is false once selectChain returns, call initChain. Render a LoadingLayout
-  // immediately (before selectChain resolves).
+  // If the navigated-to community scope differs from the active chain id at render time,
+  // and we have not begun loading the new navigated-to community data, shouldSelectChain is
+  // set to true, and the navigated-to scope is loaded.
   const shouldSelectChain =
     selectedScope &&
     selectedScope !== app.activeChainId() &&
     selectedScope !== scopeToLoad &&
     scopeMatchesChain;
 
-  // IFB 7: If scope is not defined (and we are not on a custom domain),
-  // deinitialize whatever chain is loaded by calling deinitChainOrCommunity,
-  // then set loadingScope to null. Render a LoadingLayout immediately.
-  const shouldDeInitChain =
-    !selectedScope && !app.isCustomDomain() && app.chain && app.chain.network;
-
   useNecessaryEffect(() => {
     (async () => {
       if (shouldSelectChain) {
-        // IFB 5
         setIsLoading(true);
         setScopeToLoad(selectedScope);
         await selectChain(scopeMatchesChain);
@@ -74,9 +57,13 @@ const LayoutComponent = ({
     })();
   }, [shouldSelectChain]);
 
+  // If scope is not defined (and we are not on a custom domain), deinitialize the loaded chain
+  // with deinitChainOrCommunity(), then set loadingScope to null and render a LoadingLayout.
+  const shouldDeInitChain =
+    !selectedScope && !app.isCustomDomain() && app.chain && app.chain.network;
+
   useNecessaryEffect(() => {
     (async () => {
-      // IFB 7
       if (shouldDeInitChain) {
         setIsLoading(true);
         await deinitChainOrCommunity();
@@ -86,33 +73,16 @@ const LayoutComponent = ({
     })();
   }, [shouldDeInitChain]);
 
-  // Show loading state for these cases
-  // -
-  // IFB 2: If initApp() hasn’t finished loading yet
-  // -
-  // IFB 3: If the user has navigated to an ethereum address directly,
-  // init a new token chain immediately and show loading state
-  // -
-  // IFB 5
-  // -
-  // IFB 6
-  // -
-  // IFB 7
+  // A loading state (i.e. spinner) is shown in the following cases:
+  // - user login status has not finished loaded
+  // - a community is still being initialized or deinitialized
   const shouldShowLoadingState =
-    isLoading || // general loading
-    !app.loginStatusLoaded() || // IFB 2
-    // Important: render loading state immediately for IFB 5, 6 and 7, general
-    // loading will take over later
-    shouldSelectChain || // IFB 5
-    shouldDeInitChain; // IFB 7
+    isLoading ||
+    !app.loginStatusLoaded() ||
+    shouldSelectChain ||
+    shouldDeInitChain;
 
-  // IFB 4: If the user has attempted to a community page that was not
-  // found on the list of communities from /status, show a 404 page.
-  const pageNotFound = selectedScope && !scopeMatchesChain;
-
-  // IFB 8: No pending branch case - Render the inner page as passed by router
   const childToRender = () => {
-    // IFB 1: If initApp() threw an error, show application error.
     if (app.loadingError) {
       return (
         <CWEmptyState
@@ -135,6 +105,8 @@ const LayoutComponent = ({
 
     if (shouldShowLoadingState) return Bobber;
 
+    // If attempting to navigate to a community not fetched by the /status query, return a 404
+    const pageNotFound = selectedScope && !scopeMatchesChain;
     return (
       <Suspense fallback={Bobber}>
         {pageNotFound ? <PageNotFound /> : <Component {...routerParams} />}


### PR DESCRIPTION
Following on the heels of our new App Initialization Flow docs (#4763), this branch updates the Layout.tsx inline documentation to stay in sync with the news docs (and of course, with the Layout component's current code). 

## Link to Issue
Closes: #4582 

## Description of Changes
- Removes references to deprecated `deferChain` and Ethereum address functionality
- Removes the Init-Flow-Step (IFS) structure of documentation, which is unnecessary given the current simplification of our Layout component (and which was inconsistently referenced, causing confusion; see removed references to IFB and IBS in earlier version of the file)
- Clarifies and improves language throughout
- Moves several function and const declarations for better conceptual organization. 
    - See: the new location of the `pageNotFound` const on line 109 and the new location of `shouldDeInitChain` on line 62
    - This does not alter component functionality, merely groups together conceptually interrelated code (and its respective inline documentation) for greater clarity.