### PR TITLE
5560 - Create alt-rorange and alt-green buttons

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_component_showcase.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_component_showcase.tsx
@@ -867,28 +867,28 @@ export const ComponentShowcase = () => {
           <CWText type="h4">Secondary Alt-Green</CWText>
           <CWButton
             buttonType="secondary"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             label="Secondary default"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonHeight="lg"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             label="Secondary large"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonWidth="wide"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             label="Secondary wide"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonHeight="lg"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             buttonWidth="wide"
             label="Secondary large and wide"
             onClick={() => notifySuccess('Button clicked!')}
@@ -896,27 +896,27 @@ export const ComponentShowcase = () => {
           <CWButton
             iconLeft="person"
             buttonType="secondary"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             label="Secondary default w/ left icon"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonWidth="full"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             label="Secondary full"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             label="Secondary default disabled"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             disabled
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             iconLeft="person"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             buttonType="secondary"
             label="Secondary default disabled w/ left icon"
             disabled
@@ -924,7 +924,7 @@ export const ComponentShowcase = () => {
           />
           <CWButton
             buttonType="secondary"
-            buttonAlt="alt-green"
+            buttonAlt="green"
             buttonWidth="full"
             label="Secondary disabled full"
             disabled
@@ -935,28 +935,28 @@ export const ComponentShowcase = () => {
           <CWText type="h4">Secondary Alt-Rorange</CWText>
           <CWButton
             buttonType="secondary"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             label="Secondary default"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonHeight="lg"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             label="Secondary large"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonWidth="wide"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             label="Secondary wide"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonHeight="lg"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             buttonWidth="wide"
             label="Secondary large and wide"
             onClick={() => notifySuccess('Button clicked!')}
@@ -964,27 +964,27 @@ export const ComponentShowcase = () => {
           <CWButton
             iconLeft="person"
             buttonType="secondary"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             label="Secondary default w/ left icon"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             buttonWidth="full"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             label="Secondary full"
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             buttonType="secondary"
             label="Secondary default disabled"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             disabled
             onClick={() => notifySuccess('Button clicked!')}
           />
           <CWButton
             iconLeft="person"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             buttonType="secondary"
             label="Secondary default disabled w/ left icon"
             disabled
@@ -992,7 +992,7 @@ export const ComponentShowcase = () => {
           />
           <CWButton
             buttonType="secondary"
-            buttonAlt="alt-rorange"
+            buttonAlt="rorange"
             buttonWidth="full"
             label="Secondary disabled full"
             disabled

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_component_showcase.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_component_showcase.tsx
@@ -863,6 +863,142 @@ export const ComponentShowcase = () => {
             onClick={() => notifySuccess('Button clicked!')}
           />
         </div>
+        <div className="button-row">
+          <CWText type="h4">Secondary Alt-Green</CWText>
+          <CWButton
+            buttonType="secondary"
+            buttonAlt="alt-green"
+            label="Secondary default"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonHeight="lg"
+            buttonAlt="alt-green"
+            label="Secondary large"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonWidth="wide"
+            buttonAlt="alt-green"
+            label="Secondary wide"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonHeight="lg"
+            buttonAlt="alt-green"
+            buttonWidth="wide"
+            label="Secondary large and wide"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            iconLeft="person"
+            buttonType="secondary"
+            buttonAlt="alt-green"
+            label="Secondary default w/ left icon"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonWidth="full"
+            buttonAlt="alt-green"
+            label="Secondary full"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            label="Secondary default disabled"
+            buttonAlt="alt-green"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            iconLeft="person"
+            buttonAlt="alt-green"
+            buttonType="secondary"
+            label="Secondary default disabled w/ left icon"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonAlt="alt-green"
+            buttonWidth="full"
+            label="Secondary disabled full"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+        </div>
+        <div className="button-row">
+          <CWText type="h4">Secondary Alt-Rorange</CWText>
+          <CWButton
+            buttonType="secondary"
+            buttonAlt="alt-rorange"
+            label="Secondary default"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonHeight="lg"
+            buttonAlt="alt-rorange"
+            label="Secondary large"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonWidth="wide"
+            buttonAlt="alt-rorange"
+            label="Secondary wide"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonHeight="lg"
+            buttonAlt="alt-rorange"
+            buttonWidth="wide"
+            label="Secondary large and wide"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            iconLeft="person"
+            buttonType="secondary"
+            buttonAlt="alt-rorange"
+            label="Secondary default w/ left icon"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonWidth="full"
+            buttonAlt="alt-rorange"
+            label="Secondary full"
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            label="Secondary default disabled"
+            buttonAlt="alt-rorange"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            iconLeft="person"
+            buttonAlt="alt-rorange"
+            buttonType="secondary"
+            label="Secondary default disabled w/ left icon"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+          <CWButton
+            buttonType="secondary"
+            buttonAlt="alt-rorange"
+            buttonWidth="full"
+            label="Secondary disabled full"
+            disabled
+            onClick={() => notifySuccess('Button clicked!')}
+          />
+        </div>
       </div>
       <div className="basic-gallery">
         <CWText type="h4">Content Page Card</CWText>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
@@ -15,7 +15,7 @@ type ButtonHeight = 'lg' | 'med' | 'sm';
 
 type ButtonWidth = 'narrow' | 'wide' | 'full';
 
-type ButtonAlt = 'alt-green' | 'alt-rorange';
+type ButtonAlt = 'green' | 'rorange';
 
 type ButtonStyleProps = {
   buttonType?: ButtonType;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
@@ -15,10 +15,13 @@ type ButtonHeight = 'lg' | 'med' | 'sm';
 
 type ButtonWidth = 'narrow' | 'wide' | 'full';
 
+type ButtonAlt = 'alt-green' | 'alt-rorange';
+
 type ButtonStyleProps = {
   buttonType?: ButtonType;
   buttonHeight?: ButtonHeight;
   buttonWidth?: ButtonWidth;
+  buttonAlt?: ButtonAlt;
 } & BaseStyleProps;
 
 export type ButtonProps = {
@@ -35,6 +38,7 @@ export const CWButton = (props: ButtonProps) => {
     buttonType = 'primary',
     buttonHeight = 'med',
     buttonWidth = 'narrow',
+    buttonAlt,
     className,
     disabled = false,
     iconLeft,
@@ -60,18 +64,23 @@ export const CWButton = (props: ButtonProps) => {
           {
             disabled,
             buttonType,
+            buttonAlt,
             buttonHeight,
             buttonWidth,
             className,
           },
-          ComponentType.Button
+          ComponentType.Button,
         )}
         onClick={onClick}
         disabled={disabled}
         {...otherProps}
       >
         {!!iconLeft && <CWIcon iconName={iconLeft} className="button-icon" />}
-        <CWText type={'buttonMini'} className="button-text" noWrap>
+        <CWText
+          type={buttonHeight === 'lg' ? 'buttonLg' : 'buttonSm'}
+          className="button-text"
+          noWrap
+        >
           {label}
         </CWText>
         {!!iconRight && <CWIcon iconName={iconRight} className="button-icon" />}

--- a/packages/commonwealth/client/styles/components/component_kit/cw_component_showcase.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_component_showcase.scss
@@ -200,7 +200,7 @@ $width: 360px;
       gap: 8px;
       margin-bottom: 15px;
 
-      >.Text {
+      > .Text {
         min-width: 140px;
       }
     }

--- a/packages/commonwealth/client/styles/components/component_kit/cw_component_showcase.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_component_showcase.scss
@@ -200,7 +200,7 @@ $width: 360px;
       gap: 8px;
       margin-bottom: 15px;
 
-      > .Text {
+      >.Text {
         min-width: 140px;
       }
     }
@@ -240,6 +240,7 @@ $width: 360px;
 
     .multi-select,
     .typeahead {
+
       .multi-select-row,
       .typeahead-row {
         margin-bottom: 15px;

--- a/packages/commonwealth/client/styles/components/component_kit/cw_text.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_text.scss
@@ -90,7 +90,7 @@
   &.buttonSm {
     font-family: $font-family-neue-haas-unica;
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: 0.02em;
     line-height: 24px;
   }
@@ -98,7 +98,7 @@
   &.buttonLg {
     font-family: $font-family-neue-haas-unica;
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: 0.04em;
     line-height: 28px;
   }

--- a/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_button.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_button.scss
@@ -73,8 +73,6 @@
   }
 
   .Button {
-    font-family: $font-family-neue-haas-unica;
-    font-weight: 500;
     align-items: center;
     border: 2px solid transparent;
     border-radius: $border-radius-corners-wider;
@@ -125,9 +123,6 @@
     &.sm,
     &.med {
       gap: 0.625rem;
-      .Text.button-text {
-        font-size: 0.875rem;
-      }
 
       .Icon {
         height: 1rem;
@@ -241,6 +236,56 @@
 
       &.disabled {
         background-color: $neutral-200;
+        @include iconAndTextColors($neutral-400, $neutral-400);
+      }
+    }
+
+    &.alt-green {
+      background-color: $green-50;
+      @include iconAndTextColors($neutral-800, $neutral-700);
+
+      &:hover {
+        background-color: $green-100;
+        @include iconAndTextColors($neutral-800, $neutral-800);
+      }
+
+      &:active {
+        background-color: $green-50;
+        @include iconAndTextColors($neutral-800, $neutral-700);
+      }
+
+      &:focus {
+        background-color: $green-100;
+        @include iconAndTextColors($neutral-800, $neutral-800);
+      }
+
+      &.disabled {
+        background-color: $neutral-50;
+        @include iconAndTextColors($neutral-400, $neutral-400);
+      }
+    }
+
+    &.alt-rorange {
+      background-color: $rorange-50;
+      @include iconAndTextColors($neutral-800, $neutral-700);
+
+      &:hover {
+        background-color: $rorange-100;
+        @include iconAndTextColors($neutral-800, $neutral-800);
+      }
+
+      &:active {
+        background-color: $rorange-50;
+        @include iconAndTextColors($neutral-800, $neutral-700);
+      }
+
+      &:focus {
+        background-color: $rorange-100;
+        @include iconAndTextColors($neutral-800, $neutral-800);
+      }
+
+      &.disabled {
+        background-color: $neutral-50;
         @include iconAndTextColors($neutral-400, $neutral-400);
       }
     }


### PR DESCRIPTION
This PR completes work for #5560, which asks for two additional secondary button types: alt-green and alt-rorange. Note, however, that these background colors can be added to any other button type (e.g. primary, tertiary, etc), as well. 

## Link to Issue
Closes: #5560

## Description of Changes
- adds `alt-green` and `alt-rorange` as alternative types on the CWButton component

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- visit the `/components` page and view the Secondary alt-green and alt-rorange types in the buttons section of the page

## Other Considerations
- this PR blocks issue #5505 