### PR TITLE
Sort by "Latest Activity" 

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -160,6 +160,7 @@ export class Thread implements IUniqueId {
   public associatedReactions: AssociatedReaction[];
   public links: Link[];
   public readonly discord_meta: any;
+  public readonly latestActivity: Moment;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -231,6 +232,7 @@ export class Thread implements IUniqueId {
     version_history: any[]; // TODO: fix type
     Address: any; // TODO: fix type
     discord_meta?: any;
+    latest_activity?: string;
   }) {
     this.author = Address.address;
     this.title = getDecodedString(title);
@@ -273,6 +275,7 @@ export class Thread implements IUniqueId {
       reactionType,
       addressesReacted
     );
+    // this.latestActivity = latest_activity ? moment(latest_activity) : null;
   }
 }
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -199,6 +199,7 @@ export class Thread implements IUniqueId {
     canvasHash,
     links,
     discord_meta,
+    latest_activity,
   }: {
     marked_as_spam_at: string;
     title: string;
@@ -275,7 +276,7 @@ export class Thread implements IUniqueId {
       reactionType,
       addressesReacted
     );
-    // this.latestActivity = latest_activity ? moment(latest_activity) : null;
+    this.latestActivity = latest_activity ? moment(latest_activity) : null;
   }
 }
 

