### PR TITLE
#5944 - BUG: Fix instances of broken markdown

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
@@ -81,6 +81,18 @@
       .content-body {
         @include multiline-text-ellipsis($max-lines: 2);
         word-break: break-word;
+
+        .MarkdownFormattedText {
+          @include caption;
+
+          h1,
+          h2,
+          h3,
+          h4,
+          h5 {
+            font-size: 12px;
+          }
+        }
       }
 
       .content-title {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -1,3 +1,4 @@
+import { QuillRenderer } from 'client/scripts/views/components/react_quill_editor/quill_renderer';
 import { isDefaultStage, threadStageToLabel } from 'helpers';
 import { filterLinks } from 'helpers/threads';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
@@ -80,7 +81,7 @@ export const ThreadCard = ({
 
   const discussionLink = getProposalUrlPath(
     thread.slug,
-    `${thread.identifier}-${slugify(thread.title)}`
+    `${thread.identifier}-${slugify(thread.title)}`,
   );
 
   const isStageDefault = isDefaultStage(thread.stage);
@@ -94,7 +95,7 @@ export const ThreadCard = ({
         to={threadHref}
         className={getClasses<{ isPinned?: boolean }>(
           { isPinned: thread.pinned },
-          'ThreadCard'
+          'ThreadCard',
         )}
         onClick={() => onBodyClick && onBodyClick()}
         key={thread.id}
@@ -151,7 +152,7 @@ export const ThreadCard = ({
               )}
             </div>
             <CWText type="caption" className="content-body">
-              {thread.plaintext}
+              <QuillRenderer doc={thread.plaintext} />
             </CWText>
           </div>
           {isTagsRowVisible && (

--- a/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
@@ -14,6 +14,7 @@ import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { getClasses } from '../../components/component_kit/helpers';
 import { CWTag } from '../../components/component_kit/new_designs/CWTag';
+import { QuillRenderer } from '../../components/react_quill_editor/quill_renderer';
 import { SharePopover } from '../../components/share_popover';
 import { User } from '../../components/user/user';
 import { getLastUpdated, isHot, isNewThread } from '../discussions/helpers';
@@ -133,7 +134,7 @@ export const TopicSummaryRow = ({
                 </CWText>
 
                 <CWText type="caption" className="thread-preview">
-                  {thread.plaintext}
+                  <QuillRenderer doc={thread.plaintext} />
                 </CWText>
 
                 {isTagsRowVisible && (

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -25,7 +25,7 @@
 
   table {
     width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     display: block;
     border-collapse: collapse;
 

--- a/packages/commonwealth/client/styles/pages/overview/TopicSummaryRow.scss
+++ b/packages/commonwealth/client/styles/pages/overview/TopicSummaryRow.scss
@@ -37,7 +37,7 @@
         color: $primary-500;
         width: 100%;
       }
-      
+
       .threads-count-text.Text {
         color: $neutral-500;
         width: 100%;
@@ -120,6 +120,18 @@
       .thread-preview {
         @include multiline-text-ellipsis(2);
         word-break: break-word;
+
+        .MarkdownFormattedText {
+          @include caption;
+
+          h1,
+          h2,
+          h3,
+          h4,
+          h5 {
+            font-size: 12px;
+          }
+        }
       }
 
       .row-bottom {


### PR DESCRIPTION
The work in this PR fixes the bug described in #5944 wherein some renderings of markdown tables look broken. 
The two instances of broken tables found were on the thread list page and on the thread overview page. 

## Link to Issue
Closes: #5944 

## Description of Changes
- markdown text on the thread list page and on the overview page now display with proper formatting

## "How We Fixed It"
- use QuillRenderer to render text on the thread list page and on the thread overview page

## Test Plan
- create a thread that contains a markdown table
- navigate to the thread list page and check that it displays as a table there
- navigate to the thread overview page and check the same
