### PR TITLE
Show informational banner after creating/editing group

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useInitApp.ts
+++ b/packages/commonwealth/client/scripts/hooks/useInitApp.ts
@@ -24,6 +24,7 @@ const useInitApp = () => {
       })
       .catch((err) => console.log('Failed fetching custom domain', err))
       .finally(() => setIsLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return { isLoading, customDomain };

--- a/packages/commonwealth/client/scripts/hooks/useInitApp.ts
+++ b/packages/commonwealth/client/scripts/hooks/useInitApp.ts
@@ -1,12 +1,18 @@
 import axios from 'axios';
 import React, { useEffect } from 'react';
 import app, { initAppState } from 'state';
+import useGroupMutationBannerStore from '../state/ui/group';
 
 const useInitApp = () => {
   const [isLoading, setIsLoading] = React.useState(true);
   const [customDomain, setCustomDomain] = React.useState('');
+  const { readFromStorageAndSetGatingGroupBannerForCommunities } =
+    useGroupMutationBannerStore();
 
   useEffect(() => {
+    // read localstorage and set informational banner for gated communities on the members page group section
+    readFromStorageAndSetGatingGroupBannerForCommunities();
+
     Promise.all([axios.get(`${app.serverUrl()}/domain`), initAppState()])
       .then(([domainResp]) => {
         const serverCustomDomain = domainResp.data.customDomain;

--- a/packages/commonwealth/client/scripts/state/ui/group/group.ts
+++ b/packages/commonwealth/client/scripts/state/ui/group/group.ts
@@ -9,6 +9,7 @@ interface GroupMutationBannerStore {
     shouldShow: boolean,
   ) => void;
   readFromStorageAndSetGatingGroupBannerForCommunities: () => void;
+  clearSetGatingGroupBannerForCommunities: () => void;
 }
 
 const STORAGE_KEY = 'groupMutationForCommunities';
@@ -49,6 +50,15 @@ export const GroupMutationBannerStore = createStore<GroupMutationBannerStore>()(
         return {
           ...state,
           shouldShowGroupMutationBannerForCommunities: communities,
+        };
+      });
+    },
+    clearSetGatingGroupBannerForCommunities: () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+      set((state) => {
+        return {
+          ...state,
+          shouldShowGroupMutationBannerForCommunities: [],
         };
       });
     },

--- a/packages/commonwealth/client/scripts/state/ui/group/group.ts
+++ b/packages/commonwealth/client/scripts/state/ui/group/group.ts
@@ -1,0 +1,22 @@
+import { createBoundedUseStore } from 'state/ui/utils';
+import { devtools } from 'zustand/middleware';
+import { createStore } from 'zustand/vanilla';
+
+interface groupMutationBannerStore {
+  shouldShowGroupMutationBanner: boolean;
+  setShouldShowGroupMutationBanner: (shouldShow: boolean) => void;
+}
+
+export const GroupMutationBannerStore = createStore<groupMutationBannerStore>()(
+  devtools((set) => ({
+    shouldShowGroupMutationBanner: false,
+    setShouldShowGroupMutationBanner: (shouldShow) =>
+      set({ shouldShowGroupMutationBanner: shouldShow }),
+  })),
+);
+
+const useGroupMutationBannerStore = createBoundedUseStore(
+  GroupMutationBannerStore,
+);
+
+export default useGroupMutationBannerStore;

--- a/packages/commonwealth/client/scripts/state/ui/group/group.ts
+++ b/packages/commonwealth/client/scripts/state/ui/group/group.ts
@@ -2,16 +2,56 @@ import { createBoundedUseStore } from 'state/ui/utils';
 import { devtools } from 'zustand/middleware';
 import { createStore } from 'zustand/vanilla';
 
-interface groupMutationBannerStore {
-  shouldShowGroupMutationBanner: boolean;
-  setShouldShowGroupMutationBanner: (shouldShow: boolean) => void;
+interface GroupMutationBannerStore {
+  shouldShowGroupMutationBannerForCommunities: string[];
+  setShouldShowGroupMutationBannerForCommunity: (
+    communityId: string,
+    shouldShow: boolean,
+  ) => void;
+  readFromStorageAndSetGatingGroupBannerForCommunities: () => void;
 }
 
-export const GroupMutationBannerStore = createStore<groupMutationBannerStore>()(
+const STORAGE_KEY = 'groupMutationForCommunities';
+
+export const GroupMutationBannerStore = createStore<GroupMutationBannerStore>()(
   devtools((set) => ({
-    shouldShowGroupMutationBanner: false,
-    setShouldShowGroupMutationBanner: (shouldShow) =>
-      set({ shouldShowGroupMutationBanner: shouldShow }),
+    shouldShowGroupMutationBannerForCommunities: [],
+    setShouldShowGroupMutationBannerForCommunity: (communityId, shouldShow) => {
+      set((state) => {
+        const communities = JSON.parse(
+          localStorage.getItem(STORAGE_KEY) || `[]`,
+        );
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify(
+            shouldShow
+              ? [...communities, communityId]
+              : [...communities].filter((id) => id !== communityId),
+          ),
+        );
+
+        return {
+          ...state,
+          shouldShowGroupMutationBannerForCommunities: shouldShow
+            ? [
+                ...state.shouldShowGroupMutationBannerForCommunities,
+                communityId,
+              ]
+            : [...state.shouldShowGroupMutationBannerForCommunities].filter(
+                (val) => val !== communityId,
+              ),
+        };
+      });
+    },
+    readFromStorageAndSetGatingGroupBannerForCommunities: () => {
+      const communities = JSON.parse(localStorage.getItem(STORAGE_KEY) || `[]`);
+      set((state) => {
+        return {
+          ...state,
+          shouldShowGroupMutationBannerForCommunities: communities,
+        };
+      });
+    },
   })),
 );
 

--- a/packages/commonwealth/client/scripts/state/ui/group/index.ts
+++ b/packages/commonwealth/client/scripts/state/ui/group/index.ts
@@ -1,0 +1,2 @@
+import useGroupMutationBannerStore from './group';
+export default useGroupMutationBannerStore;

--- a/packages/commonwealth/client/scripts/views/components/Header/UserDropdown/UserDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Header/UserDropdown/UserDropdown.tsx
@@ -29,13 +29,14 @@ import { WalletId } from 'common-common/src/types';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import WebWalletController from 'controllers/app/web_wallets';
 import { setDarkMode } from 'helpers/darkMode';
+import useGroupMutationBannerStore from 'state/ui/group';
 
 const resetWalletConnectSession = async () => {
   /**
    * Imp to reset wc session on logout as otherwise, subsequent login attempts will fail
    */
   const walletConnectWallet = WebWalletController.Instance.getByName(
-    WalletId.WalletConnect
+    WalletId.WalletConnect,
   );
   await walletConnectWallet.reset();
 };
@@ -57,13 +58,15 @@ const UserDropdown = () => {
   const navigate = useCommonNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [isDarkModeOn, setIsDarkModeOn] = useState<boolean>(
-    localStorage.getItem('dark-mode-state') === 'on'
+    localStorage.getItem('dark-mode-state') === 'on',
   );
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [revalidationModalData, setRevalidationModalData] = useState<{
     walletSsoSource: WalletSsoSource;
     walletAddress: string;
   }>(null);
+  const { clearSetGatingGroupBannerForCommunities } =
+    useGroupMutationBannerStore();
 
   const { authenticatedAddresses } = useCheckAuthenticatedAddresses({
     recheck: isOpen,
@@ -77,7 +80,7 @@ const UserDropdown = () => {
       const signed = authenticatedAddresses[account.address];
       const isActive = app.user.activeAccount?.address === account.address;
       const walletSsoSource = app.user.addresses.find(
-        (address) => address.address === account.address
+        (address) => address.address === account.address,
       )?.walletSsoSource;
 
       return {
@@ -100,7 +103,7 @@ const UserDropdown = () => {
           });
         },
       };
-    }
+    },
   );
 
   return (
@@ -158,7 +161,10 @@ const UserDropdown = () => {
           {
             type: 'default',
             label: 'Sign out',
-            onClick: () => handleLogout(),
+            onClick: () => {
+              clearSetGatingGroupBannerForCommunities();
+              handleLogout();
+            },
           },
         ]}
         onOpenChange={(open) => setIsOpen(open)}

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
@@ -15,7 +15,8 @@ import './CreateCommunityGroupPage.scss';
 
 const CreateCommunityGroupPage = () => {
   const navigate = useCommonNavigate();
-  const { setShouldShowGroupMutationBanner } = useGroupMutationBannerStore();
+  const { setShouldShowGroupMutationBannerForCommunity } =
+    useGroupMutationBannerStore();
   const { mutateAsync: createGroup } = useCreateGroupMutation({
     chainId: app.activeChainId(),
   });
@@ -44,7 +45,10 @@ const CreateCommunityGroupPage = () => {
         createGroup(payload)
           .then(() => {
             notifySuccess('Group Created');
-            setShouldShowGroupMutationBanner(true);
+            setShouldShowGroupMutationBannerForCommunity(
+              app.activeChainId(),
+              true,
+            );
             navigate(`/members?tab=groups`);
           })
           .catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
@@ -5,6 +5,7 @@ import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import app from 'state';
 import { useCreateGroupMutation } from 'state/api/groups';
+import useGroupMutationBannerStore from 'state/ui/group';
 import Permissions from 'utils/Permissions';
 import { MixpanelPageViewEvent } from '../../../../../../../shared/analytics/types';
 import { PageNotFound } from '../../../404';
@@ -14,6 +15,7 @@ import './CreateCommunityGroupPage.scss';
 
 const CreateCommunityGroupPage = () => {
   const navigate = useCommonNavigate();
+  const { setShouldShowGroupMutationBanner } = useGroupMutationBannerStore();
   const { mutateAsync: createGroup } = useCreateGroupMutation({
     chainId: app.activeChainId(),
   });
@@ -42,6 +44,7 @@ const CreateCommunityGroupPage = () => {
         createGroup(payload)
           .then(() => {
             notifySuccess('Group Created');
+            setShouldShowGroupMutationBanner(true);
             navigate(`/members?tab=groups`);
           })
           .catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -6,6 +6,7 @@ import { useCommonNavigate } from 'navigation/helpers';
 import React, { useState } from 'react';
 import app from 'state';
 import { useEditGroupMutation, useFetchGroupsQuery } from 'state/api/groups';
+import useGroupMutationBannerStore from 'state/ui/group';
 import Permissions from 'utils/Permissions';
 import { MixpanelPageViewEvent } from '../../../../../../../shared/analytics/types';
 import { PageNotFound } from '../../../404';
@@ -24,6 +25,7 @@ import './UpdateCommunityGroupPage.scss';
 
 const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
   const navigate = useCommonNavigate();
+  const { setShouldShowGroupMutationBanner } = useGroupMutationBannerStore();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { mutateAsync: editGroup } = useEditGroupMutation({
     chainId: app.activeChainId(),
@@ -109,6 +111,7 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
           })
             .then(() => {
               notifySuccess('Group Updated');
+              setShouldShowGroupMutationBanner(true);
               navigate(`/members?tab=groups`);
             })
             .catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -25,7 +25,8 @@ import './UpdateCommunityGroupPage.scss';
 
 const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
   const navigate = useCommonNavigate();
-  const { setShouldShowGroupMutationBanner } = useGroupMutationBannerStore();
+  const { setShouldShowGroupMutationBannerForCommunity } =
+    useGroupMutationBannerStore();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { mutateAsync: editGroup } = useEditGroupMutation({
     chainId: app.activeChainId(),
@@ -111,7 +112,10 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
           })
             .then(() => {
               notifySuccess('Group Updated');
-              setShouldShowGroupMutationBanner(true);
+              setShouldShowGroupMutationBannerForCommunity(
+                app.activeChainId(),
+                true,
+              );
               navigate(`/members?tab=groups`);
             })
             .catch(() => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -12,12 +12,14 @@ import {
 } from 'state/api/groups';
 import { useSearchProfilesQuery } from 'state/api/profiles';
 import { SearchProfilesResponse } from 'state/api/profiles/searchProfiles';
+import useGroupMutationBannerStore from 'state/ui/group';
 import { useDebounce } from 'usehooks-ts';
 import Permissions from 'utils/Permissions';
 import { Select } from 'views/components/Select';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { getClasses } from 'views/components/component_kit/helpers';
+import CWBanner from 'views/components/component_kit/new_designs/CWBanner';
 import {
   CWTab,
   CWTabsRow,
@@ -53,6 +55,8 @@ const CommunityMembersPage = () => {
     searchText: '',
     category: GROUP_AND_MEMBER_FILTERS[0],
   });
+  const { shouldShowGroupMutationBanner, setShouldShowGroupMutationBanner } =
+    useGroupMutationBannerStore();
 
   const { trackAnalytics } =
     useBrowserAnalyticsTrack<MixpanelPageViewEventPayload>({
@@ -235,6 +239,21 @@ const CommunityMembersPage = () => {
           />
         ))}
       </CWTabsRow>
+
+      {/* Gating group post-mutation banner */}
+      {shouldShowGroupMutationBanner && (
+        <section>
+          <CWBanner
+            type="info"
+            title="Don't see your group right away?"
+            body={`
+            Our app is crunching numbers, which takes some time. 
+            Give it a few minutes and refresh to see your group.
+          `}
+            onClose={() => setShouldShowGroupMutationBanner(false)}
+          />
+        </section>
+      )}
 
       {/* Filter section */}
       {featureFlags.gatingEnabled &&

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -213,6 +213,7 @@ const CommunityMembersPage = () => {
     }
 
     featureFlags.gatingEnabled && updateActiveTab(TABS[1].value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const navigateToCreateGroupPage = () => {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -55,8 +55,10 @@ const CommunityMembersPage = () => {
     searchText: '',
     category: GROUP_AND_MEMBER_FILTERS[0],
   });
-  const { shouldShowGroupMutationBanner, setShouldShowGroupMutationBanner } =
-    useGroupMutationBannerStore();
+  const {
+    shouldShowGroupMutationBannerForCommunities,
+    setShouldShowGroupMutationBannerForCommunity,
+  } = useGroupMutationBannerStore();
 
   const { trackAnalytics } =
     useBrowserAnalyticsTrack<MixpanelPageViewEventPayload>({
@@ -242,19 +244,27 @@ const CommunityMembersPage = () => {
       </CWTabsRow>
 
       {/* Gating group post-mutation banner */}
-      {shouldShowGroupMutationBanner && selectedTab === TABS[0].value && (
-        <section>
-          <CWBanner
-            type="info"
-            title="Don't see your group right away?"
-            body={`
+      {shouldShowGroupMutationBannerForCommunities.includes(
+        app.activeChainId(),
+      ) &&
+        selectedTab === TABS[0].value && (
+          <section>
+            <CWBanner
+              type="info"
+              title="Don't see your group right away?"
+              body={`
             Our app is crunching numbers, which takes some time. 
             Give it a few minutes and refresh to see your group.
           `}
-            onClose={() => setShouldShowGroupMutationBanner(false)}
-          />
-        </section>
-      )}
+              onClose={() =>
+                setShouldShowGroupMutationBannerForCommunity(
+                  app.activeChainId(),
+                  false,
+                )
+              }
+            />
+          </section>
+        )}
 
       {/* Filter section */}
       {featureFlags.gatingEnabled &&

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -242,7 +242,7 @@ const CommunityMembersPage = () => {
       </CWTabsRow>
 
       {/* Gating group post-mutation banner */}
-      {shouldShowGroupMutationBanner && (
+      {shouldShowGroupMutationBanner && selectedTab === TABS[0].value && (
         <section>
           <CWBanner
             type="info"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5678

## Description of Changes
- Shows an informational banner after creating/editing a group

## "How We Fixed It"

Not a bug

## Test Plan
- Visit members page -> group section
- Create a group and verify you see the informational banner
- Update a group and verify you see the informational banner
- Verify that the banner doesn't disappear unless the user manually closes it
- Verify the banner only shows on the "members" tab
- Change communities and verify the banner doesn't display in other communities if the groups there weren't mutated
- Refresh the page and verify the banner still displays if it wasn't closed
- Logout and login and verify the banner get's cleared permanently due to the user being logged out.

## Deployment Plan
N/A

## Other Considerations
N/A