### PR TITLE
Fix null crash in isGatedTopic check on discobot posts.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -434,7 +434,7 @@ export const CommentTree = ({
                   canReact={
                     !!hasJoinedCommunity ||
                     isAdmin ||
-                    !app.chain.isGatedTopic(thread.topic.id)
+                    !app.chain.isGatedTopic(thread.topic?.id)
                   }
                   canEdit={
                     !isLocked && (comment.isCommentAuthor || isAdminOrMod)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5269 

## Description of Changes
- One line change to fix null check crash on discobot posts, which don't have a topic as initialized in the client.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Added a null check, which is standard practice for isGatedTopic checks across the codebase.

## Test Plan
- Fresh db dump. load http://localhost:8080/kunji-finance/discussion/13585-zealy-sprint locally. Ensure it loads successfully. 
