### PR TITLE
Only show "bio" label on profile page if there is bio

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
@@ -25,7 +25,14 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
   const { bio, name } = profile;
 
   const isCurrentUser = isLoggedIn && isOwner;
-  const hasBio = renderQuillDeltaToText(JSON.parse(decodeURIComponent(bio)));
+  const hasBio = () => {
+    try {
+      if (bio.trim().length === 0) return false;
+      return renderQuillDeltaToText(JSON.parse(decodeURIComponent(bio)));
+    } catch {
+      return true;
+    }
+  };
 
   return (
     <div className="ProfileHeader">
@@ -55,7 +62,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
           {name || 'Anonymous user'}
         </CWText>
         <SocialAccounts profile={profile} />
-        {hasBio && (
+        {hasBio() && (
           <div>
             <CWText type="h4">Bio</CWText>
             <CWText className="bio">{<QuillRenderer doc={bio} />}</CWText>

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
@@ -1,15 +1,16 @@
+import jdenticon from 'jdenticon';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import jdenticon from 'jdenticon';
 
 import 'components/Profile/ProfileHeader.scss';
 
+import useUserLoggedIn from 'hooks/useUserLoggedIn';
+import { renderQuillDeltaToText } from '../../../../../shared/utils';
 import type NewProfile from '../../../models/NewProfile';
 import { CWButton } from '../component_kit/cw_button';
 import { CWText } from '../component_kit/cw_text';
-import { SocialAccounts } from '../social_accounts';
-import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { QuillRenderer } from '../react_quill_editor/quill_renderer';
+import { SocialAccounts } from '../social_accounts';
 
 type ProfileHeaderProps = {
   profile: NewProfile;
@@ -24,6 +25,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
   const { bio, name } = profile;
 
   const isCurrentUser = isLoggedIn && isOwner;
+  const hasBio = renderQuillDeltaToText(JSON.parse(decodeURIComponent(bio)));
 
   return (
     <div className="ProfileHeader">
@@ -43,7 +45,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
         ) : (
           <img
             src={`data:image/svg+xml;utf8,${encodeURIComponent(
-              jdenticon.toSvg(profile.id, 90)
+              jdenticon.toSvg(profile.id, 90),
             )}`}
           />
         )}
@@ -53,7 +55,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
           {name || 'Anonymous user'}
         </CWText>
         <SocialAccounts profile={profile} />
-        {bio && (
+        {hasBio && (
           <div>
             <CWText type="h4">Bio</CWText>
             <CWText className="bio">{<QuillRenderer doc={bio} />}</CWText>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5714

## Description of Changes
- Now only showing "bio" label on profile page if there is some "bio" content

## "How We Fixed It"

By conditionally checking "bio" content and displaying the label if there is any content

## Test Plan
- Go to any profile page that has no bio and verify you don't see the bio label
- Go to any profile page that has some bio and verify you see the bio label
- Check for both markdown and quill formatted text cases

## Deployment Plan
N/A

## Other Considerations
N/A