### PR TITLE
Updated CWSelectList classnames prefix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
@@ -11,7 +11,7 @@
     max-height: 40px;
     padding: 10px 16px;
   
-    [class$='-control'] {
+    .cwsl__control {
       gap: 8px;
       letter-spacing: 0.02em;
       width: 100%;
@@ -19,25 +19,25 @@
       align-items: flex-start !important;
       cursor: text !important;
   
-      [class$='-ValueContainer'] {
+      .cwsl__value-container {
         padding: 0 !important;
         max-height: 24px;
         line-height: 14px;
   
-        [class$='-multiValue'] {
+        .cwsl__multi-value {
           padding: 2px 8px;
           border-radius: 6px;
           margin: 0px !important;
           margin-right: 8px !important;
           background-color: $neutral-100;
   
-          [class$='-MultiValueGeneric'] {
+          .cwsl__multi-value__label {
             font-size: 14px;
             margin-right: 16px;
             padding: 0px !important;
           }
   
-          [class$='-MultiValueRemove'] {
+          .cwsl__multi-value__remove {
             padding: 0;
             cursor: pointer;
             color: $neutral-500;
@@ -54,7 +54,7 @@
           }
         }
   
-        [class$='-Input'] {
+        .cwsl__input-container {
           margin: 0;
           padding-top: 0;
           padding-bottom: 0;
@@ -62,15 +62,15 @@
       }
     }
   
-    [class$='-IndicatorsContainer'] {
+    .cwsl__indicators {
       cursor: pointer;
   
-      [class$='-indicatorSeparator'] {
+      .cwsl__indicator-separator {
         display: none;
       }
     }
   
-    [class$='-menu'] {
+    .cwsl__menu {
       left: 0;
       margin-top: 8px;
       border-radius: 6px;
@@ -79,11 +79,11 @@
       background-color: $white;
       box-shadow: 0 3px 10px rgb(0 0 0 / 0.2);
   
-      [class$='-MenuList'] {
+      .cwsl__menu-list {
         overflow: scroll;
         padding: 8px;
   
-        [class$='-option'] {
+        .cwsl__option {
           border: 0;
           outline: 0;
           border-radius: 6px;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.tsx
@@ -1,5 +1,5 @@
-import './CWSelectList.scss';
 import React, { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
 import type { GroupBase, Props } from 'react-select';
 import Select, { components } from 'react-select';
 import { CWIcon } from '../../cw_icons/cw_icon';
@@ -7,7 +7,6 @@ import { getClasses } from '../../helpers';
 import { ComponentType } from '../../types';
 import { MessageRow } from '../CWTextInput/MessageRow';
 import './CWSelectList.scss';
-import { useFormContext } from 'react-hook-form';
 
 type CustomCWSelectListProps = {
   label?: string;
@@ -47,7 +46,7 @@ export const CWSelectList = <
       props.name &&
       props.value &&
       formContext.setValue(props.name, props.value);
-    }, [props.hookToForm, props.name, props.value, formContext]);
+  }, [props.hookToForm, props.name, props.value, formContext]);
 
   return (
     <div className="CWSelectList">
@@ -111,6 +110,7 @@ export const CWSelectList = <
             </components.MultiValueRemove>
           ),
         }}
+        classNamePrefix="cwsl"
         className={getClasses<{
           className?: string;
           failure?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5531

## Description of Changes
- Updated CWSelectList dropdown classnames (this component gets used inside the gating form)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By updating classnames for CWSelectList

## Test Plan
1. Visit `/:scope/members/groups/create` on frack with a community/site admin account
2. Play around with the dropdowns and verify no styles are broken

## Deployment Plan
<!--- Omit if unneeded -->
First deploy on frack since this issue is only reproducible there and if fixed then merge.

## Other Considerations
N/A