### PR TITLE
secondary metamask provider check

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -107,9 +107,13 @@ class MetamaskWebWalletController implements IWebWallet<string> {
 
       const Web3 = (await import('web3')).default;
 
-      const ethereum = window.ethereum.overrideIsMetaMask
-        ? window.ethereum.providerMap.get('MetaMask')
-        : window.ethereum;
+      let ethereum = window.ethereum;
+
+      if (window.ethereum.providers?.length) {
+        window.ethereum.providers.forEach(async (p) => {
+          if (p.isMetaMask) ethereum = p;
+        });
+      }
 
       this._web3 =
         process.env.ETH_RPC !== 'e2e-test'

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -32,17 +32,7 @@ class MetamaskWebWalletController implements IWebWallet<string> {
   public readonly chain = ChainBase.Ethereum;
 
   public get available() {
-    let isMetamask = false;
-    if (window.ethereum) {
-      if (window.ethereum.isMetaMask) {
-        isMetamask = true;
-      } else if (window.ethereum.providers?.length) {
-        window.ethereum.providers.forEach(async (p) => {
-          if (p.isMetaMask) isMetamask = true;
-        });
-      }
-    }
-    return isMetamask;
+    return !!window.ethereum;
   }
 
   public get provider() {

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -2,21 +2,21 @@ declare let window: any;
 
 import $ from 'jquery';
 
+import type Web3 from 'web3';
 import type Account from '../../../models/Account';
 import type BlockInfo from '../../../models/BlockInfo';
 import type IWebWallet from '../../../models/IWebWallet';
-import type Web3 from 'web3';
 
+import * as siwe from 'siwe';
 import type { provider } from 'web3-core';
 import { hexToNumber } from 'web3-utils';
-import * as siwe from 'siwe';
 
 import type { SessionPayload } from '@canvas-js/interfaces';
 
-import app from 'state';
+import { createSiweMessage } from 'adapters/chain/ethereum/keys';
 import { ChainBase, ChainNetwork, WalletId } from 'common-common/src/types';
 import { setActiveAccount } from 'controllers/app/login';
-import { createSiweMessage } from 'adapters/chain/ethereum/keys';
+import app from 'state';
 
 class MetamaskWebWalletController implements IWebWallet<string> {
   // GETTERS/SETTERS
@@ -77,7 +77,7 @@ class MetamaskWebWalletController implements IWebWallet<string> {
 
   public async signCanvasMessage(
     account: Account,
-    sessionPayload: SessionPayload
+    sessionPayload: SessionPayload,
   ): Promise<string> {
     const nonce = siwe.generateNonce();
     // this must be open-ended, because of custom domains
@@ -106,9 +106,16 @@ class MetamaskWebWalletController implements IWebWallet<string> {
       // ensure we're on the correct chain
 
       const Web3 = (await import('web3')).default;
+
+      const ethereum = window.ethereum.overrideIsMetaMask
+        ? window.ethereum.providerMap.get('MetaMask')
+        : window.ethereum;
+
       this._web3 =
         process.env.ETH_RPC !== 'e2e-test'
-          ? new Web3((window as any).ethereum)
+          ? {
+              givenProvider: ethereum,
+            }
           : {
               givenProvider: window.ethereum,
               eth: {
@@ -158,7 +165,13 @@ class MetamaskWebWalletController implements IWebWallet<string> {
         }
       }
       // fetch active accounts
-      this._accounts = await this._web3.eth.getAccounts();
+      this._accounts = (
+        await this._web3.givenProvider.request({
+          method: 'eth_requestAccounts',
+        })
+      ).map((addr) => {
+        return Web3.utils.toChecksumAddress(addr);
+      });
       this._provider = this._web3.currentProvider;
       if (this._accounts.length === 0) {
         throw new Error('Metamask fetched no accounts');
@@ -183,11 +196,11 @@ class MetamaskWebWalletController implements IWebWallet<string> {
       'accountsChanged',
       async (accounts: string[]) => {
         const updatedAddress = app.user.activeAccounts.find(
-          (addr) => addr.address === accounts[0]
+          (addr) => addr.address === accounts[0],
         );
         if (!updatedAddress) return;
         await setActiveAccount(updatedAddress);
-      }
+      },
     );
     // TODO: chainChanged, disconnect events
   }

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -32,7 +32,17 @@ class MetamaskWebWalletController implements IWebWallet<string> {
   public readonly chain = ChainBase.Ethereum;
 
   public get available() {
-    return !!window.ethereum;
+    let isMetamask = false;
+    if (window.ethereum) {
+      if (window.ethereum.isMetaMask) {
+        isMetamask = true;
+      } else if (window.ethereum.providers?.length) {
+        window.ethereum.providers.forEach(async (p) => {
+          if (p.isMetaMask) isMetamask = true;
+        });
+      }
+    }
+    return isMetamask;
   }
 
   public get provider() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5968 

## Description of Changes
- Gets correct metamask provider when another wallet has also injected into `window.ethereum`

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Root cause occurs here when CB wallet and metamask are both installed. Cb wallet creates an aggregate `window.ethereum` object which does not directly or default pull up either wallet. Ultimately, the proper metamask provider should always be selected via metamask button. 

## Test Plan
- Ensure metamask button works with coinbase wallet and metamask extensions installed
- remove/disable cb wallet extension and ensure it also works with only metamask installed

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- There are still unstable race conditions where coinbase wallet appears to only inject itself(or metamask fails to inject). Docs have pointed to this being a transient race condition and the main advice is to only use one window.ethereum enabled wallet.
- Attempted to use metamasks SDK but it runs into the same issue and appears to not be built for true wallet interop 