### PR TITLE
Add models/migration for gating

### DIFF
--- a/packages/commonwealth/server/database.ts
+++ b/packages/commonwealth/server/database.ts
@@ -19,6 +19,8 @@ import NotificationFactory from './models/notification';
 import NotificationCategoryFactory from './models/notification_category';
 import NotificationsReadFactory from './models/notifications_read';
 import PollFactory from './models/poll';
+import GroupFactory from './models/group';
+import MembershipFactory from './models/membership';
 import ProfileFactory from './models/profile';
 import ReactionFactory from './models/reaction';
 import SnapshotProposalFactory from './models/snapshot_proposal';
@@ -92,6 +94,8 @@ const models: Models = {
   NotificationsRead: NotificationsReadFactory(sequelize, DataTypes),
   Comment: CommentFactory(sequelize, DataTypes),
   Poll: PollFactory(sequelize, DataTypes),
+  Group: GroupFactory(sequelize, DataTypes),
+  Membership: MembershipFactory(sequelize, DataTypes),
   Reaction: ReactionFactory(sequelize, DataTypes),
   Thread: ThreadFactory(sequelize, DataTypes),
   Topic: TopicFactory(sequelize, DataTypes),

--- a/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
+++ b/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
@@ -32,7 +32,7 @@ module.exports = {
           address_id: {
             type: Sequelize.INTEGER,
             allowNull: false,
-            references: { model: 'Address', key: 'id' },
+            references: { model: 'Addresses', key: 'id' },
           },
           last_checked: { type: Sequelize.DATE, allowNull: false },
         },

--- a/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
+++ b/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.createTable(
+        'Groups',
+        {
+          id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+          chain_id: {
+            type: Sequelize.STRING,
+            allowNull: false,
+            references: { model: 'Chains', key: 'id' },
+          },
+          metadata: { type: Sequelize.JSON, allowNull: false },
+          requirements: { type: Sequelize.JSON, allowNull: false },
+
+          created_at: { type: Sequelize.DATE, allowNull: false },
+          updated_at: { type: Sequelize.DATE, allowNull: false },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.createTable(
+        'Memberships',
+        {
+          group_id: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            references: { model: 'Groups', key: 'id' },
+          },
+          address_id: { type: Sequelize.INTEGER, allowNull: false },
+          last_checked: { type: Sequelize.DATE, allowNull: false },
+        },
+        { transaction: t }
+      );
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.dropTable('Memberships', { transaction: t })
+      await queryInterface.dropTable('Groups', { transaction: t })
+    })
+  }
+};

--- a/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
+++ b/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
@@ -20,7 +20,6 @@ module.exports = {
         },
         { transaction: t }
       );
-
       await queryInterface.createTable(
         'Memberships',
         {
@@ -34,8 +33,26 @@ module.exports = {
             allowNull: false,
             references: { model: 'Addresses', key: 'id' },
           },
+          reject_reason: { type: Sequelize.STRING, allowNull: true },
           last_checked: { type: Sequelize.DATE, allowNull: false },
         },
+        { transaction: t }
+      );
+    })
+    await queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addIndex(
+        'Groups',
+        { fields: ['chain_id'] },
+        { transaction: t }
+      );
+      await queryInterface.addIndex(
+        'Memberships',
+        { fields: ['group_id'] },
+        { transaction: t }
+      );
+      await queryInterface.addIndex(
+        'Memberships',
+        { fields: ['address_id'] },
         { transaction: t }
       );
     })

--- a/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
+++ b/packages/commonwealth/server/migrations/20230908164952-add-groups-memberships-tables.js
@@ -29,7 +29,11 @@ module.exports = {
             allowNull: false,
             references: { model: 'Groups', key: 'id' },
           },
-          address_id: { type: Sequelize.INTEGER, allowNull: false },
+          address_id: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            references: { model: 'Address', key: 'id' },
+          },
           last_checked: { type: Sequelize.DATE, allowNull: false },
         },
         { transaction: t }

--- a/packages/commonwealth/server/models.ts
+++ b/packages/commonwealth/server/models.ts
@@ -35,6 +35,8 @@ import type { WebhookModelStatic } from './models/webhook';
 import type { CommunityContractTemplateStatic } from './models/community_contract_template';
 import type { CommunityContractTemplateMetadataStatic } from './models/community_contract_metadata';
 import type { TemplateModelStatic } from './models/template';
