### PR TITLE
Fixed playwright logging

### DIFF
--- a/packages/commonwealth/test/e2e/playwright.config.ts
+++ b/packages/commonwealth/test/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   globalTeardown: './globalTeardown.ts',
   timeout: 60_000,
   fullyParallel: true,
-  reporter: [['playwright-json-summary-reporter']],
+  reporter: [['list'], ['playwright-json-summary-reporter']],
 };
 
 export default config;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5007

## Description of Changes
- Adds default reporter back to playwright, makes it so that playwright test info gets print to stdout.

## Test Plan
- Ran playwright test, made sure tests are logged to terminal.