### PR TITLE
Fix create community icon validation and crash.

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -320,19 +320,21 @@ class ChainInfo {
       remainingLinks: [],
     };
 
-    this.socialLinks.forEach((link) => {
-      if (link.includes('://discord.com') || link.includes('://discord.gg')) {
-        categorizedLinks.discords.push(link);
-      } else if (link.includes('://github.com')) {
-        categorizedLinks.githubs.push(link);
-      } else if (link.includes('://t.me')) {
-        categorizedLinks.telegrams.push(link);
-      } else if (link.includes('://matrix.to')) {
-        categorizedLinks.elements.push(link);
-      } else {
-        categorizedLinks.remainingLinks.push(link);
-      }
-    });
+    this.socialLinks
+      .filter((link) => !!link)
+      .forEach((link) => {
+        if (link.includes('://discord.com') || link.includes('://discord.gg')) {
+          categorizedLinks.discords.push(link);
+        } else if (link.includes('://github.com')) {
+          categorizedLinks.githubs.push(link);
+        } else if (link.includes('://t.me')) {
+          categorizedLinks.telegrams.push(link);
+        } else if (link.includes('://matrix.to')) {
+          categorizedLinks.elements.push(link);
+        } else {
+          categorizedLinks.remainingLinks.push(link);
+        }
+      });
 
     return categorizedLinks;
   }

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -40,7 +40,8 @@ export const createCommunitySchema = z.object({
   icon_url: z
     .string()
     .url()
-    .superRefine(async (val, ctx) => await checkIconSize(val, ctx)),
+    .superRefine(async (val, ctx) => await checkIconSize(val, ctx))
+    .optional(),
   social_links: z.array(z.string().url()).optional(),
   tags: z.array(z.nativeEnum(ChainCategoryType)).default([]),
   directory_page_enabled: z.boolean().default(false),


### PR DESCRIPTION
## Link to Issue
Closes: #5966 

## Description of Changes
- Makes icon_url optional in creating a community (preserving file validation).
- Fixes crash relating to null social links on new community (please confirm this fix @kurtisassad).

## Test Plan
- Attempt to create a community with just an id, without an icon. Ensure it loads successfully.
- Attempt to create a community with an invalid URL for an icon. Ensure it fails.
- Attempt to create a community with an icon >500 kB. Ensure it fails.

## Deployment Plan
N/A

## Other Considerations
Targeting 0.8.3 launch.