### PR TITLE
Add missing transaction to updateThread topic.

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -227,6 +227,7 @@ export async function __updateThread(
       topicName,
       this.models,
       toUpdate,
+      transaction,
     );
 
     await thread.update(
@@ -623,6 +624,7 @@ async function setThreadTopic(
   topicName: string | undefined,
   models: DB,
   toUpdate: Partial<ThreadAttributes>,
+  transaction: Transaction,
 ) {
   if (typeof topicId !== 'undefined' || typeof topicName !== 'undefined') {
     validatePermissions(permissions, {
@@ -644,6 +646,7 @@ async function setThreadTopic(
           name: topicName,
           community_id: thread.community_id,
         },
+        transaction,
       });
       toUpdate.topic_id = topic.id;
     }


### PR DESCRIPTION
## Link to Issue
**HOTFIX**

## Description of Changes
- Adds missing transaction argument to findOrCreate in updateThreads transaction.

## "How We Fixed It"
Getting database timeouts / errors due to this transaction never resolving, as it has a mid-tx update that's outside of the tx.

## Test Plan
- Update a thread's topic, verify it succeeds immediately.

## Deployment Plan
Hotfix for 0.9.0.
