### PR TITLE
Fix comment creation for gated thread for admin

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
@@ -102,7 +102,7 @@ export const CommentEditor = ({
           )}
           <CWButton
             buttonWidth="wide"
-            disabled={disabled && !isAdmin}
+            disabled={disabled}
             onClick={handleSubmitComment}
             label="Submit"
           />

--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -44,7 +44,7 @@ export const NewThreadForm = () => {
 
   const communityId = app.chain.id;
   const hasTopics = topics?.length;
-  const isAdmin = Permissions.isCommunityAdmin();
+  const isAdmin = Permissions.isCommunityAdmin() || Permissions.isSiteAdmin();
 
   const topicsForSelector = topics?.reduce(
     (acc, t) => {
@@ -123,7 +123,8 @@ export const NewThreadForm = () => {
       group.topics.find((topic) => topic.id === threadTopic?.id),
     )
     .map((group) => group.name);
-  const isRestrictedMembership = isTopicGated && !isActionAllowedInGatedTopic;
+  const isRestrictedMembership =
+    !isAdmin && isTopicGated && !isActionAllowedInGatedTopic;
 
   const handleNewThreadCreation = async () => {
     if (isRestrictedMembership) {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import app from 'state';
 import { useRefreshMembershipQuery } from 'state/api/groups';
+import Permissions from 'utils/Permissions';
 import { isHot } from 'views/pages/discussions/helpers';
 import Account from '../../../../models/Account';
 import AddressInfo from '../../../../models/AddressInfo';
@@ -130,7 +131,9 @@ export const CWContentPage = ({
       membership.topicIds.includes(thread?.topic?.id) && membership.isAllowed,
   );
 
-  const isRestrictedMembership = isTopicGated && !isActionAllowedInGatedTopic;
+  const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
+  const isRestrictedMembership =
+    !isAdmin && isTopicGated && !isActionAllowedInGatedTopic;
 
   const tabSelected = useMemo(() => {
     const tab = Object.fromEntries(urlQueryParams.entries())?.tab;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
@@ -45,7 +45,11 @@ const CWGatedTopicBanner = ({
             navigate('/members?tab=groups');
           },
         },
-        { label: 'Learn more about gating' },
+        {
+          label: 'Learn more about gating',
+          onClick: () =>
+            (window.location.href = `https://blog.commonwealth.im/introducing-common-groups/`),
+        },
       ]}
       onClose={onClose}
     />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -25,6 +25,7 @@ import { sortByFeaturedFilter, sortPinned } from './helpers';
 import { getThreadActionTooltipText } from 'helpers/threads';
 import 'pages/discussions/index.scss';
 import { useRefreshMembershipQuery } from 'state/api/groups';
+import Permissions from 'utils/Permissions';
 import GatingGrowl from 'views/components/GatingGrowl/GatingGrowl';
 import { EmptyThreadsPlaceholder } from './EmptyThreadsPlaceholder';
 
@@ -49,6 +50,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const { data: topics } = useFetchTopicsQuery({
     communityId: app.activeChainId(),
   });
+
+  const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
 
   const topicId = (topics || []).find(({ name }) => name === topicName)?.id;
 
@@ -119,11 +122,14 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
               membership.isAllowed,
           );
 
+          const isRestrictedMembership =
+            !isAdmin && isTopicGated && !isActionAllowedInGatedTopic;
+
           const disabledActionsTooltipText = getThreadActionTooltipText({
             isCommunityMember: !!hasJoinedCommunity,
             isThreadArchived: !!thread?.archivedAt,
             isThreadLocked: !!thread?.lockedAt,
-            isThreadTopicGated: isTopicGated && !isActionAllowedInGatedTopic,
+            isThreadTopicGated: isRestrictedMembership,
           });
 
           return (

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -128,6 +128,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const thread = data?.[0];
 
+  const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
+
   const { data: comments = [], error: fetchCommentsError } =
     useFetchCommentsQuery({
       communityId: app.activeChainId(),
@@ -153,7 +155,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       membership.topicIds.includes(thread?.topic?.id) && membership.isAllowed,
   );
 
-  const isRestrictedMembership = isTopicGated && !isActionAllowedInGatedTopic;
+  const isRestrictedMembership =
+    !isAdmin && isTopicGated && !isActionAllowedInGatedTopic;
 
   useEffect(() => {
     if (fetchCommentsError) notifyError('Failed to load comments');
@@ -288,7 +291,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   // Original posters have full editorial control, while added collaborators
   // merely have access to the body and title
   const isAuthor = Permissions.isThreadAuthor(thread);
-  const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
   const isAdminOrMod = isAdmin || Permissions.isCommunityModerator();
 
   const linkedSnapshots = filterLinks(thread.links, LinkSource.Snapshot);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 
- https://github.com/hicommonwealth/commonwealth/issues/6044
- https://github.com/hicommonwealth/commonwealth/issues/6046
- https://github.com/hicommonwealth/commonwealth/issues/6047

## Description of Changes
- Fixes thread comment submit button state for admins if the admin account doesn't fulfill the gated topic requirement.

## "How We Fixed It"
N/A

## Test Plan

Test - admin can bypass gating checks
- Visit a community where you are an admin
- Create a thread in a topic
- Now gate that topic with a requirement that you don't fulfill (ex: posting requires 10 tokens you have 8, so you are not eligible)
- Verify that you can still interact with the thread (aka bypass gating checks)

Test - empty comment creation as an admin
- Verify that you cannot create an empty comment as an admin in a gated topic

Test - "Learn more about gating" redirect
- Visit a gated thread where you cannot interact as a user
- Click on the "Learn more about gating" button in the gating banner
- Verify it redirects to "https://blog.commonwealth.im/introducing-common-groups/"

## Deployment Plan
N/A

## Other Considerations
N/A