### PR TITLE
Fix community deletion

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -103,6 +103,7 @@ export async function __deleteCommunity(
           const threads = await this.models.Thread.findAll({
             where: { chain: chain.id },
             attributes: ['id'],
+            paranoid: false, // necessary in order to delete associations with soft-deleted threads
           });
 
           await this.models.Collaboration.destroy({

--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -1,8 +1,8 @@
 import { AppError } from 'common-common/src/errors';
 import { Op } from 'sequelize';
+import { UserInstance } from 'server/models/user';
 import { sequelize } from '../../database';
 import { ServerCommunitiesController } from '../server_communities_controller';
-import { UserInstance } from 'server/models/user';
 
 export const Errors = {
   NotLoggedIn: 'Not signed in',
@@ -18,26 +18,25 @@ export const Errors = {
 
 export type DeleteCommunityOptions = {
   user: UserInstance;
-  id: string;
+  communityId: string;
 };
 export type DeleteCommunityResult = void;
 
 export async function __deleteCommunity(
   this: ServerCommunitiesController,
-  { user, id }: DeleteCommunityOptions
+  { user, communityId }: DeleteCommunityOptions
 ): Promise<DeleteCommunityResult> {
   if (!user.isAdmin) {
     throw new AppError(Errors.NotAdmin);
   }
 
-  if (!id) {
+  if (!communityId) {
     throw new AppError(Errors.NeedChainId);
   }
 
   const chain = await this.models.Chain.findOne({
     where: {
-      id,
-      has_chain_events_listener: false, // make sure no chain events
+      id: communityId,
     },
   });
   if (!chain) {

--- a/packages/commonwealth/server/routes/communities/delete_community_handler.ts
+++ b/packages/commonwealth/server/routes/communities/delete_community_handler.ts
@@ -1,9 +1,9 @@
-import { TypedRequestParams, TypedResponse, success } from '../../types';
-import { ServerControllers } from '../../routing/router';
 import {
   DeleteCommunityOptions,
   DeleteCommunityResult,
 } from 'server/controllers/server_communities_methods/delete_community';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequestParams, TypedResponse, success } from '../../types';
 
 type DeleteCommunityRequestParams = DeleteCommunityOptions;
 type DeleteCommunityResponse = DeleteCommunityResult;
@@ -15,7 +15,7 @@ export const deleteCommunityHandler = async (
 ) => {
   const community = await controllers.communities.deleteCommunity({
     user: req.user,
-    id: req.params.id,
+    communityId: req.params.communityId,
   });
   return success(res, community);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5448

## Description of Changes
- Updated parameter access from `id` to `communityId` (defined in the router).
- Removed requirement for `has_chain_events_listener=false` because it is no longer necessary given the chain-events 1.0 deprecation
- Added `paranoid: false` to threads query so that associations to soft deleted threads are removed (collaborations)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Updated the parameter value

## Test Plan
1. Become a god
2. Delete 'dydx' and 'osmosis'

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 