### PR TITLE
Fixed create_community to work with new create community front end.

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -261,6 +261,7 @@ export async function __createCommunity(
     description,
     network,
     type,
+    social_links,
     website,
     discord,
     telegram,
@@ -322,7 +323,13 @@ export async function __createCommunity(
     },
   });
 
-  const social_links = [website, telegram, discord, element, github];
+  const uniqueLinksArray = [
+    ...new Set(
+      [...social_links, website, telegram, discord, element, github].filter(
+        (a) => a,
+      ),
+    ),
+  ];
 
   const createdCommunity = await this.models.Community.create({
     id,
@@ -332,7 +339,7 @@ export async function __createCommunity(
     description,
     network,
     type,
-    social_links,
+    social_links: uniqueLinksArray,
     base,
     bech32_prefix,
     active: true,

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -42,7 +42,7 @@ export const createCommunitySchema = z.object({
     .url()
     .superRefine(async (val, ctx) => await checkIconSize(val, ctx))
     .optional(),
-  social_links: z.array(z.string().url()).optional(),
+  social_links: z.array(z.string().url()).default([]),
   tags: z.array(z.nativeEnum(ChainCategoryType)).default([]),
   directory_page_enabled: z.boolean().default(false),
   type: z.nativeEnum(ChainType).default(ChainType.Offchain),


### PR DESCRIPTION
## Link to Issue
Closes: #6006

## Description of Changes
- Adds support for social_links in create_community. Filters out null links.

## Test Plan
- create a community via the createCommunity route.