### PR TITLE
Group form sub requirement options update

### DIFF
--- a/packages/commonwealth/client/scripts/models/NodeInfo.ts
+++ b/packages/commonwealth/client/scripts/models/NodeInfo.ts
@@ -3,13 +3,22 @@ class NodeInfo {
   public readonly name: string;
   public readonly url: string;
   public readonly ethChainId?: number;
+  public readonly cosmosChainId?: string;
   public readonly altWalletUrl?: string;
 
-  constructor({ id, name, url, eth_chain_id, alt_wallet_url }) {
+  constructor({
+    id,
+    name,
+    url,
+    eth_chain_id,
+    cosmos_chain_id,
+    alt_wallet_url,
+  }) {
     this.id = id;
     this.name = name;
     this.url = url;
     this.ethChainId = eth_chain_id;
+    this.cosmosChainId = cosmos_chain_id;
     this.altWalletUrl = alt_wallet_url;
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -12,7 +12,7 @@ import {
   AMOUNT_CONDITIONS,
   chainTypes,
   conditionTypes,
-  requirementTypes
+  requirementTypes,
 } from '../../common/constants';
 import { DeleteGroupModal } from '../DeleteGroupModal';
 import { GroupForm } from '../common/GroupForm';
@@ -23,11 +23,11 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
   const navigate = useCommonNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { mutateAsync: editGroup } = useEditGroupMutation({
-    chainId: app.activeChainId()
+    chainId: app.activeChainId(),
   });
   const { data: groups = [], isLoading } = useFetchGroupsQuery({
     chainId: app.activeChainId(),
-    includeTopics: true
+    includeTopics: true,
   });
   const foundGroup: Group = groups.find((x) => x.id === parseInt(`${groupId}`));
 
@@ -54,8 +54,8 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
             requirementType: {
               value: x.data.source.source_type,
               label: requirementTypes.find(
-                (y) => y.value === x.data.source.source_type
-              )?.label
+                (y) => y.value === x.data.source.source_type,
+              )?.label,
             },
             requirementAmount: x.data.threshold,
             requirementChain: {
@@ -64,15 +64,15 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
               }`,
               label: chainTypes.find(
                 (c) =>
-                  c.value == x.data.source.cosmos_chain_id ||
-                  x.data.source.evm_chain_id
-              )?.label
+                  c.value ==
+                  (x.data.source.cosmos_chain_id || x.data.source.evm_chain_id),
+              )?.label,
             },
             requirementContractAddress: x.data.source.contract_address || '',
             // API doesn't return this, api internally uses the "more than" option, so we set it here explicitly
             requirementCondition: conditionTypes.find(
-              (y) => y.value === AMOUNT_CONDITIONS.MORE
-            )
+              (y) => y.value === AMOUNT_CONDITIONS.MORE,
+            ),
           })),
           requirementsToFulfill:
             foundGroup.requirementsToFulfill === foundGroup.requirements.length
@@ -80,15 +80,15 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
               : foundGroup.requirementsToFulfill,
           topics: (foundGroup.topics || []).map((x) => ({
             label: x.name,
-            value: x.id
-          }))
+            value: x.id,
+          })),
         }}
         onSubmit={(values) => {
           const payload = makeGroupDataBaseAPIPayload(values);
 
           editGroup({
             ...payload,
-            groupId: groupId
+            groupId: groupId,
           })
             .then(() => {
               notifySuccess('Group Updated');

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/RequirementSubForm/RequirementSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/RequirementSubForm/RequirementSubForm.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react';
+import app from 'state';
 import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 import { getClasses } from 'views/components/component_kit/helpers';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import { ChainBase } from '../../../../../../../../../../common-common/src/types';
 import {
+  SPECIFICATIONS,
   TOKENS,
   chainTypes,
   conditionTypes,
-  requirementTypes
+  requirementTypes,
 } from '../../../../common/constants';
 import { RequirementSubFormType } from '../index.types';
 import './RequirementSubForm.scss';
@@ -17,7 +20,7 @@ const RequirementSubForm = ({
   defaultValues = {},
   onRemove = () => null,
   isRemoveable = true,
-  onChange = () => null
+  onChange = () => null,
 }: RequirementSubFormType) => {
   const [requirementType, setRequirementType] = useState('');
   const isTokenRequirement = Object.values(TOKENS).includes(requirementType);
@@ -39,17 +42,25 @@ const RequirementSubForm = ({
           label="Requirement type"
           placeholder="Requirement type"
           {...(defaultValues.requirementType && {
-            defaultValue: [defaultValues.requirementType]
+            defaultValue: [defaultValues.requirementType],
           })}
-          options={requirementTypes.map((requirement) => ({
-            label: requirement.label,
-            value: requirement.value
-          }))}
+          options={requirementTypes
+            .filter((x) =>
+              app.chain.base === ChainBase.CosmosSDK
+                ? x.value === TOKENS.COSMOS_TOKEN
+                : [TOKENS.EVM_TOKEN, ...Object.values(SPECIFICATIONS)].includes(
+                    x.value,
+                  ),
+            )
+            .map((requirement) => ({
+              label: requirement.label,
+              value: requirement.value,
+            }))}
           onChange={(newValue) => {
             setRequirementType(newValue.value);
 
             onChange({
-              requirementType: newValue.value
+              requirementType: newValue.value,
             });
           }}
           className="w-350"
@@ -72,9 +83,9 @@ const RequirementSubForm = ({
           }>(
             {
               'cols-3': isTokenRequirement,
-              'cols-4': !isTokenRequirement
+              'cols-4': !isTokenRequirement,
             },
-            `row-2`
+            `row-2`,
           )}
         >
           <CWSelectList
@@ -83,20 +94,20 @@ const RequirementSubForm = ({
             label="Chain"
             placeholder="Chain"
             {...(defaultValues.requirementChain && {
-              defaultValue: [defaultValues.requirementChain]
+              defaultValue: [defaultValues.requirementChain],
             })}
             options={chainTypes
               .filter(
                 (x) =>
-                  x.chainBase === (isCosmosRequirement ? 'cosmos' : 'ethereum')
+                  x.chainBase === (isCosmosRequirement ? 'cosmos' : 'ethereum'),
               )
               .map((chainType) => ({
                 label: chainType.label,
-                value: `${chainType.value}`
+                value: `${chainType.value}`,
               }))}
             onChange={(newValue) => {
               onChange({
-                requirementChain: newValue.value
+                requirementChain: newValue.value,
               });
             }}
             customError={errors.requirementChain}
@@ -111,11 +122,11 @@ const RequirementSubForm = ({
               fullWidth
               manualStatusMessage=""
               {...(defaultValues.requirementContractAddress && {
-                defaultValue: defaultValues.requirementContractAddress
+                defaultValue: defaultValues.requirementContractAddress,
               })}
               onInput={(e) => {
                 onChange({
-                  requirementContractAddress: (e.target as any).value
+                  requirementContractAddress: (e.target as any).value,
                 });
               }}
               customError={errors.requirementContractAddress}
@@ -127,15 +138,15 @@ const RequirementSubForm = ({
             label="Condition"
             placeholder="Condition"
             {...(defaultValues.requirementCondition && {
-              defaultValue: [defaultValues.requirementCondition]
+              defaultValue: [defaultValues.requirementCondition],
             })}
             options={conditionTypes.map((conditionType) => ({
               label: conditionType.label,
-              value: conditionType.value
+              value: conditionType.value,
             }))}
             onChange={(newValue) => {
               onChange({
-                requirementCondition: newValue.value
+                requirementCondition: newValue.value,
               });
             }}
             customError={errors.requirementCondition}
@@ -151,11 +162,11 @@ const RequirementSubForm = ({
             label="Amount"
             placeholder="Amount"
             {...(defaultValues.requirementAmount && {
-              defaultValue: defaultValues.requirementAmount
+              defaultValue: defaultValues.requirementAmount,
             })}
             onInput={(e) => {
               onChange({
-                requirementAmount: (e.target as any).value
+                requirementAmount: (e.target as any).value,
               });
             }}
             customError={errors.requirementAmount}

--- a/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
@@ -38,17 +38,21 @@ export const conditionTypes = [
 ];
 
 // Get chain id's from the app.config.chains for all eth and cosmos chains
-const ethAndCosmosChains = app.config.chains
+const cosmosChains = app.config.chains
   .getAll()
-  .filter((x) =>
-    x.base === 'ethereum'
-      ? x?.ChainNode?.ethChainId
-      : x.base === 'cosmos'
-      ? true
-      : false,
-  );
-export const chainTypes = ethAndCosmosChains.map((chain) => ({
-  chainBase: chain.base,
-  value: chain.base === 'cosmos' ? 'cosmos' : chain?.ChainNode?.ethChainId,
-  label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
-}));
+  .filter((x) => x.base === 'cosmos');
+export const chainTypes = [
+  ...cosmosChains.map((chain) => ({
+    chainBase: chain.base,
+    value: 'cosmos',
+    label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
+  })),
+  ...app.config.nodes
+    .getAll()
+    .filter((ethChain) => ethChain.ethChainId)
+    .map((chain) => ({
+      chainBase: 'ethereum',
+      value: chain.ethChainId,
+      label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
+    })),
+];

--- a/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
@@ -38,21 +38,11 @@ export const conditionTypes = [
 ];
 
 // Get chain id's from the app.config.chains for all eth and cosmos chains
-const cosmosChains = app.config.chains
+export const chainTypes = app.config.nodes
   .getAll()
-  .filter((x) => x.base === 'cosmos');
-export const chainTypes = [
-  ...cosmosChains.map((chain) => ({
-    chainBase: chain.base,
-    value: 'cosmos',
+  .filter((chain) => chain.ethChainId || chain.cosmosChainId)
+  .map((chain) => ({
+    chainBase: chain.ethChainId ? 'ethereum' : 'cosmos',
+    value: chain.ethChainId || chain.cosmosChainId,
     label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
-  })),
-  ...app.config.nodes
-    .getAll()
-    .filter((ethChain) => ethChain.ethChainId)
-    .map((chain) => ({
-      chainBase: 'ethereum',
-      value: chain.ethChainId,
-      label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
-    })),
-];
+  }));

--- a/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
@@ -31,23 +31,24 @@ export const requirementTypes = [
   { value: TOKENS.EVM_TOKEN, label: 'EVM base tokens' },
 ];
 
-// Get eth chain id from the app.config.chains for these chains
-export const cosmosBaseChainIds = ['cosmos', 'injective'];
-export const ethBaseChainIds = ['axie-infinity', 'ethereum', 'polygon'];
-const chainIdsToFind = [...cosmosBaseChainIds, ...ethBaseChainIds];
-const foundChains = app.config.chains
-  .getAll()
-  .filter((x) => chainIdsToFind.includes(x.id.toLowerCase()));
-export const chainTypes = chainIdsToFind.map((x) => ({
-  chainBase: cosmosBaseChainIds.includes(x) ? 'cosmos' : 'ethereum',
-  value: cosmosBaseChainIds.includes(x)
-    ? 'cosmos' // cosmos and injective have 'cosmos' id
-    : foundChains.find((y) => y.id.toLowerCase() === x)?.ChainNode?.ethChainId,
-  label: x.replace(/\b\w/g, (l) => l.toUpperCase()),
-}));
-
 export const conditionTypes = [
   { value: AMOUNT_CONDITIONS.MORE, label: 'More than' },
   { value: AMOUNT_CONDITIONS.EQUAL, label: 'Equal to' },
   { value: AMOUNT_CONDITIONS.LESS, label: 'Less than' },
 ];
+
+// Get chain id's from the app.config.chains for all eth and cosmos chains
+const ethAndCosmosChains = app.config.chains
+  .getAll()
+  .filter((x) =>
+    x.base === 'ethereum'
+      ? x?.ChainNode?.ethChainId
+      : x.base === 'cosmos'
+      ? true
+      : false,
+  );
+export const chainTypes = ethAndCosmosChains.map((x) => ({
+  chainBase: x.base,
+  value: x.base === 'cosmos' ? 'cosmos' : x?.ChainNode?.ethChainId,
+  label: x.name.replace(/\b\w/g, (l) => l.toUpperCase()),
+}));

--- a/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/common/constants.ts
@@ -47,8 +47,8 @@ const ethAndCosmosChains = app.config.chains
       ? true
       : false,
   );
-export const chainTypes = ethAndCosmosChains.map((x) => ({
-  chainBase: x.base,
-  value: x.base === 'cosmos' ? 'cosmos' : x?.ChainNode?.ethChainId,
-  label: x.name.replace(/\b\w/g, (l) => l.toUpperCase()),
+export const chainTypes = ethAndCosmosChains.map((chain) => ({
+  chainBase: chain.base,
+  value: chain.base === 'cosmos' ? 'cosmos' : chain?.ChainNode?.ethChainId,
+  label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
 }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5581

## Description of Changes
- When in an EVM-compatible community, hides the Requirement option: "Cosmos Base Token"
- When in a cosmos-compatible community, hides the Requirement option: "EVM Base Token"
- Show's all chain bases = 'ethereum' when in an evm community and all chain bases = 'cosmos' when in a cosmos base community

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By adding filters depending on current chain base and showing all chains depending on current/active chain base

## Test Plan
- Go to an EVM-compatible community (ex: dydx), and verify that the Sub Requirement option: "Cosmos Base Token" is hidden
- Go to a cosmos-compatible  community (ex: osmosis), and verify that the Sub Requirement option: "EVM Base Token" is hidden
- Go to an EVM-compatible community and verify you see all options of chains that are ethereum based
- Go to a cosmos-based community and verify you see all options of chains that are cosmos based

## Deployment Plan
N/A

## Other Considerations
N/A