### PR TITLE
Persist selected account on reload

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -37,7 +37,7 @@ export async function setActiveAccount(
   const chain = app.activeChainId();
   const role = app.roles.getRoleInCommunity({ account, chain });
 
-  if (!role || role.is_user_default) {
+  if (!role) {
     app.user.ephemerallySetActiveAccount(account);
     if (
       app.user.activeAccounts.filter((a) => isSameAccount(a, account))
@@ -307,7 +307,7 @@ export async function unlinkLogin(account: AddressInfo) {
   app.roles.deleteRole({
     address: account,
     chain: account.chain.id,
-  })
+  });
   // Remove from all address stores in the frontend state.
   // This might be more gracefully handled by calling initAppState again.
   let index = app.user.activeAccounts.indexOf(account);

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -78,11 +78,6 @@ export async function setActiveAccount(
     notifyError('Could not set active account');
   }
 
-  // update is_user_default
-  app.roles.getAllRolesInCommunity({ chain }).forEach((r) => {
-    r.is_user_default = false;
-  });
-  role.is_user_default = true;
   app.user.ephemerallySetActiveAccount(account);
   if (
     app.user.activeAccounts.filter((a) => isSameAccount(a, account)).length ===

--- a/packages/commonwealth/server/routes/setDefaultRole.ts
+++ b/packages/commonwealth/server/routes/setDefaultRole.ts
@@ -1,6 +1,6 @@
 import { AppError } from 'common-common/src/errors';
 import type { NextFunction, Response } from 'express';
-import Sequelize, { Op } from 'sequelize';
+import Sequelize from 'sequelize';
 import type { DB } from '../models';
 
 export const Errors = {
@@ -32,6 +32,18 @@ const setDefaultRole = async (
   validAddress.last_active = new Date();
   validAddress.is_user_default = true;
   await validAddress.save();
+
+  await models.Address.update(
+    { is_user_default: false },
+    {
+      where: {
+        address: { [Sequelize.Op.ne]: req.body.address },
+        chain: req.body.author_chain,
+        user_id: req.user.id,
+        verified: { [Sequelize.Op.ne]: null },
+      },
+    }
+  );
 
   return res.json({ status: 'Success' });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4741 

## Description of Changes
- on frontend, removed `role.is_user_default` from if clause, because right now, it was always true, what causes early return [here](https://github.com/hicommonwealth/commonwealth/blob/a7197270ed06c116cb30631739f757fce9057004/packages/commonwealth/client/scripts/controllers/app/login.ts#L62), so `/setDefaultRole` was not set on account change
- on backend, in `setDefaultRole` route, added logic, that sets `is_user_default` to false for every user's address in particular chain apart from the one that has been selected

## Test Plan
- within a community, have at least 2 addresses connected to the profile
- select second address from user address selector
- reload page 
- currently selected address should be the same as the address selected before the reload
- select first address
- reload page 
- currently selected address should be the same as the address selected before the reload


https://github.com/hicommonwealth/commonwealth/assets/14819225/9d232df3-99fd-40be-af05-79a76c94c60b






## Deployment Plan
<!--- Omit if unneeded -->
1.  n/a
