### PR TITLE
added z-index on cover-image-overlay to push image behind

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
@@ -106,6 +106,7 @@
       justify-content: center;
       position: absolute;
       width: 100%;
+      z-index: 1;
 
       .prompt-input {
         width: 80%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6152 

## Description of Changes
- gnerated image now falls behind input field on dark mode
- 
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added a z-index: 1 to `cover-image-overlay` to make sure the image is always behind `cw_cover_image_uplaoder`

https://github.com/hicommonwealth/commonwealth/assets/69872984/f0910f2c-70e6-44cf-8807-f08865e5e65b


