### PR TITLE
Fix thread comment btn link in overview page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
@@ -75,7 +75,7 @@ export const TopicSummaryRow = ({
         {threadsToDisplay.map((thread, idx) => {
           const discussionLink = getProposalUrlPath(
             thread.slug,
-            `${thread.identifier}-${slugify(thread.title)}`
+            `${thread.identifier}-${slugify(thread.title)}`,
           );
 
           const user = app.chain.accounts.get(thread.author);
@@ -89,7 +89,7 @@ export const TopicSummaryRow = ({
               <div
                 className={getClasses<{ isPinned?: boolean }>(
                   { isPinned: thread.pinned },
-                  'recent-thread-row'
+                  'recent-thread-row',
                 )}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -114,7 +114,7 @@ export const TopicSummaryRow = ({
                       {moment(getLastUpdated(thread)).format('l')}
                     </CWText>
                     {isNewThread(thread.createdAt) && (
-                      <CWTag label={'New'} type={'new'} iconName={'newStar'} />
+                      <CWTag label="New" type="new" iconName="newStar" />
                     )}
                     {thread.readOnly && (
                       <CWIcon iconName="lock" iconSize="small" />
@@ -153,6 +153,7 @@ export const TopicSummaryRow = ({
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
+                        navigate(`${discussionLink}?focusEditor=true`);
                       }}
                     />
                   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5736

## Description of Changes
- Comment button in overview page redirects to thread details page with focused comment box



## "How We Fixed It"
- Updated redirect link

## Test Plan
1. Visit /overview page of any community
2. Click on the comment button of any thread and verify it redirects to thread details page with comment button focused

## Deployment Plan
N/A

## Other Considerations
N/A