### PR TITLE
revised h1/h2 sizing on both editor and comment

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
@@ -56,13 +56,17 @@
 
     .comment-text {
       div,
-      span,
       p {
         font-size: 16px !important;
         line-height: 24px !important;
         /* identical to box height, or 143% */
-
         letter-spacing: 0.16px !important;
+      }
+      h1 {
+        font-size: 24px !important;
+      }
+      h2 {
+        font-size: 20px !important;
       }
     }
 

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -130,6 +130,12 @@
     &.ql-blank::before {
       font-style: normal;
     }
+    & h1 {
+      font-size: 24px !important;
+    }
+    & h2 {
+      font-size: 20px !important;
+    }
   }
 
   .ondragover {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5280 

## Description of Changes
-changed the sizes of h1/h2 in quill editor and resulting comment

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added h1 and h2 css properties inside `.ql-editor` and `.comment-text` in `CommentCard.scss`
<img width="1440" alt="Screenshot 2023-12-11 at 11 59 29 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/46337f62-cdec-4bf6-b62d-fee56b3c8396">
<img width="1440" alt="Screenshot 2023-12-11 at 11 59 52 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/1bfa86a8-2bc2-4480-9b20-8c483fdfc3cd">
<img width="1440" alt="Screenshot 2023-12-11 at 11 59 41 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/ef5610a0-b988-41b5-bd2e-95994acba3bc">

