### PR TITLE
Add ddd issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_command.md
+++ b/.github/ISSUE_TEMPLATE/feature_command.md
@@ -1,0 +1,51 @@
+---
+name: Command Handler Feature Request
+about: Use this template for requesting a command handler feature within a user story.
+labels: command, enhancement, needs estimate
+---
+
+# Description
+<!-- A clear and concise description of the feature. -->
+
+## Stakeholders
+<!-- The main points of contact for questions relating to the scope of the feature. -->
+| Product   | Engineering |
+| --------- | ----------- |
+| @Jane     | @John       |
+
+## Model
+<!-- A screenshot or reference to the slice of the model in context. -->
+
+## Engineering Requirements
+<!-- List of engineering items required as part of the feature. -->
+
+1. **Authorization**
+   - Who's authorized to execute this command? Roles, Groups?
+2. **Message Schemas** - Use [zod](http://zod.dev)
+   - Command schema
+3. **Routing**
+   - Define REST path, verb - params, query string
+   - Include validation schemas (params, query)
+4. **Loading Aggregate**
+   - Define repository interface used to load (hydrate) model
+   - New interface might be required (get by id variants)
+5. **Business Rules**
+   - Define model invariants to check before accepting this command,based on current state and incoming payload
+6. **Mutations**
+   - Define model mutations produced by this command
+   - This might require new or modified schemas
+7. **Persistence**
+   - Define repository interfaces used to persist mutations, including data schemas
+8. **Events**
+   - Define mechanisms used to inform the system about this change - publishing events or synchronously calling a policy
+   - Consider integration tradeoffs - inline, retries, circuit breakers, fire-and-forget, pubsub topics, etc
+   - Define Event Schemas - Use [zod](http://zod.dev)
+9. **Response**
+   - Define success, including response schema (zod)
+   - Define errors (HTTP codes)
+
+## Unit Testing
+<!-- List unit testing scenarios in given-when-then format to cover this feature. -->
+
+## Additional Context
+<!-- (Optional) Any other context here, including unanswered hotspots. -->

--- a/.github/ISSUE_TEMPLATE/feature_policy.md
+++ b/.github/ISSUE_TEMPLATE/feature_policy.md
@@ -1,0 +1,40 @@
+---
+name: Policy Feature Request
+about: Use this template for requesting a policy feature within a user story.
+labels: policy, enhancement, needs estimate
+---
+
+# Description
+<!-- A clear and concise description of the feature. -->
+
+## Stakeholders
+<!-- The main points of contact for questions relating to the scope of the feature. -->
+| Product   | Engineering |
+| --------- | ----------- |
+| @Jane     | @John       |
+
+## Model
+<!-- A screenshot or reference to the slice of the model in context. -->
+
+## Engineering Requirements
+<!-- List of engineering items required as part of the feature. -->
+
+1. **Integration**
+   - Define integration strategy (webhook, direct model sync API call, pubsub, etc)
+2. **Routing**
+   - Define REST path, verb - Usually POST with event in body (if exposed as HTTP endpoint)
+   - Reference to event schemas (found in command features) - body contract
+3. **References**
+   - Define projections used to complement business rules, and how to query them
+4. **Business Rules**
+   - Define policy rules and commands to be invoked
+   - Reference to command schemas (found in command features)
+5. **Response**
+   - Define success, including
+   - Define errors (HTTP codes, dead-letter-queues)
+
+## Unit Testing
+<!-- List unit testing scenarios in given-when-then format to cover this feature. -->
+
+## Additional Context
+<!-- (Optional) Any other context here, including unanswered hotspots. -->

--- a/.github/ISSUE_TEMPLATE/feature_projection.md
+++ b/.github/ISSUE_TEMPLATE/feature_projection.md
@@ -1,0 +1,45 @@
+---
+name: Projection Feature Request
+about: Use this template for requesting a projection feature within a user story.
+labels: projection, enhancement, needs estimate
+---
+
+# Description
+<!-- A clear and concise description of the feature. -->
+
+## Stakeholders
+<!-- The main points of contact for questions relating to the scope of the feature. -->
+| Product   | Engineering |
+| --------- | ----------- |
+| @Jane     | @John       |
+
+## Model
+<!-- A screenshot or reference to the slice of the model in context. -->
+
+## Engineering Requirements
+<!-- List of engineering items required as part of the feature. -->
+
+1. **Authorization**
+   - Who's authorized to query this projection? Roles, Groups?
+2. **Projection Schema** - Use [zod](http://zod.dev)
+   - Projection schema (Mainly for the UI, but required for CQRS)
+3. **Routing**
+   - Define REST query paths (GET) - params, query string
+   - Include validation schemas (params, query)
+   - Include pagination requirements
+4. **Query**
+   - Define repository interface used to query this projection
+   - New interface might be required
+5. **Business Rules**
+   - Define projection rules for the events we are projecting (reference to event schemas can be found in command features)
+6. **Persistence**
+   - Define repository interfaces used to persist projections, including data schemas
+7. **Response**
+   - Define success, including response schema (zod)
+   - Define errors (HTTP codes)
+
+## Unit Testing
+<!-- List unit testing scenarios in given-when-then format to cover this feature. -->
+
+## Additional Context
+<!-- (Optional) Any other context here, including unanswered hotspots. -->


### PR DESCRIPTION
We will be adopting a new system to link tech-spec tickets against the SDD model. The ticket bodies will contain the final spec for each slice of the model, and will be written in collaboration between the assigned resource and engineering leadership. The intent here is to minimize the replication of documentation, which is prone to loss, and attempt to stick the engineering specifications as close as possible to the model.

## Description of Changes
- This PR creates GH issue templates for new features, based on DDD artifacts found in the model, including commands, policies, and projections.