### PR TITLE
Navigate to thread details page when comment btn is clicked in thread card

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -32,6 +32,7 @@ type CreateCommentProps = {
   parentCommentId?: number;
   rootThread: Thread;
   canComment: boolean;
+  shouldFocusEditor?: boolean;
 };
 
 export const CreateComment = ({
@@ -39,6 +40,7 @@ export const CreateComment = ({
   parentCommentId,
   rootThread,
   canComment,
+  shouldFocusEditor = false,
 }: CreateCommentProps) => {
   const { saveDraft, restoreDraft, clearDraft } = useDraft<DeltaStatic>(
     !parentCommentId
@@ -180,6 +182,7 @@ export const CreateComment = ({
         setContentDelta={setContentDelta}
         isDisabled={!canComment}
         tooltipLabel="Join community to comment"
+        shouldFocus={shouldFocusEditor}
       />
       {tokenPostingThreshold && tokenPostingThreshold.gt(new BN(0)) && (
         <CWText className="token-req-text">

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -197,10 +197,19 @@ const ReactQuillEditor = ({
   }, [editorRef]);
 
   useEffect(() => {
-    if (shouldFocus && editorRef && editorRef.current) {
-      editorRef.current.focus();
+    if (shouldFocus) {
+      // Important: We need to initially focus the editor and then focus it again after
+      // a small delay. Some code higher up in the tree will cause the quill
+      // editor to remount/redraw because of some force re-renders use emitters. This causes
+      // the editor to remain focused while losing the text cursor and not being able to type.
+      editorRef && editorRef.current && editorRef.current.focus();
+      setTimeout(
+        () => editorRef && editorRef.current && editorRef.current.focus(),
+        200
+      );
     }
-  }, [shouldFocus]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const showTooltip = isDisabled && isHovering;
 

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -37,6 +37,7 @@ type ReactQuillEditorProps = {
   setContentDelta: (d: SerializableDeltaStatic) => void;
   isDisabled?: boolean;
   tooltipLabel?: string;
+  shouldFocus?: boolean;
 };
 
 // ReactQuillEditor is a custom wrapper for the react-quill component
@@ -48,6 +49,7 @@ const ReactQuillEditor = ({
   setContentDelta,
   isDisabled = false,
   tooltipLabel = 'Join community',
+  shouldFocus = false,
 }: ReactQuillEditorProps) => {
   const toolbarId = useMemo(() => {
     return `cw-toolbar-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
@@ -193,6 +195,12 @@ const ReactQuillEditor = ({
     }, 100);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorRef]);
+
+  useEffect(() => {
+    if (shouldFocus && editorRef && editorRef.current) {
+      editorRef.current.focus();
+    }
+  }, [shouldFocus]);
 
   const showTooltip = isDisabled && isHovering;
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -92,6 +92,9 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                 localStorage[`${app.activeChainId()}-discussions-scrollY`] =
                   scrollEle.scrollTop;
               }}
+              onCommentBtnClick={() =>
+                navigate(`${discussionLink}?focusEditor=true`)
+              }
             />
           );
         }}
@@ -100,14 +103,12 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
         components={{
           EmptyPlaceholder: () =>
             isInitialLoading ? (
-              <div className='threads-wrapper'>
-                {Array(3).fill({}).map((x, i) =>
-                  <ThreadCard
-                    key={i}
-                    showSkeleton
-                    thread={{} as any}
-                  />
-                )}
+              <div className="threads-wrapper">
+                {Array(3)
+                  .fill({})
+                  .map((x, i) => (
+                    <ThreadCard key={i} showSkeleton thread={{} as any} />
+                  ))}
               </div>
             ) : (
               <CWText type="b1" className="no-threads-text">

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -33,6 +33,7 @@ type CardProps = AdminActionsProps & {
   threadHref?: string;
   showSkeleton?: boolean;
   canReact?: boolean;
+  onCommentBtnClick?: () => any;
 };
 
 export const ThreadCard = ({
@@ -53,6 +54,7 @@ export const ThreadCard = ({
   threadHref,
   showSkeleton,
   canReact = true,
+  onCommentBtnClick = () => null,
 }: CardProps) => {
   const { isLoggedIn } = useUserLoggedIn();
   const { isWindowSmallInclusive } = useBrowserWindow({});
@@ -208,6 +210,7 @@ export const ThreadCard = ({
               onEditCancel={onEditCancel}
               onEditConfirm={onEditConfirm}
               hasPendingEdits={hasPendingEdits}
+              onCommentBtnClick={onCommentBtnClick}
             />
           </div>
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -20,6 +20,7 @@ type OptionsProps = AdminActionsProps & {
   shareEndpoint?: string;
   canUpdateThread?: boolean;
   totalComments?: number;
+  onCommentBtnClick?: () => any;
 };
 
 export const ThreadOptions = ({
@@ -40,6 +41,7 @@ export const ThreadOptions = ({
   onSnapshotProposalFromThread,
   onSpamToggle,
   hasPendingEdits,
+  onCommentBtnClick = () => null,
 }: OptionsProps) => {
   const [isSubscribed, setIsSubscribed] = useState(
     thread &&
@@ -88,6 +90,7 @@ export const ThreadOptions = ({
             label={`${pluralize(totalComments, 'Comment')}`}
             action="comment"
             disabled={!hasJoinedCommunity}
+            onClick={onCommentBtnClick}
           />
         )}
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -52,6 +52,7 @@ import { LinkedThreadsCard } from './linked_threads_card';
 import { LockMessage } from './lock_message';
 import { ThreadPollCard, ThreadPollEditorCard } from './poll_cards';
 import { SnapshotCreationCard } from './snapshot_creation_card';
+import { useSearchParams } from 'react-router-dom';
 
 export type ThreadPrefetch = {
   [identifier: string]: {
@@ -94,6 +95,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
+  const [searchParams] = useSearchParams();
+  const shouldFocusCommentEditor = !!searchParams.get('focusEditor');
 
   const {
     data,
@@ -469,6 +472,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                     <CreateComment
                       rootThread={thread}
                       canComment={canComment}
+                      shouldFocusEditor={shouldFocusCommentEditor}
                     />
                     {showBanner && (
                       <JoinCommunityBanner


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4677

## Description of Changes
The comment in thread card now navigates to thread details page and focuses on the comment editor.

## "How We Fixed It"
By using URL search params and textarea focus method

## Test Plan
On the discussions page, click on the comment button on any thread card
1. Verify it redirects to the thread details page
2. Verify it focuses on the comment editor

## Deployment Plan
N/A 

## Other Considerations
N/A