### PR TITLE
#6035 - Extend Markdown Support Pt. 1

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/cw_checkbox.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_checkbox.scss
@@ -9,16 +9,16 @@
     position: relative;
     height: 17px;
 
-    input[type="checkbox"] {
+    input[type='checkbox'] {
       display: none;
     }
 
-    input[type="checkbox"]+.checkbox-control:before,
-    input[type="checkbox"]+.checkbox-control:after {
+    input[type='checkbox'] + .checkbox-control:before,
+    input[type='checkbox'] + .checkbox-control:after {
       transition: all 0.3s;
     }
 
-    input[type="checkbox"]+.checkbox-control:after {
+    input[type='checkbox'] + .checkbox-control:after {
       display: inline-block;
       content: ' ';
       width: 14px;
@@ -29,12 +29,12 @@
       z-index: 1000;
     }
 
-    input[type="checkbox"]:checked+.checkbox-control:after {
-      background-color: #338FFF;
-      border-color: #338FFF;
+    input[type='checkbox']:checked + .checkbox-control:after {
+      background-color: #338fff;
+      border-color: #338fff;
     }
 
-    input[type="checkbox"]:checked+.checkbox-control:before {
+    input[type='checkbox']:checked + .checkbox-control:before {
       transform: rotate(45deg);
       position: absolute;
       left: 5px;

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -129,4 +129,29 @@
     border-left: 2px solid $neutral-200;
     padding-left: 24px;
   }
+
+  code {
+    @include b2;
+    background-color: $rorange-50;
+    color: $rorange-800;
+    border-radius: 4px;
+    padding: 0 8px;
+  }
+
+  pre {
+    display: flex;
+    padding: 12px;
+    flex-direction: column;
+    align-items: flex-start;
+    border-radius: $border-radius-corners-wider;
+    background-color: $neutral-50;
+    border: 1px solid $neutral-200;
+
+    code {
+      padding: 0;
+      color: $neutral-800;
+      background-color: $neutral-50;
+      font-family: $font-family-monospace;
+    }
+  }
 }

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -13,6 +13,7 @@
   @include hidden-formatting();
 
   width: 100%;
+  overflow: visible;
 
   p {
     @include b2;
@@ -23,7 +24,10 @@
     margin-inline-end: 0;
   }
 
-  overflow: visible;
+  a {
+    @include b2;
+    color: $primary-500;
+  }
 
   table {
     width: 100%;

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -28,37 +28,34 @@
   table {
     width: 100%;
     overflow-x: auto;
-    display: block;
     border-collapse: collapse;
-
-    box-shadow: -3px -1px 9px 0px rgba(255, 255, 255, 0.5) inset;
-    -webkit-box-shadow: -3px -1px 9px 0px rgba(255, 255, 255, 0.5) inset;
-    -moz-box-shadow: -3px -1px 9px 0px rgba(255, 255, 255, 0.5) inset;
+    border-radius: $border-radius-corners-wider;
 
     thead {
-      border-bottom: 1px solid $black;
-    }
-
-    tr:first-child {
-      td {
-        padding-top: 10px;
+      tr {
+        th {
+          @include b2;
+          letter-spacing: 0.02em;
+          font-weight: 700;
+          padding: 16px;
+          border: 1px solid $neutral-200;
+          // border-radius: 6px;
+          background-color: $neutral-50;
+        }
       }
     }
 
-    th,
-    td {
-      word-break: normal;
-      padding: 5px;
-      text-align: left;
-    }
-
-    th {
-      vertical-align: bottom;
-      border: 1px solid $neutral-200;
-    }
-
-    td {
-      vertical-align: top;
+    tbody {
+      tr {
+        td {
+          @include b2;
+          letter-spacing: 0.01em;
+          font-weight: 400;
+          padding: 16px;
+          border: 1px solid $neutral-200;
+          background-color: $white;
+        }
+      }
     }
 
     th[align='center'],
@@ -69,6 +66,11 @@
     th[align='right'],
     td[align='right'] {
       text-align: right;
+    }
+
+    th[align='left'],
+    td[align='left'] {
+      text-align: left;
     }
   }
 

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -29,6 +29,33 @@
     color: $primary-500;
   }
 
+  h1 {
+    font-family: $font-family-silka;
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 36px;
+    letter-spacing: -0.24px;
+  }
+
+  h2 {
+    font-family: $font-family-silka;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 28px;
+    letter-spacing: -0.2px;
+  }
+
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: $font-family-silka;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 24px;
+    letter-spacing: -0.19px;
+  }
+
   table {
     width: 100%;
     overflow-x: auto;

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -113,5 +113,6 @@
   blockquote {
     @include b2;
     border-left: 2px solid $neutral-200;
+    padding-left: 24px;
   }
 }

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -3,6 +3,7 @@
 
 .MarkdownFormattedText {
   @include b2;
+  letter-spacing: 0.01em;
 
   position: relative;
   word-break: break-word;
@@ -85,5 +86,32 @@
 
   mark {
     background-color: $primary-50;
+  }
+
+  hr {
+    margin: 12px 0;
+    color: $neutral-200;
+  }
+
+  strong,
+  em,
+  del,
+  ins {
+    letter-spacing: 0.02em;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+
+  em,
+  del,
+  ins {
+    font-weight: 400;
+  }
+
+  blockquote {
+    @include b2;
+    border-left: 2px solid $neutral-200;
   }
 }

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -15,6 +15,7 @@
   width: 100%;
 
   p {
+    @include b2;
     display: block;
     margin-block-start: 1em;
     margin-block-end: 1em;
@@ -71,16 +72,29 @@
     }
   }
 
-  ul {
+  ul,
+  ol {
+    @include b2;
+
     &:has(li p input[type='checkbox']),
     &:has(li input[type='checkbox']) {
       list-style: none;
-      padding-left: 16px;
+      padding-left: 0;
     }
 
     li:has(p input[type='checkbox']),
     li:has(input[type='checkbox']) {
       list-style-type: none;
+      display: flex;
+      align-items: center;
+    }
+
+    li {
+      input[type='checkbox'] {
+        height: 20px;
+        width: 20px;
+        margin-right: 6px;
+      }
     }
   }
 

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -59,8 +59,9 @@
   table {
     width: 100%;
     overflow-x: auto;
-    border-collapse: collapse;
+    border-spacing: 0;
     border-radius: $border-radius-corners-wider;
+    border: 1px solid $neutral-200;
 
     thead {
       tr {
@@ -69,9 +70,16 @@
           letter-spacing: 0.02em;
           font-weight: 700;
           padding: 16px;
-          border: 1px solid $neutral-200;
-          // border-radius: 6px;
           background-color: $neutral-50;
+          border-bottom: 1px solid $neutral-200;
+
+          &:first-child {
+            border-top-left-radius: $border-radius-corners-wider;
+          }
+
+          &:last-child {
+            border-top-right-radius: $border-radius-corners-wider;
+          }
         }
       }
     }
@@ -83,25 +91,37 @@
           letter-spacing: 0.01em;
           font-weight: 400;
           padding: 16px;
-          border: 1px solid $neutral-200;
           background-color: $white;
+        }
+
+        &:last-child {
+          td {
+            &:first-child {
+              border-bottom-left-radius: $border-radius-corners-wider;
+            }
+
+            &:last-child {
+              border-bottom-right-radius: $border-radius-corners-wider;
+            }
+          }
+        }
+
+        &:not(:last-child) {
+          th,
+          td {
+            border-bottom: 1px solid $neutral-200;
+          }
         }
       }
     }
 
-    th[align='center'],
-    td[align='center'] {
-      text-align: center;
-    }
-
-    th[align='right'],
-    td[align='right'] {
-      text-align: right;
-    }
-
-    th[align='left'],
-    td[align='left'] {
-      text-align: left;
+    tr {
+      th,
+      td {
+        &:not(:last-child) {
+          border-right: 1px solid $neutral-200;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
The work in this PR adds styles for and confirms functionality for features in this list:

- [x] Headers (all 6, with proper spacing below) `# ## ###...`
  - Headers 1-5 should reflect our design system
  - Headers 6 should simply maintain the styling for H5 as we don't have a detailed H6. 
- [x] Horizontal Rule / Divider line (with proper spacing above + below)
- Inline Typography: 
  - [x] Bold
  - [x] Italic
  - [x] Bold + Italic (together)
  - [x] Strike-through
  - [x] underline
- [x] Block Quotes (and nest-able) `>` `> >`
- Lists
  - [x] Ordered
  - [x] Unordered
  - [x] Lettered (consitutional style)
  - [ ] Todo lists
- Code
  - [x] Inline (single tick)
  - [x] Block (wrapping triple tick)
- [x] Tables
  - [x] Inline Typography properly applying to text in table cells
- Links
  - [x] Standard MD format for hyperlinks (with text)
  - [x] Auto-convert pasted URL into clickable link
- Images
  - [x] D&D into editor, upload and insert MD, allow update of alt-text
  - [x] Standard MD format, with alt text (image ref to external server)
  - [x] Image Link (clickable image)
- [x] Special Character Escaping (https://www.markdownguide.org/basic-syntax/#characters-you-can-escape)

The functionality of checkboxes works, but the styling will be left to a different card. Please ignore that for this review. 

## Link to Issue
Closes: #6035 

## Description of Changes
- see above list for implemented styling.

## Test Plan
- Input markdown for the features in the list above and check that they look/work as expected

## Other Considerations
- currently discussing work around checkboxes