### PR TITLE
Fix Cosmos session key login

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -325,7 +325,6 @@ async function constructMagic(isCosmos: boolean, chain?: string) {
             // Magic has a strict cross-origin policy that restricts rpcs to whitelisted URLs,
             // so we can't use app.chain.meta?.node?.url
             rpcUrl: `${document.location.origin}/magicCosmosAPI/${chain}`,
-            // rpcUrl: app.chain?.meta?.node?.url || app.config.chains.getById('osmosis').node.url,
           }),
         ],
   });
@@ -439,14 +438,14 @@ export async function handleSocialLoginCallback({
   // Sign a session
   if (isCosmos && desiredChain) {
     // Not every chain prefix will succeed, so Magic defaults to osmo... as the Cosmos prefix
-    const bech32Prefix = desiredChain.bech32Prefix;
-    try {
-      magicAddress = await magic.cosmos.changeAddress(bech32Prefix);
-    } catch (err) {
-      console.error(
-        `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`
-      );
-    }
+    // const bech32Prefix = desiredChain.bech32Prefix;
+    // try {
+    //   magicAddress = await magic.cosmos.changeAddress(bech32Prefix);
+    // } catch (err) {
+    //   console.error(
+    //     `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`
+    //   );
+    // }
 
     // Request the cosmos chain ID, since this is used by Magic to generate
     // the signed message. The API is already used by the Magic iframe,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -202,6 +202,9 @@ export const CWWalletsList = (props: WalletsListProps) => {
               />
             </React.Fragment>
           ))}
+          {wallets.length === 0 && (
+            <CWNoAuthMethodsAvailable darkMode={darkMode} />
+          )}
 
           {!hideSocialLogins && (
             <>
@@ -275,10 +278,6 @@ export const CWWalletsList = (props: WalletsListProps) => {
               )
             }
           />
-
-          {wallets.length === 0 && (
-            <CWNoAuthMethodsAvailable darkMode={darkMode} />
-          )}
         </div>
         <div className="wallet-list-links">
           {canResetWalletConnect && (

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -12,6 +12,7 @@ import {
 } from './cosmosCache';
 import { lookupKeyDurationInReq } from 'common-common/src/cacheKeyUtils';
 import { cacheDecorator } from 'common-common/src/cacheDecorator';
+import { bech32 } from 'bech32';
 
 const log = factory.getLogger(formatFilename(__filename));
 const defaultCacheDuration = 60 * 10; // 10 minutes
@@ -57,7 +58,7 @@ function setupCosmosProxy(app: Express, models: DB) {
     }
   );
 
-  // for gov v1 queries.
+  // for gov v1 queries
   app.use(
     '/cosmosLCD/:chain',
     bodyParser.text(),
@@ -97,6 +98,130 @@ function setupCosmosProxy(app: Express, models: DB) {
             2
           )}`
         );
+        return res.send(response.data);
+      } catch (err) {
+        res.status(500).json({ message: err.message });
+      }
+    }
+  );
+
+  // two cosmos-api proxies for the magic link iframe
+  // - node_info for fetching chain status (used by magic iframe, and magic login flow)
+  // - auth/accounts/:address for fetching address status (use by magic iframe)
+  app.use(
+    '/magicCosmosAPI/:chain/node_info',
+    bodyParser.text(),
+    cacheDecorator.cacheMiddleware(
+      defaultCacheDuration,
+      lookupKeyDurationInReq
+    ),
+    async function cosmosProxy(req, res) {
+      log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      try {
+        log.trace(`Querying cosmos endpoint for chain: ${req.params.chain}`);
+        const chain = await models.Chain.findOne({
+          where: { id: req.params.chain },
+          include: models.ChainNode,
+        });
+        if (!chain) {
+          throw new AppError('Invalid chain');
+        }
+        let targetUrl = chain.ChainNode?.alt_wallet_url;
+        if (!targetUrl) {
+          const fallback = await models.Chain.findOne({
+            where: { id: 'osmosis' },
+            include: models.ChainNode,
+          });
+          targetUrl = fallback.ChainNode.alt_wallet_url;
+        }
+        log.trace(`Found cosmos endpoint: ${targetUrl}`);
+
+        const response = await axios.get(targetUrl + '/node_info', {
+          headers: {
+            origin: 'https://commonwealth.im',
+          },
+        });
+        log.trace(
+          `Got response from endpoint: ${JSON.stringify(
+            response.data,
+            null,
+            2
+          )}`
+        );
+
+        // magicCosmosAPI is CORS-approved for the magic iframe
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        return res.send(response.data);
+      } catch (err) {
+        res.status(500).json({ message: err.message });
+      }
+    }
+  );
+  app.get(
+    '/magicCosmosAPI/:chain/auth/accounts/:address',
+    bodyParser.text(),
+    cacheDecorator.cacheMiddleware(
+      defaultCacheDuration,
+      lookupKeyDurationInReq
+    ),
+    async function cosmosProxy(req, res) {
+      log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      try {
+        log.trace(`Querying cosmos endpoint for chain: ${req.params.chain}`);
+        const chain = await models.Chain.findOne({
+          where: { id: req.params.chain },
+          include: models.ChainNode,
+        });
+        if (!chain) {
+          throw new AppError('Invalid chain');
+        }
+        let targetUrl = chain.ChainNode?.alt_wallet_url;
+        if (!targetUrl) {
+          const fallback = await models.Chain.findOne({
+            where: { id: 'osmosis' },
+            include: models.ChainNode,
+          });
+          targetUrl = fallback.ChainNode.alt_wallet_url;
+        }
+        log.trace(`Found cosmos endpoint: ${targetUrl}`);
+        // special case: rewrite cosmos- prefix to chain specific prefix
+        // either the requested chain or osmo, if we're using the fallback
+        const { words } = bech32.decode(req.params.address);
+        const rewrittenAddress = bech32.encode(
+          chain.ChainNode?.alt_wallet_url ? chain.bech32_prefix : 'osmo',
+          words
+        );
+        const rewrite = req.originalUrl
+          .replace(req.baseUrl, targetUrl)
+          .replace(req.params.address, rewrittenAddress)
+          .replace(`/magicCosmosAPI/${req.params.chain}`, '');
+
+        const response = await axios.get(rewrite, {
+          headers: {
+            origin: 'https://commonwealth.im',
+          },
+        });
+        log.trace(
+          `Got response from endpoint: ${JSON.stringify(
+            response.data,
+            null,
+            2
+          )}`
+        );
+        // magic expects a cosmos-sdk/Account, because their signer is still on launchpad:
+        // https://github.com/cosmos/cosmjs/issues/702
+        if (response?.data?.result?.type === 'cosmos-sdk/BaseAccount') {
+          response.data.result.type = 'cosmos-sdk/Account';
+          response.data.result.value = {
+            address: rewrittenAddress,
+            public_key: { type: 'tendermint/PubKeySecp256k1', value: '' },
+            account_number: '0',
+            sequence: '0',
+          };
+        }
+
+        // magicCosmosAPI is CORS-approved for the magic iframe
+        res.setHeader('Access-Control-Allow-Origin', '*');
         return res.send(response.data);
       } catch (err) {
         res.status(500).json({ message: err.message });


### PR DESCRIPTION
- ESM imports don't work on server, use stringify directly instead of importing from canvas actions/sessions.
    - Fixes Cosmos session key verification on heroku envs
- Add back Cosmos API changes that were removed because of tests
    - Fixes Cosmos magic link logins

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 