### PR TITLE
Fix Login for Injective-Protocol Associated Addresses

### DIFF
--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -340,7 +340,9 @@ function getChainActivity(
   return Promise.all(
     addresses.map(async (address) => {
       const { chain, last_active } = address;
-      return [chain, last_active.toISOString()];
+      // Check if last_active is not null before calling toISOString
+      const lastActiveISO = last_active ? last_active.toISOString() : 'N/A';
+      return [chain, lastActiveISO];
     })
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5105

## Description of Changes
- Adds a nullcheck on `getChainActivity` for `last_active`, within status route, otherwise the status route errors out

## Test Plan
- Logged in before and after applying the fix (using the associated Injective-protocol) community account, detailed in ticket

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 