### PR TITLE
Fix Sidebar Collapse State when Feature Flag is not turned on

### DIFF
--- a/packages/commonwealth/client/scripts/state/ui/sidebar/sidebar.ts
+++ b/packages/commonwealth/client/scripts/state/ui/sidebar/sidebar.ts
@@ -34,7 +34,7 @@ export const sidebarStore = createStore<SidebarStore>()(
         menuName: 'default',
         menuVisible: true,
         userToggledVisibility:
-          featureFlags.sidebarToggle === false ? 'closed' : null,
+          featureFlags.sidebarToggle !== true ? 'closed' : null,
         setUserToggledVisibility: (toggled) => {
           set(() => ({ userToggledVisibility: toggled }));
           set((state) => ({

--- a/packages/commonwealth/client/scripts/state/ui/sidebar/sidebar.ts
+++ b/packages/commonwealth/client/scripts/state/ui/sidebar/sidebar.ts
@@ -5,6 +5,7 @@ import { createBoundedUseStore } from 'state/ui/utils';
 import { SidebarMenuName } from 'views/components/sidebar';
 import { MobileMenuName } from 'views/AppMobileMenus';
 import { isWindowSmallInclusive } from 'views/components/component_kit/helpers';
+import { featureFlags } from '../../../helpers/feature-flags';
 
 interface SidebarStore {
   mobileMenuName: MobileMenuName;
@@ -32,7 +33,8 @@ export const sidebarStore = createStore<SidebarStore>()(
         setMobileMenuName: (name) => set(() => ({ mobileMenuName: name })),
         menuName: 'default',
         menuVisible: true,
-        userToggledVisibility: null,
+        userToggledVisibility:
+          featureFlags.sidebarToggle === false ? 'closed' : null,
         setUserToggledVisibility: (toggled) => {
           set(() => ({ userToggledVisibility: toggled }));
           set((state) => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5223 

## Description of Changes
- Ensures that sidebar visibility should be correctly set

## "How We Fixed It"
- `userToggledVisibility` has three states null | closed | open, which is used for when the feature flag is enabled, when flag is not enabled, we force visibility to closed. Ensuring that sidebar underneath should always be visible

## Test Plan
- Open and closed Explore or Create Menu

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
~~**I am unable to actually test locally, but based on Ilija's comment this fix sees to work**~~ Confirmed working by Ilija