### PR TITLE
Allow superadmins to delete all admins

### DIFF
--- a/packages/commonwealth/server/routes/upgradeMember.ts
+++ b/packages/commonwealth/server/routes/upgradeMember.ts
@@ -82,7 +82,7 @@ const upgradeMember = async (
       },
     });
 
-    if (!otherExistingAdmin) {
+    if (!otherExistingAdmin && !req.user.isAdmin) {
       return next(new AppError(Errors.MustHaveAdmin));
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4786 

## Description of Changes
- Overrides protection on deleting the final admin in a community for superadmins.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Changed the condition that the "Communities must have at least one admin" error is thrown.

## Test Plan
- Be a superadmin, attempt to remove all admins in a community. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 