### PR TITLE
Changes CWContentPage title to h1 tag

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -170,13 +170,7 @@ export const CWContentPage = ({
   const mainBody = (
     <div className="main-body-container">
       <div className="header">
-        {typeof title === 'string' ? (
-          <CWText type="h3" fontWeight="semiBold">
-            {title}
-          </CWText>
-        ) : (
-          title
-        )}
+        {typeof title === 'string' ? <h1 className="title">{title}</h1> : title}
         {!isEditing ? authorAndPublishInfoRow : <></>}
       </div>
       {subHeader}

--- a/packages/commonwealth/client/styles/components/component_kit/CWContentPage.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/CWContentPage.scss
@@ -8,6 +8,13 @@
     max-width: 768px;
     width: 100%;
 
+    .title {
+      font-family: $font-family-silka;
+      font-size: 24px;
+      line-height: 36px;
+      font-weight: 600;
+    }
+
     .header {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4747

## Description of Changes
- Changes CWContentPage title from CWText with `type="h3"` to a h1 tag, keeping the title styling

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
h1 tag applied to title content, with same text styling, as follows:
- font-family: Silka;
- font-size: 24px;
- line-height: 36px;
- font-weight: 600;

## Test Plan
- Title tested on local, with check on text styling
