### PR TITLE
Fix `admin_only_polling`

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_poll.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_poll.ts
@@ -79,7 +79,7 @@ export async function __createThreadPoll(
       allowAdmin: true,
     });
     if (!isAdmin) {
-      new AppError(Errors.MustBeAdmin);
+      throw new AppError(Errors.MustBeAdmin);
     }
   }
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_poll.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_poll.ts
@@ -71,7 +71,7 @@ export async function __createThreadPoll(
   }
 
   // check if admin_only flag is set
-  if (thread.Chain?.admin_only_polling) {
+  if (community.admin_only_polling) {
     const isAdmin = await validateOwner({
       models: this.models,
       user,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5637

## Description of Changes
- Uses the `admin_only_polling` from a defined community variable
- Throw the not admin error

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
`thread?.Chain` was always undefined because the Thread select did not join with the "Chains" table. The `community` variable is already provided by default so just switched to use that to check the `admin_only_polling` value instead of `thread?.Chain`. Additionally, the 'not admin' error was created but not thrown so poll creation was allowed.

## Test Plan
Follow the reproducing steps in the linked issue and ensure the curl command fails with `{"status":400,"error":"Must be admin to create poll"}`