### PR TITLE
Combined all create_community PRs for integration CA

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
@@ -15,6 +15,7 @@ interface CreateCommunityProps {
   socialLinks: string[];
   nodeUrl: string;
   altWalletUrl: string;
+  userAddress: string;
 }
 
 const createCommunity = async ({
@@ -28,6 +29,7 @@ const createCommunity = async ({
   socialLinks,
   nodeUrl,
   altWalletUrl,
+  userAddress,
 }: CreateCommunityProps) => {
   const nameToSymbol = name.toUpperCase().slice(0, 4);
 
@@ -42,6 +44,7 @@ const createCommunity = async ({
     cosmos_chain_id: cosmosChainId,
     node_url: nodeUrl,
     alt_wallet_url: altWalletUrl,
+    user_address: userAddress,
 
     type: ChainType.Offchain,
     network: baseToNetwork(chainBase),

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -38,6 +38,7 @@ import './BasicInformationForm.scss';
 const ETHEREUM_MAINNET_ID = '1';
 
 const BasicInformationForm = ({
+  selectedAddress,
   selectedCommunity,
   onSubmit,
   onCancel,
@@ -197,6 +198,7 @@ const BasicInformationForm = ({
       }),
       nodeUrl: selectedChainNode.nodeUrl,
       altWalletUrl: selectedChainNode.altWalletUrl,
+      userAddress: selectedAddress.address,
     });
 
     await onSubmit(communityId);

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/types.ts
@@ -1,4 +1,5 @@
 import { SelectedCommunity } from 'views/components/component_kit/new_designs/CWCommunitySelector';
+import AddressInfo from '../../../../../../models/AddressInfo';
 
 export type SocialLinkField = {
   value?: string;
@@ -17,6 +18,7 @@ export type FormSubmitValues = {
 };
 
 export type BasicInformationFormProps = {
+  selectedAddress: AddressInfo;
   selectedCommunity: SelectedCommunity;
   onSubmit: (communityId: string) => any;
   onCancel: () => any;

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationStep.tsx
@@ -40,6 +40,7 @@ const BasicInformationStep = ({
       />
 
       <BasicInformationForm
+        selectedAddress={selectedAddress}
         selectedCommunity={selectedCommunity}
         onSubmit={handleContinue}
         onCancel={handleGoBack}

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -425,9 +425,7 @@ export async function __createCommunity(
         },
       ],
     });
-  }
-
-  if (createdCommunity.base === ChainBase.Ethereum) {
+  } else if (createdCommunity.base === ChainBase.Ethereum) {
     addressToBeAdmin = await this.models.Address.scope(
       'withPrivateData',
     ).findOne({

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -261,6 +261,7 @@ export async function __createCommunity(
     description,
     network,
     type,
+    social_links,
     website,
     discord,
     telegram,
@@ -322,7 +323,13 @@ export async function __createCommunity(
     },
   });
 
-  const social_links = [website, telegram, discord, element, github];
+  const uniqueLinksArray = [
+    ...new Set(
+      [...social_links, website, telegram, discord, element, github].filter(
+        (a) => a,
+      ),
+    ),
+  ];
 
   const createdCommunity = await this.models.Community.create({
     id,
@@ -332,7 +339,7 @@ export async function __createCommunity(
     description,
     network,
     type,
-    social_links,
+    social_links: uniqueLinksArray,
     base,
     bech32_prefix,
     active: true,

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -45,6 +45,7 @@ export const Errors = {
   InvalidCommunityIdOrUrl:
     'Could not determine a valid endpoint for provided community',
   CommunityAddressExists: 'The address already exists',
+  UserAddressNotExists: 'The user does not own the user_address specified',
   CommunityIDExists:
     'The id for this community already exists, please choose another id',
   CommunityNameExists:
@@ -270,6 +271,7 @@ export async function __createCommunity(
     base,
     bech32_prefix,
     token_name,
+    user_address,
   } = community;
   if (website && !urlHasValidHTTPPrefix(website)) {
     throw new AppError(Errors.InvalidWebsite);
@@ -283,6 +285,17 @@ export async function __createCommunity(
     throw new AppError(Errors.InvalidGithub);
   } else if (icon_url && !urlHasValidHTTPPrefix(icon_url)) {
     throw new AppError(Errors.InvalidIconUrl);
+  }
+
+  let selectedUserAddress: string;
+  if (user_address) {
+    const addresses = (await user.getAddresses()).filter(
+      (a) => a.address === user_address,
+    );
+    if (addresses.length === 0) {
+      throw new AppError(Errors.UserAddressNotExists);
+    }
+    selectedUserAddress = addresses[0].address;
   }
 
   const oldCommunity = await this.models.Community.findOne({
@@ -395,6 +408,24 @@ export async function __createCommunity(
   // TODO: @Zak extend functionality here when we have Bases + Wallets refactored
   let role: RoleInstanceWithPermission | undefined;
   let addressToBeAdmin: AddressInstance | undefined;
+
+  if (user_address) {
+    addressToBeAdmin = await this.models.Address.scope(
+      'withPrivateData',
+    ).findOne({
+      where: {
+        user_id: user.id,
+        address: selectedUserAddress,
+      },
+      include: [
+        {
+          model: this.models.Community,
+          where: { base: createdCommunity.base },
+          required: true,
+        },
+      ],
+    });
+  }
 
   if (createdCommunity.base === ChainBase.Ethereum) {
     addressToBeAdmin = await this.models.Address.scope(

--- a/packages/commonwealth/server/routes/generateImage.ts
+++ b/packages/commonwealth/server/routes/generateImage.ts
@@ -1,12 +1,12 @@
 import AWS from 'aws-sdk';
-import { v4 as uuidv4 } from 'uuid';
-import { Configuration, OpenAIApi } from 'openai';
 import fetch from 'node-fetch';
+import { Configuration, OpenAIApi } from 'openai';
+import { v4 as uuidv4 } from 'uuid';
 
+import { AppError } from '../../../common-common/src/errors';
+import type { DB } from '../models';
 import type { TypedRequestBody, TypedResponse } from '../types';
 import { success } from '../types';
-import type { DB } from '../models';
-import { AppError } from '../../../common-common/src/errors';
 
 const configuration = new Configuration({
   organization: 'org-D0ty00TJDApqHYlrn1gge2Ql',
@@ -24,7 +24,7 @@ type generateImageResp = {
 const generateImage = async (
   models: DB,
   req: TypedRequestBody<generateImageReq>,
-  res: TypedResponse<generateImageResp>
+  res: TypedResponse<generateImageResp>,
 ) => {
   const { description } = req.body;
 
@@ -36,7 +36,7 @@ const generateImage = async (
   try {
     const response = await openai.createImage({
       prompt: description,
-      size: '512x512',
+      size: '256x256',
       response_format: 'url',
     });
 

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -42,7 +42,7 @@ export const createCommunitySchema = z.object({
     .url()
     .superRefine(async (val, ctx) => await checkIconSize(val, ctx))
     .optional(),
-  social_links: z.array(z.string().url()).optional(),
+  social_links: z.array(z.string().url()).default([]),
   tags: z.array(z.nativeEnum(ChainCategoryType)).default([]),
   directory_page_enabled: z.boolean().default(false),
   type: z.nativeEnum(ChainType).default(ChainType.Offchain),

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -49,10 +49,11 @@ export const createCommunitySchema = z.object({
   base: z.nativeEnum(ChainBase),
 
   // hidden optional params
+  user_address: z.string().optional(), // address for the user
   alt_wallet_url: z.string().url().optional(),
   eth_chain_id: z.coerce.number().optional(),
   cosmos_chain_id: z.string().optional(),
-  address: z.string().optional(),
+  address: z.string().optional(), // address for the contract of the chain
   decimals: z.number().optional(),
   substrate_spec: z.string().optional(),
   bech32_prefix: z.string().optional(),


### PR DESCRIPTION
This PR allows us to see the full create_community CA flow as it fixes the remaining integration errors
## Description of Changes
- Based off #6003 (Marcin's PR)
- merged in #6033 (selectedAddress backend)
- merged in #5999 (social links)
- added in front end integration for #6033

## Test Plan
- Create a community on a wallet with 2 addresses.
- Create the first community by going through the flow with the first address, make sure that the community is created and first address is admin
- Do the same but for the second address in the dropdown, make sure that second address is admin