### PR TITLE
Fix members page load

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -68,6 +68,7 @@ const CommunityMembersPage = () => {
   const { data: memberships = null } = useRefreshMembershipQuery({
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
+    apiEnabled: !!featureFlags.gatingEnabled,
   });
 
   const debouncedSearchTerm = useDebounce<string>(
@@ -87,7 +88,10 @@ const CommunityMembersPage = () => {
     orderDirection: APIOrderDirection.Desc,
     includeRoles: true,
     includeGroupIds: true,
-    enabled: app?.user?.activeAccount?.address ? !!memberships : true,
+    enabled:
+      app?.user?.activeAccount?.address && featureFlags.gatingEnabled
+        ? !!memberships
+        : true,
     ...(searchFilters.category !== 'All groups' && {
       includeMembershipTypes: searchFilters.category
         .split(' ')
@@ -99,7 +103,10 @@ const CommunityMembersPage = () => {
   const { data: groups } = useFetchGroupsQuery({
     chainId: app.activeChainId(),
     includeTopics: true,
-    enabled: app?.user?.activeAccount?.address ? !!memberships : true,
+    enabled:
+      app?.user?.activeAccount?.address && featureFlags.gatingEnabled
+        ? !!memberships
+        : true,
   });
 
   const formattedMembers = useMemo(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5784

## Description of Changes
- Added `featureFlags.gatingEnabled` checks for enabling API calls to /profiles

## "How We Fixed It"
N/A

## Test Plan
- Visit an community members page
- Verify it displays members on both logged in/out state

## Deployment Plan
N/A

## Other Considerations
N/A