### PR TITLE
Make stakingDenom a dependency for useDepositParamsQuery

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -287,9 +287,11 @@ export class CosmosProposalV1 extends Proposal<
           ? ProposalStatus.Passing
           : ProposalStatus.Failing;
       case 'DepositPeriod':
-        return this.data.state.totalDeposit.gte(this._Governance.minDeposit)
-          ? ProposalStatus.Passing
-          : ProposalStatus.Failing;
+        return this._Governance.minDeposit
+          ? this.data.state.totalDeposit.gte(this._Governance.minDeposit)
+            ? ProposalStatus.Passing
+            : ProposalStatus.Failing
+          : ProposalStatus.None;
       default:
         return ProposalStatus.None;
     }

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1beta1/utils-v1beta1.ts
@@ -275,7 +275,8 @@ export interface CosmosDepositParams {
 }
 
 export const getDepositParams = async (
-  cosmosChain: Cosmos
+  cosmosChain: Cosmos,
+  stakingDenom?: string
 ): Promise<CosmosDepositParams> => {
   const govController = cosmosChain.governance as CosmosGovernance;
   let minDeposit;
@@ -283,7 +284,7 @@ export const getDepositParams = async (
 
   // TODO: support off-denom deposits
   const depositCoins = depositParams.minDeposit.find(
-    ({ denom }) => denom === cosmosChain.chain.denom
+    ({ denom }) => denom === stakingDenom
   );
   if (depositCoins) {
     minDeposit = new CosmosToken(

--- a/packages/commonwealth/client/scripts/state/api/chainParams/fetchDepositParams.ts
+++ b/packages/commonwealth/client/scripts/state/api/chainParams/fetchDepositParams.ts
@@ -14,10 +14,11 @@ const fetchDepositParams = async (): Promise<CosmosDepositParams> => {
   return getDepositParams(app.chain as Cosmos);
 };
 
-const useDepositParamsQuery = () => {
+// proposal.isPassing depends on staking denom being defined
+const useDepositParamsQuery = (stakingDenom: string) => {
   const chainId = app.activeChainId();
   return useQuery({
-    queryKey: ['depositParams', chainId],
+    queryKey: ['depositParams', chainId, stakingDenom],
     queryFn: fetchDepositParams,
     enabled: app.chain?.base === ChainBase.CosmosSDK,
     cacheTime: DEPOSIT_PARAMS_CACHE_TIME,

--- a/packages/commonwealth/client/scripts/state/api/chainParams/fetchDepositParams.ts
+++ b/packages/commonwealth/client/scripts/state/api/chainParams/fetchDepositParams.ts
@@ -10,17 +10,19 @@ import {
 const DEPOSIT_PARAMS_CACHE_TIME = Infinity;
 const DEPOSIT_PARAMS_STALE_TIME = 1000 * 60 * 15;
 
-const fetchDepositParams = async (): Promise<CosmosDepositParams> => {
-  return getDepositParams(app.chain as Cosmos);
+const fetchDepositParams = async (
+  stakingDenom: string
+): Promise<CosmosDepositParams> => {
+  return getDepositParams(app.chain as Cosmos, stakingDenom);
 };
 
-// proposal.isPassing depends on staking denom being defined
 const useDepositParamsQuery = (stakingDenom: string) => {
   const chainId = app.activeChainId();
   return useQuery({
+    // fetchDepositParams depends on stakingDenom being defined
     queryKey: ['depositParams', chainId, stakingDenom],
-    queryFn: fetchDepositParams,
-    enabled: app.chain?.base === ChainBase.CosmosSDK,
+    queryFn: () => fetchDepositParams(stakingDenom),
+    enabled: app.chain?.base === ChainBase.CosmosSDK && !!stakingDenom,
     cacheTime: DEPOSIT_PARAMS_CACHE_TIME,
     staleTime: DEPOSIT_PARAMS_STALE_TIME,
   });

--- a/packages/commonwealth/client/scripts/views/components/proposals/proposal_extensions.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/proposal_extensions.tsx
@@ -13,7 +13,10 @@ import { BalanceInfo } from 'views/components/proposals/balance_info';
 import { ConvictionsChooser } from 'views/components/proposals/convictions_chooser';
 import { CWText } from '../component_kit/cw_text';
 import { CWTextInput } from '../component_kit/cw_text_input';
-import { useDepositParamsQuery } from 'state/api/chainParams/fetchDepositParams';
+import {
+  useDepositParamsQuery,
+  useStakingParamsQuery,
+} from 'state/api/chainParams';
 
 type ProposalExtensionsProps = {
   proposal: AnyProposal;
@@ -35,7 +38,8 @@ export const ProposalExtensions = (props: ProposalExtensionsProps) => {
     if (setCosmosDepositAmount) setCosmosDepositAmount(0);
   }, [setCosmosDepositAmount, setDemocracyVoteAmount]);
 
-  const { data: cosmosDepositParams } = useDepositParamsQuery();
+  const { data: stakingDenom } = useStakingParamsQuery();
+  const { data: cosmosDepositParams } = useDepositParamsQuery(stakingDenom);
   const minDeposit = cosmosDepositParams?.minDeposit;
 
   if (proposal instanceof SubstrateDemocracyReferendum) {

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
@@ -38,8 +38,8 @@ export const CosmosProposalForm = () => {
   const author = app.user.activeAccount as CosmosAccount;
   const cosmos = app.chain as Cosmos;
 
-  useStakingParamsQuery();
-  const { data, isLoading } = useDepositParamsQuery();
+  const { data: stakingDenom } = useStakingParamsQuery();
+  const { data, isLoading } = useDepositParamsQuery(stakingDenom);
   const minDeposit = data?.minDeposit;
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -94,9 +94,9 @@ const ProposalsPage = () => {
   useManageDocumentTitle('Proposals');
 
   // lazy load Cosmos chain params
-  useDepositParamsQuery();
+  const { data: stakingDenom } = useStakingParamsQuery();
+  useDepositParamsQuery(stakingDenom);
   usePoolParamsQuery();
-  useStakingParamsQuery();
 
   const {
     data: activeCosmosProposals,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5011 

## Description of Changes
- Handles case: v1 `proposal.isPassing` relies on staking `denom`
- Makes `stakingDenom` a dependency for useDepositParamsQuery

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- CA (click around) tested on local and frack:
  - in /csdk, create a proposal with less than the minimum deposit
  - Confirm: the resulting page and /proposals should load

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Applies same check in `v1` for stake denom that already exists for `v1beta1`