### PR TITLE
polls data now shows under polls tab on small screen size

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -243,7 +243,7 @@ export const CWContentPage = ({
           {sidebarComponents?.length >= 2 &&
             tabSelected === 2 &&
             sidebarComponents[1].item}
-          {sidebarComponents?.length === 3 &&
+          {sidebarComponents?.length >= 3 &&
             tabSelected === 3 &&
             sidebarComponents[2].item}
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5315

## Description of Changes
- polls data now shows under polls tab on small screen size

## "How We Fixed It"
-changed small bit of logic to designate tab selection
-logic was looking for an exact length of sidebar components, changed logic to look for >= number of sidebar components

## Test Plan
- Create a thread and add a poll to thread
- use dev tools or resize screen manually
- notice poll data now shows up under Polls tab
