### PR TITLE
#5866 - Bug Fix: Unable to search within a community

### DIFF
--- a/packages/commonwealth/server/controllers/server_comments_methods/search_comments.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/search_comments.ts
@@ -93,7 +93,7 @@ export async function __searchComments(
       "Addresses".address,
       "Addresses".community_id as address_chain,
       "Comments".created_at,
-      "Threads".chain,
+      "Threads".chain as community,
       ts_rank_cd("Comments"._search, query) as rank
     FROM "Comments"
     JOIN "Threads" ON "Comments".thread_id = "Threads".id

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -92,7 +92,7 @@ export async function __searchThreads(
       "Addresses".address,
       "Addresses".community_id as address_chain,
       "Threads".created_at,
-      "Threads".chain,
+      "Threads".chain as community,
       ts_rank_cd("Threads"._search, query) as rank
     FROM "Threads"
     JOIN "Addresses" ON "Threads".address_id = "Addresses".id,

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -34,7 +34,7 @@ export async function __searchThreads(
     page,
     orderBy,
     orderDirection,
-  }: SearchThreadsOptions
+  }: SearchThreadsOptions,
 ): Promise<SearchThreadsResult> {
   // sort by rank by default
   let sortOptions: PaginationSqlOptions = {
@@ -100,7 +100,7 @@ export async function __searchThreads(
     WHERE
       ${communityWhere}
       "Threads".deleted_at IS NULL AND
-      ${searchWhere}
+      (${searchWhere})
     ${paginationSort}
   `;
 


### PR DESCRIPTION
This work goes towards completion of issue #5866, which asks for the following bugs to be fixed:

1. limit searches in which community is specified to content within the community
2. remove 'Undefined' label from search results

## Link to Issue
Closes: #5866 

## Description of Changes
- fixes logic operator precedence-related SQL bug
- adds column aliases to SQL queries on threads and comments, so that frontend doesn't display "undefined"

## Test Plan
- navigate to a community page and enter a term in the search bar at the top

## Other Considerations
While working on this bug, I noticed that removing the community tag from the search bar does not result in a global search. Ticket to change the search bar functionality so that it does is here: #5972.