### PR TITLE
Allow collaborators to edit thread body and title

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -113,7 +113,13 @@ export async function __updateThread(
     throw new AppError(`Ban error: ${banError}`);
   }
 
-  const thread = await this.models.Thread.findByPk(threadId);
+  const thread = await this.models.Thread.findByPk(threadId, {
+    include: {
+      model: this.models.Address,
+      as: 'collaborators',
+      required: false,
+    },
+  });
   if (!thread) {
     throw new AppError(`${Errors.ThreadNotFound}: ${threadId}`);
   }
@@ -129,6 +135,9 @@ export async function __updateThread(
     ['moderator', 'admin'],
   );
 
+  const isCollaborator = !!thread.collaborators.find(
+    (a) => a.address === address.address,
+  );
   const isThreadOwner = userOwnedAddressIds.includes(thread.address_id);
   const isMod = !!roles.find(
     (r) => r.chain_id === community.id && r.permission === 'moderator',
@@ -137,7 +146,13 @@ export async function __updateThread(
     (r) => r.chain_id === community.id && r.permission === 'admin',
   );
   const isSuperAdmin = user.isAdmin;
-  if (!isThreadOwner && !isMod && !isAdmin && !isSuperAdmin) {
+  if (
+    !isThreadOwner &&
+    !isMod &&
+    !isAdmin &&
+    !isSuperAdmin &&
+    !isCollaborator
+  ) {
     throw new AppError(Errors.Unauthorized);
   }
   const permissions = {
@@ -145,6 +160,7 @@ export async function __updateThread(
     isMod,
     isAdmin,
     isSuperAdmin,
+    isCollaborator,
   };
 
   const now = new Date();
@@ -357,6 +373,7 @@ export type UpdateThreadPermissions = {
   isMod: boolean;
   isAdmin: boolean;
   isSuperAdmin: boolean;
+  isCollaborator: boolean;
 };
 
 /**
@@ -367,7 +384,13 @@ export function validatePermissions(
   permissions: UpdateThreadPermissions,
   flags: Partial<UpdateThreadPermissions>,
 ) {
-  const keys = ['isThreadOwner', 'isMod', 'isAdmin', 'isSuperAdmin'];
+  const keys = [
+    'isThreadOwner',
+    'isMod',
+    'isAdmin',
+    'isSuperAdmin',
+    'isCollaborator',
+  ];
   for (const k of keys) {
     if (flags[k] && permissions[k]) {
       // at least one flag is satisfied
@@ -413,6 +436,7 @@ async function setThreadAttributes(
       isMod: true,
       isAdmin: true,
       isSuperAdmin: true,
+      isCollaborator: true,
     });
 
     // title

--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -135,7 +135,7 @@ export async function __updateThread(
     ['moderator', 'admin'],
   );
 
-  const isCollaborator = !!thread.collaborators.find(
+  const isCollaborator = !!thread.collaborators?.find(
     (a) => a.address === address.address,
   );
   const isThreadOwner = userOwnedAddressIds.includes(thread.address_id);

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.update_thread.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.update_thread.spec.ts
@@ -5,8 +5,8 @@ import {
   UpdateThreadPermissions,
   validatePermissions,
 } from 'server/controllers/server_threads_methods/update_thread';
-import { CommunityInstance } from '../../../server/models/community';
 import { BAN_CACHE_MOCK_FN } from 'test/util/banCacheMock';
+import { CommunityInstance } from '../../../server/models/community';
 
 describe('ServerThreadsController', () => {
   describe('#validatePermissions', () => {
@@ -16,6 +16,7 @@ describe('ServerThreadsController', () => {
         isMod: false,
         isAdmin: false,
         isSuperAdmin: false,
+        isCollaborator: false,
       };
       expect(() =>
         validatePermissions(permissions, {
@@ -23,7 +24,7 @@ describe('ServerThreadsController', () => {
           isMod: true,
           isAdmin: true,
           isSuperAdmin: true,
-        })
+        }),
       ).to.throw('Unauthorized');
     });
 
@@ -33,34 +34,35 @@ describe('ServerThreadsController', () => {
         isMod: false,
         isAdmin: true,
         isSuperAdmin: false,
+        isCollaborator: false,
       };
 
       // throws
       expect(() =>
         validatePermissions(permissions, {
           isThreadOwner: true,
-        })
+        }),
       ).to.throw('Unauthorized');
 
       // throws
       expect(() =>
         validatePermissions(permissions, {
           isMod: true,
-        })
+        }),
       ).to.throw('Unauthorized');
 
       // does NOT throw
       expect(() =>
         validatePermissions(permissions, {
           isAdmin: true,
-        })
+        }),
       ).to.not.throw();
 
       // throws
       expect(() =>
         validatePermissions(permissions, {
           isSuperAdmin: true,
-        })
+        }),
       ).to.throw('Unauthorized');
 
       // does NOT throw
@@ -70,7 +72,7 @@ describe('ServerThreadsController', () => {
           isMod: true,
           isAdmin: true,
           isSuperAdmin: true,
-        })
+        }),
       ).to.not.throw();
     });
   });
@@ -127,7 +129,7 @@ describe('ServerThreadsController', () => {
       const serverThreadsController = new ServerThreadsController(
         db,
         tokenBalanceCache,
-        banCache
+        banCache,
       );
       const [updatedThread, notificationOptions, analyticsOptions] =
         await serverThreadsController.updateThread(attributes);
@@ -139,7 +141,7 @@ describe('ServerThreadsController', () => {
             ...attributes.address,
             address: '0xbanned',
           },
-        })
+        }),
       ).to.be.rejectedWith('Ban error: banned');
 
       expect(updatedThread).to.be.ok;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5961

## Description of Changes
- Added the `isCollaborator` variable to the `updateThread` logic

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Joined the thread with any available collaborator address instances

## Test Plan
- Follow the reproducing plan in the linked issue -> should not throw an error when the collaborator edits a thread.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 