### PR TITLE
Fix getFileSizeBytes

### DIFF
--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -134,5 +134,3 @@ export const SEND_WEBHOOKS_EMAILS =
 
 export const FEATURE_FLAG_GROUP_CHECK_ENABLED =
   process.env.FEATURE_FLAG_GROUP_CHECK_ENABLED === 'true' || false;
-
-export const MAX_COMMUNITY_IMAGE_SIZE_BYTES = 500 * 1024;

--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -134,3 +134,5 @@ export const SEND_WEBHOOKS_EMAILS =
 
 export const FEATURE_FLAG_GROUP_CHECK_ENABLED =
   process.env.FEATURE_FLAG_GROUP_CHECK_ENABLED === 'true' || false;
+
+export const MAX_COMMUNITY_IMAGE_SIZE_BYTES = 500 * 1024;

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -12,8 +12,8 @@ import { Op } from 'sequelize';
 import { urlHasValidHTTPPrefix } from '../../../shared/utils';
 
 import type { AddressInstance } from '../../models/address';
-import type { CommunityAttributes } from '../../models/community';
 import type { ChainNodeAttributes } from '../../models/chain_node';
+import type { CommunityAttributes } from '../../models/community';
 import type { RoleAttributes } from '../../models/role';
 
 import axios from 'axios';
@@ -124,13 +124,15 @@ export async function __createCommunity(
     throw new AppError(Errors.NoBase);
   }
 
