### PR TITLE
Fix initially prefilled name for profiles

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -242,7 +242,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
     const profile = account.profile;
     setAddress(account.address);
 
-    if (profile.name) {
+    if (profile.name && profile.initialized) {
       setUsername(profile.name);
     }
 


### PR DESCRIPTION
  When logging in with a new wallet, the username was incorrectly prefilled to "Loading..."

## Link to Issue
Closes: #5159

## Description of Changes
- Checks for profile.initalized before prefilling name

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Log in with new wallet.

## Deployment Plan
n/a

## Other Considerations
n/a