### PR TITLE
account for req object missing methods

### DIFF
--- a/packages/commonwealth/server/controllers/server_analytics_controller.ts
+++ b/packages/commonwealth/server/controllers/server_analytics_controller.ts
@@ -8,12 +8,13 @@ export class ServerAnalyticsController {
    */
   async track(options: TrackOptions, req?: any) {
     let newOptions = { ...options };
+    const host = req?.get('host');
     if (req) {
       const browserInfo = getRequestBrowserInfo(req);
       newOptions = {
         ...newOptions,
         ...browserInfo,
-        isCustomDomain: SERVER_URL.includes(req.get('host')),
+        ...(host && { isCustomDomain: SERVER_URL.includes(host) }),
       };
     }
     return __track.call(this, newOptions);


### PR DESCRIPTION
When you create a new address via /createAddress, the mixpanel tracker throws [an error](https://app.rollbar.com/a/commonwealth/fix/item/Commonwealth/8004/occurrence/373870203025#detail), because it relies on a req parameter but createAddressHelper is being passed req.body instead.

## Link to Issue
Closes: #5863 

## Description of Changes
Adds conditional around `req.get` method to account for cases where it is not present.

## Test Plan
1. Login with new address
2. Check that mixpanel new user signup event is triggered