### PR TITLE
Fix firefox sort threads

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -123,7 +123,10 @@ export const getThreadSubScriptionMenuItem = (
  * function will sort those correctly.
  */
 export const sortPinned = (t: Thread[]) => {
-  return [...t].sort((a, b) => (a.pinned === b.pinned ? 1 : a.pinned ? -1 : 0));
+  return [...t].sort((a, b) => {
+    if (a.pinned === b.pinned) return 0; // return 0 when they are equal
+    return a.pinned ? -1 : 1; // sort based on the pinned status
+  });
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4637 

## Description of Changes
- Fixes a bug that was causing the thread sort to be incorrect on firefox.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Resolved ambiguities with the .sort() function (which is implemented differently in Firefox). 

## Test Plan
- Try threads page on firefox and chrome, should be the same sorted order.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 