### PR TITLE
Hide edit topic threshold modal when gating is enabled

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
 import { handleRedirectClicks } from 'helpers';
+import { featureFlags } from 'helpers/feature-flags';
+import { useCommonNavigate } from 'navigation/helpers';
+import { matchRoutes, useLocation } from 'react-router-dom';
 import app from 'state';
+import { sidebarStore } from 'state/ui/sidebar';
 import { EditTopicThresholdsModal } from '../../modals/edit_topic_thresholds_modal';
 import { NewTopicModal } from '../../modals/new_topic_modal';
 import { OrderTopicsModal } from '../../modals/order_topics_modal';
+import { isWindowSmallInclusive } from '../component_kit/helpers';
+import { CWModal } from '../component_kit/new_designs/CWModal';
 import { verifyCachedToggleTree } from './helpers';
 import { SidebarSectionGroup } from './sidebar_section';
 import type {
@@ -12,12 +18,6 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-import { CWModal } from '../component_kit/new_designs/CWModal';
-import { useCommonNavigate } from 'navigation/helpers';
-import { featureFlags } from 'helpers/feature-flags';
-import { matchRoutes, useLocation } from 'react-router-dom';
-import { sidebarStore } from 'state/ui/sidebar';
-import { isWindowSmallInclusive } from '../component_kit/helpers';
 
 const resetSidebarState = () => {
   if (isWindowSmallInclusive(window.innerWidth)) {
@@ -29,7 +29,7 @@ const resetSidebarState = () => {
 
 const setAdminToggleTree = (path: string, toggle: boolean) => {
   let currentTree = JSON.parse(
-    localStorage[`${app.activeChainId()}-admin-toggle-tree`]
+    localStorage[`${app.activeChainId()}-admin-toggle-tree`],
   );
 
   const split = path.split('.');
@@ -63,15 +63,15 @@ const AdminSectionComponent = () => {
 
   const matchesManageCommunityRoute = matchRoutes(
     [{ path: '/manage' }, { path: ':scope/manage' }],
-    location
+    location,
   );
   const matchesAnalyticsRoute = matchRoutes(
     [{ path: '/analytics' }, { path: ':scope/analytics' }],
-    location
+    location,
   );
   const matchesContractsRoute = matchRoutes(
     [{ path: '/contracts' }, { path: ':scope/contracts' }],
-    location
+    location,
   );
 
   const adminGroupData: SectionGroupAttrs[] = [
@@ -93,7 +93,7 @@ const AdminSectionComponent = () => {
           app.activeChainId(),
           () => {
             setAdminToggleTree(`children.manageCommunity.toggledState`, toggle);
-          }
+          },
         );
       },
     },
@@ -115,7 +115,7 @@ const AdminSectionComponent = () => {
           app.activeChainId(),
           () => {
             setAdminToggleTree(`children.analytics.toggledState`, toggle);
-          }
+          },
         );
       },
     },
@@ -139,7 +139,7 @@ const AdminSectionComponent = () => {
                 app.activeChainId(),
                 () => {
                   setAdminToggleTree(`children.contracts.toggledState`, toggle);
-                }
+                },
               );
             },
           },
@@ -173,20 +173,24 @@ const AdminSectionComponent = () => {
         setIsOrderTopicsModalOpen(true);
       },
     },
-    {
-      title: 'Edit topic thresholds',
-      isActive: isEditTopicThresholdsModalOpen,
-      isVisible: true,
-      containsChildren: false,
-      displayData: null,
-      isUpdated: false,
-      hasDefaultToggle: false,
-      onClick: (e) => {
-        e.preventDefault();
-        resetSidebarState();
-        setIsEditTopicThresholdsModalOpen(true);
-      },
-    },
+    ...(featureFlags.gatingEnabled
+      ? [
+          {
+            title: 'Edit topic thresholds',
+            isActive: isEditTopicThresholdsModalOpen,
+            isVisible: true,
+            containsChildren: false,
+            displayData: null,
+            isUpdated: false,
+            hasDefaultToggle: false,
+            onClick: (e) => {
+              e.preventDefault();
+              resetSidebarState();
+              setIsEditTopicThresholdsModalOpen(true);
+            },
+          },
+        ]
+      : []),
   ];
 
   // Build Toggle Tree
