### PR TITLE
Fix group access label bug

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/groups/fetchGroups.ts
+++ b/packages/commonwealth/client/scripts/state/api/groups/fetchGroups.ts
@@ -35,7 +35,8 @@ const useFetchGroupsQuery = ({
   chainId,
   includeMembers,
   includeTopics,
-}: FetchGroupsProps) => {
+  enabled = true,
+}: FetchGroupsProps & { enabled?: boolean }) => {
   return useQuery({
     queryKey: [
       ApiEndpoints.FETCH_GROUPS,
@@ -45,6 +46,7 @@ const useFetchGroupsQuery = ({
     ],
     queryFn: () => fetchGroups({ chainId, includeMembers, includeTopics }),
     staleTime: GROUPS_STALE_TIME,
+    enabled,
   });
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -92,7 +92,9 @@ const CommunityMembersPage = () => {
         groups: (groups || [])
           .filter((g) =>
             (g.members || []).find(
-              (x) => x?.address?.address === p.addresses?.[0]?.address,
+              (x) =>
+                x?.address?.address === p.addresses?.[0]?.address &&
+                !x.reject_reason,
             ),
           )
           .sort((a, b) => a.name.localeCompare(b.name))
@@ -135,10 +137,14 @@ const CommunityMembersPage = () => {
           ? true
           : searchFilters.category === 'In group'
           ? (group.members || []).find(
-              (x) => x?.address?.address === app.user.activeAccount.address,
+              (x) =>
+                x?.address?.address === app.user.activeAccount.address &&
+                !x.reject_reason,
             )
           : !(group.members || []).find(
-              (x) => x?.address?.address === app.user.activeAccount.address,
+              (x) =>
+                x?.address?.address === app.user.activeAccount.address &&
+                !x.reject_reason,
             ),
       );
 

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -3,7 +3,10 @@ import { featureFlags } from 'helpers/feature-flags';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
-import { useFetchGroupsQuery } from 'state/api/groups';
+import {
+  useFetchGroupsQuery,
+  useRefreshMembershipQuery,
+} from 'state/api/groups';
 import { useSearchProfilesQuery } from 'state/api/profiles';
 import { SearchProfilesResponse } from 'state/api/profiles/searchProfiles';
 import { useDebounce } from 'usehooks-ts';
@@ -43,6 +46,11 @@ const CommunityMembersPage = () => {
     category: GROUP_AND_MEMBER_FILTERS[0],
   });
 
+  const { data: memberships = null } = useRefreshMembershipQuery({
+    chainId: app.activeChainId(),
+    address: app?.user?.activeAccount?.address,
+  });
+
   const debouncedSearchTerm = useDebounce<string>(
     searchFilters.searchText,
     500,
@@ -59,12 +67,14 @@ const CommunityMembersPage = () => {
     orderBy: APIOrderBy.LastActive,
     orderDirection: APIOrderDirection.Desc,
     includeRoles: true,
+    enabled: app?.user?.activeAccount?.address ? !!memberships : true,
   });
 
   const { data: groups } = useFetchGroupsQuery({
     chainId: app.activeChainId(),
     includeMembers: true,
     includeTopics: true,
+    enabled: app?.user?.activeAccount?.address ? !!memberships : true,
   });
 
   const formattedMembers = useMemo(() => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/GroupsSection/GroupsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/GroupsSection/GroupsSection.tsx
@@ -52,7 +52,7 @@ const GroupsSection = ({
               groupDescription={group.description}
               requirements={group.requirements.map((r) => ({
                 requirementType: requirementTypes?.find(
-                  (x) => x.value === r?.data?.source?.source_type
+                  (x) => x.value === r?.data?.source?.source_type,
                 )?.label,
                 requirementChain:
                   chainTypes
@@ -63,7 +63,7 @@ const GroupsSection = ({
                           r?.data?.source?.evm_chain_id ||
                           r?.data?.source?.cosmos_chain_id ||
                           ''
-                        }`
+                        }`,
                     )
                     ?.label?.split('-')
                     ?.join(' ') || '',
@@ -80,7 +80,10 @@ const GroupsSection = ({
                 if (!app.user.activeAccount || app.user.activeAccount === null)
                   return;
 
-                return x?.address?.address === app.user.activeAccount.address;
+                return (
+                  x?.address?.address === app.user.activeAccount.address &&
+                  !x.reject_reason
+                );
               })}
               topics={group.topics.map((x) => ({ id: x.id, name: x.name }))}
               canEdit={canManageGroups}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5590

## Description of Changes
- Now also checking for membership reject reason to display group access labels

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
We were missing a check to see (group reject reason) for displaying the memberships (members/groups in community)

## Test Plan
- Create a group with certain requirements
- Login with a different (or same) account that doesn't meet those requirements
- Go to `/:scope/members` page and verify that you see correct membership labels

## Deployment Plan
N/A

## Other Considerations
N/A