### PR TITLE
Update chain_id to community_id in groups modal

### DIFF
--- a/packages/commonwealth/client/scripts/models/Group.ts
+++ b/packages/commonwealth/client/scripts/models/Group.ts
@@ -1,6 +1,6 @@
 interface APIResponseFormat {
   id: number;
-  chain_id: string;
+  community_id: string;
   metadata: {
     name: string;
     description?: string;
@@ -36,7 +36,7 @@ class Group {
 
   constructor({
     id,
-    chain_id,
+    community_id,
     created_at,
     updated_at,
     metadata,
@@ -45,7 +45,7 @@ class Group {
     memberships,
   }: APIResponseFormat) {
     this.id = id;
-    this.communityId = chain_id;
+    this.communityId = community_id;
     this.createdAt = created_at;
     this.updatedAt = updated_at;
     this.name = metadata.name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5650

## Description of Changes
- Fixes API response key name in frontend

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
N/A

## Test Plan
N/A -- frontend doesn't use this (`community_id`) key yet from the /groups response

## Deployment Plan
N/A

## Other Considerations
N/A