### PR TITLE
changed Login button to read Sign in. Changed Sign in button to use n…

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutHeader.tsx
@@ -136,7 +136,7 @@ export const SublayoutHeader = ({ onMobile }: SublayoutHeaderProps) => {
             <CWButton
               buttonType="primary"
               buttonHeight="sm"
-              label="Login"
+              label="Sign in"
               buttonWidth="wide"
               disabled={location.pathname.includes('/finishsociallogin')}
               onClick={() => setIsLoginModalOpen(true)}

--- a/packages/commonwealth/client/scripts/views/pages/landing/header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/landing/header.tsx
@@ -3,10 +3,10 @@ import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/landing/header.scss';
 import React, { useState } from 'react';
 import { LoginModal } from 'views/modals/login_modal';
-import { CWButton } from '../../components/component_kit/cw_button';
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
-import { CWModal } from '../../components/component_kit/new_designs/CWModal';
 import { CWText } from '../../components/component_kit/cw_text';
+import { CWModal } from '../../components/component_kit/new_designs/CWModal';
+import { CWButton } from '../../components/component_kit/new_designs/cw_button';
 
 type HeaderProps = {
   onLogin: () => void;
@@ -37,8 +37,9 @@ export const Header = ({ onLogin }: HeaderProps) => {
               Why Commonwealth?
             </CWText>
             <CWButton
+              buttonType="primary"
+              buttonHeight="sm"
               label="Sign in"
-              buttonType="primary-black"
               onClick={() => setIsModalOpen(true)}
             />
           </div>


### PR DESCRIPTION
…ew designs CWButton

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5862 

## Description of Changes
- Added button consistency across platform

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Changed "Login" button to read "Sign in", and changed "Sign in" button to use CWButton from `new_designs`.

<img width="1400" alt="Screenshot 2023-12-18 at 3 50 59 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/4740c17e-6f77-46e7-a724-d67e737a1f22">
