### PR TITLE
5233 - Update jobs link in footer

### DIFF
--- a/packages/commonwealth/client/scripts/views/Footer.tsx
+++ b/packages/commonwealth/client/scripts/views/Footer.tsx
@@ -9,7 +9,7 @@ const footercontents = [
   { text: 'Blog', externalLink: 'https://blog.commonwealth.im' },
   {
     text: 'Jobs',
-    externalLink: 'https://angel.co/company/commonwealth-labs/jobs',
+    externalLink: 'https://boards.greenhouse.io/commonwealth',
   },
   { text: 'Terms', redirectTo: '/terms' },
   { text: 'Privacy', redirectTo: '/privacy' },


### PR DESCRIPTION
When users click on the jobs link in the footer of Commonwealth's homepage, they are taken to an incorrect url. That link has been updated to point to our current jobs page here: https://boards.greenhouse.io/commonwealth

## Link to Issue
Closes: #5233 

## Description of Changes
- updates jobs link to point to Greenhouse URL