### PR TITLE
Added null checks for topic id for comment tree

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -197,7 +197,7 @@ export const CommentTree = ({
 
   const handleEditCancel = (
     comment: CommentType<any>,
-    hasContentChanged: boolean
+    hasContentChanged: boolean,
   ) => {
     if (hasContentChanged) {
       openConfirmation({
@@ -243,7 +243,7 @@ export const CommentTree = ({
 
   const handleEditStart = (comment: CommentType<any>) => {
     const editDraft = localStorage.getItem(
-      `${app.activeChainId()}-edit-comment-${comment.id}-storedText`
+      `${app.activeChainId()}-edit-comment-${comment.id}-storedText`,
     );
     if (editDraft) {
       clearEditingLocalStorage(comment.id, ContentType.Comment);
@@ -305,7 +305,7 @@ export const CommentTree = ({
 
   const handleEditConfirm = async (
     comment: CommentType<any>,
-    newDelta: DeltaStatic
+    newDelta: DeltaStatic,
   ) => {
     {
       setEdits((p) => ({
@@ -453,7 +453,7 @@ export const CommentTree = ({
                     !thread.archivedAt &&
                     (!!hasJoinedCommunity ||
                       isAdmin ||
-                      !app.chain.isGatedTopic(thread.topic.id)) &&
+                      !app.chain.isGatedTopic(thread?.topic?.id)) &&
                     canReact
                   }
                   canEdit={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5543

## Description of Changes
- Adds null checks for topic id in comments section (comment tree)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By checking for falsy/non-existant object keys using null checks `?.`

## Test Plan
1. Sign in on https://commonwealth.im/
2. Go to https://commonwealth.im/kunji-finance/discussions
2. Navigate thru pages and verify there is no page break with a msg like this -> `cannot read properties of ......`


## Deployment Plan
N.A

## Other Considerations
Not tested.