### PR TITLE
Addresses PR feedback on 6216

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useInitApp.ts
+++ b/packages/commonwealth/client/scripts/hooks/useInitApp.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import React, { useEffect } from 'react';
 import app, { initAppState } from 'state';
-import useAdminOnboardingSliderMutationStore from '../state/ui/adminOnboardingCards';
 import useGroupMutationBannerStore from '../state/ui/group';
 
 const useInitApp = () => {
@@ -9,15 +8,10 @@ const useInitApp = () => {
   const [customDomain, setCustomDomain] = React.useState('');
   const { readFromStorageAndSetGatingGroupBannerForCommunities } =
     useGroupMutationBannerStore();
-  const { readFromStorageAndSetAdminOnboardingCardVisibilityForCommunities } =
-    useAdminOnboardingSliderMutationStore();
 
   useEffect(() => {
     // read localstorage and set informational banner for gated communities on the members page group section
     readFromStorageAndSetGatingGroupBannerForCommunities();
-
-    // read localstorage and set visibility for admin onboarding cards on all page
-    readFromStorageAndSetAdminOnboardingCardVisibilityForCommunities();
 
     Promise.all([axios.get(`${app.serverUrl()}/domain`), initAppState()])
       .then(([domainResp]) => {

--- a/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/adminOnboardingCards.ts
+++ b/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/adminOnboardingCards.ts
@@ -1,65 +1,66 @@
 import { createBoundedUseStore } from 'state/ui/utils';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import { createStore } from 'zustand/vanilla';
 
 interface AdminActionCardsStore {
-  shouldHideAdminOnboardingCardsForCommunities: string[];
+  shouldHideAdminCardsTemporary: string[];
+  shouldHideAdminCardsPermanently: string[];
   setShouldHideAdminOnboardingCardsForCommunity: (
     communityId: string,
     shouldHidePermanently: boolean,
   ) => void;
-  readFromStorageAndSetAdminOnboardingCardVisibilityForCommunities: () => void;
   clearSetAdminOnboardingCardVisibilityForCommunities: () => void;
 }
 
-const STORAGE_KEY = 'adminOnboardingCardsVisibilityForCommunities';
-
 export const AdminActionCardsStore = createStore<AdminActionCardsStore>()(
-  devtools((set) => ({
-    shouldHideAdminOnboardingCardsForCommunities: [],
-    setShouldHideAdminOnboardingCardsForCommunity: (
-      communityId,
-      shouldHidePermanently,
-    ) => {
-      set((state) => {
-        const communities = JSON.parse(
-          localStorage.getItem(STORAGE_KEY) || `[]`,
-        );
-        if (shouldHidePermanently) {
-          localStorage.setItem(
-            STORAGE_KEY,
-            JSON.stringify([...communities, communityId]),
-          );
-        }
+  devtools(
+    persist(
+      (set) => ({
+        shouldHideAdminCardsTemporary: [],
+        shouldHideAdminCardsPermanently: [],
+        setShouldHideAdminOnboardingCardsForCommunity: (
+          communityId,
+          shouldHidePermanently,
+        ) => {
+          set((state) => {
+            if (shouldHidePermanently) {
+              return {
+                ...state,
+                shouldHideAdminCardsPermanently: [
+                  ...state.shouldHideAdminCardsPermanently,
+                  communityId,
+                ],
+              };
+            }
 
-        return {
-          ...state,
-          shouldHideAdminOnboardingCardsForCommunities: [
-            ...state.shouldHideAdminOnboardingCardsForCommunities,
-            communityId,
-          ],
-        };
-      });
-    },
-    readFromStorageAndSetAdminOnboardingCardVisibilityForCommunities: () => {
-      const communities = JSON.parse(localStorage.getItem(STORAGE_KEY) || `[]`);
-      set((state) => {
-        return {
-          ...state,
-          shouldHideAdminOnboardingCardsForCommunities: communities,
-        };
-      });
-    },
-    clearSetAdminOnboardingCardVisibilityForCommunities: () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
-      set((state) => {
-        return {
-          ...state,
-          shouldHideAdminOnboardingCardsForCommunities: [],
-        };
-      });
-    },
-  })),
+            return {
+              ...state,
+              shouldHideAdminCardsTemporary: [
+                ...state.shouldHideAdminCardsTemporary,
+                communityId,
+              ],
+            };
+          });
+        },
+        clearSetAdminOnboardingCardVisibilityForCommunities: () => {
+          set((state) => {
+            return {
+              ...state,
+              shouldHideAdminCardsPermanently: [],
+              shouldHideAdminCardsTemporary: [],
+            };
+          });
+        },
+      }),
+      {
+        name: 'admin-onboarding-cards-store', // unique name
+        partialize: (state) => ({
+          shouldHideAdminCardsPermanently:
+            state.shouldHideAdminCardsPermanently,
+        }), // persist only shouldHideAdminCardsPermanently
+      },
+    ),
+  ),
 );
 
 const useAdminActionCardsStore = createBoundedUseStore(AdminActionCardsStore);

--- a/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/adminOnboardingCards.ts
+++ b/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/adminOnboardingCards.ts
@@ -2,7 +2,7 @@ import { createBoundedUseStore } from 'state/ui/utils';
 import { devtools } from 'zustand/middleware';
 import { createStore } from 'zustand/vanilla';
 
-interface GroupMutationBannerStore {
+interface AdminActionCardsStore {
   shouldHideAdminOnboardingCardsForCommunities: string[];
   setShouldHideAdminOnboardingCardsForCommunity: (
     communityId: string,
@@ -14,7 +14,7 @@ interface GroupMutationBannerStore {
 
 const STORAGE_KEY = 'adminOnboardingCardsVisibilityForCommunities';
 
-export const GroupMutationBannerStore = createStore<GroupMutationBannerStore>()(
+export const AdminActionCardsStore = createStore<AdminActionCardsStore>()(
   devtools((set) => ({
     shouldHideAdminOnboardingCardsForCommunities: [],
     setShouldHideAdminOnboardingCardsForCommunity: (
@@ -62,8 +62,6 @@ export const GroupMutationBannerStore = createStore<GroupMutationBannerStore>()(
   })),
 );
 
-const useGroupMutationBannerStore = createBoundedUseStore(
-  GroupMutationBannerStore,
-);
+const useAdminActionCardsStore = createBoundedUseStore(AdminActionCardsStore);
 
-export default useGroupMutationBannerStore;
+export default useAdminActionCardsStore;

--- a/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/index.ts
+++ b/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/index.ts
@@ -1,2 +1,2 @@
-import useAdminOnboardingSliderMutationStore from './adminOnboardingCards';
-export default useAdminOnboardingSliderMutationStore;
+import useAdminActionCardsStore from './adminOnboardingCards';
+export default useAdminActionCardsStore;

--- a/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
@@ -29,7 +29,8 @@ export const AdminOnboardingSlider = () => {
 
   const navigate = useCommonNavigate();
   const {
-    shouldHideAdminOnboardingCardsForCommunities,
+    shouldHideAdminCardsTemporary,
+    shouldHideAdminCardsPermanently,
     setShouldHideAdminOnboardingCardsForCommunity,
   } = useAdminOnboardingSliderMutationStore();
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -68,7 +69,10 @@ export const AdminOnboardingSlider = () => {
       hasAnyIntegration) ||
     !(Permissions.isSiteAdmin() || Permissions.isCommunityAdmin()) ||
     !featureFlags.newAdminOnboardingEnabled ||
-    shouldHideAdminOnboardingCardsForCommunities.includes(app.activeChainId())
+    [
+      ...shouldHideAdminCardsTemporary,
+      ...shouldHideAdminCardsPermanently,
+    ].includes(app.activeChainId())
   ) {
     return;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6294

## Description of Changes
- Updated variable names in [adminOnboardingCards.ts](https://github.com/hicommonwealth/commonwealth/blob/0551b07f04a19ff512b301a3aa3789be6bf4dcd1/packages/commonwealth/client/scripts/state/ui/adminOnboardingCards/adminOnboardingCards.ts)
- Now using zustand persist to store local storage values

## "How We Fixed It"
N/A

## Test Plan
Verify that existing logic is not broken

- Create a community and visit it
- CA and verify you see the admin onboarding cards slider
- Dismiss it, and verify that after reloading the page, you again see the slider
- Reload the page, dismiss the slider again but this time with the "Don't show this again" option, verify that after reloading the page, you don't see the slider.

## Deployment Plan
N/A

## Other Considerations
N/A