### PR TITLE
X svg on input tag  no longer grows very large when loading or refres…

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/new_designs/CWTag.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/new_designs/CWTag.scss
@@ -249,6 +249,8 @@
     display: grid;
     align-items: center;
     color: $neutral-500;
+    max-width: 20px;
+    max-height: 20px;
     width: fit-content;
     height: fit-content;
     padding: 0;


### PR DESCRIPTION
…hing

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5922 
## Description of Changes
- X svg on Input Tag now longer grows very large on load/refresh while looking at platform on Safari

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added maximum height/width styling so that X svg will not grow too large. I chose 20px as the maximum to not interfere with any other svg that might be using this styling. Now when loading or refreshing the X only grows to a max of 20px for a split second and then settles as the specified 16px, whereas before the X grew very large and sometimes didn't shrink to 16px. NOTE: This is only visible on Safari. 

## Test Plan
-open Safari and sign in.
-go to any community
-notice that the Input Tag in the Search Common search bar no longer grows very large

https://github.com/hicommonwealth/commonwealth/assets/69872984/d9e7fc24-0e37-47b9-8d81-46389914491b


