### PR TITLE
Added old topic gating behind a feature flag

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -15,6 +15,7 @@ import AddressInfo from '../../models/AddressInfo';
 import type BlockInfo from '../../models/BlockInfo';
 import type ChainInfo from '../../models/ChainInfo';
 
+import { featureFlags } from 'helpers/feature-flags';
 import { getTokenBalance } from 'helpers/token_balance_helper';
 
 export function linkExistingAddressToChainOrCommunity(
@@ -165,7 +166,7 @@ export async function updateActiveAddresses({
     shouldRedraw,
   );
 
-  getTokenBalance();
+  !featureFlags.newGatingEnabled && getTokenBalance();
 
   // select the address that the new chain should be initialized with
   const memberAddresses = app.user.activeAccounts.filter((account) => {

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -3,5 +3,5 @@ export const featureFlags = {
   communityHomepage: process.env.FLAG_COMMUNITY_HOMEPAGE === 'true',
   sidebarToggle: process.env.FLAG_SIDEBAR_TOGGLE === 'true',
   newCreateCommunity: process.env.FLAG_NEW_CREATE_COMMUNITY === 'true',
-  gatingEnabled: process.env.GATING_API_ENABLED,
+  newGatingEnabled: process.env.GATING_API_ENABLED,
 };

--- a/packages/commonwealth/client/scripts/helpers/token_balance_helper.ts
+++ b/packages/commonwealth/client/scripts/helpers/token_balance_helper.ts
@@ -1,13 +1,15 @@
+import axios from 'axios';
 import BN from 'bn.js';
 import app from 'state';
 import {
   ChainNetwork,
   ContractType,
 } from '../../../../common-common/src/types';
-import axios from 'axios';
+import { featureFlags } from './feature-flags';
 
 export const getTokenBalance = async () => {
   if (
+    !featureFlags.newGatingEnabled &&
     app.user.activeAccounts[0] &&
     app.chain.gatedTopics?.length > 0 &&
     !app.user.activeAccounts[0].tokenBalance
@@ -29,7 +31,7 @@ export const getTokenBalance = async () => {
           if (balanceResp.data?.result) {
             balanceResp.data.result.forEach((balObj) => {
               const account = app.user.activeAccounts.find(
-                (acc) => acc.address == balObj.address.distinctAddress
+                (acc) => acc.address == balObj.address.distinctAddress,
               );
               if (account) account.setTokenBalance(new BN(balObj.balance, 10));
             });

--- a/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import Account from 'client/scripts/models/Account';
 import clsx from 'clsx';
 import { getDecimals, weiToTokens } from 'helpers';
+import { featureFlags } from 'helpers/feature-flags';
 import type { DeltaStatic } from 'quill';
 import React from 'react';
 import app from 'state';
@@ -82,19 +83,21 @@ export const CommentEditor = ({
         tooltipLabel={tooltipText}
         shouldFocus={shouldFocus}
       />
-      {tokenPostingThreshold && tokenPostingThreshold.gt(new BN(0)) && (
-        <CWText className="token-req-text">
-          Commenting in {topicName} requires{' '}
-          {weiToTokens(tokenPostingThreshold.toString(), decimals)}{' '}
-          {app.chain.meta.default_symbol}.{' '}
-          {userBalance && (
-            <>
-              You have {weiToTokens(userBalance.toString(), decimals)}{' '}
-              {app.chain.meta.default_symbol}.
-            </>
-          )}
-        </CWText>
-      )}
+      {!featureFlags.newGatingEnabled &&
+        tokenPostingThreshold &&
+        tokenPostingThreshold.gt(new BN(0)) && (
+          <CWText className="token-req-text">
+            Commenting in {topicName} requires{' '}
+            {weiToTokens(tokenPostingThreshold.toString(), decimals)}{' '}
+            {app.chain.meta.default_symbol}.{' '}
+            {userBalance && (
+              <>
+                You have {weiToTokens(userBalance.toString(), decimals)}{' '}
+                {app.chain.meta.default_symbol}.
+              </>
+            )}
+          </CWText>
+        )}
       <div className="form-bottom">
         <div className="form-buttons">
           {editorValue.length > 0 && (

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -7,6 +7,7 @@ import type { DeltaStatic } from 'quill';
 import Thread from '../../../models/Thread';
 
 import { SessionKeyError } from 'controllers/server/sessions';
+import { featureFlags } from 'helpers/feature-flags';
 import { getTokenBalance } from 'helpers/token_balance_helper';
 import { useDraft } from 'hooks/useDraft';
 import app from 'state';
@@ -71,7 +72,11 @@ export const CreateComment = ({
   }, [activeTopic]);
 
   useEffect(() => {
-    if (!tokenPostingThreshold.isZero() && !balanceLoading) {
+    if (
+      !tokenPostingThreshold.isZero() &&
+      !balanceLoading &&
+      !featureFlags.newGatingEnabled
+    ) {
       setBalanceLoading(true);
       if (!app.user.activeAccount?.tokenBalance) {
         getTokenBalance().then(() => {
@@ -144,7 +149,8 @@ export const CreateComment = ({
     }
   };
 
-  const userFailsThreshold = app.chain.isGatedTopic(activeTopic?.id);
+  const userFailsThreshold =
+    !featureFlags.newGatingEnabled && app.chain.isGatedTopic(activeTopic?.id);
   const isAdmin = Permissions.isCommunityAdmin();
   const disabled =
     editorValue.length === 0 ||

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -86,6 +86,7 @@ export const CreateComment = ({
         setUserBalance(app.user.activeAccount?.tokenBalance);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tokenPostingThreshold]);
 
   const {

--- a/packages/commonwealth/client/scripts/views/components/Header/useJoinCommunity.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Header/useJoinCommunity.tsx
@@ -4,6 +4,7 @@ import {
   setActiveAccount,
 } from 'controllers/app/login';
 import { isSameAccount } from 'helpers';
+import { featureFlags } from 'helpers/feature-flags';
 import AddressInfo from 'models/AddressInfo';
 import ITokenAdapter from 'models/ITokenAdapter';
 import React, { useState } from 'react';
@@ -169,7 +170,11 @@ const useJoinCommunity = () => {
         }
 
         // If token forum make sure has token and add to app.chain obj
-        if (app.chain && ITokenAdapter.instanceOf(app.chain)) {
+        if (
+          app.chain &&
+          ITokenAdapter.instanceOf(app.chain) &&
+          !featureFlags.newGatingEnabled
+        ) {
           await app.chain.activeAddressHasToken(app.user.activeAccount.address);
         }
       } catch (err) {

--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -48,14 +48,18 @@ export const NewThreadForm = () => {
 
   const topicsForSelector = topics?.reduce(
     (acc, t) => {
-      if (
-        isAdmin ||
-        t.tokenThreshold.isZero() ||
-        !app.chain.isGatedTopic(t.id)
-      ) {
+      if (featureFlags.newGatingEnabled) {
         acc?.enabledTopics?.push(t);
       } else {
-        acc?.disabledTopics?.push(t);
+        if (
+          isAdmin ||
+          t.tokenThreshold.isZero() ||
+          !app.chain.isGatedTopic(t.id)
+        ) {
+          acc?.enabledTopics?.push(t);
+        } else {
+          acc?.disabledTopics?.push(t);
+        }
       }
       return acc;
     },
@@ -268,7 +272,7 @@ export const NewThreadForm = () => {
               />
             )}
 
-            {featureFlags.gatingEnabled &&
+            {featureFlags.newGatingEnabled &&
               isRestrictedMembership &&
               canShowGatingBanner && (
                 <div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/admin_section.tsx
@@ -173,7 +173,7 @@ const AdminSectionComponent = () => {
         setIsOrderTopicsModalOpen(true);
       },
     },
-    ...(!featureFlags.gatingEnabled
+    ...(!featureFlags.newGatingEnabled
       ? [
           {
             title: 'Edit topic thresholds',

--- a/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { featureFlags } from 'helpers/feature-flags';
 import Permissions from 'utils/Permissions';
 import type Thread from '../../models/Thread';
 import type Topic from '../../models/Topic';
@@ -31,16 +32,20 @@ export const ChangeThreadTopicModal = ({
   const isAdmin = Permissions.isCommunityAdmin();
   const topicsForSelector = topics?.reduce(
     (acc, t) => {
-      if (
-        isAdmin ||
-        t.tokenThreshold.isZero() ||
-        !app.chain.isGatedTopic(t.id)
-      ) {
+      if (featureFlags.newGatingEnabled) {
         acc.enabledTopics.push(t);
       } else {
-        acc.disabledTopics.push(t);
+        if (
+          isAdmin ||
+          t.tokenThreshold.isZero() ||
+          !app.chain.isGatedTopic(t.id)
+        ) {
+          acc.enabledTopics.push(t);
+        } else {
+          acc.disabledTopics.push(t);
+        }
+        return acc;
       }
-      return acc;
     },
     { enabledTopics: [], disabledTopics: [] },
   );

--- a/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_topic_modal.tsx
@@ -128,7 +128,7 @@ export const NewTopicModal = (props: NewTopicModalProps) => {
             setDescription(e.target.value);
           }}
         />
-        {!featureFlags.gatingEnabled && app.activeChainId() && (
+        {!featureFlags.newGatingEnabled && app.activeChainId() && (
           <React.Fragment>
             <CWLabel
               label={`Number of tokens needed to post (${app.chain?.meta.default_symbol})`}

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Create/CreateCommunityGroupPage.tsx
@@ -26,7 +26,7 @@ const CreateCommunityGroupPage = () => {
   });
 
   if (
-    !featureFlags.gatingEnabled ||
+    !featureFlags.newGatingEnabled ||
     !app.isLoggedIn() ||
     !(Permissions.isCommunityAdmin() || Permissions.isSiteAdmin())
   ) {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -45,7 +45,7 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
   });
 
   if (
-    !featureFlags.gatingEnabled ||
+    !featureFlags.newGatingEnabled ||
     !app.isLoggedIn() ||
     !(Permissions.isCommunityAdmin() || Permissions.isSiteAdmin())
   ) {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -37,7 +37,9 @@ import { GroupCategory, MembershipFilter, SearchFilters } from './index.types';
 
 const TABS = [
   { value: 'all-members', label: 'All members' },
-  ...(featureFlags.gatingEnabled ? [{ value: 'groups', label: 'Groups' }] : []),
+  ...(featureFlags.newGatingEnabled
+    ? [{ value: 'groups', label: 'Groups' }]
+    : []),
 ];
 
 const GROUP_AND_MEMBER_FILTERS: GroupCategory[] = [
@@ -69,7 +71,7 @@ const CommunityMembersPage = () => {
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
     apiEnabled:
-      app?.user?.activeAccount?.address && !!featureFlags.gatingEnabled,
+      app?.user?.activeAccount?.address && !!featureFlags.newGatingEnabled,
   });
 
   const debouncedSearchTerm = useDebounce<string>(
@@ -90,7 +92,7 @@ const CommunityMembersPage = () => {
     includeRoles: true,
     includeGroupIds: true,
     enabled:
-      app?.user?.activeAccount?.address && featureFlags.gatingEnabled
+      app?.user?.activeAccount?.address && featureFlags.newGatingEnabled
         ? !!memberships
         : true,
     ...(searchFilters.category !== 'All groups' && {
@@ -105,7 +107,7 @@ const CommunityMembersPage = () => {
     communityId: app.activeChainId(),
     includeTopics: true,
     enabled:
-      app?.user?.activeAccount?.address && featureFlags.gatingEnabled
+      app?.user?.activeAccount?.address && featureFlags.newGatingEnabled
         ? !!memberships
         : true,
   });
@@ -222,7 +224,7 @@ const CommunityMembersPage = () => {
       return;
     }
 
-    featureFlags.gatingEnabled && updateActiveTab(TABS[1].value);
+    featureFlags.newGatingEnabled && updateActiveTab(TABS[1].value);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -275,7 +277,7 @@ const CommunityMembersPage = () => {
         )}
 
       {/* Filter section */}
-      {featureFlags.gatingEnabled &&
+      {featureFlags.newGatingEnabled &&
       selectedTab === TABS[1].value &&
       groups?.length === 0 ? (
         <></>
@@ -286,8 +288,8 @@ const CommunityMembersPage = () => {
             'cols-4': boolean;
           }>(
             {
-              'cols-3': featureFlags.gatingEnabled && !isAdmin,
-              'cols-4': featureFlags.gatingEnabled && isAdmin,
+              'cols-3': featureFlags.newGatingEnabled && !isAdmin,
+              'cols-4': featureFlags.newGatingEnabled && isAdmin,
             },
             'filters',
           )}
@@ -308,7 +310,7 @@ const CommunityMembersPage = () => {
               }))
             }
           />
-          {featureFlags.gatingEnabled && app.user.activeAccount && (
+          {featureFlags.newGatingEnabled && app.user.activeAccount && (
             <div className="select-dropdown-container">
               <CWText type="b2" fontWeight="bold" className="filter-text">
                 Filter
@@ -328,7 +330,7 @@ const CommunityMembersPage = () => {
               />
             </div>
           )}
-          {featureFlags.gatingEnabled && isAdmin && (
+          {featureFlags.newGatingEnabled && isAdmin && (
             <CWButton
               buttonWidth="full"
               label="Create group"
@@ -340,7 +342,7 @@ const CommunityMembersPage = () => {
       )}
 
       {/* Main content section: based on the selected tab */}
-      {featureFlags.gatingEnabled && selectedTab === TABS[1].value ? (
+      {featureFlags.newGatingEnabled && selectedTab === TABS[1].value ? (
         <GroupsSection
           filteredGroups={filteredGroups}
           canManageGroups={isAdmin}

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/MembersSection/MembersSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/MembersSection/MembersSection.tsx
@@ -28,7 +28,7 @@ const columns = [
     numeric: false,
     sortable: true,
   },
-  ...(featureFlags.gatingEnabled
+  ...(featureFlags.newGatingEnabled
     ? [
         {
           key: 'groups',

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { SessionKeyError } from 'controllers/server/sessions';
+import { featureFlags } from 'helpers/feature-flags';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { CommentsFeaturedFilterTypes } from 'models/types';
@@ -453,7 +454,8 @@ export const CommentTree = ({
                     !thread.archivedAt &&
                     (!!hasJoinedCommunity ||
                       isAdmin ||
-                      !app.chain.isGatedTopic(thread?.topic?.id)) &&
+                      (!app.chain.isGatedTopic(thread?.topic?.id) &&
+                        !featureFlags.newGatingEnabled)) &&
                     canReact
                   }
                   canEdit={

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -1,4 +1,5 @@
 import { SessionKeyError } from 'controllers/server/sessions';
+import { featureFlags } from 'helpers/feature-flags';
 import type Thread from 'models/Thread';
 import React, { useState } from 'react';
 import app from 'state';
@@ -80,7 +81,10 @@ export const ReactionButton = ({
 
   // token balance check if needed
   const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
-  const isUserForbidden = !isAdmin && app.chain.isGatedTopic(thread.topic?.id);
+  const isUserForbidden =
+    !isAdmin &&
+    app.chain.isGatedTopic(thread.topic?.id) &&
+    !featureFlags.newGatingEnabled;
 
   const handleVoteClick = async (event) => {
     event.stopPropagation();

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -320,7 +320,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const canComment =
     (!!hasJoinedCommunity ||
-      (!isAdminOrMod && app.chain.isGatedTopic(thread?.topic?.id))) &&
+      (!isAdminOrMod &&
+        app.chain.isGatedTopic(thread?.topic?.id) &&
+        !featureFlags.newGatingEnabled)) &&
     !isRestrictedMembership;
 
   const handleNewSnapshotChange = async ({
@@ -532,7 +534,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                       shouldFocusEditor={shouldFocusCommentEditor}
                       tooltipText={disabledActionsTooltipText}
                     />
-                    {featureFlags.gatingEnabled &&
+                    {featureFlags.newGatingEnabled &&
                       foundGatedTopic &&
                       !hideGatingBanner &&
                       isRestrictedMembership && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6039

## Description of Changes
Added old tbc behind the `GATING_API_ENABLED` (the new gating) feature flag
- Implementation of `app.chain.isGatedTopic` moved behind the `featureFlags.newGatingEnabled` flag
- `getTokenBalance()`  moved behind the `featureFlags.newGatingEnabled` flag
- UI depending on token balance will not be triggered if `featureFlags.newGatingEnabled` flag is enabled

## "How We Fixed It"
By adding client token balance logic behind `GATING_API_ENABLED` feature flag

## Test Plan

Verify that pre-gating logic works as expected

- Disable the `GATING_API_ENABLED` flag
- Visit any community where we have topics that require a certain token balance to participate in.
- CA and Verify the token threshold logic works as expected
- Verify that any post-gating (the new gating UI and related logic) logic is not triggered (aka disabled)

Verify that post-gating logic works as expected

- Enable the `GATING_API_ENABLED` flag
- Visit any community having a gated topic and you being a member of that gated topic
- Visit threads for that gated topic and verify you can interact with those specific gated threads
- Now Visit any community having a gated topic and you not being a member of that gated topic
- Visit threads for that gated topic and verify you are unable to interact with those specific gated threads
- In all of these interactions verify that you don't see UI (any prompts, messages etc) that was triggered by the old token balance logic

## Deployment Plan
N/A

## Other Considerations
N/A