### PR TITLE
Fixed address error screen on discussions page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -61,7 +61,7 @@ export const ReactionButton = ({
   const { mutateAsync: deleteThreadReaction, isLoading: isDeletingReaction } =
     useDeleteThreadReactionMutation({
       chainId: app.activeChainId(),
-      address: app.user.activeAccount.address,
+      address: app.user.activeAccount?.address,
       threadId: thread.id,
     });
 


### PR DESCRIPTION
When deleteReactionHook is used and user is not logged in `app.user.activeAccount` resolves to null which throws an NPE `on app.user.activeAccount.address`

## Link to Issue
Closes: #4823

## Description of Changes
- Add null-conditional operator to avoid NPE

## How we fixed it
- Since the original bug is the null pointer error screen, fixing the NPE fixes this portion
- In order to react on a button, you need an address. But we have checks in place to only allow the reaction button to be clicked if logged in, in which case the user must have an active address (see code snippet from `handleVoteClick` in ReactionButton.tsx).
```
    if (!app.isLoggedIn() || !app.user.activeAccount) {
      setIsModalOpen(true);
      return;
    }
```
So for this reason, the solution proposed in this PR doesn't break reacting to threads.

## Test Plan
- CA (click around) tested on local
- Passes CI
