### PR TITLE
Delete chain fix 

### DIFF
--- a/packages/commonwealth/server/migrations/20230927204115-discord-bot-config-cascade.js
+++ b/packages/commonwealth/server/migrations/20230927204115-discord-bot-config-cascade.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // Drop the old foreign key constraint
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "DiscordBotConfig" DROP CONSTRAINT "DiscordBotConfig_chain_id_fkey"`,
+        { transaction: t }
+      );
+
+      // Add the new foreign key constraint with onDelete: 'CASCADE'
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "DiscordBotConfig" ADD CONSTRAINT "DiscordBotConfig_chain_id_fkey" FOREIGN KEY ("chain_id") REFERENCES "Chains" ("id") ON DELETE CASCADE`,
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // Drop the new foreign key constraint
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "DiscordBotConfig" DROP CONSTRAINT "DiscordBotConfig_chain_id_fkey"`,
+        { transaction: t }
+      );
+
+      // Add the old foreign key constraint without onDelete: 'CASCADE'
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "DiscordBotConfig" ADD CONSTRAINT "DiscordBotConfig_chain_id_fkey" FOREIGN KEY ("chain_id") REFERENCES "Chains" ("id")`,
+        { transaction: t }
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/models/discord_bot_config.ts
+++ b/packages/commonwealth/server/models/discord_bot_config.ts
@@ -58,7 +58,7 @@ export default (
     models.DiscordBotConfig.belongsTo(models.Chain, {
       foreignKey: 'chain_id',
       targetKey: 'id',
-      onDelete: 'CASCADE', // add this line
+      onDelete: 'CASCADE',
     });
   };
 

--- a/packages/commonwealth/server/models/discord_bot_config.ts
+++ b/packages/commonwealth/server/models/discord_bot_config.ts
@@ -58,6 +58,7 @@ export default (
     models.DiscordBotConfig.belongsTo(models.Chain, {
       foreignKey: 'chain_id',
       targetKey: 'id',
+      onDelete: 'CASCADE', // add this line
     });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5126 

## Description of Changes
- Adds a migration to remove a foreign key constraint that was preventing us from deleting chains that had a Discord bot connected. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Migration, added a cascade delete on the DiscordBotConfig table.

## Test Plan
- Attempt to delete a chain with a discord bot connected via the admin panel. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 