### PR TITLE
Switch devnet tests to use Compound

### DIFF
--- a/packages/commonwealth/server/workers/evmChainEvents/hardCodedAbis.ts
+++ b/packages/commonwealth/server/workers/evmChainEvents/hardCodedAbis.ts
@@ -703,6 +703,757 @@ export const rawAaveAbi = [
   },
 ];
 
+export const rawCompoundAbi = [
+  {
+    type: 'constructor',
+    inputs: [
+      {
+        name: 'tribe',
+        type: 'address',
+        internalType: 'contract ERC20VotesComp',
+      },
+      {
+        name: 'timelock',
+        type: 'address',
+        internalType: 'contract ICompoundTimelock',
+      },
+      { name: 'guardian', type: 'address', internalType: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'ProposalCanceled',
+    type: 'event',
+    inputs: [
+      {
+        name: 'proposalId',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'ProposalCreated',
+    type: 'event',
+    inputs: [
+      {
+        name: 'proposalId',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'proposer',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+      {
+        name: 'targets',
+        type: 'address[]',
+        indexed: false,
+        internalType: 'address[]',
+      },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        indexed: false,
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'signatures',
+        type: 'string[]',
+        indexed: false,
+        internalType: 'string[]',
+      },
+      {
+        name: 'calldatas',
+        type: 'bytes[]',
+        indexed: false,
+        internalType: 'bytes[]',
+      },
+      {
+        name: 'startBlock',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'endBlock',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'ProposalExecuted',
+    type: 'event',
+    inputs: [
+      {
+        name: 'proposalId',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'ProposalQueued',
+    type: 'event',
+    inputs: [
+      {
+        name: 'proposalId',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'eta',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'ProposalThresholdUpdated',
+    type: 'event',
+    inputs: [
+      {
+        name: 'oldProposalThreshold',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'newProposalThreshold',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'QuorumUpdated',
+    type: 'event',
+    inputs: [
+      {
+        name: 'oldQuorum',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'newQuorum',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  { name: 'Rollback', type: 'event', inputs: [], anonymous: false },
+  {
+    name: 'RollbackQueued',
+    type: 'event',
+    inputs: [
+      { name: 'eta', type: 'uint256', indexed: false, internalType: 'uint256' },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'TimelockChange',
+    type: 'event',
+    inputs: [
+      {
+        name: 'oldTimelock',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+      {
+        name: 'newTimelock',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'VoteCast',
+    type: 'event',
+    inputs: [
+      {
+        name: 'voter',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'proposalId',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      { name: 'support', type: 'uint8', indexed: false, internalType: 'uint8' },
+      {
+        name: 'weight',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'reason',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'VotingDelayUpdated',
+    type: 'event',
+    inputs: [
+      {
+        name: 'oldVotingDelay',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'newVotingDelay',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'VotingPeriodUpdated',
+    type: 'event',
+    inputs: [
+      {
+        name: 'oldVotingPeriod',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'newVotingPeriod',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    name: 'BACKUP_GOVERNOR',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'BALLOT_TYPEHASH',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'COUNTING_MODE',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'string', internalType: 'string' }],
+    stateMutability: 'pure',
+  },
+  {
+    name: 'ROLLBACK_DEADLINE',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: '__acceptAdmin',
+    type: 'function',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: '__executeRollback',
+    type: 'function',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: '__rollback',
+    type: 'function',
+    inputs: [{ name: 'eta', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'cancel',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'castVote',
+    type: 'function',
+    inputs: [
+      { name: 'proposalId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'support',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'castVoteBySig',
+    type: 'function',
+    inputs: [
+      { name: 'proposalId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'support',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+      { name: 'v', type: 'uint8', internalType: 'uint8' },
+      {
+        name: 'r',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      { name: 's', type: 'bytes32', internalType: 'bytes32' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'castVoteWithReason',
+    type: 'function',
+    inputs: [
+      { name: 'proposalId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'support',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+      { name: 'reason', type: 'string', internalType: 'string' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'execute',
+    type: 'function',
+    inputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'calldatas', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'descriptionHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'payable',
+  },
+  {
+    name: 'execute',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    name: 'getActions',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'signatures', type: 'string[]', internalType: 'string[]' },
+      {
+        name: 'calldatas',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    name: 'getReceipt',
+    type: 'function',
+    inputs: [
+      { name: 'proposalId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'voter',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'hasVoted', type: 'bool', internalType: 'bool' },
+          {
+            name: 'support',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          { name: 'votes', type: 'uint96', internalType: 'uint96' },
+        ],
+        internalType: 'struct IGovernorCompatibilityBravo.Receipt',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    name: 'getVotes',
+    type: 'function',
+    inputs: [
+      { name: 'account', type: 'address', internalType: 'address' },
+      {
+        name: 'blockNumber',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'hasVoted',
+    type: 'function',
+    inputs: [
+      { name: 'proposalId', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'hashProposal',
+    type: 'function',
+    inputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'calldatas', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'descriptionHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'pure',
+  },
+  {
+    name: 'name',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'string', internalType: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'proposalDeadline',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'proposalEta',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'proposalSnapshot',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'proposalThreshold',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'proposals',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      { name: 'id', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'proposer',
+        type: 'address',
+        internalType: 'address',
+      },
+      { name: 'eta', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'startBlock',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'endBlock', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'forVotes',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'againstVotes', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'abstainVotes',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'canceled', type: 'bool', internalType: 'bool' },
+      {
+        name: 'executed',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    name: 'propose',
+    type: 'function',
+    inputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'calldatas', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'description',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'propose',
+    type: 'function',
+    inputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'signatures', type: 'string[]', internalType: 'string[]' },
+      {
+        name: 'calldatas',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
+      { name: 'description', type: 'string', internalType: 'string' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'queue',
+    type: 'function',
+    inputs: [
+      { name: 'targets', type: 'address[]', internalType: 'address[]' },
+      {
+        name: 'values',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      { name: 'calldatas', type: 'bytes[]', internalType: 'bytes[]' },
+      {
+        name: 'descriptionHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'queue',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'quorum',
+    type: 'function',
+    inputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'quorumVotes',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'setProposalThreshold',
+    type: 'function',
+    inputs: [
+      {
+        name: 'newProposalThreshold',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'setQuorum',
+    type: 'function',
+    inputs: [{ name: 'newQuorum', type: 'uint256', internalType: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'setVotingDelay',
+    type: 'function',
+    inputs: [
+      { name: 'newVotingDelay', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'setVotingPeriod',
+    type: 'function',
+    inputs: [
+      { name: 'newVotingPeriod', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'state',
+    type: 'function',
+    inputs: [{ name: 'proposalId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [
+      { name: '', type: 'uint8', internalType: 'enum IGovernor.ProposalState' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    name: 'supportsInterface',
+    type: 'function',
+    inputs: [{ name: 'interfaceId', type: 'bytes4', internalType: 'bytes4' }],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'timelock',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'token',
+    type: 'function',
+    inputs: [],
+    outputs: [
+      { name: '', type: 'address', internalType: 'contract ERC20VotesComp' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    name: 'updateTimelock',
+    type: 'function',
+    inputs: [
+      {
+        name: 'newTimelock',
+        type: 'address',
+        internalType: 'contract ICompoundTimelock',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    name: 'version',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'string', internalType: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'votingDelay',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'votingPeriod',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+];
+
 export const rawDydxAbi = [
   {
     inputs: [

--- a/packages/commonwealth/test/devnet/evm/evmChainEvents/logProcessing.spec.ts
+++ b/packages/commonwealth/test/devnet/evm/evmChainEvents/logProcessing.spec.ts
@@ -15,8 +15,8 @@ import {
 } from '../../../../server/workers/evmChainEvents/types';
 import { AbiType } from '../../../../shared/types';
 import {
-  aavePropCreatedSignature,
-  aavePropQueuedSignature,
+  compoundPropCreatedSignature,
+  compoundPropQueuedSignature,
   getEvmSecondsAndBlocks,
   localRpc,
   sdk,
@@ -39,7 +39,7 @@ describe('EVM Chain Events Log Processing Tests', () => {
   before(async () => {
     const abiRes = await models.ContractAbi.findOne({
       where: {
-        nickname: 'AaveGovernanceV2',
+        nickname: 'FeiDAO',
       },
     });
 
@@ -104,19 +104,19 @@ describe('EVM Chain Events Log Processing Tests', () => {
     it('should restrict the maximum block range fetched to 500 blocks', async () => {
       expectAbi();
 
-      await sdk.getVotingPower(1, '400000', 'aave');
-      propCreatedResult = await sdk.createProposal(1, 'aave');
+      await sdk.getVotingPower(1, '400000');
+      propCreatedResult = await sdk.createProposal(1);
       await sdk.safeAdvanceTime(propCreatedResult.block + 501);
 
       // fetch logs
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -138,11 +138,11 @@ describe('EVM Chain Events Log Processing Tests', () => {
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -167,24 +167,21 @@ describe('EVM Chain Events Log Processing Tests', () => {
 
       let res = getEvmSecondsAndBlocks(3);
       await sdk.safeAdvanceTime(propCreatedResult.block + res.blocks);
-      await sdk.castVote(propCreatedResult.proposalId, 1, true, 'aave');
+      await sdk.castVote(propCreatedResult.proposalId, 1, true);
       res = getEvmSecondsAndBlocks(3);
       await sdk.advanceTime(String(res.secs), res.blocks);
 
-      propQueuedResult = await sdk.queueProposal(
-        propCreatedResult.proposalId,
-        'aave',
-      );
+      propQueuedResult = await sdk.queueProposal(propCreatedResult.proposalId);
 
       // fetch logs
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropQueuedSignature,
+                event_signature: compoundPropQueuedSignature,
                 kind: 'proposal-queued',
               },
             ],
@@ -217,10 +214,10 @@ describe('EVM Chain Events Log Processing Tests', () => {
       let evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -234,11 +231,11 @@ describe('EVM Chain Events Log Processing Tests', () => {
       evmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi: 'invalid abi' as unknown as AbiType,
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -252,11 +249,11 @@ describe('EVM Chain Events Log Processing Tests', () => {
       evmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi: [],
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -274,11 +271,11 @@ describe('EVM Chain Events Log Processing Tests', () => {
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -293,9 +290,9 @@ describe('EVM Chain Events Log Processing Tests', () => {
 
         removed: false,
 
-        address: sdk.contractAddrs.aave.governance.toLowerCase(),
+        address: sdk.contractAddrs.compound.governance.toLowerCase(),
         data: '0x1',
-        topics: [aavePropCreatedSignature],
+        topics: [compoundPropCreatedSignature],
         transactionHash: '0x1',
         logIndex: 1,
       };
@@ -312,7 +309,7 @@ describe('EVM Chain Events Log Processing Tests', () => {
 
       expect(events.length).to.equal(1);
       expect(events[0].contractAddress).to.equal(
-        sdk.contractAddrs.aave.governance,
+        sdk.contractAddrs.compound.governance,
       );
       expect(events[0].kind).to.equal('proposal-created');
       expect(events[0].blockNumber).to.equal(
@@ -327,11 +324,11 @@ describe('EVM Chain Events Log Processing Tests', () => {
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropQueuedSignature,
+                event_signature: compoundPropQueuedSignature,
                 kind: 'proposal-queued',
               },
             ],
@@ -345,7 +342,7 @@ describe('EVM Chain Events Log Processing Tests', () => {
       ]);
       expect(events.length).to.equal(1);
       expect(events[0].contractAddress).to.equal(
-        sdk.contractAddrs.aave.governance,
+        sdk.contractAddrs.compound.governance,
       );
       expect(events[0].kind).to.equal('proposal-queued');
       expect(events[0].blockNumber).to.equal(
@@ -372,15 +369,15 @@ describe('EVM Chain Events Log Processing Tests', () => {
       const evmSource: EvmSource = {
         rpc: localRpc,
         contracts: {
-          [sdk.contractAddrs.aave.governance]: {
+          [sdk.contractAddrs.compound.governance]: {
             abi,
             sources: [
               {
-                event_signature: aavePropQueuedSignature,
+                event_signature: compoundPropQueuedSignature,
                 kind: 'proposal-queued',
               },
               {
-                event_signature: aavePropCreatedSignature,
+                event_signature: compoundPropCreatedSignature,
                 kind: 'proposal-created',
               },
             ],
@@ -401,7 +398,7 @@ describe('EVM Chain Events Log Processing Tests', () => {
       );
       expect(propCreatedEvent).to.exist;
       expect(propCreatedEvent.contractAddress).to.equal(
-        sdk.contractAddrs.aave.governance,
+        sdk.contractAddrs.compound.governance,
       );
       expect(propCreatedEvent.kind).to.equal('proposal-created');
       expect(propCreatedEvent.blockNumber).to.equal(
@@ -412,7 +409,7 @@ describe('EVM Chain Events Log Processing Tests', () => {
       const propQueuedEvent = events.find((e) => e.kind === 'proposal-queued');
       expect(propQueuedEvent).to.exist;
       expect(propQueuedEvent.contractAddress).to.equal(
-        sdk.contractAddrs.aave.governance,
+        sdk.contractAddrs.compound.governance,
       );
       expect(propQueuedEvent.kind).to.equal('proposal-queued');
       expect(propQueuedEvent.blockNumber).to.equal(

--- a/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
+++ b/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
@@ -101,8 +101,8 @@ describe('EVM Chain Events End to End Tests', () => {
     await getTestSignatures();
 
     // create proposal notification
-    await sdk.getVotingPower(1, '400000', 'aave');
-    propCreatedResult = await sdk.createProposal(1, 'aave');
+    await sdk.getVotingPower(1, '400000');
+    propCreatedResult = await sdk.createProposal(1);
     console.log(
       `Proposal created at block ${propCreatedResult.block} with id ${propCreatedResult.proposalId}`,
     );

--- a/packages/commonwealth/test/devnet/evm/evmChainEvents/util.ts
+++ b/packages/commonwealth/test/devnet/evm/evmChainEvents/util.ts
@@ -9,6 +9,11 @@ export const aavePropCreatedSignature =
 export const aavePropQueuedSignature =
   '0x11a0b38e70585e4b09b794bd1d9f9b1a51a802eb8ee2101eeee178d0349e73fe';
 
+export const compoundPropCreatedSignature =
+  '0x7d84a6263ae0d98d3329bd7b46bb4e8d6f98cd35a7adb45c274c8b7fd5ebd5e0';
+export const compoundPropQueuedSignature =
+  '0x9a2e42fd6722813d69113e7d0079d3d940171428df7373df9c7f7617cfda2892';
+
 export function getEvmSecondsAndBlocks(days: number) {
   const secs = Math.round(days * 86400);
   const blocks = Math.round(secs / 12 + 500);

--- a/packages/commonwealth/test/integration/evmChainEvents/util.ts
+++ b/packages/commonwealth/test/integration/evmChainEvents/util.ts
@@ -7,19 +7,19 @@ import {
 import models from '../../../server/database';
 import { hashAbi } from '../../../server/util/abiValidation';
 import {
-  rawAaveAbi,
+  rawCompoundAbi,
   rawDydxAbi,
 } from '../../../server/workers/evmChainEvents/hardCodedAbis';
 import {
-  aavePropCreatedSignature,
-  aavePropQueuedSignature,
+  compoundPropCreatedSignature,
+  compoundPropQueuedSignature,
   localRpc,
   sdk,
 } from '../../devnet/evm/evmChainEvents/util';
 
-export const testChainId = 'aave-test';
+export const testChainId = 'compound-test';
 export const testChainIdV2 = 'dydx-test';
-export const testAbiNickname = 'AaveGovernanceV2';
+export const testAbiNickname = 'FeiDAO';
 export const testAbiNicknameV2 = 'DydxGovernor';
 
 export async function getTestChainNode(version?: 'v1' | 'v2') {
@@ -51,8 +51,8 @@ export async function getTestChain(version?: 'v1' | 'v2') {
   let chainId: string, name: string, defaultSymbol: string;
   if (!version || version === 'v1') {
     chainId = testChainId;
-    name = 'Aave Test';
-    defaultSymbol = 'AAVE';
+    name = 'Compound Test';
+    defaultSymbol = 'COW';
   } else {
     chainId = testChainIdV2;
     name = 'DyDx Test';
@@ -66,7 +66,7 @@ export async function getTestChain(version?: 'v1' | 'v2') {
     },
     defaults: {
       name,
-      network: ChainNetwork.Aave,
+      network: ChainNetwork.Compound,
       type: ChainType.Chain,
       base: ChainBase.Ethereum,
       default_symbol: defaultSymbol,
@@ -74,12 +74,12 @@ export async function getTestChain(version?: 'v1' | 'v2') {
   });
 
   if (
-    (!created && chain.network !== ChainNetwork.Aave) ||
+    (!created && chain.network !== ChainNetwork.Compound) ||
     chain.type !== ChainType.Chain ||
     chain.base !== ChainBase.Ethereum
   ) {
     await chain.update({
-      network: ChainNetwork.Aave,
+      network: ChainNetwork.Compound,
       type: ChainType.Chain,
       base: ChainBase.Ethereum,
     });
@@ -91,7 +91,7 @@ export async function getTestChain(version?: 'v1' | 'v2') {
 export async function getTestAbi(version?: 'v1' | 'v2') {
   let hash: string, nickname: string;
   if (!version || version === 'v1') {
-    hash = hashAbi(rawAaveAbi);
+    hash = hashAbi(rawCompoundAbi);
     nickname = testAbiNickname;
   } else {
     hash = hashAbi(rawDydxAbi);
@@ -107,7 +107,7 @@ export async function getTestAbi(version?: 'v1' | 'v2') {
   if (existingAbi) return existingAbi;
 
   return await models.ContractAbi.create({
-    abi: !version || version === 'v1' ? rawAaveAbi : rawDydxAbi,
+    abi: !version || version === 'v1' ? rawCompoundAbi : rawDydxAbi,
     nickname: nickname,
     abi_hash: hash,
   });
@@ -118,7 +118,7 @@ export async function getTestContract(version?: 'v1' | 'v2') {
 
   let address: string;
   if (!version || version === 'v1') {
-    address = sdk.contractAddrs.aave.governance;
+    address = sdk.contractAddrs.compound.governance;
   } else {
     address = '0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2';
   }
@@ -187,7 +187,7 @@ export async function getTestSignatures(version?: 'v1' | 'v2') {
 
   let contractAddress: string;
   if (!version || version === 'v1') {
-    contractAddress = sdk.contractAddrs.aave.governance;
+    contractAddress = sdk.contractAddrs.compound.governance;
   } else {
     contractAddress = '0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2';
   }
@@ -197,7 +197,7 @@ export async function getTestSignatures(version?: 'v1' | 'v2') {
     where: {
       chain_node_id: chainNode.id,
       contract_address: contractAddress,
-      event_signature: aavePropCreatedSignature,
+      event_signature: compoundPropCreatedSignature,
       kind: 'proposal-created',
     },
   });
@@ -206,7 +206,7 @@ export async function getTestSignatures(version?: 'v1' | 'v2') {
     where: {
       chain_node_id: chainNode.id,
       contract_address: contractAddress,
-      event_signature: aavePropQueuedSignature,
+      event_signature: compoundPropQueuedSignature,
       kind: 'proposal-queued',
     },
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Alleviates but does not close #6164

## Description of Changes
The EVM chain testing SDK supports 2 governance contract types Aave and Compound. It seems that the Aave proposal creation process is broken so to fix the devnets I switched all tests to use Compound instead of Aave.

Don't let the high change count fool you. The majority of line changes are due to the addition of the Compound (specifically Tribe) governance contract ABI which you can safely ignore.

## Test Plan
- Ensure CI passes