-  if (
-    community.icon_url &&
-    (await getFileSizeBytes(community.icon_url)) / 1024 > MAX_IMAGE_SIZE_KB
-  ) {
-    throw new AppError(Errors.ImageTooLarge);
+  if (community.icon_url) {
+    const iconFileSize = await getFileSizeBytes(community.icon_url);
+    if (iconFileSize === 0) {
+      throw new AppError(Errors.ImageDoesntExist);
+    }
+    if (iconFileSize / 1024 > MAX_IMAGE_SIZE_KB) {
+      throw new AppError(Errors.ImageTooLarge);
+    }
   }
-
   const existingBaseChain = await this.models.Community.findOne({
     where: { base: community.base },
   });

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -17,10 +17,12 @@ import type { CommunityAttributes } from '../../models/community';
 import type { RoleAttributes } from '../../models/role';
 
 import axios from 'axios';
-import { MAX_COMMUNITY_IMAGE_SIZE_BYTES } from '../../config';
 import { ALL_CHAINS } from '../../middleware/databaseValidationService';
 import { UserInstance } from '../../models/user';
-import { checkUrlFileSize } from '../../util/checkUrlFileSize';
+import {
+  MAX_COMMUNITY_IMAGE_SIZE_BYTES,
+  checkUrlFileSize,
+} from '../../util/checkUrlFileSize';
 import { RoleInstanceWithPermission } from '../../util/roles';
 import testSubstrateSpec from '../../util/testSubstrateSpec';
 import { ServerCommunitiesController } from '../server_communities_controller';

--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -20,10 +20,12 @@ import { success } from '../types';
 
 import axios from 'axios';
 import { MixpanelCommunityCreationEvent } from '../../shared/analytics/types';
-import { MAX_COMMUNITY_IMAGE_SIZE_BYTES } from '../config';
 import { ServerAnalyticsController } from '../controllers/server_analytics_controller';
 import { ALL_CHAINS } from '../middleware/databaseValidationService';
-import { checkUrlFileSize } from '../util/checkUrlFileSize';
+import {
+  MAX_COMMUNITY_IMAGE_SIZE_BYTES,
+  checkUrlFileSize,
+} from '../util/checkUrlFileSize';
 import { RoleInstanceWithPermission } from '../util/roles';
 import testSubstrateSpec from '../util/testSubstrateSpec';
 

--- a/packages/commonwealth/server/util/checkUrlFileSize.ts
+++ b/packages/commonwealth/server/util/checkUrlFileSize.ts
@@ -1,6 +1,8 @@
 import { AppError } from '../../../common-common/src/errors';
 import { getFileSizeBytes } from './getFilesSizeBytes';
 
+export const MAX_COMMUNITY_IMAGE_SIZE_BYTES = 500 * 1024;
+
 const Errors = {
   ImageDoesntExist: `Image url provided doesn't exist`,
   ImageTooLarge: (max: number) => `Image must be smaller than ${max}kb`,

--- a/packages/commonwealth/server/util/checkUrlFileSize.ts
+++ b/packages/commonwealth/server/util/checkUrlFileSize.ts
@@ -1,0 +1,17 @@
+import { AppError } from '../../../common-common/src/errors';
+import { getFileSizeBytes } from './getFilesSizeBytes';
+
+const Errors = {
+  ImageDoesntExist: `Image url provided doesn't exist`,
+  ImageTooLarge: (max: number) => `Image must be smaller than ${max}kb`,
+};
+
+export async function checkUrlFileSize(url: string, maxFileSizeBytes: number) {
+  const fileSizeBytes = await getFileSizeBytes(url);
+  if (fileSizeBytes === 0) {
+    throw new AppError(Errors.ImageDoesntExist);
+  }
+  if (fileSizeBytes > maxFileSizeBytes) {
+    throw new AppError(Errors.ImageTooLarge(maxFileSizeBytes));
+  }
+}

--- a/packages/commonwealth/server/util/getFilesSizeBytes.ts
+++ b/packages/commonwealth/server/util/getFilesSizeBytes.ts
@@ -1,13 +1,17 @@
 import fetch from 'node-fetch';
 
 export async function getFileSizeBytes(url: string): Promise<number> {
-  if (!url) {
+  try {
+    if (!url) {
+      return 0;
+    }
+    // Range header is to prevent it from reading any bytes from the GET request because we only want the headers.
+    const resp = await fetch(url, { headers: { Range: 'bytes=0-0' } });
+    if (!resp) {
+      return 0;
+    }
+    return parseInt(resp.headers.get('content-range').split('/')[1], 10);
+  } catch (err) {
     return 0;
   }
-  // Range header is to prevent it from reading any bytes from the GET request because we only want the headers.
-  const resp = await fetch(url, { headers: { Range: 'bytes=0-0' } });
-  if (!resp) {
-    return 0;
-  }
-  return parseInt(resp.headers.get('content-range').split('/')[1], 10);
 }

--- a/packages/commonwealth/test/unit/chainIconSizeLimit.spec.ts
+++ b/packages/commonwealth/test/unit/chainIconSizeLimit.spec.ts
@@ -1,24 +1,17 @@
-import chai from 'chai';
+import { expect } from 'chai';
 import { getFileSizeBytes } from '../../server/util/getFilesSizeBytes';
 
 describe('ChainIconSizeLimit tests', () => {
-  it("should fail if the url provided doesn't exist", async () => {
-    let errorCaught = false;
-    try {
-      await getFileSizeBytes('badUrl');
-    } catch (e) {
-      errorCaught = true;
-      chai.assert.equal(e.message, 'Only absolute URLs are supported');
-    }
-
-    chai.assert.isTrue(errorCaught);
+  it("should return zero if url provided doesn't exist", async () => {
+    const fileSizeBytes = await getFileSizeBytes('badUrl');
+    expect(fileSizeBytes).to.equal(0);
   });
 
+  // TODO: make this test not require a remote HTTP request?
   it('should return the image size', async () => {
-    const fileSize = await getFileSizeBytes(
+    const fileSizeBytes = await getFileSizeBytes(
       'https://commonwealth-uploads.s3.us-east-2.amazonaws.com/bebbda6b-6b10-4cbd-8839-4fa8d2a0b266.jpg'
     );
-
-    chai.assert.equal(fileSize, 14296);
+    expect(fileSizeBytes).to.equal(14296);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5533

## "How We Fixed It"
- Remove duplicate function for `getFileSizeBytes`
- Add error handling in case it throws an error

## Test Plan
- Updated existing unit test
- CA testing
  - Create a community with icon url `badUrl`– confirm that the UI shows error "Image url provided doesn't exist"
  - Create a community with icon url `https://images6.alphacoders.com/133/1330094.png`– confirm that the UI shows error "Image size must be smaller…"
  - Create a community with icon url `https://commonwealth-uploads.s3.us-east-2.amazonaws.com/bebbda6b-6b10-4cbd-8839-4fa8d2a0b266.jpg`– confirm that it works successfully

## Deployment Plan
N/A

## Other Considerations
N/A