### PR TITLE
5111 - Session key resign-in prompt only shows option that was used

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -230,52 +230,51 @@ export const CWWalletsList = (props: WalletsListProps) => {
                   Sign in with another email address
                 </a>
               </CWText>
-            </>
-          )}
 
-          <CWDivider className="wallets-divider" />
-          {/* <CWAuthButton
+              <CWDivider className="wallets-divider" />
+              {/* <CWAuthButton
             type="email"
             label="Email"
             darkMode={darkMode}
             onClick={onConnectAnotherWay}
             className="CustomIcon large email-auth-btn"
           /> */}
-          <CWAuthButton
-            type="discord"
-            label="Discord"
-            darkMode={darkMode}
-            onClick={async () =>
-              onSocialLogin(
-                WalletSsoSource.Discord,
-                useSessionKeyRevalidationFlow
-              )
-            }
-            className="DiscordAuthButton"
-          />
-          <CWAuthButton
-            type="github"
-            label="Github"
-            darkMode={darkMode}
-            onClick={() =>
-              onSocialLogin(
-                WalletSsoSource.Github,
-                useSessionKeyRevalidationFlow
-              )
-            }
-          />
-          <CWAuthButton
-            type="twitter"
-            label="Twitter"
-            darkMode={darkMode}
-            onClick={() =>
-              onSocialLogin(
-                WalletSsoSource.Twitter,
-                useSessionKeyRevalidationFlow
-              )
-            }
-          />
-
+              <CWAuthButton
+                type="discord"
+                label="Discord"
+                darkMode={darkMode}
+                onClick={async () =>
+                  onSocialLogin(
+                    WalletSsoSource.Discord,
+                    useSessionKeyRevalidationFlow
+                  )
+                }
+                className="DiscordAuthButton"
+              />
+              <CWAuthButton
+                type="github"
+                label="Github"
+                darkMode={darkMode}
+                onClick={() =>
+                  onSocialLogin(
+                    WalletSsoSource.Github,
+                    useSessionKeyRevalidationFlow
+                  )
+                }
+              />
+              <CWAuthButton
+                type="twitter"
+                label="Twitter"
+                darkMode={darkMode}
+                onClick={() =>
+                  onSocialLogin(
+                    WalletSsoSource.Twitter,
+                    useSessionKeyRevalidationFlow
+                  )
+                }
+              />
+            </>
+          )}
           {wallets.length === 0 && (
             <CWNoAuthMethodsAvailable darkMode={darkMode} />
           )}

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -19,7 +19,7 @@ import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/te
 import { X } from '@phosphor-icons/react';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { setActiveAccount } from 'controllers/app/login';
