### PR TITLE
create community bech32

### DIFF
--- a/packages/commonwealth/client/scripts/models/NodeInfo.ts
+++ b/packages/commonwealth/client/scripts/models/NodeInfo.ts
@@ -6,6 +6,7 @@ class NodeInfo {
   public readonly cosmosChainId?: string;
   public readonly altWalletUrl?: string;
   public readonly balanceType?: string;
+  public readonly bech32?: string;
 
   constructor({
     id,
@@ -15,6 +16,7 @@ class NodeInfo {
     cosmos_chain_id,
     alt_wallet_url,
     balance_type,
+    bech32,
   }) {
     this.id = id;
     this.name = name;
@@ -23,6 +25,7 @@ class NodeInfo {
     this.cosmosChainId = cosmos_chain_id;
     this.altWalletUrl = alt_wallet_url;
     this.balanceType = balance_type;
+    this.bech32 = bech32;
   }
 
   public static fromJSON(json) {

--- a/packages/commonwealth/client/scripts/models/NodeInfo.ts
+++ b/packages/commonwealth/client/scripts/models/NodeInfo.ts
@@ -7,6 +7,7 @@ class NodeInfo {
   public readonly altWalletUrl?: string;
   public readonly balanceType?: string;
   public readonly bech32?: string;
+  public readonly network?: string;
 
   constructor({
     id,

--- a/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
@@ -36,6 +36,9 @@ const createCommunity = async ({
   bech32Prefix,
 }: CreateCommunityProps) => {
   const nameToSymbol = name.toUpperCase().slice(0, 4);
+  const communityNetwork = ChainBase.CosmosSDK
+    ? cosmosChainId
+    : baseToNetwork(chainBase);
 
   return await axios.post(`${app.serverUrl()}/communities`, {
     id,
@@ -51,7 +54,7 @@ const createCommunity = async ({
     user_address: userAddress,
 
     type: ChainType.Offchain,
-    network: baseToNetwork(chainBase),
+    network: communityNetwork,
     default_symbol: nameToSymbol,
     bech32_prefix: bech32Prefix,
     jwt: app.user.jwt,

--- a/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
@@ -18,7 +18,7 @@ interface CreateCommunityProps {
   nodeUrl: string;
   altWalletUrl: string;
   userAddress: string;
-  bech32Prefix?: 'osmo';
+  bech32Prefix?: string;
 }
 
 const createCommunity = async ({

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -205,7 +205,7 @@ const BasicInformationForm = ({
         nodeUrl: selectedChainNode.nodeUrl,
         altWalletUrl: selectedChainNode.altWalletUrl,
         userAddress: selectedAddress.address,
-        bech32Prefix: selectedCommunity.type === 'cosmos' ? 'osmo' : null,
+        bech32Prefix: selectedChainNode.bech32Prefix,
       });
       onSubmit(communityId);
     } catch (err) {

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -201,11 +201,11 @@ const BasicInformationForm = ({
         }),
         ...(selectedCommunity.chainBase === ChainBase.CosmosSDK && {
           cosmosChainId: values.chain.value,
+          bech32Prefix: selectedChainNode.bech32Prefix,
         }),
         nodeUrl: selectedChainNode.nodeUrl,
         altWalletUrl: selectedChainNode.altWalletUrl,
         userAddress: selectedAddress.address,
-        bech32Prefix: selectedChainNode.bech32Prefix,
       });
       onSubmit(communityId);
     } catch (err) {

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/constants.ts
@@ -32,4 +32,5 @@ export const chainTypes = app.config.nodes
     nodeUrl: chain.url,
     value: chain.ethChainId || chain.cosmosChainId || 'solana',
     label: chain.name.replace(/\b\w/g, (l) => l.toUpperCase()),
+    bech32Prefix: chain.bech32,
   }));

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -1,7 +1,6 @@
 import {
   ChainBase,
   ChainCategoryType,
-  ChainNetwork,
   ChainType,
 } from 'common-common/src/types';
 import { z } from 'zod';
@@ -61,7 +60,7 @@ export const createCommunitySchema = z.object({
 
   // deprecated params to be removed
   node_url: z.string().url(),
-  network: z.nativeEnum(ChainNetwork),
+  network: z.string(),
   default_symbol: z.string().max(9),
   website: z.string().url().optional(),
   github: z.string().url().startsWith('https://github.com/').optional(),

--- a/packages/commonwealth/shared/schemas/createCommunitySchema.ts
+++ b/packages/commonwealth/shared/schemas/createCommunitySchema.ts
@@ -56,7 +56,7 @@ export const createCommunitySchema = z.object({
   address: z.string().optional(), // address for the contract of the chain
   decimals: z.number().optional(),
   substrate_spec: z.string().optional(),
-  bech32_prefix: z.string().optional(),
+  bech32_prefix: z.string().optional(), // required for cosmos communities
   token_name: z.string().optional(),
 
   // deprecated params to be removed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Related: #5896 

## Description of Changes

- Fixes the ability to join a new cosmos community with a cosmos address. The community must have a bech32_prefix to be able to verify new addresses

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Adds bech32_prefix to payload of POST /communities in BasicInfomationForm
- 
## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 