### PR TITLE
Fixed social links on manage page

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -295,7 +295,7 @@ class ChainInfo {
     const updatedChain = r.data.result;
     this.name = updatedChain.name;
     this.description = updatedChain.description;
-    this.socialLinks = updatedChain.socialLinks;
+    this.socialLinks = updatedChain.social_links;
     this.stagesEnabled = updatedChain.stages_enabled;
     this.customStages = updatedChain.custom_stages;
     this.customDomain = updatedChain.custom_domain;

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -235,7 +235,7 @@ class ChainInfo {
   public async updateChainData({
     name,
     description,
-    socialLinks,
+    social_links,
     stagesEnabled,
     customStages,
     customDomain,
@@ -253,7 +253,7 @@ class ChainInfo {
   }: {
     name?: string;
     description?: string;
-    socialLinks?: string[];
+    social_links?: string[];
     discord?: string;
     stagesEnabled?: boolean;
     customStages?: string;
@@ -275,7 +275,7 @@ class ChainInfo {
       id,
       name,
       description,
-      socialLinks,
+      social_links,
       stages_enabled: stagesEnabled,
       custom_stages: customStages,
       custom_domain: customDomain,

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/community_metadata_rows.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/community_metadata_rows.tsx
@@ -152,12 +152,18 @@ export const CommunityMetadataRows = ({
     } catch (err) {
       console.log(err);
     }
-    const socialLinks: string[] = [website, discord, element, telegram, github];
+    const social_links: string[] = [
+      website,
+      discord,
+      element,
+      telegram,
+      github,
+    ];
     try {
       await community.updateChainData({
         name,
         description,
-        socialLinks,
+        social_links,
         stagesEnabled,
         customStages,
         customDomain,

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -102,10 +102,11 @@ export async function __updateCommunity(
     snapshot = [];
   }
 
-  const invalidSocialLinks = social_links?.filter(
+  const nonEmptySocialLinks = social_links.filter((s) => s && s !== '');
+  const invalidSocialLinks = nonEmptySocialLinks?.filter(
     (s) => !urlHasValidHTTPPrefix(s),
   );
-  if (social_links && invalidSocialLinks.length > 0) {
+  if (nonEmptySocialLinks && invalidSocialLinks.length > 0) {
     throw new AppError(`${invalidSocialLinks[0]}: ${Errors.InvalidSocialLink}`);
   } else if (custom_domain && custom_domain.includes('commonwealth')) {
     throw new AppError(Errors.InvalidCustomDomain);
@@ -175,8 +176,8 @@ export async function __updateCommunity(
   if (icon_url) chain.icon_url = icon_url;
   if (active !== undefined) chain.active = active;
   if (type) chain.type = type;
-  if (social_links !== undefined && social_links.length > 0)
-    chain.social_links = social_links;
+  if (nonEmptySocialLinks !== undefined && nonEmptySocialLinks.length > 0)
+    chain.social_links = nonEmptySocialLinks;
   if (hide_projects) chain.hide_projects = hide_projects;
   if (stages_enabled) chain.stages_enabled = stages_enabled;
   if (custom_stages) chain.custom_stages = custom_stages;

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -102,7 +102,7 @@ export async function __updateCommunity(
     snapshot = [];
   }
 
-  const nonEmptySocialLinks = social_links.filter((s) => s && s !== '');
+  const nonEmptySocialLinks = social_links?.filter((s) => s && s !== '');
   const invalidSocialLinks = nonEmptySocialLinks?.filter(
     (s) => !urlHasValidHTTPPrefix(s),
   );


### PR DESCRIPTION
## Link to Issue
Closes: #5963

## Description of Changes
- Fixed typo where getting socialLinks instead of social_links
- Filtered out null values from social_link array so we are not storing redundant data.

### Test plan
- Join dydx
- Set self as admin
- go to manage page
- Change social links to valid http(s) urls
- Go to discussions page, make sure urls are updated.

## Other Considerations
I really would like type support. The reason for this error (Aside from my bad CA job) is that we don't have typing.