### PR TITLE
5406-Prevent long single strings

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/truncate.ts
+++ b/packages/commonwealth/client/scripts/helpers/truncate.ts
@@ -3,14 +3,14 @@ export const truncate = (
   maxCharLength = 140,
   ellipsisPadding = 4
 ): string => {
-
   // Get the available width of the container or the window
   const availableWidth = window.innerWidth;
 
   // Define the maximum allowed width as half of the available width
   const maxWidth = 0.5 * availableWidth;
 
-  // Check if the string is longer than the specified maximum length or if the available width is less than the maximum width
+  // Check if the string is longer than the specified maximum length or
+  // if the available width is less than the maximum width
   if (str.length > maxCharLength || availableWidth < maxWidth) {
     // Calculate the width of the ellipsis
     const ellipsisWidth = '...'.length * ellipsisPadding;
@@ -24,7 +24,6 @@ export const truncate = (
     );
 
     return str.substring(0, truncatedLength) + '...';
-
   }
 
   return str;

--- a/packages/commonwealth/client/scripts/helpers/truncate.ts
+++ b/packages/commonwealth/client/scripts/helpers/truncate.ts
@@ -3,6 +3,7 @@ export const truncate = (
   maxCharLength = 140,
   ellipsisPadding = 4
 ): string => {
+
   // Get the available width of the container or the window
   const availableWidth = window.innerWidth;
 
@@ -23,6 +24,7 @@ export const truncate = (
     );
 
     return str.substring(0, truncatedLength) + '...';
+
   }
 
   return str;

--- a/packages/commonwealth/client/styles/components/component_kit/CWContentPage.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/CWContentPage.scss
@@ -13,6 +13,7 @@
       font-size: 24px;
       line-height: 36px;
       font-weight: 600;
+      word-break: break-word;
     }
 
     .header {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5406 

## Description of Changes
- Added `word-break` to the title to prevent crazy long titles.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added `word-break` to the title to prevent crazy long titles.

## Test Plan
- Ensure long single strings wrap correctly
