### PR TITLE
Update get profiles route to filter by membership status

### DIFF
--- a/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
+++ b/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
@@ -101,10 +101,10 @@ export async function __searchProfiles(
   if (memberships) {
     switch (memberships) {
       case 'in-group':
-        membershipsWhere = `AND EXISTS (${membershipsWhere})`;
+        membershipsWhere = `AND EXISTS (${membershipsWhere} AND "Memberships".reject_reason IS NULL)`;
         break;
       case 'not-in-group':
-        membershipsWhere = `AND NOT EXISTS (${membershipsWhere})`;
+        membershipsWhere = `AND EXISTS (${membershipsWhere} AND "Memberships".reject_reason IS NOT NULL)`;
         break;
       default:
         throw new AppError(`unsupported memberships param: ${memberships}`);

--- a/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
+++ b/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
@@ -12,12 +12,15 @@ import {
 const Errors = {
   InvalidCommunityId: 'Invalid community ID',
   NoCommunity: 'No community resolved to execute search',
+  NoCommunityForMemberships:
+    'Must specify community ID when filtering by membership status',
 };
 
 type SearchCommentsRequestParams = {
   search: string;
   community_id?: string;
   include_roles?: string;
+  memberships?: string;
 } & PaginationQueryParams;
 
 type SearchCommentsResponse = SearchProfilesResult;
@@ -33,6 +36,10 @@ export const searchProfilesHandler = async (
     throw new AppError(Errors.NoCommunity);
   }
 
+  if (options.memberships && !req.chain) {
+    throw new AppError(Errors.NoCommunityForMemberships);
+  }
+
   const profileSearchResults = await controllers.profiles.searchProfiles({
     community: req.chain,
     search: options.search,
@@ -41,6 +48,7 @@ export const searchProfilesHandler = async (
     page: parseInt(options.page, 10) || 0,
     orderBy: options.order_by,
     orderDirection: options.order_direction as any,
+    memberships: options.memberships,
   });
 
   return success(res, profileSearchResults);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5605

## Description of Changes
- Updates `GET /profiles` route to accept `?memberships` query param
  - `?memberships=in-group` filters to return only profiles which are part of a group in the community
  - `?memberships=not-in-group` filters to return only profiles which are NOT part of a group in the community

## Test Plan
- Create a group for the Stargate community
- Make a request to: http://localhost:8080/api/profiles?community_id=stargatetoken&search=&limit=10&page=1&memberships=in-group
  - Confirm that it returns profiles that are in a group
- Make a request to: http://localhost:8080/api/profiles?community_id=stargatetoken&search=&limit=10&page=1&memberships=not-in-group
  - Confirm this it returns profiles that are NOT in a group

## Deployment Plan
N/A

## Other Considerations
When a group is first created, memberships are computed in the background. This can take up to a few minutes depending on the number of members in the community.