### PR TITLE
Remove deleted threads from user dashboards

### DIFF
--- a/packages/commonwealth/server/util/activityQuery.ts
+++ b/packages/commonwealth/server/util/activityQuery.ts
@@ -15,7 +15,7 @@ export async function getActivityFeed(models: DB, id = 0) {
                                   t.max_notif_id
                                 FROM "Threads" t 
                                 ${filterByChainForUsers}
-                                WHERE t.max_notif_id IS NOT NULL
+                                WHERE t.max_notif_id IS NOT NULL AND deleted_at IS NULL
                                 ORDER BY t.max_notif_id DESC
                                 LIMIT 50
                                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5175 

## Description of Changes
- Adds where condition to filter out deleted threads from activity query.

## Test Plan
- Go to any community you have joined
- Create a thread
- View your 'for you' page to ensure there is a new row for the thread
- Go back and delete the thread
- When you return to the 'for you' page the row that was created before should no longer exist.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 