### PR TITLE
Fix page update on re-auth

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -1,5 +1,6 @@
 import { APIOrderBy, APIOrderDirection } from 'helpers/constants';
 import { featureFlags } from 'helpers/feature-flags';
+import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
@@ -39,6 +40,7 @@ const GROUP_AND_MEMBER_FILTERS: GroupCategory[] = [
 ];
 
 const CommunityMembersPage = () => {
+  useUserActiveAccount();
   const navigate = useCommonNavigate();
 
   const [selectedTab, setSelectedTab] = useState(TABS[0].value);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5609

## Description of Changes
Now added the `useUserActiveAccount` hook to trigger page update on re-auth

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By triggering page update on re-auth

## Test Plan
1. Go to /:scope/members
2. Logout
3. Login again
4. Verify page updates data

## Deployment Plan
N/A

## Other Considerations
N/A