### PR TITLE
Suggested Communities column now able to scroll

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/CommunityPreviewCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/CommunityPreviewCard.tsx
@@ -1,0 +1,71 @@
+import { pluralize } from 'helpers';
+import { useCommonNavigate } from 'navigation/helpers';
+import React from 'react';
+import app from 'state';
+import CommunityInfo from '../../../models/ChainInfo';
+import { CWCard } from '../../components/component_kit/cw_card';
+import { CWCommunityAvatar } from '../../components/component_kit/cw_community_avatar';
+import { CWText } from '../../components/component_kit/cw_text';
+
+type CommunityPreviewCardProps = {
+  community: CommunityInfo;
+};
+
+const CommunityPreviewCard = ({ community }: CommunityPreviewCardProps) => {
+  const navigate = useCommonNavigate();
+
+  const { unseenPosts } = app.user;
+  const visitedChain = !!unseenPosts[community.id];
+  const updatedThreads = unseenPosts[community.id]?.activePosts || 0;
+  const monthlyThreadCount = app.recentActivity.getCommunityThreadCount(
+    community.id,
+  );
+  const isMember = app.roles.isMember({
+    account: app.user.activeAccount,
+    community: community.id,
+  });
+
+  return (
+    <CWCard
+      className="CommunityPreviewCard"
+      elevation="elevation-1"
+      interactive
+      onClick={(e) => {
+        e.preventDefault();
+        navigate(`/${community.id}`);
+      }}
+    >
+      <div className="card-top">
+        <CWCommunityAvatar community={community} />
+        <CWText type="h4" fontWeight="medium">
+          {community.name}
+        </CWText>
+      </div>
+      <CWText className="card-subtext" type="b2">
+        {community.description}
+      </CWText>
+      {/* if no recently active threads, hide this module altogether */}
+      {!!monthlyThreadCount && (
+        <>
+          <CWText className="card-subtext" type="b2" fontWeight="medium">
+            {`${pluralize(monthlyThreadCount, 'new thread')} this month`}
+          </CWText>
+          {isMember && (
+            <>
+              {app.isLoggedIn() && !visitedChain && (
+                <CWText className="new-activity-tag">New</CWText>
+              )}
+              {updatedThreads > 0 && (
+                <CWText className="new-activity-tag">
+                  {updatedThreads} new
+                </CWText>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </CWCard>
+  );
+};
+
+export default CommunityPreviewCard;

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/dashboard_communities_preview.tsx
@@ -1,75 +1,10 @@
-import { pluralize } from 'helpers';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/user_dashboard/dashboard_communities_preview.scss';
 import React from 'react';
-import CommunityInfo from '../../../models/ChainInfo';
-
 import app from 'state';
 import { CWButton } from '../../components/component_kit/cw_button';
-import { CWCard } from '../../components/component_kit/cw_card';
-import { CWCommunityAvatar } from '../../components/component_kit/cw_community_avatar';
 import { CWText } from '../../components/component_kit/cw_text';
-
-type CommunityPreviewCardProps = {
-  community: CommunityInfo;
-};
-
-const CommunityPreviewCard = ({ community }: CommunityPreviewCardProps) => {
-  const navigate = useCommonNavigate();
-
-  const { unseenPosts } = app.user;
-  const visitedChain = !!unseenPosts[community.id];
-  const updatedThreads = unseenPosts[community.id]?.activePosts || 0;
-  const monthlyThreadCount = app.recentActivity.getCommunityThreadCount(
-    community.id,
-  );
-  const isMember = app.roles.isMember({
-    account: app.user.activeAccount,
-    community: community.id,
-  });
-
-  return (
-    <CWCard
-      className="CommunityPreviewCard"
-      elevation="elevation-1"
-      interactive
-      onClick={(e) => {
-        e.preventDefault();
-        navigate(`/${community.id}`);
-      }}
-    >
-      <div className="card-top">
-        <CWCommunityAvatar community={community} />
-        <CWText type="h4" fontWeight="medium">
-          {community.name}
-        </CWText>
-      </div>
-      <CWText className="card-subtext" type="b2">
-        {community.description}
-      </CWText>
-      {/* if no recently active threads, hide this module altogether */}
-      {!!monthlyThreadCount && (
-        <>
-          <CWText className="card-subtext" type="b2" fontWeight="medium">
-            {`${pluralize(monthlyThreadCount, 'new thread')} this month`}
-          </CWText>
-          {isMember && (
-            <>
-              {app.isLoggedIn() && !visitedChain && (
-                <CWText className="new-activity-tag">New</CWText>
-              )}
-              {updatedThreads > 0 && (
-                <CWText className="new-activity-tag">
-                  {updatedThreads} new
-                </CWText>
-              )}
-            </>
-          )}
-        </>
-      )}
-    </CWCard>
-  );
-};
+import CommunityPreviewCard from './CommunityPreviewCard';
 
 export const DashboardCommunitiesPreview = () => {
   const navigate = useCommonNavigate();

--- a/packages/commonwealth/client/styles/pages/user_dashboard/dashboard_communities_preview.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/dashboard_communities_preview.scss
@@ -43,6 +43,10 @@
   float: right;
   top: 70px;
   z-index: 1;
+  flex-grow: 1;
+  overflow-y: auto;
+  max-height: 100vh;
+  padding-bottom: 100px;
 
   @include mediumSmallInclusive {
     display: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5860 

## Description of Changes
- Suggested Communities column is now able to scroll, allowing users to click Explore communities button on different window sizes

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added `overflow-y` , `max-height` , and `padding-bottom` styling to `.DashboardCommunitiesPreview`
-Also moved CommunityPreviewCard into its own file to clean up code and avoid failing CI/CD tests. 

NOTE: In the below video I changed the number of suggested communities to 5 instead of 3 to make up for the lack of information/space in the h1aaa and $ALEX communities, and thus have enough content to trigger the overflow. The logic has been reset to 3 before making this PR.

https://github.com/hicommonwealth/commonwealth/assets/69872984/6a0715aa-a852-4820-a103-121af47a2cc6


