### PR TITLE
Fix duplicate data on dashboard/for-you section

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/helpers.tsx
@@ -12,7 +12,7 @@ export const subscribeToThread = async (
   threadId: string,
   bothActive: boolean,
   commentSubscription: NotificationSubscription,
-  reactionSubscription: NotificationSubscription
+  reactionSubscription: NotificationSubscription,
 ) => {
   if (bothActive) {
     await app.user.notifications.disableSubscriptions([
@@ -84,6 +84,16 @@ export const fetchActivity = async (requestType: DashboardViews) => {
   } else if (requestType === DashboardViews.Global) {
     activity = await $.post(`${app.serverUrl()}/viewGlobalActivity`);
   }
+
+  if (activity.result) {
+    const uniqueActivity: number[] = [];
+    activity.result = activity?.result?.filter(
+      (x) =>
+        !uniqueActivity.includes(x?.thread_id) &&
+        uniqueActivity.push(x?.thread_id),
+    );
+  }
+
   return activity;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5328

## Description of Changes
- Removes duplicated data on `/dashboard/for-you` section for a user that joined a community with 2 different addresses

## "How We Fixed It"
By filtering out duplicate data

## Test Plan
1. On metamask create two accounts
2. Go to https://commonwealth.im/
3. Sign in with one address
4. Join some community
5. In Account drop menu connect new address from metamask
6. Join same community with new address
7. Go to For you page and verify that you don't see duplicate data

## Deployment Plan
N/A

## Other Considerations
N/A