### PR TITLE
handle case: no amount in communitySpendProposal

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
@@ -164,12 +164,14 @@ export const msgToIProposal = (p: Proposal): ICosmosProposal | null => {
     const spend = CommunityPoolSpendProposal.decode(content.value);
     type = 'communitySpend';
     spendRecipient = spend.recipient;
-    spendAmount = [
-      new CosmosToken(
-        spend.amount[0].denom.toUpperCase(),
-        spend.amount[0].amount
-      ).toCoinObject(),
-    ];
+    spendAmount = spend.amount[0]
+      ? [
+          new CosmosToken(
+            spend.amount[0]?.denom?.toUpperCase(),
+            spend.amount[0]?.amount
+          ).toCoinObject(),
+        ]
+      : [];
   }
   return {
     identifier: p.proposalId.toString(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4822 

## Description of Changes
- Fixes silent fail of proposal load in juno and injective

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Handled a null case: CommunitySpendProposal with nothing in `amount` array

## Test Plan
- proposals.spec.ts E2E tests pass (they use juno)
- CA (click around) tested on local and frack:
  - http://localhost:8080/injective/proposals proposals load
  - http://localhost:8080/juno/proposals same

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 