### PR TITLE
Fix community launch screen img

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/SuccessStep/SuccessStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/SuccessStep/SuccessStep.tsx
@@ -17,7 +17,7 @@ const SuccessStep = ({ communityId }: SuccessStepProps) => {
 
   return (
     <div className="SuccessStep" style={animationStyles}>
-      <img src="../../static/img/communityIslive.png" alt="" className="img" />
+      <img src="/static/img/communityIslive.png" alt="" className="img" />
       <CWText type="h2">Your community is live!</CWText>
       <div className="container" style={animationStyles}>
         <CWText type="b1" className="description">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6084

## Description of Changes
- Fixes broken image on community is live screen

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_NEW_CREATE_COMMUNITY` flag
- Create a community
- On the success screen ("community is live" screen), verify you see the main image.

## Deployment Plan
N/A

## Other Considerations
N/A