### PR TITLE
5835-BUG Poll wasn't allowing EUs to type

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -128,7 +128,7 @@ export const PollEditorModal = ({
         <CWTextInput
           label="Question"
           placeholder="Do you support this proposal?"
-          defaultValue={prompt}
+          value={prompt}
           onInput={(e) => {
             setPrompt(e.target.value);
           }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5835

## Description of Changes
- `defaultValue` prop was not working to store the value of the poll. 
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Switched `defaultValue` for `value`
## Test Plan
1. Sign in
2. Create some thread 
3. Open thread and click on Create poll
4. Ensure typing in Poll Title works. 
