### PR TITLE
Fix unable to remove website links from admin page

### DIFF
--- a/packages/commonwealth/server/routes/updateChain.ts
+++ b/packages/commonwealth/server/routes/updateChain.ts
@@ -172,17 +172,19 @@ const updateChain = async (
     });
   }
 
+  console.log({ website });
+
   if (name) chain.name = name;
   if (description) chain.description = description;
   if (default_symbol) chain.default_symbol = default_symbol;
   if (icon_url) chain.icon_url = icon_url;
   if (active !== undefined) chain.active = active;
   if (type) chain.type = type;
-  if (website) chain.website = website;
-  if (discord) chain.discord = discord;
+  if (website !== null) chain.website = website;
+  if (discord !== null) chain.discord = discord;
   if (element) chain.element = element;
-  if (telegram) chain.telegram = telegram;
-  if (github) chain.github = github;
+  if (telegram !== null) chain.telegram = telegram;
+  if (github !== null) chain.github = github;
   if (hide_projects) chain.hide_projects = hide_projects;
   if (stages_enabled) chain.stages_enabled = stages_enabled;
   if (custom_stages) chain.custom_stages = custom_stages;

--- a/packages/commonwealth/server/routes/updateChain.ts
+++ b/packages/commonwealth/server/routes/updateChain.ts
@@ -172,8 +172,6 @@ const updateChain = async (
     });
   }
 
-  console.log({ website });
-
   if (name) chain.name = name;
   if (description) chain.description = description;
   if (default_symbol) chain.default_symbol = default_symbol;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4807 

## Description of Changes
- Fixes route so that community links can be removed from communities.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Route fix.

## Test Plan
- Add a website link to a community + save. Then remove and save, it should be removed on next refresh.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 