### PR TITLE
Fix validateGroupMembership when required requirements is set

### DIFF
--- a/packages/commonwealth/server/util/requirementsModule/validateGroupMembership.ts
+++ b/packages/commonwealth/server/util/requirementsModule/validateGroupMembership.ts
@@ -9,6 +9,7 @@ export type ValidateGroupMembershipResponse = {
     requirement: Requirement;
     message: string;
   }[];
+  numRequirementsMet?: number;
 };
 
 /**
@@ -22,7 +23,7 @@ export default async function validateGroupMembership(
   userAddress: string,
   requirements: Requirement[],
   tbc?: TokenBalanceCache,
-  numRequiredRequirements: number = 0
+  numRequiredRequirements: number = 0,
 ): Promise<ValidateGroupMembershipResponse> {
   const response: ValidateGroupMembershipResponse = {
     isValid: true,
@@ -30,6 +31,7 @@ export default async function validateGroupMembership(
   };
   let allowListOverride = false;
   let numRequirementsMet = 0;
+
   const checks = requirements.map(async (requirement) => {
     let checkResult: { result: boolean; message: string };
     switch (requirement.rule) {
@@ -40,7 +42,7 @@ export default async function validateGroupMembership(
       case 'allow': {
         checkResult = await _allowlistCheck(
           userAddress,
-          requirement.data as AllowlistData
+          requirement.data as AllowlistData,
         );
         if (checkResult.result) {
           allowListOverride = true;
@@ -54,6 +56,7 @@ export default async function validateGroupMembership(
         };
         break;
     }
+
     if (checkResult.result) {
       numRequirementsMet++;
     } else {
@@ -64,17 +67,21 @@ export default async function validateGroupMembership(
       });
     }
   });
+
   await Promise.all(checks);
+
   if (allowListOverride) {
     // allow if address is whitelisted
     return { isValid: true };
   }
-  if (
-    numRequiredRequirements &&
-    numRequirementsMet >= numRequiredRequirements
-  ) {
-    // allow if minimum number of requirements met
-    return { isValid: true };
+
+  if (numRequiredRequirements) {
+    if (numRequirementsMet >= numRequiredRequirements) {
+      // allow if minimum number of requirements met
+      return { isValid: true, numRequirementsMet };
+    } else {
+      return { isValid: false, numRequirementsMet };
+    }
   }
   return response;
 }
@@ -82,7 +89,7 @@ export default async function validateGroupMembership(
 async function _thresholdCheck(
   userAddress: string,
   thresholdData: ThresholdData,
-  tbc: TokenBalanceCache
+  tbc: TokenBalanceCache,
 ): Promise<{ result: boolean; message: string }> {
   try {
     let chainNetwork: ChainNetwork;
@@ -119,7 +126,7 @@ async function _thresholdCheck(
       chainNetwork,
       userAddress,
       chainId,
-      contractAddress
+      contractAddress,
     );
 
     const result = toBN(balance).gt(toBN(thresholdData.threshold));
@@ -139,7 +146,7 @@ async function _thresholdCheck(
 
 async function _allowlistCheck(
   userAddress: string,
-  allowlistData: AllowlistData
+  allowlistData: AllowlistData,
 ): Promise<{ result: boolean; message: string }> {
   try {
     const result = allowlistData.allow.includes(userAddress);

--- a/packages/commonwealth/test/unit/requirementsModule/requirements.spec.ts
+++ b/packages/commonwealth/test/unit/requirementsModule/requirements.spec.ts
@@ -1,351 +1,347 @@
 import { assert } from 'chai';
+import { ChainNetwork } from '../../../../common-common/src/types';
+import { TokenBalanceCache } from '../../../../token-balance-cache/src';
 import { Requirement } from '../../../server/util/requirementsModule/requirementsTypes';
 import validateGroupMembership, {
   ValidateGroupMembershipResponse,
 } from '../../../server/util/requirementsModule/validateGroupMembership';
-import { TokenBalanceCache } from '../../../../token-balance-cache/src';
-import { ChainNetwork } from '../../../../common-common/src/types';
 
 describe('validateGroupMembership', () => {
-  it('should return a valid response', async () => {
-    const userAddress: string = 'mockUserAddress';
-    const requirements: Requirement[] = [];
-    it('should pass basic erc20 check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1000',
-            source: {
-              source_type: 'erc20',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
+  it('should pass basic erc20 check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1000',
+          source: {
+            source_type: 'erc20',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
           },
         },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
-          return '2000';
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        return '2000';
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
 
-      assert.equal(result.isValid, true);
-    });
-    it('should pass basic erc721 check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1',
-            source: {
-              source_type: 'erc721',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
+    assert.equal(result.isValid, true);
+  });
+  it('should pass basic erc721 check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1',
+          source: {
+            source_type: 'erc721',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
           },
         },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        return '2';
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+
+    assert.equal(result.isValid, true);
+  });
+  it('should pass basic ethNative check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1000',
+          source: {
+            source_type: 'eth_native',
+            evm_chain_id: 1,
+          },
+        },
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        return '2000';
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+
+    assert.equal(result.isValid, true);
+  });
+  it('should fail basic eth_native check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '2000',
+          source: {
+            source_type: 'erc20',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
+          },
+        },
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        return '1';
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+
+    assert.equal(result.isValid, false);
+    assert.equal(result.messages.length, 1);
+  });
+  it('should fail basic erc20 check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '2000',
+          source: {
+            source_type: 'erc20',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
+          },
+        },
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        return '1000';
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+
+    assert.equal(result.isValid, false);
+    assert.equal(result.messages.length, 1);
+  });
+  it('should pass allowlist', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'allow',
+        data: {
+          allow: ['0x123456'],
+        },
+      },
+    ];
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(userAddress, requirements);
+
+    assert.equal(result.isValid, true);
+  });
+  it('should fail allowlist', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'allow',
+        data: {
+          allow: ['0x1234564545'],
+        },
+      },
+    ];
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(userAddress, requirements);
+
+    assert.equal(result.isValid, false);
+    assert.equal(result.messages.length, 1);
+  });
+  it('should pass multi-requirement check', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '2000',
+          source: {
+            source_type: 'erc20',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
+          },
+        },
+      },
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1',
+          source: {
+            source_type: 'erc721',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
+          },
+        },
+      },
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1000',
+          source: {
+            source_type: 'eth_native',
+            evm_chain_id: 1,
+          },
+        },
+      },
+      {
+        rule: 'allow',
+        data: {
+          allow: ['0x123456'],
+        },
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        if (network == ChainNetwork.ERC20) {
+          return '3000';
+        } else if (network == ChainNetwork.ERC721) {
           return '2';
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
-
-      assert.equal(result.isValid, true);
-    });
-    it('should pass basic ethNative check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1000',
-            source: {
-              source_type: 'eth_native',
-              evm_chain_id: 1,
-            },
-          },
-        },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
+        } else if (network == ChainNetwork.Ethereum) {
           return '2000';
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
+        }
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
 
-      assert.equal(result.isValid, true);
-    });
-    it('should fail basic eth_native check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '2000',
-            source: {
-              source_type: 'erc20',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
+    assert.equal(result.isValid, true);
+  });
+  it('should fail multi-requirement check with 2 messages', async () => {
+    const userAddress: string = '0x123456';
+    const requirements: Requirement[] = [
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '2000',
+          source: {
+            source_type: 'erc20',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
           },
         },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
-          return '1';
+      },
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '5',
+          source: {
+            source_type: 'erc721',
+            evm_chain_id: 1,
+            contract_address: '0x12345',
+          },
         },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
+      },
+      {
+        rule: 'threshold',
+        data: {
+          threshold: '1000',
+          source: {
+            source_type: 'eth_native',
+            evm_chain_id: 1,
+          },
+        },
+      },
+      {
+        rule: 'allow',
+        data: {
+          allow: ['0x12345'],
+        },
+      },
+    ];
+    const tbc = {
+      fetchUserBalanceWithChain: async function (
+        network,
+        userAddress: string,
+        chainId: string,
+        contractAddress?: string,
+      ): Promise<string> {
+        if (network == ChainNetwork.ERC20) {
+          return '3000';
+        } else if (network == ChainNetwork.ERC721) {
+          return '2';
+        } else if (network == ChainNetwork.Ethereum) {
+          return '2000';
+        }
+      },
+    };
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        userAddress,
+        requirements,
+        tbc as TokenBalanceCache,
+      );
 
-      assert.equal(result.isValid, false);
-      assert.equal(result.messages.length, 1);
-    });
-    it('should fail basic erc20 check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '2000',
-            source: {
-              source_type: 'erc20',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
-          },
-        },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
-          return '1000';
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
-
-      assert.equal(result.isValid, false);
-      assert.equal(result.messages.length, 1);
-    });
-    it('should pass allowlist', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'allow',
-          data: {
-            allow: ['0x123456'],
-          },
-        },
-      ];
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(userAddress, requirements);
-
-      assert.equal(result.isValid, true);
-    });
-    it('should fail allowlist', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'allow',
-          data: {
-            allow: ['0x1234564545'],
-          },
-        },
-      ];
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(userAddress, requirements);
-
-      assert.equal(result.isValid, false);
-      assert.equal(result.messages.length, 1);
-    });
-    it('should pass multi-requirement check', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '2000',
-            source: {
-              source_type: 'erc20',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
-          },
-        },
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1',
-            source: {
-              source_type: 'erc721',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
-          },
-        },
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1000',
-            source: {
-              source_type: 'eth_native',
-              evm_chain_id: 1,
-            },
-          },
-        },
-        {
-          rule: 'allow',
-          data: {
-            allow: ['0x123456'],
-          },
-        },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
-          if (network == ChainNetwork.ERC20) {
-            return '3000';
-          } else if (network == ChainNetwork.ERC721) {
-            return '2';
-          } else if (network == ChainNetwork.Ethereum) {
-            return '2000';
-          }
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
-
-      assert.equal(result.isValid, true);
-    });
-    it('should fail multi-requirement check with 2 messages', async () => {
-      const userAddress: string = '0x123456';
-      const requirements: Requirement[] = [
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '2000',
-            source: {
-              source_type: 'erc20',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
-          },
-        },
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '5',
-            source: {
-              source_type: 'erc721',
-              evm_chain_id: 1,
-              contract_address: '0x12345',
-            },
-          },
-        },
-        {
-          rule: 'threshold',
-          data: {
-            threshold: '1000',
-            source: {
-              source_type: 'eth_native',
-              evm_chain_id: 1,
-            },
-          },
-        },
-        {
-          rule: 'allow',
-          data: {
-            allow: ['0x12345'],
-          },
-        },
-      ];
-      const tbc = {
-        fetchUserBalanceWithChain: async function (
-          network,
-          userAddress: string,
-          chainId: string,
-          contractAddress?: string
-        ): Promise<string> {
-          if (network == ChainNetwork.ERC20) {
-            return '3000';
-          } else if (network == ChainNetwork.ERC721) {
-            return '2';
-          } else if (network == ChainNetwork.Ethereum) {
-            return '2000';
-          }
-        },
-      };
-      const result: ValidateGroupMembershipResponse =
-        await validateGroupMembership(
-          userAddress,
-          requirements,
-          tbc as TokenBalanceCache
-        );
-
-      assert.equal(result.isValid, false);
-      assert.equal(result.messages.length, 2);
-    });
+    assert.equal(result.isValid, false);
+    assert.equal(result.messages.length, 2);
   });
 });

--- a/packages/commonwealth/test/unit/requirementsModule/validateGroupMembership.spec.ts
+++ b/packages/commonwealth/test/unit/requirementsModule/validateGroupMembership.spec.ts
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { Requirement } from 'server/util/requirementsModule/requirementsTypes';
+import validateGroupMembership, {
+  ValidateGroupMembershipResponse,
+} from 'server/util/requirementsModule/validateGroupMembership';
+import { ChainNetwork } from '../../../../common-common/src/types';
+import { TokenBalanceCache } from '../../../../token-balance-cache/src';
+
+function createMockRequirements(thresholds: string[]): Requirement[] {
+  return [
+    {
+      rule: 'threshold',
+      data: {
+        threshold: thresholds[0] || '0',
+        source: {
+          source_type: 'erc20',
+          evm_chain_id: 1,
+          contract_address: '0x12345',
+        },
+      },
+    },
+    {
+      rule: 'threshold',
+      data: {
+        threshold: thresholds[1] || '0',
+        source: {
+          source_type: 'erc721',
+          evm_chain_id: 1,
+          contract_address: '0x12345',
+        },
+      },
+    },
+    {
+      rule: 'threshold',
+      data: {
+        threshold: thresholds[2] || '0',
+        source: {
+          source_type: 'eth_native',
+          evm_chain_id: 1,
+        },
+      },
+    },
+  ];
+}
+
+function createMockTBC(thresholds: string[]) {
+  return {
+    fetchUserBalanceWithChain: async function (
+      network,
+      userAddress: string,
+      chainId: string,
+      contractAddress?: string,
+    ): Promise<string> {
+      if (network == ChainNetwork.ERC20) {
+        return thresholds[0] || '0';
+      } else if (network == ChainNetwork.ERC721) {
+        return thresholds[1] || '0';
+      } else if (network == ChainNetwork.Ethereum) {
+        return thresholds[2] || '0';
+      }
+    },
+  } as TokenBalanceCache;
+}
+
+describe('validateGroupMembership', () => {
+  it('should fail if 0 of 3 requirements met with 3 required', async () => {
+    const tbc = createMockTBC(['0', '0', '0']);
+    const requirements = createMockRequirements(['1', '1', '1']);
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        '0x123',
+        requirements,
+        tbc as TokenBalanceCache,
+        3,
+      );
+
+    expect(result.numRequirementsMet).to.equal(0);
+    expect(result.isValid).to.equal(false);
+  });
+
+  it('should succeed if 2 of 3 requirements met with 2 required', async () => {
+    const tbc = createMockTBC(['2', '2', '0']);
+    const requirements = createMockRequirements(['1', '1', '1']);
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        '0x123',
+        requirements,
+        tbc as TokenBalanceCache,
+        2,
+      );
+
+    expect(result.numRequirementsMet).to.equal(2);
+    expect(result.isValid).to.equal(true);
+  });
+
+  it('should fail if 2 of 3 requirements met with no num requirements set', async () => {
+    const tbc = createMockTBC(['2', '2', '0']);
+    const requirements = createMockRequirements(['1', '1', '1']);
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        '0x123',
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+    expect(result.isValid).to.equal(false);
+  });
+
+  it('should succeed if 3 of 3 requirements met with no num requirements set', async () => {
+    const tbc = createMockTBC(['2', '2', '2']);
+    const requirements = createMockRequirements(['1', '1', '1']);
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        '0x123',
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+    expect(result.isValid).to.equal(true);
+  });
+
+  it('should fail if balances are equal to threshold', async () => {
+    const tbc = createMockTBC(['1', '1', '1']);
+    const requirements = createMockRequirements(['1', '1', '1']);
+    const result: ValidateGroupMembershipResponse =
+      await validateGroupMembership(
+        '0x123',
+        requirements,
+        tbc as TokenBalanceCache,
+      );
+    expect(result.isValid).to.equal(false);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5683

## Description of Changes
- Fixes logic for `required_requirements` check
- Adds more unit test coverage

## "How We Fixed It"
- Fix conditional

## Test Plan
  - Create a group with 2 requirements: 1 that you pass and 1 you fail
  - Set required requirements to 1
  - Confirm that you are part of the group

## Deployment Plan
- In QA/Demo environment, run the `yarn refresh-all-memberships` script to recompute all memberships based on new logic

## Other Considerations
N/A