### PR TITLE
Update `makeGetBalancesOptions` to support ERC1155

### DIFF
--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -114,7 +114,6 @@
     "@terra-money/terra.js": "^3.1.7",
     "@terra-money/wallet-controller": "^3.11.2",
     "@todesktop/client-core": "^1.1.3",
-    "@types/bluebird": "^3.5.36",
     "@types/bn.js": "^4.11.6",
     "@types/bs58": "^4.0.1",
     "@types/express": "^4.17.1",

--- a/packages/commonwealth/server/migrations/20231220172832-invalidate-erc1155-memberships.js
+++ b/packages/commonwealth/server/migrations/20231220172832-invalidate-erc1155-memberships.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const result = await queryInterface.sequelize.query(
+        `
+        SELECT id
+        FROM "Groups" G,
+             jsonb_array_elements(requirements::JSONB) AS elem
+        WHERE elem -> 'data' -> 'source' ->> 'source_type' = 'erc1155';
+      `,
+        { type: 'SELECT', transaction },
+      );
+
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      await queryInterface.bulkUpdate(
+        'Memberships',
+        {
+          last_checked: yesterday,
+        },
+        {
+          group_id: result.map((g) => g.id),
+        },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // not possible
+  },
+};

--- a/packages/commonwealth/server/migrations/20231220172832-invalidate-erc1155-memberships.js
+++ b/packages/commonwealth/server/migrations/20231220172832-invalidate-erc1155-memberships.js
@@ -23,6 +23,9 @@ module.exports = {
         {
           group_id: result.map((g) => g.id),
         },
+        {
+          transaction,
+        },
       );
     });
   },

--- a/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
+++ b/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
@@ -18,8 +18,7 @@ export function makeGetBalancesOptions(
   groups: GroupAttributes[],
   addresses: AddressAttributes[],
 ): GetBalancesOptions[] {
-  const allOptions: Exclude<GetBalancesOptions, GetErc1155BalanceOptions>[] =
-    [];
+  const allOptions: GetBalancesOptions[] = [];
 
   const addressStrings = addresses.map((a) => a.address);
 
@@ -48,6 +47,34 @@ export function makeGetBalancesOptions(
                 sourceOptions: {
                   contractAddress: castedSource.contract_address,
                   evmChainId: castedSource.evm_chain_id,
+                },
+                addresses: addressStrings,
+              });
+            }
+            break;
+          }
+          case BalanceSourceType.ERC1155: {
+            const castedSource = requirement.data.source as ContractSource;
+            const existingOptions = allOptions.find((opt) => {
+              const castedOpt = opt as GetErc1155BalanceOptions;
+              return (
+                castedOpt.balanceSourceType === BalanceSourceType.ERC1155 &&
+                castedOpt.sourceOptions.evmChainId ===
+                  castedSource.evm_chain_id &&
+                castedOpt.sourceOptions.contractAddress ===
+                  castedSource.contract_address &&
+                castedOpt.sourceOptions.tokenId ===
+                  parseInt(castedSource.token_id, 10)
+              );
+            });
+
+            if (!existingOptions) {
+              allOptions.push({
+                balanceSourceType: BalanceSourceType.ERC1155,
+                sourceOptions: {
+                  evmChainId: castedSource.evm_chain_id,
+                  contractAddress: castedSource.contract_address,
+                  tokenId: parseInt(castedSource.token_id, 10),
                 },
                 addresses: addressStrings,
               });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6796,7 +6796,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bluebird@*", "@types/bluebird@^3.5.36":
+"@types/bluebird@*":
   version "3.5.36"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
   integrity sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6118 

## Description of Changes
- title
- modified `refresh-all-memberships` script to allow specifying a specific community to refresh
- removed bluebird usage + types package

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Added support for ERC1155 in a crucial option formatting function.

## Test Plan
- Run `DELETE FROM "Memberships" WHERE group_id IN (112, 113, 114);`
- Run `yarn rerfresh-all-memberships`
- Run `SELECT * FROM "Memberships" WHERE group_id = 112;`

The final select query should return all memberships and only 1 should have an error message in the `reject_reason` column that says "Error: Failed to get balance for address" (this is the discobot address and the other memberships should have a balance threshold error).

## Deployment Plan
<!--- Omit if unneeded -->
1. Deploy
2. Run the `refresh-all-memberships` script on a one-off dyno immediately after the deployment is finished

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 