### PR TITLE
#5426 - filter out spam and archived threads from overview page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -12,8 +12,8 @@ import type Topic from '../../../models/Topic';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
-import { PageLoading } from '../loading';
 import { CWText } from '../../components/component_kit/cw_text';
+import { PageLoading } from '../loading';
 import { TopicSummaryRow } from './TopicSummaryRow';
 
 const OverviewPage = () => {
@@ -57,7 +57,12 @@ const OverviewPage = () => {
     topic: Topic;
   }> = topicsSorted.map((topic) => {
     const monthlyThreads = (recentlyActiveThreads || []).filter(
-      (thread) => topic?.id && thread.topic?.id && topic.id === thread.topic.id
+      (thread) =>
+        topic?.id &&
+        thread.topic?.id &&
+        topic.id === thread.topic.id &&
+        thread.archivedAt === null &&
+        !thread.markedAsSpamAt
     );
 
     return {


### PR DESCRIPTION
Currently, the Overview page shows both archived and spam threads. This PR removes archived and spammy threads from the page.

## Link to Issue
Closes: #5426 

## Description of Changes
- provides additional filtering such that the Overview page only shows recent threads that are not archived or spam. 

## Test Plan
- visit overview page
- select a thread and mark it as spam or archive it
- navigate back to the overview page. Aforementioned thread should no longer be present on the page. 

## Other Considerations
- This is a fast follow for PR #4338 (adds ability for moderator to archive thread).