### PR TITLE
Fixed eslint warning on test changes

### DIFF
--- a/scripts/lint-branch.sh
+++ b/scripts/lint-branch.sh
@@ -18,7 +18,7 @@ then
 else
     echo $LINES
     if [ -n "$FAIL_WARNINGS" ]; then
-        NODE_OPTIONS="--max-old-space-size=8192" eslint --max-warnings=0 $LINES
+        NODE_OPTIONS="--max-old-space-size=8192" eslint --max-warnings=0 $LINES --no-ignore
     else
         NODE_OPTIONS="--max-old-space-size=8192" eslint $LINES
     fi


### PR DESCRIPTION
## Link to Issue
Closes: Hotfix

## Description of Changes
- Adds --no-ignore flag to get eslint to not complain about needing to lint tests

## Test Plan
- Ran the CI pipeline