### PR TITLE
vertical dots now show up on tablet size

### DIFF
--- a/packages/commonwealth/client/styles/SublayoutHeader.scss
+++ b/packages/commonwealth/client/styles/SublayoutHeader.scss
@@ -70,6 +70,10 @@ html.todesktop .SublayoutHeader {
       @include extraSmall {
         display: flex;
       }
+
+      @include smallInclusive {
+        display: flex;
+      }
     }
 
     .DesktopMenuContainer {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5347  

## Description of Changes
-Vertical dots now show up in header on tablet size

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added `@include smallInclusive` to SublayoutHeader.scss

NOTE:This is a redone PR for a previous ticket that was never merged. Found better solution. 

https://github.com/hicommonwealth/commonwealth/assets/69872984/6609332f-ca2d-4641-8e90-3e29648cc7fc



