### PR TITLE
Fix trending tag on thread details page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import app from 'state';
 import { useRefreshMembershipQuery } from 'state/api/groups';
+import { isHot } from 'views/pages/discussions/helpers';
 import Account from '../../../../models/Account';
 import AddressInfo from '../../../../models/AddressInfo';
 import MinimumProfile from '../../../../models/MinimumProfile';
@@ -29,7 +30,7 @@ export type ContentPageSidebarItem = {
 export type SidebarComponents = [
   item?: ContentPageSidebarItem,
   item?: ContentPageSidebarItem,
-  item?: ContentPageSidebarItem
+  item?: ContentPageSidebarItem,
 ];
 
 type ContentPageProps = {
@@ -180,6 +181,7 @@ export const CWContentPage = ({
         isSpamThread={isSpamThread}
         threadStage={stageLabel}
         archivedAt={thread?.archivedAt}
+        isHot={isHot(thread)}
       />
     </div>
   );
@@ -227,7 +229,7 @@ export const CWContentPage = ({
             onProposalStageChange={onProposalStageChange}
             disabledActionTooltipText={disabledActionsTooltipText}
             onSnapshotProposalFromThread={onSnapshotProposalFromThread}
-          />
+          />,
         )}
 
       {subBody}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5412

## Description of Changes
- Fix "trending" tag on view thread page

## "How We Fixed It"


## Test Plan
- Visit a new thread and verify it contains a "trending" tag on both thread list and detail pages

## Deployment Plan
N/A

## Other Considerations
N/A