### PR TITLE
Chain-event notification linking fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
@@ -7,11 +7,7 @@ import AddressInfo from '../../../models/AddressInfo';
 import type { NotificationRowProps } from './notification_row';
 import type { CWEvent } from 'chain-events/src';
 import { Label as ChainEventLabel, SupportedNetwork } from 'chain-events/src';
-import {
-  ChainNetwork,
-  NotificationCategories,
-  ProposalType,
-} from 'common-common/src/types';
+import { NotificationCategories, ProposalType } from 'common-common/src/types';
 
 import app from 'state';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';

--- a/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/notification_row_components.tsx
@@ -5,9 +5,13 @@ import 'pages/notifications/notification_row.scss';
 import AddressInfo from '../../../models/AddressInfo';
 
 import type { NotificationRowProps } from './notification_row';
-import { Label as ChainEventLabel } from 'chain-events/src';
 import type { CWEvent } from 'chain-events/src';
-import { NotificationCategories } from 'common-common/src/types';
+import { Label as ChainEventLabel, SupportedNetwork } from 'chain-events/src';
+import {
+  ChainNetwork,
+  NotificationCategories,
+  ProposalType,
+} from 'common-common/src/types';
 
 import app from 'state';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
@@ -18,6 +22,7 @@ import { getBatchNotificationFields } from './helpers';
 import { UserGallery } from '../../components/user/user_gallery';
 import { useCommonNavigate } from 'navigation/helpers';
 import { useNavigate } from 'react-router';
+import { getProposalUrlPath } from 'identifiers';
 
 export const ChainEventNotificationRow = (
   props: Omit<NotificationRowProps, 'allRead'>
@@ -63,12 +68,32 @@ export const ChainEventNotificationRow = (
     );
   }
 
+  let proposalType: ProposalType;
+  if (chainEvent.network === SupportedNetwork.Cosmos) {
+    proposalType = ProposalType.CosmosProposal;
+  } else if (chainEvent.network === SupportedNetwork.Aave) {
+    proposalType = ProposalType.AaveProposal;
+  } else if (chainEvent.network === SupportedNetwork.Compound) {
+    proposalType = ProposalType.CompoundProposal;
+  }
+
+  if (!proposalType) {
+    return;
+  }
+
+  const path = getProposalUrlPath(
+    proposalType,
+    (chainEvent.data as any).id,
+    false,
+    chainId
+  );
+
   return (
     <div
       className={
         !notification.isRead ? 'NotificationRow unread' : 'NotificationRow'
       }
-      onClick={() => navigate(`/notifications?id=${notification.id}`)}
+      onClick={() => navigate(path)}
     >
       <div className="comment-body">
         <div className="comment-body-top chain-event-notification-top">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4943 

## Description of Changes
- Uses an existing function to create the proper links for chain-event notifications.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Run `yarn emit-notification -c dydx -w [your wallet address]`
- Login with the same address
- In the notification drop-down click on the dydx notification.
- The associated proposal page should load.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 