### PR TITLE
Added timeout to tests to avoid CI from hanging

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
         node: [ 18 ]
     name: Commonwealth E2E Test
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 10
 
     services:
       postgres:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
         node: [ 18 ]
     name: Commonwealth E2E Test
     runs-on: ubuntu-latest
+    timeout-minutes: 1
 
     services:
       postgres:
@@ -99,6 +100,7 @@ jobs:
         node: [ 18 ]
     name: Commonwealth E2E Test Serial
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       postgres:
@@ -175,6 +177,7 @@ jobs:
         node: [ 18 ]
     name: Code Quality checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -218,6 +221,7 @@ jobs:
         node: [ 18 ]
     name: Commonwealth Unit And Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       postgres:
@@ -279,6 +283,7 @@ jobs:
   commonwealth-devnet-tests:
     name: Devnet Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node: [ 18 ]
@@ -384,6 +389,7 @@ jobs:
         node: [ 18 ]
     name: Chain Events Integration and Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       postgres:


### PR DESCRIPTION
Tests hanging in CI suite, adds timeout to ensure they timeout so they do not hang. See for example (manually cancelled):
https://github.com/hicommonwealth/commonwealth/actions/runs/5955991022/job/16190772056?pr=4878

## Link to Issue
Closes: #4895

## Description of Changes
- Adds timeout to integration and unit tests (e2e tests already have timeout)

## Test Plan
- Ran on CI with small timeout, assert works, see here:
<img width="1088" alt="Screenshot 2023-08-24 at 1 08 58 PM" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/382d34f1-edd6-4e05-9ffb-86ea047039dd">

- Ran on CI with normal timeout, assert doesn't fail (See this run)
