### PR TITLE
Fix magic and other text input issue

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_input.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_input.tsx
@@ -224,7 +224,7 @@ export const CWTextInput = ({
               onenterkey(e);
             }
           }}
-          value={value || ''}
+          value={value}
           defaultValue={defaultValue}
         />
         {iconRightonClick && !!iconRight && !disabled ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5840

## Description of Changes
- Remove Or condition that was always setting text in CWTextInput to ''

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Noticed this was added in https://github.com/hicommonwealth/commonwealth/commit/b81c7c2ff1aca15df4af717b3dfdaae2ee05a236
- @kurtisassad can you confirm if this is required or not? Issue was that multiple text boxes were setting to `''` after each input character

## Test Plan
- Click login with email 
- ensure a valid email can be typed ?
- click sign and ensure magic prompts are correct

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- I suspect this will clear up other issues found in this and the above thread: https://commonxyz.slack.com/archives/C050AE0URFH/p1701728054731039