### PR TITLE
Replace user.lastVisted property

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -144,28 +144,6 @@ export async function completeClientLogin(account: Account) {
   }
 }
 
-export async function updateLastVisited(
-  activeEntity: ChainInfo,
-  updateFrontend?: boolean
-) {
-  if (!app.isLoggedIn()) return;
-  try {
-    const timestamp = moment();
-    const obj = { activeEntity: activeEntity.id, timestamp };
-    const value = JSON.stringify(obj);
-    if (updateFrontend) {
-      app.user.lastVisited[activeEntity.id] = new Date().toISOString();
-    }
-    await $.post(`${app.serverUrl()}/writeUserSetting`, {
-      jwt: app.user.jwt,
-      key: 'lastVisited',
-      value,
-    });
-  } catch (e) {
-    console.log('Could not update lastVisited:', e);
-  }
-}
-
 export async function updateActiveAddresses({
   chain,
   shouldRedraw = true,
@@ -226,7 +204,6 @@ export function updateActiveUser(data) {
 
     app.user.setSiteAdmin(false);
     app.user.setDisableRichText(false);
-    app.user.setLastVisited({});
     app.user.setUnseenPosts({});
 
     app.user.setActiveAccounts([]);
@@ -258,7 +235,6 @@ export function updateActiveUser(data) {
 
     app.user.setSiteAdmin(data.isAdmin);
     app.user.setDisableRichText(data.disableRichText);
-    app.user.setLastVisited(data.lastVisited);
     app.user.setUnseenPosts(data.unseenPosts);
   }
 }
@@ -307,7 +283,7 @@ export async function unlinkLogin(account: AddressInfo) {
   app.roles.deleteRole({
     address: account,
     chain: account.chain.id,
-  })
+  });
   // Remove from all address stores in the frontend state.
   // This might be more gracefully handled by calling initAppState again.
   let index = app.user.activeAccounts.indexOf(account);

--- a/packages/commonwealth/client/scripts/controllers/server/user.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/user.ts
@@ -133,15 +133,6 @@ export class UserController {
     this._notifications = notifications;
   }
 
-  private _lastVisited: object;
-  public get lastVisited(): object {
-    return this._lastVisited;
-  }
-
-  private _setLastVisited(lastVisited: object): void {
-    this._lastVisited = lastVisited;
-  }
-
   private _starredCommunities: StarredCommunity[];
   public get starredCommunities(): StarredCommunity[] {
     return this._starredCommunities;
@@ -292,10 +283,6 @@ export class UserController {
 
   public setNotifications(notifications: NotificationsController): void {
     this._setNotifications(notifications);
-  }
-
-  public setLastVisited(lastVisited: object): void {
-    this._setLastVisited(lastVisited);
   }
 
   public setStarredCommunities(star: StarredCommunity[]): void {

--- a/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { updateLastVisited } from 'controllers/app/login';
 import Comment from 'models/Comment';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
@@ -71,11 +70,6 @@ const useCreateCommentMutation = ({
       queryClient.setQueryData(key, () => {
         return [...comments, newComment];
       });
-
-      // TODO: these types of async calls should also have a dedicated react query handler
-      // update last visisted
-      updateLastVisited(app.chain.meta, true);
-
       updateThreadInAllCaches(chainId, threadId, {
         numberOfComments: existingNumberOfComments + 1,
       });

--- a/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
@@ -1,6 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
-import { updateLastVisited } from 'controllers/app/login';
 import MinimumProfile from 'models/MinimumProfile';
 import Thread from 'models/Thread';
 import Topic from 'models/Topic';
@@ -83,9 +82,6 @@ const useCreateThreadMutation = ({ chainId }: Partial<CreateThreadProps>) => {
               : totalThreadsInCommunityForVoting,
         })
       );
-      const activeEntity = app.chain;
-      updateLastVisited(activeEntity.meta, true);
-
       return newThread;
     },
   });

--- a/packages/commonwealth/server-test.ts
+++ b/packages/commonwealth/server-test.ts
@@ -98,7 +98,6 @@ const resetServer = (debug = false): Promise<void> => {
         email: 'drewstone329@gmail.com',
         emailVerified: true,
         isAdmin: true,
-        lastVisited: '{}',
       });
 
       const nodes = [

--- a/packages/commonwealth/server/migrations/20230825152245-remove-users-lastvisited.js
+++ b/packages/commonwealth/server/migrations/20230825152245-remove-users-lastvisited.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', 'lastVisited');
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'lastVisited', {
+      type: Sequelize.TEXT,
+      allowNull: false,
+      defaultValue: '{}',
+    });
+  }
+};

