### PR TITLE
Admin panel updates community to ChainType.Chain

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -255,6 +255,7 @@ class ChainInfo {
     discord_bot_webhooks_enabled,
     directory_page_enabled,
     directory_page_chain_node_id,
+    type,
   }: {
     name?: string;
     description?: string;
@@ -274,6 +275,7 @@ class ChainInfo {
     discord_bot_webhooks_enabled?: boolean;
     directory_page_enabled?: boolean;
     directory_page_chain_node_id?: number;
+    type?: string;
   }) {
     const id = app.activeChainId() ?? this.id;
     const r = await axios.patch(`${app.serverUrl()}/communities/${id}`, {
@@ -295,6 +297,7 @@ class ChainInfo {
       discord_bot_webhooks_enabled,
       directory_page_enabled,
       directory_page_chain_node_id,
+      type,
       jwt: app.user.jwt,
     });
     const updatedChain = r.data.result;
@@ -314,6 +317,7 @@ class ChainInfo {
     this.discordBotWebhooksEnabled = updatedChain.discord_bot_webhooks_enabled;
     this.directoryPageEnabled = updatedChain.directory_page_enabled;
     this.directoryPageChainNodeId = updatedChain.directory_page_chain_node_id;
+    this.type = updatedChain.type;
   }
 
   public categorizeSocialLinks(): CategorizedSocialLinks {

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
@@ -1,4 +1,4 @@
-import { BalanceType } from '@hicommonwealth/core';
+import { BalanceType, ChainType } from '@hicommonwealth/core';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { detectURL } from 'helpers/threads';
 import CommunityInfo from 'models/ChainInfo';
@@ -112,6 +112,7 @@ const RPCEndpointTask = () => {
 
       await rpcEndpointChain.updateChainData({
         chain_node_id: nodeId ?? rpcEndpointChainNode.id.toString(),
+        type: ChainType.Chain,
       });
       setRpcEndpointChainValue('');
       setRpcEndpoint('');
@@ -213,7 +214,7 @@ const RPCEndpointTask = () => {
               <CWTextInput
                 value={ethChainId}
                 onInput={(e) => {
-                  setEthChainId(e.target.value);
+                  setEthChainId(parseInt(e.target.value));
                 }}
                 inputValidationFn={ethChainIdEndpointValidationFn}
                 placeholder="Enter an ETH chain id"

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/RPCEndpointTask.tsx
@@ -42,7 +42,9 @@ const RPCEndpointTask = () => {
       rpcEndpointChainValueValidated &&
       balanceType !== BalanceType.Ethereum &&
       !ethChainIdValueValidated) ||
-    (rpcName !== '' && bech32 !== '' && rpcEndpoint !== '');
+    (rpcName !== '' &&
+      (bech32 !== '' || balanceType === BalanceType.Ethereum) &&
+      rpcEndpoint !== '');
 
   const setCommunityIdInput = (e) => {
     setRpcEndpointChainValue(e.target.value);

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
@@ -1,5 +1,6 @@
 import { AppError, BalanceType } from '@hicommonwealth/core';
 import { UserInstance } from '@hicommonwealth/model';
+import { Op } from 'sequelize';
 import { ServerCommunitiesController } from '../server_communities_controller';
 
 export const Errors = {
@@ -37,9 +38,9 @@ export async function __createChainNode(
     throw new AppError(Errors.ChainIdNaN);
   }
 
-  const chainNode = await this.models.ChainNode.findOne({
-    where: { url },
-  });
+  const where = eth_chain_id ? { [Op.or]: { url, eth_chain_id } } : { url };
+
+  const chainNode = await this.models.ChainNode.findOne({ where });
 
   if (chainNode) {
     throw new AppError(Errors.ChainNodeExists);

--- a/packages/commonwealth/test/integration/api/updateChain.spec.ts
+++ b/packages/commonwealth/test/integration/api/updateChain.spec.ts
@@ -37,24 +37,28 @@ describe('UpdateChain Tests', () => {
     }) as UserInstance;
 
     let response = await controller.updateCommunity({
+      ...baseRequest,
       directory_page_enabled: true,
       directory_page_chain_node_id: 1,
-      ...baseRequest,
+      type: ChainType.Offchain,
       user: user,
     });
 
     assert.equal(response.directory_page_enabled, true);
     assert.equal(response.directory_page_chain_node_id, 1);
+    assert.equal(response.type, 'offchain');
 
     response = await controller.updateCommunity({
+      ...baseRequest,
       directory_page_enabled: false,
       directory_page_chain_node_id: null,
-      ...baseRequest,
+      type: ChainType.Chain,
       user: user,
     });
 
     assert.equal(response.directory_page_enabled, false);
     assert.equal(response.directory_page_chain_node_id, null);
+    assert.equal(response.type, 'chain');
   });
 
   it('Fails if namespace present but no transaction hash', async () => {


### PR DESCRIPTION
## Link to Issue
Closes: #5537 

## Description of Changes
- When user adds or updates an RPC endpoint through the admin-panel, it updates the community to ChainType.Chain.

## Test Plan
Front end
1. Create an account
2. In DB upgrade Users table to isAdmin = true
3. Go to localhost:8080/admin-panel
4. check in DB community that is type=off-chain with type ethereum
5. Under the Switch/Add RPC Endpoint, fill out the fields
6. Press update. When successful check type updated to type=chain

Perform the same steps above for cosmos chain, Added a valid unique RPC url. Made sure it loads proposals under the governance section correctly

Back end
- Added case to integration test for backend