### PR TITLE
Fix `viewChainIcons` route

### DIFF
--- a/packages/commonwealth/server/routes/viewChainIcons.ts
+++ b/packages/commonwealth/server/routes/viewChainIcons.ts
@@ -6,17 +6,17 @@ const viewChainIcons = async (
   models: DB,
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ) => {
-  if (!req.body.chains) {
+  if (!req.body.communities) {
     return next(new AppError('Must provide a list of chains'));
   }
-  const chains = JSON.parse(req.body.chains);
+  const communities = JSON.parse(req.body.communities);
 
   const iconUrls = await models.Community.findAll({
     attributes: ['id', 'icon_url'],
     where: {
-      id: chains,
+      id: communities,
     },
     raw: true,
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5679

## Description of Changes
- Updates route body parameter to `communities`.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Client was already sending `communities` in the body but the route expected `chains` so updated `chains` to `communities`

## Test Plan
- Sign in
- Ensure chain dashboard renders without an error

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 