### PR TITLE
Fixed feed spacing

### DIFF
--- a/packages/commonwealth/client/styles/pages/user_dashboard/index.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/index.scss
@@ -3,7 +3,6 @@
 .UserDashboard {
   display: flex;
   flex: 1;
-  gap: 56px;
   justify-content: space-between;
   width: auto;
   z-index: 0;

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
@@ -27,7 +27,7 @@
   border-bottom: 1px solid $neutral-100;
   display: flex;
   gap: 16px;
-  padding: 16px;
+  padding: 16px 0px 16px 0px;
   width: 768px;
 
   @include mediumSmallInclusive {

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
@@ -46,6 +46,7 @@
   max-width: 0;
   color: unset !important;
   text-decoration: none;
+  padding-left: 0;
 
   a {
     color: unset !important;

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row.scss
@@ -27,7 +27,7 @@
   border-bottom: 1px solid $neutral-100;
   display: flex;
   gap: 16px;
-  padding: 16px 0px 16px 0px;
+  padding: 16px;
   width: 768px;
 
   @include mediumSmallInclusive {
@@ -46,7 +46,10 @@
   max-width: 0;
   color: unset !important;
   text-decoration: none;
-  padding-left: 0;
+
+  @include smallInclusive {
+    padding: 16px 0 16px 0;
+  }
 
   a {
     color: unset !important;

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row_top.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row_top.scss
@@ -36,6 +36,7 @@
   .comment-thread-info {
     .noWrap {
       display: flex;
+      flex-wrap: wrap;
     }
 
     .User {
@@ -50,5 +51,6 @@
 
   .comment-preview {
     color: $neutral-600;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5302

## Description of Changes
- Makes right spacing = left spacing as shown in picture (notice right padding of feed container in relation to the left padding)
Old:
<img width="1410" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/aca6b0cf-fdbc-47b0-8fb9-a7ce66a0f023">

New:
<img width="1388" alt="Screenshot 2023-10-17 at 12 25 33 PM" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/121c0832-697e-41d1-9b66-fa7f77fd42a1">


Adds wrap instead of truncation for titles

## Test Plan
- CA