### PR TITLE
5241 sidebar bugs

### DIFF
--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -22,7 +22,7 @@ const Sublayout = ({
   hasCommunitySidebar,
 }: SublayoutProps) => {
   const forceRerender = useForceRerender();
-  const { menuVisible, mobileMenuName, setMenu } = useSidebarStore();
+  const { menuVisible, mobileMenuName, setMenu, menuName } = useSidebarStore();
   const [resizing, setResizing] = useState(false);
   const { isWindowSmallInclusive } = useBrowserWindow({
     onResize: () => setResizing(true),
@@ -78,11 +78,15 @@ const Sublayout = ({
         <div className="sidebar-and-body-container">
           <Sidebar isInsideCommunity={hasCommunitySidebar} />
           <div
-            className={clsx('body-and-sticky-headers-container', {
-              'menu-visible': menuVisible,
-              'menu-hidden': !menuVisible,
-              resizing,
-            })}
+            className={clsx(
+              'body-and-sticky-headers-container',
+              menuVisible ? 'menu-visible' : 'menu-hidden',
+              (menuName === 'exploreCommunities' ||
+                menuName === 'createContent' ||
+                hasCommunitySidebar) &&
+                'quick-switcher-visible',
+              resizing
+            )}
           >
             <SublayoutBanners banner={banner} chain={chain} terms={terms} />
 

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -38,29 +38,26 @@ const Sublayout = ({
   }, [forceRerender]);
 
   useEffect(() => {
-    let timer;
+    setMenu({ name: 'default', isVisible: !isWindowSmallInclusive });
+  }, [isWindowSmallInclusive]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+
     if (resizing) {
       timer = setTimeout(() => {
         setResizing(false);
-      }, 200); // adjust delay as needed
+      }, 200); // Adjust delay as needed
     }
+
     return () => {
       clearTimeout(timer);
     };
   }, [resizing]);
 
   useEffect(() => {
-    if (
-      localStorage.getItem('dark-mode-state') === 'on' &&
-      localStorage.getItem('user-dark-mode-state') === 'on'
-    ) {
-      document.getElementsByTagName('html')[0].classList.add('invert');
-    }
-
     const onResize = () => {
-      if (!isWindowSmallInclusive) {
-        setMenu({ name: 'default', isVisible: true });
-      }
+      setMenu({ name: 'default', isVisible: !isWindowSmallInclusive });
     };
 
     window.addEventListener('resize', onResize);
@@ -68,7 +65,7 @@ const Sublayout = ({
     return () => {
       window.removeEventListener('resize', onResize);
     };
-  }, []);
+  }, [isWindowSmallInclusive, menuVisible, mobileMenuName, setMenu]);
 
   const chain = app.chain ? app.chain.meta : null;
   const terms = app.chain ? chain.terms : null;

--- a/packages/commonwealth/client/styles/Sublayout.scss
+++ b/packages/commonwealth/client/styles/Sublayout.scss
@@ -30,7 +30,18 @@
       }
 
       &.menu-visible {
-        margin-left: calc(calc(#{$sidebar-width} + #{$quick-switcher-width}) + 1px);
+        margin-left: calc(#{$quick-switcher-width} + 1px);
+
+        transition: margin-left 0.2s ease-in-out;
+
+        @include smallInclusive {
+          margin-left: 100vw;
+        }
+      }
+
+      &.quick-switcher-visible {
+        margin-left: calc(#{$sidebar-width} + #{$quick-switcher-width} + 1px);
+
         transition: margin-left 0.2s ease-in-out;
 
         @include smallInclusive {
@@ -48,12 +59,16 @@
 
         .Banner {
           padding-left: calc(#{$sidebar-width} + 20px);
-          margin-left: calc(-#{$sidebar-width} + 1px); // give it a negative margin equal to the parent's margin
+          margin-left: calc(
+            -#{$sidebar-width} + 1px
+          ); // give it a negative margin equal to the parent's margin
         }
 
         .MessageBanner {
           padding-left: calc(#{$sidebar-width} + 20px);
-          margin-left: calc(-#{$sidebar-width} + 1px); // give it a negative margin equal to the parent's margin
+          margin-left: calc(
+            -#{$sidebar-width} + 1px
+          ); // give it a negative margin equal to the parent's margin
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5241 

## Description of Changes
- Implemented fixes where the sidebar would disappear when dismissed on mobile then expanded back to desktop
- Added a fix for the padding to be more dynamic and take in consideration the state of the sidebar and quick switcher

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Built a default state on component mount to better handle the switching between responsiveness points
- Added more classes to the CSS file to handle the different states of the sidebar and make the dashboard screen padding more fluid.


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
Loom: https://www.loom.com/share/6588f02c34fc49b0ae4759f0c1aede3f?sid=1bf2e5d9-cb67-49bf-93be-2021dd0e20de