### PR TITLE
Improve create chain error display

### DIFF
--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -41,7 +41,7 @@ export const Errors = {
   NoBase: 'Must provide chain base',
   NoNodeUrl: 'Must provide node url',
   InvalidNodeUrl: 'Node url must begin with http://, https://, ws://, wss://',
-  InvalidNode: 'Node url returned invalid response',
+  InvalidNode: 'RPC url returned invalid response. Check your node url',
   MustBeWs: 'Node must support websockets on ethereum',
   InvalidBase: 'Must provide valid chain base',
   InvalidChainId: 'Ethereum chain ID not provided or unsupported',
@@ -243,7 +243,7 @@ const createChain = async (
       const tmClient = await cosm.Tendermint34Client.connect(url);
       await tmClient.block();
     } catch (err) {
-      return next(new ServerError(Errors.InvalidNode));
+      return next(new AppError(Errors.InvalidNode));
     }
 
     // TODO: test altWalletUrl if available
@@ -256,7 +256,7 @@ const createChain = async (
       try {
         sanitizedSpec = await testSubstrateSpec(spec, req.body.node_url);
       } catch (e) {
-        return next(new ServerError(Errors.InvalidNode));
+        return next(new AppError(Errors.InvalidNode));
       }
     }
   } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4808

## Description of Changes
- Improves the error output for broken rpc urls.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Changed a ServerError to AppError and copy changes. 

## Test Plan
- Create a new cosmos community with a broken rpc url, you should see the correct error message indicating the rpc url is broken. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 