### PR TITLE
Use memberships filter for profiles

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
@@ -35,7 +35,7 @@ interface SearchProfilesProps {
   orderBy: APIOrderBy;
   orderDirection: APIOrderDirection;
   includeRoles: boolean;
-
+  includeMembershipTypes?: 'in-group' | 'not-in-group';
   enabled?: boolean;
 }
 
@@ -46,6 +46,7 @@ const searchProfiles = async ({
   limit,
   orderBy,
   orderDirection,
+  includeMembershipTypes,
   includeRoles,
 }: SearchProfilesProps & { pageParam: number }) => {
   const {
@@ -64,6 +65,7 @@ const searchProfiles = async ({
         order_by: orderBy,
         order_direction: orderDirection,
         include_roles: includeRoles,
+        ...(includeMembershipTypes && { memberships: includeMembershipTypes }),
       },
     },
   );
@@ -77,6 +79,7 @@ const useSearchProfilesQuery = ({
   orderBy,
   orderDirection,
   includeRoles,
+  includeMembershipTypes,
   enabled = true,
 }: SearchProfilesProps) => {
   const key = [
@@ -86,6 +89,7 @@ const useSearchProfilesQuery = ({
       orderBy,
       orderDirection,
       includeRoles,
+      includeMembershipTypes,
     },
   ];
   return useInfiniteQuery(
@@ -98,6 +102,7 @@ const useSearchProfilesQuery = ({
         limit,
         orderBy,
         orderDirection,
+        includeMembershipTypes,
         includeRoles,
       }),
     {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -25,7 +25,7 @@ import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
 import './CommunityMembersPage.scss';
 import GroupsSection from './GroupsSection';
 import MembersSection from './MembersSection';
-import { GroupCategory, SearchFilters } from './index.types';
+import { GroupCategory, MembershipFilter, SearchFilters } from './index.types';
 
 const TABS = [
   { value: 'all-members', label: 'All members' },
@@ -69,6 +69,12 @@ const CommunityMembersPage = () => {
     orderDirection: APIOrderDirection.Desc,
     includeRoles: true,
     enabled: app?.user?.activeAccount?.address ? !!memberships : true,
+    ...(searchFilters.category !== 'All groups' && {
+      includeMembershipTypes: searchFilters.category
+        .split(' ')
+        .join('-')
+        .toLowerCase() as MembershipFilter,
+    }),
   });
 
   const { data: groups } = useFetchGroupsQuery({
@@ -118,21 +124,10 @@ const CommunityMembersPage = () => {
             ) ||
             p.name.toLowerCase().includes(debouncedSearchTerm.toLowerCase())
           : true,
-      )
-      .filter((p) => {
-        if (searchFilters.category === GROUP_AND_MEMBER_FILTERS[0]) {
-          return true;
-        }
-
-        if (searchFilters.category === GROUP_AND_MEMBER_FILTERS[1]) {
-          return p.groups.length > 0;
-        }
-
-        return p.groups.length === 0;
-      });
+      );
 
     return results;
-  }, [members, groups, debouncedSearchTerm, searchFilters.category]);
+  }, [members, groups, debouncedSearchTerm]);
 
   const filteredGroups = useMemo(() => {
     const filteredGroupsArr = (groups || [])

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/index.types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/index.types.ts
@@ -4,3 +4,5 @@ export type SearchFilters = {
   searchText?: string;
   category?: GroupCategory;
 };
+
+export type MembershipFilter = 'in-group' | 'not-in-group';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5604

## Description of Changes
We updated the API in https://github.com/hicommonwealth/commonwealth/pull/5613 to return profiles that are either a member of a group or not based on a `memberships` query param. This PR adds frontend changes to use the new API params and fix the infinite load bug

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
N/A

## Test Plan
- Go to a community members page (make sure the community has no members that are a part of group and overall member count is more than 1000 -- this is to replicate the multiple API calls)
- From the filter select "In group"
- Confirm that you don't see multiple API calls to `/profiles` in network tab

## Deployment Plan
~~We need to merge https://github.com/hicommonwealth/commonwealth/pull/5613 before this can go in.~~ its merged

## Other Considerations
N/A