### PR TITLE
Truncation of long title strings

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/truncate.ts
+++ b/packages/commonwealth/client/scripts/helpers/truncate.ts
@@ -1,14 +1,8 @@
-type Truncate = {
-  str: string;
-  maxCharLength?: number;
-  ellipsisPadding?: number;
-};
-
-export const truncate = ({
-  str,
+export const truncate = (
+  str: string,
   maxCharLength = 140,
-  ellipsisPadding = 4,
-}: Truncate): string => {
+  ellipsisPadding = 4
+): string => {
   // Get the available width of the container or the window
   const availableWidth = window.innerWidth;
 

--- a/packages/commonwealth/client/scripts/helpers/truncate.ts
+++ b/packages/commonwealth/client/scripts/helpers/truncate.ts
@@ -1,0 +1,35 @@
+type Truncate = {
+  str: string;
+  maxCharLength?: number;
+  ellipsisPadding?: number;
+};
+
+export const truncate = ({
+  str,
+  maxCharLength = 140,
+  ellipsisPadding = 4,
+}: Truncate): string => {
+  // Get the available width of the container or the window
+  const availableWidth = window.innerWidth;
+
+  // Define the maximum allowed width as half of the available width
+  const maxWidth = 0.5 * availableWidth;
+
+  // Check if the string is longer than the specified maximum length or if the available width is less than the maximum width
+  if (str.length > maxCharLength || availableWidth < maxWidth) {
+    // Calculate the width of the ellipsis
+    const ellipsisWidth = '...'.length * ellipsisPadding;
+
+    //Allow for a little more space for the ellipsis to prevent too much whitespace
+    const lengthModifier = availableWidth < maxWidth ? 8 : 3;
+
+    // Calculate the maximum truncated length based on the available width and ellipsis width
+    const truncatedLength = Math.floor(
+      (maxWidth - ellipsisWidth) / lengthModifier
+    );
+
+    return str.substring(0, truncatedLength) + '...';
+  }
+
+  return str;
+};

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -170,7 +170,7 @@ export const CWContentPage = ({
     <div className="main-body-container">
       <div className="header">
         {typeof title === 'string' ? (
-          <h1 className="title">{truncate({ str: title })}</h1>
+          <h1 className="title">{truncate(title)}</h1>
         ) : (
           title
         )}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import type Account from '../../../../models/Account';
+import { truncate } from 'helpers/truncate';
 import AddressInfo from '../../../../models/AddressInfo';
 import MinimumProfile from '../../../../models/MinimumProfile';
 import { Thread } from '../../../../models/Thread';
@@ -128,22 +129,6 @@ export const CWContentPage = ({
     });
   };
 
-  const truncate = (str: string) => {
-    // Get the available width of the container or the window
-    const availableWidth = window.innerWidth;
-
-    // Define the maximum allowed width
-    const maxWidth = 0.5 * availableWidth;
-
-    if (str.length > 140 || availableWidth < maxWidth) {
-      const ellipsisWidth = '...'.length * 4;
-      const truncatedLength = Math.floor((maxWidth - ellipsisWidth) / 8);
-      return str.substring(0, truncatedLength) + '...';
-    }
-
-    return str;
-  };
-
   if (showSkeleton) {
     return (
       <CWContentPageSkeleton
@@ -185,7 +170,7 @@ export const CWContentPage = ({
     <div className="main-body-container">
       <div className="header">
         {typeof title === 'string' ? (
-          <h1 className="title">{truncate(title)}</h1>
+          <h1 className="title">{truncate({ str: title })}</h1>
         ) : (
           title
         )}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -128,6 +128,22 @@ export const CWContentPage = ({
     });
   };
 
+  const truncate = (str: string) => {
+    // Get the available width of the container or the window
+    const availableWidth = window.innerWidth;
+
+    // Define the maximum allowed width
+    const maxWidth = 0.5 * availableWidth;
+
+    if (str.length > 140 || availableWidth < maxWidth) {
+      const ellipsisWidth = '...'.length * 4;
+      const truncatedLength = Math.floor((maxWidth - ellipsisWidth) / 8);
+      return str.substring(0, truncatedLength) + '...';
+    }
+
+    return str;
+  };
+
   if (showSkeleton) {
     return (
       <CWContentPageSkeleton
@@ -168,7 +184,11 @@ export const CWContentPage = ({
   const mainBody = (
     <div className="main-body-container">
       <div className="header">
-        {typeof title === 'string' ? <h1 className="title">{title}</h1> : title}
+        {typeof title === 'string' ? (
+          <h1 className="title">{truncate(title)}</h1>
+        ) : (
+          title
+        )}
         {!isEditing ? authorAndPublishInfoRow : <></>}
       </div>
       {subHeader}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5272 

## Description of Changes
- Strings that are longer than 120 characters get truncated with an ellipses after. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Built a function to take in account the width of the device and the max allowed characters and truncate accorded to truthy values.

## Test Plan
- Find longer titles and make sure it truncates correctly. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
loom: https://www.loom.com/share/634359c395314910b9cf256b969f5df9?sid=e26203a0-5e73-4f62-bf39-d06bbf3bf0a8