### PR TITLE
Fix unnecessary re-render

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -1,26 +1,25 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import ReactQuill, { Quill } from 'react-quill';
-import { RangeStatic } from 'quill';
-import MagicUrl from 'quill-magic-url';
-import ImageUploader from 'quill-image-uploader';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import clsx from 'clsx';
+import { RangeStatic } from 'quill';
+import ImageUploader from 'quill-image-uploader';
+import MagicUrl from 'quill-magic-url';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import ReactQuill, { Quill } from 'react-quill';
 
-import { SerializableDeltaStatic } from './utils';
-import { getTextFromDelta } from './utils';
-import { PreviewModal } from '../../modals/preview_modal';
-import { CWModal } from '../component_kit/new_designs/CWModal';
 import { nextTick } from 'process';
 import { openConfirmation } from '../../modals/confirmation_modal';
+import { PreviewModal } from '../../modals/preview_modal';
+import { CWModal } from '../component_kit/new_designs/CWModal';
+import QuillTooltip from './QuillTooltip';
 import { LoadingIndicator } from './loading_indicator';
-import { useMention } from './use_mention';
+import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
+import { convertTwitterLinksToEmbeds } from './twitter_embed';
 import { useClipboardMatchers } from './use_clipboard_matchers';
 import { useImageDropAndPaste } from './use_image_drop_and_paste';
-import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
-import { useMarkdownShortcuts } from './use_markdown_shortcuts';
 import { useImageUploader } from './use_image_uploader';
-import { convertTwitterLinksToEmbeds } from './twitter_embed';
-import QuillTooltip from './QuillTooltip';
+import { useMarkdownShortcuts } from './use_markdown_shortcuts';
+import { useMention } from './use_mention';
+import { SerializableDeltaStatic, getTextFromDelta } from './utils';
 
 import 'components/react_quill/react_quill_editor.scss';
 import 'react-quill/dist/quill.snow.css';
@@ -190,11 +189,18 @@ const ReactQuillEditor = ({
     if (!editorRef.current) {
       return;
     }
-    setIsMarkdownEnabled(!!contentDelta?.___isMarkdown);
-    // sometimes a force refresh is needed to render the editor
-    setTimeout(() => {
-      refreshQuillComponent();
-    }, 100);
+    // since we only want to focus on setting setIsMarkdownEnabled if
+    // 1- the editor is present
+    // 2- the initial contentDelta?.___isMarkdown is true
+    // 3- the initial isMarkdownEnabled is false
+    // so we dont have to include them in the dependency array
+    if (isMarkdownEnabled !== !!contentDelta?.___isMarkdown) {
+      setIsMarkdownEnabled(!!contentDelta?.___isMarkdown);
+      // sometimes a force refresh is needed to render the editor
+      setTimeout(() => {
+        refreshQuillComponent();
+      }, 100);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorRef]);
 
@@ -210,7 +216,7 @@ const ReactQuillEditor = ({
       editorRef && editorRef.current && editorRef.current.focus();
       setTimeout(
         () => editorRef && editorRef.current && editorRef.current.focus(),
-        200
+        200,
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/4877

## Description of Changes
- Fixes condition which causes unnecessary quill editor flick/re-render
 
## "How We Fixed It"
N/A

## Test Plan
1. From the thread list page, click the comment button on a thread, and you will be redirected to the thread details page
2. Verify the quill editor doesn't flicker many times

## Deployment Plan
N/A

## Other Considerations
N/A