### PR TITLE
4986 missing headers

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -19,6 +19,7 @@ import { TopicSelector } from 'views/components/topic_selector';
 import { ThreadKind, ThreadStage } from '../../../models/types';
 import Permissions from '../../../utils/Permissions';
 import { ReactQuillEditor } from '../react_quill_editor';
+import { CWText } from '../../components/component_kit/cw_text';
 import {
   createDeltaFromText,
   getTextFromDelta,
@@ -137,6 +138,11 @@ export const NewThreadForm = () => {
   return (
     <>
       <div className="NewThreadForm">
+        <div className="header">
+          <CWText type="h2" fontWeight="medium">
+            Proposals
+          </CWText>
+        </div>
         <div className="new-thread-header">
           <CWTabBar>
             <CWTab

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -12,6 +12,7 @@ import { CWSpinner } from '../component_kit/cw_spinner';
 import type { CommentWithAssociatedThread } from './ProfileActivity';
 import ProfileActivity from './ProfileActivity';
 import ProfileHeader from './ProfileHeader';
+import { CWText } from '../../components/component_kit/cw_text';
 
 enum ProfileError {
   None,
@@ -43,9 +44,7 @@ const Profile = ({ profileId }: ProfileProps) => {
 
       setProfile(new NewProfile(result.profile));
       setThreads(result.threads.map((t) => new Thread(t)));
-      const responseComments = result.comments.map((c) =>
-        new Comment(c)
-      );
+      const responseComments = result.comments.map((c) => new Comment(c));
       const commentsWithAssociatedThread = responseComments.map((c) => {
         const thread = result.commentThreads.find(
           (t) => t.id === parseInt(c.threadId, 10)
@@ -116,24 +115,30 @@ const Profile = ({ profileId }: ProfileProps) => {
         style={
           profile.backgroundImage
             ? {
-              backgroundImage: `url(${backgroundUrl})`,
-              backgroundRepeat: `${backgroundImageBehavior === ImageBehavior.Fill
-                  ? 'no-repeat'
-                  : 'repeat'
+                backgroundImage: `url(${backgroundUrl})`,
+                backgroundRepeat: `${
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'no-repeat'
+                    : 'repeat'
                 }`,
-              backgroundSize:
-                backgroundImageBehavior === ImageBehavior.Fill
-                  ? 'cover'
-                  : '100px',
-              backgroundPosition:
-                backgroundImageBehavior === ImageBehavior.Fill
-                  ? 'center'
-                  : '56px 56px',
-              backgroundAttachment: 'fixed',
-            }
+                backgroundSize:
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'cover'
+                    : '100px',
+                backgroundPosition:
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'center'
+                    : '56px 56px',
+                backgroundAttachment: 'fixed',
+              }
             : {}
         }
       >
+        <div className="header">
+          <CWText type="h2" fontWeight="medium">
+            {profile.name}'s Profile
+          </CWText>
+        </div>
         <div
           className={
             profile.backgroundImage

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
@@ -113,6 +113,7 @@ const Analytics = () => {
         <>
           <div className="AnalyticsSection">
             <CWText type="h4">Site Statistics</CWText>
+
             <CWText type="caption">
               All stats pulled from the last 30 days of global site activity.
             </CWText>

--- a/packages/commonwealth/client/scripts/views/pages/communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/communities.tsx
@@ -134,9 +134,14 @@ const CommunitiesPage = () => {
   return (
     <div className="CommunitiesPage">
       <div className="header-section">
-        <CWText type="h3" fontWeight="semiBold" className="communities-count">
-          {buildCommunityString(sortedChains.length)}
-        </CWText>
+        <div>
+          <CWText type="h3" fontWeight="semiBold" className="communities-count">
+            Explore Communities
+          </CWText>
+          <CWText type="h3" fontWeight="semiBold" className="communities-count">
+            {buildCommunityString(sortedChains.length)}
+          </CWText>
+        </div>
         <div className="filter-buttons">
           {chainCategories.map((cat, i) => {
             return (

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/ManageCommunityPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/ManageCommunityPage.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
 import { useDebounce } from 'usehooks-ts';
 import { AccessLevel } from '../../../../../shared/permissions';
+import { CWText } from '../../components/component_kit/cw_text';
 import NewProfilesController from '../../../controllers/server/newProfiles';
 import RoleInfo from '../../../models/RoleInfo';
 import Permissions from '../../../utils/Permissions';
@@ -152,6 +153,9 @@ const ManageCommunityPage = () => {
 
   return (
     <div className="ManageCommunityPage">
+      <CWText type="h2" fontWeight="medium">
+        Manage Community
+      </CWText>
       <ChainMetadataRows
         admins={admins}
         chain={app.config.chains.getById(app.activeChainId())}

--- a/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
@@ -26,6 +26,9 @@ const NotificationsPage = () => {
 
   return (
     <div className="NotificationsPage">
+      <CWText type="h2" fontWeight="medium">
+        Notifications
+      </CWText>
       <div className="notifications-buttons-row">
         <CWButton
           label="Mark all as read"

--- a/packages/commonwealth/client/scripts/views/pages/proposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/proposals.tsx
@@ -18,6 +18,7 @@ import { CardsCollection } from '../components/cards_collection';
 import { CWSpinner } from '../components/component_kit/cw_spinner';
 import { getStatusText } from '../components/ProposalCard/helpers';
 import { AaveProposalCardDetail } from '../components/proposals/aave_proposal_card_detail';
+import { CWText } from '../components/component_kit/cw_text';
 import {
   CompoundProposalStats,
   SubstrateProposalStats,
@@ -301,6 +302,11 @@ const ProposalsPage = () => {
 
   return (
     <div className="ProposalsPage">
+      <div className="header">
+        <CWText type="h2" fontWeight="medium">
+          Proposals
+        </CWText>
+      </div>
       {onSubstrate && (
         <SubstrateProposalStats
           nextLaunchBlock={

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/index.tsx
@@ -31,12 +31,10 @@ const SnapshotProposalsPage = ({ snapshotId }: SnapshotProposalsPageProps) => {
 
   const spaceSubscription = useMemo(
     () =>
-      app.user.notifications.findNotificationSubscription(
-        {
-          categoryId: NotificationCategories.SnapshotProposal,
-          options: { snapshotId },
-        }
-      ),
+      app.user.notifications.findNotificationSubscription({
+        categoryId: NotificationCategories.SnapshotProposal,
+        options: { snapshotId },
+      }),
     [snapshotId]
   );
 
@@ -91,6 +89,9 @@ const SnapshotProposalsPage = ({ snapshotId }: SnapshotProposalsPageProps) => {
 
   return (
     <div className="SnapshotProposalsPage">
+      <CWText type="h2" fontWeight="medium">
+        Snapshots
+      </CWText>
       <div className="top-bar">
         <CWTabBar>
           {['Active', 'Ended'].map((tabName, index) => (

--- a/packages/commonwealth/client/scripts/views/pages/stats.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/stats.tsx
@@ -156,6 +156,9 @@ const StatsPage = () => {
 
   return (
     <div className="StatsPage">
+      <CWText type="h2" fontWeight="medium">
+        Analytics
+      </CWText>
       <div className="stat-row dark top">
         <CWText fontWeight="medium">Duration</CWText>
         <CWText fontWeight="medium">New Addresses</CWText>

--- a/packages/commonwealth/client/scripts/views/pages/stats.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/stats.tsx
@@ -156,9 +156,11 @@ const StatsPage = () => {
 
   return (
     <div className="StatsPage">
-      <CWText type="h2" fontWeight="medium">
-        Analytics
-      </CWText>
+      <div className="header">
+        <CWText type="h2" fontWeight="medium">
+          Analytics
+        </CWText>
+      </div>
       <div className="stat-row dark top">
         <CWText fontWeight="medium">Duration</CWText>
         <CWText fontWeight="medium">New Addresses</CWText>

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -8,6 +8,7 @@ import app, { LoginState } from 'state';
 import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 import DashboardActivityNotification from '../../../models/DashboardActivityNotification';
 import { CWTab, CWTabBar } from '../../components/component_kit/cw_tabs';
+import { CWText } from '../../components/component_kit/cw_text';
 import { Feed } from '../../components/feed';
 import { DashboardCommunitiesPreview } from './dashboard_communities_preview';
 import { fetchActivity } from './helpers';
@@ -69,6 +70,9 @@ const UserDashboard = (props: UserDashboardProps) => {
     <div ref={setScrollElement} className="UserDashboard" key={`${isLoggedIn}`}>
       <div className="dashboard-column">
         <div className="dashboard-header">
+          <CWText type="h2" fontWeight="medium">
+            Home
+          </CWText>
           <CWTabBar>
             <CWTab
               label={DashboardViews.ForYou}

--- a/packages/commonwealth/client/styles/components/NewThreadForm.scss
+++ b/packages/commonwealth/client/styles/components/NewThreadForm.scss
@@ -7,6 +7,10 @@
   padding: 24px;
   width: 100%;
 
+  .header {
+    padding: 32px 0 32px 0px;
+  }
+
   &.isModal {
     padding: 16px;
   }

--- a/packages/commonwealth/client/styles/components/NewThreadForm.scss
+++ b/packages/commonwealth/client/styles/components/NewThreadForm.scss
@@ -8,7 +8,7 @@
   width: 100%;
 
   .header {
-    padding: 32px 0 32px 0px;
+    padding: 32px 0px 32px 0px;
   }
 
   &.isModal {

--- a/packages/commonwealth/client/styles/components/Profile/Profile.scss
+++ b/packages/commonwealth/client/styles/components/Profile/Profile.scss
@@ -6,6 +6,11 @@
   flex-direction: column;
   width: 100%;
 
+  .header {
+    margin: 0px 80px;
+    padding: 16px 0 0px 0px;
+  }
+
   &.loading {
     height: 100%;
     align-items: center;

--- a/packages/commonwealth/client/styles/pages/proposals.scss
+++ b/packages/commonwealth/client/styles/pages/proposals.scss
@@ -4,6 +4,10 @@
   flex: 1;
   padding: 24px;
 
+  .header {
+    padding: 32px 0 32px 0px;
+  }
+
   .active-proposals,
   .inactive-proposals {
     display: flex;

--- a/packages/commonwealth/client/styles/pages/stats.scss
+++ b/packages/commonwealth/client/styles/pages/stats.scss
@@ -5,6 +5,10 @@
   padding: 24px;
   padding-left: 36px;
 
+  .header {
+    padding: 32px 0px 32px 0px;
+  }
+
   .stat-row {
     border: 1px solid $neutral-100;
     border-top: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4986 

## Description of Changes

- Adds headers to: 

- For you page : Home
- Explore Communities: Explore Communities
- Analytics (within admin capabilities): Analytics
- Manage Community (within admin capabilities): Manage Community
- Notifications: Notifications
- Proposals listing : Proposals
- Snapshot listing: Snapshots
- Create thread: New Thread
- Profile pages -> Profile page headers will be the user’s [displayname]’s + profile 

## Test Plan

- Go to all the pages above an ensure the headers are present, do note that the padding top is a bit more due to #4985 being a fast follow.