### PR TITLE
community icons now scroll behind header

### DIFF
--- a/packages/commonwealth/client/styles/pages/communities.scss
+++ b/packages/commonwealth/client/styles/pages/communities.scss
@@ -16,6 +16,7 @@
     padding: 24px;
     position: sticky;
     top: 0;
+    z-index: 1;
 
     .filter-buttons {
       display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5410 

## Description of Changes
Community icons now scroll behind header in dark mode

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added z-index:1 to .header-section in `communities.scss`

<img width="1403" alt="Screenshot 2023-10-31 at 2 36 28 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/4b1980cf-0219-4272-a47b-619cbe1af4a1">

