### PR TITLE
Fix sidebar header visibility b/w switching communities

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -20,7 +20,7 @@ const SidebarHeader = () => {
         }
       />
 
-      <CWText className="header" type={'h5'}>
+      <CWText className="header" type="h5">
         {app?.chain?.meta?.name || <Skeleton width="70%" />}
       </CWText>
     </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -1,10 +1,11 @@
 import 'components/component_kit/CWSidebarHeader/CWSidebarHeader.scss';
 import React from 'react';
 
+import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
+import { Skeleton } from '../../Skeleton';
 import { CWCommunityAvatar } from '../../component_kit/cw_community_avatar';
 import { CWText } from '../../component_kit/cw_text';
-import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 
 const SidebarHeader = () => {
   const navigate = useCommonNavigate();
@@ -12,17 +13,16 @@ const SidebarHeader = () => {
   return (
     <div className="SidebarHeader">
       <CWCommunityAvatar
-        community={app.chain && app.chain.meta}
+        showSkeleton={!app?.chain?.meta}
+        community={app?.chain?.meta}
         onClick={() =>
           navigateToCommunity({ navigate, path: '', chain: app.chain.id })
         }
       />
 
-      {app.chain && (
-        <CWText className="header" type={'h5'}>
-          {app.chain.meta.name}
-        </CWText>
-      )}
+      <CWText className="header" type={'h5'}>
+        {app?.chain?.meta?.name || <Skeleton width="70%" />}
+      </CWText>
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_community_avatar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_community_avatar.tsx
@@ -17,7 +17,7 @@ type CommunityAvatarProps = {
 const CWCommunityAvatarSkeleton = () => {
   return (
     <div className={ComponentType.CommunityAvatar}>
-      <Skeleton circle width={16} height={16} />
+      <Skeleton circle width={31} height={31} />
     </div>
   );
 };
@@ -36,7 +36,7 @@ export const CWCommunityAvatar = (props: CommunityAvatarProps) => {
     <div
       className={getClasses<{ onClick: boolean; size: IconSize }>(
         { onClick: !!onClick, size },
-        ComponentType.CommunityAvatar
+        ComponentType.CommunityAvatar,
       )}
       onClick={onClick}
     >

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -28,7 +28,7 @@ export const Sidebar = ({
 
   useEffect(() => {
     setRecentlyUpdatedVisibility(false);
-  }, []);
+  }, [setRecentlyUpdatedVisibility]);
 
   const sidebarClass = useMemo(() => {
     return clsx('Sidebar', {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -1,25 +1,29 @@
+import clsx from 'clsx';
 import 'components/sidebar/index.scss';
 import React, { useEffect, useMemo } from 'react';
 import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { CreateContentSidebar } from '../../menus/create_content_menu';
+import { SidebarHeader } from '../component_kit/CWSidebarHeader';
 import { CommunitySection } from './CommunitySection';
 import { ExploreCommunitiesSidebar } from './explore_sidebar';
 import { SidebarQuickSwitcher } from './sidebar_quick_switcher';
-import { SidebarHeader } from '../component_kit/CWSidebarHeader';
-import clsx from 'clsx';
 
 export type SidebarMenuName =
   | 'default'
   | 'createContent'
   | 'exploreCommunities';
 
-export const Sidebar = ({ isInsideCommunity }) => {
+export const Sidebar = ({
+  isInsideCommunity,
+}: {
+  isInsideCommunity: boolean;
+}) => {
   const {
     menuName,
     menuVisible,
     setRecentlyUpdatedVisibility,
-    recentlyUpdatedVisibility
+    recentlyUpdatedVisibility,
   } = useSidebarStore();
 
   useEffect(() => {
@@ -29,13 +33,13 @@ export const Sidebar = ({ isInsideCommunity }) => {
   const sidebarClass = useMemo(() => {
     return clsx('Sidebar', {
       onadd: menuVisible && recentlyUpdatedVisibility,
-      onremove: !menuVisible
+      onremove: !menuVisible,
     });
   }, [menuVisible, recentlyUpdatedVisibility]);
 
   return (
     <div className={sidebarClass}>
-      {app.chain && (
+      {isInsideCommunity && (
         <div className="sidebar-header-wrapper">
           <SidebarHeader />
         </div>

--- a/packages/commonwealth/client/styles/components/component_kit/CWSidebarHeader/CWSidebarHeader.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/CWSidebarHeader/CWSidebarHeader.scss
@@ -14,5 +14,7 @@
 
   .header {
     padding: 0px 8px 0px 12px;
+    display: block;
+    width: 100%;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5529

## Description of Changes
- Keeps the sidebar header structurally visible when switching b/w communities

## "How We Fixed It"
By always displaying the header structure 

## Test Plan
- Switch b/w communities and verify the sidebar header doesn't disappear when switching b/w communities

## Deployment Plan
N/A

## Other Considerations
N/A