### PR TITLE
fix cosmos devnet tx tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -471,11 +471,11 @@ jobs:
       cosmos_test_app:
         image: mhagel1/csdk-v1
         ports:
-         - 5050:5050
+         - 5051:5051
       cosmos_beta_test_app:
         image: mhagel1/csdk-beta
         ports:
-         - 5051:5051
+         - 5050:5050
       evmos_test_app:
         image: mhagel1/evmos-dev
         ports:

--- a/knowledge_base/Devnet.md
+++ b/knowledge_base/Devnet.md
@@ -26,7 +26,7 @@ Note: Currently, the sandbox communities csdk, csdk-beta, and evmos-dev are on a
 
 See: <https://dashboard.heroku.com/apps/cosmos-devnet/deploy/heroku-container>
 
-1. In terminal go to packages/chain-events/cosmos-chain-testing/v1 directory
+1. In terminal go to packages/commonwealth/test/util/cosmos-chain-testing/v1 directory
 2. `heroku git:remote -a cosmos-devnet`
 3. `heroku login`
 4. `heroku container:login`
@@ -38,7 +38,7 @@ Note: If you get error "No images to push," make sure Dockerfile is capitalized
 ### Deploying Updates to a CI Deployment
 
 1. Create a remote Docker Hub repo called (for ex) "csdk-v1"
-2. In terminal go to packages/chain-events/cosmos-chain-testing/v1 directory
+2. In terminal go to packages/commonwealth/test/util/cosmos-chain-testing/v1 directory
 3. `docker build -t {your-docker-remote-hub}/csdk-v1 .`
 4. `docker push {your-docker-remote-hub}/csdk-v1`
 5. If you use a new docker remote, update the reference for tests in CI.yml
@@ -152,6 +152,7 @@ CI community (ephemeral spin-up for automated tests):
 
 ## Change Log
 
+- 231211: Updated directory of devnet files.
 - 231031: Flagged by Timothee Legros as needing EVM documentation similar to current CSDK info.
 - 231031: Flagged by Graham Johnson; `chain-events` package references are obsolete.
 - 230727: Updated with Cosmos SDK info by Mark Hagelberg.

--- a/packages/commonwealth/server/workers/cosmosGovNotifications/proposalFetching/v1ProposalFetching.ts
+++ b/packages/commonwealth/server/workers/cosmosGovNotifications/proposalFetching/v1ProposalFetching.ts
@@ -1,12 +1,12 @@
-import { CommunityInstance } from '../../../models/community';
+import { PageRequest } from 'common-common/src/cosmos-ts/src/codegen/cosmos/base/query/v1beta1/pagination';
 import {
   ProposalSDKType,
   ProposalStatus,
 } from 'common-common/src/cosmos-ts/src/codegen/cosmos/gov/v1/gov';
 import { LCDQueryClient as GovV1Client } from 'common-common/src/cosmos-ts/src/codegen/cosmos/gov/v1/query.lcd';
-import { PageRequest } from 'common-common/src/cosmos-ts/src/codegen/cosmos/base/query/v1beta1/pagination';
 import { numberToLong } from 'common-common/src/cosmos-ts/src/codegen/helpers';
 import { factory, formatFilename } from 'common-common/src/logging';
+import { CommunityInstance } from '../../../models/community';
 import { getCosmosClient } from './getCosmosClient';
 import { numberToUint8ArrayBE, uint8ArrayToNumberBE } from './util';
 
