### PR TITLE
Fix searchbar suggestion dropdown zindex

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.scss
@@ -13,7 +13,7 @@
   border-radius: 6px;
   overflow: auto;
   outline: 0px;
-  z-index: 1;
+  z-index: 999;
   background-color: $white;
   border: 1px solid $neutral-200;
   color: $neutral-900;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5030

## Description of Changes
Added a higher zindex to searchbar dropdown, if visible, it will be shown above every other element in the screen.

## "How We Fixed It"
By updating the z-index CSS property.

## Test Plan
- Visit any community page
- Search something from the search bar in header (make sure it gives results)
- Now make sure that the dropdown overlays the community sidebar (reduce/increase the screen size to mimic it)
- Reload the page, and quickly search for something before the community sidebar loads
- Verify that the search dropdown properly overlays the community sidebar when the community sidebar is showing a skeleton loader.

## Deployment Plan
N/A 

## Other Considerations
N/A