### PR TITLE
5491: Mixpanel - Directory Page Logging

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
@@ -56,7 +56,7 @@ export const CWRelatedCommunityCard = ({
       }
       navigateToCommunity({ navigate, path: '', chain: communityId });
     },
-    [navigate],
+    [navigate, trackAnalytics],
   );
 
   return (

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
@@ -1,7 +1,12 @@
 import type ChainInfo from 'client/scripts/models/ChainInfo';
 import { isCommandClick, pluralizeWithoutNumberPrefix } from 'helpers';
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback } from 'react';
+import {
+  MixpanelClickthroughEvent,
+  MixpanelClickthroughPayload,
+} from '../../../../../../../shared/analytics/types';
 import { CWCommunityAvatar } from '../../cw_community_avatar';
 import { CWIcon } from '../../cw_icons/cw_icon';
 import { CWText } from '../../cw_text';
@@ -34,16 +39,24 @@ export const CWRelatedCommunityCard = ({
     name: communityName,
   } as ChainInfo;
 
+  const { trackAnalytics } =
+    useBrowserAnalyticsTrack<MixpanelClickthroughPayload>({
+      onAction: true,
+    });
+
   const handleClick = useCallback(
     (e, communityId: string) => {
       e.preventDefault();
+      trackAnalytics({
+        event: MixpanelClickthroughEvent.DIRECTORY_TO_COMMUNITY_PAGE,
+      });
       if (isCommandClick(e)) {
         window.open(`/${communityId}`, '_blank');
         return;
       }
       navigateToCommunity({ navigate, path: '', chain: communityId });
     },
-    [navigate]
+    [navigate],
   );
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPage.tsx
@@ -1,10 +1,10 @@
 import { MagnifyingGlass } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React, { useState } from 'react';
-import { useDebounce } from 'usehooks-ts';
-
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { useCommonNavigate } from 'navigation/helpers';
+import React, { useState } from 'react';
 import app from 'state';
+import { useDebounce } from 'usehooks-ts';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -15,6 +15,7 @@ import useDirectoryPageData, {
   ViewType,
 } from 'views/pages/DirectoryPage/useDirectoryPageData';
 import ErrorPage from 'views/pages/error';
+import { MixpanelPageViewEvent } from '../../../../../shared/analytics/types';
 import './DirectoryPage.scss';
 
 const DirectoryPage = () => {
@@ -24,11 +25,11 @@ const DirectoryPage = () => {
   const communitySearchDebounced = useDebounce<string>(communitySearch, 500);
 
   const directoryPageEnabled = app.config.chains.getById(
-    app.activeChainId()
+    app.activeChainId(),
   )?.directoryPageEnabled;
   const communityDefaultChainNodeId = app.chain.meta.ChainNode.id;
   const selectedChainNodeId = app.config.chains.getById(
-    app.activeChainId()
+    app.activeChainId(),
   )?.directoryPageChainNodeId;
   const defaultChainNodeId = selectedChainNodeId ?? communityDefaultChainNodeId;
   const baseChain = app.config.nodes.getById(defaultChainNodeId);
@@ -48,6 +49,12 @@ const DirectoryPage = () => {
   const handleCreateCommunity = () => {
     navigate('/createCommunity/starter', {}, null);
   };
+
+  useBrowserAnalyticsTrack({
+    payload: {
+      event: MixpanelPageViewEvent.DIRECTORY_PAGE_VIEW,
+    },
+  });
 
   if (!directoryPageEnabled) {
     return (

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
@@ -49,7 +49,7 @@ const useDirectoryPageData = ({
       }
       navigateToCommunity({ navigate, path: '', chain: communityId });
     },
-    [navigate],
+    [navigate, trackAnalytics],
   );
 
   const relatedCommunitiesData = useMemo(

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
@@ -1,10 +1,15 @@
 import { isCommandClick } from 'helpers';
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import ChainInfo from 'models/ChainInfo';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback, useMemo } from 'react';
 import { useFetchRelatedCommunitiesQuery } from 'state/api/communities';
 import { CWCommunityAvatar } from 'views/components/component_kit/cw_community_avatar';
 import { CWText } from 'views/components/component_kit/cw_text';
+import {
+  MixpanelClickthroughEvent,
+  MixpanelClickthroughPayload,
+} from '../../../../../shared/analytics/types';
 
 export enum ViewType {
   Rows = 'Rows',
@@ -27,16 +32,24 @@ const useDirectoryPageData = ({
       chainNodeId,
     });
 
+  const { trackAnalytics } =
+    useBrowserAnalyticsTrack<MixpanelClickthroughPayload>({
+      onAction: true,
+    });
+
   const handleClick = useCallback(
     (e, communityId: string) => {
       e.preventDefault();
+      trackAnalytics({
+        event: MixpanelClickthroughEvent.DIRECTORY_TO_COMMUNITY_PAGE,
+      });
       if (isCommandClick(e)) {
         window.open(`/${communityId}`, '_blank');
         return;
       }
       navigateToCommunity({ navigate, path: '', chain: communityId });
     },
-    [navigate]
+    [navigate],
   );
 
   const relatedCommunitiesData = useMemo(
@@ -50,13 +63,13 @@ const useDirectoryPageData = ({
         iconUrl: c.icon_url,
         id: c.id,
       })),
-    [relatedCommunities]
+    [relatedCommunities],
   );
 
   const filteredRelatedCommunitiesData = useMemo(
     () =>
       relatedCommunitiesData.filter((c) => c.nameLower.includes(searchTerm)),
-    [searchTerm, relatedCommunitiesData]
+    [searchTerm, relatedCommunitiesData],
   );
 
   const tableData = useMemo(() => {

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/DirectoryPageSection/DirectoryPageSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/DirectoryPageSection/DirectoryPageSection.tsx
@@ -40,12 +40,12 @@ const DirectoryPageSection = ({
     label: chain.name,
   }));
   const chainNodeOptionsSorted = chainNodeOptions.sort((a, b) =>
-    a.label.localeCompare(b.label)
+    a.label.localeCompare(b.label),
   );
   const communityDefaultChainNodeId = app.chain.meta.ChainNode.id;
   const defaultChainNodeId = selectedChainNodeId ?? communityDefaultChainNodeId;
   const defaultOption = chainNodeOptionsSorted.find(
-    (option) => option.value === String(defaultChainNodeId)
+    (option) => option.value === String(defaultChainNodeId),
   );
 
   const handleSelectChange = (newOption: SelectListOption) => {

--- a/packages/commonwealth/server/routes/communities/update_community_handler.ts
+++ b/packages/commonwealth/server/routes/communities/update_community_handler.ts
@@ -1,11 +1,7 @@
-import { TypedRequestBody, TypedResponse, success } from '../../types';
-import { ServerControllers } from '../../routing/router';
-import {
-  UpdateCommunityOptions,
-  UpdateCommunityResult,
-} from 'server/controllers/server_communities_methods/update_community';
-import { MixpanelCommunityCreationEvent } from 'shared/analytics/types';
+import { UpdateCommunityResult } from 'server/controllers/server_communities_methods/update_community';
 import { CommunityAttributes } from '../../models/community';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequestBody, TypedResponse, success } from '../../types';
 
 type UpdateCommunityRequestBody = CommunityAttributes & {
   id: string;
@@ -17,18 +13,22 @@ type UpdateCommunityResponse = UpdateCommunityResult;
 export const updateCommunityHandler = async (
   controllers: ServerControllers,
   req: TypedRequestBody<UpdateCommunityRequestBody>,
-  res: TypedResponse<UpdateCommunityResponse>
+  res: TypedResponse<UpdateCommunityResponse>,
 ) => {
   const {
     'featured_topics[]': featuredTopics,
     'snapshot[]': snapshot,
     ...rest
   } = req.body;
-  const community = await controllers.communities.updateCommunity({
-    user: req.user,
-    featuredTopics,
-    snapshot,
-    ...rest,
-  });
+  const { analyticsOptions, ...community } =
+    await controllers.communities.updateCommunity({
+      user: req.user,
+      featuredTopics,
+      snapshot,
+      ...rest,
+    });
+
+  controllers.analytics.track(analyticsOptions, req).catch(console.error);
+
   return success(res, community);
 };

--- a/packages/commonwealth/shared/analytics/types.ts
+++ b/packages/commonwealth/shared/analytics/types.ts
@@ -39,6 +39,7 @@ export const enum MixpanelErrorCaptureEvent {
 
 export const enum MixpanelClickthroughEvent {
   VIEW_THREAD_TO_MEMBERS_PAGE = 'Clickthrough: View Thread to Members Page -> Groups Tab',
+  DIRECTORY_TO_COMMUNITY_PAGE = 'Clickthrough: Directory to Community Page',
 }
 
 export const enum MixpanelCommunityCreationEvent {

--- a/packages/commonwealth/shared/analytics/types.ts
+++ b/packages/commonwealth/shared/analytics/types.ts
@@ -7,6 +7,7 @@ export const enum MixpanelPageViewEvent {
   GROUPS_PAGE_VIEW = 'Groups Page Viewed',
   GROUPS_CREATION_PAGE_VIEW = 'Create Group Page Viewed',
   GROUPS_EDIT_PAGE_VIEW = 'Edit Group Page Viewed',
+  DIRECTORY_PAGE_VIEW = 'Directory Page Viewed',
 }
 
 export const enum MixpanelCommunityInteractionEvent {

--- a/packages/commonwealth/shared/analytics/types.ts
+++ b/packages/commonwealth/shared/analytics/types.ts
@@ -18,6 +18,8 @@ export const enum MixpanelCommunityInteractionEvent {
   LINKED_THREAD = 'Linked Thread',
   UPDATE_STAGE = 'Update Stage',
   UPDATE_GROUP = 'Update Group',
+  DIRECTORY_PAGE_ENABLED = 'Directory Page Enabled',
+  DIRECTORY_PAGE_DISABLED = 'Directory Page Disabled',
 }
 
 export const enum MixpanelLoginEvent {
@@ -77,6 +79,7 @@ export interface BaseMixpanelPayload extends AnalyticsPayload {
   community?: string;
   communityType?: string;
   userId?: number;
+  communitySelected?: string;
 }
 
 export interface MixpanelLoginPayload extends BaseMixpanelPayload {


### PR DESCRIPTION
This PR contains work that adds Mixpanel logging around the related communities directory feature. 

- Events to Track within the Directory Page Feature:
    - [x] Turning it On: feature usage
    - [x] Chain Selected: ecosystem usage,
    - [x] Turning it Off: feature usage
    - [x] Directory Page Views: member utility, usage
    - [x] Redirects to another community from the Directory Page: utility/usage

A list of the events being logged to Mixpanel can be found in `/shared/analytics/types.ts`

## Link to Issue
Closes: #5491 

## Description of Changes
Add logging for turning on and on the directory page, the chain selected, the number of directory views, and the number of redirects to other communities via the directory page.

## Test Plan
- set the relevant env variables: NODE_ENV, MIXPANEL_TOKEN, MIXPANEL_DEV_TOKEN
