### PR TITLE
5280/israel/h1 h2 changes

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
@@ -10,7 +10,7 @@
 
     .title {
       font-family: $font-family-silka;
-      font-size: 24px;
+      font-size: 28px;
       line-height: 36px;
       font-weight: 600;
       word-break: break-word;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
@@ -60,7 +60,6 @@
       div,
       span,
       p {
-        font-size: 16px !important;
         line-height: 24px !important;
         /* identical to box height, or 143% */
 

--- a/packages/commonwealth/client/styles/components/quill/quill.snow.css
+++ b/packages/commonwealth/client/styles/components/quill/quill.snow.css
@@ -225,7 +225,7 @@
 }
 
 .ql-snow .ql-editor h1 {
-  font-size: 2em;
+  font-size: 24px;
 }
 
 .ql-snow .ql-editor h2 {
@@ -557,7 +557,7 @@
 .ql-toolbar.ql-snow {
   border: 1px solid #ccc;
   box-sizing: border-box;
-  font-family: helvetica neue, helvetica, arial, sans-serif;
+  font-family: times, helvetica neue, helvetica, arial, sans-serif;
   padding: 8px;
 }
 

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -54,7 +54,7 @@
 
   h1 {
     font-size: 26px;
-    font-family: Silka;
+    font-family: $font-family-silka;
   }
 
   h2,
@@ -62,8 +62,8 @@
   h4,
   h5,
   h6 {
-    font-size: 19.5px;
-    font-family: Silka;
+    font-size: 20px;
+    font-family: $font-family-silka;
   }
 
   img {

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -53,7 +53,7 @@
   }
 
   h1 {
-    font-size: 26px;
+    font-size: 24px;
     font-family: $font-family-silka;
   }
 

--- a/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/quill/quill_formatted_text.scss
@@ -53,7 +53,8 @@
   }
 
   h1 {
-    font-size: 1.5em;
+    font-size: 26px;
+    font-family: Silka;
   }
 
   h2,
@@ -61,7 +62,8 @@
   h4,
   h5,
   h6 {
-    font-size: 1.23em;
+    font-size: 19.5px;
+    font-family: Silka;
   }
 
   img {

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -121,6 +121,12 @@
     &.ql-blank::before {
       font-style: normal;
     }
+    & h1 {
+      font-size: 24px !important;
+    }
+    & h2 {
+      font-size: 20px !important;
+    }
   }
 
   .ondragover {

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -116,6 +116,7 @@
 
   .ql-editor {
     min-height: 212px;
+    font-family: silka;
 
     &.ql-blank::before {
       font-style: normal;

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -116,7 +116,7 @@
 
   .ql-editor {
     min-height: 212px;
-    font-family: silka;
+    font-family: $font-family-silka;
 
     &.ql-blank::before {
       font-style: normal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5280 

## Description of Changes
- Changed h1 and h2 font sizes and styles

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed font sizes and added styles in react_quill_editor.scss and quill_formatted_text.scss, changed Title size in CommentCard to 28px as per Jess designs

NOTE: I was unable to figure out how to change the font size in the quill editor, despite being able to change the font family. What I think is happening is every time a new editor is opened the default settings from quill are overriding the css font size styles we have in place. The default font sizes can be referenced [here from the quill docs](https://quilljs.com/docs/formats/)(inspect their editor and see the default pixel sizes for h1 and h2, 26px and 19.5px respectively). 
