### PR TITLE
Fix ban check bug + add ban check to unit tests

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
@@ -5,11 +5,15 @@ import { ApiEndpoints } from 'state/api/config';
 import useFetchCommentsQuery from './fetchComments';
 
 interface DeleteReactionProps {
+  chainId: string;
+  address: string;
   canvasHash: string;
   reactionId: number;
 }
 
 const deleteReaction = async ({
+  chainId,
+  address,
   canvasHash,
   reactionId,
 }: DeleteReactionProps) => {
@@ -20,10 +24,11 @@ const deleteReaction = async ({
   } = await app.sessions.signDeleteCommentReaction({
     comment_id: canvasHash,
   });
-
   return await axios
     .delete(`${app.serverUrl()}/reactions/${reactionId}`, {
       data: {
+        author_chain: chainId,
+        address: address,
         jwt: app.user.jwt,
         canvas_action: action,
         canvas_session: session,

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -5,6 +5,7 @@ import { updateThreadInAllCaches } from './helpers/cache';
 
 interface UseDeleteThreadReactionMutationProps {
   chainId: string;
+  address: string;
   threadId: number;
 }
 
@@ -13,6 +14,8 @@ interface DeleteReactionProps extends UseDeleteThreadReactionMutationProps {
 }
 
 const deleteReaction = async ({
+  chainId,
+  address,
   reactionId,
   threadId,
 }: DeleteReactionProps) => {
@@ -28,6 +31,8 @@ const deleteReaction = async ({
     `${app.serverUrl()}/reactions/${reactionId}`,
     {
       data: {
+        author_chain: chainId,
+        address: address,
         jwt: app.user.jwt,
         canvas_action: action,
         canvas_session: session,

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
@@ -8,13 +8,20 @@ import { removeThreadFromAllCaches } from './helpers/cache';
 interface DeleteThreadProps {
   chainId: string;
   threadId: number;
+  address: string;
 }
 
-const deleteThread = async ({ chainId, threadId }: DeleteThreadProps) => {
+const deleteThread = async ({
+  chainId,
+  threadId,
+  address,
+}: DeleteThreadProps) => {
   return await axios.delete(`${app.serverUrl()}/threads/${threadId}`, {
     data: {
+      author_chain: chainId,
+      chain: chainId,
+      address: address,
       jwt: app.user.jwt,
-      chain_id: chainId,
     },
   });
 };

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -56,6 +56,8 @@ export const CommentReactionButton = ({
         return r.author === activeAddress;
       });
       deleteCommentReaction({
+        chainId: app.activeChainId(),
+        address: app.user.activeAccount.address,
         canvasHash: foundReaction.canvasHash,
         reactionId: foundReaction.id,
       }).catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -103,6 +103,7 @@ export const AdminActions = ({
               await deleteThread({
                 threadId: thread.id,
                 chainId: app.activeChainId(),
+                address: app.user.activeAccount.address,
               })
                 .then(() => {
                   onDelete && onDelete();

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -50,7 +50,8 @@ export const ReactionButton = ({
     (r) => r.address === activeAddress
   );
   const hasReacted = thisUserReaction?.length !== 0;
-  const reactedId = thisUserReaction?.length === 0 ? -1 : thisUserReaction?.[0]?.id;
+  const reactedId =
+    thisUserReaction?.length === 0 ? -1 : thisUserReaction?.[0]?.id;
 
   const { mutateAsync: createThreadReaction, isLoading: isAddingReaction } =
     useCreateThreadReactionMutation({
@@ -60,10 +61,11 @@ export const ReactionButton = ({
   const { mutateAsync: deleteThreadReaction, isLoading: isDeletingReaction } =
     useDeleteThreadReactionMutation({
       chainId: app.activeChainId(),
+      address: app.user.activeAccount.address,
       threadId: thread.id,
     });
 
-  if (showSkeleton) return <ReactionButtonSkeleton />
+  if (showSkeleton) return <ReactionButtonSkeleton />;
   const isLoading = isAddingReaction || isDeletingReaction;
 
   // token balance check if needed
@@ -82,6 +84,7 @@ export const ReactionButton = ({
     if (hasReacted) {
       deleteThreadReaction({
         chainId: app.activeChainId(),
+        address: app.user.activeAccount.address,
         threadId: thread.id,
         reactionId: reactedId as number,
       }).catch((e) => {
@@ -115,8 +118,9 @@ export const ReactionButton = ({
       ) : (
         <button
           onClick={handleVoteClick}
-          className={`ThreadReactionButton ${isLoading || isUserForbidden ? ' disabled' : ''
-            }${hasReacted ? ' has-reacted' : ''}`}
+          className={`ThreadReactionButton ${
+            isLoading || isUserForbidden ? ' disabled' : ''
+          }${hasReacted ? ' has-reacted' : ''}`}
         >
           {reactors.length > 0 ? (
             <CWTooltip

--- a/packages/commonwealth/server/controllers/server_comments_methods/delete_comment.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/delete_comment.ts
@@ -47,7 +47,7 @@ export async function __deleteComment(
     address: address.address,
   });
   if (!canInteract) {
-    throw new AppError(`${Errors.BanError}; ${error}`);
+    throw new AppError(`${Errors.BanError}: ${error}`);
   }
 
   const userOwnedAddressIds = (await user.getAddresses())

--- a/packages/commonwealth/server/controllers/server_reactions_methods/delete_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_reactions_methods/delete_reaction.ts
@@ -2,6 +2,7 @@ import { UserInstance } from 'server/models/user';
 import { ServerReactionsController } from '../server_reactions_controller';
 import { Op } from 'sequelize';
 import { AppError } from '../../../../common-common/src/errors';
+import { AddressInstance } from 'server/models/address';
 
 const Errors = {
   ReactionNotFound: 'Reaction not found',
@@ -10,6 +11,7 @@ const Errors = {
 
 export type DeleteReactionOptions = {
   user: UserInstance;
+  address: AddressInstance;
   reactionId: any;
 };
 
@@ -17,7 +19,7 @@ export type DeleteReactionResult = void;
 
 export async function __deleteReaction(
   this: ServerReactionsController,
-  { user, reactionId }: DeleteReactionOptions
+  { user, address, reactionId }: DeleteReactionOptions
 ): Promise<DeleteReactionResult> {
   const userOwnedAddressIds = (await user.getAddresses())
     .filter((addr) => !!addr.verified)
@@ -38,7 +40,7 @@ export async function __deleteReaction(
   // check if author is banned
   const [canInteract, banError] = await this.banCache.checkBan({
     chain: reaction.chain,
-    address: reaction.Address.address,
+    address: address.address,
   });
   if (!canInteract) {
     throw new AppError(`${Errors.BanError}: ${banError}`);

--- a/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
@@ -4,6 +4,7 @@ import { ServerThreadsController } from '../server_threads_controller';
 import { Op } from 'sequelize';
 import deleteThreadFromDb from '../../util/deleteThread';
 import { AppError } from '../../../../common-common/src/errors';
+import { AddressInstance } from 'server/models/address';
 
 export const Errors = {
   ThreadNotFound: 'Thread not found',
@@ -12,6 +13,7 @@ export const Errors = {
 
 export type DeleteThreadOptions = {
   user: UserInstance;
+  address: AddressInstance;
   threadId?: number;
   messageId?: string;
 };
@@ -20,7 +22,7 @@ export type DeleteThreadResult = void;
 
 export async function __deleteThread(
   this: ServerThreadsController,
-  { user, threadId, messageId }: DeleteThreadOptions
+  { user, address, threadId, messageId }: DeleteThreadOptions
 ): Promise<DeleteThreadResult> {
   if (!threadId) {
     // Special handling for discobot threads
@@ -49,7 +51,7 @@ export async function __deleteThread(
   // check ban
   const [canInteract, banError] = await this.banCache.checkBan({
     chain: thread.chain,
-    address: thread.Address.address,
+    address: address.address,
   });
   if (!canInteract) {
     throw new AppError(`Ban error: ${banError}`);

--- a/packages/commonwealth/server/routes/reactions/delete_reaction_handler.ts
+++ b/packages/commonwealth/server/routes/reactions/delete_reaction_handler.ts
@@ -21,6 +21,7 @@ export const deleteReactionHandler = async (
 
   await controllers.reactions.deleteReaction({
     user: req.user,
+    address: req.address,
     reactionId,
   });
 

--- a/packages/commonwealth/server/routes/threads/delete_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/delete_thread_handler.ts
@@ -14,7 +14,7 @@ export const deleteThreadHandler = async (
   req: TypedRequestParams<DeleteThreadRequestParams>,
   res: TypedResponse<DeleteThreadResponse>
 ) => {
-  const { user } = req;
+  const { user, address } = req;
   const { id } = req.params;
 
   const threadId = parseInt(id, 10) || 0;
@@ -22,7 +22,7 @@ export const deleteThreadHandler = async (
     throw new AppError(Errors.InvalidThreadID);
   }
 
-  await controllers.threads.deleteThread({ user, threadId });
+  await controllers.threads.deleteThread({ user, address, threadId });
 
   return success(res, undefined);
 };

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -622,6 +622,7 @@ function setupRouter(
     'delete',
     '/threads/:id',
     passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
     databaseValidationService.validateChain,
     deleteThreadHandler.bind(this, serverControllers)
   );
@@ -810,6 +811,7 @@ function setupRouter(
     'delete',
     '/reactions/:id',
     passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
     deleteReactionHandler.bind(this, serverControllers)
   );
   registerRoute(

--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -4,6 +4,7 @@ import { ServerCommentsController } from 'server/controllers/server_comments_con
 import { SearchCommentsOptions } from 'server/controllers/server_comments_methods/search_comments';
 import { ChainInstance } from 'server/models/chain';
 import Sinon from 'sinon';
+import { BAN_CACHE_MOCK_FN } from 'test/util/banCacheMock';
 
 describe('ServerCommentsController', () => {
   describe('#createCommentReaction', () => {
@@ -50,9 +51,7 @@ describe('ServerCommentsController', () => {
         },
       };
       const tokenBalanceCache = {};
-      const banCache = {
-        checkBan: sandbox.stub().resolves([true, null]),
-      };
+      const banCache = BAN_CACHE_MOCK_FN('ethereum');
 
       const user = {
         getAddresses: sandbox.stub().resolves([{ id: 1, verified: true }]),
@@ -80,6 +79,19 @@ describe('ServerCommentsController', () => {
           reaction: reaction as any,
           commentId,
         });
+
+      expect(
+        serverCommentsController.createCommentReaction({
+          user: user as any,
+          address: {
+            ...(address as any),
+            address: '0xbanned',
+          },
+          chain: chain as any,
+          reaction: reaction as any,
+          commentId,
+        })
+      ).to.be.rejectedWith('Ban error: banned');
 
       expect(newReaction).to.be.ok;
 
@@ -546,9 +558,7 @@ describe('ServerCommentsController', () => {
         },
       };
       const tokenBalanceCache = {};
-      const banCache = {
-        checkBan: async () => [true, null],
-      };
+      const banCache = BAN_CACHE_MOCK_FN('ethereum');
 
       const serverCommentsController = new ServerCommentsController(
         db as any,
@@ -578,6 +588,19 @@ describe('ServerCommentsController', () => {
           commentId,
           commentBody,
         });
+
+      expect(
+        serverCommentsController.updateComment({
+          user: user as any,
+          address: {
+            ...(address as any),
+            address: '0xbanned',
+          },
+          chain: chain as any,
+          commentId,
+          commentBody,
+        })
+      ).to.be.rejectedWith('Ban error: banned');
 
       expect(updatedComment).to.include({
         id: 123,
@@ -760,9 +783,7 @@ describe('ServerCommentsController', () => {
         },
       };
       const tokenBalanceCache = {};
-      const banCache = {
-        checkBan: async () => [true, null],
-      };
+      const banCache = BAN_CACHE_MOCK_FN('ethereum');
 
       const serverCommentsController = new ServerCommentsController(
         db as any,
@@ -774,7 +795,9 @@ describe('ServerCommentsController', () => {
         getAddresses: async () => [{ id: 1, verified: true }],
       };
       const address = {};
-      const chain = {};
+      const chain = {
+        id: 'ethereum',
+      };
       const commentId = 1;
       await serverCommentsController.deleteComment({
         user: user as any,
@@ -783,6 +806,18 @@ describe('ServerCommentsController', () => {
         commentId,
       });
       expect(didDestroy).to.be.true;
+
+      expect(
+        serverCommentsController.deleteComment({
+          user: user as any,
+          address: {
+            ...(address as any),
+            address: '0xbanned',
+          },
+          chain: chain as any,
+          commentId,
+        })
+      ).to.be.rejectedWith('Ban error: banned');
     });
   });
 });

--- a/packages/commonwealth/test/util/banCacheMock.ts
+++ b/packages/commonwealth/test/util/banCacheMock.ts
@@ -1,0 +1,8 @@
+export const BAN_CACHE_MOCK_FN = (chainId: string) => ({
+  checkBan: async (options: any) => {
+    if (options.chain === chainId && options.address === '0xbanned') {
+      return [false, 'banned'];
+    }
+    return [true, null];
+  },
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4802

## Description of Changes
- Fixes issue where ban check did not use request user's address
- Adds unit test coverage for ban check on mutation routes

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
N/A

## Other Considerations
N/A