### PR TITLE
Use csdk-beta sandbox for v1beta1 cache tests

### DIFF
--- a/packages/commonwealth/server-test.ts
+++ b/packages/commonwealth/server-test.ts
@@ -120,6 +120,13 @@ const resetServer = (debug = false): Promise<void> => {
           BalanceType.Cosmos,
         ],
         [
+          'https://cosmos-devnet-beta.herokuapp.com/rpc',
+          'Cosmos SDK v0.45.0 devnet',
+          null,
+          BalanceType.Cosmos,
+          'https://cosmos-devnet-beta.herokuapp.com/lcd/',
+        ],
+        [
           'https://cosmos-devnet.herokuapp.com/rpc',
           'Cosmos SDK v0.46.11 devnet',
           null,
@@ -128,21 +135,27 @@ const resetServer = (debug = false): Promise<void> => {
         ],
       ];
 
-      const [edgewareNode, mainnetNode, testnetNode, osmosisNode, csdkNode] =
-        await Promise.all(
-          nodes.map(([url, name, eth_chain_id, balance_type, alt_wallet_url]) =>
-            models.ChainNode.create({
-              url,
-              name,
-              eth_chain_id: eth_chain_id ? +eth_chain_id : null,
-              balance_type:
-                balance_type || eth_chain_id
-                  ? BalanceType.Ethereum
-                  : BalanceType.Substrate,
-              alt_wallet_url,
-            })
-          )
-        );
+      const [
+        edgewareNode,
+        mainnetNode,
+        testnetNode,
+        osmosisNode,
+        csdkBetaNode,
+        csdkNode,
+      ] = await Promise.all(
+        nodes.map(([url, name, eth_chain_id, balance_type, alt_wallet_url]) =>
+          models.ChainNode.create({
+            url,
+            name,
+            eth_chain_id: eth_chain_id ? +eth_chain_id : null,
+            balance_type:
+              balance_type || eth_chain_id
+                ? BalanceType.Ethereum
+                : BalanceType.Substrate,
+            alt_wallet_url,
+          })
+        )
+      );
 
       // Initialize different chain + node URLs
       await models.Chain.create({
@@ -193,6 +206,18 @@ const resetServer = (debug = false): Promise<void> => {
         base: ChainBase.CosmosSDK,
         has_chain_events_listener: false,
         chain_node_id: osmosisNode.id,
+      });
+      await models.Chain.create({
+        id: 'csdk-beta',
+        network: ChainNetwork.Osmosis,
+        default_symbol: 'STAKE',
+        name: 'Cosmos SDK v0.45.0 devnet',
+        icon_url: '/static/img/protocols/cosmos.png',
+        active: true,
+        type: ChainType.Chain,
+        base: ChainBase.CosmosSDK,
+        has_chain_events_listener: false,
+        chain_node_id: csdkBetaNode.id,
       });
       await models.Chain.create({
         id: 'csdk',

--- a/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
+++ b/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
@@ -16,7 +16,8 @@ import {
   cosmosRPCKey,
 } from 'server/util/cosmosCache';
 
-const v1beta1ChainId = 'osmosis';
+const v1beta1ChainId = 'csdk-beta';
+const v1ChainId = 'csdk';
 
 function verifyNoCacheResponse(res) {
   expect(res.body).to.not.be.null;
@@ -256,7 +257,7 @@ describe('Cosmos Cache', () => {
       proposalStatus: string,
       expectedDuration: number
     ) => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
       lcdTestDuration(expectedDuration, url, {
         proposal_status: proposalStatus,
       });
@@ -267,7 +268,7 @@ describe('Cosmos Cache', () => {
       param: string,
       expectedDuration: number
     ) => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/params/${param}`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/params/${param}`;
       lcdTestDuration(expectedDuration, url);
       await lcdTestIsCached(url);
     };
@@ -295,19 +296,19 @@ describe('Cosmos Cache', () => {
     }
 
     it('should have 7-day duration for an an individual proposal', async () => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1`;
       lcdTestDuration(60 * 60 * 24 * 7, url);
     });
     it("should have 6-second duration for an an individual proposal's live votes", async () => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/votes`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/votes`;
       lcdTestDuration(6, url);
     });
     it("should have 6-second duration for an individual proposal's live tally", async () => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/tally`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/tally`;
       lcdTestDuration(6, url);
     });
     it("should have 6-second duration for an individual proposal's live deposits", async () => {
-      const url = `/cosmosLCD/csdk/cosmos/gov/v1/proposals/1/deposits`;
+      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/deposits`;
       lcdTestDuration(6, url);
     });
     it('should cache deposit period proposals', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5070 

## Description of Changes
- use `csdk-beta` for v1beta1 cache tests instead of osmosis

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Since this failure was intermittent, we can guess that it had to do with the osmosis node returning an error sometimes. 

Since the cache tests only depend on identifying keys and setting durations, we can use our sandbox. There is no need for robust proposal data with osmosis.

## Test Plan
- Devnet tests should succeed more reliably

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 