### PR TITLE
Updated gating group form copy + growl updates

### DIFF
--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -1,15 +1,16 @@
+import 'Sublayout.scss';
+import clsx from 'clsx';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import useForceRerender from 'hooks/useForceRerender';
 import React, { useEffect, useState } from 'react';
 import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
-import 'Sublayout.scss';
 import { Sidebar } from 'views/components/sidebar';
 import { AppMobileMenus } from './AppMobileMenus';
 import { Footer } from './Footer';
 import { SublayoutBanners } from './SublayoutBanners';
 import { SublayoutHeader } from './SublayoutHeader';
-import clsx from 'clsx';
+import GatingGrowl from './components/GatingGrowl/GatingGrowl';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -88,7 +89,7 @@ const Sublayout = ({
                   menuName === 'createContent' ||
                   hasCommunitySidebar,
               },
-              resizing
+              resizing,
             )}
           >
             <SublayoutBanners banner={banner} chain={chain} terms={terms} />
@@ -103,6 +104,7 @@ const Sublayout = ({
             )}
           </div>
         </div>
+        {hasCommunitySidebar && <GatingGrowl />}
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -584,8 +584,8 @@ const GroupForm = ({
                   Gate topics
                 </CWText>
                 <CWText type="b2">
-                  Add topics to gate to auto-lock it for group members who
-                  satisfy the requirements above
+                  Add topics that only group members who satisfy the
+                  requirements above can participate in.
                 </CWText>
               </div>
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -26,7 +26,6 @@ import { getThreadActionTooltipText } from 'helpers/threads';
 import 'pages/discussions/index.scss';
 import { useRefreshMembershipQuery } from 'state/api/groups';
 import Permissions from 'utils/Permissions';
-import GatingGrowl from 'views/components/GatingGrowl/GatingGrowl';
 import { EmptyThreadsPlaceholder } from './EmptyThreadsPlaceholder';
 
 type DiscussionsPageProps = {
@@ -101,7 +100,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
 
   return (
     <div className="DiscussionsPage">
-      <GatingGrowl />
       <Virtuoso
         className="thread-list"
         style={{ height: '100%', width: '100%' }}

--- a/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/index.tsx
@@ -11,7 +11,6 @@ import { useFetchTopicsQuery } from 'state/api/topics';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
 import type Thread from '../../../models/Thread';
 import type Topic from '../../../models/Topic';
-import GatingGrowl from '../../components/GatingGrowl/GatingGrowl';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { CWText } from '../../components/component_kit/cw_text';
@@ -78,7 +77,6 @@ const OverviewPage = () => {
     <PageLoading />
   ) : (
     <div className="OverviewPage">
-      <GatingGrowl />
       <div className="header-row">
         <div className="header-row-left">
           <CWText type="h3" fontWeight="semiBold">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 

https://github.com/hicommonwealth/commonwealth/issues/6054
https://github.com/hicommonwealth/commonwealth/issues/6052

## Description of Changes
- Updated copy on gating group forms.
- Gating growl now shows up on all community pages

## "How We Fixed It"
N/A

## Test Plan
- Visit gating group forms, verify you see the copy `Add topics that only group members who satisfy the requirements above can participate in.` in the create/edit group form pages
- Visit different community level pages, verify you see the gating growl on all those pages (if you didn't close it already), also verify that gating growl doesn't appear outside of community level pages.

## Deployment Plan
N/A

## Other Considerations
N/A