### PR TITLE
Increased CI timeout for unit/integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -327,7 +327,7 @@ jobs:
         node: [ 18 ]
     name: Commonwealth Unit And Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     services:
       postgres:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: Hotfix

## Description of Changes
- Adds extra timeout to unit/integration tests

## Test Plan
- Ran in github CI

## Other Considerations
- Will permanently fix with: #5322
