### PR TITLE
Fix not-in-group tags

### DIFF
--- a/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
+++ b/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
@@ -109,7 +109,7 @@ export async function __searchProfiles(
         membershipsWhere = `AND EXISTS (${membershipsWhere} AND "Memberships".reject_reason IS NULL)`;
         break;
       case 'not-in-group':
-        membershipsWhere = `AND EXISTS (${membershipsWhere} AND "Memberships".reject_reason IS NOT NULL)`;
+        membershipsWhere = `AND NOT EXISTS (${membershipsWhere} AND "Memberships".reject_reason IS NULL)`;
         break;
       default:
         throw new AppError(`unsupported memberships param: ${memberships}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5666

## Description of Changes
-  Fixes not-in-group `group_ids` array for the `GET /profiles` route

## "How We Fixed It"
- Fix SQL query to properly exclude groups the member is accepted in

## Test Plan
- As super admin, go to http://localhost:8080/stargatetoken/members?tab=all-members
- Ensure that there are multiple groups with different requirements
- Set filter to "Not in group"
  - Confirm that all listed profiles do NOT show any group tags

## Deployment Plan
N/A

## Other Considerations
N/A