### PR TITLE
Show gating banner on new thread page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/useNewThreadForm.ts
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/useNewThreadForm.ts
@@ -20,6 +20,7 @@ const useNewThreadForm = (chainId: string, topicsForSelector: Topic[]) => {
   const { saveDraft, restoreDraft, clearDraft } = useDraft<NewThreadDraft>(
     `new-thread-${chainId}-info`,
   );
+  const [canShowGatingBanner, setCanShowGatingBanner] = useState(true);
 
   // get restored draft on init
   const restoredDraft: NewThreadDraft | null = useMemo(() => {
@@ -116,6 +117,8 @@ const useNewThreadForm = (chainId: string, topicsForSelector: Topic[]) => {
     setIsSaving,
     isDisabled,
     clearDraft,
+    canShowGatingBanner,
+    setCanShowGatingBanner,
   };
 };
 

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
@@ -1,0 +1,55 @@
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
+import { useCommonNavigate } from 'navigation/helpers';
+import React from 'react';
+import {
+  MixpanelClickthroughEvent,
+  MixpanelClickthroughPayload,
+} from '../../../../../../shared/analytics/types';
+import CWBanner from '../new_designs/CWBanner';
+import { CWTag } from '../new_designs/CWTag';
+
+interface CWGatedTopicBannerProps {
+  groupNames: string[];
+  onClose: () => any;
+}
+
+const CWGatedTopicBanner = ({
+  groupNames = [],
+  onClose = () => {},
+}: CWGatedTopicBannerProps) => {
+  const navigate = useCommonNavigate();
+  const { trackAnalytics } =
+    useBrowserAnalyticsTrack<MixpanelClickthroughPayload>({
+      onAction: true,
+    });
+
+  return (
+    <CWBanner
+      title="This topic is gated"
+      body="Only members within the following group(s) can interact with this topic:"
+      type="info"
+      footer={
+        <div className="gating-tags">
+          {groupNames.map((name) => (
+            <CWTag key={name} label={name} type="referendum" />
+          ))}
+        </div>
+      }
+      buttons={[
+        {
+          label: 'See all groups',
+          onClick: () => {
+            trackAnalytics({
+              event: MixpanelClickthroughEvent.VIEW_THREAD_TO_MEMBERS_PAGE,
+            });
+            navigate('/members?tab=groups');
+          },
+        },
+        { label: 'Learn more about gating' },
+      ]}
+      onClose={onClose}
+    />
+  );
+};
+
+export default CWGatedTopicBanner;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/index.ts
@@ -1,0 +1,3 @@
+import CWGatedTopicBanner from './CWGatedTopicBanner';
+
+export { CWGatedTopicBanner };

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -32,10 +32,7 @@ import ExternalLink from 'views/components/ExternalLink';
 import useJoinCommunity from 'views/components/Header/useJoinCommunity';
 import JoinCommunityBanner from 'views/components/JoinCommunityBanner';
 import { PageNotFound } from 'views/pages/404';
-import {
-  MixpanelClickthroughPayload,
-  MixpanelPageViewEvent,
-} from '../../../../../shared/analytics/types';
+import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 import useManageDocumentTitle from '../../../hooks/useManageDocumentTitle';
 import Poll from '../../../models/Poll';
 import { Link, LinkDisplay, LinkSource } from '../../../models/Thread';
@@ -194,11 +191,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       );
     }
   });
-
-  const { trackAnalytics } =
-    useBrowserAnalyticsTrack<MixpanelClickthroughPayload>({
-      onAction: true,
-    });
 
   useBrowserAnalyticsTrack({
     payload: {

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -33,7 +33,6 @@ import useJoinCommunity from 'views/components/Header/useJoinCommunity';
 import JoinCommunityBanner from 'views/components/JoinCommunityBanner';
 import { PageNotFound } from 'views/pages/404';
 import {
-  MixpanelClickthroughEvent,
   MixpanelClickthroughPayload,
   MixpanelPageViewEvent,
 } from '../../../../../shared/analytics/types';
@@ -46,6 +45,7 @@ import { CreateComment } from '../../components/Comments/CreateComment';
 import { Select } from '../../components/Select';
 import type { SidebarComponents } from '../../components/component_kit/CWContentPage';
 import { CWContentPage } from '../../components/component_kit/CWContentPage';
+import { CWGatedTopicBanner } from '../../components/component_kit/CWGatedTopicBanner';
 import { CWCheckbox } from '../../components/component_kit/cw_checkbox';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
@@ -54,8 +54,6 @@ import {
   breakpointFnValidator,
   isWindowMediumSmallInclusive,
 } from '../../components/component_kit/helpers';
-import CWBanner from '../../components/component_kit/new_designs/CWBanner';
-import { CWTag } from '../../components/component_kit/new_designs/CWTag';
 import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
 import { CommentTree } from '../discussions/CommentTree';
 import { clearEditingLocalStorage } from '../discussions/CommentTree/helpers';
@@ -544,34 +542,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                     {featureFlags.gatingEnabled &&
                       foundGatedTopic &&
                       !hideGatingBanner && (
-                        <CWBanner
-                          title="This topic is gated"
-                          body="Only members within the following group(s) can interact with this topic:"
-                          type="info"
-                          footer={
-                            <div className="gating-tags">
-                              {gatedGroupsMatchingTopic.map((t) => (
-                                <CWTag
-                                  key={t.id}
-                                  label={t.name}
-                                  type="referendum"
-                                />
-                              ))}
-                            </div>
-                          }
-                          buttons={[
-                            {
-                              label: 'See all groups',
-                              onClick: () => {
-                                trackAnalytics({
-                                  event:
-                                    MixpanelClickthroughEvent.VIEW_THREAD_TO_MEMBERS_PAGE,
-                                });
-                                navigate('/members?tab=groups');
-                              },
-                            },
-                            { label: 'Learn more about gating' },
-                          ]}
+                        <CWGatedTopicBanner
+                          groupNames={gatedGroupsMatchingTopic.map(
+                            (g) => g.name,
+                          )}
                           onClose={() => setHideGatingBanner(true)}
                         />
                       )}

--- a/packages/commonwealth/client/styles/components/NewThreadForm.scss
+++ b/packages/commonwealth/client/styles/components/NewThreadForm.scss
@@ -7,7 +7,7 @@
   padding: 24px;
   width: 100%;
 
-  .header {
+  & > .header {
     padding: 32px 0px 32px 0px;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5397

## Description of Changes
- Adds the gated group banner on new thread page -- for topics the user can't participate in

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
N/A

## Test Plan
- Visit new thread page
- Select a topic that is gated and you (as user) can't participate in - verify you see the gated topic banner and quill editor is disabled with a "Topic is gated" tooltip
- Close the banner and select the same topic again - verify you see the banner again
- Select any other topic and verify the banner disappears and quill editor is enabled again 

## Deployment Plan
N/A

## Other Considerations
N/A