### PR TITLE
Open gating link in new tab

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWGatedTopicBanner/CWGatedTopicBanner.tsx
@@ -48,7 +48,9 @@ const CWGatedTopicBanner = ({
         {
           label: 'Learn more about gating',
           onClick: () =>
-            (window.location.href = `https://blog.commonwealth.im/introducing-common-groups/`),
+            window.open(
+              `https://blog.commonwealth.im/introducing-common-groups/`,
+            ),
         },
       ]}
       onClose={onClose}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6051

## Description of Changes
- Opens the link in new tab, when "Learn more about gating" is clicked

## "How We Fixed It"
N/A

## Test Plan
- Visit a community having a gated topic and you are restricted from that topic
- Visit a thread of that topic, find the gating banner and click on "learn more about gating"
- Verify the link opens in a new tab

## Deployment Plan
N/A

## Other Considerations
N/A