### PR TITLE
latest activity derived using last_comment_on

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -160,7 +160,7 @@ export class Thread implements IUniqueId {
   public associatedReactions: AssociatedReaction[];
   public links: Link[];
   public readonly discord_meta: any;
-  public readonly latestActivity: number;
+  public readonly latestActivity: Moment;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -276,7 +276,9 @@ export class Thread implements IUniqueId {
       reactionType,
       addressesReacted
     );
-    this.latestActivity = Number(latest_activity || '0');
+    this.latestActivity = last_commented_on
+      ? moment(last_commented_on)
+      : moment(created_at);
   }
 }
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -160,7 +160,7 @@ export class Thread implements IUniqueId {
   public associatedReactions: AssociatedReaction[];
   public links: Link[];
   public readonly discord_meta: any;
-  public readonly latestActivity: Moment;
+  public readonly latestActivity: number;
 
   public get uniqueIdentifier() {
     return `${this.slug}_${this.identifier}`;
@@ -276,7 +276,7 @@ export class Thread implements IUniqueId {
       reactionType,
       addressesReacted
     );
-    this.latestActivity = latest_activity ? moment(latest_activity) : null;
+    this.latestActivity = Number(latest_activity || '0');
   }
 }
 

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -199,7 +199,6 @@ export class Thread implements IUniqueId {
     canvasHash,
     links,
     discord_meta,
-    latest_activity,
   }: {
     marked_as_spam_at: string;
     title: string;
@@ -233,7 +232,6 @@ export class Thread implements IUniqueId {
     version_history: any[]; // TODO: fix type
     Address: any; // TODO: fix type
     discord_meta?: any;
-    latest_activity?: string;
   }) {
     this.author = Address.address;
     this.title = getDecodedString(title);

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -146,9 +146,7 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
   }
 
   if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
-    return [...t].sort((a, b) =>
-      moment(b.latestActivity).diff(moment(a.latestActivity))
-    );
+    return [...t].sort((a, b) => b.latestActivity - a.latestActivity);
   }
 
   // Default: Assuming featuredFilter === 'newest'

--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -146,7 +146,9 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
   }
 
   if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {
-    return [...t].sort((a, b) => b.latestActivity - a.latestActivity);
+    return [...t].sort((a, b) =>
+      moment(b.latestActivity).diff(moment(a.latestActivity))
+    );
   }
 
   // Default: Assuming featuredFilter === 'newest'

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -96,7 +96,7 @@ export async function __getBulkThreads(
       RIGHT JOIN (
         SELECT t.id AS thread_id, t.title AS thread_title, t.address_id, t.last_commented_on,
           t.created_at AS thread_created,
-          COALESCE(t.last_commented_on, t.created_at) AS latest_activity,
+          t.max_notif_id AS latest_activity,
           t.marked_as_spam_at,
           t.archived_at,
           t.updated_at AS thread_updated,
@@ -133,9 +133,9 @@ export async function __getBulkThreads(
           ${archived ? ` AND t.archived_at IS NOT NULL ` : ''}
           AND (${includePinnedThreads ? 't.pinned = true OR' : ''}
           (COALESCE(t.last_commented_on, t.created_at) < $to_date AND t.pinned = false))
-          GROUP BY (t.id, COALESCE(t.last_commented_on, t.created_at), t.comment_count,
+          GROUP BY (t.id, t.max_notif_id, t.comment_count,
           reactions.reaction_ids, reactions.reaction_type, reactions.addresses_reacted)
-          ORDER BY t.pinned DESC, COALESCE(t.last_commented_on, t.created_at) DESC
+          ORDER BY t.pinned DESC, t.max_notif_id DESC
         ) threads
       ON threads.address_id = addr.id
       LEFT JOIN "Topics" topics

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -123,6 +123,7 @@ export async function __getBulkThreads(
             FROM "Reactions" as r
             LEFT JOIN "Addresses" ad
             ON r.address_id = ad.id
+            where r.chain = $chain
             GROUP BY thread_id
         ) reactions
         ON t.id = reactions.thread_id

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -90,8 +90,7 @@ export async function __getBulkThreads(
         topics.id AS topic_id, topics.name AS topic_name, topics.description AS topic_description,
         topics.chain_id AS topic_chain,
         topics.telegram AS topic_telegram,
-        collaborators,
-        threads.latest_activity AS latest_activity
+        collaborators
       FROM "Addresses" AS addr
       RIGHT JOIN (
         SELECT t.id AS thread_id, t.title AS thread_title, t.address_id, t.last_commented_on,

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -120,6 +120,10 @@ export async function __getBulkThreads(
             STRING_AGG(r.reaction::text, ',') AS reaction_type,
             STRING_AGG(r.id::text, ',') AS reaction_ids
             FROM "Reactions" as r
+            JOIN "Threads" t2 
+            ON r.thread_id = t2.id and t2.chain = $chain ${
+              topicId ? ` AND t2.topic_id = $topic_id ` : ''
+            }
             LEFT JOIN "Addresses" ad
             ON r.address_id = ad.id
             where r.chain = $chain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4956 

## Description of Changes
- using `last_commented_on` property on `Thread` model instead of expensive query against `Comment` table to find latest comment
- using `max_notif_id` instead of `COALESCE(t.last_commented_on, t.created_at)` for group by
- using `max_notif_id` for sorting
- added `chain` filter to `Reactions` sub-query

## Test Plan
- Performance test for query performance difference
- Click around testing Frick - > applying all the filter for on forum discussion pages

## Deployment Plan
1. Merge changed query to master

## Other Considerations