### PR TITLE
Adds Tooltip Preview for Links in Threads and Comments

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
@@ -69,7 +69,7 @@ export const QuillFormattedText = ({
   }, [hideFormatting, navigate, openLinksInNewTab, searchTerm, truncatedDoc]);
 
   (finalDoc as any[])?.forEach((line: any) => {
-    let elements = line[0].props.children;
+    const elements = line[0].props.children;
     elements?.forEach((el: any, i: number) => {
       if (el.type === 'a') {
         elements[i] = (

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
@@ -10,6 +10,7 @@ import { DeltaStatic } from 'quill';
 import { renderTruncatedHighlights } from './highlighter';
 import { QuillRendererProps } from './quill_renderer';
 import { countLinesQuill, getTextFromDelta } from './utils';
+import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 
 type QuillFormattedTextProps = Omit<QuillRendererProps, 'doc'> & {
   doc: DeltaStatic;
@@ -66,6 +67,29 @@ export const QuillFormattedText = ({
     // wrap all elements in span to avoid container-based positioning
     return <span>{textWithHighlights}</span>;
   }, [hideFormatting, navigate, openLinksInNewTab, searchTerm, truncatedDoc]);
+
+  (finalDoc as any[])?.forEach((line: any) => {
+    let elements = line[0].props.children;
+    elements?.forEach((el: any, i: number) => {
+      if (el.type === 'a') {
+        elements[i] = (
+          <CWTooltip
+            content={el.props.href}
+            placement="top"
+            renderTrigger={(handleInteraction) => (
+              <div
+                onMouseEnter={handleInteraction}
+                onMouseLeave={handleInteraction}
+              >
+                {el}
+              </div>
+            )}
+          />
+        );
+        line[0] = <div className="line-with-link">{elements}</div>;
+      }
+    });
+  });
 
   const toggleDisplay = () => setUserExpand(!userExpand);
 

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -361,6 +361,9 @@
 }
 
 .line-with-link {
-  display: flex;
-  gap: 4px;
+  display: inline;
+
+  div {
+    display: inherit;
+  }
 }

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -359,3 +359,8 @@
   margin-bottom: 30px;
   position: relative;
 }
+
+.line-with-link {
+  display: flex;
+  gap: 4px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4959 

## Description of Changes
- Adds a Tooltip Preview with URL whenever there is a Link in Threads or Comments

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
A Tooltip component was added wrapping every HTML `a` element

## Test Plan
- CA (click around) tested on local, adding also multiple links on the same line of text
