### PR TITLE
#5984 - Scroll to bottom of editor on paste

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -278,7 +278,7 @@ const ReactQuillEditor = ({
                         className={clsx('QuillEditor', className, {
                           markdownEnabled: isMarkdownEnabled,
                         })}
-                        scrollingContainer="html"
+                        scrollingContainer="ql-container"
                         placeholder={placeholder}
                         tabIndex={tabIndex}
                         theme="snow"

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -120,19 +120,22 @@
   .ql-container {
     min-height: 212px;
     max-height: 512px;
-    overflow-y: scroll;
+    overflow: auto;
     border: none !important;
   }
 
   .ql-editor {
     min-height: 212px;
+    max-height: 512px;
 
     &.ql-blank::before {
       font-style: normal;
     }
+
     & h1 {
       font-size: 24px !important;
     }
+
     & h2 {
       font-size: 20px !important;
     }
@@ -162,11 +165,9 @@
 
     .inner-circle {
       border-radius: inherit;
-      background-image: conic-gradient(
-        #fff,
-        rgba(80, 200, 120, 0.3),
-        rgb(80, 200, 120)
-      );
+      background-image: conic-gradient(#fff,
+          rgba(80, 200, 120, 0.3),
+          rgb(80, 200, 120));
       position: absolute;
       z-index: -1;
       margin: auto;
@@ -181,6 +182,7 @@
       0% {
         transform: rotate(0deg);
       }
+
       100% {
         transform: rotate(360deg);
       }


### PR DESCRIPTION
This PR fixes the bug described in issue #5984. Currently, after pasting enough text in the quill editor that scrolling is required, the editor remains scrolled to the top. This fix scrolls to the bottom of the editor.

## Link to Issue
Closes: #5984

## Description of Changes
- set the scrolling container to `.ql-container`
- set a max-height on `.ql-editor`, which is inside of `.ql-container`

## Test Plan
- navigate to `[community]/new/discussion`
- paste in a large amount of text. The editor should scroll to the bottom.