### PR TITLE
Fix: redis caching for IPFS, skip for images

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -31,6 +31,7 @@ export const isNewThread = (threadCreatedAt: moment.Moment) => {
 };
 
 export const getLastUpdate = (thread: Thread): number => {
+  if (!thread) return 0;
   const lastComment = thread.lastCommentedOn?.unix() || 0;
   const createdAt = thread.createdAt?.unix() || 0;
   const lastUpdate = Math.max(createdAt, lastComment);

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -21,7 +21,7 @@ import { User } from '../../components/user/user';
 import { PageLoading } from '../loading';
 import {
   SubscriptionRowMenu,
-  SubscriptionRowTextContainer
+  SubscriptionRowTextContainer,
 } from './helper_components';
 import { bundleSubs, extractSnapshotProposals } from './helpers';
 
@@ -30,7 +30,7 @@ const emailIntervalFrequencyMap = {
   weekly: 'Once a week',
   daily: 'Everyday',
   twoweeks: 'Every two weeks',
-  monthly: 'Once a month'
+  monthly: 'Once a month',
 };
 
 type SnapshotInfo = {
@@ -51,17 +51,17 @@ const NotificationSettingsPage = () => {
   const [snapshotsInfo, setSnapshotsInfo] = useState(null);
 
   const [currentFrequency, setCurrentFrequency] = useState(
-    app.user.emailInterval
+    app.user.emailInterval,
   );
 
   useEffect(() => {
     app.user.notifications.isLoaded.once('redraw', forceRerender);
-  }, [app?.user.notifications, app.user.emailInterval]);
+  }, [forceRerender]);
 
   useEffect(() => {
     // bundled snapshot subscriptions
     const bundledSnapshotSubs = extractSnapshotProposals(
-      app.user.notifications.discussionSubscriptions
+      app.user.notifications.discussionSubscriptions,
     );
     const snapshotIds = Object.keys(bundledSnapshotSubs);
 
@@ -72,7 +72,7 @@ const NotificationSettingsPage = () => {
         const snapshotsInfoArr = snapshotIds.map((snapshotId) => ({
           snapshotId,
           space: getSpaceById.find((x: { id: string }) => x.id === snapshotId),
-          subs: bundledSnapshotSubs[snapshotId]
+          subs: bundledSnapshotSubs[snapshotId],
         }));
 
         setSnapshotsInfo(snapshotsInfoArr);
@@ -87,7 +87,7 @@ const NotificationSettingsPage = () => {
 
   const handleSubscriptions = async (
     hasSomeInAppSubs: boolean,
-    subs: NotificationSubscription[]
+    subs: NotificationSubscription[],
   ) => {
     if (hasSomeInAppSubs) {
       await app.user.notifications.disableSubscriptions(subs);
@@ -99,7 +99,7 @@ const NotificationSettingsPage = () => {
 
   const handleEmailSubscriptions = async (
     hasSomeEmailSubs: boolean,
-    subs: NotificationSubscription[]
+    subs: NotificationSubscription[],
   ) => {
     if (hasSomeEmailSubs) {
       await app.user.notifications.disableImmediateEmails(subs);
@@ -123,12 +123,12 @@ const NotificationSettingsPage = () => {
 
   // bundled discussion subscriptions
   const bundledSubs = bundleSubs(
-    app?.user.notifications.discussionSubscriptions
+    app?.user.notifications.discussionSubscriptions,
   );
 
   // bundled chain-event subscriptions
   const chainEventSubs = bundleSubs(
-    app?.user.notifications.chainEventSubscriptions
+    app?.user.notifications.chainEventSubscriptions,
   );
 
   const subscribedCommunityIds =
@@ -138,7 +138,7 @@ const NotificationSettingsPage = () => {
   const relevantSubscribedCommunities = app?.user.addresses
     .map((x) => x.community)
     .filter(
-      (x) => subscribedCommunityIds.includes(x.id) && !chainEventSubs[x.id]
+      (x) => subscribedCommunityIds.includes(x.id) && !chainEventSubs[x.id],
     );
 
   return (
@@ -175,7 +175,7 @@ const NotificationSettingsPage = () => {
                   app.user.updateEmailInterval('weekly');
                   setCurrentFrequency('weekly');
                   forceRerender();
-                }
+                },
               },
               {
                 label: 'Never',
@@ -183,8 +183,8 @@ const NotificationSettingsPage = () => {
                   app.user.updateEmailInterval('never');
                   setCurrentFrequency('never');
                   forceRerender();
-                }
-              }
+                },
+              },
             ]}
           />
         ) : (
@@ -221,7 +221,7 @@ const NotificationSettingsPage = () => {
                         setEmailValidated(false);
                         return [
                           'failure',
-                          'Please enter a valid email address'
+                          'Please enter a valid email address',
                         ];
                       } else {
                         setEmailValidated(true);
@@ -313,7 +313,7 @@ const NotificationSettingsPage = () => {
                     app.user.notifications
                       .subscribe({
                         categoryId: NotificationCategories.ChainEvent,
-                        options: { chainId: community.id }
+                        options: { chainId: community.id },
                       })
                       .then(() => {
                         forceRerender();
@@ -596,7 +596,7 @@ const NotificationSettingsPage = () => {
                   <div className="avatar-and-name">
                     <img
                       className="snapshot-icon"
-                      src={`${app.serverUrl()}/ipfsProxy?hash=${avatar}`}
+                      src={`${app.serverUrl()}/ipfsProxy?hash=${avatar}&image=true`}
                     />
                     <CWText type="h5" fontWeight="medium">
                       {space.name}

--- a/packages/commonwealth/client/styles/pages/notification_settings/index.scss
+++ b/packages/commonwealth/client/styles/pages/notification_settings/index.scss
@@ -112,7 +112,7 @@
   }
 
   .chain-events-section-margin {
-    margin: 0 0 16px 0;
+    margin: 30px 0 16px 0;
   }
 
   .chain-events-subscriptions-padding {

--- a/packages/commonwealth/server/util/ipfsProxy.ts
+++ b/packages/commonwealth/server/util/ipfsProxy.ts
@@ -1,19 +1,22 @@
 import axios from 'axios';
-import type { Express } from 'express';
 import { cacheDecorator } from 'common-common/src/cacheDecorator';
+import type { Express } from 'express';
+import { lookupKeyDurationInReq } from '../../../common-common/src/cacheKeyUtils';
+
+const defaultCacheDuration = 24 * 60 * 60; // 1 day
 
 function setupIpfsProxy(app: Express) {
-  // using bodyParser here because cosmjs generates text/plain type headers
-  // caching for 1 day
   app.get(
     '/api/ipfsProxy',
+    calcIpfsCacheKeyDuration,
     cacheDecorator.cacheMiddleware(
-      24 * 60 * 60,
-      (req) => `/api/ipfsProxy_${req.query.hash}`
+      defaultCacheDuration,
+      lookupKeyDurationInReq,
     ),
     async function (req, res) {
       try {
         const hash = req.query.hash;
+        const isImageRequest = req.query.image === 'true';
         const response = await axios.get(
           `https://cloudflare-ipfs.com/ipfs/${hash}#x-ipfs-companion-no-redirect`,
           {
@@ -21,8 +24,8 @@ function setupIpfsProxy(app: Express) {
               origin: 'https://commonwealth.im',
             },
             timeout: 5000,
-            responseType: 'arraybuffer',
-          }
+            responseType: isImageRequest ? 'arraybuffer' : 'json',
+          },
         );
         const contentType = response.headers['content-type'];
         if (contentType) {
@@ -32,8 +35,19 @@ function setupIpfsProxy(app: Express) {
       } catch (err) {
         res.status(500).json({ message: err.message });
       }
-    }
+    },
   );
+}
+
+function calcIpfsCacheKeyDuration(req, res, next) {
+  if (req.query?.image === 'true') {
+    req.cacheDuration = null; // not not cache images
+    return next();
+  }
+
+  req.cacheDuration = 24 * 60 * 60; // cache for 1 day
+  req.cacheKey = `/api/ipfsProxy_${req.query.hash}`;
+  return next();
 }
 
 export default setupIpfsProxy;

--- a/packages/commonwealth/server/util/ipfsProxy.ts
+++ b/packages/commonwealth/server/util/ipfsProxy.ts
@@ -16,7 +16,7 @@ function setupIpfsProxy(app: Express) {
     async function (req, res) {
       try {
         const hash = req.query.hash;
-        const isImageRequest = req.query.image === 'true';
+        const isImageRequest = req.query?.image === 'true';
         const response = await axios.get(
           `https://cloudflare-ipfs.com/ipfs/${hash}#x-ipfs-companion-no-redirect`,
           {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5557 

## Description of Changes
- Handles images loaded via IPFS with a `&image` param
- Skips redis caching for images, because our cacheDecorator is not set up to store vital header info

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Avatars in Snapshot descriptions will bypass redis cache (our only use case for IPFS images so far)
- Proposal metadata loaded via IPFS will be cached as before. And not returned as arraybuffer. In the bug, the cache was storing arraybuffer data instead of JSON. Since header context is not persisted to cache, the browser did not know how to handle cached responses, so it just had to deal with arraybuffers.

## Test Plan
- CA (click around) tested on local:
  - Make sure redis caching is on. You may need to clear it: `redis-cli` -> `flushall`
  - Proposals:
    - go to http://localhost:8080/dydx/proposals -> Expect titles and descriptions to lazy-load
    - inspect `ipfsProxy` network requests -> expect response header `X-Cache: Miss`
    - refresh -> expect same titles and descriptions
    - inspect `ipfsProxy` network requests -> expect response header `X-Cache: Hit`
    - repeat for http://localhost:8080/regen/proposals
  - Snapshot notification avatar
    - go to http://localhost:8080/dydx/snapshot/dydxgov.eth
    - join community and subscribe to Notifications and subscribe to Snapshots
    - In profile dropdown, click Notifications
    - Expect dydx logo to lazy-load under "Snapshot Descriptions": <img width="940" alt="Screenshot 2023-11-09 at 10 01 49 PM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/1e1a7921-749a-4710-a0af-a5f94318cde4">
    - inspect `ipfsProxy` network requests -> expect response header `X-Cache: NOKEY`
    - refresh and expect the same


## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- We may want to cache IPFS images in the future, but we haven't actually achieved this yet. It should be a separate effort from fixing this bug.