--- a/packages/commonwealth/client/scripts/models/types.ts
+++ b/packages/commonwealth/client/scripts/models/types.ts
@@ -35,6 +35,7 @@ export enum ThreadFeaturedFilterTypes {
   Oldest = 'oldest',
   MostLikes = 'mostLikes',
   MostComments = 'mostComments',
+  LatestActivity = 'latestActivity',
 }
 
 export enum CommentsFeaturedFilterTypes {

--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -35,7 +35,12 @@ interface FetchBulkThreadsProps extends CommonProps {
   topicId?: number;
   stage?: string;
   includePinnedThreads?: boolean;
-  orderBy?: 'newest' | 'oldest' | 'mostLikes' | 'mostComments';
+  orderBy?:
+    | 'newest'
+    | 'oldest'
+    | 'mostLikes'
+    | 'mostComments'
+    | 'latestActivity';
 }
 
 interface FetchActiveThreadsProps extends CommonProps {
@@ -48,6 +53,7 @@ const featuredFilterQueryMap = {
   oldest: 'createdAt:asc',
   mostLikes: 'numberOfLikes:desc',
   mostComments: 'numberOfComments:desc',
+  latestActivity: 'latestActivity:desc',
 };
 
 const useDateCursor = ({
@@ -62,7 +68,8 @@ const useDateCursor = ({
 
   useEffect(() => {
     const updater = () => {
-      const { toDate, fromDate } = getToAndFromDatesRangesForThreadsTimelines(dateRange)
+      const { toDate, fromDate } =
+        getToAndFromDatesRangesForThreadsTimelines(dateRange);
       setDateCursor({ toDate, fromDate });
     };
 
@@ -107,7 +114,7 @@ const getFetchThreadsQueryKey = (props) => {
       props.topicsPerThread,
     ];
   }
-}
+};
 
 const fetchBulkThreads = (props) => {
   return async ({ pageParam = 1 }) => {
@@ -141,11 +148,10 @@ const fetchBulkThreads = (props) => {
 
     return {
       data: transformedData,
-      pageParam:
-        transformedData.threads.length > 0 ? pageParam + 1 : undefined,
+      pageParam: transformedData.threads.length > 0 ? pageParam + 1 : undefined,
     };
   };
-}
+};
 
 const fetchActiveThreads = (props) => {
   return async () => {
@@ -163,7 +169,7 @@ const fetchActiveThreads = (props) => {
     // transform response
     return response.data.result.map((c) => new Thread(c));
   };
-}
+};
 
 const useFetchThreadsQuery = (
   props: FetchBulkThreadsProps | FetchActiveThreadsProps
@@ -174,8 +180,8 @@ const useFetchThreadsQuery = (
   const chosenQueryType = queryTypeToRQMap[queryType]({
     queryKey: getFetchThreadsQueryKey(props),
     queryFn: (() => {
-      if (isFetchBulkThreadsProps(props)) return fetchBulkThreads(props)
-      if (isFetchActiveThreadsProps(props)) return fetchActiveThreads(props)
+      if (isFetchBulkThreadsProps(props)) return fetchBulkThreads(props);
+      if (isFetchActiveThreadsProps(props)) return fetchActiveThreads(props);
     })(),
     ...(() => {
       if (isFetchBulkThreadsProps(props)) {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -48,18 +48,19 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     dateRange: searchParams.get('dateRange') as ThreadTimelineFilterTypes,
   });
 
-  const { fetchNextPage, data, isInitialLoading } = useFetchThreadsQuery({
-    chainId: app.activeChainId(),
-    queryType: 'bulk',
-    page: 1,
-    limit: 20,
-    topicId: (topics || []).find(({ name }) => name === topicName)?.id,
-    stage: stageName,
-    includePinnedThreads: true,
-    orderBy: featuredFilter,
-    toDate: dateCursor.toDate,
-    fromDate: dateCursor.fromDate,
-  });
+  const { fetchNextPage, data, isInitialLoading, hasNextPage } =
+    useFetchThreadsQuery({
+      chainId: app.activeChainId(),
+      queryType: 'bulk',
+      page: 1,
+      limit: 20,
+      topicId: (topics || []).find(({ name }) => name === topicName)?.id,
+      stage: stageName,
+      includePinnedThreads: true,
+      orderBy: featuredFilter,
+      toDate: dateCursor.toDate,
+      fromDate: dateCursor.fromDate,
+    });
 
   const threads = sortPinned(sortByFeaturedFilter(data || [], featuredFilter));
 
@@ -103,7 +104,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
             />
           );
         }}
-        endReached={() => fetchNextPage()}
+        endReached={() => hasNextPage && fetchNextPage()}
         overscan={200}
         components={{
           EmptyPlaceholder: () =>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -236,12 +236,12 @@ export const HeaderWithFilters = ({
                   label: 'Comments',
                   iconLeft: 'chatDots',
                 },
-                // {
-                //   id: 5,
-                //   value: ThreadFeaturedFilterTypes.LatestActivity,
-                //   label: 'Latest Activity',
-                //   iconLeft: 'bellRinging',
-                // },
+                {
+                  id: 5,
+                  value: ThreadFeaturedFilterTypes.LatestActivity,
+                  label: 'Latest Activity',
+                  iconLeft: 'bellRinging',
+                },
               ]}
             />
           </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -236,6 +236,12 @@ export const HeaderWithFilters = ({
                   label: 'Comments',
                   iconLeft: 'chatDots',
                 },
+                // {
+                //   id: 5,
+                //   value: ThreadFeaturedFilterTypes.LatestActivity,
+                //   label: 'Latest Activity',
+                //   iconLeft: 'bellRinging',
+                // },
               ]}
             />
           </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -145,7 +145,7 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
 
   // if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
   //   return [...t].sort((a, b) =>
-  //     moment(a.latestActivity).diff(moment(b.latestActivity))
+  //     moment(b.latestActivity).diff(moment(a.latestActivity))
   //   );
   // }
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -143,11 +143,11 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
     );
   }
 
-  // if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
-  //   return [...t].sort((a, b) =>
-  //     moment(b.latestActivity).diff(moment(a.latestActivity))
-  //   );
-  // }
+  if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
+    return [...t].sort((a, b) =>
+      moment(b.latestActivity).diff(moment(a.latestActivity))
+    );
+  }
 
   // Default: Assuming featuredFilter === 'newest'
   return [...t].sort((a, b) => moment(b.createdAt).diff(moment(a.createdAt)));

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -143,6 +143,12 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
     );
   }
 
+  // if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
+  //   return [...t].sort((a, b) =>
+  //     moment(a.latestActivity).diff(moment(b.latestActivity))
+  //   );
+  // }
+
   // Default: Assuming featuredFilter === 'newest'
   return [...t].sort((a, b) => moment(b.createdAt).diff(moment(a.createdAt)));
 };

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -68,6 +68,8 @@ export async function __getBulkThreads(
     'numberOfComments:desc': 'threads_number_of_comments DESC',
     'numberOfLikes:asc': 'threads_total_likes ASC',
     'numberOfLikes:desc': 'threads_total_likes DESC',
+    'latestActivity:asc': 'latest_activity ASC',
+    'latestActivity:desc': 'latest_activity DESC',
   };
 
   // get response threads from query
@@ -88,11 +90,13 @@ export async function __getBulkThreads(
         topics.id AS topic_id, topics.name AS topic_name, topics.description AS topic_description,
         topics.chain_id AS topic_chain,
         topics.telegram AS topic_telegram,
-        collaborators
+        collaborators,
+        threads.latest_activity AS latest_activity
       FROM "Addresses" AS addr
       RIGHT JOIN (
         SELECT t.id AS thread_id, t.title AS thread_title, t.address_id, t.last_commented_on,
           t.created_at AS thread_created,
+          COALESCE(latest_comments.latest_comment_date, t.created_at) AS latest_activity,
           t.marked_as_spam_at,
           t.archived_at,
           t.updated_at AS thread_updated,
@@ -119,6 +123,13 @@ export async function __getBulkThreads(
         ) comments
         ON t.id = comments.thread_id
         LEFT JOIN (
+          SELECT thread_id, MAX(created_at) AS latest_comment_date
+          FROM "Comments"
+          WHERE deleted_at IS NULL
+          GROUP BY thread_id
+        ) latest_comments
+        ON t.id = latest_comments.thread_id
+        LEFT JOIN (
             SELECT thread_id,
             COUNT(r.id)::int AS total_likes,
             STRING_AGG(ad.address::text, ',') AS addresses_reacted,
@@ -138,7 +149,7 @@ export async function __getBulkThreads(
           AND (${includePinnedThreads ? 't.pinned = true OR' : ''}
           (COALESCE(t.last_commented_on, t.created_at) < $to_date AND t.pinned = false))
           GROUP BY (t.id, COALESCE(t.last_commented_on, t.created_at), comments.number_of_comments,
-          reactions.reaction_ids, reactions.reaction_type, reactions.addresses_reacted, reactions.total_likes)
+          reactions.reaction_ids, reactions.reaction_type, reactions.addresses_reacted, reactions.total_likes, latest_comments.latest_comment_date)
           ORDER BY t.pinned DESC, COALESCE(t.last_commented_on, t.created_at) DESC
         ) threads
       ON threads.address_id = addr.id
@@ -211,6 +222,7 @@ export async function __getBulkThreads(
       reactionType: t.reaction_type ? t.reaction_type.split(',') : [],
       marked_as_spam_at: t.marked_as_spam_at,
       archived_at: t.archived_at,
+      latest_activity: t.latest_activity,
     };
     if (t.topic_id) {
       data['topic'] = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4908 

## Description of Changes
- Adds a thread sort option for "latest activity". This is a sort on the "created_at" of the most recent comment on a thread, or the created_at of the thread itself if no comments have been added. Also fixes a pagination error caused by the Virtuoso component on the DiscussionPage. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Changes to bulk threads SQL query + appropriate handling on the frontend. 

## Test Plan
- Visit a community, comment on an old thread, and then sort by "latest activity". That thread should move to the top of the sort. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 