### PR TITLE
Fix fetchUserFromAddresses and remove null user_id from search option

### DIFF
--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -74,8 +74,10 @@ export default async function emitNotifications(
     if (addressModels && addressModels.length > 0) {
       const userIds = addressModels.map((a) => a.user_id);
 
-      // remove duplicates
-      const userIdsDedup = userIds.filter((a, b) => userIds.indexOf(a) === b);
+      // remove duplicates and null user_ids
+      const userIdsDedup = userIds.filter(
+        (a, b) => userIds.indexOf(a) === b && a !== null
+      );
       return userIdsDedup;
     } else {
       return [];


### PR DESCRIPTION
emitNotification fails because we are searching for null addresses, if any user in that search option has removed an address. No subscriptions will be found

## Link to Issue
Closes: #5131 

## "How We Fixed It"
- One link fix that filters null user_ids out in `fetchUserFromAddresses`

## Test Plan

**Before**
1. Remove Address from Edit Profile Page ("leaving a community")
2. Post comment with active subscriptions
3. No subscriptions will be emitted

**After**
1. Remove Address from Edit Profile Page ("leaving a community")
2. Post comment on thread with active subscriptions
3. Subscriptions will be emitted

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 