### PR TITLE
Relocate remaining utils

### DIFF
--- a/libs/adapters/src/rabbitmq/index.ts
+++ b/libs/adapters/src/rabbitmq/index.ts
@@ -6,5 +6,6 @@ export {
   RabbitMQControllerError,
 } from './rabbitMQController';
 export { RepublishFailedMessages } from './republishFailedMessages';
+export * from './serviceConsumer';
 export * from './types';
 export * from './util';

--- a/libs/adapters/src/rabbitmq/serviceConsumer.ts
+++ b/libs/adapters/src/rabbitmq/serviceConsumer.ts
@@ -1,16 +1,16 @@
+import crypto from 'crypto';
+import Rollbar from 'rollbar';
+import { Logger } from 'typescript-logging';
 import type {
+  AbstractRabbitMQController,
   RascalSubscriptions,
   TRmqMessages,
-} from '@hicommonwealth/adapters';
+} from '.';
 import {
-  AbstractRabbitMQController,
   addPrefix,
   formatFilename,
   loggerFactory,
-} from '@hicommonwealth/adapters';
-import crypto from 'crypto';
-import type Rollbar from 'rollbar';
-import type { Logger } from 'typescript-logging';
+} from '../typescript-logging';
 
 export type RabbitMQSubscription = {
   messageProcessor: (data: TRmqMessages, ...args: any) => Promise<void>;

--- a/libs/adapters/src/typescript-logging/index.ts
+++ b/libs/adapters/src/typescript-logging/index.ts
@@ -1,4 +1,4 @@
-import type { LogGroupControlSettings } from 'typescript-logging';
+import type { LogGroupControlSettings, Logger } from 'typescript-logging';
 import {
   LFService,
   LogGroupRule,
@@ -6,6 +6,9 @@ import {
   LoggerFactoryOptions,
   getLogControl,
 } from 'typescript-logging';
+
+// TODO: Is this the port interface?
+export interface ILogger extends Logger {}
 
 const options = new LoggerFactoryOptions()
   .addLogGroupRule(new LogGroupRule(new RegExp('model.+'), LogLevel.Debug))

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "web3": "1.8.2",
     "web3-core": "1.8.2",
     "web3-utils": "1.8.2",
-    "pg": "^8.8.0",
-    "typescript-logging": "^0.6.4"
+    "pg": "^8.8.0"
   },
   "devDependencies": {
     "@osmonauts/lcd": "^0.10.0",

--- a/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
+++ b/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
@@ -1,15 +1,15 @@
 import {
   RabbitMQController,
+  RabbitMQSubscription,
   RascalConfigServices,
   RascalSubscriptions,
+  ServiceConsumer,
   ServiceKey,
   formatFilename,
   getRabbitMQConfig,
   loggerFactory,
   startHealthCheckLoop,
 } from '@hicommonwealth/adapters';
-import type { RabbitMQSubscription } from 'common-common/src/serviceConsumer';
-import { ServiceConsumer } from 'common-common/src/serviceConsumer';
 import type { BrokerConfig } from 'rascal';
 import Rollbar from 'rollbar';
 import { RABBITMQ_URI, ROLLBAR_ENV, ROLLBAR_SERVER_TOKEN } from '../../config';

--- a/packages/commonwealth/server/workers/commonwealthConsumer/messageProcessors/snapshotConsumer.ts
+++ b/packages/commonwealth/server/workers/commonwealthConsumer/messageProcessors/snapshotConsumer.ts
@@ -1,16 +1,16 @@
 import {
+  ILogger,
   RmqSnapshotNotification,
   StatsDController,
 } from '@hicommonwealth/adapters';
 import { NotificationCategories } from '@hicommonwealth/core';
 import axios from 'axios';
 import { SnapshotEventType } from 'types';
-import type { Logger } from 'typescript-logging';
 import type { DB } from '../../../models';
 import emitNotifications from '../../../util/emitNotifications';
 
 export async function processSnapshotMessage(
-  this: { models: DB; log: Logger },
+  this: { models: DB; log: ILogger },
   data: RmqSnapshotNotification.RmqMsgType,
 ) {
   const { space, id, title, body, choices, start, expire } = data;


### PR DESCRIPTION
This is part of common-common refactoring

## Link to Issue
Closes: #6211

## Description of Changes
- Moved remaining service consumer to rabbitmq in libs/adapters
- Renamed imports  