### PR TITLE
Fixed errorsome requests to /topics, /groups and /threads from admin slider

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -24,6 +24,7 @@ const queryTypeToRQMap = {
 interface CommonProps {
   queryType: typeof QueryTypes[keyof typeof QueryTypes];
   chainId: string;
+  apiEnabled?: boolean;
 }
 
 interface FetchBulkThreadsProps extends CommonProps {
@@ -186,6 +187,8 @@ const fetchActiveThreads = (props) => {
 const useFetchThreadsQuery = (
   props: FetchBulkThreadsProps | FetchActiveThreadsProps,
 ) => {
+  const { apiEnabled = true } = props; // destruct to assign default value
+
   // better to use this in case someone updates this props, we wont reflect those changes
   const [queryType] = useState(props.queryType);
 
@@ -204,6 +207,7 @@ const useFetchThreadsQuery = (
     })(),
     staleTime: THREADS_STALE_TIME,
     keepPreviousData: true,
+    enabled: apiEnabled,
   });
 
   if (isFetchBulkThreadsProps(props)) {

--- a/packages/commonwealth/client/scripts/state/api/topics/fetchTopics.ts
+++ b/packages/commonwealth/client/scripts/state/api/topics/fetchTopics.ts
@@ -8,6 +8,7 @@ const TOPICS_STALE_TIME = 30 * 1_000; // 30 s
 
 interface FetchTopicsProps {
   communityId: string;
+  apiEnabled?: boolean;
 }
 
 const fetchTopics = async ({
@@ -25,11 +26,15 @@ const fetchTopics = async ({
   return response.data.result.map((t) => new Topic(t));
 };
 
-const useFetchTopicsQuery = ({ communityId }: FetchTopicsProps) => {
+const useFetchTopicsQuery = ({
+  communityId,
+  apiEnabled = true,
+}: FetchTopicsProps) => {
   return useQuery({
     queryKey: [ApiEndpoints.BULK_TOPICS, communityId],
     queryFn: () => fetchTopics({ communityId }),
     staleTime: TOPICS_STALE_TIME,
+    enabled: apiEnabled,
   });
 };
 

--- a/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
@@ -37,10 +37,12 @@ export const AdminOnboardingSlider = () => {
   const { data: topics = [], isLoading: isLoadingTopics = false } =
     useFetchTopicsQuery({
       communityId: app.activeChainId(),
+      apiEnabled: !!app.activeChainId(),
     });
   const { data: groups = [], isLoading: isLoadingGroups = false } =
     useFetchGroupsQuery({
       communityId: app.activeChainId(),
+      enabled: !!app.activeChainId(),
     });
   const { data: threads = [], isLoading: isLoadingThreads = false } =
     useFetchThreadsQuery({
@@ -48,6 +50,7 @@ export const AdminOnboardingSlider = () => {
       queryType: 'bulk',
       page: 1,
       limit: 20,
+      apiEnabled: !!app.activeChainId(),
     });
 
   const redirectToPage = (
@@ -59,6 +62,7 @@ export const AdminOnboardingSlider = () => {
   };
 
   if (
+    !app.activeChainId() ||
     isLoadingTopics ||
     isLoadingGroups ||
     isLoadingThreads ||


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6291

## Description of Changes
In https://github.com/hicommonwealth/commonwealth/pull/6216, we missed the condition that checks if the community(/data) is loaded i.e app.activeChainId() which was needed to make API calls to /topics, /groups, and /threads. This PR adds those checks.

## "How We Fixed It"
By adding checks to only call /topics, /groups, and /threads when the community is loaded.

## Test Plan
- Open network tab
- Visit any community that doesn't have any topics or groups or integrations (snapshot, discord etc), or threads. If none, create a new community.
- Once you are redirected to community page, verify that there is no errorsome request to /topics, /groups and /threads  in the networks tab
- Verify that you see the admin onboarding slider (see screenshot)

<img width="1136" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/b8293bb9-df83-4097-a20e-20083f979972">


## Deployment Plan
N/A

## Other Considerations
N/A