+import type { GroupModelStatic } from './models/group';
+import type { MembershipModelStatic } from './models/membership';
 
 export type Models = {
   Address: AddressModelStatic;
@@ -57,6 +59,8 @@ export type Models = {
   NotificationsRead: NotificationsReadModelStatic;
   Comment: CommentModelStatic;
   Poll: PollModelStatic;
+  Group: GroupModelStatic;
+  Membership: MembershipModelStatic;
   Reaction: ReactionModelStatic;
   Thread: ThreadModelStatic;
   Topic: TopicModelStatic;

--- a/packages/commonwealth/server/models/group.ts
+++ b/packages/commonwealth/server/models/group.ts
@@ -1,0 +1,67 @@
+import type * as Sequelize from 'sequelize';
+import { DataTypes } from 'sequelize';
+import { ChainAttributes } from './chain';
+import { ModelInstance, ModelStatic } from './types';
+import { Requirement } from '../util/requirementsModule/requirementsTypes';
+
+export type GroupMetadata = {
+  name: string;
+  description: string;
+  required_requirements: number;
+  membership_ttl: number;
+};
+
+export type GroupAttributes = {
+  id: number;
+  chain_id: string;
+  metadata: GroupMetadata;
+  requirements: Requirement[];
+
+  created_at?: Date;
+  updated_at?: Date;
+
+  // associations
+  Chain?: ChainAttributes;
+};
+
+export type GroupInstance = ModelInstance<GroupAttributes>;
+export type GroupModelStatic = ModelStatic<GroupInstance>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: typeof DataTypes
+): GroupModelStatic => {
+  const Group = <GroupModelStatic>sequelize.define(
+    'Group',
+    {
+      id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+      chain_id: { type: dataTypes.STRING, allowNull: false },
+      metadata: { type: dataTypes.JSON, allowNull: false },
+      requirements: { type: dataTypes.JSON, allowNull: false },
+
+      created_at: { type: dataTypes.DATE, allowNull: false },
+      updated_at: { type: dataTypes.DATE, allowNull: false },
+    },
+    {
+      timestamps: true,
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+      underscored: true,
+      tableName: 'Groups',
+      indexes: [{ fields: ['chain_id'] }],
+    }
+  );
+
+  Group.associate = (models) => {
+    models.Group.belongsTo(models.Chain, {
+      foreignKey: 'chain_id',
+      targetKey: 'id',
+    });
+    models.Group.hasMany(models.Membership, {
+      foreignKey: 'group_id',
+      as: 'memberships',
+    });
+  };
+
+  return Group;
+};

--- a/packages/commonwealth/server/models/membership.ts
+++ b/packages/commonwealth/server/models/membership.ts
@@ -1,0 +1,44 @@
+import type * as Sequelize from 'sequelize';
+import { DataTypes } from 'sequelize';
+import { ModelInstance, ModelStatic } from './types';
+import { GroupAttributes } from './group';
+
+export type MembershipAttributes = {
+  group_id: number;
+  address_id: number;
+  last_checked: Date;
+
+  // associations
+  Group?: GroupAttributes;
+};
+
+export type MembershipInstance = ModelInstance<MembershipAttributes>;
+export type MembershipModelStatic = ModelStatic<MembershipInstance>;
+
+export default (
+  sequelize: Sequelize.Sequelize,
+  dataTypes: typeof DataTypes
+): MembershipModelStatic => {
+  const Membership = <MembershipModelStatic>sequelize.define(
+    'Membership',
+    {
+      group_id: { type: dataTypes.INTEGER, allowNull: false },
+      address_id: { type: dataTypes.INTEGER, allowNull: false },
+      last_checked: { type: dataTypes.DATE, allowNull: false },
+    },
+    {
+      underscored: true,
+      tableName: 'Memberships',
+      indexes: [{ fields: ['group_id'] }],
+    }
+  );
+
+  Membership.associate = (models) => {
+    models.Membership.belongsTo(models.Group, {
+      foreignKey: 'group_id',
+      targetKey: 'id',
+    });
+  };
+
+  return Membership;
+};

--- a/packages/commonwealth/server/models/membership.ts
+++ b/packages/commonwealth/server/models/membership.ts
@@ -6,6 +6,7 @@ import { GroupAttributes } from './group';
 export type MembershipAttributes = {
   group_id: number;
   address_id: number;
+  reject_reason?: string;
   last_checked: Date;
 
   // associations
@@ -24,6 +25,7 @@ export default (
     {
       group_id: { type: dataTypes.INTEGER, allowNull: false },
       address_id: { type: dataTypes.INTEGER, allowNull: false },
+      reject_reason: { type: dataTypes.STRING, allowNull: true },
       last_checked: { type: dataTypes.DATE, allowNull: false },
     },
     {
@@ -36,6 +38,10 @@ export default (
   Membership.associate = (models) => {
     models.Membership.belongsTo(models.Group, {
       foreignKey: 'group_id',
+      targetKey: 'id',
+    });
+    models.Membership.belongsTo(models.Address, {
+      foreignKey: 'address_id',
       targetKey: 'id',
     });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5019 

## Description of Changes
- Adds models and migration for groups and memberships

## Test Plan
- Run migration locally
- Confirm that `Groups` and `Memberships` table is created

## Deployment Plan
- Run migration in prod

## Other Considerations
- The ORM model *should* work fine, but it's the first one I've implemented so I may have missed something– won't know for sure if it works until it's used in the groups controller.