### PR TITLE
Use env for tbc balance TTL

### DIFF
--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -122,3 +122,7 @@ export const MEMBERSHIP_REFRESH_BATCH_SIZE = process.env
   .MEMBERSHIP_REFRESH_BATCH_SIZE
   ? parseInt(process.env.MEMBERSHIP_REFRESH_BATCH_SIZE, 10)
   : 1000;
+
+export const TBC_BALANCE_TTL_SECONDS = process.env.TBC_BALANCE_TTL_SECONDS
+  ? parseInt(process.env.TBC_BALANCE_TTL_SECONDS, 10)
+  : 300;

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -145,7 +145,7 @@ import { ServerReactionsController } from '../controllers/server_reactions_contr
 import { ServerThreadsController } from '../controllers/server_threads_controller';
 import { ServerTopicsController } from '../controllers/server_topics_controller';
 
-import { TBC_BALANCE_TTL_SECONDS } from 'server/config';
+import { TBC_BALANCE_TTL_SECONDS } from '../config';
 import { createCommentReactionHandler } from '../routes/comments/create_comment_reaction_handler';
 import { deleteBotCommentHandler } from '../routes/comments/delete_comment_bot_handler';
 import { deleteCommentHandler } from '../routes/comments/delete_comment_handler';

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -145,6 +145,7 @@ import { ServerReactionsController } from '../controllers/server_reactions_contr
 import { ServerThreadsController } from '../controllers/server_threads_controller';
 import { ServerTopicsController } from '../controllers/server_topics_controller';
 
+import { TBC_BALANCE_TTL_SECONDS } from 'server/config';
 import { createCommentReactionHandler } from '../routes/comments/create_comment_reaction_handler';
 import { deleteBotCommentHandler } from '../routes/comments/delete_comment_bot_handler';
 import { deleteCommentHandler } from '../routes/comments/delete_comment_handler';
@@ -215,7 +216,11 @@ function setupRouter(
 ) {
   // controllers
 
-  const tokenBalanceCacheV2 = new NewTokenBalanceCache(models, redisCache);
+  const tokenBalanceCacheV2 = new NewTokenBalanceCache(
+    models,
+    redisCache,
+    TBC_BALANCE_TTL_SECONDS,
+  );
 
   const serverControllers: ServerControllers = {
     threads: new ServerThreadsController(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5807

## Description of Changes
- Adds env `TBC_BALANCE_TTL_SECONDS`
- Passes env to TBC v2 constructor to init

## Test Plan
N/A

## Deployment Plan
N/A

## Other Considerations
N/A