### PR TITLE
Add ETH chain ID to Horizen EON community.

### DIFF
--- a/packages/commonwealth/server/migrations/20231018183655-fix-horizen-eon-eth-chain-id.js
+++ b/packages/commonwealth/server/migrations/20231018183655-fix-horizen-eon-eth-chain-id.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "ChainNodes"
+      SET eth_chain_id = 7332
+      WHERE name = 'Horizen EON';
+      `,
+      { raw: true }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "ChainNodes"
+      SET eth_chain_id = NULL
+      WHERE name = 'Horizen EON';
+      `,
+      { raw: true }
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5373 

## Description of Changes
- Adds ETH chain ID to Horizen EON community via migration.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Via some digging, determined that a configuration failure left the Horizen EON EVM chain without an ETH chain id, which means that despite having an RPC url, we cannot get signers to recognize it as a valid chain.

The fix is to ensure we respect the contract where ETH chains have eth_chain_ids via adding one in a migration.

## Test Plan
- Reproduced crash locally.
- Ensured migration fixed crash.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
This is a fairly infrequent issue, as we rarely add entirely new ETH chains, but #5375 will fix the root cause.