### PR TITLE
Fix proposal modal overflow issue

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -1,3 +1,4 @@
+import { SessionKeyError } from 'controllers/server/sessions';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useState } from 'react';
 import app from 'state';
@@ -5,13 +6,14 @@ import {
   useDeleteThreadMutation,
   useEditThreadMutation,
 } from 'state/api/threads';
-import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
 import { PopoverMenu } from 'views/components/component_kit/cw_popover/cw_popover_menu';
+import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
+import { ArchiveThreadModal } from 'views/modals/ArchiveThreadModal';
+import { useSessionRevalidationModal } from 'views/modals/SessionRevalidationModal';
 import { ChangeThreadTopicModal } from 'views/modals/change_thread_topic_modal';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { UpdateProposalStatusModal } from 'views/modals/update_proposal_status_modal';
-import { ArchiveThreadModal } from 'views/modals/ArchiveThreadModal';
 import {
   notifyError,
   notifySuccess,
@@ -22,8 +24,6 @@ import { ThreadStage } from '../../../../../../models/types';
 import Permissions from '../../../../../../utils/Permissions';
 import { EditCollaboratorsModal } from '../../../../../modals/edit_collaborators_modal';
 import './AdminActions.scss';
-import { useSessionRevalidationModal } from 'views/modals/SessionRevalidationModal';
-import { SessionKeyError } from 'controllers/server/sessions';
 
 export type AdminActionsProps = {
   thread: Thread;
@@ -183,7 +183,7 @@ export const AdminActions = ({
                 .then((t: Thread | any) => onSpamToggle && onSpamToggle(t))
                 .catch(() => {
                   notifyError(
-                    `Could not ${!isSpam ? 'mark' : 'unmark'} thread as spam`
+                    `Could not ${!isSpam ? 'mark' : 'unmark'} thread as spam`,
                   );
                 });
             } catch (err) {
@@ -262,7 +262,7 @@ export const AdminActions = ({
     navigate(
       snapshotSpaces.length > 1
         ? '/multiple-snapshots'
-        : `/snapshot/${snapshotSpaces}`
+        : `/snapshot/${snapshotSpaces}`,
     );
   };
 
@@ -278,12 +278,14 @@ export const AdminActions = ({
       })
         .then(() => {
           notifySuccess(
-            `Thread has been ${thread?.archivedAt ? 'unarchived' : 'archived'}!`
+            `Thread has been ${
+              thread?.archivedAt ? 'unarchived' : 'archived'
+            }!`,
           );
         })
         .catch(() => {
           notifyError(
-            `Could not ${thread?.archivedAt ? 'unarchive' : 'archive'} thread.`
+            `Could not ${thread?.archivedAt ? 'unarchive' : 'archive'} thread.`,
           );
         });
     }
@@ -382,7 +384,7 @@ export const AdminActions = ({
                             navigate(
                               snapshotSpaces.length > 1
                                 ? '/multiple-snapshots'
-                                : `/snapshot/${snapshotSpaces}`
+                                : `/snapshot/${snapshotSpaces}`,
                             );
                           },
                         },
@@ -449,7 +451,6 @@ export const AdminActions = ({
         }
         onClose={() => setIsUpdateProposalStatusModalOpen(false)}
         open={isUpdateProposalStatusModalOpen}
-        visibleOverflow
       />
 
       <CWModal

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -11,11 +11,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import app from 'state';
 import type Thread from '../../../models/Thread';
-import { CWButton } from '../../components/component_kit/cw_button';
 import { CWContentPageCard } from '../../components/component_kit/CWContentPageCard';
-import { CWModal } from '../../components/component_kit/new_designs/CWModal';
+import { CWButton } from '../../components/component_kit/cw_button';
 import { CWSpinner } from '../../components/component_kit/cw_spinner';
 import { CWText } from '../../components/component_kit/cw_text';
+import { CWModal } from '../../components/component_kit/new_designs/CWModal';
 import { UpdateProposalStatusModal } from '../../modals/update_proposal_status_modal';
 
 type LinkedProposalProps = {
@@ -56,12 +56,12 @@ export const LinkedProposalsCard = ({
 
   const initialSnapshotLinks = useMemo(
     () => filterLinks(thread.links, LinkSource.Snapshot),
-    [thread.links]
+    [thread.links],
   );
 
   const initialProposalLinks = useMemo(
     () => filterLinks(thread.links, LinkSource.Proposal),
-    [thread.links]
+    [thread.links],
   );
 
   useEffect(() => {
@@ -71,20 +71,20 @@ export const LinkedProposalsCard = ({
         setSnapshotUrl(
           `${app.isCustomDomain() ? '' : `/${thread.chain}`}/snapshot/${
             proposal.identifier
-          }`
+          }`,
         );
       } else {
         loadMultipleSpacesData(app.chain.meta.snapshot).then((data) => {
           for (const { space: _space, proposals } of data) {
             const matchingSnapshot = proposals.find(
-              (sn) => sn.id === proposal.identifier
+              (sn) => sn.id === proposal.identifier,
             );
             if (matchingSnapshot) {
               setSnapshotTitle(matchingSnapshot.title);
               setSnapshotUrl(
                 `${app.isCustomDomain() ? '' : `/${thread.chain}`}/snapshot/${
                   _space.id
-                }/${matchingSnapshot.id}`
+                }/${matchingSnapshot.id}`,
               );
               break;
             }
@@ -161,7 +161,6 @@ export const LinkedProposalsCard = ({
         }
         onClose={() => setIsModalOpen(false)}
         open={isModalOpen}
-        visibleOverflow
       />
     </>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5730

## Description of Changes
Fixes overflow for linked proposal modal instances

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
By using CSS overflow properties

## Test Plan
1. Go to any thread
2. Resize screen to 13 inch (2560x1600 px)
3. Open linked proposal modal
4. Verify the buttons don't overflow in linked proposals modal

## Deployment Plan
N/A

## Other Considerations
N/A