### PR TITLE
added logic to disable button and show tooltip

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -9,8 +9,10 @@ import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import { MessageRow } from 'views/components/component_kit/new_designs/CWTextInput/MessageRow';
+import { CWTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
 import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
+import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
 import { ZodError, ZodObject } from 'zod';
 import TopicGatingHelpMessage from '../../TopicGatingHelpMessage';
 import './GroupForm.scss';
@@ -390,14 +392,35 @@ const GroupForm = ({
               ))}
 
               {requirementSubForms.length < MAX_REQUIREMENTS && (
-                <CWButton
-                  type="button"
-                  label="Add requirement"
-                  iconLeft="plus"
-                  buttonWidth="full"
-                  buttonType="secondary"
-                  buttonHeight="med"
-                  onClick={addRequirementSubForm}
+                <CWTooltip
+                  content="Cannot add more than 10 requirements"
+                  placement="bottom"
+                  renderTrigger={(handleInteraction, isTooltipOpen) => (
+                    <CWButton
+                      type="button"
+                      label="Add requirement"
+                      iconLeft="plus"
+                      buttonWidth="full"
+                      buttonType="secondary"
+                      buttonHeight="med"
+                      onClick={addRequirementSubForm}
+                      disabled={requirementSubForms.length >= MAX_REQUIREMENTS}
+                      onMouseEnter={(e) => {
+                        if (requirementSubForms.length >= MAX_REQUIREMENTS) {
+                          handleMouseEnter({ e, handleInteraction });
+                        }
+                      }}
+                      onMouseLeave={(e) => {
+                        if (requirementSubForms.length >= MAX_REQUIREMENTS) {
+                          handleMouseLeave({
+                            e,
+                            isTooltipOpen,
+                            handleInteraction,
+                          });
+                        }
+                      }}
+                    />
+                  )}
                 />
               )}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5394 

## Description of Changes
Have "Add requirement" button be disabled when max amount of requirements are added

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added logic to button to check if requirementSubForms.length >= MAX_REQUIREMENTS and if so be disabled. Added tooltip with logic to appear when requirementSubForms.length >= MAX_REQUIREMENTS. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-Please note I am unable to completely test this as the feature is not completely built out yet. 
