### PR TITLE
5973 delete community

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -181,6 +181,24 @@ export async function __deleteCommunity(
             transaction: t,
           });
 
+          await this.models.sequelize.query(
+            `
+            WITH addresses_to_delete AS (
+                SELECT id 
+                FROM "Addresses"
+                WHERE community_id = :community_id
+            ) DELETE FROM "Collaborations" C
+            USING addresses_to_delete atd
+            WHERE atd.id = C.address_id;
+          `,
+            {
+              transaction: t,
+              replacements: {
+                community_id: community.id,
+              },
+            },
+          );
+
           await this.models.Address.destroy({
             where: { community_id: community.id },
             transaction: t,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5973 

## Description of Changes
- Added a sequelize command to delete memberships before the community

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Sequelize command prevented the foreign key error from occuring

## Test Plan
- Go to Admin Panel
- Delete Community 
