### PR TITLE
Added floating createThread button for mobile discussions page

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -21,7 +21,7 @@ import { getTokenBalance } from 'helpers/token_balance_helper';
 export function linkExistingAddressToChainOrCommunity(
   address: string,
   chain: string,
-  originChain: string
+  originChain: string,
 ) {
   return $.post(`${app.serverUrl()}/linkExistingAddressToChain`, {
     address,
@@ -33,7 +33,7 @@ export function linkExistingAddressToChainOrCommunity(
 
 export async function setActiveAccount(
   account: Account,
-  shouldRedraw = true
+  shouldRedraw = true,
 ): Promise<void> {
   const chain = app.activeChainId();
   const role = app.roles.getRoleInCommunity({ account, chain });
@@ -46,7 +46,7 @@ export async function setActiveAccount(
     ) {
       app.user.setActiveAccounts(
         app.user.activeAccounts.concat([account]),
-        shouldRedraw
+        shouldRedraw,
       );
     }
 
@@ -92,7 +92,7 @@ export async function setActiveAccount(
   ) {
     app.user.setActiveAccounts(
       app.user.activeAccounts.concat([account]),
-      shouldRedraw
+      shouldRedraw,
     );
   }
 }
@@ -101,7 +101,8 @@ export async function completeClientLogin(account: Account) {
   try {
     let addressInfo = app.user.addresses.find(
       (a) =>
-        a.address === account.address && a.community.id === account.community.id
+        a.address === account.address &&
+        a.community.id === account.community.id,
     );
 
     if (!addressInfo && account.addressId) {
@@ -162,7 +163,7 @@ export async function updateActiveAddresses({
       .filter((a) => a.community.id === chain.id)
       .map((addr) => app.chain?.accounts.get(addr.address, addr.keytype, false))
       .filter((addr) => addr),
-    shouldRedraw
+    shouldRedraw,
   );
 
   getTokenBalance();
@@ -229,13 +230,13 @@ export function updateActiveUser(data) {
             walletId: a.wallet_id,
             walletSsoSource: a.wallet_sso_source,
             ghostAddress: a.ghost_address,
-          })
-      )
+          }),
+      ),
     );
     app.user.setSocialAccounts(
       data.socialAccounts.map(
-        (sa) => new SocialAccount(sa.provider, sa.provider_username)
-      )
+        (sa) => new SocialAccount(sa.provider, sa.provider_username),
+      ),
     );
 
     app.user.setSiteAdmin(data.isAdmin);
@@ -250,7 +251,7 @@ export async function createUserWithAddress(
   walletSsoSource: WalletSsoSource,
   chain: string,
   sessionPublicAddress?: string,
-  validationBlockInfo?: BlockInfo
+  validationBlockInfo?: BlockInfo,
 ): Promise<{ account: Account; newlyCreated: boolean }> {
   const response = await $.post(`${app.serverUrl()}/createAddress`, {
     address,
@@ -331,7 +332,7 @@ export async function startLoginWithMagicLink({
       provider: provider as any,
       redirectURI: new URL(
         '/finishsociallogin' + params,
-        window.location.origin
+        window.location.origin,
       ).href,
     });
 
@@ -368,6 +369,7 @@ function getProfileMetadata({ provider, userInfo }): {
   } else if (provider === 'google') {
     return { username: userInfo.name, avatarUrl: userInfo.picture };
   }
+
   return {};
 }
 
@@ -429,7 +431,7 @@ export async function handleSocialLoginCallback({
         magicAddress = await magic.cosmos.changeAddress(bech32Prefix);
       } catch (err) {
         console.error(
-          `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`
+          `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`,
         );
       }
 
@@ -437,7 +439,7 @@ export async function handleSocialLoginCallback({
       // the signed message. The API is already used by the Magic iframe,
       // but they don't expose the results.
       const nodeInfo = await $.get(
-        `${document.location.origin}/magicCosmosAPI/${desiredChain.id}/node_info`
+        `${document.location.origin}/magicCosmosAPI/${desiredChain.id}/node_info`,
       );
       const chainId = nodeInfo.node_info.network;
 
@@ -448,7 +450,7 @@ export async function handleSocialLoginCallback({
         ChainBase.CosmosSDK,
         signer,
         magicAddress,
-        timestamp
+        timestamp,
       );
       // TODO: provide blockhash as last argument to signSessionWithMagic
       signature.signatures[0].chain_id = chainId;
@@ -457,13 +459,13 @@ export async function handleSocialLoginCallback({
         chainBaseToCanvasChainId(ChainBase.CosmosSDK, bech32Prefix), // not the cosmos chain id, since that might change
         magicAddress,
         sessionPayload,
-        JSON.stringify(signature.signatures[0])
+        JSON.stringify(signature.signatures[0]),
       );
       authedSessionPayload = JSON.stringify(sessionPayload);
       authedSignature = JSON.stringify(signature.signatures[0]);
       console.log(
         'Reauthenticated Cosmos session from magic address:',
-        magicAddress
+        magicAddress,
       );
     } else {
       const { Web3Provider } = await import('@ethersproject/providers');
@@ -478,7 +480,7 @@ export async function handleSocialLoginCallback({
         ChainBase.Ethereum,
         signer,
         checksumAddress,
-        timestamp
+        timestamp,
       );
       // TODO: provide blockhash as last argument to signSessionWithMagic
 
@@ -487,13 +489,13 @@ export async function handleSocialLoginCallback({
         chainBaseToCanvasChainId(ChainBase.Ethereum, 1), // magic defaults to mainnet
         checksumAddress,
         sessionPayload,
-        signature
+        signature,
       );
       authedSessionPayload = JSON.stringify(sessionPayload);
       authedSignature = signature;
       console.log(
         'Reauthenticated Ethereum session from magic address:',
-        checksumAddress
+        checksumAddress,
       );
     }
   } catch (err) {

--- a/packages/commonwealth/client/scripts/hooks/useBrowserWindow.ts
+++ b/packages/commonwealth/client/scripts/hooks/useBrowserWindow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   isWindowExtraSmall,
   isWindowLarge,
@@ -31,7 +31,7 @@ const useBrowserWindow = ({
     isWindowMedium: isWindowMedium(windowSize),
     isWindowMediumSmallInclusive: isWindowMediumSmallInclusive(windowSize),
     isWindowMediumSmall: isWindowMediumSmall(windowSize),
-    isWindowSmallInclusive: isWindowSmallInclusive(windowSize),
+    isWindowSmallInclusive: isWindowSmallInclusive(windowSize), // We are using this one for mobile
     isWindowSmall: isWindowSmall(windowSize),
   };
   useEffect(() => {
@@ -42,6 +42,11 @@ const useBrowserWindow = ({
       window.removeEventListener('resize', _onResize);
     };
   }, []);
+
+  const dependencyArray = useMemo(
+    () => [...resizeListenerUpdateDeps],
+    [resizeListenerUpdateDeps],
+  );
 
   /**
    * Resize listener
@@ -54,7 +59,7 @@ const useBrowserWindow = ({
       // eslint-disable-next-line no-restricted-globals
       onResize && window.removeEventListener('resize', onResize);
     };
-  }, resizeListenerUpdateDeps);
+  }, [onResize, dependencyArray]);
 
   return {
     // window sizes

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -9,7 +9,7 @@ import { useFetchThreadsQuery } from 'state/api/threads';
 import { useDateCursor } from 'state/api/threads/fetchThreads';
 import useEXCEPTION_CASE_threadCountersStore from 'state/ui/thread';
 import { slugify } from 'utils';
-import { CWText } from 'views/components/component_kit/cw_text';
+import useBrowserWindow from '../../../hooks/useBrowserWindow';
 import useManageDocumentTitle from '../../../hooks/useManageDocumentTitle';
 import {
   ThreadFeaturedFilterTypes,
@@ -17,6 +17,8 @@ import {
 } from '../../../models/types';
 import app from '../../../state';
 import { useFetchTopicsQuery } from '../../../state/api/topics';
+import { CWIconButton } from '../../components/component_kit/cw_icon_button';
+import { DiscussionsPageEmptyPlaceholder } from './DiscussionsPageEmptyPlaceholder';
 import { HeaderWithFilters } from './HeaderWithFilters';
 import { ThreadCard } from './ThreadCard';
 import { sortByFeaturedFilter, sortPinned } from './helpers';
@@ -55,6 +57,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   });
 
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
+  const { isWindowSmallInclusive } = useBrowserWindow({});
 
   const { dateCursor } = useDateCursor({
     dateRange: searchParams.get('dateRange') as ThreadTimelineFilterTypes,
@@ -148,40 +151,43 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
         endReached={() => hasNextPage && fetchNextPage()}
         overscan={200}
         components={{
-          EmptyPlaceholder: () =>
-            isInitialLoading ? (
-              <div className="threads-wrapper">
-                {Array(3)
-                  .fill({})
-                  .map((x, i) => (
-                    <ThreadCard key={i} showSkeleton thread={{} as any} />
-                  ))}
-              </div>
-            ) : (
-              <CWText type="b1" className="no-threads-text">
-                {isOnArchivePage
-                  ? 'There are no archived threads matching your filter.'
-                  : 'There are no threads matching your filter.'}
-              </CWText>
-            ),
-          Header: () => {
-            return (
-              <HeaderWithFilters
-                topic={topicName}
-                stage={stageName}
-                featuredFilter={featuredFilter}
-                dateRange={dateRange}
-                totalThreadCount={threads ? totalThreadsInCommunity : 0}
-                isIncludingSpamThreads={includeSpamThreads}
-                onIncludeSpamThreads={setIncludeSpamThreads}
-                isIncludingArchivedThreads={includeArchivedThreads}
-                onIncludeArchivedThreads={setIncludeArchivedThreads}
-                isOnArchivePage={isOnArchivePage}
-              />
-            );
-          },
+          // eslint-disable-next-line react/no-multi-comp
+          EmptyPlaceholder: () => (
+            <DiscussionsPageEmptyPlaceholder
+              isInitialLoading={isInitialLoading}
+              isOnArchivePage={isOnArchivePage}
+            />
+          ),
+          // eslint-disable-next-line react/no-multi-comp
+          Header: () => (
+            <HeaderWithFilters
+              topic={topicName}
+              stage={stageName}
+              featuredFilter={featuredFilter}
+              dateRange={dateRange}
+              totalThreadCount={threads ? totalThreadsInCommunity : 0}
+              isIncludingSpamThreads={includeSpamThreads}
+              onIncludeSpamThreads={setIncludeSpamThreads}
+              isIncludingArchivedThreads={includeArchivedThreads}
+              onIncludeArchivedThreads={setIncludeArchivedThreads}
+              isOnArchivePage={isOnArchivePage}
+            />
+          ),
         }}
       />
+      {isWindowSmallInclusive && (
+        <div className="floating-mobile-button">
+          <CWIconButton
+            iconName="plusCircle"
+            iconButtonTheme="black"
+            iconSize="xl"
+            onClick={() => {
+              navigate('/new/discussion');
+            }}
+            disabled={!hasJoinedCommunity}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPageEmptyPlaceholder.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPageEmptyPlaceholder.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { CWText } from '../../components/component_kit/cw_text';
+import { ThreadCard } from './ThreadCard/index';
+
+type DiscussionsPageEmptyPlaceholderProps = {
+  isInitialLoading: boolean;
+  isOnArchivePage: boolean;
+};
+
+export const DiscussionsPageEmptyPlaceholder = ({
+  isInitialLoading,
+  isOnArchivePage,
+}: DiscussionsPageEmptyPlaceholderProps) => {
+  return isInitialLoading ? (
+    <div className="threads-wrapper">
+      {Array(3)
+        .fill({})
+        .map((x, i) => (
+          <ThreadCard key={i} showSkeleton thread={{} as any} />
+        ))}
+    </div>
+  ) : (
+    <CWText type="b1" className="no-threads-text">
+      {isOnArchivePage
+        ? 'There are no archived threads matching your filter.'
+        : 'There are no threads matching your filter.'}
+    </CWText>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -11,7 +11,6 @@ import { useFetchTopicsQuery } from 'state/api/topics';
 import useEXCEPTION_CASE_threadCountersStore from 'state/ui/thread';
 import { Select } from 'views/components/Select';
 import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
-import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
@@ -175,16 +174,7 @@ export const HeaderWithFilters = ({
           >
             {totalThreadCount} Threads
           </CWText>
-          {isWindowExtraSmall ? (
-            <CWIconButton
-              iconName="plusCircle"
-              iconButtonTheme="black"
-              onClick={() => {
-                navigate('/new/discussion');
-              }}
-              disabled={!hasJoinedCommunity}
-            />
-          ) : (
+          {!isWindowExtraSmall && (
             <CWButton
               buttonType="primary"
               buttonHeight="sm"

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -2,6 +2,7 @@ import useBrowserWindow from 'hooks/useBrowserWindow';
 import useForceRerender from 'hooks/useForceRerender';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
+import 'pages/discussions/index.scss';
 import 'pages/overview/index.scss';
 import React, { useEffect } from 'react';
 import app from 'state';
@@ -19,7 +20,7 @@ import { TopicSummaryRow } from './TopicSummaryRow';
 const OverviewPage = () => {
   const navigate = useCommonNavigate();
   const forceRerender = useForceRerender();
-  const { isWindowExtraSmall } = useBrowserWindow({});
+  const { isWindowSmallInclusive } = useBrowserWindow({});
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
   const { data: recentlyActiveThreads, isLoading } = useFetchThreadsQuery({
@@ -92,16 +93,7 @@ const OverviewPage = () => {
             }}
           />
         </div>
-        {isWindowExtraSmall ? (
-          <CWIconButton
-            iconName="plusCircle"
-            iconButtonTheme="black"
-            onClick={() => {
-              navigate('/new/discussion');
-            }}
-            disabled={!hasJoinedCommunity}
-          />
-        ) : (
+        {!isWindowSmallInclusive && (
           <CWButton
             buttonType="primary"
             buttonHeight="sm"
@@ -136,6 +128,19 @@ const OverviewPage = () => {
       {topicSummaryRows.map((row, i) => (
         <TopicSummaryRow {...row} key={i} isLoading={isLoading} />
       ))}
+      {isWindowSmallInclusive && (
+        <div className="floating-mobile-button">
+          <CWIconButton
+            iconName="plusCircle"
+            iconButtonTheme="black"
+            iconSize="xl"
+            onClick={() => {
+              navigate('/new/discussion');
+            }}
+            disabled={!hasJoinedCommunity}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -134,9 +134,7 @@ const UserDashboard = (props: UserDashboardProps) => {
           )}
         </>
       </div>
-      <div>
-        <DashboardCommunitiesPreview />
-      </div>
+      <DashboardCommunitiesPreview />
     </div>
   );
 };

--- a/packages/commonwealth/client/styles/pages/discussions/index.scss
+++ b/packages/commonwealth/client/styles/pages/discussions/index.scss
@@ -8,8 +8,8 @@ $size: 48px;
   flex-direction: column;
   width: 100%;
 
-  div[data-test-id=virtuoso-item-list],
-  div[data-viewport-type=element]>div:first-child,
+  div[data-test-id='virtuoso-item-list'],
+  div[data-viewport-type='element'] > div:first-child,
   .threads-wrapper {
     display: flex;
     flex-direction: column;
@@ -29,11 +29,11 @@ $size: 48px;
     }
   }
 
-  div[data-test-id=virtuoso-item-list] {
+  div[data-test-id='virtuoso-item-list'] {
     gap: 2px;
   }
 
-  div[data-viewport-type=element]>div:first-child {
+  div[data-viewport-type='element'] > div:first-child {
     padding-bottom: 16px !important;
   }
 
@@ -67,4 +67,11 @@ $size: 48px;
     align-items: center;
     padding: 24px;
   }
+}
+
+.floating-mobile-button {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  z-index: 1;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5174

## Description of Changes
- Adds create thread button that floats over text in mobile view
- Removes old create thread button when in mobile view


Old (disregard bottom left icon, will not be present on production):
<img width="542" alt="Screenshot 2023-10-17 at 12 53 05 PM" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/c04e102f-8147-438a-8aff-dff71b7310b9">

New:
<img width="528" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/a816c1c9-e0fa-4452-bc35-25aeadd0ba51">

<img width="575" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/239dce98-f521-4c09-b869-495638ab4b45">

## Test Plan
- CA

## Other Considerations
- I am not sure the sizing/ spacing for the create thread button