### PR TITLE
5836-Couldn't type in edit thread title

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -57,13 +57,13 @@ import { clearEditingLocalStorage } from '../discussions/CommentTree/helpers';
 import ViewTemplate from '../view_template/view_template';
 import { LinkedUrlCard } from './LinkedUrlCard';
 import { TemplateActionCard } from './TemplateActionCard';
+import { ThreadPollCard } from './ThreadPollCard';
+import { ThreadPollEditorCard } from './ThreadPollEditorCard';
 import { ViewTemplateFormCard } from './ViewTemplateFormCard';
 import { EditBody } from './edit_body';
 import { LinkedProposalsCard } from './linked_proposals_card';
 import { LinkedThreadsCard } from './linked_threads_card';
 import { LockMessage } from './lock_message';
-import { ThreadPollCard } from './ThreadPollCard';
-import { ThreadPollEditorCard } from './ThreadPollEditorCard';
 import { SnapshotCreationCard } from './snapshot_creation_card';
 
 export type ThreadPrefetch = {
@@ -410,7 +410,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
               onInput={(e) => {
                 setDraftTitle(e.target.value);
               }}
-              defaultValue={thread.title}
+              value={draftTitle || thread.title}
             />
           ) : (
             thread.title


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5836 

## Description of Changes
- Fixed the ability to edit title of threads

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- `defaultValue` prop was not working as intended, switched to using the standard `value` prop and cleared errors in console.

## Test Plan
1 Create some thread
2 On thread details page click on three dots (...) and try to edit Thread name
