### PR TITLE
Show token gated/disabled topics

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -38,7 +38,7 @@ export const NewThreadForm = () => {
   const hasTopics = topics?.length;
   const isAdmin = Permissions.isCommunityAdmin();
 
-  const { enabledTopics, disabledTopics } = topics?.reduce(
+  const topicsForSelector = topics?.reduce(
     (acc, t) => {
       if (
         isAdmin ||
@@ -68,7 +68,7 @@ export const NewThreadForm = () => {
     setIsSaving,
     isDisabled,
     clearDraft,
-  } = useNewThreadForm(chainId, enabledTopics);
+  } = useNewThreadForm(chainId, topicsForSelector.enabledTopics);
 
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();
@@ -142,7 +142,8 @@ export const NewThreadForm = () => {
   const handleCancel = () => {
     setThreadTitle('');
     setThreadTopic(
-      enabledTopics.find((t) => t.name.includes('General')) || null
+      topicsForSelector.enabledTopics.find((t) => t.name.includes('General')) ||
+        null
     );
     setThreadContentDelta(createDeltaFromText(''));
   };
@@ -171,8 +172,8 @@ export const NewThreadForm = () => {
             <div className="topics-and-title-row">
               {hasTopics && (
                 <TopicSelector
-                  enabledTopics={enabledTopics}
-                  disabledTopics={disabledTopics}
+                  enabledTopics={topicsForSelector.enabledTopics}
+                  disabledTopics={topicsForSelector.disabledTopics}
                   value={threadTopic}
                   onChange={setThreadTopic}
                 />

--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -38,11 +38,21 @@ export const NewThreadForm = () => {
   const hasTopics = topics?.length;
   const isAdmin = Permissions.isCommunityAdmin();
 
-  const topicsForSelector = topics?.filter((t) => {
-    return (
-      isAdmin || t.tokenThreshold.isZero() || !app.chain.isGatedTopic(t.id)
-    );
-  });
+  const { enabledTopics, disabledTopics } = topics?.reduce(
+    (acc, t) => {
+      if (
+        isAdmin ||
+        t.tokenThreshold.isZero() ||
+        !app.chain.isGatedTopic(t.id)
+      ) {
+        acc.enabledTopics.push(t);
+      } else {
+        acc.disabledTopics.push(t);
+      }
+      return acc;
+    },
+    { enabledTopics: [], disabledTopics: [] }
+  );
 
   const {
     threadTitle,
@@ -58,7 +68,7 @@ export const NewThreadForm = () => {
     setIsSaving,
     isDisabled,
     clearDraft,
-  } = useNewThreadForm(chainId, topicsForSelector);
+  } = useNewThreadForm(chainId, enabledTopics);
 
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();
@@ -132,7 +142,7 @@ export const NewThreadForm = () => {
   const handleCancel = () => {
     setThreadTitle('');
     setThreadTopic(
-      topicsForSelector.find((t) => t.name.includes('General')) || null
+      enabledTopics.find((t) => t.name.includes('General')) || null
     );
     setThreadContentDelta(createDeltaFromText(''));
   };
@@ -161,7 +171,8 @@ export const NewThreadForm = () => {
             <div className="topics-and-title-row">
               {hasTopics && (
                 <TopicSelector
-                  topics={topicsForSelector}
+                  enabledTopics={enabledTopics}
+                  disabledTopics={disabledTopics}
                   value={threadTopic}
                   onChange={setThreadTopic}
                 />

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
@@ -1,20 +1,65 @@
 import React from 'react';
-import type { GroupBase, Props } from 'react-select';
-import Select from 'react-select';
+import type { GroupBase, OptionProps, Props } from 'react-select';
+import Select, { components } from 'react-select';
 
 import 'components/component_kit/cw_select_list.scss';
+import { CWTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 
+const CustomOption = (
+  props: OptionProps & { disabledOptionTooltipText?: string }
+) => {
+  if ((props.data as any)?.disabled) {
+    return (
+      <CWTooltip
+        disablePortal
+        content={props.disabledOptionTooltipText || 'Option not allowed'}
+        placement="top"
+        renderTrigger={(handleInteraction) => (
+          <components.Option
+            {...props}
+            isDisabled
+            innerProps={{
+              onMouseEnter: handleInteraction,
+              onMouseLeave: handleInteraction,
+              style: {
+                color: '#A09DA1', // neutral-400
+                cursor: 'not-allowed',
+              },
+            }}
+          >
+            {props.children}
+          </components.Option>
+        )}
+      />
+    );
+  }
+
+  return <components.Option {...props}>{props.children}</components.Option>;
+};
+
+interface SelectListProps {
+  disabledOptionTooltipText?: string;
+}
 export const SelectList = <
   Option,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
-  props: Props<Option, IsMulti, Group>
+  props: Props<Option, IsMulti, Group> & SelectListProps
 ) => {
   return (
     <Select
       {...props}
-      isOptionDisabled={(option) => option.disabled}
+      isOptionDisabled={(option) => (option as any)?.disabled}
+      components={{
+        Option: (optionProps) => (
+          <CustomOption
+            {...optionProps}
+            children={optionProps.children}
+            disabledOptionTooltipText={props.disabledOptionTooltipText}
+          />
+        ),
+      }}
       styles={{
         control: (baseStyles) => ({
           ...baseStyles,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_select_list.tsx
@@ -14,6 +14,7 @@ export const SelectList = <
   return (
     <Select
       {...props}
+      isOptionDisabled={(option) => option.disabled}
       styles={{
         control: (baseStyles) => ({
           ...baseStyles,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTooltip.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTooltip.tsx
@@ -12,6 +12,7 @@ import { Placement } from '@popperjs/core/lib';
 type TooltipProps = {
   content: string | React.ReactNode;
   placement?: Placement;
+  disablePortal?: boolean;
 } & PopoverTriggerProps;
 
 type ContainerProps = {
@@ -44,6 +45,7 @@ export const CWTooltip: FC<TooltipProps> = ({
   content,
   renderTrigger,
   placement,
+  disablePortal,
 }) => {
   const popoverProps = usePopover();
 
@@ -51,6 +53,7 @@ export const CWTooltip: FC<TooltipProps> = ({
     <>
       {renderTrigger(popoverProps.handleInteraction, popoverProps.open)}
       <Popover
+        disablePortal={disablePortal}
         placement={placement}
         content={
           <Container placement={placement}>

--- a/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
@@ -1,29 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type Topic from '../../models/Topic';
 
 import { SelectList } from 'views/components/component_kit/cw_select_list';
 import 'components/topic_selector.scss';
+import { CWTooltip } from './component_kit/new_designs/CWTooltip';
 
 interface TopicSelectorProps {
-  topics: Topic[];
+  enabledTopics: Topic[];
+  disabledTopics: Topic[];
   value: Topic;
   onChange: (topic: Topic) => void;
 }
 
-const topicToOption = (topic: Topic) => ({
+const topicToOption = (topic: Topic, disabled: boolean) => ({
   value: topic?.id,
   label: topic?.name,
+  disabled,
 });
 
 export const TopicSelector = ({
-  topics,
+  enabledTopics,
+  disabledTopics,
   value,
   onChange,
 }: TopicSelectorProps) => {
-  const options = topics.sort((a, b) => a.order - b.order).map(topicToOption);
+  const enabledOptions = enabledTopics
+    .sort((a, b) => a.order - b.order)
+    .map((t) => topicToOption(t, false));
+  const disabledOptions = disabledTopics
+    .sort((a, b) => a.order - b.order)
+    .map((t) => topicToOption(t, true));
+  const allOptions = enabledOptions.concat(disabledOptions);
 
   const handleOnChange = ({ value: newValue }) => {
-    const selectedTopic = topics.find(({ id }) => id === newValue);
+    const selectedTopic = enabledTopics.find(({ id }) => id === newValue);
     onChange(selectedTopic);
   };
 
@@ -31,9 +41,8 @@ export const TopicSelector = ({
     <SelectList
       placeholder="Select the topic"
       isSearchable={false}
-      options={options}
+      options={allOptions}
       className="TopicSelector"
-      value={topicToOption(value)}
       onChange={handleOnChange}
     />
   );

--- a/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/topic_selector.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type Topic from '../../models/Topic';
 
 import { SelectList } from 'views/components/component_kit/cw_select_list';
 import 'components/topic_selector.scss';
-import { CWTooltip } from './component_kit/new_designs/CWTooltip';
 
 interface TopicSelectorProps {
   enabledTopics: Topic[];
@@ -40,6 +39,7 @@ export const TopicSelector = ({
   return (
     <SelectList
       placeholder="Select the topic"
+      disabledOptionTooltipText="You don't have enough token to select this topic."
       isSearchable={false}
       options={allOptions}
       className="TopicSelector"

--- a/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
@@ -25,7 +25,7 @@ export const ChangeThreadTopicModal = ({
   });
 
   const isAdmin = Permissions.isCommunityAdmin();
-  const { enabledTopics, disabledTopics } = topics?.reduce(
+  const topicsForSelector = topics?.reduce(
     (acc, t) => {
       if (
         isAdmin ||
@@ -73,8 +73,8 @@ export const ChangeThreadTopicModal = ({
       </div>
       <div className="compact-modal-body">
         <TopicSelector
-          enabledTopics={enabledTopics}
-          disabledTopics={disabledTopics}
+          enabledTopics={topicsForSelector.enabledTopics}
+          disabledTopics={topicsForSelector.disabledTopics}
           value={activeTopic}
           onChange={setActiveTopic}
         />

--- a/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
@@ -8,6 +8,7 @@ import { useFetchTopicsQuery } from 'state/api/topics';
 import { CWButton } from '../components/component_kit/cw_button';
 import { CWIconButton } from '../components/component_kit/cw_icon_button';
 import { TopicSelector } from '../components/topic_selector';
+import Permissions from 'utils/Permissions';
 
 type ChangeThreadTopicModalProps = {
   onModalClose: () => void;
@@ -22,6 +23,23 @@ export const ChangeThreadTopicModal = ({
   const { data: topics } = useFetchTopicsQuery({
     chainId: app.activeChainId(),
   });
+
+  const isAdmin = Permissions.isCommunityAdmin();
+  const { enabledTopics, disabledTopics } = topics?.reduce(
+    (acc, t) => {
+      if (
+        isAdmin ||
+        t.tokenThreshold.isZero() ||
+        !app.chain.isGatedTopic(t.id)
+      ) {
+        acc.enabledTopics.push(t);
+      } else {
+        acc.disabledTopics.push(t);
+      }
+      return acc;
+    },
+    { enabledTopics: [], disabledTopics: [] }
+  );
 
   const { mutateAsync: editThread } = useEditThreadMutation({
     chainId: app.activeChainId(),
@@ -55,7 +73,8 @@ export const ChangeThreadTopicModal = ({
       </div>
       <div className="compact-modal-body">
         <TopicSelector
-          topics={topics}
+          enabledTopics={enabledTopics}
+          disabledTopics={disabledTopics}
           value={activeTopic}
           onChange={setActiveTopic}
         />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5099

## Description of Changes
- Allows all topics to populate the TopicSelector and renders topics with an un-met threshold as disabled 

## Test Plan
- As an admin create some token gated topics in a community and some non-gated
- Attempt to create a thread
- Confirm that gated topics are disabled, but visible, select an enabled topic and confirm thread works
- Extra testing: get enough tokens to meet topic and ensure it becomes visible 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 