-import IWebWallet from '../../../../../client/scripts/models/IWebWallet';
+import IWebWallet from 'models/IWebWallet';
 
 interface SessionRevalidationModalProps {
   onModalClose: () => void;
@@ -190,7 +190,7 @@ const SessionRevalidationModal = ({
                     }
                     hasNoWalletsLink={false}
                     canResetWalletConnect={wcEnabled}
-                    hideSocialLogins={findSelectedWallet().length > 0}
+                    hideSocialLogins={!!findSelectedWallet()}
                   />
                 )
               )}

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -78,7 +78,7 @@ const SessionRevalidationModal = ({
   const chainbase = app.chain?.meta?.base;
   const wallets = WebWalletController.Instance.availableWallets(chainbase);
 
-  const findSelectedWallet = () => {
+  const findSelectedWallet = (): Array<IWebWallet<any>> => {
     const selectedWallet = app.user.addresses.find(
       (w) => w.address === walletAddress
     );
@@ -184,10 +184,7 @@ const SessionRevalidationModal = ({
                       onSocialLogin(provider)
                     }
                     darkMode={false}
-                    wallets={
-                      (findSelectedWallet() as Array<IWebWallet<any>>) ||
-                      wallets
-                    }
+                    wallets={findSelectedWallet() || wallets}
                     hasNoWalletsLink={false}
                     canResetWalletConnect={wcEnabled}
                     hideSocialLogins={!!findSelectedWallet()}

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -172,26 +172,23 @@ const SessionRevalidationModal = ({
                   </div>
                 </div>
               ) : (
-                <>
-                  <CWWalletsList
-                    useSessionKeyRevalidationFlow={true}
-                    onResetWalletConnect={onResetWalletConnect}
-                    onWalletAddressSelect={onWalletAddressSelect}
-                    onWalletSelect={onWalletSelect}
-                    onConnectAnotherWay={() => setConnectWithEmail(true)}
-                    onSocialLogin={(provider: WalletSsoSource) =>
-                      onSocialLogin(provider)
-                    }
-                    darkMode={false}
-                    wallets={
-                      (findSelectedWallet() as Array<IWebWallet<any>>) ||
-                      wallets
-                    }
-                    hasNoWalletsLink={false}
-                    canResetWalletConnect={wcEnabled}
-                    hideSocialLogins
-                  />
-                </>
+                <CWWalletsList
+                  useSessionKeyRevalidationFlow={true}
+                  onResetWalletConnect={onResetWalletConnect}
+                  onWalletAddressSelect={onWalletAddressSelect}
+                  onWalletSelect={onWalletSelect}
+                  onConnectAnotherWay={() => setConnectWithEmail(true)}
+                  onSocialLogin={(provider: WalletSsoSource) =>
+                    onSocialLogin(provider)
+                  }
+                  darkMode={false}
+                  wallets={
+                    (findSelectedWallet() as Array<IWebWallet<any>>) || wallets
+                  }
+                  hasNoWalletsLink={false}
+                  canResetWalletConnect={wcEnabled}
+                  hideSocialLogins
+                />
               )}
             </div>
           </div>

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -187,7 +187,7 @@ const SessionRevalidationModal = ({
                   }
                   hasNoWalletsLink={false}
                   canResetWalletConnect={wcEnabled}
-                  hideSocialLogins
+                  hideSocialLogins={findSelectedWallet().length > 0}
                 />
               )}
             </div>

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -19,6 +19,8 @@ import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/te
 import { X } from '@phosphor-icons/react';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { setActiveAccount } from 'controllers/app/login';
+import IWebWallet from 'client/scripts/models/IWebWallet';
+import AddressInfo from 'client/scripts/models/AddressInfo';
 
 interface SessionRevalidationModalProps {
   onModalClose: () => void;
@@ -76,6 +78,15 @@ const SessionRevalidationModal = ({
 
   const chainbase = app.chain?.meta?.base;
   const wallets = WebWalletController.Instance.availableWallets(chainbase);
+
+  const findSelectedWallet = () => {
+    const selectedWallet = app.user.addresses.find(
+      (w) => w.address === walletAddress
+    );
+    return selectedWallet
+      ? [wallets.find((wallet) => wallet.name === selectedWallet.walletId)]
+      : [selectedWallet];
+  };
 
   const wcEnabled = _.any(
     wallets,
@@ -161,21 +172,26 @@ const SessionRevalidationModal = ({
                   </div>
                 </div>
               ) : (
-                <CWWalletsList
-                  useSessionKeyRevalidationFlow={true}
-                  onResetWalletConnect={onResetWalletConnect}
-                  onWalletAddressSelect={onWalletAddressSelect}
-                  onWalletSelect={onWalletSelect}
-                  onConnectAnotherWay={() => setConnectWithEmail(true)}
-                  onSocialLogin={(provider: WalletSsoSource) =>
-                    onSocialLogin(provider)
-                  }
-                  darkMode={false}
-                  wallets={wallets}
-                  hasNoWalletsLink={false}
-                  canResetWalletConnect={wcEnabled}
-                  hideSocialLogins={false}
-                />
+                <>
+                  <CWWalletsList
+                    useSessionKeyRevalidationFlow={true}
+                    onResetWalletConnect={onResetWalletConnect}
+                    onWalletAddressSelect={onWalletAddressSelect}
+                    onWalletSelect={onWalletSelect}
+                    onConnectAnotherWay={() => setConnectWithEmail(true)}
+                    onSocialLogin={(provider: WalletSsoSource) =>
+                      onSocialLogin(provider)
+                    }
+                    darkMode={false}
+                    wallets={
+                      (findSelectedWallet() as Array<IWebWallet<any>>) ||
+                      wallets
+                    }
+                    hasNoWalletsLink={false}
+                    canResetWalletConnect={wcEnabled}
+                    hideSocialLogins
+                  />
+                </>
               )}
             </div>
           </div>

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -19,8 +19,7 @@ import TerraWalletConnectWebWalletController from 'controllers/app/webWallets/te
 import { X } from '@phosphor-icons/react';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { setActiveAccount } from 'controllers/app/login';
-import IWebWallet from 'client/scripts/models/IWebWallet';
-import AddressInfo from 'client/scripts/models/AddressInfo';
+import IWebWallet from '../../../../../client/scripts/models/IWebWallet';
 
 interface SessionRevalidationModalProps {
   onModalClose: () => void;
@@ -83,9 +82,11 @@ const SessionRevalidationModal = ({
     const selectedWallet = app.user.addresses.find(
       (w) => w.address === walletAddress
     );
-    return selectedWallet
-      ? [wallets.find((wallet) => wallet.name === selectedWallet.walletId)]
-      : [selectedWallet];
+    return (
+      selectedWallet && [
+        wallets.find((wallet) => wallet.name === selectedWallet.walletId),
+      ]
+    );
   };
 
   const wcEnabled = _.any(
@@ -172,23 +173,26 @@ const SessionRevalidationModal = ({
                   </div>
                 </div>
               ) : (
-                <CWWalletsList
-                  useSessionKeyRevalidationFlow={true}
-                  onResetWalletConnect={onResetWalletConnect}
-                  onWalletAddressSelect={onWalletAddressSelect}
-                  onWalletSelect={onWalletSelect}
-                  onConnectAnotherWay={() => setConnectWithEmail(true)}
-                  onSocialLogin={(provider: WalletSsoSource) =>
-                    onSocialLogin(provider)
-                  }
-                  darkMode={false}
-                  wallets={
-                    (findSelectedWallet() as Array<IWebWallet<any>>) || wallets
-                  }
-                  hasNoWalletsLink={false}
-                  canResetWalletConnect={wcEnabled}
-                  hideSocialLogins={findSelectedWallet().length > 0}
-                />
+                wallets.length > 0 && (
+                  <CWWalletsList
+                    useSessionKeyRevalidationFlow={true}
+                    onResetWalletConnect={onResetWalletConnect}
+                    onWalletAddressSelect={onWalletAddressSelect}
+                    onWalletSelect={onWalletSelect}
+                    onConnectAnotherWay={() => setConnectWithEmail(true)}
+                    onSocialLogin={(provider: WalletSsoSource) =>
+                      onSocialLogin(provider)
+                    }
+                    darkMode={false}
+                    wallets={
+                      (findSelectedWallet() as Array<IWebWallet<any>>) ||
+                      wallets
+                    }
+                    hasNoWalletsLink={false}
+                    canResetWalletConnect={wcEnabled}
+                    hideSocialLogins={findSelectedWallet().length > 0}
+                  />
+                )
               )}
             </div>
           </div>

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -100,8 +100,6 @@ const NotificationSettingsPage = () => {
     .map((x) => x.chain)
     .filter((x) => subscribedChainIds.includes(x.id) && !chainEventSubs[x.id]);
 
-  console.log(app.user.notifications, relevantSubscribedChains);
-
   return (
     <div className="NotificationSettingsPage">
       <CWText type="h3" fontWeight="semiBold" className="page-header-text">

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -100,6 +100,8 @@ const NotificationSettingsPage = () => {
     .map((x) => x.chain)
     .filter((x) => subscribedChainIds.includes(x.id) && !chainEventSubs[x.id]);
 
+  console.log(app.user.notifications, relevantSubscribedChains);
+
   return (
     <div className="NotificationSettingsPage">
       <CWText type="h3" fontWeight="semiBold" className="page-header-text">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5111 

## Description of Changes
- Added a find to compare the selected address with the available wallets addresses 
- Only show the selected addresses' auth option

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added a .find method to compare state to the selected wallet address and grab that auth method
