### PR TITLE
Remove Ropsten

### DIFF
--- a/packages/commonwealth/server/migrations/20240102133459-remove-ropsten-chain-node.js
+++ b/packages/commonwealth/server/migrations/20240102133459-remove-ropsten-chain-node.js
@@ -1,0 +1,88 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // re-link Ropsten communities to Ethereum
+      await queryInterface.sequelize.query(
+        `
+        with ropsten_communities as (SELECT C.id
+                             FROM "Communities" C
+                                      JOIN "ChainNodes" CN on C.chain_node_id = CN.id
+                             WHERE CN.eth_chain_id = 3)
+        UPDATE "Communities" C
+        SET chain_node_id = (SELECT id FROM "ChainNodes" WHERE eth_chain_id = 1)
+        FROM "ropsten_communities" rp
+        WHERE rp.id = C.id;
+      `,
+        { transaction },
+      );
+
+      // remove linked community contracts
+      await queryInterface.sequelize.query(
+        `
+        WITH deprecated_contracts as (
+            SELECT C.id
+            FROM "Contracts" C
+            JOIN "ChainNodes" CN on CN.id = C.chain_node_id
+            WHERE CN.eth_chain_id = 3
+        ) DELETE FROM "CommunityContracts" cc
+        USING deprecated_contracts dc
+        WHERE cc.contract_id = dc.id;
+      `,
+        { transaction },
+      );
+
+      // delete Ropsten contracts
+      await queryInterface.sequelize.query(
+        `
+        DELETE FROM "Contracts" C
+        USING "ChainNodes" CN
+        WHERE C.chain_node_id = CN.id AND CN.eth_chain_id = 3;
+      `,
+        { transaction },
+      );
+
+      // delete memberships of groups associated to Ropsten communities
+      await queryInterface.sequelize.query(
+        `
+        with ropsten_groups as (
+            SELECT g.id
+            FROM "Groups" g
+            JOIN "Communities" c ON g.community_id = c.id
+            JOIN "ChainNodes" cn on c.chain_node_id = cn.id
+            WHERE cn.eth_chain_id = 3
+        ) DELETE FROM "Memberships" m
+        USING ropsten_groups rg
+        WHERE rg.id = m.group_id;
+      `,
+        { transaction },
+      );
+
+      // delete groups associated to Ropsten communities
+      await queryInterface.sequelize.query(
+        `
+        with ropsten_communities as (
+            SELECT C.id
+            FROM "Communities" C
+            JOIN "ChainNodes" CN on C.chain_node_id = CN.id
+            WHERE CN.eth_chain_id = 3
+        ) DELETE FROM "Groups" g
+            USING ropsten_communities rc
+        WHERE rc.id = g.community_id;
+      `,
+        { transaction },
+      );
+
+      await queryInterface.bulkDelete(
+        'ChainNodes',
+        {
+          eth_chain_id: 3,
+        },
+        { transaction },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/packages/commonwealth/server/routes/etherscanAPI.ts
+++ b/packages/commonwealth/server/routes/etherscanAPI.ts
@@ -1,28 +1,22 @@
 import axios from 'axios';
 import { AppError } from 'common-common/src/errors';
-import type { DB } from '../models';
-import type { TypedRequestBody, TypedResponse } from '../types';
-import { success } from '../types';
+import { NextFunction } from 'express';
 import { ETHERSCAN_JS_API_KEY } from '../config';
+import type { DB } from '../models';
 import type { ContractAttributes } from '../models/contract';
 import type { ContractAbiAttributes } from '../models/contract_abi';
+import type { TypedRequestBody, TypedResponse } from '../types';
+import { success } from '../types';
 import validateAbi, { hashAbi } from '../util/abiValidation';
-import { NextFunction } from 'express';
 
 export enum Network {
   Mainnet = 'Mainnet',
-  Rinkeby = 'Rinkeby',
-  Ropsten = 'Ropsten',
-  Kovan = 'Kovan',
   Goerli = 'Goerli',
 }
 
 export const networkIdToName = {
   1: Network.Mainnet,
-  3: Network.Ropsten,
-  4: Network.Rinkeby,
   5: Network.Goerli,
-  42: Network.Kovan,
 };
 
 export const Errors = {
@@ -45,7 +39,7 @@ type FetchEtherscanContractResp = {
 export const fetchEtherscanContract = async (
   models: DB,
   req: TypedRequestBody<FetchEtherscanContractReq>,
-  res: TypedResponse<FetchEtherscanContractResp>
+  res: TypedResponse<FetchEtherscanContractResp>,
 ) => {
   if (!ETHERSCAN_JS_API_KEY) {
     throw new AppError(Errors.NoEtherscanApiKey);
@@ -137,7 +131,7 @@ export const fetchEtherscanContractAbi = async (
   models: DB,
   req: TypedRequestBody<FetchEtherscanContractAbiReq>,
   res: TypedResponse<FetchEtherscanContractAbiResp>,
-  next: NextFunction
+  next: NextFunction,
 ) => {
   if (!ETHERSCAN_JS_API_KEY) {
     throw new AppError(Errors.NoEtherscanApiKey);

--- a/packages/commonwealth/server/util/tokenBalanceCache/util.ts
+++ b/packages/commonwealth/server/util/tokenBalanceCache/util.ts
@@ -240,12 +240,8 @@ export function mapNodeToBalanceFetcherContract(
     case 1: // Ethereum Mainnet
     case 1337: // Local Ganache - assuming fork of mainnet
       return '0xb1f8e55c7f64d203c1400b9d8555d050f94adf39';
-    case 3: // Ropsten
-      return '0x8D9708f3F514206486D7E988533f770a16d074a7';
     case 5: // Goerli
       return '0x9788C4E93f9002a7ad8e72633b11E8d1ecd51f9b';
-    case 4: // Rinkeby
-      return '0x3183B673f4816C94BeF53958BaF93C671B7F8Cf2';
     case 56: // BSC
     case 97: // BSC Testnet
       return '0x2352c63A83f9Fd126af8676146721Fa00924d7e4';
@@ -253,7 +249,6 @@ export function mapNodeToBalanceFetcherContract(
     case 80001: // Polygon Mumbai
       return '0x2352c63A83f9Fd126af8676146721Fa00924d7e4';
     case 10: // Optimism Mainnet
-    case 69: // Optimism Kovan
       return '0xB1c568e9C3E6bdaf755A60c7418C269eb11524FC';
     case 42161: // Arbitrum One
       return '0x151E24A486D7258dd7C33Fb67E4bB01919B7B32c';

--- a/packages/commonwealth/test/util/resetDatabase.ts
+++ b/packages/commonwealth/test/util/resetDatabase.ts
@@ -36,10 +36,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
           eth_chain_id: 1,
           balance_type: BalanceType.Ethereum,
         },
-        ropsten: {
-          url: 'https://eth-ropsten.alchemyapi.io/v2/dummy_key',
-          name: 'Ropsten Testnet',
-          eth_chain_id: 3,
+        goerli: {
+          url: 'https://eth-goerli.alchemyapi.io/v2/dummy_key',
+          name: 'Goerli Testnet',
+          eth_chain_id: 5,
           balance_type: BalanceType.Ethereum,
         },
         osmosis: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5823 

## Description of Changes
- Creates a migration which transfers Ropsten communities to Ethereum and then deletes their associated contracts and groups.

## Test Plan
- Join and interact with the `insuretoken` community.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- There are only 5 affected communities all 5 of which have no had any active members since 2022.