### PR TITLE
vertical dots in header now show up on tablet size screen

### DIFF
--- a/packages/commonwealth/client/styles/SublayoutHeader.scss
+++ b/packages/commonwealth/client/styles/SublayoutHeader.scss
@@ -70,6 +70,10 @@ html.todesktop .SublayoutHeader {
       @include extraSmall {
         display: flex;
       }
+
+      @include smallInclusive {
+        display: flex;
+      }
     }
 
     .DesktopMenuContainer {
@@ -98,6 +102,10 @@ html.todesktop .SublayoutHeader {
       }
 
       @include extraSmall {
+        display: none;
+      }
+
+      @include smallInclusive {
         display: none;
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5347 

## Description of Changes
-vertical dots in header now shows up on tablet sized screens

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added css to show dots on `@include smallInclusive` and to not show `DesktopMenuContainer`

Uploading Screen Recording 2023-11-30 at 3.56.08 PM.mov…
