### PR TITLE
Starred communities model semantics

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/user.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/user.ts
@@ -264,10 +264,10 @@ export class UserController {
     this._setStarredCommunities(star);
   }
 
-  public isCommunityStarred(chain: string): boolean {
+  public isCommunityStarred(community_id: string): boolean {
     return (
       this._starredCommunities.findIndex((c) => {
-        return c.chain === chain;
+        return c.community_id === community_id;
       }) !== -1
     );
   }
@@ -276,9 +276,9 @@ export class UserController {
     this._starredCommunities.push(star);
   }
 
-  public removeStarredCommunity(chain: string, userId: number): void {
+  public removeStarredCommunity(community_id: string, userId: number): void {
     const index = this._starredCommunities.findIndex(
-      (s) => s.user_id === userId && s.chain === chain,
+      (s) => s.user_id === userId && s.community_id === community_id,
     );
     this._starredCommunities.splice(index, 1);
   }

--- a/packages/commonwealth/client/scripts/models/StarredCommunity.ts
+++ b/packages/commonwealth/client/scripts/models/StarredCommunity.ts
@@ -2,8 +2,14 @@ class StarredCommunity {
   user_id: number;
   community_id: string;
 
-  constructor(chain: string, user_id: number) {
-    this.community_id = chain;
+  constructor({
+    community_id,
+    user_id,
+  }: {
+    community_id: string;
+    user_id: number;
+  }) {
+    this.community_id = community_id;
     this.user_id = user_id;
   }
 }

--- a/packages/commonwealth/client/scripts/models/StarredCommunity.ts
+++ b/packages/commonwealth/client/scripts/models/StarredCommunity.ts
@@ -1,9 +1,9 @@
 class StarredCommunity {
   user_id: number;
-  chain: string;
+  community_id: string;
 
-  constructor(chain, user_id) {
-    this.chain = chain;
+  constructor(chain: string, user_id: number) {
+    this.community_id = chain;
     this.user_id = user_id;
   }
 }

--- a/packages/commonwealth/client/scripts/state/api/communities/toggleCommunityStar.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/toggleCommunityStar.ts
@@ -30,12 +30,7 @@ const useToggleCommunityStarMutation = () => {
       const starredCommunity = response.data.result;
 
       if (starredCommunity) {
-        app.user.addStarredCommunity(
-          new StarredCommunity(
-            starredCommunity.chain,
-            starredCommunity.user_id,
-          ),
-        );
+        app.user.addStarredCommunity(new StarredCommunity(starredCommunity));
       } else {
         const star = app.user.starredCommunities.find((c) => {
           return c.community_id === community;

--- a/packages/commonwealth/client/scripts/state/api/communities/toggleCommunityStar.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/toggleCommunityStar.ts
@@ -5,20 +5,15 @@ import app from 'state';
 
 interface ToggleCommunityStarProps {
   community: string;
-  isAlreadyStarred: boolean; // TODO: rename to `shouldStar`
 }
 
-const toggleCommunityStar = async ({
-  community,
-  isAlreadyStarred,
-}: ToggleCommunityStarProps) => {
+const toggleCommunityStar = async ({ community }: ToggleCommunityStarProps) => {
   // TODO: the endpoint is really a toggle to star/unstar a community, migrate
   // this to use the new restful standard
   const response = await axios.post(`${app.serverUrl()}/starCommunity`, {
     chain: community,
     auth: true,
     jwt: app.user.jwt,
-    isAlreadyStarred: isAlreadyStarred + '', // backend expects a string
   });
 
   return {
@@ -43,9 +38,9 @@ const useToggleCommunityStarMutation = () => {
         );
       } else {
         const star = app.user.starredCommunities.find((c) => {
-          return c.chain === community;
+          return c.community_id === community;
         });
-        app.user.removeStarredCommunity(star.chain, star.user_id);
+        app.user.removeStarredCommunity(star.community_id, star.user_id);
       }
     },
   });

--- a/packages/commonwealth/client/scripts/state/index.ts
+++ b/packages/commonwealth/client/scripts/state/index.ts
@@ -21,6 +21,7 @@ import ChainInfo from 'models/ChainInfo';
 import type IChainAdapter from 'models/IChainAdapter';
 import NodeInfo from 'models/NodeInfo';
 import NotificationCategory from 'models/NotificationCategory';
+import StarredCommunity from 'models/StarredCommunity';
 import { ChainStore, NodeStore } from 'stores';
 
 export enum ApiStatus {
@@ -103,6 +104,7 @@ export interface IApp {
   isProduction(): boolean;
 
   isDesktopApp(win): boolean;
+
   isNative(win): boolean;
 
   serverUrl(): string;
@@ -297,7 +299,11 @@ export async function initAppState(
     }
 
     app.user.setStarredCommunities(
-      statusRes.result.user ? statusRes.result.user.starredCommunities : [],
+      statusRes.result.user?.starredCommunities
+        ? statusRes.result.user?.starredCommunities.map(
+            (c) => new StarredCommunity(c),
+          )
+        : [],
     );
     // update the selectedChain, unless we explicitly want to avoid
     // changing the current state (e.g. when logging in through link_new_address_modal)

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -124,7 +124,6 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
                 e.stopPropagation();
                 await toggleCommunityStar({
                   community: item.id,
-                  isAlreadyStarred: app.user.isCommunityStarred(item.id),
                 });
                 setIsStarred((prevState) => !prevState);
               }}

--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -137,7 +137,7 @@ export async function __deleteCommunity(
           });
 
           await this.models.StarredCommunity.destroy({
-            where: { chain: community.id },
+            where: { community_id: community.id },
             transaction: t,
           });
 

--- a/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
+++ b/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.renameColumn(
+        'StarredCommunities',
+        'chain',
+        'community_id',
+        {
+          transaction,
+        },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.renameColumn(
+        'StarredCommunities',
+        'community_id',
+        'chain',
+        {
+          transaction,
+        },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
+++ b/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
@@ -26,7 +26,7 @@ module.exports = {
       );
 
       await queryInterface.addIndex('StarredCommunities', {
-        fields: ['community_id', 'user_id'],
+        fields: ['user_id', 'community_id'],
         unique: true,
         name: 'starred_communities_community_id_user_id',
         transaction,

--- a/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
+++ b/packages/commonwealth/server/migrations/20240109181822-starred-communities-semantics.js
@@ -11,6 +11,26 @@ module.exports = {
           transaction,
         },
       );
+
+      // remove duplicates
+      await queryInterface.sequelize.query(
+        `
+        DELETE FROM "StarredCommunities"
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM "StarredCommunities"
+            GROUP BY community_id, user_id
+        );
+      `,
+        { transaction },
+      );
+
+      await queryInterface.addIndex('StarredCommunities', {
+        fields: ['community_id', 'user_id'],
+        unique: true,
+        name: 'starred_communities_community_id_user_id',
+        transaction,
+      });
     });
   },
 
@@ -20,6 +40,13 @@ module.exports = {
         'StarredCommunities',
         'community_id',
         'chain',
+        {
+          transaction,
+        },
+      );
+      await queryInterface.removeIndex(
+        'StarredCommunities',
+        'starred_communities_community_id_user_id',
         {
           transaction,
         },

--- a/packages/commonwealth/server/models/community.ts
+++ b/packages/commonwealth/server/models/community.ts
@@ -181,7 +181,9 @@ export default (
     });
     models.Community.hasMany(models.Thread, { foreignKey: 'community_id' });
     models.Community.hasMany(models.Comment, { foreignKey: 'community_id' });
-    models.Community.hasMany(models.StarredCommunity, { foreignKey: 'chain' });
+    models.Community.hasMany(models.StarredCommunity, {
+      foreignKey: 'community_id',
+    });
     models.Community.belongsToMany(models.Contract, {
       through: models.CommunityContract,
     });

--- a/packages/commonwealth/server/models/starred_community.ts
+++ b/packages/commonwealth/server/models/starred_community.ts
@@ -39,7 +39,7 @@ export default (
       underscored: true,
       createdAt: 'created_at',
       updatedAt: 'updated_at',
-      indexes: [{ fields: ['user_id'] }, { fields: ['community_id'] }],
+      indexes: [{ fields: ['user_id', 'community_id'], unique: true }],
     },
   );
 

--- a/packages/commonwealth/server/models/starred_community.ts
+++ b/packages/commonwealth/server/models/starred_community.ts
@@ -7,13 +7,13 @@ import type { UserAttributes } from './user';
 export type StarredCommunityAttributes = {
   user_id: number;
   id?: number;
-  chain: string;
+  community_id: string;
   created_at?: Date;
   updated_at?: Date;
 
   // associations
   User?: UserAttributes | UserAttributes['id'];
-  Chain?: CommunityAttributes;
+  Community?: CommunityAttributes;
 };
 
 export type StarredCommunityInstance =
@@ -23,14 +23,14 @@ export type StarredCommunityModelStatic = ModelStatic<StarredCommunityInstance>;
 
 export default (
   sequelize: Sequelize.Sequelize,
-  dataTypes: typeof DataTypes
+  dataTypes: typeof DataTypes,
 ): StarredCommunityModelStatic => {
   const StarredCommunity = <StarredCommunityModelStatic>sequelize.define(
     'StarredCommunity',
     {
       id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
       user_id: { type: dataTypes.INTEGER, allowNull: false },
-      chain: { type: dataTypes.STRING, allowNull: false },
+      community_id: { type: dataTypes.STRING, allowNull: false },
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },
     },
@@ -39,14 +39,17 @@ export default (
       underscored: true,
       createdAt: 'created_at',
       updatedAt: 'updated_at',
-      indexes: [{ fields: ['user_id'] }, { fields: ['chain'] }],
-    }
+      indexes: [{ fields: ['user_id'] }, { fields: ['community_id'] }],
+    },
   );
 
   StarredCommunity.associate = (models) => {
-    models.StarredCommunity.belongsTo(models.User);
+    models.StarredCommunity.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      targetKey: 'id',
+    });
     models.StarredCommunity.belongsTo(models.Community, {
-      foreignKey: 'chain',
+      foreignKey: 'community_id',
       targetKey: 'id',
     });
   };

--- a/packages/commonwealth/server/models/user.ts
+++ b/packages/commonwealth/server/models/user.ts
@@ -133,7 +133,10 @@ export default (
     });
     models.User.hasMany(models.Address);
     models.User.hasMany(models.Profile);
-    models.User.hasMany(models.StarredCommunity);
+    models.User.hasMany(models.StarredCommunity, {
+      foreignKey: 'user_id',
+      sourceKey: 'id',
+    });
   };
 
   return User;

