### PR TITLE
refresh community membership optimizations + pagination bug fix

### DIFF
--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
@@ -120,7 +120,7 @@ async function paginateAddresses(
       as: 'Memberships',
       required: false,
     },
-    order: ['id', 'ASC'],
+    order: [['id', 'ASC']],
     limit: MEMBERSHIP_REFRESH_BATCH_SIZE,
   });
 

--- a/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/refresh_community_memberships.ts
@@ -44,53 +44,47 @@ export async function __refreshCommunityMemberships(
   let totalNumUpdated = 0;
   let totalNumAddresses = 0;
 
-  await paginateAddresses(
-    this.models,
-    community.id,
-    1,
-    MEMBERSHIP_REFRESH_BATCH_SIZE,
-    async (addresses, page) => {
-      const pageStartedAt = Date.now();
+  await paginateAddresses(this.models, community.id, 0, async (addresses) => {
+    const pageStartedAt = Date.now();
 
-      const getBalancesOptions = makeGetBalancesOptions(
-        groupsToUpdate,
-        addresses,
-      );
-      const balances = await Promise.all(
-        getBalancesOptions.map(async (options) => {
-          let result: Balances = {};
-          try {
-            result = await this.tokenBalanceCacheV2.getBalances(options);
-          } catch (err) {
-            console.error(err);
-          }
-          return {
-            options,
-            balances: result,
-          };
-        }),
-      );
+    const getBalancesOptions = makeGetBalancesOptions(
+      groupsToUpdate,
+      addresses,
+    );
+    const balances = await Promise.all(
+      getBalancesOptions.map(async (options) => {
+        let result: Balances = {};
+        try {
+          result = await this.tokenBalanceCacheV2.getBalances(options);
+        } catch (err) {
+          console.error(err);
+        }
+        return {
+          options,
+          balances: result,
+        };
+      }),
+    );
 
-      const [numCreated, numUpdated] = await processMemberships(
-        this.models,
-        groupsToUpdate,
-        addresses,
-        balances,
-      );
+    const [numCreated, numUpdated] = await processMemberships(
+      this.models,
+      groupsToUpdate,
+      addresses,
+      balances,
+    );
 
-      totalNumCreated += numCreated;
-      totalNumUpdated += numUpdated;
-      totalNumAddresses += addresses.length;
+    totalNumCreated += numCreated;
+    totalNumUpdated += numUpdated;
+    totalNumAddresses += addresses.length;
 
-      console.log(
-        `  * [${page}] Created ${numCreated} and updated ${numUpdated} memberships in ${
-          community.id
-        } across ${addresses.length} addresses in ${
-          (Date.now() - pageStartedAt) / 1000
-        }s`,
-      );
-    },
-  );
+    // console.log(
+    //   `  * [${page}] Created ${numCreated} and updated ${numUpdated} memberships in ${
+    //     community.id
+    //   } across ${addresses.length} addresses in ${
+    //     (Date.now() - pageStartedAt) / 1000
+    //   }s`,
+    // );
+  });
 
   console.log(
     `Created ${totalNumCreated} and updated ${totalNumUpdated} total memberships in ${
@@ -106,19 +100,17 @@ export async function __refreshCommunityMemberships(
 async function paginateAddresses(
   models: DB,
   communityId: string,
-  page: number,
-  pageSize: number,
-  callback: (addresses: AddressAttributes[], page: number) => Promise<void>,
+  minAddressId: number,
+  callback: (addresses: AddressAttributes[]) => Promise<void>,
 ): Promise<void> {
-  const offset = (page - 1) * pageSize;
-  const limit = pageSize;
-
+  console.log(`Page starting at address id ${minAddressId}`);
   const addresses = await models.Address.findAll({
     where: {
       community_id: communityId,
       verified: {
         [Op.ne]: null,
       },
+      id: { [Op.gt]: minAddressId },
     },
     attributes: ['id', 'address'],
     include: {
@@ -126,17 +118,22 @@ async function paginateAddresses(
       as: 'Memberships',
       required: false,
     },
-    offset,
-    limit,
+    order: ['id', 'ASC'],
+    limit: MEMBERSHIP_REFRESH_BATCH_SIZE,
   });
 
   if (addresses.length === 0) {
     return;
   }
 
-  await callback(addresses, page);
+  await callback(addresses);
 
-  return paginateAddresses(models, communityId, page + 1, pageSize, callback);
+  return paginateAddresses(
+    models,
+    communityId,
+    addresses[addresses.length - 1].id,
+    callback,
+  );
 }
 
 type ComputedMembership = {

--- a/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
+++ b/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
@@ -21,95 +21,82 @@ export function makeGetBalancesOptions(
   const allOptions: Exclude<GetBalancesOptions, GetErc1155BalanceOptions>[] =
     [];
 
-  for (const address of addresses) {
-    for (const group of groups) {
-      for (const requirement of group.requirements) {
-        if (requirement.rule === 'threshold') {
-          // for each requirement, upsert the appropriate option
-          switch (requirement.data.source.source_type) {
-            // ContractSource
-            case BalanceSourceType.ERC20:
-            case BalanceSourceType.ERC721: {
-              const castedSource = requirement.data.source as ContractSource;
-              const existingOptions = allOptions.find((opt) => {
-                const castedOpt = opt as GetErcBalanceOptions;
-                return (
-                  castedOpt.balanceSourceType === castedSource.source_type &&
-                  castedOpt.sourceOptions.evmChainId ===
-                    castedSource.evm_chain_id &&
-                  castedOpt.sourceOptions.contractAddress ===
-                    castedSource.contract_address
-                );
+  const addressStrings = addresses.map((a) => a.address);
+
+  for (const group of groups) {
+    for (const requirement of group.requirements) {
+      if (requirement.rule === 'threshold') {
+        // for each requirement, upsert the appropriate option
+        switch (requirement.data.source.source_type) {
+          // ContractSource
+          case BalanceSourceType.ERC20:
+          case BalanceSourceType.ERC721: {
+            const castedSource = requirement.data.source as ContractSource;
+            const existingOptions = allOptions.find((opt) => {
+              const castedOpt = opt as GetErcBalanceOptions;
+              return (
+                castedOpt.balanceSourceType === castedSource.source_type &&
+                castedOpt.sourceOptions.evmChainId ===
+                  castedSource.evm_chain_id &&
+                castedOpt.sourceOptions.contractAddress ===
+                  castedSource.contract_address
+              );
+            });
+            if (!existingOptions) {
+              allOptions.push({
+                balanceSourceType: castedSource.source_type as any,
+                sourceOptions: {
+                  contractAddress: castedSource.contract_address,
+                  evmChainId: castedSource.evm_chain_id,
+                },
+                addresses: addressStrings,
               });
-              if (existingOptions) {
-                if (!existingOptions.addresses.includes(address.address)) {
-                  existingOptions.addresses.push(address.address);
-                }
-              } else {
-                allOptions.push({
-                  balanceSourceType: castedSource.source_type as any,
-                  sourceOptions: {
-                    contractAddress: castedSource.contract_address,
-                    evmChainId: castedSource.evm_chain_id,
-                  },
-                  addresses: [address.address],
-                });
-              }
-              break;
             }
-            // NativeSource
-            case BalanceSourceType.ETHNative: {
-              const castedSource = requirement.data.source as NativeSource;
-              const existingOptions = allOptions.find((opt) => {
-                const castedOpt = opt as GetEthNativeBalanceOptions;
-                return (
-                  castedOpt.balanceSourceType === BalanceSourceType.ETHNative &&
-                  castedOpt.sourceOptions.evmChainId ===
-                    castedSource.evm_chain_id
-                );
+            break;
+          }
+          // NativeSource
+          case BalanceSourceType.ETHNative: {
+            const castedSource = requirement.data.source as NativeSource;
+            const existingOptions = allOptions.find((opt) => {
+              const castedOpt = opt as GetEthNativeBalanceOptions;
+              return (
+                castedOpt.balanceSourceType === BalanceSourceType.ETHNative &&
+                castedOpt.sourceOptions.evmChainId === castedSource.evm_chain_id
+              );
+            });
+            if (!existingOptions) {
+              allOptions.push({
+                balanceSourceType: BalanceSourceType.ETHNative,
+                sourceOptions: {
+                  evmChainId: castedSource.evm_chain_id,
+                },
+                addresses: addressStrings,
               });
-              if (existingOptions) {
-                if (!existingOptions.addresses.includes(address.address)) {
-                  existingOptions.addresses.push(address.address);
-                }
-              } else {
-                allOptions.push({
-                  balanceSourceType: BalanceSourceType.ETHNative,
-                  sourceOptions: {
-                    evmChainId: castedSource.evm_chain_id,
-                  },
-                  addresses: [address.address],
-                });
-              }
-              break;
             }
-            // CosmosSource
-            case BalanceSourceType.CosmosNative: {
-              const castedSource = requirement.data.source as CosmosSource;
-              const existingOptions = allOptions.find((opt) => {
-                const castedOpt = opt as GetCosmosBalancesOptions;
-                return (
-                  castedOpt.balanceSourceType ===
-                    BalanceSourceType.CosmosNative &&
-                  castedOpt.sourceOptions.cosmosChainId ===
-                    castedSource.cosmos_chain_id
-                );
+            break;
+          }
+          // CosmosSource
+          case BalanceSourceType.CosmosNative: {
+            const castedSource = requirement.data.source as CosmosSource;
+            const existingOptions = allOptions.find((opt) => {
+              const castedOpt = opt as GetCosmosBalancesOptions;
+              return (
+                castedOpt.balanceSourceType ===
+                  BalanceSourceType.CosmosNative &&
+                castedOpt.sourceOptions.cosmosChainId ===
+                  castedSource.cosmos_chain_id
+              );
+            });
+            if (!existingOptions) {
+              allOptions.push({
+                balanceSourceType: BalanceSourceType.CosmosNative,
+                sourceOptions: {
+                  cosmosChainId: castedSource.cosmos_chain_id,
+                },
+                addresses: addressStrings,
               });
-              if (existingOptions) {
-                if (!existingOptions.addresses.includes(address.address)) {
-                  existingOptions.addresses.push(address.address);
-                }
-              } else {
-                allOptions.push({
-                  balanceSourceType: BalanceSourceType.CosmosNative,
-                  sourceOptions: {
-                    cosmosChainId: castedSource.cosmos_chain_id,
-                  },
-                  addresses: [address.address],
-                });
-              }
-              break;
             }
+            break;
           }
         }
       }

--- a/packages/commonwealth/server/util/tokenBalanceCache/util.ts
+++ b/packages/commonwealth/server/util/tokenBalanceCache/util.ts
@@ -74,7 +74,7 @@ export async function evmOffChainRpcBatching(
   const chainNodeErrorMsg =
     `${failingChainNodeError} RPC batch request failed for method '${rpc.method}' ` +
     `with batch size ${rpc.batchSize} on evm chain id ${source.evmChainId}${
-      source.contractAddress ? `for token ${source.contractAddress}` : ''
+      source.contractAddress ? ` for token ${source.contractAddress}` : ''
     }.`;
   responses.forEach((res, index) => {
     // handle a failed batch request


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5809

## Description of Changes
After reviewing the gating implementation, it seems that using a query like I initially suggested in the associated issue would require quite a lot of changes which aren't worth implementing at this time right before launch but we can reap the vast majority of the performance benefits with minimal changes.

- In the `makeGetBalancesOptions` function precompute the array of addresses and only iterate through each requirement of each group once since the addresses are guaranteed to be unique and the same for each requirement.
  - If we process 10k addresses for 10 groups with 5 requirements each, the new implementation reduces the number of iterations from dozens of billions to 10,050. Tangibly this means processing takes ~2 ms instead of ~8.5 seconds. This change also reduces the memory footprint because rather than duplicating the address array for each requirement we use the same array by reference.
- Alter pagination logic to use keyset pagination instead of offset pagination. Keyset pagination performance is comparable to offset pagination for the first page but more performant for subsequent pages
  - The new pagination logic resolves a bug with the previous pagination logic which returned duplicates and resulted in missing memberships.
  - Added check to end pagination early if possible (i.e. num returned address < max addresses to fetch)

## Test Plan
- Refresh all community memberships with the script

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
