### PR TITLE
6060-gatingClosingBug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/GatingGrowl/GatingGrowl.scss
+++ b/packages/commonwealth/client/scripts/views/components/GatingGrowl/GatingGrowl.scss
@@ -31,6 +31,7 @@
     color: $white;
     top: 1rem;
     right: 0rem;
+    z-index: 2;
 
     &:hover {
       color: $neutral-400;
@@ -44,6 +45,7 @@
     border-top-left-radius: 0.3125rem;
     border-top-right-radius: 0.3125rem;
     overflow: hidden;
+    z-index: 1;
   }
 
   .checkbox {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6060

## Description of Changes
- Added z-index to the img and the x

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added z-index to the img and the x because the image would go in front of the X icon during the inversion 

## Test Plan
1. Go to: http://localhost:8080/ethereum/discussions
2. Switch to dark mode
3. Attempt to exit the growl
