### PR TITLE
Fix auto-scroll after pasting

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -1,26 +1,25 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ReactQuill, { Quill } from 'react-quill';
-import { RangeStatic } from 'quill';
-import MagicUrl from 'quill-magic-url';
-import ImageUploader from 'quill-image-uploader';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import clsx from 'clsx';
+import { RangeStatic } from 'quill';
+import ImageUploader from 'quill-image-uploader';
+import MagicUrl from 'quill-magic-url';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import ReactQuill, { Quill } from 'react-quill';
 
-import { SerializableDeltaStatic } from './utils';
-import { getTextFromDelta } from './utils';
-import { PreviewModal } from '../../modals/preview_modal';
-import { CWModal } from '../component_kit/new_designs/CWModal';
 import { nextTick } from 'process';
 import { openConfirmation } from '../../modals/confirmation_modal';
+import { PreviewModal } from '../../modals/preview_modal';
+import { CWModal } from '../component_kit/new_designs/CWModal';
+import QuillTooltip from './QuillTooltip';
 import { LoadingIndicator } from './loading_indicator';
-import { useMention } from './use_mention';
+import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
+import { convertTwitterLinksToEmbeds } from './twitter_embed';
 import { useClipboardMatchers } from './use_clipboard_matchers';
 import { useImageDropAndPaste } from './use_image_drop_and_paste';
-import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
-import { useMarkdownShortcuts } from './use_markdown_shortcuts';
 import { useImageUploader } from './use_image_uploader';
-import { convertTwitterLinksToEmbeds } from './twitter_embed';
-import QuillTooltip from './QuillTooltip';
+import { useMarkdownShortcuts } from './use_markdown_shortcuts';
+import { useMention } from './use_mention';
+import { SerializableDeltaStatic, getTextFromDelta } from './utils';
 
 import 'components/react_quill/react_quill_editor.scss';
 import 'react-quill/dist/quill.snow.css';
@@ -210,7 +209,7 @@ const ReactQuillEditor = ({
       editorRef && editorRef.current && editorRef.current.focus();
       setTimeout(
         () => editorRef && editorRef.current && editorRef.current.focus(),
-        200
+        200,
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -276,6 +275,7 @@ const ReactQuillEditor = ({
                         className={clsx('QuillEditor', className, {
                           markdownEnabled: isMarkdownEnabled,
                         })}
+                        scrollingContainer="html"
                         placeholder={placeholder}
                         tabIndex={tabIndex}
                         theme="snow"

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -76,6 +76,16 @@
   }
 }
 
+// IMP: this CSS fixes 2 bugs in the editor
+// 1- Flickering when pasting some content
+// 2- Auto scrolling to top when pasting some content
+.ql-clipboard {
+  position: fixed !important;
+  left: 50% !important;
+  top: 50% !important;
+  display: none;
+}
+
 .QuillEditorWrapper {
   border-radius: 6px;
   border: 1px solid $neutral-200;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5763

## Description of Changes
- Fixed the auto scroll-top after pasting some content
- Fixed editor flickering after pasting some content

## "How We Fixed It"
It was a CSS issue with the quill editor, we fixed it by updating some CSS values

## Test Plan
- Go to any editor page
- Paste content in editor until scrollbar apperas
- Verify the pasting further content doesn't scroll editor to top

## Deployment Plan
N/A

## Other Considerations
N/A