### PR TITLE
Only send requirements to api if they are updated

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/groups/editGroup.ts
+++ b/packages/commonwealth/client/scripts/state/api/groups/editGroup.ts
@@ -22,7 +22,7 @@ const editGroup = async ({
   groupDescription,
   topicIds,
   requirementsToFulfill,
-  requirements = [],
+  requirements,
 }: EditGroupProps) => {
   return await axios.put(`${app.serverUrl()}/groups/${groupId}`, {
     jwt: app.user.jwt,
@@ -36,7 +36,7 @@ const editGroup = async ({
         required_requirements: requirementsToFulfill,
       }),
     },
-    requirements,
+    ...(requirements && { requirements }),
     topics: topicIds,
   });
 };

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
@@ -1,7 +1,8 @@
-import NodeInfo from 'models/NodeInfo';
-import CommunityInfo from 'models/ChainInfo';
-import { notifySuccess, notifyError } from 'controllers/app/notifications';
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { detectURL } from 'helpers/threads';
+import CommunityInfo from 'models/ChainInfo';
+import NodeInfo from 'models/NodeInfo';
+import 'pages/AdminPanel.scss';
 import React, { useState } from 'react';
 import app from 'state';
 import { BalanceType } from '../../../../../../common-common/src/types';
@@ -9,10 +10,9 @@ import { CWButton } from '../../components/component_kit/cw_button';
 import { CWDropdown } from '../../components/component_kit/cw_dropdown';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
+import { ValidationStatus } from '../../components/component_kit/cw_validation_text';
 import { openConfirmation } from '../../modals/confirmation_modal';
 import { createChainNode } from './utils';
-import 'pages/AdminPanel.scss';
-import { ValidationStatus } from '../../components/component_kit/cw_validation_text';
 
 const RPCEndpointTask = () => {
   const [rpcEndpointChainValue, setRpcEndpointChainValue] =
@@ -28,7 +28,7 @@ const RPCEndpointTask = () => {
   const [rpcName, setRpcName] = useState<string>('');
   const [bech32, setBech32] = useState<string>('');
   const [balanceType, setBalanceType] = useState<BalanceType>(
-    BalanceType.Ethereum
+    BalanceType.Ethereum,
   );
   const [chainNodeNotCreated, setChainNodeNotCreated] =
     useState<boolean>(false);
@@ -45,7 +45,7 @@ const RPCEndpointTask = () => {
   };
 
   const RPCEndpointValidationFn = (
-    value: string
+    value: string,
   ): [ValidationStatus, string] | [] => {
     if (
       !detectURL(value) &&

--- a/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
+++ b/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
@@ -1,6 +1,6 @@
-import { TypedRequestBody, TypedResponse, success } from '../../types';
-import { ServerControllers } from '../../routing/router';
 import { CreateChainNodeResult } from '../../controllers/server_communities_methods/create_chain_node';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequestBody, TypedResponse, success } from '../../types';
 
 type CreateChainNodeRequestBody = {
   url: string;
@@ -13,7 +13,7 @@ type CreateChainNodeResponse = CreateChainNodeResult;
 export const createChainNodeHandler = async (
   controllers: ServerControllers,
   req: TypedRequestBody<CreateChainNodeRequestBody>,
-  res: TypedResponse<CreateChainNodeResponse>
+  res: TypedResponse<CreateChainNodeResponse>,
 ) => {
   const results = await controllers.communities.createChainNode({
     user: req.user,

--- a/packages/commonwealth/server/routes/groups/update_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/update_group_handler.ts
@@ -55,10 +55,12 @@ export const updateGroupHandler = async (
     topics,
   });
 
-  // refresh memberships in background
-  controllers.groups
-    .refreshCommunityMemberships({ community })
-    .catch(console.error);
+  // refresh memberships in background if requirements updated
+  if (requirements?.length > 0) {
+    controllers.groups
+      .refreshCommunityMemberships({ community })
+      .catch(console.error);
+  }
 
   controllers.analytics.track(analyticsOptions, req).catch(console.error);
 

--- a/packages/commonwealth/test/integration/api/chainNodes.spec.ts
+++ b/packages/commonwealth/test/integration/api/chainNodes.spec.ts
@@ -1,7 +1,7 @@
-import { expect, assert } from 'chai';
-import models from 'server/database';
+import { assert, expect } from 'chai';
 import { BalanceType } from 'common-common/src/types';
 import { resetDatabase } from 'server-test';
+import models from 'server/database';
 
 describe('ChainNode Tests', () => {
   before(async () => {
@@ -13,7 +13,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { eth_chain_id: 123 },
       }),
-      0
+      0,
     );
 
     await models.ChainNode.findOrCreate({
@@ -28,7 +28,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { eth_chain_id: 123 },
       }),
-      1
+      1,
     );
   });
 
@@ -38,7 +38,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { eth_chain_id: ethChainId },
       }),
-      0
+      0,
     );
 
     await models.ChainNode.findOrCreate({
@@ -74,7 +74,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { cosmos_chain_id: cosmosChainId },
       }),
-      0
+      0,
     );
 
     await models.ChainNode.findOrCreate({
@@ -90,7 +90,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { cosmos_chain_id: cosmosChainId },
       }),
-      1
+      1,
     );
   });
 
@@ -100,7 +100,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { cosmos_chain_id: cosmosChainId },
       }),
-      0
+      0,
     );
 
     await models.ChainNode.findOrCreate({
@@ -133,7 +133,7 @@ describe('ChainNode Tests', () => {
       await models.ChainNode.count({
         where: { cosmos_chain_id: cosmosChainId },
       }),
-      1
+      1,
     );
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/pull/5693

## Description of Changes
- Now in edit group mode -- only sending requirements to API if they are updated in frontend

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
N/A

## Test Plan
- Edit a group and don't change requirements - verify in network tab that the payload doesn't contain a `requirements` key -- also verify the normal case where requirements change and they are present in payload
- Verify that if you edit a group and don't change requirements -- you don't see the informational banner on members tab of members page

## Deployment Plan
N/A

## Other Considerations
N/A