### PR TITLE
bug fix: upvoter list now displays on hover over entire button

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -113,39 +113,45 @@ export const ReactionButton = ({
           })}
         />
       ) : (
-        <button
-          onClick={handleVoteClick}
-          className={`ThreadReactionButton ${isLoading || isUserForbidden ? ' disabled' : ''
-            }${hasReacted ? ' has-reacted' : ''}`}
-        >
-          {reactors.length > 0 ? (
-            <CWTooltip
-              content={getDisplayedReactorsForPopup({
-                reactors,
-              })}
-              renderTrigger={(handleInteraction) => (
-                <div
-                  onMouseEnter={handleInteraction}
-                  onMouseLeave={handleInteraction}
-                >
-                  <div className="reactions-container">
-                    <CWIcon
-                      iconName="upvote"
-                      iconSize="small"
-                      {...(hasReacted && { weight: 'fill' })}
-                    />
-                    <div
-                      className={`reactions-count ${
-                        hasReacted ? ' has-reacted' : ''
-                      }`}
-                    >
-                      {reactors.length}
-                    </div>
+        reactors.length > 0 ? (
+          <CWTooltip
+          content={getDisplayedReactorsForPopup({
+            reactors,
+          })}
+          renderTrigger={(handleInteraction) => (
+            <button
+              onClick={handleVoteClick}
+              className={`ThreadReactionButton ${isLoading || isUserForbidden ? ' disabled' : ''
+                }${hasReacted ? ' has-reacted' : ''}`}
+                onMouseEnter={handleInteraction}
+                onMouseLeave={handleInteraction}
+            >
+              <div
+              >
+                <div className="reactions-container">
+                  <CWIcon
+                    iconName="upvote"
+                    iconSize="small"
+                    {...(hasReacted && { weight: 'fill' })}
+                  />
+                  <div
+                    className={`reactions-count ${
+                      hasReacted ? ' has-reacted' : ''
+                    }`}
+                  >
+                    {reactors.length}
                   </div>
                 </div>
-              )}
-            />
-          ) : (
+              </div>
+            </button>
+          )}
+        />
+        ) : (
+          <button
+            onClick={handleVoteClick}
+            className={`ThreadReactionButton ${isLoading || isUserForbidden ? ' disabled' : ''
+              }${hasReacted ? ' has-reacted' : ''}`}
+          >
             <div className="reactions-container">
               <CWIcon iconName="upvote" iconSize="small" />
               <div
@@ -156,8 +162,8 @@ export const ReactionButton = ({
                 {reactors.length}
               </div>
             </div>
-          )}
-        </button>
+          </button>
+        )
       )}
       <Modal
         content={<LoginModal onModalClose={() => setIsModalOpen(false)} />}


### PR DESCRIPTION
Bug: the list of upvoters only appears when hovering over the internal element consisting of the up arrow and vote count in the center of the upvote button. This fix makes it such that the upvote list displays when you hover over any part of the upvote button.

## Link to Issue
Closes: #4727 

## Description of Changes
- display upvoter list when hovering over any part of the upvote button

## "How We Fixed It"
- move mouse over event to button, instead of internal button element

## Test Plan
- click around on the demo branch
