### PR TITLE
Admin actions dropdown should be in compact mode

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -265,7 +265,7 @@ export const AdminActions = ({
         }}
       >
         <PopoverMenu
-          className="AdminActions"
+          className="AdminActions compact"
           menuItems={[
             ...(hasAdminPermissions ||
             isThreadAuthor ||

--- a/packages/commonwealth/client/styles/components/component_kit/cw_popover/cw_popover_menu.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_popover/cw_popover_menu.scss
@@ -76,4 +76,10 @@
     height: 1px;
     width: 100%;
   }
+
+  &.compact {
+    .PopoverMenuItem {
+      padding: 6px 12px;
+    }
+  }
 }


### PR DESCRIPTION
Dropdown menus have two modes: default and compact. The difference between the two is that compact has less padding on menu items. The dropdown for admin actions (accessed by clicking on the 3 dots beneath a thread preview) has default padding, but should be compact. 

This PR updates admin actions to be compact. 

## Link to Issue
Closes: #4969 

## Description of Changes
- reduces padding on admin actions dropdown menu items

## Test Plan
- visit a [discussions page on demo](https://commonwealth-demo.herokuapp.com/1inch/discussions)
- open admin actions menu