### PR TITLE
Edit role row width on admin removal widget in the Admin Panel

### DIFF
--- a/packages/commonwealth/client/styles/pages/manage_community/manage_roles.scss
+++ b/packages/commonwealth/client/styles/pages/manage_community/manage_roles.scss
@@ -20,7 +20,7 @@
       flex-direction: row;
       height: 24px;
       justify-content: space-between;
-      width: 240px;
+      width: auto;
 
       svg {
         cursor: pointer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4742 

## Description of Changes
- Edits role row width on admin removal widget in the Admin Panel

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Role row width changed from fixed value to `auto`

## Test Plan
- CA (click around) tested on local 