### PR TITLE
Added new create community cta button in create menu popovers

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWPopoverMenu/CWPopoverMenu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWPopoverMenu/CWPopoverMenu.tsx
@@ -12,6 +12,7 @@ import CWPopover, {
 import { CWIcon } from '../cw_icons/cw_icon';
 import { CWText } from '../cw_text';
 import { getClasses } from '../helpers';
+import { CWButton } from '../new_designs/cw_button';
 import type {
   DefaultMenuItem,
   DividerMenuItem,
@@ -84,7 +85,36 @@ export const PopoverMenu = ({
                     iconLeftSize,
                     label,
                     onClick,
+                    isButton,
                   } = item;
+
+                  const clickHandler = (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onClick(e);
+
+                    if (item.type === 'default' && item.preventClosing) {
+                      return;
+                    }
+
+                    handleInteraction(e);
+                  };
+
+                  if (isButton) {
+                    return (
+                      <CWButton
+                        containerClassName={`${className} m-auto no-outline`}
+                        key={label as string}
+                        label={label}
+                        buttonHeight="sm"
+                        iconLeft={iconLeft}
+                        iconLeftWeight={iconLeftWeight}
+                        disabled={disabled}
+                        onClick={clickHandler}
+                      />
+                    );
+                  }
+
                   return (
                     <div
                       className={getClasses<{
@@ -94,17 +124,7 @@ export const PopoverMenu = ({
                         { disabled, isSecondary },
                         `PopoverMenuItem ${item.className}`,
                       )}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        onClick(e);
-
-                        if (item.type === 'default' && item.preventClosing) {
-                          return;
-                        }
-
-                        handleInteraction(e);
-                      }}
+                      onClick={clickHandler}
                       key={i}
                     >
                       {iconLeft && (

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
@@ -38,6 +38,7 @@ import {
   Trash,
   TwitterLogo,
   Users,
+  UsersThree,
 } from '@phosphor-icons/react';
 import * as CustomIcons from './cw_custom_icons';
 import * as Icons from './cw_icons';
@@ -144,6 +145,7 @@ export const iconLookup = {
   notepad: withPhosphorIcon(Notepad),
   paperPlaneTilt: withPhosphorIcon(PaperPlaneTilt),
   people: Icons.CWPeople,
+  peopleNew: withPhosphorIcon(UsersThree),
   person: Icons.CWPerson,
   // pin: Icons.CWPin,
   pin: withPhosphorIcon(PushPin),

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -11,6 +11,7 @@ import { User } from '../user/user';
 import { CWIcon } from './cw_icons/cw_icon';
 import { CWText } from './cw_text';
 import { getClasses, isWindowSmallInclusive } from './helpers';
+import { CWButton } from './new_designs/cw_button';
 import type { MenuItem } from './types';
 import { ComponentType } from './types';
 
@@ -36,8 +37,33 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
   const { mutateAsync: toggleCommunityStar } = useToggleCommunityStarMutation();
 
   if (props.type === 'default') {
-    const { disabled, iconLeft, iconRight, isSecondary, label, onClick } =
-      props;
+    const {
+      disabled,
+      iconLeft,
+      iconLeftWeight,
+      iconRight,
+      isSecondary,
+      label,
+      onClick,
+      isButton,
+      className,
+    } = props;
+
+    if (isButton) {
+      return (
+        <CWButton
+          containerClassName={`${className} px-16 no-outline`}
+          key={label as string}
+          label={label}
+          buttonHeight="sm"
+          buttonWidth="full"
+          iconLeft={iconLeft}
+          iconLeftWeight={iconLeftWeight}
+          disabled={disabled}
+          onClick={onClick}
+        />
+      );
+    }
 
     return (
       <div

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_button.tsx
@@ -26,6 +26,7 @@ type ButtonStyleProps = {
 
 export type ButtonProps = {
   iconLeft?: IconName;
+  iconLeftWeight?: 'bold' | 'light' | 'fill';
   iconRight?: IconName;
   label: string | React.ReactNode;
   type?: 'reset' | 'submit' | 'button';
@@ -42,6 +43,7 @@ export const CWButton = (props: ButtonProps) => {
     className,
     disabled = false,
     iconLeft,
+    iconLeftWeight,
     iconRight,
     label,
     onClick,
@@ -75,7 +77,13 @@ export const CWButton = (props: ButtonProps) => {
         disabled={disabled}
         {...otherProps}
       >
-        {!!iconLeft && <CWIcon iconName={iconLeft} className="button-icon" />}
+        {!!iconLeft && (
+          <CWIcon
+            weight={iconLeftWeight}
+            iconName={iconLeft}
+            className="button-icon"
+          />
+        )}
         <CWText
           type={buttonHeight === 'lg' ? 'buttonLg' : 'buttonSm'}
           className="button-text"

--- a/packages/commonwealth/client/scripts/views/components/component_kit/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/types.ts
@@ -85,6 +85,7 @@ export type DefaultMenuItem = {
   type?: 'default';
   className?: string;
   preventClosing?: boolean;
+  isButton?: boolean;
 };
 
 type NotificationMenuItem = {

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -128,8 +128,12 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
 
   const getUniversalCreateItems = (): PopoverMenuItem[] => [
     {
-      label: 'New Community',
-      iconLeft: 'people',
+      label: featureFlags.newCreateCommunity
+        ? 'Create community'
+        : 'New Community',
+      isButton: featureFlags.newCreateCommunity,
+      iconLeft: featureFlags.newCreateCommunity ? 'peopleNew' : 'people',
+      ...(featureFlags.newCreateCommunity && { iconLeftWeight: 'bold' }),
       onClick: (e) => {
         e?.preventDefault();
         resetSidebarState();

--- a/packages/commonwealth/client/styles/utils.scss
+++ b/packages/commonwealth/client/styles/utils.scss
@@ -1,3 +1,7 @@
+.m-auto {
+  margin: auto !important;
+}
+
 .ml-auto {
   margin-left: auto !important;
 }
@@ -16,4 +20,15 @@
 
 .capitalize {
   text-transform: capitalize;
+}
+
+.px-16 {
+  padding: 0 16px !important;
+}
+
+.no-outline {
+  outline: none !important;
+  &:focus-within {
+    border: none !important;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6110

## Description of Changes
- Added new create community CTA in "create" menu's.

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_NEW_CREATE_COMMUNITY` in env
- Go to a community and open the create menu from the header -- verify you see the new create community button

<img width="397" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/921c44ab-c42b-44d7-b402-582a3f019486">


- Open the create menu from the app sidebar -- verify you see the new create community button
<img width="284" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/c63bcafc-fc6f-44bc-87d3-002f4efb1509">



## Deployment Plan
N/A

## Other Considerations
N/A