### PR TITLE
6061-gatingGrowlAdminBug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/GatingGrowl/GatingGrowl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/GatingGrowl/GatingGrowl.tsx
@@ -41,7 +41,7 @@ const GatingGrowl = () => {
           className="closeButton"
           onClick={handleExit}
         />
-        <img src="../../static/img/groupGrowl.png" alt="" className="img" />
+        <img src="../../../static/img/groupGrowl.png" alt="" className="img" />
         <div className="container">
           <CWText type="h1" fontWeight="semiBold" isCentered>
             Introducing Groups


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6061 

## Description of Changes
- Updated the relative path

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Updated the relative path fixes the img breaking when in the create group page
## Test Plan
- Be Admin
- Go into community
- Go to Groups Tab on Members Page
- Click Create Group => Make sure image is there.
