### PR TITLE
Updated frontend gating flag

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -3,5 +3,5 @@ export const featureFlags = {
   communityHomepage: process.env.FLAG_COMMUNITY_HOMEPAGE === 'true',
   sidebarToggle: process.env.FLAG_SIDEBAR_TOGGLE === 'true',
   newCreateCommunity: process.env.FLAG_NEW_CREATE_COMMUNITY === 'true',
-  newGatingEnabled: process.env.GATING_API_ENABLED,
+  newGatingEnabled: process.env.FLAG_GATING_ENABLED,
 };

--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -75,7 +75,7 @@ module.exports = {
       'process.env.ETH_RPC': JSON.stringify(process.env.ETH_RPC),
     }),
     new webpack.DefinePlugin({
-      'process.env.GATING_API_ENABLED': process.env.GATING_API_ENABLED,
+      'process.env.FLAG_GATING_ENABLED': process.env.FLAG_GATING_ENABLED,
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../client/index.html'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6055

## Description of Changes
Updated frontend gating flag from `GATING_API_ENABLED` to `FLAG_GATING_ENABLED`

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_GATING_ENABLED` in `.env`
- Test gating features and verify they work well.

## Deployment Plan
N/A

## Other Considerations
N/A