### PR TITLE
Added eth_chain_id to admin panel

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
@@ -7,17 +7,20 @@ export const createChainNode = async ({
   name,
   bech32,
   balance_type,
+  eth_chain_id
 }: {
   url: string;
   name: string;
   bech32: string;
   balance_type: BalanceType;
+  eth_chain_id: number;
 }) => {
   return await axios.post(`${app.serverUrl()}/nodes`, {
     url,
     name,
     bech32,
     balance_type,
+    eth_chain_id,
     jwt: app.user.jwt,
   });
 };

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
@@ -6,6 +6,7 @@ import { ServerCommunitiesController } from '../server_communities_controller';
 export const Errors = {
   ChainNodeExists: 'Chain Node already exists',
   NotAdmin: 'Not an admin',
+  ChainIdNaN: 'eth_chain_id is required on ethereum Chain Nodes',
 };
 
 export type CreateChainNodeOptions = {
@@ -14,15 +15,20 @@ export type CreateChainNodeOptions = {
   name?: string;
   bech32?: string;
   balanceType?: string;
+  eth_chain_id?: number;
 };
 export type CreateChainNodeResult = { node_id: number };
 
 export async function __createChainNode(
   this: ServerCommunitiesController,
-  { user, url, name, bech32, balanceType }: CreateChainNodeOptions,
+  { user, url, name, bech32, balanceType, eth_chain_id }: CreateChainNodeOptions,
 ): Promise<CreateChainNodeResult> {
   if (!user.isAdmin) {
     throw new AppError(Errors.NotAdmin);
+  }
+
+  if (balanceType === 'ethereum' && typeof eth_chain_id !== 'number') {
+    throw new AppError(Errors.ChainIdNaN);
   }
 
   const chainNode = await this.models.ChainNode.findOne({
@@ -38,6 +44,7 @@ export async function __createChainNode(
     name,
     balance_type: balanceType as BalanceType,
     bech32,
+    eth_chain_id
   });
 
   return { node_id: newChainNode.id };

--- a/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
+++ b/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
@@ -7,6 +7,7 @@ type CreateChainNodeRequestBody = {
   name?: string;
   bech32?: string;
   balance_type?: string;
+  eth_chain_id?: number;
 };
 type CreateChainNodeResponse = CreateChainNodeResult;
 
@@ -21,6 +22,7 @@ export const createChainNodeHandler = async (
     name: req.body.name,
     bech32: req.body.bech32,
     balanceType: req.body.balance_type,
+    eth_chain_id: req.body.eth_chain_id,
   });
   return success(res, results);
 };

--- a/packages/commonwealth/test/integration/api/chainNodes.spec.ts
+++ b/packages/commonwealth/test/integration/api/chainNodes.spec.ts
@@ -2,10 +2,28 @@ import { expect, assert } from 'chai';
 import models from 'server/database';
 import { BalanceType } from 'common-common/src/types';
 import { resetDatabase } from 'server-test';
+import { ServerCommunitiesController } from '../../../server/controllers/server_communities_controller';
+import { UserInstance } from '../../../server/models/user';
+import { buildUser } from '../../unit/unitHelpers';
 
 describe('ChainNode Tests', () => {
-  before(async () => {
+  beforeEach(async () => {
     await resetDatabase();
+  });
+
+  it('Creates new ChainNode when', async () => {
+    const controller = new ServerCommunitiesController(models, null, null);
+    const user: UserInstance =
+      buildUser({ models, userAttributes: { email: '', id: 1, isAdmin: true } }) as UserInstance;
+    const resp = await controller.createChainNode(
+      { user, url: 'wss://', name: 'asd', balanceType: 'ethereum', eth_chain_id: 123 }
+    );
+
+    const createdNode = await models.ChainNode.findOne({ where: {id: resp.node_id} });
+    assert.equal(createdNode.url, 'wss://');
+    assert.equal(createdNode.name, 'asd');
+    assert.equal(createdNode.balance_type, 'ethereum');
+    assert.equal(createdNode.eth_chain_id, 123);
   });
 
   it('adds eth chain node to db', async () => {

--- a/packages/commonwealth/test/integration/api/createChain.spec.ts
+++ b/packages/commonwealth/test/integration/api/createChain.spec.ts
@@ -1,0 +1,40 @@
+import { assert } from 'chai';
+import { ServerCommunitiesController } from '../../../server/controllers/server_communities_controller';
+import { Errors } from '../../../server/controllers/server_communities_methods/create_chain_node';
+import models from '../../../server/database';
+import { UserInstance } from '../../../server/models/user';
+import { buildUser } from '../../unit/unitHelpers';
+
+describe('create chain tests', () => {
+  it('fails when no eth_chain_id is provided when chain is ethereum', async () => {
+    const controller = new ServerCommunitiesController(models, null, null);
+    const user: UserInstance =
+      buildUser({ models, userAttributes: { email: '', id: 1, isAdmin: true } }) as UserInstance;
+    try {
+      await controller.createChainNode({ user, url: 'wss://', name: 'test', balanceType: 'ethereum' });
+    } catch (e) {
+      assert.equal(e.status, 400);
+      assert.equal(e.message, Errors.ChainIdNaN);
+      return;
+    }
+
+    assert.fail(0, 1, 'Exception not thrown');
+  });
+
+  it('fails when eth_chain_id is not a number', async () => {
+    const controller = new ServerCommunitiesController(models, null, null);
+    const user: UserInstance =
+      buildUser({ models, userAttributes: { email: '', id: 1, isAdmin: true } }) as UserInstance;
+    try {
+      await controller.createChainNode(
+        { user, url: 'wss://', balanceType: 'ethereum', name: 'test', eth_chain_id: 'test' as unknown as number }
+      );
+    } catch (e) {
+      assert.equal(e.status, 400);
+      assert.equal(e.message, Errors.ChainIdNaN);
+      return;
+    }
+
+    assert.fail(0, 1, 'Exception not thrown');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5375

## Description of Changes
- Adds option to update eth chain id

## Test Plan
For frontend:
- Open up admin-panel
- add a new chainNode to existing etherum community
- Assert ChainNode is made
- Assert Community is updated

For Backend:
- Created integration tests

## Other Considerations
- Looks like this visually (only shows up when ethereum is selected from the dropdown):
<img width="924" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/644c2cc5-f4ae-478f-9c44-154fa0dd03d0">
