### PR TITLE
Add struct support to templates

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
@@ -27,6 +27,7 @@ export enum TemplateComponents {
   INPUT = 'input',
   DROPDOWN = 'dropdown',
   FUNCTIONFORM = 'function',
+  STRUCTFORM = 'struct',
 }
 
 type Json = {
@@ -136,6 +137,18 @@ const ViewTemplatePage = () => {
               });
 
               break;
+            case TemplateComponents.STRUCTFORM:
+              setFormState((prevState) => {
+                const newState = { ...prevState };
+                const form = {};
+                field.struct.form_fields.forEach((field) => {
+                  form[field.input.field_ref] = null;
+                });
+                newState[field.struct.field_ref] = form;
+                return newState;
+              });
+              break;
+
             default:
               break;
           }
@@ -269,9 +282,14 @@ const ViewTemplatePage = () => {
                   const newState = { ...prevState };
 
                   if (nested_field_ref) {
-                    newState[nested_field_ref][nested_index][
-                      field[component].field_ref
-                    ] = e.target.value;
+                    if (nested_index) {
+                      newState[nested_field_ref][nested_index][
+                        field[component].field_ref
+                      ] = e.target.value;
+                    } else {
+                      newState[nested_field_ref][field[component].field_ref] =
+                        e.target.value;
+                    }
                   } else {
                     newState[field[component].field_ref] = e.target.value;
                   }
@@ -297,6 +315,21 @@ const ViewTemplatePage = () => {
             })
           );
 
+          functionComponents.push(<CWDivider />);
+          return functionComponents;
+        }
+        case TemplateComponents.STRUCTFORM: {
+          const functionComponents = [
+            <CWDivider />,
+            <CWText type="h3">{field[component].field_label}</CWText>,
+          ];
+
+          functionComponents.push(
+            ...renderTemplate(
+              field[component].form_fields,
+              field[component].field_ref
+            )
+          );
           functionComponents.push(<CWDivider />);
           return functionComponents;
         }

--- a/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_template/view_template.tsx
@@ -141,8 +141,8 @@ const ViewTemplatePage = () => {
               setFormState((prevState) => {
                 const newState = { ...prevState };
                 const form = {};
-                field.struct.form_fields.forEach((field) => {
-                  form[field.input.field_ref] = null;
+                field.struct.form_fields.forEach((nestField) => {
+                  form[nestField.input.field_ref] = null;
                 });
                 newState[field.struct.field_ref] = form;
                 return newState;

--- a/packages/commonwealth/shared/validateJson.ts
+++ b/packages/commonwealth/shared/validateJson.ts
@@ -227,8 +227,5 @@ type AnyKeyAnyValue = Record<string, any>;
 
 export default function isValidJson(data: AnyKeyAnyValue): boolean {
   const validate = validator(JSON.parse(JSON.stringify(schema)));
-  const result = validate(data);
-  console.log(validate.errors);
-  console.log(result);
-  return result;
+  return validate(data);
 }

--- a/packages/commonwealth/shared/validateJson.ts
+++ b/packages/commonwealth/shared/validateJson.ts
@@ -12,6 +12,7 @@ const schema = {
           { $ref: '#/$defs/input' },
           { $ref: '#/$defs/dropdown' },
           { $ref: '#/$defs/function' },
+          { $ref: '#/$defs/struct' },
         ],
       },
     },
@@ -156,6 +157,36 @@ const schema = {
       required: ['function'],
       additionalProperties: false,
     },
+    struct: {
+      type: 'object',
+      properties: {
+        struct: {
+          type: 'object',
+          properties: {
+            field_name: { type: 'string' },
+            field_label: { type: 'string' },
+            field_ref: { type: 'string' },
+            form_fields: {
+              type: 'array',
+              items: {
+                oneOf: [
+                  { $ref: '#/$defs/divider' },
+                  { $ref: '#/$defs/text' },
+                  { $ref: '#/$defs/input' },
+                  { $ref: '#/$defs/dropdown' },
+                  { $ref: '#/$defs/function' },
+                  { $ref: '#/$defs/struct' },
+                ],
+              },
+            },
+          },
+          required: ['field_name', 'field_label', 'field_ref', 'form_fields'],
+          additionalProperties: false,
+        },
+      },
+      required: ['struct'],
+      additionalProperties: false,
+    },
     dropdown: {
       type: 'object',
       properties: {
@@ -196,5 +227,8 @@ type AnyKeyAnyValue = Record<string, any>;
 
 export default function isValidJson(data: AnyKeyAnyValue): boolean {
   const validate = validator(JSON.parse(JSON.stringify(schema)));
-  return validate(data);
+  const result = validate(data);
+  console.log(validate.errors);
+  console.log(result);
+  return result;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4771 

## Description of Changes
- Adds a new `form_field` type 'struct' to support building struct inputs for templates
- adds render and state to track and encode structs - see other considerations for details on new schema for structs 

## Test Plan
- Create a struct template 
- ensure metamask can open + args are formatted properly in preview


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- New form field type will be added to notion doc in summary it looks as follows:
```
{
          "struct":{
             "field_name":"",
             "field_label":"",
             "field_ref":"",
             "form_fields": []
}
```

Where form_fields includes regular input form fields with `field_refs` equal to the struct key they should populate