### PR TITLE
5413 - Fix Padding on Mobile

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.scss
@@ -16,7 +16,7 @@
   }
 
   @include smallInclusive {
-    padding: 24px;
+    padding: 16px;
   }
 
   .filters {
@@ -74,7 +74,7 @@
         margin-left: auto;
         margin-right: 16px;
         width: fit-content;
-  
+
         @include extraSmall {
           margin-left: 0;
         }

--- a/packages/commonwealth/client/styles/components/NewThreadForm.scss
+++ b/packages/commonwealth/client/styles/components/NewThreadForm.scss
@@ -7,7 +7,11 @@
   padding: 24px;
   width: 100%;
 
-  & > .header {
+  @include smallInclusive {
+    padding: 16px;
+  }
+
+  &>.header {
     padding: 32px 0px 32px 0px;
   }
 

--- a/packages/commonwealth/client/styles/components/Profile/Profile.scss
+++ b/packages/commonwealth/client/styles/components/Profile/Profile.scss
@@ -35,7 +35,8 @@
       }
 
       @include smallInclusive {
-        margin: 24px 32px;
+        margin: 0;
+        padding: 16px;
       }
     }
 

--- a/packages/commonwealth/client/styles/components/edit_profile.scss
+++ b/packages/commonwealth/client/styles/components/edit_profile.scss
@@ -3,6 +3,10 @@
 .EditProfile {
   padding: 50px;
 
+  @include smallInclusive {
+    padding: 16px;
+  }
+
   &.full-height {
     height: 100%;
   }

--- a/packages/commonwealth/client/styles/pages/discussions/index.scss
+++ b/packages/commonwealth/client/styles/pages/discussions/index.scss
@@ -9,7 +9,7 @@ $size: 48px;
   width: 100%;
 
   div[data-test-id='virtuoso-item-list'],
-  div[data-viewport-type='element'] > div:first-child,
+  div[data-viewport-type='element']>div:first-child,
   .threads-wrapper {
     display: flex;
     flex-direction: column;
@@ -25,7 +25,7 @@ $size: 48px;
     }
 
     @include smallInclusive {
-      padding: 24px;
+      padding: 16px;
     }
   }
 
@@ -33,7 +33,7 @@ $size: 48px;
     gap: 2px;
   }
 
-  div[data-viewport-type='element'] > div:first-child {
+  div[data-viewport-type='element']>div:first-child {
     padding-bottom: 16px !important;
   }
 

--- a/packages/commonwealth/client/styles/pages/manage_community/index.scss
+++ b/packages/commonwealth/client/styles/pages/manage_community/index.scss
@@ -11,5 +11,6 @@
 
   @include smallInclusive {
     width: 100%;
+    padding: 16px;
   }
 }

--- a/packages/commonwealth/client/styles/pages/new_proposal/index.scss
+++ b/packages/commonwealth/client/styles/pages/new_proposal/index.scss
@@ -7,4 +7,8 @@
   flex: 1;
   padding: 24px;
   max-width: 432px;
+
+  @include smallInclusive {
+    padding: 16px;
+  }
 }

--- a/packages/commonwealth/client/styles/pages/new_snapshot_proposal.scss
+++ b/packages/commonwealth/client/styles/pages/new_snapshot_proposal.scss
@@ -11,6 +11,10 @@
     width: 100%;
   }
 
+  @include smallInclusive {
+    padding: 16px;
+  }
+
   .date-range {
     display: flex;
     flex-direction: column;

--- a/packages/commonwealth/client/styles/pages/notification_settings/index.scss
+++ b/packages/commonwealth/client/styles/pages/notification_settings/index.scss
@@ -21,8 +21,8 @@
     padding: 24px 72px;
   }
 
-  @include small {
-    padding: 24px 56px;
+  @include smallInclusive {
+    padding: 16px;
   }
 
   @include extraSmall {

--- a/packages/commonwealth/client/styles/pages/proposals.scss
+++ b/packages/commonwealth/client/styles/pages/proposals.scss
@@ -4,6 +4,10 @@
   flex: 1;
   padding: 24px;
 
+  @include smallInclusive {
+    padding: 16px;
+  }
+
   .header {
     padding: 32px 0 32px 0px;
   }

--- a/packages/commonwealth/client/styles/pages/snapshot/multiple_snapshots_page.scss
+++ b/packages/commonwealth/client/styles/pages/snapshot/multiple_snapshots_page.scss
@@ -1,6 +1,12 @@
+@import '../../shared';
+
 .MultipleSnapshotsPage {
   flex: 1;
   padding: 24px;
+
+  @include smallInclusive {
+    padding: 16px;
+  }
 
   h3 {
     margin-bottom: 24px;

--- a/packages/commonwealth/client/styles/pages/stats.scss
+++ b/packages/commonwealth/client/styles/pages/stats.scss
@@ -5,6 +5,10 @@
   padding: 24px;
   padding-left: 36px;
 
+  @include smallInclusive {
+    padding: 16px;
+  }
+
   .header {
     padding: 32px 0px 32px 0px;
   }
@@ -19,6 +23,7 @@
     .Text:first-of-type {
       justify-content: start;
     }
+
     .Text {
       justify-content: right;
       margin-right: 8px;

--- a/packages/commonwealth/client/styles/shared.scss
+++ b/packages/commonwealth/client/styles/shared.scss
@@ -54,7 +54,9 @@ $font-family-monospace: 'DM Mono', monospace;
       border-radius: $border-radius-corners;
       background-color: $neutral-200;
     }
-  } @else if $theme ==dark {
+  }
+
+  @else if $theme ==dark {
     &::-webkit-scrollbar-track {
       background: $neutral-700;
       border-radius: $border-radius-corners;
@@ -79,7 +81,7 @@ $font-family-monospace: 'DM Mono', monospace;
   }
 
   @include smallInclusive {
-    padding: 24px;
+    padding: 16px;
   }
 }
 
@@ -90,13 +92,17 @@ $font-family-monospace: 'DM Mono', monospace;
       display: block;
       font-size: 14px;
     }
-  } @else if $size ==medium {
+  }
+
+  @else if $size ==medium {
     .flame::after {
       content: '\1F525';
       display: block;
       font-size: 22px;
     }
-  } @else if $size ==large {
+  }
+
+  @else if $size ==large {
     .flame::after {
       content: '\1F525';
       display: block;


### PR DESCRIPTION
The padding on content for mobile devices should be 16px. This PR corrects the padding for the pages listed here:

- [x] /dashboard - current padding 56px
- [x] /discussions - current padding 40px
- [x] /discussion - current padding 56px
- [x] /members - current padding 24px
- [x] /overview - current padding 56px
- [x] /profile - current padding 16px
- [x] /profile/edit - current padding 50px
- [x] /notification-settings - current padding 176px
- [x] /proposals - current padding 24px
- [x] /discussions/:section - current padding 40px
- [x] /manage - current padding 24px
- [x] /new/discussion - current padding 24px
- [x] /snapshot - current padding 56px
- [x] /analytics - current padding 36px
- [x] /new/snapshot - current padding 24px
- [x] /new/proposal - current padding 24px

## Link to Issue
Closes: #5413 

## Description of Changes
- set the padding to 16px on mobile screens

## Test Plan
- check the pages listed above for correct padding on smaller screens