### PR TITLE
Start TBC + avoid deadlock in first-time membership refresh script.

### DIFF
--- a/packages/commonwealth/scripts/refresh-all-memberships.ts
+++ b/packages/commonwealth/scripts/refresh-all-memberships.ts
@@ -9,6 +9,7 @@ async function main() {
   const models = db;
   const tokenBalanceCache = new TokenBalanceCache();
   await tokenBalanceCache.initBalanceProviders();
+  await tokenBalanceCache.start();
   const banCache = new BanCache(models);
 
   const communitiesController = new ServerCommunitiesController(
@@ -34,7 +35,7 @@ async function main() {
         community,
       });
     },
-    { concurrency: 10 }, // limit concurrency
+    { concurrency: 1 }, // limit concurrency
   );
 
   console.log(`done- refreshed ${communitiesResult.length} communities`);

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
@@ -125,7 +125,7 @@ export async function __refreshCommunityMemberships(
     `Done checking. Starting ${toCreate.length} creates and ${toUpdate.length} updates...`,
   );
 
-  // first create new rows
+  // perform creates and updates
   await this.models.Membership.bulkCreate([...toCreate, ...toUpdate], {
     updateOnDuplicate: ['reject_reason', 'last_checked'],
   });

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
@@ -139,7 +139,7 @@ export async function __refreshCommunityMemberships(
       return existingMembership.update({ reject_reason, last_checked });
     },
     {
-      concurrency: 5,
+      concurrency: 1,
     },
   );
 

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
@@ -74,11 +74,6 @@ export async function __refreshCommunityMemberships(
       return;
     }
 
-    console.log(
-      currentGroup.id,
-      address.id,
-      address.Memberships.map(({ group_id }) => group_id),
-    );
     // membership does not exist, create
     const computedMembership = await refreshAndQueueOperation(
       address,

--- a/packages/commonwealth/server/migrations/20231110202631-add-unique-membership-constraint.js
+++ b/packages/commonwealth/server/migrations/20231110202631-add-unique-membership-constraint.js
@@ -2,19 +2,45 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('Memberships', 'id', {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true,
-    });
-    await queryInterface.addIndex('Memberships', {
-      fields: ['address_id', 'group_id'],
-      unique: true,
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        TRUNCATE TABLE "Memberships";
+      `,
+        {
+          raw: true,
+          type: 'RAW',
+          transaction,
+        },
+      );
+      await queryInterface.addColumn(
+        'Memberships',
+        'id',
+        {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+        {
+          transaction,
+        },
+      );
+      await queryInterface.addIndex('Memberships', {
+        fields: ['address_id', 'group_id'],
+        unique: true,
+        transaction,
+      });
     });
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeIndex('Memberships', ['address_id', 'group_id']);
-    await queryInterface.removeColumn('Memberships', 'id');
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex(
+        'Memberships',
+        ['address_id', 'group_id'],
+        { transaction },
+      );
+      await queryInterface.removeColumn('Memberships', 'id', { transaction });
+    });
   },
 };

--- a/packages/commonwealth/server/migrations/20231110202631-add-unique-membership-constraint.js
+++ b/packages/commonwealth/server/migrations/20231110202631-add-unique-membership-constraint.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Memberships', 'id', {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    });
+    await queryInterface.addIndex('Memberships', {
+      fields: ['address_id', 'group_id'],
+      unique: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Memberships', ['address_id', 'group_id']);
+    await queryInterface.removeColumn('Memberships', 'id');
+  },
+};

--- a/packages/commonwealth/server/models/membership.ts
+++ b/packages/commonwealth/server/models/membership.ts
@@ -5,6 +5,7 @@ import { GroupAttributes } from './group';
 import { ModelInstance, ModelStatic } from './types';
 
 export type MembershipAttributes = {
+  id?: number;
   group_id: number;
   address_id: number;
   reject_reason?: string;
@@ -20,11 +21,12 @@ export type MembershipModelStatic = ModelStatic<MembershipInstance>;
 
 export default (
   sequelize: Sequelize.Sequelize,
-  dataTypes: typeof DataTypes
+  dataTypes: typeof DataTypes,
 ): MembershipModelStatic => {
   const Membership = <MembershipModelStatic>sequelize.define(
     'Membership',
     {
+      id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
       group_id: { type: dataTypes.INTEGER, allowNull: false },
       address_id: { type: dataTypes.INTEGER, allowNull: false },
       reject_reason: { type: dataTypes.STRING, allowNull: true },
@@ -36,11 +38,13 @@ export default (
       createdAt: false,
       updatedAt: false,
       tableName: 'Memberships',
-      indexes: [{ fields: ['group_id'] }],
-    }
+      indexes: [
+        { fields: ['group_id'] },
+        { fields: ['address_id', 'group_id'], unique: true },
+      ],
+    },
   );
 
-  Membership.removeAttribute('id');
   Membership.removeAttribute('created_at');
   Membership.removeAttribute('updated_at');
 

--- a/packages/commonwealth/server/routes/groups/update_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/update_group_handler.ts
@@ -58,7 +58,7 @@ export const updateGroupHandler = async (
   // refresh memberships in background if requirements updated
   if (requirements?.length > 0) {
     controllers.groups
-      .refreshCommunityMemberships({ community })
+      .refreshCommunityMemberships({ community, group })
       .catch(console.error);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes
- Start TBC so balances are fetched properly (TBC was previously not initialized).
- Reduce concurrency to 1 to avoid deadlocking.
- Adds id to Memberships so the `include` in refresh for community works properly.
- Adds unique index to Memberships to ensure that we don't have duplicate rows (was happening as result of issue with `include` not fetching ALL associated objects).