### PR TITLE
Updated email validation on edit profile page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import app from 'state';
 import { useUpdateProfileByAddressMutation } from 'state/api/profiles';
 import _ from 'underscore';
+import { z } from 'zod';
 import Account from '../../models/Account';
 import AddressInfo from '../../models/AddressInfo';
 import MinimumProfile from '../../models/MinimumProfile';
@@ -93,7 +94,7 @@ const EditProfileComponent = () => {
             console.error(`Could not return AddressInfo: "${err}"`);
             return null;
           }
-        })
+        }),
       );
     } catch (err) {
       if (
@@ -124,7 +125,7 @@ const EditProfileComponent = () => {
 
     if (!_.isEqual(backgroundImageRef, profile?.backgroundImage))
       profileUpdate.backgroundImage = JSON.stringify(
-        backgroundImageRef.current
+        backgroundImageRef.current,
       );
 
     if (Object.keys(profileUpdate)?.length > 0) {
@@ -172,7 +173,7 @@ const EditProfileComponent = () => {
     if (addresses?.length > 0) {
       const oldProfile = new MinimumProfile(
         addresses[0].community.name,
-        addresses[0].address
+        addresses[0].address,
       );
 
       oldProfile.initialize(
@@ -181,7 +182,7 @@ const EditProfileComponent = () => {
         avatarUrl,
         profile.id,
         addresses[0].community.name,
-        null
+        null,
       );
 
       setAccount(
@@ -190,7 +191,7 @@ const EditProfileComponent = () => {
           address: addresses[0].address,
           profile: oldProfile,
           ignoreProfile: false,
-        })
+        }),
       );
     } else {
       setAccount(null);
@@ -299,10 +300,11 @@ const EditProfileComponent = () => {
               <CWTextInput
                 name="email-form-field"
                 inputValidationFn={(val: string) => {
-                  if (!val.match(/\S+@\S+\.\S+/)) {
-                    return ['failure', 'Must enter valid email'];
-                  } else {
+                  try {
+                    z.string().email().parse(val.trim());
                     return ['success', 'Input validated'];
+                  } catch {
+                    return ['failure', 'Must enter valid email'];
                   }
                 }}
                 label="Email"
@@ -343,7 +345,7 @@ const EditProfileComponent = () => {
             <CWCoverImageUploader
               uploadCompleteCallback={(
                 url: string,
-                imageBehavior: ImageBehavior
+                imageBehavior: ImageBehavior,
               ) => {
                 backgroundImageRef.current = {
                   url,
@@ -352,7 +354,7 @@ const EditProfileComponent = () => {
               }}
               generatedImageCallback={(
                 url: string,
-                imageBehavior: ImageBehavior
+                imageBehavior: ImageBehavior,
               ) => {
                 backgroundImageRef.current = {
                   url,
@@ -374,7 +376,7 @@ const EditProfileComponent = () => {
               refreshProfiles={(address: string) => {
                 getProfile();
                 app.user.removeAddress(
-                  addresses.find((a) => a.address === address)
+                  addresses.find((a) => a.address === address),
                 );
               }}
             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5712

## Description of Changes
- Updated email validation on edit profile page to validate emails correctly

## "How We Fixed It"
By updating email validation

## Test Plan
- Go to edit profile page and enter `test@+.com` (or any other invalid email) in the email field and verify it throws validation error

## Deployment Plan
N/A


## Other Considerations
N/A