### PR TITLE
Make chain-event-id optional in chain-event notifications

### DIFF
--- a/packages/commonwealth/server/routes/viewNotifications.ts
+++ b/packages/commonwealth/server/routes/viewNotifications.ts
@@ -111,7 +111,7 @@ export default async (
   for (const nr of notificationsRead) {
     let chainEvent;
     // if the Notification instance defines a chain_event_id then this is a chain-event notification so parse it
-    if (nr.Notification.chain_event_id) {
+    if (nr.Notification.category_id === 'chain-event') {
       chainEvent = JSON.parse(nr.Notification.notification_data);
     }
     // creates an object for each subscription for which we have a NotificationsRead instance.

--- a/packages/commonwealth/server/scripts/emitTestNotification.ts
+++ b/packages/commonwealth/server/scripts/emitTestNotification.ts
@@ -241,6 +241,7 @@ async function main() {
           'is especially useful to test duplicate emission of a notification.',
       },
     })
+    // eslint-disable-next-line @typescript-eslint/no-shadow
     .check((argv) => {
       if (!argv.mock_notification) return true;
 

--- a/packages/commonwealth/server/scripts/emitTestNotification.ts
+++ b/packages/commonwealth/server/scripts/emitTestNotification.ts
@@ -19,37 +19,58 @@ enum SupportedNotificationSpaces {
   stgdao = 'stgdao.eth',
 }
 
-const randomInt = () => Math.floor(Math.random() * (2 ** 31 - 1)) + 1;
-const propCreateBlock = randomInt();
-const ceNotifications = {
-  [SupportedNotificationChains.dydx]: {
-    block_number: propCreateBlock,
-    event_data: {
-      id: randomInt(),
-      kind: 'proposal-created',
-    },
-    network: 'aave',
-    chain: 'dydx',
-  },
-};
+function getMockNotification(
+  randomData: boolean,
+  chain?: string,
+  snapshot?: string
+) {
+  const constantBlockNumber = 987654321;
+  const constantPropId = 999999999;
 
-const startTime = randomInt();
-const randomString = Array.from(
-  { length: 64 },
-  () => 'abcdefghijklmnopqrstuvwxyz0123456789'[Math.floor(Math.random() * 36)]
-).join('');
-const snapshotNotifications = {
-  [SupportedNotificationSpaces.stgdao]: {
-    eventType: 'proposal/created',
-    space: SupportedNotificationSpaces.stgdao,
-    id: `0x${randomString}`,
-    title: 'Test Snapshot Proposal Title',
-    body: 'Test snapshot proposal body',
-    choices: ['Yes', 'No', 'Abstain'],
-    start: startTime,
-    expire: startTime + 450_000,
-  },
-};
+  const randomInt = () => Math.floor(Math.random() * (2 ** 31 - 1)) + 1;
+
+  const ceNotifications = {
+    [SupportedNotificationChains.dydx]: {
+      block_number: randomData ? randomInt() : constantBlockNumber,
+      event_data: {
+        id: randomData ? randomInt() : constantPropId,
+        kind: 'proposal-created',
+      },
+      network: 'aave',
+      chain: 'dydx',
+    },
+  };
+
+  const constantStartTime = 987654321;
+  const constantId = '0x123456789';
+
+  const startTime = randomInt();
+  const randomString = Array.from(
+    { length: 64 },
+    () => 'abcdefghijklmnopqrstuvwxyz0123456789'[Math.floor(Math.random() * 36)]
+  ).join('');
+
+  const snapshotNotifications = {
+    [SupportedNotificationSpaces.stgdao]: {
+      eventType: 'proposal/created',
+      space: SupportedNotificationSpaces.stgdao,
+      id: randomData ? `0x${randomString}` : constantId,
+      title: 'Test Snapshot Proposal Title',
+      body: 'Test snapshot proposal body',
+      choices: ['Yes', 'No', 'Abstain'],
+      start: randomData ? startTime : constantStartTime,
+      expire: randomData ? startTime + 450_000 : constantStartTime + 450_000,
+    },
+  };
+
+  if (chain) {
+    return ceNotifications[chain];
+  } else if (snapshot) {
+    return snapshotNotifications[snapshot];
+  } else {
+    throw new Error('Must provide either a chain or snapshot space');
+  }
+}
 
 async function getExistingNotifications(
   transaction: Transaction,
@@ -91,6 +112,7 @@ async function getExistingNotifications(
 async function setupNotification(
   transaction: Transaction,
   mockNotification: boolean,
+  dontReplace: boolean,
   chainId?: string,
   snapshotId?: string
 ): Promise<string> {
@@ -100,28 +122,30 @@ async function setupNotification(
 
   let existingNotifications: NotificationInstance[];
   if (mockNotification && chainId) {
+    const mockNotif = getMockNotification(!dontReplace, chainId);
     // handles the case where a mock notification is emitted multiple times
     // this is necessary because chain-event notifications have a unique constraint on the id
     const existingCeMockNotif = await models.Notification.findAll({
       where: {
         category_id: NotificationCategories.ChainEvent,
         chain_id: chainId,
-        chain_event_id: ceNotifications[chainId].id || null,
+        chain_event_id: mockNotif.id || null,
         [Sequelize.Op.and]: [
           Sequelize.literal(
-            `notification_data::jsonb -> 'event_data' ->> 'id' = '${ceNotifications[chainId].event_data.id}'`
+            `notification_data::jsonb -> 'event_data' ->> 'id' = '${mockNotif.event_data.id}'`
           ),
         ],
       },
       transaction,
     });
 
-    if (existingCeMockNotif.length > 0)
+    if (existingCeMockNotif.length > 0 && !dontReplace) {
       existingNotifications = existingCeMockNotif;
-    // if the mock does not already exist then we can just return the mock data, so it is emitted as a brand new notif
-    else return JSON.stringify(ceNotifications[chainId]);
+    } else return JSON.stringify(mockNotif);
   } else if (mockNotification && snapshotId) {
-    return JSON.stringify(snapshotNotifications[snapshotId]);
+    return JSON.stringify(
+      getMockNotification(!dontReplace, undefined, snapshotId)
+    );
   }
 
   if (!existingNotifications) {
@@ -147,21 +171,21 @@ async function setupNotification(
   }
 
   const existingNotif = existingNotifications[0];
-  log.info(`Replacing existing notification with id ${existingNotif.id}`);
 
-  await models.NotificationsRead.destroy({
-    where: {
-      notification_id: existingNotif.id,
-    },
-    transaction,
-  });
-  await existingNotif.destroy({ transaction });
-  log.info(`Deleted the existing notification and notifications read.`);
+  if (!dontReplace) {
+    log.info(`Replacing existing notification with id ${existingNotif.id}`);
+    await models.NotificationsRead.destroy({
+      where: {
+        notification_id: existingNotif.id,
+      },
+      transaction,
+    });
+    await existingNotif.destroy({ transaction });
+    log.info(`Deleted the existing notification and notifications read.`);
+  }
 
   const newNotifData = existingNotif.toJSON();
 
-  // const result = await models.Notification.create(newNotifData, { transaction });
-  // log.info(`Created a new (replicated) notification with id ${result.id}`);
   return newNotifData.notification_data;
 }
 
@@ -207,6 +231,14 @@ async function main() {
         description:
           'Whether to create a mock notification or use a real existing one. ' +
           'A mock notification will not link to a real chain-event or snapshot-proposal.',
+      },
+      dont_replace: {
+        alias: 'd',
+        type: 'boolean',
+        default: false,
+        description:
+          'Whether to replace an existing notification if it is found or emit the same notification. This option' +
+          'is especially useful to test duplicate emission of a notification.',
       },
     })
     .check((argv) => {
@@ -291,6 +323,7 @@ async function main() {
     notifData = await setupNotification(
       transaction,
       argv.mock_notification,
+      argv.dont_replace,
       argv.chain_id,
       argv.snapshot_id
     );

--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -103,19 +103,19 @@ export default async function emitNotifications(
 
   // get notification if it already exists
   let notification: NotificationInstance;
-  notification = await models.Notification.findOne(
-    isChainEventData
-      ? {
-          where: {
-            chain_event_id: chainEvent.id,
-          },
-        }
-      : {
-          where: {
-            notification_data: JSON.stringify(notification_data),
-          },
-        }
-  );
+  if (isChainEventData && chainEvent.id) {
+    notification = await models.Notification.findOne({
+      where: {
+        chain_event_id: chainEvent.id,
+      },
+    });
+  } else {
+    notification = await models.Notification.findOne({
+      where: {
+        notification_data: JSON.stringify(notification_data),
+      },
+    });
+  }
 
   // if the notification does not yet exist create it here
   if (!notification) {

--- a/packages/commonwealth/shared/types.ts
+++ b/packages/commonwealth/shared/types.ts
@@ -5,6 +5,7 @@ import {
   NotificationCategories,
   NotificationCategory,
 } from 'common-common/src/types';
+import { SupportedNetwork } from 'chain-events/src';
 
 export enum WebsocketMessageNames {
   ChainEventNotification = 'chain-event-notification',
@@ -141,7 +142,17 @@ export interface ICommentEditNotificationData
   comment_text: string;
 }
 
-export interface IChainEventNotificationData extends ChainEventAttributes {}
+export interface IChainEventNotificationData {
+  id?: number;
+  block_number?: number;
+  event_data: any;
+  network: SupportedNetwork;
+  chain: string;
+
+  // TODO: @Timothee remove these once chain-events is removed
+  queued?: number;
+  entity_id?: number;
+}
 
 export type NotificationDataTypes =
   | IForumNotificationData


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5090 

## Description of Changes
- Modified `viewNotificaitons` so that chain-event notifications are fetched if the category is 'chain-event' rather than checking for the existence of `chain_event_id`
- Modified `emitNotifications` so it only uses `chain_event_id` if it exists.
- Loosened type restrictions on chain-event notifications.
- Updated `emitTestNotification`
  - allow emitting duplicate notifications via the `-d` flag. Simply put, this flag skips the step in which the old notification is deleted before it is re-emitted.
  - modified the mock notification to test emitting a notification without a `chain_event_id`

## Test Plan
- Run `yarn emit-notification -c dydx -w [your wallet address] -m -d`
  - This emits a notification with constant/hardcoded/non-random data values (without a chain event id)
  - Check that you can see the notification in your notifications drop-down
- Run the same command again
  - This should throw an error indicating a duplicate notification cannot be emitted due to duplicate NotificationsRead.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 