### PR TITLE
Fix crash in quill renderer from embedding image in h1/h2.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/render_quill_delta.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/render_quill_delta.tsx
@@ -348,25 +348,11 @@ export const renderQuillDelta = (
               ? 'unchecked'
               : '';
 
-          if (parent.attributes?.header === 1) {
-            return (
-              <h1 key={ii} className={className}>
-                {parent.children[0].insert}
-              </h1>
-            );
-          } else if (parent.attributes?.header === 2) {
-            return (
-              <h2 key={ii} className={className}>
-                {parent.children[0].insert}
-              </h2>
-            );
-          } else {
-            return (
-              <Tag key={ii} className={className}>
-                {parent.children.map(renderChild)}
-              </Tag>
-            );
-          }
+          return (
+            <Tag key={ii} className={className}>
+              {parent.children.map(renderChild)}
+            </Tag>
+          );
         };
 
         // special handler for lists, which need to be un-flattened and turned into a tree


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5276

## Description of Changes
- Removes logic from #5108 which skipped quill rendering of elements beneath h1/h2 tags.
- **NOTE: outstanding issue is h1/h2 tags don't render properly, due to the `font-size: 14px !important;` added in #4065.** (updated to 16px in #5138).

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Solution was to revert specialized h1/h2 changes and treat them like normal elements, which worked previously.

## Test Plan
- Create a new thread with an image, then apply H2 formatting to the image. The result should not crash.
- Also: try creating comments using h1/h2 tags. They should appear properly as headers.