--- a/packages/commonwealth/server/routes/starCommunity.ts
+++ b/packages/commonwealth/server/routes/starCommunity.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, Response } from 'express';
 import type { DB } from '../models';
 
 export const Errors = {
-  NoStarValue: 'Must pass isAlreadyStarred boolean to set starred status',
+  FailedToToggle: 'Failed to toggle community star',
 };
 
 const starCommunity = async (
@@ -15,21 +15,21 @@ const starCommunity = async (
   const chain = req.chain;
 
   try {
-    const [star] = await models.StarredCommunity.findOrCreate({
+    const [star, created] = await models.StarredCommunity.findOrCreate({
       where: {
-        chain: chain.id,
+        community_id: chain.id,
         user_id: req.user.id,
       },
     });
 
-    if (req.body.isAlreadyStarred === 'true') {
+    if (!created) {
       await star.destroy();
       return res.json({ status: 'Success' });
     }
 
     return res.json({ status: 'Success', result: star.toJSON() });
   } catch (err) {
-    return next(new ServerError(Errors.NoStarValue));
+    return next(new ServerError(Errors.FailedToToggle));
   }
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5358 

## Description of Changes
- Updated `StarredCommunities.chain` to `StarredCommunities.community_id` (and all references)
- Updated the toggle community star route to remove the unnecessary `isAlreadyStarred` parameter
- Removed duplicates from `StarredCommunities` and created a unique index to prevent future duplicates

## Test Plan
- [x] Delete a community that has been starred
- [x] Toggle community stars

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 