### PR TITLE
Fix profile link on global search members tab

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarMemberPreviewRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarMemberPreviewRow.tsx
@@ -14,7 +14,7 @@ interface SearchBarMemberPreviewRowProps {
 export const SearchBarMemberPreviewRow: FC<SearchBarMemberPreviewRowProps> = ({
   searchResult,
 }) => {
-  const community = searchResult.addresses[0].community;
+  const community = searchResult.addresses[0].chain;
   const address = searchResult.addresses[0].address;
 
   const navigate = useCommonNavigate();

--- a/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
@@ -203,7 +203,7 @@ export type MemberResult = {
   avatar_url: string;
   addresses: {
     id: number;
-    community: string;
+    chain: string;
     address: string;
   }[];
   roles?: any[];
@@ -213,7 +213,7 @@ type MemberResultRowProps = {
   setRoute: any;
 };
 const MemberResultRow = ({ addr, setRoute }: MemberResultRowProps) => {
-  const { chain: community, address } = addr.addresses[0] as any;
+  const { chain: community, address } = addr.addresses[0];
   const { data: users } = useFetchProfilesByAddressesQuery({
     profileChainIds: [community],
     profileAddresses: [address],

--- a/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
@@ -213,7 +213,7 @@ type MemberResultRowProps = {
   setRoute: any;
 };
 const MemberResultRow = ({ addr, setRoute }: MemberResultRowProps) => {
-  const { community, address } = addr.addresses[0];
+  const { chain: community, address } = addr.addresses[0] as any;
   const { data: users } = useFetchProfilesByAddressesQuery({
     profileChainIds: [community],
     profileAddresses: [address],

--- a/packages/commonwealth/client/scripts/views/pages/search/search_bar_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/search_bar_components.tsx
@@ -159,7 +159,7 @@ export const SearchBarMemberPreviewRow = (
   props: SearchBarMemberPreviewRowProps,
 ) => {
   const { searchResult } = props;
-  const community = searchResult.addresses[0].community;
+  const community = searchResult.addresses[0].chain;
   const address = searchResult.addresses[0].address;
 
   const navigate = useCommonNavigate();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5731

## Description of Changes
- Fixes profile link from global search members tab

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
It was a problem with restructuring variable from an API response object. We corrected the object destructuring.

## Test Plan
1. Type dydx in global search
2. From the results, click on the members tab
3. Click on any member
4. Verify the profile links correctly

## Deployment Plan
N/A

## Other Considerations
The issue seems to be more related to semantics and I think we can have a deeper fix. Right now the fix involves using the correct restructured key from API object 