### PR TITLE
Fixed prettier script

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -5,16 +5,15 @@ RED='\033[31m'
 YELLOW='\033[33m'
 NC='\033[0m' 
 
-FILES=$(git diff --staged --name-only --diff-filter=d)
+FILES=$(git diff --name-only master)
 
 if [ -n "$FILES" ]
 then
     echo -e -n $YELLOW
     echo -e "📐 prettier staged before commit..."
     echo "------------------------------------"
-    echo -e -n $GRAY
-    echo "$FILES" | tr ' ' '\n' | xargs -I {} echo "- {}"
     echo -e $NC
-    echo "$FILES" | tr ' ' '\n' | xargs -I {} npx prettier --write --ignore-unknown {}
-    git add .
+    echo "$FILES" | xargs npx prettier --write --ignore-unknown
+    echo "$FILES" | xargs git add
+    exit 0
 fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -5,6 +5,13 @@ RED='\033[31m'
 YELLOW='\033[33m'
 NC='\033[0m' 
 
+# Prettier best practice for pre-commit hooks
+# Using option 5 until we decide to integrate eslint (and switch to option 1)
+# https://prettier.io/docs/en/precommit.html#option-5-shell-script
+# FILES=$(git diff --staged --name-only --diff-filter=d)
+
+# Getting diff from master as suggested by Timothy 
+# while we establish our formatting rules
 FILES=$(git diff --name-only master)
 
 if [ -n "$FILES" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5550

## Description of Changes
- Simplified prettier script making it run faster

## "How We Fixed It"
So according to the man page, the xargs -I creates a buffer to store, search and replace the string passed in. This buffer creation seems to be the cause of the issue because when I remove this option, the script runs as fast as before.

Although to fix this, I just removed the whole pipe chain completely, as prettier takes in a list of files anyways.

## Test Plan
- Run the prettier script on some files. Make sure that the time per file ~50ms