### PR TITLE
Added null checks to fix discussion page load

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -105,12 +105,12 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
           );
 
           const isTopicGated = !!(memberships || []).find((membership) =>
-            membership.topicIds.includes(thread.topic.id),
+            membership.topicIds.includes(thread?.topic?.id),
           );
 
           const isActionAllowedInGatedTopic = !!(memberships || []).find(
             (membership) =>
-              membership.topicIds.includes(thread.topic.id) &&
+              membership.topicIds.includes(thread?.topic?.id) &&
               membership.isAllowed,
           );
 
@@ -123,7 +123,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
 
           return (
             <ThreadCard
-              key={thread.id + '-' + thread.readOnly}
+              key={thread?.id + '-' + thread.readOnly}
               thread={thread}
               canReact={!disabledActionsTooltipText}
               canComment={!disabledActionsTooltipText}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5787

## Description of Changes
- Added null checks for thread topic ids

## "How We Fixed It"
N/A

## Test Plan
- Visit https://commonwealth.im/kunji-finance/discussions (both with logged in/out state)
- Verify that page doesn't break

## Deployment Plan
N/A

## Other Considerations
Not tested, as it was not reproducible for me.