--- a/packages/commonwealth/server/models/user.ts
+++ b/packages/commonwealth/server/models/user.ts
@@ -17,7 +17,6 @@ export type UserAttributes = {
   id?: number;
   emailVerified?: boolean;
   isAdmin?: boolean;
-  lastVisited?: string;
   disableRichText?: boolean;
   emailNotificationInterval?: EmailNotificationInterval;
   selected_chain_id?: number | null;
@@ -90,11 +89,6 @@ export default (
         allowNull: false,
       },
       isAdmin: { type: dataTypes.BOOLEAN, defaultValue: false },
-      lastVisited: {
-        type: dataTypes.TEXT,
-        allowNull: false,
-        defaultValue: '{}',
-      },
       disableRichText: {
         type: dataTypes.BOOLEAN,
         defaultValue: false,

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -285,7 +285,7 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
       };
     } else {
       // if the chain does have activePosts convert the set of ids to simply the length of the set
-      unseenPosts[name].activePosts = unseenPosts[name].activePosts.size;
+      unseenPosts[name].activePosts = unseenPosts[name].activePosts?.size || 0;
     }
   }
   /**

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -47,7 +47,6 @@ type StatusResp = {
     selectedChain: ChainInstance;
     isAdmin: boolean;
     disableRichText: boolean;
-    lastVisited: string;
     starredCommunities: StarredCommunityAttributes[];
     unseenPosts: { [chain: string]: number };
   };
@@ -132,24 +131,17 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
 
   const unfilteredAddresses = await user.getAddresses();
   // TODO: fetch all this data with a single query
-  const [
-    addresses,
-    socialAccounts,
-    selectedChain,
-    isAdmin,
-    disableRichText,
-    lastVisited,
-  ] = await Promise.all([
-    unfilteredAddresses.filter(
-      (address) =>
-        !!address.verified && chains.map((c) => c.id).includes(address.chain)
-    ),
-    user.getSocialAccounts(),
-    user.getSelectedChain(),
-    user.isAdmin,
-    user.disableRichText,
-    user.lastVisited,
-  ]);
+  const [addresses, socialAccounts, selectedChain, isAdmin, disableRichText] =
+    await Promise.all([
+      unfilteredAddresses.filter(
+        (address) =>
+          !!address.verified && chains.map((c) => c.id).includes(address.chain)
+      ),
+      user.getSocialAccounts(),
+      user.getSelectedChain(),
+      user.isAdmin,
+      user.disableRichText,
+    ]);
 
   // look up my roles & private communities
   const myAddressIds: number[] = Array.from(
@@ -170,10 +162,7 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
   /**
    * Purpose of this section is to count the number of threads that have new updates grouped by community
    */
-  const commsAndChains = Object.entries(JSON.parse(user.lastVisited));
-  const commsAndChains2 = await getChainActivity(addresses);
-  console.log('commsAndChains: ', commsAndChains);
-  console.log('commsAndChains2: ', commsAndChains2);
+  const commsAndChains = await getChainActivity(addresses);
   const unseenPosts = {};
   let query = ``;
   let replacements = [];
@@ -325,7 +314,6 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
       selectedChain,
       isAdmin,
       disableRichText,
