### PR TITLE
polls now show under polls tab

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -287,7 +287,7 @@ export const CWContentPage = ({
           {sidebarComponents?.length >= 2 &&
             tabSelected === 2 &&
             sidebarComponents[1].item}
-          {sidebarComponents?.length === 3 &&
+          {sidebarComponents?.length >= 3 &&
             tabSelected === 3 &&
             sidebarComponents[2].item}
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5315 

## Description of Changes
-Polls now show under the Polls Tab when screen is sized to any size. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed logic to look for `sidebarComponents?.length >= 3` rather than `=== 3`

## To Replicate
-Create a thread
-add polls to the thread
-resize screen

NOTE: This is a redo of a previous PR because neither Marcin or Malik were able to replicate it. I pulled master at 5pm on Thursday Nov 9th and created a new branch from that. Please see the video below of the polls showing under the polls tab. 


https://github.com/hicommonwealth/commonwealth/assets/69872984/8f88d4e8-e060-4afa-a3c6-7ac5d839904f

