### PR TITLE
Replace "Gate Discord" with "Connect Discord"

### DIFF
--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -3,6 +3,7 @@ import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import app from 'state';
+import { uuidv4 } from 'lib/util';
 import useSidebarStore, { sidebarStore } from 'state/ui/sidebar';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
 import { CWMobileMenu } from '../components/component_kit/cw_mobile_menu';
@@ -11,6 +12,7 @@ import { PopoverMenu } from '../components/component_kit/cw_popover/cw_popover_m
 import { CWSidebarMenu } from '../components/component_kit/cw_sidebar_menu';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { featureFlags } from 'helpers/feature-flags';
+import Permissions from '../../utils/Permissions';
 
 const resetSidebarState = () => {
   sidebarStore.getState().setMenu({ name: 'default', isVisible: false });
@@ -165,22 +167,45 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
         navigate('/createCommunity/starter', {}, null);
       },
     },
-    {
-      label: 'Gate your Discord',
-      iconLeft: 'discord',
-      onClick: (e) => {
-        e?.preventDefault();
-        resetSidebarState();
-        window.open(
-          `https://discord.com/oauth2/authorize?client_id=${
-            process.env.DISCORD_CLIENT_ID
-          }&permissions=8&scope=applications.commands%20bot&redirect_uri=${encodeURI(
-            process.env.DISCORD_UI_URL
-          )}/callback&response_type=code&scope=bot`
-        );
-      },
-    },
   ];
+
+  const getDiscordBotConnectionItems = (): PopoverMenuItem[] => {
+    const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
+    const botNotConnected = app.chain.meta.discordConfigId === null;
+
+    if (isAdmin && botNotConnected) {
+      return [
+        {
+          label: 'Connect Discord',
+          iconLeft: 'discord',
+          onClick: async (e) => {
+            try {
+              const verification_token = uuidv4();
+              await app.discord.createConfig(verification_token);
+
+              window.open(
+                `https://discord.com/oauth2/authorize?client_id=${
+                  process.env.DISCORD_CLIENT_ID
+                }&permissions=1024&scope=applications.commands%20bot&redirect_uri=${encodeURI(
+                  `${window.location.origin}`
+                )}/discord-callback&response_type=code&scope=bot&state=${encodeURI(
+                  JSON.stringify({
+                    cw_chain_id: app.activeChainId(),
+                    verification_token,
+                  })
+                )}`,
+                '_parent'
+              );
+            } catch (err) {
+              console.log(err);
+            }
+          },
+        },
+      ];
+    } else {
+      return [];
+    }
+  };
 
   return [
     ...(app.activeChainId()
@@ -202,6 +227,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           ...getSubstrateProposalItems(),
           ...getSnapshotProposalItem(),
           ...getTemplateItems(),
+          ...getDiscordBotConnectionItems(),
         ]
       : []),
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4832

## Description of Changes
- Allows admins to connect discord via "connect discord" option in the sidebar. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Details in ticket; basically just replicated existing connection flow in manage community page. 

## Test Plan
- In a community without a discord bot connected, click the sidebar, click "connect discord", and complete the flow. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 