### PR TITLE
Only call /refersh-memberships when logged in

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -78,6 +78,7 @@ export const NewThreadForm = () => {
   const { data: memberships = [] } = useRefreshMembershipQuery({
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
+    apiEnabled: !!app?.user?.activeAccount?.address,
   });
 
   const {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -120,6 +120,7 @@ export const CWContentPage = ({
   const { data: memberships = [] } = useRefreshMembershipQuery({
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
+    apiEnabled: !!app?.user?.activeAccount?.address,
   });
 
   const isTopicGated = !!(memberships || []).find((membership) =>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -57,6 +57,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const { data: memberships = [] } = useRefreshMembershipQuery({
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
+    apiEnabled: !!app?.user?.activeAccount?.address,
   });
 
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -144,6 +144,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const { data: memberships = [] } = useRefreshMembershipQuery({
     chainId: app.activeChainId(),
     address: app?.user?.activeAccount?.address,
+    apiEnabled: !!app?.user?.activeAccount?.address,
   });
 
   const isTopicGated = !!(memberships || []).find((membership) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6250

## Description of Changes
- Now only calling /refresh-membership API when logged in

## "How We Fixed It"
N/A

## Test Plan
- Visit any community that has gating enabled
- Logout
- Open network tab and verify that there are no failing calls to /refresh-memberships 

## Deployment Plan
N/A

## Other Considerations
N/A