### PR TITLE
Bring back tooltips and remove logout button from navbar

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useSidebarStore from 'state/ui/sidebar';
 import 'SublayoutHeader.scss';
-import app, { initAppState } from '../state';
+import app from '../state';
 import { CWDivider } from './components/component_kit/cw_divider';
 import { CWIconButton } from './components/component_kit/cw_icon_button';
 import {
@@ -16,16 +16,13 @@ import { NotificationsMenuPopover } from './menus/notifications_menu';
 import UserDropdown from 'views/components/Header/UserDropdown/UserDropdown';
 import { Modal } from 'views/components/component_kit/cw_modal';
 import { FeedbackModal } from 'views/modals/feedback_modal';
-import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import { setDarkMode } from 'helpers/darkMode';
-import WebWalletController from 'controllers/app/web_wallets';
-import { WalletId } from 'common-common/src/types';
-import axios from 'axios';
 import clsx from 'clsx';
 import { CWButton } from './components/component_kit/new_designs/cw_button';
 import { LoginModal } from 'views/modals/login_modal';
 import { CWSearchBar } from './components/component_kit/new_designs/CWSearchBar';
 import { featureFlags } from '../helpers/feature-flags';
+import { CWTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
+import { HelpMenuPopover } from 'views/menus/help_menu';
 
 type SublayoutHeaderProps = {
   onMobile: boolean;
@@ -58,29 +55,6 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
       setUserToggledVisibility(isVisible ? 'open' : 'closed');
     }, 200);
   }
-
-  const resetWalletConnectSession = async () => {
-    /**
-     * Imp to reset wc session on logout as subsequent login attempts fail
-     */
-    const walletConnectWallet = WebWalletController.Instance.getByName(
-      WalletId.WalletConnect
-    );
-    await walletConnectWallet.reset();
-  };
-
-  const handleLogout = async () => {
-    try {
-      await axios.get(`${app.serverUrl()}/logout`);
-      await initAppState();
-      await resetWalletConnectSession();
-      notifySuccess('Logged out');
-      setDarkMode(false);
-    } catch (err) {
-      notifyError('Something went wrong during logging out.');
-      window.location.reload();
-    }
-  };
 
   return (
     <>
@@ -136,34 +110,25 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
             })}
           >
             <CreateContentPopover />
-            <CWIconButton
-              iconButtonTheme="black"
-              iconName="compassPhosphor"
-              onClick={() => navigate('/communities', {}, null)}
+            <CWTooltip
+              content="Explore communities"
+              placement="bottom"
+              renderTrigger={(handleInteraction) => (
+                <CWIconButton
+                  iconButtonTheme="black"
+                  iconName="compassPhosphor"
+                  onClick={() => navigate('/communities', {}, null)}
+                  onMouseEnter={handleInteraction}
+                  onMouseLeave={handleInteraction}
+                />
+              )}
             />
-            <CWIconButton
-              iconButtonTheme="black"
-              iconName="question"
-              onClick={() => setIsFeedbackModalOpen(true)}
-            />
-            <CWIconButton
-              iconButtonTheme="black"
-              iconName="paperPlaneTilt"
-              onClick={() =>
-                window.open('https://docs.commonwealth.im/commonwealth/')
-              }
-            />
+
+            <HelpMenuPopover />
+
             {isLoggedIn && <NotificationsMenuPopover />}
           </div>
           {isLoggedIn && <UserDropdown />}
-          {isLoggedIn && (
-            <CWIconButton
-              className="logout-button"
-              iconButtonTheme="black"
-              iconName="signOut"
-              onClick={handleLogout}
-            />
-          )}
           {!isLoggedIn && (
             <CWButton
               buttonType="primary"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5286 

## Description of Changes
- brought back proper code from the git history so the
- tooltips on navbar work
- help is a dropdown including help and feedback
- logout button is removed from the navbar (it is in user dropdown menu)


https://github.com/hicommonwealth/commonwealth/assets/14819225/8246a13f-0663-40e0-89ef-29594f83eb8e



## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- there were some merge conflicts in `SublayoutHeader` file that were resolved not correctly so I just brought back the proper code from the git history

## Test Plan
- login and check the navbar icons/tooltips
- make sure that login button is not viisble in the navbar

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a
