### PR TITLE
quill editor no longer flashes when content is pasted

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -83,6 +83,7 @@
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
+  opacity: 0;
 }
 
 .QuillEditorWrapper {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5989 

## Description of Changes
- This change stops the editor from flashing when pasting content

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added `opacity: 0` to `.ql-clipboard`

## Test Plan
-go to any editor, Create thread works, and past content in. Notice there is no flashing. 

BEFORE
https://github.com/hicommonwealth/commonwealth/assets/69872984/550c8a54-bb6d-4de4-a296-a32a570202ee

AFTER
https://github.com/hicommonwealth/commonwealth/assets/69872984/0d43ddc0-afd0-4b87-b0d5-4d3ef092733e
