### PR TITLE
stripped previous logic and changed setting in ReactQuill modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,12 +68,12 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-import-resolver-webpack": "^0.13.2",
+    "husky": "^8.0.0",
     "prettier": "2.7.1",
     "prettier-plugin-organize-imports": "^3.2.3",
     "stylelint": "^14.14.1",
     "stylelint-config-prettier": "^9.0.4",
-    "stylelint-config-standard": "^29.0.0",
-    "husky": "^8.0.0"
+    "stylelint-config-standard": "^29.0.0"
   },
   "resolutions": {
     "quill": "^1.3.6",

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -14,7 +14,6 @@ import QuillTooltip from './QuillTooltip';
 import { LoadingIndicator } from './loading_indicator';
 import { CustomQuillToolbar, useMarkdownToolbarHandlers } from './toolbar';
 import { convertTwitterLinksToEmbeds } from './twitter_embed';
-import { useClipboardMatchers } from './use_clipboard_matchers';
 import { useImageDropAndPaste } from './use_image_drop_and_paste';
 import { useImageUploader } from './use_image_uploader';
 import { useMarkdownShortcuts } from './use_markdown_shortcuts';
@@ -71,8 +70,10 @@ const ReactQuillEditor = ({
     lastSelectionRef,
   });
 
+  // This is no longer used but I kept it here in case we
+  // need it in the future.
   // handle clipboard behavior
-  const { clipboardMatchers } = useClipboardMatchers();
+  // const { clipboardMatchers } = useClipboardMatchers();
 
   // handle image upload for drag and drop
   const { handleImageDropAndPaste } = useImageDropAndPaste({
@@ -119,16 +120,6 @@ const ReactQuillEditor = ({
       ...newContent,
       ___isMarkdown: isMarkdownEnabled,
     } as SerializableDeltaStatic);
-
-    // sets the correct cursor position after pasting content
-    if (editorRef?.current?.getEditor?.()?.getSelection?.()) {
-      const selection = editorRef.current.getEditor().getSelection();
-      setTimeout(() => {
-        editorRef.current
-          .getEditor()
-          .setSelection(selection.index, selection.length);
-      });
-    }
   };
 
   const handleToggleMarkdown = () => {
@@ -319,7 +310,7 @@ const ReactQuillEditor = ({
                             handler: handleImageDropAndPaste,
                           },
                           clipboard: {
-                            matchers: clipboardMatchers,
+                            matchVisual: false,
                           },
                           mention,
                           magicUrl: !isMarkdownEnabled,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5816 and #5829 

## Description of Changes
-Changes now allow users to type in text and press return to a new line. This also works on h1s and h2s as well as pasting text either from an app like Notes or copy and pasted text from web browsers. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Replaced `matchers: clipboardMatchers,` with `matchVisual: false,` in ReactQuill. Stripped out logic previously used to compensate for copy and pasting. I realized that even though the previous logic worked when copying and pasting text from a website, it would still add a new line, or <br>, when copying and pasting from Notes or Word. 

https://github.com/hicommonwealth/commonwealth/assets/69872984/033bc209-5aa5-4d70-aa07-b97e7cc33d8a


