### PR TITLE
Fix name of communityIsLive image link.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/SuccessStep/SuccessStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/SuccessStep/SuccessStep.tsx
@@ -17,7 +17,7 @@ const SuccessStep = ({ communityId }: SuccessStepProps) => {
 
   return (
     <div className="SuccessStep" style={animationStyles}>
-      <img src="/static/img/communityIslive.png" alt="" className="img" />
+      <img src="/static/img/communityIsLive.png" alt="" className="img" />
       <CWText type="h2">Your community is live!</CWText>
       <div className="container" style={animationStyles}>
         <CWText type="b1" className="description">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6084

## Description of Changes
- Fixes link to communityIsLive image.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Casing was incorrect on the previous solution's link.
