### PR TITLE
Fix null profile data display

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -47,7 +47,7 @@ const Profile = ({ profileId }: ProfileProps) => {
       const responseComments = result.comments.map((c) => new Comment(c));
       const commentsWithAssociatedThread = responseComments.map((c) => {
         const thread = result.commentThreads.find(
-          (t) => t.id === parseInt(c.threadId, 10)
+          (t) => t.id === parseInt(c.threadId, 10),
         );
         return { ...c, thread };
       });
@@ -68,7 +68,7 @@ const Profile = ({ profileId }: ProfileProps) => {
             console.error(`Could not return AddressInfo: "${err}"`);
             return null;
           }
-        })
+        }),
       );
       setIsOwner(result.isOwner);
     } catch (err) {
@@ -137,7 +137,9 @@ const Profile = ({ profileId }: ProfileProps) => {
       >
         <div className="header">
           <CWText type="h2" fontWeight="medium">
-            {`${profile.name}'s Profile`}
+            {profile.name
+              ? `${profile.name}'s Profile`
+              : `Anonymous user's Profile`}
           </CWText>
         </div>
         <div

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader.tsx
@@ -27,7 +27,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
   const isCurrentUser = isLoggedIn && isOwner;
   const hasBio = () => {
     try {
-      if (bio.trim().length === 0) return false;
+      if (!bio || bio.trim().length === 0) return false;
       return renderQuillDeltaToText(JSON.parse(decodeURIComponent(bio)));
     } catch {
       return true;
@@ -65,7 +65,9 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
         {hasBio() && (
           <div>
             <CWText type="h4">Bio</CWText>
-            <CWText className="bio">{<QuillRenderer doc={bio} />}</CWText>
+            <CWText className="bio">
+              <QuillRenderer doc={bio} />
+            </CWText>
           </div>
         )}
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/5958

## Description of Changes
- Hides "bio" field from view profile page when bio in null
- Displays `Anonymous user's Profile` when profile has no name

## "How We Fixed It"
By adding conditional checks for null object data

## Test Plan
- Create a new account, in the signup phase make sure to not add a profile name 
- Visit profile
- Verify you see `Anonymous user's Profile` as the main heading and you don't see bio field at all.
- Now update name and bio and verify you see updated contents

## Deployment Plan
N/A

## Other Considerations
N/A