### PR TITLE
FIX: cosmos starter community

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/cosmos_evm_metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/cosmos_evm_metamask_web_wallet.ts
@@ -5,12 +5,12 @@ import { setActiveAccount } from 'controllers/app/login';
 import app from 'state';
 import type Web3 from 'web3';
 
-import type {
-  provider,
-  TransactionConfig,
-  RLPEncodedTransaction,
-} from 'web3-core';
 import type { SessionPayload } from '@canvas-js/interfaces';
+import type {
+  RLPEncodedTransaction,
+  TransactionConfig,
+  provider,
+} from 'web3-core';
 import Account from '../../../models/Account';
 import IWebWallet from '../../../models/IWebWallet';
 
@@ -19,7 +19,7 @@ declare let window: any;
 function encodeEthAddress(bech32Prefix: string, address: string): string {
   return bech32.encode(
     bech32Prefix,
-    bech32.toWords(Buffer.from(address.slice(2), 'hex'))
+    bech32.toWords(Buffer.from(address.slice(2), 'hex')),
   );
 }
 
@@ -84,19 +84,19 @@ class CosmosEvmWebWalletController implements IWebWallet<string> {
 
   public async signCanvasMessage(
     account: Account,
-    canvasSessionPayload: SessionPayload
+    canvasSessionPayload: SessionPayload,
   ): Promise<string> {
     const canvas = await import('@canvas-js/interfaces');
     const signature = await this._web3.eth.personal.sign(
       canvas.serializeSessionPayload(canvasSessionPayload),
       this._ethAccounts[0],
-      ''
+      '',
     );
     return signature;
   }
 
   public async signTransaction(
-    tx: TransactionConfig
+    tx: TransactionConfig,
   ): Promise<RLPEncodedTransaction> {
     const rlpEncodedTx = await this._web3.eth.personal.signTransaction(tx, '');
     return rlpEncodedTx;
@@ -119,14 +119,14 @@ class CosmosEvmWebWalletController implements IWebWallet<string> {
       } else {
         for (const acc of this._ethAccounts) {
           this._accounts.push(
-            encodeEthAddress(app.chain?.meta.bech32Prefix || 'inj', acc)
+            encodeEthAddress(app.chain?.meta.bech32Prefix || 'inj', acc),
           );
         }
       }
 
       // fetch chain id from URL using stargate client
       const url = `${window.location.origin}/cosmosAPI/${
-        app.chain?.id || this.defaultNetwork
+        app.chain?.network || this.defaultNetwork
       }`;
       const cosm = await import('@cosmjs/stargate');
       const client = await cosm.StargateClient.connect(url);
@@ -147,14 +147,14 @@ class CosmosEvmWebWalletController implements IWebWallet<string> {
       'accountsChanged',
       async (accounts: string[]) => {
         const encodedAccounts = accounts.map((a) =>
-          encodeEthAddress(app.chain?.meta.bech32Prefix || 'inj', a)
+          encodeEthAddress(app.chain?.meta.bech32Prefix || 'inj', a),
         );
         const updatedAddress = app.user.activeAccounts.find(
-          (addr) => addr.address === encodedAccounts[0]
+          (addr) => addr.address === encodedAccounts[0],
         );
         if (!updatedAddress) return;
         await setActiveAccount(updatedAddress);
-      }
+      },
     );
     // TODO: chainChanged, disconnect events
   }

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_ethereum_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_ethereum_web_wallet.ts
@@ -73,7 +73,7 @@ class EVMKeplrWebWalletController implements IWebWallet<AccountData> {
 
   public async signCanvasMessage(
     account: Account,
-    canvasSessionPayload: SessionPayload
+    canvasSessionPayload: SessionPayload,
   ): Promise<string> {
     const keplr = await import('@keplr-wallet/types');
     const canvas = await import('@canvas-js/interfaces');
@@ -81,7 +81,7 @@ class EVMKeplrWebWalletController implements IWebWallet<AccountData> {
       this._chainId,
       account.address,
       canvas.serializeSessionPayload(canvasSessionPayload),
-      keplr.EthSignType.MESSAGE
+      keplr.EthSignType.MESSAGE,
     );
     return `0x${Buffer.from(signature).toString('hex')}`;
   }
@@ -99,7 +99,7 @@ class EVMKeplrWebWalletController implements IWebWallet<AccountData> {
     this._enabling = true;
     try {
       // fetch chain id from URL using stargate client
-      const url = `${window.location.origin}/cosmosAPI/${app.chain.id}`;
+      const url = `${window.location.origin}/cosmosAPI/${app.chain.network}`;
       const cosm = await import('@cosmjs/stargate');
       const client = await cosm.StargateClient.connect(url);
       const chainId = await client.getChainId();
@@ -110,7 +110,7 @@ class EVMKeplrWebWalletController implements IWebWallet<AccountData> {
         await window.keplr.enable(this._chainId);
       } catch (err) {
         console.log(
-          `Failed to enable chain: ${err.message}. Trying experimentalSuggestChain...`
+          `Failed to enable chain: ${err.message}. Trying experimentalSuggestChain...`,
         );
 
         const bech32Prefix = app.chain.meta.bech32Prefix?.toLowerCase();

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_web_wallet.ts
@@ -1,10 +1,10 @@
+import type { SessionPayload } from '@canvas-js/interfaces';
 import type {
   AccountData,
   OfflineDirectSigner,
   OfflineSigner,
 } from '@cosmjs/proto-signing';
 import type { ChainInfo, Window as KeplrWindow } from '@keplr-wallet/types';
-import type { SessionPayload } from '@canvas-js/interfaces';
 
 import { ChainBase, ChainNetwork, WalletId } from 'common-common/src/types';
 import app from 'state';
@@ -75,14 +75,14 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
 
   public async signCanvasMessage(
     account: Account,
-    canvasSessionPayload: SessionPayload
+    canvasSessionPayload: SessionPayload,
   ): Promise<string> {
     const canvas = await import('@canvas-js/interfaces');
     const chainId = this.getChainId();
     const stdSignature = await window.keplr.signArbitrary(
       chainId,
       account.address,
-      canvas.serializeSessionPayload(canvasSessionPayload)
+      canvas.serializeSessionPayload(canvasSessionPayload),
     );
     return JSON.stringify(stdSignature);
   }
@@ -101,7 +101,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
     try {
       // fetch chain id from URL using stargate client
       const url = `${window.location.origin}/cosmosAPI/${
-        app.chain?.id || this.defaultNetwork
+        app.chain?.network || this.defaultNetwork
       }`;
       const cosm = await import('@cosmjs/stargate');
       const client = await cosm.StargateClient.connect(url);
@@ -113,7 +113,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
         await window.keplr.enable(this._chainId);
       } catch (err) {
         console.log(
-          `Failed to enable chain: ${err.message}. Trying experimentalSuggestChain...`
+          `Failed to enable chain: ${err.message}. Trying experimentalSuggestChain...`,
         );
 
         const bech32Prefix = app.chain.meta.bech32Prefix?.toLowerCase();
@@ -164,7 +164,7 @@ class KeplrWebWalletController implements IWebWallet<AccountData> {
       console.log(`Enabled web wallet for ${this._chainId}`);
 
       this._offlineSigner = await window.keplr.getOfflineSignerAuto(
-        this._chainId
+        this._chainId,
       );
       this._accounts = await this._offlineSigner.getAccounts();
       this._enabled = true;

--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -1,6 +1,6 @@
-import app, { ApiStatus } from 'state';
 import { ChainBase, ChainNetwork, ChainType } from 'common-common/src/types';
 import { updateActiveAddresses } from 'controllers/app/login';
+import app, { ApiStatus } from 'state';
 import ChainInfo from '../models/ChainInfo';
 
 export const deinitChainOrCommunity = async () => {

--- a/packages/commonwealth/client/scripts/views/pages/communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/communities.tsx
@@ -21,7 +21,7 @@ const communityToCategoriesMap = app.config.chainCategoryMap;
 // Handle mapping provided by ChainCategories table
 const communityCategories = Object.values(ChainCategoryType);
 const communityNetworks = Object.keys(ChainNetwork).filter(
-  (val) => val === 'ERC20'
+  (val) => val === 'ERC20',
 ); // We only are allowing ERC20 for now
 const communityBases = Object.keys(ChainBase);
 
@@ -35,7 +35,7 @@ const getInitialFilterMap = (): Record<string, unknown> => {
   }));
   const allArrays = filterMapCommunityCategories.concat(
     filterMapCommunityBases,
-    filterMapCommunityNetworks
+    filterMapCommunityNetworks,
   );
 
   return Object.assign({}, ...allArrays);
@@ -43,7 +43,7 @@ const getInitialFilterMap = (): Record<string, unknown> => {
 
 const CommunitiesPage = () => {
   const [filterMap, setFilterMap] = React.useState<Record<string, unknown>>(
-    getInitialFilterMap()
+    getInitialFilterMap(),
   );
 
   const handleSetFilterMap = (key: string) => {
@@ -81,7 +81,7 @@ const CommunitiesPage = () => {
           filterMap[cat] &&
           (!communityToCategoriesMap[data.id] ||
             !communityToCategoriesMap[data.id].includes(
-              cat as ChainCategoryType
+              cat as ChainCategoryType,
             ))
         ) {
           return false;

--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -97,7 +97,7 @@ export const MIXPANEL_TOKEN = process.env.MIXPANEL_TOKEN;
 
 export const MAGIC_API_KEY = process.env.MAGIC_API_KEY;
 export const MAGIC_SUPPORTED_BASES = (process.env.MAGIC_SUPPORTED_BASES?.split(
-  ','
+  ',',
 ) as ChainBase[]) || [ChainBase.Ethereum];
 export const MAGIC_DEFAULT_CHAIN =
   process.env.MAGIC_DEFAULT_CHAIN || 'ethereum';
@@ -116,6 +116,9 @@ export const ETH_RPC = process.env.ETH_RPC || 'prod';
 export const COSMOS_GOV_V1_CHAIN_IDS = process.env.COSMOS_GOV_V1
   ? process.env.COSMOS_GOV_V1.split(',')
   : [];
+
+export const COSMOS_REGISTRY_API =
+  process.env.COSMOS_REGISTRY_API || 'https://cosmoschains.thesilverfox.pro';
 
 export const CW_BOT_KEY = process.env.CW_BOT_KEY;
 // Don't set default value so if env var is not set the database cleaner will not run

--- a/packages/commonwealth/server/migrations/20231102190018-devnet-networks.js
+++ b/packages/commonwealth/server/migrations/20231102190018-devnet-networks.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "Communities" SET network = 'csdk-beta' where id = 'csdk-beta';
+      UPDATE "Communities" SET network = 'csdk-v1' where id = 'csdk-v1';
+      UPDATE "Communities" SET network = 'csdk' where id = 'csdk';
+      UPDATE "Communities" SET network = 'csdk-beta-ci' where id = 'csdk-beta-ci';
+      UPDATE "Communities" SET network = 'evmos-dev' where id = 'evmos-dev';
+      UPDATE "Communities" SET network = 'evmos-dev-ci' where id = 'evmos-dev-ci';
+      `,
+      { raw: true },
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `
+      UPDATE "Communities" SET network = 'cosmos' where id = 'csdk-beta';
+      UPDATE "Communities" SET network = 'cosmos' where id = 'csdk-v1';
+      UPDATE "Communities" SET network = 'cosmos' where id = 'csdk';
+      UPDATE "Communities" SET network = 'cosmos' where id = 'csdk-beta-ci';
+      UPDATE "Communities" SET network = 'cosmos' where id = 'evmos-dev';
+      UPDATE "Communities" SET network = 'cosmos' where id = 'evmos-dev-ci';
+      `,
+      { raw: true },
+    );
+  },
+};

--- a/packages/commonwealth/server/migrations/20231127213238-devnet-networks.js
+++ b/packages/commonwealth/server/migrations/20231127213238-devnet-networks.js
@@ -2,8 +2,9 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(
-      `
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
       UPDATE "Communities" SET network = 'csdk-beta' where id = 'csdk-beta';
       UPDATE "Communities" SET network = 'csdk-v1' where id = 'csdk-v1';
       UPDATE "Communities" SET network = 'csdk' where id = 'csdk';
@@ -11,13 +12,15 @@ module.exports = {
       UPDATE "Communities" SET network = 'evmos-dev' where id = 'evmos-dev';
       UPDATE "Communities" SET network = 'evmos-dev-ci' where id = 'evmos-dev-ci';
       `,
-      { raw: true },
-    );
+        { raw: true, transaction },
+      );
+    });
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(
-      `
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
       UPDATE "Communities" SET network = 'cosmos' where id = 'csdk-beta';
       UPDATE "Communities" SET network = 'cosmos' where id = 'csdk-v1';
       UPDATE "Communities" SET network = 'cosmos' where id = 'csdk';
@@ -25,7 +28,8 @@ module.exports = {
       UPDATE "Communities" SET network = 'cosmos' where id = 'evmos-dev';
       UPDATE "Communities" SET network = 'cosmos' where id = 'evmos-dev-ci';
       `,
-      { raw: true },
-    );
+        { raw: true, transaction },
+      );
+    });
   },
 };

--- a/packages/commonwealth/server/routes/createChain.ts
+++ b/packages/commonwealth/server/routes/createChain.ts
@@ -20,6 +20,7 @@ import { success } from '../types';
 
 import axios from 'axios';
 import { MixpanelCommunityCreationEvent } from '../../shared/analytics/types';
+import { COSMOS_REGISTRY_API } from '../config';
 import { ServerAnalyticsController } from '../controllers/server_analytics_controller';
 import { ALL_COMMUNITIES } from '../middleware/databaseValidationService';
 import {
@@ -63,7 +64,7 @@ export const Errors = {
   InvalidGithub: 'Github must begin with https://github.com/',
   InvalidAddress: 'Address is invalid',
   NotAdmin: 'Must be admin',
-  UnegisteredCosmosChain: `Check https://cosmos.directory.
+  UnegisteredCosmosChain: `Check https://cosmos.directory. 
   Provided chain_name is not registered in the Cosmos Chain Registry`,
 };
 
@@ -191,9 +192,8 @@ const createChain = async (
       }
     }
 
-    const REGISTRY_API_URL = 'https://cosmoschains.thesilverfox.pro';
     const { data: chains } = await axios.get(
-      `${REGISTRY_API_URL}/api/v1/mainnet`,
+      `${COSMOS_REGISTRY_API}/api/v1/mainnet`,
     );
     const foundRegisteredChain = chains?.find(
       (chain) => chain === cosmos_chain_id,
@@ -352,7 +352,7 @@ const createChain = async (
   }
 
   const [node] = await models.ChainNode.scope('withPrivateData').findOrCreate({
-    where: { [Op.or]: [{ url }, { eth_chain_id }] },
+    where: { url },
     defaults: {
       url,
       eth_chain_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5540 

## Description of Changes
- Only applies `cosmos_chain_id` requirement for new "chain" communities (not offchain)
- Gets default ChainInfo from DB instead of hardcode
- Keplr sign-in pulls target chain from `chain.network` instead of `chain.id` (these are same for onchain, but different for offchain communities)
- Migration to make devnet sandboxes correct network

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- CA (click around) tested on local:
  - sign in to homepage with keplr - expect to sign in with `osmo1..` address by default
  - go to sidebar -> (+) -> New Community
  - Fill out "Name" and select `cosmos` as Base Chain. Save Changes
  - Expect to go to http://localhost:8080/{new-name}/discussions
  - Expect to be Connected with your osmo address
  - Expect to have "Admin Capabilites"

- Regression
  - repeat above steps with Magic sign-in (expect to create community with `cosmos1..` address)
  - repeat above steps for Ethereum or Near Starter Communities (log in with metamask)
  - sign out and go to any Cosmos SDK community and sign in
    - if community is a Chain (kyve, stargaze, csdk, injective), expect to sign in with that chain's address
    - if community is offchain, expect to sign in with `osmo1...` address, (unless that community has updated to a different ChainNode) Ex: /raw-dao-junoswap will be juno

## Deployment Plan
<!--- Omit if unneeded -->

- [x]   env var `COSMOS_REGISTRY_API = https://cosmoschains.thesilverfox.pro` (this is the fallback if omitted)

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 