### PR TITLE
Revert useInitApp changes.

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useInitApp.ts
+++ b/packages/commonwealth/client/scripts/hooks/useInitApp.ts
@@ -7,21 +7,16 @@ const useInitApp = () => {
   const [customDomain, setCustomDomain] = React.useState('');
 
   useEffect(() => {
-    setIsLoading(true);
-    const isWebPlatform = app.platform() === 'web';
-    const domainPromise = isWebPlatform
-      ? axios
-          .get(`${app.serverUrl()}/domain`)
-          .then((res) => {
-            const serverCustomDomain = res.data.customDomain || '';
-            setCustomDomain(serverCustomDomain);
-            return serverCustomDomain;
-          })
-          .catch((err) => console.log('Failed fetching custom domain', err))
-      : Promise.resolve();
-
-    Promise.all([domainPromise, initAppState(true)])
-      .then(([serverCustomDomain]) => serverCustomDomain)
+    Promise.all([axios.get(`${app.serverUrl()}/domain`), initAppState()])
+      .then(([domainResp]) => {
+        const serverCustomDomain = domainResp.data.customDomain;
+        if (serverCustomDomain) {
+          app.setCustomDomain(serverCustomDomain);
+        }
+        setCustomDomain(serverCustomDomain);
+        return Promise.resolve(serverCustomDomain);
+      })
+      .catch((err) => console.log('Failed fetching custom domain', err))
       .finally(() => setIsLoading(false));
   }, []);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5266

## Description of Changes
- Removes modified useInitApp logic which broke custom domain loading.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
`app.platform` was being set incorrectly on custom domains, causing an indefinite loading state when visiting a custom domain.

## Test Plan
- Validate custom domains load as expected locally.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- CI test should have detected custom domain breakage. Separately ticket + update CI as needed.