### PR TITLE
Added gating stub API routes + controller + unit tests

### DIFF
--- a/packages/commonwealth/server/controllers/server_groups_controller.ts
+++ b/packages/commonwealth/server/controllers/server_groups_controller.ts
@@ -1,0 +1,61 @@
+import { DB } from '../models';
+import BanCache from '../util/banCheckCache';
+import { TokenBalanceCache } from '../../../token-balance-cache/src';
+import {
+  RefreshMembershipOptions,
+  RefreshMembershipResult,
+  __refreshMembership,
+} from './server_groups_methods/refresh_membership';
+import {
+  GetGroupsOptions,
+  GetGroupsResult,
+  __getGroups,
+} from './server_groups_methods/get_groups';
+import {
+  CreateGroupOptions,
+  CreateGroupResult,
+  __createGroup,
+} from './server_groups_methods/create_group';
+import {
+  UpdateGroupOptions,
+  UpdateGroupResult,
+  __updateGroup,
+} from './server_groups_methods/update_group';
+import {
+  DeleteGroupOptions,
+  DeleteGroupResult,
+  __deleteGroup,
+} from './server_groups_methods/delete_group';
+
+/**
+ * Implements methods related to groups
+ */
+export class ServerGroupsController {
+  constructor(
+    public models: DB,
+    public tokenBalanceCache: TokenBalanceCache,
+    public banCache: BanCache
+  ) {}
+
+  async refreshMembership(
+    options: RefreshMembershipOptions
+  ): Promise<RefreshMembershipResult> {
+    return __refreshMembership.call(this, options);
+  }
+
+  async getGroups(options: GetGroupsOptions): Promise<GetGroupsResult> {
+    return __getGroups.call(this, options);
+  }
+
+  async createGroup(options: CreateGroupOptions): Promise<CreateGroupResult> {
+    return __createGroup.call(this, options);
+  }
+
+  async updateGroup(options: UpdateGroupOptions): Promise<UpdateGroupResult> {
+    return __updateGroup.call(this, options);
+  }
+
+  async deleteGroup(options: DeleteGroupOptions): Promise<DeleteGroupResult> {
+    return __deleteGroup.call(this, options);
+  }
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
@@ -1,8 +1,8 @@
 import { ChainInstance } from 'server/models/chain';
 import { ServerChainsController } from '../server_chains_controller';
-import { AddressInstance } from 'server/models/address';
-import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
-import { UserInstance } from 'server/models/user';
+import { AddressInstance } from '../../models/address';
+import { Requirement } from '../../util/requirementsModule/requirementsTypes';
+import { UserInstance } from '../../models/user';
 
 export type CreateGroupOptions = {
   user: UserInstance;

--- a/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
@@ -30,6 +30,7 @@ export async function __createGroup(
   this: ServerChainsController,
   { requirements }: CreateGroupOptions
 ): Promise<CreateGroupResult> {
+  // TODO: require community admin
   if (!validateRequirements(requirements)) {
     throw new AppError(Errors.InvalidRequirements);
   }

--- a/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
@@ -1,0 +1,42 @@
+import { ChainInstance } from 'server/models/chain';
+import { ServerChainsController } from '../server_chains_controller';
+import { AddressInstance } from 'server/models/address';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import { UserInstance } from 'server/models/user';
+
+export type CreateGroupOptions = {
+  user: UserInstance;
+  chain: ChainInstance;
+  address: AddressInstance;
+  metadata: any;
+  requirements: Requirement[];
+  topics: number[];
+};
+// TODO: replace with GroupInstance after migration is complete
+export type CreateGroupResult = {
+  id: number;
+  chain_id: string;
+  metadata: any;
+  requirements: Requirement[];
+}[];
+
+export async function __createGroup(
+  this: ServerChainsController,
+  options: CreateGroupOptions
+): Promise<CreateGroupResult> {
+  /*
+    TODO:
+      - validate schema
+      - restrict to 20 groups per chain
+      - save group
+      - optionally add group to each specified topics
+  */
+  return [
+    {
+      id: 1,
+      chain_id: 'ethereum',
+      metadata: {},
+      requirements: [],
+    },
+  ];
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
@@ -3,6 +3,12 @@ import { ServerChainsController } from '../server_chains_controller';
 import { AddressInstance } from '../../models/address';
 import { Requirement } from '../../util/requirementsModule/requirementsTypes';
 import { UserInstance } from '../../models/user';
+import validateRequirements from '../../util/requirementsModule/validateRequirements';
+import { AppError } from '../../../../common-common/src/errors';
+
+const Errors = {
+  InvalidRequirements: 'Invalid requirements',
+};
 
 export type CreateGroupOptions = {
   user: UserInstance;
@@ -22,8 +28,11 @@ export type CreateGroupResult = {
 
 export async function __createGroup(
   this: ServerChainsController,
-  options: CreateGroupOptions
+  { requirements }: CreateGroupOptions
 ): Promise<CreateGroupResult> {
+  if (!validateRequirements(requirements)) {
+    throw new AppError(Errors.InvalidRequirements);
+  }
   /*
     TODO:
       - validate schema

--- a/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
@@ -16,5 +16,6 @@ export async function __deleteGroup(
   this: ServerChainsController,
   options: DeleteGroupOptions
 ): Promise<DeleteGroupResult> {
+  // TODO: require community admin
   // TODO: delete all memberships for group along with group itself
 }

--- a/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
@@ -1,7 +1,7 @@
 import { ChainInstance } from 'server/models/chain';
 import { ServerChainsController } from '../server_chains_controller';
-import { AddressInstance } from 'server/models/address';
-import { UserInstance } from 'server/models/user';
+import { AddressInstance } from '../../models/address';
+import { UserInstance } from '../../models/user';
 
 export type DeleteGroupOptions = {
   user: UserInstance;

--- a/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/delete_group.ts
@@ -1,0 +1,20 @@
+import { ChainInstance } from 'server/models/chain';
+import { ServerChainsController } from '../server_chains_controller';
+import { AddressInstance } from 'server/models/address';
+import { UserInstance } from 'server/models/user';
+
+export type DeleteGroupOptions = {
+  user: UserInstance;
+  chain: ChainInstance;
+  address: AddressInstance;
+  groupId: number;
+};
+
+export type DeleteGroupResult = void;
+
+export async function __deleteGroup(
+  this: ServerChainsController,
+  options: DeleteGroupOptions
+): Promise<DeleteGroupResult> {
+  // TODO: delete all memberships for group along with group itself
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/get_groups.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/get_groups.ts
@@ -1,5 +1,5 @@
 import { ServerChainsController } from '../server_chains_controller';
-import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import { Requirement } from '../../util/requirementsModule/requirementsTypes';
 
 export type GetGroupsOptions = {
   withMembers?: boolean;

--- a/packages/commonwealth/server/controllers/server_groups_methods/get_groups.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/get_groups.ts
@@ -1,0 +1,47 @@
+import { ServerChainsController } from '../server_chains_controller';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+
+export type GetGroupsOptions = {
+  withMembers?: boolean;
+  address?: string;
+};
+// TODO: replace with GroupInstance after migration is complete
+export type GetGroupsResult = {
+  id: number;
+  chain_id: string;
+  metadata: any;
+  requirements: Requirement[];
+  members?: {
+    group_id: number;
+    address_id: number;
+    allowed: boolean;
+    last_checked: Date;
+  }[];
+}[];
+
+export async function __getGroups(
+  this: ServerChainsController,
+  options: GetGroupsOptions
+): Promise<GetGroupsResult> {
+  /*
+    TODO: Query groups from DB, optionally include allowed membership
+  */
+  return [
+    {
+      id: 1,
+      chain_id: 'ethereum',
+      metadata: {},
+      requirements: [],
+      members: !options.withMembers
+        ? []
+        : [
+            {
+              group_id: 1,
+              address_id: 1,
+              allowed: true,
+              last_checked: new Date(),
+            },
+          ],
+    },
+  ];
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
@@ -1,0 +1,40 @@
+import { ChainInstance } from 'server/models/chain';
+import { ServerChainsController } from '../server_chains_controller';
+import { AddressInstance } from 'server/models/address';
+import { UserInstance } from 'server/models/user';
+
+export type RefreshMembershipOptions = {
+  user: UserInstance;
+  chain: ChainInstance;
+  address: AddressInstance;
+  topicId: number;
+};
+export type RefreshMembershipResult = {
+  topicId: number;
+  allowed: boolean;
+  rejectReason?: string;
+};
+
+export async function __refreshMembership(
+  this: ServerChainsController,
+  options: RefreshMembershipOptions
+): Promise<RefreshMembershipResult> {
+  /*
+    TODO: Check membership status of address for groups on specified topic
+      - if membership missing or stale => recompute, save and return membership
+      - else if membership fresh => return membership
+
+      Membership model:
+      {
+        group_id: number
+        address_id: number
+        allowed: boolean
+        reject_reason?: string
+        last_checked: Date
+      }
+  */
+  return {
+    topicId: 1,
+    allowed: true,
+  };
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
@@ -10,7 +10,7 @@ export type RefreshMembershipOptions = {
   topicId: number;
 };
 export type RefreshMembershipResult = {
-  topicId: number;
+  topicId?: number;
   allowed: boolean;
   rejectReason?: string;
 };
@@ -20,7 +20,8 @@ export async function __refreshMembership(
   options: RefreshMembershipOptions
 ): Promise<RefreshMembershipResult> {
   /*
-    TODO: Check membership status of address for groups on specified topic
+    TODO: Check membership status of address for all groups for all topics within the chain,
+    or optionally for the single specified topic
       - if membership missing or stale => recompute, save and return membership
       - else if membership fresh => return membership
 

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_membership.ts
@@ -1,7 +1,7 @@
 import { ChainInstance } from 'server/models/chain';
 import { ServerChainsController } from '../server_chains_controller';
-import { AddressInstance } from 'server/models/address';
-import { UserInstance } from 'server/models/user';
+import { AddressInstance } from '../../models/address';
+import { UserInstance } from '../../models/user';
 
 export type RefreshMembershipOptions = {
   user: UserInstance;

--- a/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
@@ -3,6 +3,12 @@ import { ServerChainsController } from '../server_chains_controller';
 import { AddressInstance } from '../../models/address';
 import { Requirement } from '../../util/requirementsModule/requirementsTypes';
 import { UserInstance } from '../../models/user';
+import validateRequirements from '../../util/requirementsModule/validateRequirements';
+import { AppError } from '../../../../common-common/src/errors';
+
+const Errors = {
+  InvalidRequirements: 'Invalid requirements',
+};
 
 export type UpdateGroupOptions = {
   user: UserInstance;
@@ -21,8 +27,11 @@ export type UpdateGroupResult = {
 
 export async function __updateGroup(
   this: ServerChainsController,
-  options: UpdateGroupOptions
+  { requirements }: UpdateGroupOptions
 ): Promise<UpdateGroupResult> {
+  if (!validateRequirements(requirements)) {
+    throw new AppError(Errors.InvalidRequirements);
+  }
   // TODO: delete all existing memberships for group before update
   return [
     {

--- a/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
@@ -29,6 +29,7 @@ export async function __updateGroup(
   this: ServerChainsController,
   { requirements }: UpdateGroupOptions
 ): Promise<UpdateGroupResult> {
+  // TODO: require community admin
   if (!validateRequirements(requirements)) {
     throw new AppError(Errors.InvalidRequirements);
   }

--- a/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
@@ -1,0 +1,35 @@
+import { ChainInstance } from 'server/models/chain';
+import { ServerChainsController } from '../server_chains_controller';
+import { AddressInstance } from 'server/models/address';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import { UserInstance } from 'server/models/user';
+
+export type UpdateGroupOptions = {
+  user: UserInstance;
+  chain: ChainInstance;
+  address: AddressInstance;
+  metadata: any;
+  requirements: Requirement[];
+};
+// TODO: replace with GroupInstance after migration is complete
+export type UpdateGroupResult = {
+  id: number;
+  chain_id: string;
+  metadata: any;
+  requirements: Requirement[];
+}[];
+
+export async function __updateGroup(
+  this: ServerChainsController,
+  options: UpdateGroupOptions
+): Promise<UpdateGroupResult> {
+  // TODO: delete all existing memberships for group before update
+  return [
+    {
+      id: 1,
+      chain_id: 'ethereum',
+      metadata: {},
+      requirements: [],
+    },
+  ];
+}

--- a/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/update_group.ts
@@ -1,8 +1,8 @@
 import { ChainInstance } from 'server/models/chain';
 import { ServerChainsController } from '../server_chains_controller';
-import { AddressInstance } from 'server/models/address';
-import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
-import { UserInstance } from 'server/models/user';
+import { AddressInstance } from '../../models/address';
+import { Requirement } from '../../util/requirementsModule/requirementsTypes';
+import { UserInstance } from '../../models/user';
 
 export type UpdateGroupOptions = {
   user: UserInstance;

--- a/packages/commonwealth/server/routes/groups/create_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/create_group_handler.ts
@@ -1,7 +1,15 @@
 import { TypedRequestBody, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
-import { CreateGroupResult } from 'server/controllers/server_groups_methods/create_group';
-import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import { CreateGroupResult } from '../../controllers/server_groups_methods/create_group';
+import { Requirement } from '../../util/requirementsModule/requirementsTypes';
+import { AppError } from '../../../../common-common/src/errors';
+import validateRequirements from '../../util/requirementsModule/validateRequirements';
+
+const Errors = {
+  InvalidMetadata: 'Invalid metadata',
+  InvalidRequirements: 'Invalid requirements',
+  InvalidTopics: 'Invalid topics',
+};
 
 type CreateGroupBody = {
   metadata: any; // TODO: use proper type
@@ -17,6 +25,19 @@ export const createGroupHandler = async (
 ) => {
   const { user, address, chain } = req;
   const { metadata, requirements, topics } = req.body;
+  if (!metadata) {
+    throw new AppError(Errors.InvalidMetadata);
+  }
+  if (!requirements || !validateRequirements(requirements)) {
+    throw new AppError(Errors.InvalidRequirements);
+  }
+  if (topics) {
+    for (const topicId of topics) {
+      if (typeof topicId !== 'number') {
+        throw new AppError(Errors.InvalidTopics);
+      }
+    }
+  }
   const result = await controllers.groups.createGroup({
     user,
     chain,

--- a/packages/commonwealth/server/routes/groups/create_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/create_group_handler.ts
@@ -1,0 +1,29 @@
+import { TypedRequestBody, TypedResponse, success } from '../../types';
+import { ServerControllers } from '../../routing/router';
+import { CreateGroupResult } from 'server/controllers/server_groups_methods/create_group';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+
+type CreateGroupBody = {
+  metadata: any; // TODO: use proper type
+  requirements: Requirement[];
+  topics: number[];
+};
+type CreateGroupResponse = CreateGroupResult;
+
+export const createGroupHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestBody<CreateGroupBody>,
+  res: TypedResponse<CreateGroupResponse>
+) => {
+  const { user, address, chain } = req;
+  const { metadata, requirements, topics } = req.body;
+  const result = await controllers.groups.createGroup({
+    user,
+    chain,
+    address,
+    metadata,
+    requirements,
+    topics,
+  });
+  return success(res, result);
+};

--- a/packages/commonwealth/server/routes/groups/create_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/create_group_handler.ts
@@ -3,7 +3,6 @@ import { ServerControllers } from '../../routing/router';
 import { CreateGroupResult } from '../../controllers/server_groups_methods/create_group';
 import { Requirement } from '../../util/requirementsModule/requirementsTypes';
 import { AppError } from '../../../../common-common/src/errors';
-import validateRequirements from '../../util/requirementsModule/validateRequirements';
 
 const Errors = {
   InvalidMetadata: 'Invalid metadata',
@@ -28,7 +27,7 @@ export const createGroupHandler = async (
   if (!metadata) {
     throw new AppError(Errors.InvalidMetadata);
   }
-  if (!requirements || !validateRequirements(requirements)) {
+  if (!requirements) {
     throw new AppError(Errors.InvalidRequirements);
   }
   if (topics) {

--- a/packages/commonwealth/server/routes/groups/delete_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/delete_group_handler.ts
@@ -1,6 +1,6 @@
 import { TypedRequestParams, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
-import { DeleteGroupResult } from 'server/controllers/server_groups_methods/delete_group';
+import { DeleteGroupResult } from '../../controllers/server_groups_methods/delete_group';
 
 type DeleteGroupParams = {
   id: string;

--- a/packages/commonwealth/server/routes/groups/delete_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/delete_group_handler.ts
@@ -1,0 +1,24 @@
+import { TypedRequestParams, TypedResponse, success } from '../../types';
+import { ServerControllers } from '../../routing/router';
+import { DeleteGroupResult } from 'server/controllers/server_groups_methods/delete_group';
+
+type DeleteGroupParams = {
+  id: string;
+};
+type DeleteGroupResponse = DeleteGroupResult;
+
+export const deleteGroupHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestParams<DeleteGroupParams>,
+  res: TypedResponse<DeleteGroupResponse>
+) => {
+  const { user, address, chain } = req;
+  const { id } = req.params;
+  const result = await controllers.groups.deleteGroup({
+    user,
+    chain,
+    address,
+    groupId: parseInt(id, 10),
+  });
+  return success(res, result);
+};

--- a/packages/commonwealth/server/routes/groups/get_groups_handler.ts
+++ b/packages/commonwealth/server/routes/groups/get_groups_handler.ts
@@ -1,0 +1,22 @@
+import { TypedRequestQuery, TypedResponse, success } from '../../types';
+import { ServerControllers } from '../../routing/router';
+import { GetGroupsResult } from 'server/controllers/server_groups_methods/get_groups';
+
+type GetGroupsQueryQuery = {
+  members?: string;
+  address?: string;
+};
+type GetGroupsResponse = GetGroupsResult;
+
+export const getGroupsHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestQuery<GetGroupsQueryQuery>,
+  res: TypedResponse<GetGroupsResponse>
+) => {
+  const { members, address } = req.query;
+  const result = await controllers.groups.getGroups({
+    withMembers: members === 'true',
+    address,
+  });
+  return success(res, result);
+};

--- a/packages/commonwealth/server/routes/groups/get_groups_handler.ts
+++ b/packages/commonwealth/server/routes/groups/get_groups_handler.ts
@@ -1,6 +1,6 @@
 import { TypedRequestQuery, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
-import { GetGroupsResult } from 'server/controllers/server_groups_methods/get_groups';
+import { GetGroupsResult } from '../../controllers/server_groups_methods/get_groups';
 
 type GetGroupsQueryQuery = {
   members?: string;

--- a/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
+++ b/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
@@ -1,0 +1,24 @@
+import { TypedRequestBody, TypedResponse, success } from '../../types';
+import { ServerControllers } from '../../routing/router';
+import { RefreshMembershipResult } from 'server/controllers/server_groups_methods/refresh_membership';
+
+type RefreshMembershipBody = {
+  topic_id: number;
+};
+type RefreshMembershipResponse = RefreshMembershipResult;
+
+export const refreshMembershipHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestBody<RefreshMembershipBody>,
+  res: TypedResponse<RefreshMembershipResponse>
+) => {
+  const { user, address, chain } = req;
+  const { topic_id: topicId } = req.body;
+  const result = await controllers.groups.refreshMembership({
+    user,
+    chain,
+    address,
+    topicId,
+  });
+  return success(res, result);
+};

--- a/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
+++ b/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
@@ -19,9 +19,7 @@ export const refreshMembershipHandler = async (
 ) => {
   const { user, address, chain } = req;
   const { topic_id: topicId } = req.body;
-  if (typeof topicId !== 'number') {
-    throw new AppError(Errors.InvalidTopicId);
-  }
+
   const result = await controllers.groups.refreshMembership({
     user,
     chain,

--- a/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
+++ b/packages/commonwealth/server/routes/groups/refresh_membership_handler.ts
@@ -1,6 +1,11 @@
 import { TypedRequestBody, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
-import { RefreshMembershipResult } from 'server/controllers/server_groups_methods/refresh_membership';
+import { RefreshMembershipResult } from '../../controllers/server_groups_methods/refresh_membership';
+import { AppError } from '../../../../common-common/src/errors';
+
+const Errors = {
+  InvalidTopicId: 'Invalid topic ID',
+};
 
 type RefreshMembershipBody = {
   topic_id: number;
@@ -14,6 +19,9 @@ export const refreshMembershipHandler = async (
 ) => {
   const { user, address, chain } = req;
   const { topic_id: topicId } = req.body;
+  if (typeof topicId !== 'number') {
+    throw new AppError(Errors.InvalidTopicId);
+  }
   const result = await controllers.groups.refreshMembership({
     user,
     chain,

--- a/packages/commonwealth/server/routes/groups/update_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/update_group_handler.ts
@@ -1,0 +1,27 @@
+import { TypedRequestBody, TypedResponse, success } from '../../types';
+import { ServerControllers } from '../../routing/router';
+import { UpdateGroupResult } from 'server/controllers/server_groups_methods/update_group';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+
+type UpdateGroupBody = {
+  metadata: any; // TODO: use proper type
+  requirements: Requirement[];
+};
+type UpdateGroupResponse = UpdateGroupResult;
+
+export const updateGroupHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestBody<UpdateGroupBody>,
+  res: TypedResponse<UpdateGroupResponse>
+) => {
+  const { user, address, chain } = req;
+  const { metadata, requirements } = req.body;
+  const result = await controllers.groups.updateGroup({
+    user,
+    chain,
+    address,
+    metadata,
+    requirements,
+  });
+  return success(res, result);
+};

--- a/packages/commonwealth/server/routes/groups/update_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/update_group_handler.ts
@@ -1,7 +1,13 @@
 import { TypedRequestBody, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
-import { UpdateGroupResult } from 'server/controllers/server_groups_methods/update_group';
-import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import { UpdateGroupResult } from '../../controllers/server_groups_methods/update_group';
+import { Requirement } from '../../util/requirementsModule/requirementsTypes';
+import validateRequirements from '../../util/requirementsModule/validateRequirements';
+import { AppError } from '../../../../common-common/src/errors';
+
+const Errors = {
+  InvalidRequirements: 'Invalid requirements',
+};
 
 type UpdateGroupBody = {
   metadata: any; // TODO: use proper type
@@ -16,6 +22,9 @@ export const updateGroupHandler = async (
 ) => {
   const { user, address, chain } = req;
   const { metadata, requirements } = req.body;
+  if (requirements || !validateRequirements(requirements)) {
+    throw new AppError(Errors.InvalidRequirements);
+  }
   const result = await controllers.groups.updateGroup({
     user,
     chain,

--- a/packages/commonwealth/server/routes/groups/update_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/update_group_handler.ts
@@ -2,12 +2,6 @@ import { TypedRequestBody, TypedResponse, success } from '../../types';
 import { ServerControllers } from '../../routing/router';
 import { UpdateGroupResult } from '../../controllers/server_groups_methods/update_group';
 import { Requirement } from '../../util/requirementsModule/requirementsTypes';
-import validateRequirements from '../../util/requirementsModule/validateRequirements';
-import { AppError } from '../../../../common-common/src/errors';
-
-const Errors = {
-  InvalidRequirements: 'Invalid requirements',
-};
 
 type UpdateGroupBody = {
   metadata: any; // TODO: use proper type
@@ -22,9 +16,6 @@ export const updateGroupHandler = async (
 ) => {
   const { user, address, chain } = req;
   const { metadata, requirements } = req.body;
-  if (requirements || !validateRequirements(requirements)) {
-    throw new AppError(Errors.InvalidRequirements);
-  }
   const result = await controllers.groups.updateGroup({
     user,
     chain,

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -161,6 +161,7 @@ import { ServerAnalyticsController } from '../controllers/server_analytics_contr
 import { ServerProfilesController } from '../controllers/server_profiles_controller';
 import { ServerChainsController } from '../controllers/server_chains_controller';
 import { ServerProposalsController } from '../controllers/server_proposals_controller';
+import { ServerGroupsController } from '../controllers/server_groups_controller';
 
 import { deleteReactionHandler } from '../routes/reactions/delete_reaction_handler';
 import { createThreadReactionHandler } from '../routes/threads/create_thread_reaction_handler';
@@ -182,6 +183,11 @@ import exportMembersList from '../routes/exportMembersList';
 import { getProposalsHandler } from '../routes/proposals/getProposalsHandler';
 import { getProposalVotesHandler } from '../routes/proposals/getProposalVotesHandler';
 import viewChainActivity from '../routes/viewChainActivity';
+import { refreshMembershipHandler } from '../routes/groups/refresh_membership_handler';
+import { createGroupHandler } from '../routes/groups/create_group_handler';
+import { getGroupsHandler } from '../routes/groups/get_groups_handler';
+import { updateGroupHandler } from '../routes/groups/update_group_handler';
+import { deleteGroupHandler } from '../routes/groups/delete_group_handler';
 
 export type ServerControllers = {
   threads: ServerThreadsController;
@@ -192,6 +198,7 @@ export type ServerControllers = {
   profiles: ServerProfilesController;
   chains: ServerChainsController;
   proposals: ServerProposalsController;
+  groups: ServerGroupsController;
 };
 
 function setupRouter(
@@ -216,6 +223,7 @@ function setupRouter(
     profiles: new ServerProfilesController(models),
     chains: new ServerChainsController(models, tokenBalanceCache, banCache),
     proposals: new ServerProposalsController(models, redisCache),
+    groups: new ServerGroupsController(models, tokenBalanceCache, banCache),
   };
 
   // ---
@@ -1325,6 +1333,54 @@ function setupRouter(
     'get',
     '/proposalVotes',
     getProposalVotesHandler.bind(this, serverControllers)
+  );
+
+  // Group routes
+  registerRoute(
+    router,
+    'put',
+    '/refresh-membership',
+    passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
+    databaseValidationService.validateChain,
+    refreshMembershipHandler.bind(this, serverControllers)
+  );
+
+  registerRoute(
+    router,
+    'get',
+    '/groups',
+    getGroupsHandler.bind(this, serverControllers)
+  );
+
+  registerRoute(
+    router,
+    'post',
+    '/groups',
+    passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
+    databaseValidationService.validateChain,
+    createGroupHandler.bind(this, serverControllers)
+  );
+
+  registerRoute(
+    router,
+    'put',
+    '/groups',
+    passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
+    databaseValidationService.validateChain,
+    updateGroupHandler.bind(this, serverControllers)
+  );
+
+  registerRoute(
+    router,
+    'delete',
+    '/groups/:id',
+    passport.authenticate('jwt', { session: false }),
+    databaseValidationService.validateAuthor,
+    databaseValidationService.validateChain,
+    deleteGroupHandler.bind(this, serverControllers)
   );
 
   app.use(endpoint, router);

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -1366,7 +1366,7 @@ function setupRouter(
   registerRoute(
     router,
     'put',
-    '/groups',
+    '/groups/:id',
     passport.authenticate('jwt', { session: false }),
     databaseValidationService.validateAuthor,
     databaseValidationService.validateChain,

--- a/packages/commonwealth/test/unit/server_controllers/server_groups_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_groups_controller.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import { ServerGroupsController } from 'server/controllers/server_groups_controller';
+import { AddressInstance } from 'server/models/address';
+import { ChainInstance } from 'server/models/chain';
+import { UserInstance } from 'server/models/user';
+
+const createMockedGroupsController = () => {
+  const db: any = {};
+  const tokenBalanceCache: any = {};
+  const banCache: any = {};
+  const controller = new ServerGroupsController(
+    db,
+    tokenBalanceCache,
+    banCache
+  );
+  return controller;
+};
+
+describe('ServerGroupsController', () => {
+  describe('#refreshMembership', async () => {
+    const controller = createMockedGroupsController();
+    const result = await controller.refreshMembership({
+      user: {} as UserInstance,
+      chain: {} as ChainInstance,
+      address: {} as AddressInstance,
+      topicId: 1,
+    });
+    expect(result).to.have.property('topicId');
+    expect(result).to.have.property('allowed');
+    expect(result).to.not.have.property('rejectReason');
+  });
+
+  describe('#getGroups', async () => {
+    const controller = createMockedGroupsController();
+    const result = await controller.getGroups({
+      withMembers: true,
+    });
+    expect(result).to.have.length(1);
+    expect(result[0]).to.have.property('id');
+    expect(result[0]).to.have.property('chain_id');
+    expect(result[0]).to.have.property('metadata');
+    expect(result[0]).to.have.property('requirements');
+    expect(result[0]).to.have.property('members');
+    expect(result[0].members).to.have.length(1);
+    expect(result[0].members[0]).to.have.property('group_id');
+    expect(result[0].members[0]).to.have.property('address_id');
+    expect(result[0].members[0]).to.have.property('allowed');
+    expect(result[0].members[0]).to.have.property('last_checked');
+  });
+
+  describe('#createGroup', async () => {
+    const controller = createMockedGroupsController();
+    const result = await controller.createGroup({
+      user: {} as UserInstance,
+      chain: {} as ChainInstance,
+      address: {} as AddressInstance,
+      metadata: {},
+      requirements: [],
+      topics: [],
+    });
+    expect(result).to.have.length(1);
+    expect(result[0]).to.have.property('id');
+    expect(result[0]).to.have.property('chain_id');
+    expect(result[0]).to.have.property('metadata');
+    expect(result[0]).to.have.property('requirements');
+  });
+
+  describe('#updateGroup', async () => {
+    const controller = createMockedGroupsController();
+    const result = await controller.updateGroup({
+      user: {} as UserInstance,
+      chain: {} as ChainInstance,
+      address: {} as AddressInstance,
+      metadata: {},
+      requirements: [],
+    });
+    expect(result).to.have.length(1);
+    expect(result[0]).to.have.property('id');
+    expect(result[0]).to.have.property('chain_id');
+    expect(result[0]).to.have.property('metadata');
+    expect(result[0]).to.have.property('requirements');
+  });
+
+  describe('#deleteGroup', async () => {
+    const controller = createMockedGroupsController();
+    const result = await controller.deleteGroup({
+      user: {} as UserInstance,
+      chain: {} as ChainInstance,
+      address: {} as AddressInstance,
+      groupId: 1,
+    });
+    expect(result).to.be.undefined;
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5013
Closes: #5014
Closes: #5015 

## Description of Changes
- Added stub API routes for groups
- Added groups controller
  - Wires up the `validateRequirements` function
- Added units tests for groups controller

## Test Plan
- Unit tested groups controller
- Test routes via HTTP request (Postman)
  - Refresh membership: `PUT http://localhost:8080/api/refresh-membership`
  - Create group: `POST http://localhost:8080/api/groups`
  - Get groups w/ memberships: `GET http://localhost:8080/api/groups?members=true`
  - Update group: `PUT http://localhost:8080/api/groups/1`
  - Delete group: `DELETE http://localhost:8080/api/groups/1`

## Deployment Plan
N/A

## Other Considerations
N/A