@@ -18,7 +18,7 @@ const log = factory.getLogger(formatFilename(__filename));
  * See /gov/v1beta1/proposals at https://v1.cosmos.network/rpc/v0.45.1 for more details on pagination values.
  */
 export async function fetchLatestCosmosProposalV1(
-  chain: CommunityInstance
+  chain: CommunityInstance,
 ): Promise<ProposalSDKType[]> {
   const client = await getCosmosClient<GovV1Client>(chain);
   let nextKey: Uint8Array, finalProposalsPage: ProposalSDKType[];
@@ -46,7 +46,7 @@ export async function fetchLatestCosmosProposalV1(
     log.info(
       `Fetched proposal ${
         finalProposalsPage[finalProposalsPage.length - 1].id
-      } from ${chain.id}`
+      } from ${chain.id}`,
     );
     return [finalProposalsPage[finalProposalsPage.length - 1]];
   } else return [];
@@ -59,7 +59,7 @@ export async function fetchLatestCosmosProposalV1(
  */
 export async function fetchUpToLatestCosmosProposalV1(
   proposalId: number,
-  chain: CommunityInstance
+  chain: CommunityInstance,
 ): Promise<ProposalSDKType[]> {
   const client = await getCosmosClient<GovV1Client>(chain);
 
@@ -72,7 +72,7 @@ export async function fetchUpToLatestCosmosProposalV1(
       });
       proposal = result.proposal;
     } catch (e) {
-      if (!e.message.includes('rpc error: code = NotFound')) {
+      if (!e.message.includes('Request failed with status code 404')) {
         throw e;
       }
     }

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxEthermint.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxEthermint.spec.ts
@@ -108,6 +108,25 @@ describe('Proposal Transaction Tests - ethermint chain (evmos-dev-ci)', () => {
     return vote;
   };
 
+  const voteTest = async (
+    voteOption: VoteOption,
+    expectedVoteString: string,
+  ): Promise<void> => {
+    await waitOneBlock(rpcUrl);
+    const activeProposals = await getActiveVotingProposals();
+
+    assert.isAtLeast(activeProposals.length, 1);
+    const proposal = activeProposals[activeProposals.length - 1];
+
+    const msg = encodeMsgVote(signerAddr, proposal.proposalId, voteOption);
+    const resp = await sendTx(lcdUrl, msg);
+
+    expect(resp.transactionHash).to.not.be.undefined;
+    expect(resp.rawLog).to.not.be.undefined;
+    const voteValue = parseVoteValue(resp.rawLog);
+    expect(voteValue).to.eql(expectedVoteString);
+  };
+
   it('creates a proposal', async () => {
     const content = encodeTextProposal(
       `evmos test title`,
@@ -126,85 +145,22 @@ describe('Proposal Transaction Tests - ethermint chain (evmos-dev-ci)', () => {
   });
 
   it('votes NO on an active proposal', async () => {
-    await waitOneBlock(rpcUrl);
-    const activeProposals = await getActiveVotingProposals();
-
-    assert.isAtLeast(activeProposals.length, 1);
-    const proposal = activeProposals[0];
-
-    const msg = encodeMsgVote(
-      signerAddr,
-      proposal.proposalId,
-      VoteOption.VOTE_OPTION_NO,
-    );
-    const resp = await sendTx(lcdUrl, msg);
-
-    expect(resp.transactionHash).to.not.be.undefined;
-    expect(resp.rawLog).to.not.be.undefined;
-    const voteValue = parseVoteValue(resp.rawLog);
-    expect(voteValue).to.eql('VOTE_OPTION_NO');
+    await voteTest(VoteOption.VOTE_OPTION_NO, 'VOTE_OPTION_NO');
   });
 
   it('votes NO WITH VETO on an active proposal', async () => {
-    await waitOneBlock(rpcUrl);
-    const activeProposals = await getActiveVotingProposals();
-
-    assert.isAtLeast(activeProposals.length, 1);
-    const proposal = activeProposals[0];
-
-    const msg = encodeMsgVote(
-      signerAddr,
-      proposal.proposalId,
+    await voteTest(
       VoteOption.VOTE_OPTION_NO_WITH_VETO,
+      'VOTE_OPTION_NO_WITH_VETO',
     );
-    const resp = await sendTx(lcdUrl, msg);
-
-    expect(resp.transactionHash).to.not.be.undefined;
-    expect(resp.rawLog).to.not.be.undefined;
-    const voteValue = parseVoteValue(resp.rawLog);
-    expect(voteValue).to.eql('VOTE_OPTION_NO_WITH_VETO');
   });
 
   it('votes ABSTAIN on an active proposal', async () => {
-    await waitOneBlock(rpcUrl);
-    const activeProposals = await getActiveVotingProposals();
-
-    assert.isAtLeast(activeProposals.length, 1);
-    const proposal = activeProposals[0];
-
-    const msg = encodeMsgVote(
-      signerAddr,
-      proposal.proposalId,
-      VoteOption.VOTE_OPTION_ABSTAIN,
-    );
-    const resp = await sendTx(lcdUrl, msg);
-
-    expect(resp.transactionHash).to.not.be.undefined;
-    expect(resp.rawLog).to.not.be.undefined;
-    const voteValue = parseVoteValue(resp.rawLog);
-    expect(voteValue).to.eql('VOTE_OPTION_ABSTAIN');
+    await voteTest(VoteOption.VOTE_OPTION_ABSTAIN, 'VOTE_OPTION_ABSTAIN');
   });
 
   it('votes YES on an active proposal', async () => {
-    await waitOneBlock(rpcUrl);
-    const activeProposals = await getActiveVotingProposals();
-
-    expect(activeProposals).to.not.be.undefined;
-    expect(activeProposals.length).to.be.greaterThan(0);
-
-    const proposal = activeProposals[0];
-
-    const msg = encodeMsgVote(
-      signerAddr,
-      proposal.proposalId,
-      VoteOption.VOTE_OPTION_YES,
-    );
-    const resp = await sendTx(lcdUrl, msg);
-
-    expect(resp.transactionHash).to.not.be.undefined;
-    expect(resp.rawLog).to.not.be.undefined;
-    const voteValue = parseVoteValue(resp.rawLog);
-    expect(voteValue).to.eql('VOTE_OPTION_YES');
+    await voteTest(VoteOption.VOTE_OPTION_YES, 'VOTE_OPTION_YES');
   });
 });
 

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
@@ -1,22 +1,23 @@
-import chai from 'chai';
 import { isDeliverTxSuccess } from '@cosmjs/stargate';
+import chai from 'chai';
 
+import { longify } from '@cosmjs/stargate/build/queryclient';
 import {
   ProposalStatus as ProposalStatusV1,
+  VoteOption as VoteOptionV1,
   voteOptionToJSON,
 } from 'common-common/src/cosmos-ts/src/codegen/cosmos/gov/v1/gov';
-import { VoteOption as VoteOptionV1 } from 'common-common/src/cosmos-ts/src/codegen/cosmos/gov/v1/gov';
-import {
-  encodeMsgVote,
-  encodeMsgSubmitProposal,
-  encodeTextProposal,
-  encodeCommunitySpend,
-} from 'controllers/chain/cosmos/gov/v1beta1/utils-v1beta1';
 import { getLCDClient } from 'controllers/chain/cosmos/chain.utils';
 import {
   getActiveProposalsV1,
   getCompletedProposalsV1,
 } from 'controllers/chain/cosmos/gov/v1/utils-v1';
+import {
+  encodeCommunitySpend,
+  encodeMsgSubmitProposal,
+  encodeMsgVote,
+  encodeTextProposal,
+} from 'controllers/chain/cosmos/gov/v1beta1/utils-v1beta1';
 import { LCD } from '../../../shared/chain/types/cosmos';
 import {
   deposit,
@@ -49,10 +50,33 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
     return activeProposals;
   };
 
+  const waitForOnchainProposal = async (proposalId: number) => {
+    // Set up a loop to check for a new block
+    let newProposal;
+    while (!newProposal) {
+      // Wait for a short period
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      try {
+        const proposalResponse = await lcd.cosmos.gov.v1.proposal({
+          proposalId: longify(proposalId),
+        });
+        newProposal = proposalResponse.proposal;
+      } catch (e) {
+        console.error(
+          `Error fetching proposal by id ${proposalId}. Trying again...`,
+        );
+        newProposal = null;
+      }
+    }
+
+    return newProposal;
+  };
+
   const proposalTest = async (
     content: any,
     expectedProposalType: string,
-    isAmino?: boolean
+    isAmino?: boolean,
   ) => {
     const msg = encodeMsgSubmitProposal(signer, deposit, content);
     const resp = await sendTx(rpcUrl, msg, isAmino);
@@ -60,20 +84,23 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
     expect(resp.transactionHash).to.not.be.undefined;
     expect(resp.rawLog).to.not.be.undefined;
     expect(isDeliverTxSuccess(resp), 'TX failed').to.be.true;
-
-    await waitOneBlock(rpcUrl);
-    await waitOneBlock(rpcUrl);
-    await waitOneBlock(rpcUrl);
-    const activeProposals = await getActiveVotingProposals();
-    const onchainProposal = activeProposals[activeProposals?.length - 1];
-    expect((onchainProposal?.messages?.[0] as any)?.content?.['@type']).to.eql(
-      expectedProposalType
+    const rawLog = JSON.parse(resp.rawLog);
+    const submitProposalEvent = rawLog[0]?.events?.find(
+      (e) => e['type'] === 'submit_proposal',
     );
+    const proposalId = submitProposalEvent?.attributes.find(
+      (a) => a.key === 'proposal_id',
+    )?.value;
+
+    const onChainProposal = await waitForOnchainProposal(proposalId);
+    const messageType = onChainProposal.messages[0]?.content['@type'];
+
+    expect(messageType).to.eql(expectedProposalType);
   };
 
   const voteTest = async (
     voteOption: number,
-    isAmino?: boolean
+    isAmino?: boolean,
   ): Promise<void> => {
     await waitOneBlock(rpcUrl);
     const activeProposals = await getActiveVotingProposals();
@@ -106,17 +133,16 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
       await voteTest(VoteOptionV1.VOTE_OPTION_YES);
     });
     it('creates a community spend proposal', async () => {
-      await waitOneBlock(rpcUrl);
       const content = encodeCommunitySpend(
         `v1 spend title`,
         `v1 spend description`,
         'cosmos18q3tlnx8vguv2fadqslm7x59ejauvsmnlycckg',
         '5',
-        'ustake'
+        'ustake',
       );
       await proposalTest(
         content,
-        '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal'
+        '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal',
       );
     });
   });
@@ -140,18 +166,17 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
     // TODO: Unsupported. Un-skip this in
     // https://github.com/hicommonwealth/commonwealth/issues/4821
     it.skip('creates a community spend proposal with legacy amino', async () => {
-      await waitOneBlock(rpcUrl);
       const content = encodeCommunitySpend(
         `v1 spend title amino`,
         `v1 spend description amino`,
         'cosmos18q3tlnx8vguv2fadqslm7x59ejauvsmnlycckg',
         '5',
-        'ustake'
+        'ustake',
       );
       await proposalTest(
         content,
         '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal',
-        true
+        true,
       );
     });
   });

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
@@ -51,7 +51,6 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
   };
 
   const waitForOnchainProposal = async (proposalId: number) => {
-    // Set up a loop to check for a new block
     let newProposal;
     while (!newProposal) {
       // Wait for a short period

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
@@ -104,13 +104,14 @@ describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1
     await waitOneBlock(rpcUrl);
     const activeProposals = await getActiveVotingProposals();
     assert.isAtLeast(activeProposals.length, 1);
-    const proposal = activeProposals[0];
-    const msg = encodeMsgVote(signer, proposal.id, voteOption);
+    const latestProposal = activeProposals[activeProposals.length - 1];
+    const msg = encodeMsgVote(signer, latestProposal.id, voteOption);
 
     const resp = await sendTx(rpcUrl, msg, isAmino);
 
     expect(resp.transactionHash).to.not.be.undefined;
     expect(resp.rawLog).to.not.be.undefined;
+    expect(resp.rawLog).to.not.include('failed to execute message');
     expect(resp.rawLog).to.include(voteOptionToJSON(voteOption));
   };
 

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
@@ -72,9 +72,9 @@ describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', (
     const submitProposalEvent = rawLog[0]?.['events']?.find(
       (e) => e['type'] === 'submit_proposal',
     );
-    const proposalType = submitProposalEvent.attributes.find(
+    const proposalType = submitProposalEvent?.attributes.find(
       (a) => a.key === 'proposal_type',
-    ).value;
+    )?.value;
 
     expect(proposalType).to.eql(expectedProposalType);
   };
@@ -137,7 +137,7 @@ describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', (
         `beta text title`,
         `beta text description`,
       );
-      await proposalTest(content, '/cosmos.gov.v1beta1.TextProposal', true);
+      await proposalTest(content, 'Text', true);
     });
     it('votes NO on an active proposal with legacy amino', async () => {
       await voteTest(VoteOption.VOTE_OPTION_NO, true);
@@ -160,11 +160,7 @@ describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', (
         '5',
         'ustake',
       );
-      await proposalTest(
-        content,
-        '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal',
-        true,
-      );
+      await proposalTest(content, 'CommunityPoolSpend', true);
     });
   });
 });

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
@@ -1,21 +1,21 @@
-import chai from 'chai';
 import { isDeliverTxSuccess } from '@cosmjs/stargate';
-import {
-  ProposalStatus,
-  VoteOption,
-} from 'cosmjs-types/cosmos/gov/v1beta1/gov';
-import {
-  encodeMsgVote,
-  encodeMsgSubmitProposal,
-  encodeTextProposal,
-  getActiveProposalsV1Beta1,
-  encodeCommunitySpend,
-} from 'controllers/chain/cosmos/gov/v1beta1/utils-v1beta1';
+import chai from 'chai';
+import { CosmosApiType } from 'controllers/chain/cosmos/chain';
 import {
   getRPCClient,
   getTMClient,
 } from 'controllers/chain/cosmos/chain.utils';
-import { CosmosApiType } from 'controllers/chain/cosmos/chain';
+import {
+  encodeCommunitySpend,
+  encodeMsgSubmitProposal,
+  encodeMsgVote,
+  encodeTextProposal,
+  getActiveProposalsV1Beta1,
+} from 'controllers/chain/cosmos/gov/v1beta1/utils-v1beta1';
+import {
+  ProposalStatus,
+  VoteOption,
+} from 'cosmjs-types/cosmos/gov/v1beta1/gov';
 import {
   deposit,
   sendTx,
@@ -25,7 +25,7 @@ import {
 
 const { expect, assert } = chai;
 
-describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => {
+describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => {
   let rpc: CosmosApiType;
   let signer: string;
   // v1beta1 CI devnet
@@ -43,7 +43,7 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
     const { proposals: activeProposals } = await rpc.gov.proposals(
       ProposalStatus.PROPOSAL_STATUS_VOTING_PERIOD,
       '',
-      ''
+      '',
     );
     return activeProposals;
   };
@@ -58,7 +58,7 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
   const proposalTest = async (
     content: any,
     expectedProposalType: string,
-    isAmino?: boolean
+    isAmino?: boolean,
   ) => {
     const msg = encodeMsgSubmitProposal(signer, deposit, content);
     const resp = await sendTx(rpcUrlBeta, msg, isAmino);
@@ -67,16 +67,21 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
     expect(resp.rawLog).to.not.be.undefined;
     expect(isDeliverTxSuccess(resp), 'TX failed').to.be.true;
 
-    await waitOneBlock(rpcUrlBeta);
-    await waitOneBlock(rpcUrlBeta);
-    const activeProposals = await getActiveVotingProposals();
-    const onchainProposal = activeProposals[activeProposals.length - 1];
-    expect(onchainProposal?.content?.typeUrl).to.eql(expectedProposalType);
+    const rawLog = JSON.parse(resp.rawLog);
+
+    const submitProposalEvent = rawLog[0]?.['events']?.find(
+      (e) => e['type'] === 'submit_proposal',
+    );
+    const proposalType = submitProposalEvent.attributes.find(
+      (a) => a.key === 'proposal_type',
+    ).value;
+
+    expect(proposalType).to.eql(expectedProposalType);
   };
 
   const voteTest = async (
     voteOption: number,
-    isAmino?: boolean
+    isAmino?: boolean,
   ): Promise<void> => {
     await waitOneBlock(rpcUrlBeta);
     const activeProposals = await getActiveVotingProposals();
@@ -96,9 +101,9 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
     it('creates a text proposal', async () => {
       const content = encodeTextProposal(
         `beta text title`,
-        `beta text description`
+        `beta text description`,
       );
-      await proposalTest(content, '/cosmos.gov.v1beta1.TextProposal');
+      await proposalTest(content, 'Text');
     });
     it('votes NO on an active proposal', async () => {
       await voteTest(VoteOption.VOTE_OPTION_NO);
@@ -119,12 +124,9 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
         `beta spend description`,
         'cosmos18q3tlnx8vguv2fadqslm7x59ejauvsmnlycckg',
         '5',
-        'ustake'
+        'ustake',
       );
-      await proposalTest(
-        content,
-        '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal'
-      );
+      await proposalTest(content, 'CommunityPoolSpend');
     });
   });
 
@@ -133,7 +135,7 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
       await waitOneBlock(rpcUrlBeta);
       const content = encodeTextProposal(
         `beta text title`,
-        `beta text description`
+        `beta text description`,
       );
       await proposalTest(content, '/cosmos.gov.v1beta1.TextProposal', true);
     });
@@ -156,12 +158,12 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
         `beta spend description amino`,
         'cosmos18q3tlnx8vguv2fadqslm7x59ejauvsmnlycckg',
         '5',
-        'ustake'
+        'ustake',
       );
       await proposalTest(
         content,
         '/cosmos.distribution.v1beta1.CommunityPoolSpendProposal',
-        true
+        true,
       );
     });
   });
@@ -172,7 +174,7 @@ describe('Cosmos Governance v1beta1 util Tests', () => {
     it('should fetch active proposals (csdk-beta-ci)', async () => {
       const id = 'csdk-beta-ci'; // CI devnet for v1beta1
       const tmClient = await getTMClient(
-        `http://localhost:8080/cosmosAPI/${id}`
+        `http://localhost:8080/cosmosAPI/${id}`,
       );
       const rpc = await getRPCClient(tmClient);
 

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
@@ -25,7 +25,7 @@ import {
 
 const { expect, assert } = chai;
 
-describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => {
+describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => {
   let rpc: CosmosApiType;
   let signer: string;
   // v1beta1 CI devnet
@@ -69,7 +69,7 @@ describe.only('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', (
 
     const rawLog = JSON.parse(resp.rawLog);
 
-    const submitProposalEvent = rawLog[0]?.['events']?.find(
+    const submitProposalEvent = rawLog[0]?.events?.find(
       (e) => e['type'] === 'submit_proposal',
     );
     const proposalType = submitProposalEvent?.attributes.find(

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts
@@ -86,7 +86,7 @@ describe('Proposal Transaction Tests - gov v1beta1 chain (csdk-beta-ci)', () => 
     await waitOneBlock(rpcUrlBeta);
     const activeProposals = await getActiveVotingProposals();
     assert.isAtLeast(activeProposals.length, 1);
-    const proposal = activeProposals[0];
+    const proposal = activeProposals[activeProposals.length - 1];
     const msg = encodeMsgVote(signer, proposal.proposalId, voteOption);
 
     const resp = await sendTx(rpcUrlBeta, msg, isAmino);

--- a/packages/commonwealth/test/devnet/cosmos/utils/helpers.ts
+++ b/packages/commonwealth/test/devnet/cosmos/utils/helpers.ts
@@ -1,5 +1,5 @@
-import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { Secp256k1HdWallet, StdFee } from '@cosmjs/amino';
+import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 
 import { CosmosToken } from 'controllers/chain/cosmos/types';
@@ -38,14 +38,14 @@ export const setupTestSigner = async (rpcUrl: string, isAmino?: boolean) => {
 export const sendTx = async (
   rpcUrl: string,
   tx: any,
-  isAmino?: boolean
+  isAmino?: boolean,
 ): Promise<DeliverTxResponse> => {
   const { client, signerAddress } = await setupTestSigner(rpcUrl, isAmino);
   const result = await client.signAndBroadcast(
     signerAddress,
     [tx],
     DEFAULT_FEE,
-    DEFAULT_MEMO
+    DEFAULT_MEMO,
   );
   return result;
 };
@@ -60,7 +60,7 @@ export const waitOneBlock = async (rpcUrl: string): Promise<void> => {
   let newHeight = currentHeight;
   while (newHeight === currentHeight) {
     // Wait for a short period
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Check the current block height again
     const block = await tm.block();

--- a/packages/commonwealth/test/devnet/cosmos/utils/helpers.ts
+++ b/packages/commonwealth/test/devnet/cosmos/utils/helpers.ts
@@ -10,7 +10,8 @@ import {
 } from 'controllers/chain/cosmos/chain.utils';
 
 const mnemonic =
-  'ignore medal pitch lesson catch stadium victory jewel first stairs humble excuse scrap clutch cup daughter bench length sell goose deliver critic favorite thought';
+  `ignore medal pitch lesson catch stadium victory jewel first stairs humble excuse ` +
+  `scrap clutch cup daughter bench length sell goose deliver critic favorite thought`;
 const DEFAULT_FEE: StdFee = {
   gas: '180000',
   amount: [{ amount: '0', denom: 'ustake' }],
@@ -63,7 +64,7 @@ export const waitOneBlock = async (rpcUrl: string): Promise<void> => {
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     // Check the current block height again
-    const block = await tm.block();
-    newHeight = block.block.header.height;
+    const latestBlock = await tm.block();
+    newHeight = latestBlock.block.header.height;
   }
 };

--- a/packages/commonwealth/test/util/cosmos-chain-testing/ethermint/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/ethermint/bootstrap.sh
@@ -34,7 +34,7 @@ dasel put -t string -r json -f $GENESIS -v "aevmos" '.app_state.txfees.basedenom
 dasel put -t string -r json -f $GENESIS -v "aevmos" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -r json -t string -f $GENESIS -v "90s" '.app_state.gov.voting_params.voting_period'
+dasel put -r json -t string -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
 # 20 EVMOS deposit:
 dasel put -r json -t string -f $GENESIS -v "20000000000000000000" '.app_state.gov.deposit_params.min_deposit.index(0).amount'
 dasel put -r json -t string -f $GENESIS -v "aevmos" '.app_state.gov.deposit_params.min_deposit.index(0).denom'

--- a/packages/commonwealth/test/util/cosmos-chain-testing/ethermint/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/ethermint/bootstrap.sh
@@ -34,7 +34,7 @@ dasel put -t string -r json -f $GENESIS -v "aevmos" '.app_state.txfees.basedenom
 dasel put -t string -r json -f $GENESIS -v "aevmos" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -r json -t string -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
+dasel put -r json -t string -f $GENESIS -v "180s" '.app_state.gov.voting_params.voting_period'
 # 20 EVMOS deposit:
 dasel put -r json -t string -f $GENESIS -v "20000000000000000000" '.app_state.gov.deposit_params.min_deposit.index(0).amount'
 dasel put -r json -t string -f $GENESIS -v "aevmos" '.app_state.gov.deposit_params.min_deposit.index(0).denom'

--- a/packages/commonwealth/test/util/cosmos-chain-testing/v1/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/v1/bootstrap.sh
@@ -35,7 +35,7 @@ dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.crisis.constant_
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -t string -r json -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
+dasel put -t string -r json -f $GENESIS -v "180s" '.app_state.gov.voting_params.voting_period'
 dasel put -t string -r json -f $GENESIS -v "2000000" '.app_state.gov.deposit_params.min_deposit.[0].amount'
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.gov.deposit_params.min_deposit.[0].denom'
 

--- a/packages/commonwealth/test/util/cosmos-chain-testing/v1/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/v1/bootstrap.sh
@@ -35,7 +35,7 @@ dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.crisis.constant_
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -t string -r json -f $GENESIS -v "90s" '.app_state.gov.voting_params.voting_period'
+dasel put -t string -r json -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
 dasel put -t string -r json -f $GENESIS -v "2000000" '.app_state.gov.deposit_params.min_deposit.[0].amount'
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.gov.deposit_params.min_deposit.[0].denom'
 

--- a/packages/commonwealth/test/util/cosmos-chain-testing/v1beta1/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/v1beta1/bootstrap.sh
@@ -35,7 +35,7 @@ dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.crisis.constant_
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -t string -r json -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
+dasel put -t string -r json -f $GENESIS -v "180s" '.app_state.gov.voting_params.voting_period'
 dasel put -t string -r json -f $GENESIS -v "2000000" '.app_state.gov.deposit_params.min_deposit.[0].amount'
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.gov.deposit_params.min_deposit.[0].denom'
 

--- a/packages/commonwealth/test/util/cosmos-chain-testing/v1beta1/bootstrap.sh
+++ b/packages/commonwealth/test/util/cosmos-chain-testing/v1beta1/bootstrap.sh
@@ -35,7 +35,7 @@ dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.crisis.constant_
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.mint.params.mint_denom'
 
 # Update gov module
-dasel put -t string -r json -f $GENESIS -v "90s" '.app_state.gov.voting_params.voting_period'
+dasel put -t string -r json -f $GENESIS -v "240s" '.app_state.gov.voting_params.voting_period'
 dasel put -t string -r json -f $GENESIS -v "2000000" '.app_state.gov.deposit_params.min_deposit.[0].amount'
 dasel put -t string -r json -f $GENESIS -v "ustake" '.app_state.gov.deposit_params.min_deposit.[0].denom'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Related #5707 

## Description of Changes
- Improves devnet proposal TX test reliability. 
- Makes them less reliant on block timing.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Instead of waiting a block, wait for a new proposal to be onchain to test it, or
- test the ProposalSubmit response

## Test Plan
- when `yarn test-devnet cosmos`, all these tests should pass
- commonwealth/test/devnet/cosmos/proposalTxEthermint.spec.ts
- commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
- commonwealth/test/devnet/cosmos/proposalTxV1beta1.spec.ts


## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 