### PR TITLE
5156 - Add inline scroll when table width exceeds screen width

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.scss
@@ -1,6 +1,8 @@
 @import '../../../../../../styles/shared.scss';
 
 .Table {
+  overflow-x: auto;
+
   table {
     @include b2;
     letter-spacing: 0.14px;


### PR DESCRIPTION
Currently, the table component does not have a mobile design. As a stopgap measure (until mobile designs are completed) to allow users to easily scroll when the table width is greater than the screen width, this PR adds inline scrolling to the table. 

## Link to Issue
Closes: #5156 

## Description of Changes
- adds inline scroll to table component

## Test Plan
- navigate to components page; scroll down to table component
- use browser dev tools to view in mobile (or just reduce the screen width manually) 
