### PR TITLE
Fix delete thread for super admin

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
@@ -64,6 +64,7 @@ export async function __deleteThread(
     models: this.models,
     user,
     communityId: thread.chain,
+    entity: thread,
     allowMod: true,
     allowAdmin: true,
     allowGodMode: true,

--- a/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/delete_thread.ts
@@ -1,9 +1,8 @@
-import { Op } from 'sequelize';
-import { AddressInstance } from 'server/models/address';
 import { AppError } from '../../../../common-common/src/errors';
+import { AddressInstance } from '../../models/address';
 import { UserInstance } from '../../models/user';
 import deleteThreadFromDb from '../../util/deleteThread';
-import { findOneRole } from '../../util/roles';
+import { validateOwner } from '../../util/validateOwner';
 import { ServerThreadsController } from '../server_threads_controller';
 
 export const Errors = {
@@ -61,19 +60,15 @@ export async function __deleteThread(
   }
 
   // check ownership (bypass if admin)
-  const userOwnedAddressIds = (await user.getAddresses())
-    .filter((addr) => !!addr.verified)
-    .map((addr) => addr.id);
-
-  const isAuthor = userOwnedAddressIds.includes(thread.Address.id);
-
-  const isAdminOrMod = await findOneRole(
-    this.models,
-    { where: { address_id: { [Op.in]: userOwnedAddressIds } } },
-    thread.chain,
-    ['admin', 'moderator'],
-  );
-  if (!isAuthor && !isAdminOrMod) {
+  const isOwnerOrAdmin = await validateOwner({
+    models: this.models,
+    user,
+    communityId: thread.chain,
+    allowMod: true,
+    allowAdmin: true,
+    allowGodMode: true,
+  });
+  if (!isOwnerOrAdmin) {
     throw new AppError(Errors.NotOwned);
   }
 

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
@@ -1021,6 +1021,7 @@ describe('ServerThreadsController', () => {
           findOne: async () => ({
             id: 1,
             chain: 'ethereum',
+            address_id: 1,
             Address: {
               id: 1,
               address: '0x123',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5706 

## Description of Changes
- Fixes issue where super admin could not delete a thread

## "How We Fixed It"
- Updated ownership check logic

## Test Plan
- CA test
  - As super admin, delete a thread that you do not own

## Deployment Plan
N/A

## Other Considerations
N/A