### PR TITLE
Docs Improvement: Lint Platform Coding Guidelines, Add TOC

### DIFF
--- a/knowledge_base/.markdownlint.json
+++ b/knowledge_base/.markdownlint.json
@@ -2,6 +2,7 @@
   "MD003": { "style": "atx" },
   "MD004": false,
   "MD013": false,
+  "MD024": false,
   "MD048": { "style": "backtick" },
   "MD050": { "style": "asterisk" }
 }

--- a/knowledge_base/Code-Style.md
+++ b/knowledge_base/Code-Style.md
@@ -6,6 +6,8 @@ Unless otherwise noted, code styles in this guideline are for NodeJS & TypeScrip
 
 For a list of React-specific guidelines, see [React Best Practices](./React-Best-Practices-And-Improvements.md).
 
+For a list of API-specific guidelines, see [Platform Coding Guidelines](./Platform-Coding-Guidelines.md).
+
 ## Contents
 
 - [Inline Documentation](#inline-documentation)

--- a/knowledge_base/Platform-Coding-Guidelines.md
+++ b/knowledge_base/Platform-Coding-Guidelines.md
@@ -1,10 +1,30 @@
-Platform Coding Guidelines – Structuring code for the backend API
+# Platform Coding Guidelines
 
-# RESTful API
-#### Problem
+Structuring code for the backend API.
+
+## Contents
+
+- [RESTful API](#restful-api)
+  + [Problem](#problem)
+  + [Solution + Guidelines](#solution--guidelines)
+- [Route Handlers and Controllers](#route-handlers-and-controllers)
+  + [Problem](#problem-1)
+  + [Solution + Guidelines](#solution--guidelines-1)
+  + [Route Handler](#route-handler)
+  + [Controller](#controller)
+  + [Method](#method)
+  + [Wiring Up The Route](#wiring-up-the-route)
+- [Testing](#testing)
+- [Change Log](#change-log)
+
+## RESTful API
+
+### Problem
+
 The problem with creating an API is that there are many possible ways to define an API endpoint. Different developers tend to use different conventions for the URL pattern, resulting in inconsistency across the API.
 
-#### Solution + Guidelines
+### Solution + Guidelines
+
 By using RESTful API conventions, the API becomes predictable and intuitive for both internal and external developers who build clients for the API.
 
 - Each API endpoint should use RESTful conventions:
@@ -17,18 +37,21 @@ By using RESTful API conventions, the API becomes predictable and intuitive for 
   - ❌ `PUT /threads/3/topic`
   - ❌ `PUT /threads/3/archived`
   - ✅ `PATCH /threads/3`
-- Reference: https://restfulapi.net/resource-naming/
+- Reference: <https://restfulapi.net/resource-naming/>
 
 ## Route Handlers and Controllers
-#### Problem
+
+### Problem
+
 The straightforward approach for implementing a route is to simply add business logic directly into the route handler. The problem with that approach is that it results in business logic which is tightly coupled with the Express server, difficult to reuse, and difficult to write automated tests for.
 
-#### Solution + Guidelines
+### Solution + Guidelines
+
 The chosen solution is for routes to use controllers as the way to access business logic. Controller classes are used in order to bucket business logic into logical domains (e.g. Threads, Comments, Reactions), and also to hold references to stateful objects (e.g. DB handle, TBC, banCache).
 
 The stack for an API endpoint is: `Route -> Controller -> Method`
 
-##### Route Handler
+### Route Handler
 
 ```ts
 // Example Route Handler
@@ -53,6 +76,7 @@ export const getItemHandler = async (
 ```
 
 A route handler is a function that is bound to a particular endpoint
+
 - All route handlers should be stored at `server/routes/{entity}/{handler}.ts`
   - e.g. `server/routes/threads/get_threads_handler.ts`
     - Should use snake_case filename suffixed with `_handler.ts`
@@ -67,7 +91,7 @@ A route handler is a function that is bound to a particular endpoint
 - Route handlers should not directly contain business logic, but should use
 controllers to invoke logic
 
-##### Controller
+### Controller
 
 ```ts
 // Example Controller
@@ -89,14 +113,17 @@ export class ServerItemsController {
   }
 }
 ```
+
 A controller is a class that contains business logic
+
 - Each controller file should be placed at
 `server/controllers/server_{entity}_controller.ts`:
   - e.g. `server_items_controller.ts`
 - Use explicit types for argument and return value
 - Methods are invoked with `call` so that the `this` context is bound to the
 function being called
-##### Method
+
+### Method
 
 ```ts
 // Example Method
@@ -121,9 +148,10 @@ export async function __getItem(
 To prevent each controller file from becoming inconveniently long, method
 logic should be placed in a seperate file (not inline in the class) at
 `server/controllers/server_{entity}_methods/{method_name}.ts`
-  - Should use snake_case for method file
-  - Method name prefixed with two underscores, e.g. `__getItem` to indicate that this method is private and should not be imported anywhere except for the controller
-  - Method arguments (options) and return value (result) have explicit defined types
+
+- Should use snake_case for method file
+- Method name prefixed with two underscores, e.g. `__getItem` to indicate that this method is private and should not be imported anywhere except for the controller
+- Method arguments (options) and return value (result) have explicit defined types
 - Class should use dependency injection for common objects like TBC (passed via
 constructor)
 - Method argument type should have suffix `Options`
@@ -133,9 +161,10 @@ constructor)
 function
 - Return type should be explicitly set, not inferred
 
-##### Wiring up the route
+### Wiring Up The Route
 
 In the root router file, instantiate the controller and register the route:
+
 ```ts
 // > routing/router.ts
 
@@ -154,7 +183,7 @@ registerRoute(
 );
 ```
 
-# Testing
+## Testing
 
 Since the business logic is encapsulated in controller classes and decoupled from the server, controllers can be unit tested via mocking.
 
@@ -189,3 +218,7 @@ describe('ServerItemsController', () => {
 ```
 
 For logic which uses raw SQL queries, API tests provide stronger guarantees.
+
+## Change Log
+
+- 231016: Authored by Ryan Bennett (#5325).

--- a/knowledge_base/_README.md
+++ b/knowledge_base/_README.md
@@ -4,9 +4,12 @@
 
 - [Navigating The Docs](#navigating-the-docs)
 - [Updating The Docs: How & When](#updating-the-docs-how--when)
+  * [Inline Documentation](#inline-documentation)
   * [Documentation Language](#documentation-language)
     + [Indexicality & Timestamps](#indexicality--timestamps)
     + [Must, Should, & May](#must-should--may)
+    + [Responsible, Accountable, Consulted, Informed](#responsible-accountable-consulted-informed)
+  * [Linting](#linting)
 - [Mermaid Visualizations](#mermaid-visualizations)
 - [Tracking Documentation Status](#tracking-documentation-status)
   * [Change Logs](#change-logs)
@@ -70,6 +73,12 @@ Per [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), the following prescripti
 #### Responsible, Accountable, Consulted, Informed
 
 Common as a team uses the RACI model for designating a spectrum of responsibility levels. **Responsible** parties perform the project's primary work. **Accountable** parties answer for the final deliverable. Consulted parties lend expertise to the project. **Informed** parties are kept up-to-date on the project's progress.
+
+### Linting
+
+The knowledge base uses David Anson's Markdownlint tool for linting and formatting; Markdownlint integrates with Prettier, once set as Prettier's default Markdown formatter.
+
+See our [markdownlint.json](./.markdownlint.json) file for current configuration, and a glossary of formatting rules in Markdownlint's [official repo](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).
 
 ## Mermaid Visualizations
 

--- a/knowledge_base/_TOC.md
+++ b/knowledge_base/_TOC.md
@@ -6,6 +6,7 @@
 - [Ways of Working](Ways-Of-Working.md)
 - [Code Style (under development)](Code-Style.md)
 - [React Best Practices](React-Best-Practices-And-Improvements.md)
+- [Platform Coding Guidelines](Platform-Coding-Guidelines.md)
 
 ## Common App
 


### PR DESCRIPTION
@rbennettcw did an awesome job with #5325. This PR just crosses the entry's t's and dots its i's.

## Link to Issue

Links to, but keeps open, #4800.

## Description of Changes

- Adds `Platform-Coding-Guidelines.md` reference to our global Table of Contents
- Adds `Platform-Coding-Guidelines.md` reference our `Code-Style.md` overview doc
- Lints `Platform-Coding-Guidelines.md` and adds a table of contents + change log
- Documents our new Markdownlint tool in the knowledge base ReadMe
- Disables an onerous Markdownlint rule ("no duplicate section headers") 