### PR TITLE
remove unwanted header styling from modal header

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.scss
@@ -6,7 +6,7 @@
   border-radius: 6px 6px 0 0;
   padding: 24px 24px 16px 24px;
 
-  .Header {
+  .ModalHeader {
     display: flex;
     align-items: start;
     justify-content: space-between;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from 'react';
 import { Warning, WarningOctagon, X } from '@phosphor-icons/react';
+import React, { FC } from 'react';
 
 import { CWText } from '../../../cw_text';
 
@@ -22,7 +22,7 @@ const CWModalHeader: FC<CWModalHeaderProps> = ({
 }) => {
   return (
     <div className="CWModalHeader">
-      <div className="Header">
+      <div className="ModalHeader">
         {icon === 'warning' && (
           <Warning className="warning-icon" weight="fill" size={24} />
         )}


### PR DESCRIPTION
Bug fix for issue wherein modal headers appeared "above" the modal body.

## Link to Issue
Closes: #5457 

## Description of Changes
Removes `.Header` styling from modals

## "How We Fixed It"
Styles  in `header.scss` were being misapplied to modal headers. The `Header` class in `CWModalHeader` was updated to `ModalHeader` to avoid the name clash. 

## Test Plan
- open modals of your choice to check that the header behavior is as expected. 