### PR TITLE
Drop `OldChatMessages`

### DIFF
--- a/packages/commonwealth/server/migrations/20231019141218-drop-old-chat-messages.js
+++ b/packages/commonwealth/server/migrations/20231019141218-drop-old-chat-messages.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('OldChatMessages');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      create table "OldChatMessages"
+      (
+          address    varchar(255)             not null,
+          chain      varchar(255)             not null,
+          text       text                     not null,
+          room       varchar(255)             not null,
+          created_at timestamp with time zone not null,
+          updated_at timestamp with time zone not null
+      );
+    `);
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5329

## Description of Changes
- Drops the unused `OldChatMessages` table

## Test Plan
- Ensure migration runs successfully.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 