### PR TITLE
Fixed freezing on createCommunity

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/create_community/starter_community_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/create_community/starter_community_form.tsx
@@ -105,9 +105,9 @@ export const StarterCommunityForm = () => {
 
           // TODO: switch to using ChainNode.name instead of URL
           // defaults to be overridden when chain is no longer "starter" type
-          additionalArgs.node_url = defaultChain.node.url;
-          additionalArgs.alt_wallet_url = defaultChain.node.altWalletUrl;
-          additionalArgs.eth_chain_id = defaultChain.node.ethChainId;
+          additionalArgs.node_url = defaultChain.node?.url;
+          additionalArgs.alt_wallet_url = defaultChain.node?.altWalletUrl;
+          additionalArgs.eth_chain_id = defaultChain.node?.ethChainId;
           additionalArgs.bech32_prefix = defaultChain.bech32Prefix;
 
           try {


### PR DESCRIPTION
## Link to Issue
Closes: Hotfix

## Description of Changes
- additionalArgs were not taking into account NPEs.

## Test Plan
- Try to create a starter community with only community name. Make sure it throws an error instead of freezing.
- Try to create a starter community with only community name and image url. It should pass instead of freeze.