### PR TITLE
Fix back button on homepage

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import useSidebarStore from 'state/ui/sidebar';
 import 'SublayoutHeader.scss';
 import { HelpMenuPopover } from 'views/menus/help_menu';
-import app, { LoginState, initAppState } from '../state';
+import app, { initAppState } from '../state';
 import { CWCommunityAvatar } from './components/component_kit/cw_community_avatar';
 import { CWDivider } from './components/component_kit/cw_divider';
 import { CWIconButton } from './components/component_kit/cw_icon_button';

--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import useSidebarStore from 'state/ui/sidebar';
 import 'SublayoutHeader.scss';
 import { HelpMenuPopover } from 'views/menus/help_menu';
-import app, { initAppState } from '../state';
+import app, { LoginState, initAppState } from '../state';
 import { CWCommunityAvatar } from './components/component_kit/cw_community_avatar';
 import { CWDivider } from './components/component_kit/cw_divider';
 import { CWIconButton } from './components/component_kit/cw_icon_button';
@@ -76,7 +76,11 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
               if (app.isCustomDomain()) {
                 navigate('/', {}, null);
               } else {
-                navigate('/dashboard/for-you', {}, null);
+                if (isLoggedIn) {
+                  navigate('/dashboard/for-you', {}, null);
+                } else {
+                  navigate('/dashboard/global', {}, null);
+                }
               }
             }}
           />
@@ -184,7 +188,11 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
             if (app.isCustomDomain()) {
               navigate('/', {}, null);
             } else {
-              navigate('/dashboard/for-you', {}, null);
+              if (isLoggedIn) {
+                navigate('/dashboard/for-you', {}, null);
+              } else {
+                navigate('/dashboard/global', {}, null);
+              }
             }
           }}
         />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4916 

## Description of Changes
- Fixes back button / common logo interactions so that when logged out, clicking the back button will always function as expected. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
The problem was caused by a redirect from `for-you` to `global` that was unnecessary; simply added a checked for logged in status to see which subpage to redirect to when the common logo is clicked. 

## Test Plan
- Log out, go to global page, click on any community, click the CW logo (taking you back to global page). Then click the back button in your browser, it should take you to the community page again. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 