### PR TITLE
Changing thread topics no longer throws error

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/change_thread_topic_modal.tsx
@@ -44,8 +44,8 @@ export const ChangeThreadTopicModal = ({
         } else {
           acc.disabledTopics.push(t);
         }
-        return acc;
       }
+      return acc;
     },
     { enabledTopics: [], disabledTopics: [] },
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6114 

## Description of Changes
-Changing thread topics no longer throws an error. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-fixed placement of `return acc` inside reduce in `change_thread_topic_modal.tsx`

## Test Plan
-Go to 1inch community on local
-make sure you're an admin
-go to a thread 
-click the three dots and select Change Topic, pick new topic
-go to topic and confirm the thread has been moved. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
Team effort on this including @jnaviask @timolegros and @ilijabojanovic 