### PR TITLE
Fix crash page when the comment uses h1 or h2 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/quill_formatted_text.tsx
@@ -70,6 +70,14 @@ export const QuillFormattedText = ({
 
   (finalDoc as any[])?.forEach((line: any) => {
     const elements = line[0].props.children;
+    if (!elements) {
+      return;
+    }
+
+    if (typeof elements === 'string') {
+      return elements;
+    }
+
     elements?.forEach((el: any, i: number) => {
       if (el.type === 'a') {
         elements[i] = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5195 
## Description of Changes
- The root cause is in another PR https://github.com/hicommonwealth/commonwealth/pull/5108/files because for some reason we are getting string instead of an array when user uses h1 or h2
- This fix checks if the element is a string and if it is, just returns it. 


## Test Plan
- create comment using h1 or h2
- page should render properly without the crash 

## Deployment Plan
<!--- Omit if unneeded -->
1. normal deployment

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
