### PR TITLE
Stop duplicate comment notification emission

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
@@ -105,6 +105,7 @@ export async function __createThreadComment(
         id: parentId,
         chain: chain.id,
       },
+      include: [this.models.Address],
     });
     if (!parentComment) {
       throw new AppError(Errors.InvalidParent);
@@ -250,6 +251,11 @@ export async function __createThreadComment(
   const excludedAddrs = (mentionedAddresses || []).map((addr) => addr.address);
   excludedAddrs.push(finalComment.Address.address);
 
+  const rootNotifExcludeAddresses = [...excludedAddrs];
+  if (parentComment && parentComment.Address) {
+    rootNotifExcludeAddresses.push(parentComment.Address.address);
+  }
+
   const cwUrl = getThreadUrl(thread, finalComment.id);
   const root_title = thread.title || '';
 
@@ -279,7 +285,7 @@ export async function __createThreadComment(
       chain: finalComment.chain,
       body: finalComment.text,
     },
-    excludeAddresses: excludedAddrs,
+    excludeAddresses: rootNotifExcludeAddresses,
   });
 
   // if child comment, build notification for parent author


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4345

## Description of Changes
- Added the parent comment author's addresses as excluded from the root thread notification.
- This does not remove duplicate notifications that have been emitted in the past but ensures that users don't see duplicate notifications in the future.
- This also does not stop notifications from having near-duplicate data as the issue describes. To normalize that data would require reworking how we fetch and emit comment notifications which is an excessive amount of work when there is a trivial solution. In other words, the denormalized data should be acceptable here given the trivial solution.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Parent comment authors are excluded from the notification sent to all users subscribed to a thread.

## Test Plan
- Sign-in on account 1.
- Sign-in on account 2 on a separate browser.
- Create a thread from account 2 in any community.
- Subscribe to that thread from account 1.
- Create a comment on that thread with account 1.
- Reply to the new comment from account 2.
- Ensure there is only 1 notification in the notification drop-down of both accounts 1 and 2.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 