### PR TITLE
#5972 - Removing the Community Tag from the Search Tag Results in Global Search

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/search.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/search.ts
@@ -31,7 +31,7 @@ class SearchController {
       return this.getByQuery(searchQuery);
     }
     const searchCache = this._store.getOrAdd(searchQuery);
-    const { searchTerm, chainScope, isSearchPreview, sort } = searchQuery;
+    const { searchTerm, communityScope, isSearchPreview, sort } = searchQuery;
     const pageSize = isSearchPreview ? SEARCH_PREVIEW_SIZE : SEARCH_PAGE_SIZE;
     const scope = searchQuery.getSearchScope();
 
@@ -42,7 +42,7 @@ class SearchController {
       ) {
         const discussions = await this.searchDiscussions(searchTerm, {
           pageSize,
-          chainScope,
+          communityScope,
           sort,
         });
 
@@ -58,7 +58,7 @@ class SearchController {
       if (scope.includes(SearchScope.Replies)) {
         const comments = await this.searchComments(searchTerm, {
           pageSize,
-          chainScope,
+          communityScope,
           sort,
         });
 
@@ -90,7 +90,7 @@ class SearchController {
       if (scope.includes(SearchScope.Members)) {
         const { profiles } = await this.searchMentionableProfiles(
           searchTerm,
-          chainScope,
+          communityScope,
         );
 
         searchCache.results[SearchScope.Members] = profiles
@@ -143,10 +143,10 @@ class SearchController {
     page: number,
     pageSize: number,
   ) {
-    const { searchTerm, chainScope, sort } = searchQuery;
+    const { searchTerm, communityScope, sort } = searchQuery;
     const searchParams = {
       pageSize,
-      chainScope,
+      communityScope,
       sort,
     };
     switch (tab) {
@@ -188,10 +188,10 @@ class SearchController {
     params: SearchParams,
     page?: number,
   ) => {
-    const { pageSize, chainScope, communityScope, sort } = params;
+    const { pageSize, communityScope, sort } = params;
     try {
       const queryParams = {
-        chain: chainScope,
+        chain: communityScope,
         community: communityScope,
         search: searchTerm,
         page_size: pageSize,
@@ -218,10 +218,10 @@ class SearchController {
     params: SearchParams,
     page?: number,
   ) => {
-    const { pageSize, chainScope, communityScope, sort } = params;
+    const { pageSize, communityScope, sort } = params;
     try {
       const queryParams = {
-        chain: chainScope,
+        chain: communityScope,
         community: communityScope,
         search: searchTerm,
         page_size: pageSize,
@@ -247,11 +247,11 @@ class SearchController {
     searchTerm: string,
     params: SearchParams,
   ): Promise<Thread[]> => {
-    const { pageSize, chainScope, communityScope } = params;
+    const { pageSize, communityScope } = params;
     try {
       const response = await axios.get(`${app.serverUrl()}/threads`, {
         params: {
-          chain: chainScope,
+          chain: communityScope,
           community: communityScope,
           search: searchTerm,
           results_size: pageSize,
@@ -272,14 +272,14 @@ class SearchController {
 
   public searchMentionableProfiles = async (
     searchTerm: string,
-    chainScope: string,
+    communityScope: string,
     pageSize?: number,
     page?: number,
     includeRoles?: boolean,
   ) => {
     const response = await axios.get(`${app.serverUrl()}/profiles`, {
       params: {
-        chain: chainScope,
+        chain: communityScope,
         search: searchTerm,
         page_size: pageSize,
         page,

--- a/packages/commonwealth/client/scripts/hooks/useSearchResults.ts
+++ b/packages/commonwealth/client/scripts/hooks/useSearchResults.ts
@@ -31,7 +31,9 @@ const useSearchResults = (
 ): {
   searchResults: SearchResults;
 } => {
-  const communityId = app.activeChainId() || 'all_communities';
+  const communityId = filters.includes('communities')
+    ? 'all_communities'
+    : app.activeChainId();
   const debouncedSearchTerm = useDebounce<string>(searchTerm, 500);
 
   const sharedQueryOptions = {

--- a/packages/commonwealth/client/scripts/models/SearchQuery.ts
+++ b/packages/commonwealth/client/scripts/models/SearchQuery.ts
@@ -24,7 +24,6 @@ export enum SearchSort {
 
 export interface SearchParams {
   communityScope?: string;
-  chainScope?: string;
   isSearchPreview?: boolean;
   searchScope?: Array<SearchScope>;
   sort?: SearchSort;
@@ -33,7 +32,7 @@ export interface SearchParams {
 
 export default class SearchQuery implements SearchParams {
   public searchTerm: Lowercase<string>;
-  public chainScope?: string;
+  public communityScope?: string;
   public isSearchPreview?: boolean;
   public searchScope: Array<SearchScope>;
   public sort: SearchSort;
@@ -41,7 +40,7 @@ export default class SearchQuery implements SearchParams {
   constructor(searchTerm = '', params?: SearchParams) {
     this.searchTerm = <Lowercase<string>>searchTerm.toLowerCase();
     this.searchScope = params?.searchScope || [SearchScope.All];
-    this.chainScope = params?.chainScope;
+    this.communityScope = params?.communityScope;
     this.isSearchPreview = !!params?.isSearchPreview;
     this.sort = params?.sort || SearchSort.Best;
   }
@@ -49,7 +48,7 @@ export default class SearchQuery implements SearchParams {
   public toEncodedString() {
     let encodedString =
       this.searchTerm.trim().replace(/\s+/g, '%20') +
-      (this.chainScope ? ` chainScope=${this.chainScope}` : '') +
+      (this.communityScope ? ` communityScope=${this.communityScope}` : '') +
       (this.isSearchPreview ? ` isSearchPreview=${this.isSearchPreview}` : '') +
       (this.sort ? ` sort=${this.sort}` : '');
 
@@ -107,7 +106,7 @@ export default class SearchQuery implements SearchParams {
 
   public static fromUrlParams(url: Record<string, any>) {
     const sq = new SearchQuery(url['q']);
-    sq.chainScope = url['chainScope'] || undefined;
+    sq.communityScope = url['communityScope'] || undefined;
     sq.isSearchPreview = url['preview'] === 'true';
     sq.sort = url['sort'] || SearchSort.Best;
     sq.searchScope = url['scope'] || [SearchScope.All];

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
@@ -52,7 +52,9 @@ export const CWSearchBar: FC<SearchBarProps> = ({
 }) => {
   const navigate = useCommonNavigate();
   const [showTag, setShowTag] = useState(true);
-  const communityId = app.activeChainId() || 'all_communities';
+  const communityId = showTag
+    ? app.activeChainId() || 'all_communities'
+    : 'all_communities';
   const community = app.config.chains.getById(communityId);
   const [searchTerm, setSearchTerm] = useState('');
   const { searchResults } = useSearchResults(searchTerm, [
@@ -95,7 +97,7 @@ export const CWSearchBar: FC<SearchBarProps> = ({
   const handleGoToSearchPage = () => {
     const searchQuery = new SearchQuery(searchTerm, {
       isSearchPreview: false,
-      chainScope: showTag ? communityId : 'all_communities',
+      communityScope: showTag ? communityId : 'all_communities',
     });
     goToSearchPage(searchQuery, navigate);
     resetSearchBar();

--- a/packages/commonwealth/client/scripts/views/pages/search/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/index.tsx
@@ -103,7 +103,7 @@ const SearchPage = () => {
     SORT_MAP[queryParams.sort] || DEFAULT_SORT_OPTIONS;
 
   const sharedQueryOptions = {
-    communityId: app.activeChainId() || 'all_communities',
+    communityId: community,
     searchTerm: queryParams.q,
     limit: 20,
     orderBy,


### PR DESCRIPTION
The work in this PR makes it such that when a user is on any of a community's pages, removing the community tag from the search bar makes the search results global. 

Currently, if you are on a community's page, regardless of whether the community tag is there, the search results are limited to the current community.

## Link to Issue
Closes: #5972 

## Description of Changes
- Removing the tag from the search bar when on a community page gives global search results

## Test Plan
- navigate to any community's page
- enter a common search term in the search bar when the community tag is present. 
- remove the community tag and enter the same search term. You should see results from multiple communities.
