### PR TITLE
Fixed CI mature-e2e-tests job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,13 +169,23 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium
 
+      - name: Install proxy
+        run: npm install -g local-ssl-proxy
+
+      - name: Add custom domain to /etc/hosts
+        run: sudo sh -c 'echo "127.0.0.1 customdomain.com" >> /etc/hosts'
+
       - name: Run e2e tests (yarn test-e2e)
-        run: yarn --cwd packages/commonwealth e2e-start-server & (yarn --cwd packages/commonwealth wait-server && yarn --cwd packages/commonwealth test-e2e)
         env:
           PORT: 8080
+          IS_CI: true
           USES_DOCKER_PGSQL: true
           ETH_ALCHEMY_API_KEY: ${{ secrets.ETH_ALCHEMY_API_KEY }}
           ENTITIES_URL: ${{ secrets.ENTITIES_URL }}
+        run: |
+          sudo local-ssl-proxy --source 443 --target 8080 &
+          yarn --cwd packages/commonwealth e2e-start-server &
+          yarn --cwd packages/commonwealth wait-server && yarn --cwd packages/commonwealth test-e2e-mature
 
       - name: Archive test status
         uses: actions/upload-artifact@v3

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -64,7 +64,7 @@
     "test-devnet": "nyc ts-mocha --project tsconfig.json './test/devnet/**/*.spec.ts'",
     "test-e2e": "TEST_ENV=playwright npx playwright test -c ./test/e2e/playwright.config.ts --workers 2 ./test/e2e/e2eRegular/*",
     "test-e2e-serial": "TEST_ENV=playwright npx playwright test --workers 1 ./test/e2e/e2eSerial/*",
-    "test-e2e-mature": "TEST_ENV=playwright npx playwright test -c ./test/e2e/playwright.config.ts test --workers 2 ./test/e2e/mature/*",
+    "test-e2e-mature": "TEST_ENV=playwright npx playwright test -c ./test/e2e/playwright.config.ts --workers 2 ./test/e2e/mature/*",
     "test-events": "nyc ts-mocha --project tsconfig.json ./test/integration/events/*.spec.ts",
     "test-integration-util": "NODE_ENV=test nyc ts-mocha --project tsconfig.json ./test/integration/*.spec.ts",
     "test-query": "ts-node server/scripts/testQuery.ts",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5042

## Description of Changes
- Made CI run only mature directory
- Fixed incorrect error in test-e2e-mature command
- Added custom host test setup for the mature e2e suite in the CI

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Ran command yarn test-e2e-mature to make sure it only runs the mature directory