### PR TITLE
Fix for rerender of sidebar when using create picker

### DIFF
--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -28,7 +28,6 @@ const resetSidebarState = () => {
   }
 };
 
-console.log('is', isMobile);
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
     app.user.activeAccount && !!app.chain?.meta.snapshot.length;

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -21,6 +21,8 @@ import {
 import { isMobile } from 'react-device-detect';
 
 const resetSidebarState = () => {
+  //Bouncer pattern -- I have found isMobile does not always detect screen
+  //size when responsively resizing so added a redundancy with window.innerWidth
   if (!isMobile || window.innerWidth > 425) return;
 
   if (sidebarStore.getState().userToggledVisibility !== 'open') {

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -18,6 +18,7 @@ import {
   handleMouseEnter,
   handleMouseLeave,
 } from 'views/menus/utils';
+import { isMobile } from 'react-device-detect';
 
 const resetSidebarState = () => {
   if (sidebarStore.getState().userToggledVisibility !== 'open') {
@@ -27,6 +28,7 @@ const resetSidebarState = () => {
   }
 };
 
+console.log('is', isMobile);
 const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
   const showSnapshotOptions =
     app.user.activeAccount && !!app.chain?.meta.snapshot.length;
@@ -235,7 +237,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New Thread',
             onClick: () => {
-              resetSidebarState();
+              isMobile && resetSidebarState();
               navigate('/new/discussion');
             },
             iconLeft: 'write',

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -21,6 +21,8 @@ import {
 import { isMobile } from 'react-device-detect';
 
 const resetSidebarState = () => {
+  if (!isMobile || window.innerWidth > 425) return;
+
   if (sidebarStore.getState().userToggledVisibility !== 'open') {
     sidebarStore.getState().setMenu({ name: 'default', isVisible: false });
   } else {
@@ -236,7 +238,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
           {
             label: 'New Thread',
             onClick: () => {
-              isMobile && resetSidebarState();
+              resetSidebarState();
               navigate('/new/discussion');
             },
             iconLeft: 'write',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5281 

## Description of Changes
- Conditionally fire `resetSidebarState` -- the state of the sidebar is handled on the component level
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-- Added a check to see if we're in mobile and fire the `resetSidebarState()` function based on the truthy of that. 

## Test Plan
- Ensure that the UX is correct with the sidebar remaining open on desktop when a selection is made, otherwise; we'll have to create a state method to handle the sidebar to be more granular.
