### PR TITLE
Fix threads can appear in wrong community

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -234,7 +234,11 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     );
   }
 
-  if ((!isLoading && !thread) || fetchThreadError) {
+  if (
+    (!isLoading && !thread) ||
+    fetchThreadError ||
+    thread.chain !== app.activeChainId()
+  ) {
     return <PageNotFound />;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5133 

## Description of Changes
- Prevents users from accessing threads that are not from the same community they are currently in.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Added a check that the thread has a chain that matches the active chain id.

## Test Plan
- Visit a page like `/community/discussion/id-from-another-community` and you should see the 404 page instead of the actual thread.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 