### PR TITLE
Fix: add to deposit

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/proposal-v1.ts
@@ -1,7 +1,6 @@
 import type { MsgDepositEncodeObject } from '@cosmjs/stargate';
-import BN from 'bn.js';
-import moment from 'moment';
 import { longify } from '@cosmjs/stargate/build/queryclient';
+import BN from 'bn.js';
 import {
   QueryDepositsResponseSDKType,
   QueryTallyResultResponseSDKType,
@@ -14,7 +13,9 @@ import type {
   CosmosVoteChoice,
   ICosmosProposal,
 } from 'controllers/chain/cosmos/types';
+import moment from 'moment';
 
+import Proposal from 'models/Proposal';
 import { ITXModalData } from 'models/interfaces';
 import {
   ProposalEndTime,
@@ -23,15 +24,14 @@ import {
   VotingUnit,
 } from 'models/types';
 import { DepositVote } from 'models/votes';
-import Proposal from 'models/Proposal';
 import CosmosAccount from '../../account';
 import type CosmosAccounts from '../../accounts';
 import type CosmosChain from '../../chain';
 import type { CosmosApiType } from '../../chain';
-import { marshalTallyV1 } from './utils-v1';
-import type CosmosGovernanceV1 from './governance-v1';
 import { CosmosVote } from '../v1beta1/proposal-v1beta1';
 import { encodeMsgVote } from '../v1beta1/utils-v1beta1';
+import type CosmosGovernanceV1 from './governance-v1';
+import { marshalTallyV1 } from './utils-v1';
 
 const voteToEnumV1 = (voteOption: number | string): CosmosVoteChoice => {
   switch (voteOption) {

--- a/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchActiveCosmosProposals.ts
+++ b/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchActiveCosmosProposals.ts
@@ -1,11 +1,11 @@
-import app from 'state';
 import { useQuery } from '@tanstack/react-query';
+import { ChainBase } from 'common-common/src/types';
 import Cosmos from 'controllers/chain/cosmos/adapter';
 import { getActiveProposals } from 'controllers/chain/cosmos/gov/utils';
 import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
-import { ChainBase } from 'common-common/src/types';
+import app from 'state';
 
-const ACTIVE_PROPOSALS_STALE_TIME = 1000 * 30;
+const ACTIVE_PROPOSALS_STALE_TIME = 1000 * 10;
 
 const fetchActiveProposals = async (): Promise<CosmosProposal[]> => {
   return getActiveProposals(app.chain as Cosmos);

--- a/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchCosmosProposal.ts
+++ b/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchCosmosProposal.ts
@@ -1,12 +1,12 @@
-import app from 'state';
 import { useQuery } from '@tanstack/react-query';
-import Cosmos from 'controllers/chain/cosmos/adapter';
 import { ChainBase } from 'common-common/src/types';
-import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+import Cosmos from 'controllers/chain/cosmos/adapter';
 import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+import app from 'state';
 
 const PROPOSAL_CACHE_TIME = 1000 * 60 * 60;
-const PROPOSAL_STALE_TIME = 1000 * 60 * 60;
+const PROPOSAL_STALE_TIME = 1000 * 10;
 
 const fetchCosmosProposal = async (
   proposalId: string

--- a/packages/commonwealth/client/scripts/views/components/proposals/cannot_vote.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/cannot_vote.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CWButton } from '../component_kit/cw_button';
+
+type CannotVoteProps = { label: string };
+
+export const CannotVote = ({ label }: CannotVoteProps) => {
+  return (
+    <div className="CannotVote">
+      <CWButton disabled label={label} />
+    </div>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/components/proposals/proposal_extensions.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/proposal_extensions.tsx
@@ -1,50 +1,61 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import 'components/proposals/proposal_extensions.scss';
-import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
 import type { AnyProposal } from '../../../models/types';
 
 import app from 'state';
 
-import { CWText } from '../component_kit/cw_text';
-import { CWTextInput } from '../component_kit/cw_text_input';
+import Cosmos from 'controllers/chain/cosmos/adapter';
+import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
+import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
 import {
   useDepositParamsQuery,
   useStakingParamsQuery,
 } from 'state/api/chainParams';
+import { minimalToNaturalDenom } from '../../../../../shared/utils';
+import { CWText } from '../component_kit/cw_text';
+import { CWTextInput } from '../component_kit/cw_text_input';
 
 type ProposalExtensionsProps = {
   proposal: AnyProposal;
   setDemocracyVoteConviction?;
   setDemocracyVoteAmount?;
-  setCosmosDepositAmount?;
+  setCosmosDepositAmount?: (amount: number) => void;
 };
 
 export const ProposalExtensions = (props: ProposalExtensionsProps) => {
-  const { proposal, setCosmosDepositAmount, setDemocracyVoteAmount } = props;
-
-  React.useEffect(() => {
-    if (setDemocracyVoteAmount) setDemocracyVoteAmount(0);
-    if (setCosmosDepositAmount) setCosmosDepositAmount(0);
-  }, [setCosmosDepositAmount, setDemocracyVoteAmount]);
-
+  const { setCosmosDepositAmount, setDemocracyVoteAmount, proposal } = props;
   const { data: stakingDenom } = useStakingParamsQuery();
   const { data: cosmosDepositParams } = useDepositParamsQuery(stakingDenom);
-  const minDeposit = cosmosDepositParams?.minDeposit;
+
+  useEffect(() => {
+    if (setDemocracyVoteAmount) setDemocracyVoteAmount(0);
+  }, [setDemocracyVoteAmount]);
+
+  useEffect(() => {
+    if (setCosmosDepositAmount) setCosmosDepositAmount(0);
+  }, [setCosmosDepositAmount]);
 
   if (
-    proposal instanceof CosmosProposal &&
+    (proposal instanceof CosmosProposal ||
+      proposal instanceof CosmosProposalV1) &&
     proposal.status === 'DepositPeriod'
   ) {
+    const cosmos = app.chain as Cosmos;
+    const meta = cosmos.meta;
+    const minDeposit = parseFloat(
+      minimalToNaturalDenom(+cosmosDepositParams?.minDeposit, meta?.decimals)
+    );
+
     if (!setCosmosDepositAmount) return <CWText>Misconfigured</CWText>;
 
     return (
       <div className="ProposalExtensions">
-        <CWText>Must deposit at least: {minDeposit?.format()}</CWText>
+        <CWText>Must deposit at least: {minDeposit}</CWText>
         <CWTextInput
-          placeholder={`Amount to deposit (${app.chain?.chain?.denom})`}
+          placeholder={`Amount to deposit (${meta?.default_symbol})`}
           onInput={(e) => {
-            setCosmosDepositAmount(parseInt(e.target.value, 10));
+            setCosmosDepositAmount(e.target.value);
           }}
         />
       </div>

--- a/packages/commonwealth/client/scripts/views/components/proposals/voting_actions.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/voting_actions.tsx
@@ -4,11 +4,11 @@ import 'components/proposals/voting_actions.scss';
 import { notifyError } from 'controllers/app/notifications';
 import type CosmosAccount from 'controllers/chain/cosmos/account';
 import type Cosmos from 'controllers/chain/cosmos/adapter';
+import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
 import {
   CosmosProposal,
   CosmosVote,
 } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
-import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
 import AaveProposal, {
   AaveProposalVote,
 } from 'controllers/chain/ethereum/aave/proposal';
@@ -29,21 +29,13 @@ import { VotingType } from '../../../models/types';
 
 import app from 'state';
 
+import { naturalDenomToMinimal } from '../../../../../shared/utils';
 import { CompoundCancelButton } from '../../pages/view_proposal/proposal_components';
 import { CWButton } from '../component_kit/cw_button';
 import { CWText } from '../component_kit/cw_text';
+import { CannotVote } from './cannot_vote';
 import { getCanVote, getVotingResults } from './helpers';
 import { ProposalExtensions } from './proposal_extensions';
-
-type CannotVoteProps = { label: string };
-
-const CannotVote = (props: CannotVoteProps) => {
-  return (
-    <div className="CannotVote">
-      <CWButton disabled label={props.label} />
-    </div>
-  );
-};
 
 type VotingActionsProps = {
   onModalClose: () => void;
@@ -57,8 +49,7 @@ export const VotingActions = (props: VotingActionsProps) => {
 
   const [amount, setAmount] = useState<number>();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(app.isLoggedIn());
-  const [conviction, setConviction] = useState<number>();
-  // conviction isn't used anywhere?
+  const [, setConviction] = useState<number>();
 
   useEffect(() => {
     app.loginStateEmitter.once('redraw', () => {
@@ -68,7 +59,7 @@ export const VotingActions = (props: VotingActionsProps) => {
     return () => {
       app.loginStateEmitter.removeAllListeners();
     };
-  }, [app.loginState]);
+  }, []);
 
   if (!isLoggedIn) {
     return <CannotVote label="Sign in to vote" />;
@@ -109,9 +100,14 @@ export const VotingActions = (props: VotingActionsProps) => {
       proposal instanceof CosmosProposalV1
     ) {
       if (proposal.status === 'DepositPeriod') {
-        // TODO: configure deposit amount
+        const chain = app.chain as Cosmos;
+        const depositAmountInMinimalDenom = parseInt(
+          naturalDenomToMinimal(amount, chain.meta?.decimals),
+          10
+        );
+
         proposal
-          .submitDepositTx(user, (app.chain as Cosmos).chain.coins(amount))
+          .submitDepositTx(user, chain.chain.coins(depositAmountInMinimalDenom))
           .then(emitRedraw)
           .catch((err) => notifyError(err.toString()));
       } else {
@@ -352,9 +348,7 @@ export const VotingActions = (props: VotingActionsProps) => {
         <div className="button-row">{multiDepositApproveButton}</div>
         <ProposalExtensions
           proposal={proposal}
-          setCosmosDepositAmount={(c) => {
-            setAmount(c);
-          }}
+          setCosmosDepositAmount={setAmount}
         />
       </>
     );

--- a/packages/commonwealth/client/scripts/views/components/proposals/voting_results.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/voting_results.tsx
@@ -10,7 +10,14 @@ import type NearSputnikProposal from 'controllers/chain/near/sputnik/proposal';
 import type { AnyProposal } from '../../../models/types';
 import { VotingType } from '../../../models/types';
 
+import { ChainNetwork } from 'common-common/src/types';
+import { CosmosProposalV1 } from 'controllers/chain/cosmos/gov/v1/proposal-v1';
+import useForceRerender from 'hooks/useForceRerender';
 import app from 'state';
+import {
+  useAaveProposalVotesQuery,
+  useCompoundProposalVotesQuery,
+} from 'state/api/proposals';
 import Web3 from 'web3-utils';
 import {
   AaveVotingResult,
@@ -20,12 +27,6 @@ import {
   YesNoAbstainVetoVotingResult,
   YesNoRejectVotingResult,
 } from './voting_result_components';
-import useForceRerender from 'hooks/useForceRerender';
-import {
-  useAaveProposalVotesQuery,
-  useCompoundProposalVotesQuery,
-} from 'state/api/proposals';
-import { ChainNetwork } from 'common-common/src/types';
 
 type VotingResultsProps = { proposal: AnyProposal };
 
@@ -99,7 +100,7 @@ export const VotingResults = (props: VotingResultsProps) => {
     );
   } else if (
     proposal.votingType === VotingType.SimpleYesApprovalVoting &&
-    proposal instanceof CosmosProposal
+    (proposal instanceof CosmosProposal || proposal instanceof CosmosProposalV1)
   ) {
     // special case for cosmos proposals in deposit stage
     return (

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
@@ -1,31 +1,31 @@
-import React, { useState } from 'react';
 import type { Any as ProtobufAny } from 'cosmjs-types/google/protobuf/any';
+import React, { useState } from 'react';
 
 import { notifyError } from 'controllers/app/notifications';
 import type CosmosAccount from 'controllers/chain/cosmos/account';
 import type Cosmos from 'controllers/chain/cosmos/adapter';
-import { CosmosToken } from 'controllers/chain/cosmos/types';
 import {
   encodeCommunitySpend,
   encodeTextProposal,
 } from 'controllers/chain/cosmos/gov/v1beta1/utils-v1beta1';
+import { CosmosToken } from 'controllers/chain/cosmos/types';
 import {
   useDepositParamsQuery,
   useStakingParamsQuery,
 } from 'state/api/chainParams';
 
+import { useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
+import {
+  minimalToNaturalDenom,
+  naturalDenomToMinimal,
+} from '../../../../../shared/utils';
+import { Skeleton } from '../../components/Skeleton';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWLabel } from '../../components/component_kit/cw_label';
 import { CWRadioGroup } from '../../components/component_kit/cw_radio_group';
 import { CWTextArea } from '../../components/component_kit/cw_text_area';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
-import { useCommonNavigate } from 'navigation/helpers';
-import { Skeleton } from '../../components/Skeleton';
-import {
-  minimalToNaturalDenom,
-  naturalDenomToMinimal,
-} from '../../../../../shared/utils';
 
 export const CosmosProposalForm = () => {
   const [cosmosProposalType, setCosmosProposalType] = useState<
@@ -121,8 +121,17 @@ export const CosmosProposalForm = () => {
 
           let prop: ProtobufAny;
 
+          const depositInMinimalDenom = naturalDenomToMinimal(
+            deposit,
+            meta?.decimals
+          );
+
           const _deposit = deposit
-            ? new CosmosToken(depositParams?.minDeposit?.denom, deposit, false)
+            ? new CosmosToken(
+                depositParams?.minDeposit?.denom,
+                depositInMinimalDenom,
+                false
+              )
             : depositParams?.minDeposit;
 
           if (cosmosProposalType === 'textProposal') {

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -1,42 +1,42 @@
-import React, { useState, useEffect } from 'react';
 import { ChainNetwork } from 'common-common/src/types';
-import _ from 'lodash';
-import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
 import { CosmosProposal } from 'controllers/chain/cosmos/gov/v1beta1/proposal-v1beta1';
+import AaveProposal from 'controllers/chain/ethereum/aave/proposal';
+import useForceRerender from 'hooks/useForceRerender';
 import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
 import useNecessaryEffect from 'hooks/useNecessaryEffect';
-import useForceRerender from 'hooks/useForceRerender';
 import {
   chainToProposalSlug,
   getProposalUrlPath,
   idToProposal,
 } from 'identifiers';
+import _ from 'lodash';
 import { useCommonNavigate } from 'navigation/helpers';
+import React, { useEffect, useState } from 'react';
 import app from 'state';
-import { slugify } from 'utils';
-import { PageNotFound } from 'views/pages/404';
-import { PageLoading } from 'views/pages/loading';
-import type { AnyProposal } from '../../../models/types';
-import { CollapsibleProposalBody } from '../../components/collapsible_body_text';
-import { CWContentPage } from '../../components/component_kit/CWContentPage';
-import { VotingActions } from '../../components/proposals/voting_actions';
-import { VotingResults } from '../../components/proposals/voting_results';
-import { Skeleton } from '../../components/Skeleton';
-import { AaveViewProposalDetail } from './aave_summary';
-import type { SubheaderProposalType } from './proposal_components';
-import { ProposalSubheader } from './proposal_components';
-import { JSONDisplay } from './json_display';
-import useManageDocumentTitle from '../../../hooks/useManageDocumentTitle';
+import { usePoolParamsQuery } from 'state/api/chainParams';
 import {
   useAaveProposalsQuery,
   useCompoundProposalsQuery,
+  useCosmosProposalDepositsQuery,
   useCosmosProposalMetadataQuery,
   useCosmosProposalQuery,
   useCosmosProposalTallyQuery,
   useCosmosProposalVotesQuery,
-  useCosmosProposalDepositsQuery,
 } from 'state/api/proposals';
-import { usePoolParamsQuery } from 'state/api/chainParams';
+import { slugify } from 'utils';
+import { PageNotFound } from 'views/pages/404';
+import { PageLoading } from 'views/pages/loading';
+import useManageDocumentTitle from '../../../hooks/useManageDocumentTitle';
+import type { AnyProposal } from '../../../models/types';
+import { Skeleton } from '../../components/Skeleton';
+import { CollapsibleProposalBody } from '../../components/collapsible_body_text';
+import { CWContentPage } from '../../components/component_kit/CWContentPage';
+import { VotingActions } from '../../components/proposals/voting_actions';
+import { VotingResults } from '../../components/proposals/voting_results';
+import { AaveViewProposalDetail } from './aave_summary';
+import { JSONDisplay } from './json_display';
+import type { SubheaderProposalType } from './proposal_components';
+import { ProposalSubheader } from './proposal_components';
 
 type ViewProposalPageAttrs = {
   identifier: string;
@@ -73,7 +73,7 @@ const ViewProposalPage = ({
     setProposal(cosmosProposal);
     setTitle(cosmosProposal?.title);
     setDescription(cosmosProposal?.description);
-  }, [cosmosProposal, app.chain.apiInitialized]);
+  }, [cosmosProposal]);
 
   useEffect(() => {
     if (_.isEmpty(metadata)) return;
@@ -134,7 +134,17 @@ const ViewProposalPage = ({
       );
       setProposal(foundProposal);
     }
-  }, [cachedAaveProposals, cachedCompoundProposals, isAdapterLoaded]);
+  }, [
+    cachedAaveProposals,
+    cachedCompoundProposals,
+    isAdapterLoaded,
+    aaveProposalsLoading,
+    compoundProposalsLoading,
+    fetchAaveData,
+    fetchCompoundData,
+    proposal,
+    proposalId,
+  ]);
 
   useNecessaryEffect(() => {
     const afterAdapterLoaded = async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5469

## Description of Changes
- Properly displays deposit input for v1 proposal in Deposit state
- displays input in natural DENOM, instead of minimal udenom (to match initial deposit UX)
- fixes a state rendering problem that was resetting input to zero
  - this fixes the "0 udenom Invalid coins" chain error because the correct amount is sent
- fixes Partial Deposit case (inputting less than minimum initial deposit was not getting converted back to minimal denom)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan

- CA (click around) tested on local:
  - login to csdk with [shared account](https://github.com/hicommonwealth/commonwealth/blob/master/knowledge_base/Devnet.md#how-to-manually-test-transactions-on-the-csdk-or-csdk-beta-sandbox-community)
  - create onchain proposal
  - only deposit 1/2 of required deposit (1 STAKE in this case). Complete Keplr transaction.
  - expect this view:
      - <img width="770" alt="Screenshot 2023-10-31 at 1 54 55 PM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/2e319be7-ae62-469a-8a4e-140478e0a2e4">
  - deposit another 0.5 STAKE
  - expect to see "Approved 1" and your deposit reflected as "YourName   500k ustake"
  - refresh page, deposit another 0.5 STAKE, click to "Proposals"
  - Click the proposal you created
  - Expect it to now be in Voting stage (sufficient 2 STAKE deposit received onchain)

Optional:
- repeat for /csdk-beta and /evmos-dev

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- I lowered the cache time for active proposals to 10 seconds. This relieves some of the stale states between one onchain action reflecting in the UI, but you may still experience some stale UI. For these scenarios, we optimize for performance over data freshness.
- /evmos-dev works as described above except there is an error popup that says "Assertion failed." This is misleading because the TX succeeds. Will ticket..
- Nice to haves for the future: 
  - Show remaining amount needed to complete deposit, instead of total amount
  - Show all depositors and amounts added so far
  - When full deposit is reached, automatically reload to show Voting-state proposal