-      lastVisited: JSON.parse(lastVisited),
       starredCommunities,
       unseenPosts,
     },

--- a/packages/commonwealth/server/routes/writeUserSetting.ts
+++ b/packages/commonwealth/server/routes/writeUserSetting.ts
@@ -31,15 +31,7 @@ const writeUserSetting = async (
     return next(new AppError(Errors.NoKeyValue));
   }
 
-  if (key === 'lastVisited') {
-    const obj = JSON.parse(req.user.lastVisited);
-    const val = JSON.parse(value);
-    const { activeEntity, timestamp } = val;
-    obj[activeEntity] = timestamp;
-    const str = JSON.stringify(obj);
-    req.user.lastVisited = str;
-    await req.user.save();
-  } else if (key === 'disableRichText' && value === 'true') {
+  if (key === 'disableRichText' && value === 'true') {
     req.user.disableRichText = true;
     await req.user.save();
   } else if (key === 'disableRichText' && value === 'false') {

--- a/packages/commonwealth/server/util/databaseCleaner.ts
+++ b/packages/commonwealth/server/util/databaseCleaner.ts
@@ -220,11 +220,12 @@ export default class DatabaseCleaner {
         await this._models.sequelize.query(
           `
             CREATE TEMPORARY TABLE sub_ids_to_delete as (
-              WITH user_ids_to_delete as MATERIALIZED (
-                  SELECT U.id, U.updated_at
+              WITH user_ids_to_delete AS MATERIALIZED (
+                  SELECT U.id
                   FROM "Users" U
-                  WHERE U.updated_at < NOW() - interval '12 months'
-                  ORDER BY U.updated_at
+                  LEFT JOIN "Addresses" A ON U.id = A.user_id
+                  WHERE A.last_active < NOW() - INTERVAL '12 months' OR A.last_active IS NULL
+                  GROUP BY U.id
               )
               SELECT S.id
               FROM "Subscriptions" S

--- a/packages/commonwealth/test/e2e/hooks/e2eDbEntityHooks.spec.ts
+++ b/packages/commonwealth/test/e2e/hooks/e2eDbEntityHooks.spec.ts
@@ -162,7 +162,6 @@ export async function createTestEntities() {
                 email: `test${i - 1}@gmail.com`,
                 emailVerified: true,
                 isAdmin: true,
-                lastVisited: '{}',
               },
             })
           )[0]

--- a/packages/commonwealth/test/e2e/utils/e2eUtils.ts
+++ b/packages/commonwealth/test/e2e/utils/e2eUtils.ts
@@ -175,7 +175,6 @@ export async function createInitialUser() {
         '2023-07-14 13:03:56.196-07',
         false,
         false,
-        '{}',
         false,
         NULL,
         'never'

--- a/packages/commonwealth/test/e2e/utils/e2eUtils.ts
+++ b/packages/commonwealth/test/e2e/utils/e2eUtils.ts
@@ -69,10 +69,10 @@ export async function addAlchemyKey() {
   // If it does exist, update the key
   await testDb.query(`
   UPDATE "ChainNodes"
-  SET 
+  SET
     url = 'https://eth-mainnet.g.alchemy.com/v2/${apiKey}',
     alt_wallet_url = 'https://eth-mainnet.g.alchemy.com/v2/${apiKey}'
-  WHERE 
+  WHERE
     eth_chain_id = 1
     AND NOT EXISTS (select 1 from "ChainNodes" where url = 'https://eth-mainnet.g.alchemy.com/v2/${apiKey}')
   `);
@@ -166,7 +166,6 @@ export async function createInitialUser() {
         updated_at,
         "isAdmin",
         "disableRichText",
-        "lastVisited",
         "emailVerified",
         selected_chain_id,
         "emailNotificationInterval"

--- a/packages/commonwealth/test/integration/api/external/dbEntityHooks.spec.ts
+++ b/packages/commonwealth/test/integration/api/external/dbEntityHooks.spec.ts
@@ -70,7 +70,6 @@ export async function createTestEntities() {
               email: `test${i - 1}@gmail.com`,
               emailVerified: true,
               isAdmin: true,
-              lastVisited: '{}',
             },
           })
         )[0]

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -195,8 +195,8 @@ describe('DatabaseCleaner Tests', () => {
       const oldUser = <any>(
         await models.sequelize.query(
           `
-        INSERT INTO "Users"(email, created_at, updated_at, "lastVisited", "emailNotificationInterval")
-        VALUES ('dbCleanerOld@test.com', NOW() - INTERVAL '1 year' - INTERVAL '2 days', NOW() - INTERVAL '1 year' - INTERVAL '2 days', '{}', 'never')
+        INSERT INTO "Users"(email, created_at, updated_at, "emailNotificationInterval")
+        VALUES ('dbCleanerOld@test.com', NOW() - INTERVAL '1 year' - INTERVAL '2 days', NOW() - INTERVAL '1 year' - INTERVAL '2 days', 'never')
         RETURNING id;
       `,
           { type: QueryTypes.INSERT, raw: true }
@@ -206,8 +206,8 @@ describe('DatabaseCleaner Tests', () => {
       const newUser = <any>(
         await models.sequelize.query(
           `
-        INSERT INTO "Users"(email, created_at, updated_at, "lastVisited", "emailNotificationInterval")
-        VALUES ('dbCleanerNew@test.com', NOW(), NOW(), '{}', 'never')
+        INSERT INTO "Users"(email, created_at, updated_at, "emailNotificationInterval")
+        VALUES ('dbCleanerNew@test.com', NOW(), NOW(), 'never')
         RETURNING id;
       `,
           { type: QueryTypes.INSERT, raw: true }

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -196,7 +196,7 @@ describe('DatabaseCleaner Tests', () => {
         email: 'dbCleanerTest@old.com',
         emailVerified: true,
       });
-      const addrOld = await models.Address.create({
+      await models.Address.create({
         user_id: oldUser.id,
         address: '0x1234',
         chain: 'ethereum',
@@ -209,7 +209,7 @@ describe('DatabaseCleaner Tests', () => {
         email: 'dbCleanerTest@new.com',
         emailVerified: true,
       });
-      const addrNew = await models.Address.create({
+      await models.Address.create({
         user_id: newUser.id,
         address: '0x2345',
         chain: 'ethereum',

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -5,9 +5,8 @@ import DatabaseCleaner from '../../server/util/databaseCleaner';
 import models from '../../server/database';
 import sinon from 'sinon';
 import { NotificationCategories } from 'common-common/src/types';
-import { QueryTypes, Sequelize } from 'sequelize';
+import { Sequelize } from 'sequelize';
 import { RedisCache } from 'common-common/src/redisCache';
-import { REDIS_URL } from '../../server/config';
 
 chai.use(chaiHttp);
 const { expect } = chai;

--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -17,5 +17,5 @@ then
     echo "There is nothing to lint"
 else
     echo $LINES
-    NODE_OPTIONS="--max-old-space-size=4096" eslint $LINES
+    NODE_OPTIONS="--max-old-space-size=8192" eslint $LINES
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4576 

## Description of Changes
- Removes the `"Users".lastVisted` column from DB, and all references to it in frontend/backend code
- Updates the /status route to use `address.last_active` in place of `user.lastVisited` for user's per-chain activity
- Updates the `DatabaseCleaner` class to use `address.last_active` in place of `user.last_updated` for subscription deletions

## Test Plan
- Load up the app and confirm it loads any page properly (confirms that /status route is functioning correctly)
- As for the `DatabaseCleaner` class, there's an integration test for it

## Deployment Plan
- Must run migration which removes the `"Users".lastVisited` column

## Other Considerations
- Users with addresses that have a null value for `address.last_active` will be included in the "subs to delete" list