### PR TITLE
Updated thread comment icon

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_bottom.tsx
@@ -76,7 +76,7 @@ export const UserDashboardRowBottom = (props: UserDashboardRowBottomProps) => {
     <div className="UserDashboardRowBottom">
       <div className="comments">
         <div className="count">
-          <CWIcon iconName="feedback" iconSize="small" className="icon" />
+          <CWIcon iconName="comment" iconSize="small" />
           <CWText type="caption" className="text">
             {commentCount} {commentCount == 1 ? 'Comment' : 'Comments'}
           </CWText>

--- a/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row_bottom.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/user_dashboard_row_bottom.scss
@@ -14,7 +14,11 @@
     .count {
       display: flex;
       align-items: center;
-      width: 120px;
+      gap: 4px;
+      align-items: center;
+      width: fit-content;
+      color: $neutral-500;
+      border: 0;
     }
 
     .icon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5737

## Description of Changes
- Updated older comment button icon to match the one in communities.

## "How We Fixed It"
N/A

## Test Plan
1. Visit user dashboard page -- notice the thread comment button
2. Visit any community and any thread card/page -- notice the thread comment button
3. Verify both icons are same

## Deployment Plan
N/A 

## Other Considerations
N/A