### PR TITLE
[Experimental] Added votes section to thread page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_content_page.tsx
@@ -10,6 +10,7 @@ import Topic from '../../../models/Topic';
 import { ThreadStage } from '../../../models/types';
 import { AuthorAndPublishInfo } from '../../pages/discussions/ThreadCard/AuthorAndPublishInfo';
 import { ThreadOptions } from '../../pages/discussions/ThreadCard/ThreadOptions';
+import { FocusType } from '../../pages/discussions/ThreadCard/ThreadOptions/ThreadOptions';
 import { CWCard } from './cw_card';
 import { CWIconButton } from './cw_icon_button';
 import { CWTab, CWTabBar } from './cw_tabs';
@@ -73,6 +74,10 @@ type ContentPageProps = {
   hasPendingEdits?: boolean;
   canUpdateThread?: boolean;
   showTabs?: boolean;
+  threadOptionFocused?;
+  setThreadOptionFocused?;
+  votes?;
+  voteView?;
 };
 
 export const CWContentPage = ({
@@ -108,6 +113,10 @@ export const CWContentPage = ({
   hasPendingEdits,
   canUpdateThread,
   showTabs = false,
+  threadOptionFocused,
+  setThreadOptionFocused,
+  voteView,
+  votes,
 }: ContentPageProps) => {
   const [tabSelected, setTabSelected] = useState<number>(0);
   const createdOrEditedDate = lastEdited ? lastEdited : createdAt;
@@ -181,11 +190,15 @@ export const CWContentPage = ({
             hasPendingEdits={hasPendingEdits}
             onProposalStageChange={onProposalStageChange}
             onSnapshotProposalFromThread={onSnapshotProposalFromThread}
+            threadOptionFocused={threadOptionFocused}
+            setThreadOptionFocused={setThreadOptionFocused}
+            votes={votes}
           />
         )}
 
       {subBody}
-      {comments}
+      {threadOptionFocused === FocusType.comment ? comments : null}
+      {threadOptionFocused === FocusType.votes ? voteView : null}
     </div>
   );
 

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_thread_action.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_thread_action.tsx
@@ -69,6 +69,7 @@ type CWThreadActionProps = {
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   label?: string;
   selected?: boolean;
+  style?;
 };
 
 interface TooltipWrapperProps {
@@ -120,6 +121,7 @@ export const CWThreadAction: FC<CWThreadActionProps> = ({
   onClick,
   label,
   selected,
+  style,
 }) => {
   const handleClick = (e) => {
     if (disabled) {
@@ -139,6 +141,7 @@ export const CWThreadAction: FC<CWThreadActionProps> = ({
           {
             disabled,
             upvoteSelected,
+            style,
           },
           ComponentType.ThreadAction
         )}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -20,7 +20,15 @@ type OptionsProps = AdminActionsProps & {
   shareEndpoint?: string;
   canUpdateThread?: boolean;
   totalComments?: number;
+  threadOptionFocused: FocusType;
+  setThreadOptionFocused?;
+  votes?;
 };
+
+export enum FocusType {
+  'comment',
+  'votes',
+}
 
 export const ThreadOptions = ({
   thread,
@@ -41,6 +49,9 @@ export const ThreadOptions = ({
   onSnapshotProposalFromThread,
   onSpamToggle,
   hasPendingEdits,
+  threadOptionFocused,
+  setThreadOptionFocused,
+  votes,
 }: OptionsProps) => {
   const [isSubscribed, setIsSubscribed] = useState(
     thread &&
@@ -89,6 +100,26 @@ export const ThreadOptions = ({
             label={`${pluralize(totalComments, 'Comment')}`}
             action="comment"
             disabled={!hasJoinedCommunity}
+            onClick={() => setThreadOptionFocused(FocusType.comment)}
+            style={
+              votes && threadOptionFocused === FocusType.comment
+                ? 'blueUnderline'
+                : ''
+            }
+          />
+        )}
+
+        {votes && (
+          <CWThreadAction
+            label={`${pluralize(totalComments, 'Vote')}`}
+            action="comment"
+            disabled={!hasJoinedCommunity}
+            onClick={() => setThreadOptionFocused(FocusType.votes)}
+            style={
+              votes && threadOptionFocused === FocusType.votes
+                ? 'blueUnderline'
+                : ''
+            }
           />
         )}
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -57,10 +57,12 @@ import { QuillRenderer } from '../../components/react_quill_editor/quill_rendere
 import { Select } from '../../components/Select';
 import { CommentTree } from '../discussions/CommentTree';
 import { clearEditingLocalStorage } from '../discussions/CommentTree/helpers';
+import { FocusType } from '../discussions/ThreadCard/ThreadOptions/ThreadOptions';
 import { useProposalData } from '../view_proposal/index';
 import { useSnapshotProposalData } from '../view_snapshot_proposal/index';
 import { SnapshotInformationCard } from '../view_snapshot_proposal/snapshot_information_card';
 import { SnapshotPollCardContainer } from '../view_snapshot_proposal/snapshot_poll_card_container';
+import { SnapshotVotesTable } from '../view_snapshot_proposal/snapshot_votes_table';
 import { EditBody } from './edit_body';
 import { LinkedProposalsCard } from './linked_proposals_card';
 import { LinkedThreadsCard } from './linked_threads_card';
@@ -137,6 +139,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     validatedAgainstStrategies,
     loadVotes,
   } = useSnapshotProposalData(snapshotProposalId, snapshotId);
+
+  const [threadOptionFocused, setThreadOptionFocused] = useState(
+    FocusType.comment
+  );
 
   const { error, metadata, isAdapterLoaded, proposal } = useProposalData(
     proposalId,
@@ -691,6 +697,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             </ExternalLink>
           )
         }
+        threadOptionFocused={threadOptionFocused}
+        setThreadOptionFocused={setThreadOptionFocused}
         thread={thread}
         onLockToggle={(isLock) => {
           setIsGloballyEditing(false);
@@ -755,6 +763,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           }));
         }}
         hasPendingEdits={!!editsToSave}
+        votes={snapshotProposalId ? votes : null}
         body={(threadOptionsComp) => (
           <div className="thread-content">
             {isEditingBody ? (
@@ -801,11 +810,13 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 ) : !isGloballyEditing && isLoggedIn ? (
                   <>
                     {threadOptionsComp}
-                    <CreateComment
-                      updatedCommentsCallback={updatedCommentsCallback}
-                      rootThread={thread}
-                      canComment={canComment}
-                    />
+                    {threadOptionFocused === FocusType.comment ? (
+                      <CreateComment
+                        updatedCommentsCallback={updatedCommentsCallback}
+                        rootThread={thread}
+                        canComment={canComment}
+                      />
+                    ) : null}
                     {showBanner && (
                       <JoinCommunityBanner
                         onClose={handleCloseBanner}
@@ -818,6 +829,15 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             )}
           </div>
         )}
+        voteView={
+          votes.length > 0 && (
+            <SnapshotVotesTable
+              choices={snapshotProposal.choices}
+              symbol={symbol}
+              voters={votes}
+            />
+          )
+        }
         comments={
           <>
             {comments.length > 0 && (

--- a/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
@@ -54,3 +54,9 @@
     }
   }
 }
+
+.blueUnderline {
+  margin-bottom: -2px;
+  border-radius: 0;
+  border-bottom: 2px solid $primary-500;
+}


### PR DESCRIPTION
NOTE: This should not go in before parent branch
NOTE: votes icon is not yet specified in figma. As a result only the comment icon was used for it (like in the figma). This should be resolved before this is merged

## Link to Issue
Closes: #4709 

## Description of Changes
- Adds extra tab for votes
- shows vote page if clicked

View when in Comments tab:
<img width="1137" alt="Screenshot 2023-08-30 at 2 11 16 PM" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/4495fdb7-8366-4a43-a119-0f6916b707b7">

View when in Votes tab:
<img width="1111" alt="Screenshot 2023-08-30 at 2 11 46 PM" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/3bea2754-c28d-4f52-ba32-590e5e651686">

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Made sure discussions page was unaffected
- created discussion, linked snapshot proposal. Made sure that we could click on the 'vote' tab and see the votes