### PR TITLE
Fixed search causing a crash bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -188,7 +188,7 @@ export const User = ({
                 to={profile?.id ? `/profile/id/${profile?.id}` : undefined}
               >
                 {!profile || !profile?.id ? (
-                  !profile?.id ? (
+                  !profile?.id && userAddress ? (
                     `${userAddress.slice(0, 8)}...${userAddress.slice(-5)}`
                   ) : (
                     redactedAddress


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5188 

## Description of Changes
- Added a check to ensure we're not slicing an undefined value.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Checked for the presence of `userAddress`

## Test Plan
- Go to: dashboard/global
- In Search type QA
- Select 1st result from drop down menu
