### PR TITLE
Fixed cursor position after pasting text

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -1,26 +1,25 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ReactQuill, { Quill } from 'react-quill';
-import { RangeStatic } from 'quill';
-import MagicUrl from 'quill-magic-url';
-import ImageUploader from 'quill-image-uploader';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import clsx from 'clsx';
+import { RangeStatic } from 'quill';
+import ImageUploader from 'quill-image-uploader';
+import MagicUrl from 'quill-magic-url';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import ReactQuill, { Quill } from 'react-quill';
 
-import { SerializableDeltaStatic } from './utils';
-import { getTextFromDelta } from './utils';
-import { PreviewModal } from '../../modals/preview_modal';
-import { CWModal } from '../component_kit/new_designs/CWModal';
 import { nextTick } from 'process';
 import { openConfirmation } from '../../modals/confirmation_modal';
+import { PreviewModal } from '../../modals/preview_modal';
+import { CWModal } from '../component_kit/new_designs/CWModal';
+import QuillTooltip from './QuillTooltip';
 import { LoadingIndicator } from './loading_indicator';
-import { useMention } from './use_mention';
+import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
+import { convertTwitterLinksToEmbeds } from './twitter_embed';
 import { useClipboardMatchers } from './use_clipboard_matchers';
 import { useImageDropAndPaste } from './use_image_drop_and_paste';
-import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
-import { useMarkdownShortcuts } from './use_markdown_shortcuts';
 import { useImageUploader } from './use_image_uploader';
-import { convertTwitterLinksToEmbeds } from './twitter_embed';
-import QuillTooltip from './QuillTooltip';
+import { useMarkdownShortcuts } from './use_markdown_shortcuts';
+import { useMention } from './use_mention';
+import { SerializableDeltaStatic, getTextFromDelta } from './utils';
 
 import 'components/react_quill/react_quill_editor.scss';
 import 'react-quill/dist/quill.snow.css';
@@ -120,6 +119,16 @@ const ReactQuillEditor = ({
       ...newContent,
       ___isMarkdown: isMarkdownEnabled,
     } as SerializableDeltaStatic);
+
+    // sets the correct cursor position after pasting content
+    if (editorRef?.current?.getEditor?.()?.getSelection?.()) {
+      const selection = editorRef.current.getEditor().getSelection();
+      setTimeout(() => {
+        editorRef.current
+          .getEditor()
+          .setSelection(selection.index, selection.length);
+      });
+    }
   };
 
   const handleToggleMarkdown = () => {
@@ -210,7 +219,7 @@ const ReactQuillEditor = ({
       editorRef && editorRef.current && editorRef.current.focus();
       setTimeout(
         () => editorRef && editorRef.current && editorRef.current.focus(),
-        200
+        200,
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5782

## Description of Changes
- Fixed quill editor cursor position after pasting text 

## "How We Fixed It"
By using quill cursor selection methods 

## Test Plan
- Paste content into any quill editor
- Verify the cursor position comes after the pasted content

## Deployment Plan
N/A

## Other Considerations
N/A