### PR TITLE
Remove old banner that is confusing with new Groups

### DIFF
--- a/packages/commonwealth/client/scripts/views/SublayoutBanners.tsx
+++ b/packages/commonwealth/client/scripts/views/SublayoutBanners.tsx
@@ -3,10 +3,7 @@ import { isNonEmptyString } from 'helpers/typeGuards';
 import React, { useState } from 'react';
 import app from 'state';
 import ChainInfo from '../models/ChainInfo';
-import {
-  CWMessageBanner,
-  Old_CWBanner,
-} from './components/component_kit/cw_banner';
+import { CWMessageBanner } from './components/component_kit/cw_banner';
 import { TermsBanner } from './components/terms_banner';
 
 type SublayoutBannersProps = {
@@ -40,12 +37,7 @@ export const SublayoutBanners = ({
         app.isLoggedIn() &&
         ([ChainNetwork.Aave, ChainNetwork.Compound].includes(chain.network) ||
           chain.base === ChainBase.CosmosSDK) &&
-        [ChainType.DAO, ChainType.Chain].includes(chain.type as ChainType) &&
-        !app.user.activeAccount && (
-          <Old_CWBanner
-            bannerContent={`Link an address that holds ${chain.default_symbol} to participate in governance.`}
-          />
-        )}
+        [ChainType.DAO, ChainType.Chain].includes(chain.type as ChainType)}
       {isNonEmptyString(terms) && <TermsBanner terms={terms} />}
     </>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 🤷 

## Description of Changes
- Removes our OldBanner that appears when a user doesn't have an active address as it is confusing given new Groups. Banner is no longer useful as we also show the "join" button when they do not have an active address in the left sidebar.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Deleted the code. 

## Test Plan
- CA