### PR TITLE
Fixed the render bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -49,7 +49,7 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
 
   useEffect(() => {
     setRecentlyUpdatedVisibility(menuVisible);
-  }, [menuVisible]);
+  }, [menuVisible, setRecentlyUpdatedVisibility]);
 
   function handleToggle() {
     const isVisible = !menuVisible;

--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -100,6 +100,7 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
                 navigate('/', {}, null);
               } else {
                 if (isLoggedIn) {
+                  setMobileMenuName(null);
                   navigate('/dashboard/for-you', {}, null);
                 } else {
                   navigate('/dashboard/global', {}, null);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_mobile_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_mobile_menu.tsx
@@ -73,9 +73,11 @@ type MobileMenuProps = {
   menuItems: Array<MenuItem>;
 };
 
-export const CWMobileMenu = (props: MobileMenuProps) => {
-  const { className, menuHeader, menuItems } = props;
-
+export const CWMobileMenu = ({
+  className,
+  menuHeader,
+  menuItems,
+}: MobileMenuProps) => {
   return (
     <div
       className={getClasses<{ className: string }>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5148 

## Description of Changes
- Added a function to null `mobileMenuName` state on SublayoutHeader

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added a function to null `mobileMenuName` state on SublayoutHeader

## Test Plan
On Mobile, open menu and click home button, menus should close, and if navigated into a further menu option, sidebar menu state should reset:

click 3 dot in top nav see two options (help + notifications)
click notifications (opens a submenu)
click home.



Loom: https://www.loom.com/share/5b50142f408549d08eb5dc24a6976dbb?sid=77319796-86b7-406d-b3c1-5f45357be06e