### PR TITLE
Hide social links input for new create community front end

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -17,7 +17,6 @@ import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelec
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
 import { openConfirmation } from 'views/modals/confirmation_modal';
-
 import './BasicInformationForm.scss';
 import {
   ETHEREUM_MAINNET_ID,
@@ -30,6 +29,8 @@ import { BasicInformationFormProps, FormSubmitValues } from './types';
 import { basicInformationFormValidationSchema } from './validation';
 
 import useSocialLinks from './useSocialLinks';
+
+const socialLinksDisplay = false; // TODO: Set this when design figures out how we will integrate the social links
 
 const BasicInformationForm = ({
   selectedAddress,
@@ -227,57 +228,60 @@ const BasicInformationForm = ({
         enableGenerativeAI
       />
 
-      <section className="header">
-        <CWText type="h4">
-          Community Links{' '}
-          <CWText type="b1" className="optional-label">
-            &#40;Optional&#41;
-          </CWText>
-        </CWText>
-        <CWText type="b1" className="description">
-          Add your Discord, Twitter (X), Telegram, Website, etc.
-        </CWText>
-      </section>
+      {socialLinksDisplay ? (
+        <>
+          <section className="header">
+            <CWText type="h4">
+              Community Links{' '}
+              <CWText type="b1" className="optional-label">
+                &#40;Optional&#41;
+              </CWText>
+            </CWText>
+            <CWText type="b1" className="description">
+              Add your Discord, Twitter (X), Telegram, Website, etc.
+            </CWText>
+          </section>
 
-      {/* Social links */}
-      <section className="social-links">
-        <CWText type="caption">Social Links</CWText>
+          <section className="social-links">
+            <CWText type="caption">Social Links</CWText>
 
-        {socialLinks.map((socialLink, index) => (
-          <div className="link-input-container" key={index}>
-            <CWTextInput
-              containerClassName="w-full"
-              placeholder="https://example.com"
-              fullWidth
-              value={socialLink.value}
-              customError={socialLink.error}
-              onInput={(e) =>
-                updateAndValidateSocialLinkAtIndex(
-                  e.target.value?.trim(),
-                  index,
-                )
-              }
-              onBlur={() =>
-                updateAndValidateSocialLinkAtIndex(socialLink.value, index)
-              }
-              onFocus={() =>
-                updateAndValidateSocialLinkAtIndex(socialLink.value, index)
-              }
-            />
-            <CWIconButton
-              iconButtonTheme="neutral"
-              iconName="trash"
-              iconSize="large"
-              onClick={() => removeLinkAtIndex(index)}
-              disabled={socialLinks.length === 1}
-            />
-          </div>
-        ))}
+            {socialLinks.map((socialLink, index) => (
+              <div className="link-input-container" key={index}>
+                <CWTextInput
+                  containerClassName="w-full"
+                  placeholder="https://example.com"
+                  fullWidth
+                  value={socialLink.value}
+                  customError={socialLink.error}
+                  onInput={(e) =>
+                    updateAndValidateSocialLinkAtIndex(
+                      e.target.value?.trim(),
+                      index,
+                    )
+                  }
+                  onBlur={() =>
+                    updateAndValidateSocialLinkAtIndex(socialLink.value, index)
+                  }
+                  onFocus={() =>
+                    updateAndValidateSocialLinkAtIndex(socialLink.value, index)
+                  }
+                />
+                <CWIconButton
+                  iconButtonTheme="neutral"
+                  iconName="trash"
+                  iconSize="large"
+                  onClick={() => removeLinkAtIndex(index)}
+                  disabled={socialLinks.length === 1}
+                />
+              </div>
+            ))}
 
-        <button type="button" className="add-link-button" onClick={addLink}>
-          + Add social link
-        </button>
-      </section>
+            <button type="button" className="add-link-button" onClick={addLink}>
+              + Add social link
+            </button>
+          </section>
+        </>
+      ) : null}
 
       {/* Action buttons */}
       <section className="action-buttons">


### PR DESCRIPTION
## Link to Issue
Closes: #6119

## Description of Changes
- Removes inputs for social links on new create communities page

## Test Plan
- Created a new community. Made sure it created correctly
- Navigated to manage page, made sure I was able to add social links 

bottom of new create community page looks like:

<img width="672" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/c95f1dfe-74b1-4682-aeef-8f16fd7e4ffa">
