### PR TITLE
Sequelize pool size increase

### DIFF
--- a/packages/commonwealth/Procfile
+++ b/packages/commonwealth/Procfile
@@ -1,4 +1,4 @@
-web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) ts-node -P tsconfig.server.json -T server.ts
+web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) MAX_SEQUELIZE_POOL_SIZE=20 ts-node -P tsconfig.server.json -T server.ts
 consumer: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.js run-as-script
 evm-ce: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/evmChainEvents/startEvmPolling.js
 release: cd packages/commonwealth && npx sequelize-cli db:migrate --config server/sequelize.json

--- a/packages/commonwealth/Procfile
+++ b/packages/commonwealth/Procfile
@@ -1,4 +1,4 @@
-web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) MAX_SEQUELIZE_POOL_SIZE=5 ts-node -P tsconfig.server.json -T server.ts
+web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) MAX_SEQUELIZE_POOL_SIZE=20 ts-node -P tsconfig.server.json -T server.ts
 consumer: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.js run-as-script
 evm-ce: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/evmChainEvents/startEvmPolling.js
 release: cd packages/commonwealth && npx sequelize-cli db:migrate --config server/sequelize.json

--- a/packages/commonwealth/Procfile
+++ b/packages/commonwealth/Procfile
@@ -1,4 +1,4 @@
-web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) MAX_SEQUELIZE_POOL_SIZE=20 ts-node -P tsconfig.server.json -T server.ts
+web: cd packages/commonwealth && NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) MAX_SEQUELIZE_POOL_SIZE=5 ts-node -P tsconfig.server.json -T server.ts
 consumer: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.js run-as-script
 evm-ce: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/commonwealth/server/workers/evmChainEvents/startEvmPolling.js
 release: cd packages/commonwealth && npx sequelize-cli db:migrate --config server/sequelize.json

--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -131,3 +131,7 @@ export const MEMBERSHIP_REFRESH_TTL_SECONDS = process.env
 export const TBC_BALANCE_TTL_SECONDS = process.env.TBC_BALANCE_TTL_SECONDS
   ? parseInt(process.env.TBC_BALANCE_TTL_SECONDS, 10)
   : 300;
+
+export const MAX_SEQUELIZE_POOL_SIZE = process.env.MAX_SEQUELIZE_POOL_SIZE
+  ? parseInt(process.env.MAX_SEQUELIZE_POOL_SIZE, 10)
+  : 10;

--- a/packages/commonwealth/server/database.ts
+++ b/packages/commonwealth/server/database.ts
@@ -62,7 +62,7 @@ export const sequelize = new Sequelize(DATABASE_URI, {
       : { requestTimeout: 40000, ssl: { rejectUnauthorized: false } },
   pool: {
     max: MAX_SEQUELIZE_POOL_SIZE,
-    min: 1,
+    min: 20,
     acquire: 40000,
     idle: 40000,
   },

--- a/packages/commonwealth/server/database.ts
+++ b/packages/commonwealth/server/database.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Sequelize } from 'sequelize';
-import { DATABASE_URI } from './config';
+import { DATABASE_URI, MAX_SEQUELIZE_POOL_SIZE } from './config';
 
 import { factory, formatFilename } from 'common-common/src/logging';
 import type { DB, Models } from './models';
@@ -61,7 +61,7 @@ export const sequelize = new Sequelize(DATABASE_URI, {
       ? { requestTimeout: 40000, ssl: false }
       : { requestTimeout: 40000, ssl: { rejectUnauthorized: false } },
   pool: {
-    max: 10,
+    max: MAX_SEQUELIZE_POOL_SIZE,
     min: 0,
     acquire: 40000,
     idle: 40000,

--- a/packages/commonwealth/server/database.ts
+++ b/packages/commonwealth/server/database.ts
@@ -62,7 +62,7 @@ export const sequelize = new Sequelize(DATABASE_URI, {
       : { requestTimeout: 40000, ssl: { rejectUnauthorized: false } },
   pool: {
     max: MAX_SEQUELIZE_POOL_SIZE,
-    min: 0,
+    min: 1,
     acquire: 40000,
     idle: 40000,
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #4674 

## Description of Changes
- Added `MAX_SEQUELIZE_POOL_SIZE`
- Added env var set to 20 for web dynos
- Bumped minimum pool size to 1

## Test Plan
- Deploy to Frick and observe db stats on Datadog during load test

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 