### PR TITLE
Validate requirement contract address

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/validateTypes.ts
+++ b/packages/commonwealth/client/scripts/helpers/validateTypes.ts
@@ -1,13 +1,24 @@
-import type { ValidationStatus } from '../views/components/component_kit/cw_validation_text';
+import { bech32 } from 'bech32';
 import { isAddress } from 'web3-utils';
+import type { ValidationStatus } from '../views/components/component_kit/cw_validation_text';
 
 enum FormType {
   AddressRef = 'address-ref',
   Address = 'address',
   Token = 'token',
 }
-function isValidEthAddress(address: string) {
+export function isValidEthAddress(address: string) {
   return isAddress(address);
+}
+
+export function isValidCosmosAddress(address) {
+  try {
+    const decodedAddress = bech32.decode(address);
+    bech32.fromWords(decodedAddress.words);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isValidToken(input: string) {
@@ -17,7 +28,7 @@ function isValidToken(input: string) {
 
 export default function validateType(
   input: string,
-  type: FormType
+  type: FormType,
 ): [ValidationStatus, string] | [] {
   switch (type) {
     case FormType.Address:

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import { isValidCosmosAddress, isValidEthAddress } from 'helpers/validateTypes';
+import { isValidEthAddress } from 'helpers/validateTypes';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import app from 'state';
@@ -306,11 +306,7 @@ const GroupForm = ({
           allRequirements[index].values.requirementType,
         ) && !isValidEthAddress(val.requirementContractAddress);
 
-      const isInvalidCosmosAddress =
-        TOKENS.COSMOS_TOKEN === allRequirements[index].values.requirementType &&
-        !isValidCosmosAddress(val.requirementContractAddress);
-
-      if (isInvalidEthAddress || isInvalidCosmosAddress) {
+      if (isInvalidEthAddress) {
         allRequirements[index] = {
           ...allRequirements[index],
           errors: {

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-multi-comp */
+import { isValidCosmosAddress, isValidEthAddress } from 'helpers/validateTypes';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import app from 'state';
@@ -296,6 +297,28 @@ const GroupForm = ({
           [key]: message,
         },
       };
+    }
+
+    // Validate if contract address is valid based on the selected requirement type
+    if (val.requirementContractAddress) {
+      const isInvalidEthAddress =
+        [...Object.values(SPECIFICATIONS), TOKENS.EVM_TOKEN].includes(
+          allRequirements[index].values.requirementType,
+        ) && !isValidEthAddress(val.requirementContractAddress);
+
+      const isInvalidCosmosAddress =
+        TOKENS.COSMOS_TOKEN === allRequirements[index].values.requirementType &&
+        !isValidCosmosAddress(val.requirementContractAddress);
+
+      if (isInvalidEthAddress || isInvalidCosmosAddress) {
+        allRequirements[index] = {
+          ...allRequirements[index],
+          errors: {
+            ...allRequirements[index].errors,
+            [key]: VALIDATION_MESSAGES.INVALID_INPUT,
+          },
+        };
+      }
     }
 
     setRequirementSubForms([...allRequirements]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6081

## Description of Changes
- Add validation logic to group form for validating contract address based on the selected requirement type

## "How We Fixed It"
By adding validation for contract addresses in group form

## Test Plan
- Visit the create/edit community group pages from cosmos and ethereum communities.
- When on the cosmos community, verify that the requirement contract address field validates the cosmos contract address correctly, if invalid it will show an "Invalid input" error msg.
- When on the ethereum community, verify that the requirement contract address field validates the ethereum contract address correctly, if invalid it will show an "Invalid input" error msg. 

## Deployment Plan
N/A

## Other Considerations
N/A