### PR TITLE
quill editor now works as it should

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -83,7 +83,6 @@
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
-  display: none;
 }
 
 .QuillEditorWrapper {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5909 and #5816 

## Description of Changes
-react-quill editor now works as it should, allowing returns, copying and pasting from Notion, VSCode, Telegram, Notes, the browser without the cursor going to the beginning of the line or the end of the line. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-removed `display: none` from `.ql-clipboard` 🤦 
-Thank you Ifu.

## Test Plan
-go to any editor and type, paste to your heart's content

https://github.com/hicommonwealth/commonwealth/assets/69872984/a0b75b42-be86-41fc-b1ec-eef731c07ea7