@@ -198,16 +202,16 @@ const AdminSectionComponent = () => {
   // Check if an existing toggle tree is stored
   if (!localStorage[`${app.activeChainId()}-admin-toggle-tree`]) {
     localStorage[`${app.activeChainId()}-admin-toggle-tree`] = JSON.stringify(
-      adminDefaultToggleTree
+      adminDefaultToggleTree,
     );
   } else if (!verifyCachedToggleTree('admin', adminDefaultToggleTree)) {
     localStorage[`${app.activeChainId()}-admin-toggle-tree`] = JSON.stringify(
-      adminDefaultToggleTree
+      adminDefaultToggleTree,
     );
   }
 
   const toggleTreeState = JSON.parse(
-    localStorage[`${app.activeChainId()}-admin-toggle-tree`]
+    localStorage[`${app.activeChainId()}-admin-toggle-tree`],
   );
 
   const sidebarSectionData: SidebarSectionAttrs = {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -173,7 +173,7 @@ const AdminSectionComponent = () => {
         setIsOrderTopicsModalOpen(true);
       },
     },
-    ...(featureFlags.gatingEnabled
+    ...(!featureFlags.gatingEnabled
       ? [
           {
             title: 'Edit topic thresholds',

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -1,32 +1,33 @@
-import React, { useEffect } from 'react';
 import type { DeltaStatic } from 'quill';
+import React, { useEffect } from 'react';
 
-import app from '../../state';
 import { ChainBase, ChainNetwork } from 'common-common/src/types';
+import { pluralizeWithoutNumberPrefix } from '../../helpers';
 import { useCommonNavigate } from '../../navigation/helpers';
+import app from '../../state';
 import {
   useCreateTopicMutation,
   useFetchTopicsQuery,
 } from '../../state/api/topics';
-import { pluralizeWithoutNumberPrefix } from '../../helpers';
-import { CWTextInput } from '../components/component_kit/cw_text_input';
-import { TokenDecimalInput } from '../components/token_decimal_input';
-import { CWButton } from '../components/component_kit/new_designs/cw_button';
 import { CWCheckbox } from '../components/component_kit/cw_checkbox';
 import { CWLabel } from '../components/component_kit/cw_label';
+import { CWTextInput } from '../components/component_kit/cw_text_input';
 import { CWValidationText } from '../components/component_kit/cw_validation_text';
-import {
-  createDeltaFromText,
-  getTextFromDelta,
-  ReactQuillEditor,
-} from '../components/react_quill_editor';
-import { serializeDelta } from '../components/react_quill_editor/utils';
 import {
   CWModalBody,
   CWModalFooter,
   CWModalHeader,
 } from '../components/component_kit/new_designs/CWModal';
+import { CWButton } from '../components/component_kit/new_designs/cw_button';
+import {
+  ReactQuillEditor,
+  createDeltaFromText,
+  getTextFromDelta,
+} from '../components/react_quill_editor';
+import { serializeDelta } from '../components/react_quill_editor/utils';
+import { TokenDecimalInput } from '../components/token_decimal_input';
 
+import { featureFlags } from 'helpers/feature-flags';
 import '../../../styles/modals/new_topic_modal.scss';
 
 type NewTopicModalProps = {
@@ -43,7 +44,7 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
 
   const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
   const [contentDelta, setContentDelta] = React.useState<DeltaStatic>(
-    createDeltaFromText('')
+    createDeltaFromText(''),
   );
   const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const [description, setDescription] = React.useState<string>('');
@@ -88,7 +89,7 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
           }}
           inputValidationFn={(text: string) => {
             const currentCommunityTopicNames = topics.map((t) =>
-              t.name.toLowerCase()
+              t.name.toLowerCase(),
             );
 
             if (currentCommunityTopicNames.includes(text.toLowerCase())) {
@@ -102,7 +103,7 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
             if (disallowedCharMatches) {
               const err = `The ${pluralizeWithoutNumberPrefix(
                 disallowedCharMatches.length,
-                'char'
+                'char',
               )}
                 ${disallowedCharMatches.join(', ')} are not permitted`;
               setErrorMsg(err);
@@ -126,7 +127,7 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
             setDescription(e.target.value);
           }}
         />
-        {app.activeChainId() && (
+        {!featureFlags.gatingEnabled && app.activeChainId() && (
           <React.Fragment>
             <CWLabel
               label={`Number of tokens needed to post (${app.chain?.meta.default_symbol})`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5583

## Description of Changes
- Hides the "Edit topic thresholds" option from admin panel when gating feature flag is enabled

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By only rendering the option when the gating featured flag is enabled

## Test Plan
- Go to any community as an admin and verify you don't see the "Edit topic thresholds" option in the "Admin capabilities" section in sidebar

## Deployment Plan
N/A

## Other Considerations
ATM I haven't completely removed the modal since its used by the app when the gating feature flag is not enabled -- we will have to remove it once gating feature is no longer behind a feature flag