### PR TITLE
Fix Edit + Delete thread Bridged Forums functionality

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
@@ -49,13 +49,15 @@ export async function __deleteThread(
     throw new AppError(`${Errors.ThreadNotFound}: ${threadId}`);
   }
 
-  // check ban
-  const [canInteract, banError] = await this.banCache.checkBan({
-    chain: thread.chain,
-    address: address.address,
-  });
-  if (!canInteract) {
-    throw new AppError(`Ban error: ${banError}`);
+  if (address) {
+    // check ban
+    const [canInteract, banError] = await this.banCache.checkBan({
+      chain: thread.chain,
+      address: address.address,
+    });
+    if (!canInteract) {
+      throw new AppError(`Ban error: ${banError}`);
+    }
   }
 
   // check ownership (bypass if admin)

--- a/packages/commonwealth/server/routes/threads/update_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/update_thread_handler.ts
@@ -26,7 +26,7 @@ type UpdateThreadRequestBody = {
   canvasSession?: any;
   canvasAction?: any;
   canvasHash?: any;
-  discordMeta?: any;
+  discord_meta?: any; // Only comes from the discord bot
 };
 type UpdateThreadResponse = ThreadAttributes;
 
@@ -52,10 +52,10 @@ export const updateThreadHandler = async (
     canvasSession,
     canvasAction,
     canvasHash,
-    discordMeta,
+    discord_meta: discordMeta,
   } = req.body;
 
-  const threadId = parseInt(id, 10) || 0;
+  const threadId = parseInt(id, 10) || null;
 
   // this is a patch update, so properties should be
   // `undefined` if they are not intended to be updated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4960 

## Description of Changes
- Fixes routes so that bridged forums will have Discord edits reflected on CW. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Some small changes in #4751 were causing the discord consumer to not correctly hit the routes. Made the necessary fixes. Verified that create, edit, and delete works for comments and threads in all cases.

## Test Plan
- Create a discord post in a bridged channel, edit the post, and delete it. All actions should reflect on CW. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 