### PR TITLE
Added extra validation for group form

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
@@ -29,6 +29,7 @@ const CWForm = ({
   const formMethods: UseFormReturn = useForm({
     resolver: zodResolver(validationSchema),
     defaultValues: initialValues,
+    mode: 'all',
   });
 
   const handleFormSubmit = async (event) => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -389,7 +389,7 @@ const GroupForm = ({
               label="Group name"
               placeholder="Group name"
               fullWidth
-              instructionalMessage="Can be up to 40 characters long."
+              instructionalMessage="Can be up to 40 characters long"
               customError={isNameTaken ? 'Group name is already taken' : ''}
               onInput={(e) => {
                 setIsNameTaken(
@@ -402,7 +402,7 @@ const GroupForm = ({
               hookToForm
               label="Description"
               placeholder="Add a description for your group"
-              instructionalMessage="Can be up to 250 characters long."
+              instructionalMessage="Can be up to 250 characters long"
             />
           </section>
 


### PR DESCRIPTION
## Link to Issue
Closes: #5596

## Description of Changes
- Adds input validation for name < 40 characters.
- Adds input validation for description < 250 characters
- Remove the period “.” from helper text copy

## Test Plan
- Create a group. Try to make the name > 40 characters and submit. Make sure it doesn't submit, and an error label pops up. Make under 40 characters, make sure it submits properly.
- Perform the same for description but with 250 character threshold
- Perform these two above steps on the edit group form.

## Other Considerations
- @zakhap All spacing is included in this character count currently (newlines and spaces), is this correct behaviour? The Figma only specifies spacing towards counting, but is ambiguous on newlines.

Looks like:
<img width="443" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/c4cd8b67-de90-4647-b4df-c2299f3d3fdd">
