### PR TITLE
Reduce generated image size

### DIFF
--- a/packages/commonwealth/server/routes/generateImage.ts
+++ b/packages/commonwealth/server/routes/generateImage.ts
@@ -1,12 +1,12 @@
 import AWS from 'aws-sdk';
-import { v4 as uuidv4 } from 'uuid';
-import { Configuration, OpenAIApi } from 'openai';
 import fetch from 'node-fetch';
+import { Configuration, OpenAIApi } from 'openai';
+import { v4 as uuidv4 } from 'uuid';
 
+import { AppError } from '../../../common-common/src/errors';
+import type { DB } from '../models';
 import type { TypedRequestBody, TypedResponse } from '../types';
 import { success } from '../types';
-import type { DB } from '../models';
-import { AppError } from '../../../common-common/src/errors';
 
 const configuration = new Configuration({
   organization: 'org-D0ty00TJDApqHYlrn1gge2Ql',
@@ -24,7 +24,7 @@ type generateImageResp = {
 const generateImage = async (
   models: DB,
   req: TypedRequestBody<generateImageReq>,
-  res: TypedResponse<generateImageResp>
+  res: TypedResponse<generateImageResp>,
 ) => {
   const { description } = req.body;
 
@@ -36,7 +36,7 @@ const generateImage = async (
   try {
     const response = await openai.createImage({
       prompt: description,
-      size: '512x512',
+      size: '256x256',
       response_format: 'url',
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6009

## Description of Changes
- Generates images of `256x256` px size instead of `512x512` px when generating with AI

## "How We Fixed It"
By reducing generated image size

## Test Plan
- Enable FLAG_NEW_CREATE_COMMUNITY flag
- Visit http://localhost:8080/createCommunity
- Click on the next button that has an arrow, to visit step 2 (aka basic information form)
- Fill the form and generate an image with AI, verify the form submits successfully and there is no error.

## Deployment Plan
N/A

## Other Considerations
N/A