### PR TITLE
Create script to switch discobot-listener-staging associated app

### DIFF
--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -8,7 +8,8 @@
     "start-consumer": "ts-node discord-consumer/discordConsumer.ts",
     "check-types": "tsc --noEmit",
     "start-prod-consumer": "node build/discord-bot/discord-consumer/discordConsumer.js",
-    "start-prod-listener": "node build/discord-bot/discord-listener/discordListener.js"
+    "start-prod-listener": "node build/discord-bot/discord-listener/discordListener.js",
+    "switch-staging-app": "chmod u+x scripts/switch-discobot-staging-env.sh && ./scripts/switch-discobot-staging-env.sh"
   },
   "keywords": [],
   "author": "",

--- a/packages/discord-bot/scripts/switch-discobot-staging-env.sh
+++ b/packages/discord-bot/scripts/switch-discobot-staging-env.sh
@@ -24,7 +24,7 @@ update_env_vars() {
         heroku config:set "$var=$value" -a "$target_app"
     done
 
-    SERVER_URL=$(heroku info -s -a "$app_name" | grep web_url | cut -d= -f2)
+    SERVER_URL=$(heroku info -s -a "$app_name" | grep web_url | cut -d= -f2 | sed 's:/*$::')
     heroku config:set SERVER_URL="$SERVER_URL" -a "$target_app"
 
     echo "Environment variables updated successfully."

--- a/packages/discord-bot/scripts/switch-discobot-staging-env.sh
+++ b/packages/discord-bot/scripts/switch-discobot-staging-env.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script Usage Description
+usage="Usage: $0 [commonwealth-beta|commonwealth-frick]"
+target_app="discobot-listener-staging"
+
+# Function to retrieve and update environment variables
+update_env_vars() {
+    app_name=$1
+
+    # List of environment variables to update
+    env_vars=("CLOUDAMQP_APIKEY" "CLOUDAMQP_URL" "DATABASE_URL")
+
+    for var in "${env_vars[@]}"; do
+        # Retrieve the value from the source app
+        value=$(heroku config:get "$var" -a "$app_name")
+
+        if [ -z "$value" ]; then
+            echo "Error retrieving $var from $app_name"
+            exit 1
+        fi
+
+        # Update the value in the target app
+        heroku config:set "$var=$value" -a "$target_app"
+    done
+
+    SERVER_URL=$(heroku info -s -a "$app_name" | grep web_url | cut -d= -f2)
+    heroku config:set SERVER_URL="$SERVER_URL" -a "$target_app"
+
+    echo "Environment variables updated successfully."
+}
+
+# Check the first command line argument
+if [ "$1" == "commonwealth-beta" ] || [ "$1" == "commonwealth-frick" ]; then
+    echo "Linking discobot-staging to $1"
+    echo "Putting $target_app in maintenance mode"
+    heroku maintenance:on -a "$target_app"
+
+    # Call the function to update environment variables
+    update_env_vars "$1"
+    heroku maintenance:off -a "$target_app"
+else
+    echo "Invalid argument."
+    echo "$usage"
+    # Exit the script with a non-zero exit status to indicate incorrect usage
+    exit 1
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6168

## Description of Changes
Create a script which takes in an app name as an argument (for now just `commonwealth-frick` or `commonwealth-beta`) and then copies the relevant environment variables to the `discobot-listener-staging` app. The script puts the `discobot-listener-staging` app in maintenance mode before updating the variables to avoid any unexpected errors.

There is 1 caveat to the script. Since the environment variable updates can not be transactionalized together, if a network failure occurs midway through the execution of the script, the `discobot-listener-staging` environment variables could be left in an inconsistent state. Not to worry though you can simply re-run the script to re-update any of the variables

## Test Plan
**Before executing the test plan ensure no one is using the `discobot-listener-staging` app as this test plan could interfere with their testing.**
- Navigate to `packages/discord-bot/`
- Run `yarn switch-staging-app commonwealth-frick`
- Run `yarn switch-staging-app commonwealth-beta`
- Both commands should complete successfully.