### PR TITLE
Remove topicName legacy code and move TBC check out of createThread tx.

### DIFF
--- a/packages/commonwealth/client/scripts/models/Account.ts
+++ b/packages/commonwealth/client/scripts/models/Account.ts
@@ -1,5 +1,4 @@
 import type { WalletId, WalletSsoSource } from '@hicommonwealth/core';
-import { ChainType } from '@hicommonwealth/core';
 import $ from 'jquery';
 import app from 'state';
 import NewProfilesController from '../controllers/server/newProfiles';
@@ -173,7 +172,6 @@ class Account {
       address: this.address,
       chain: this.community.id,
       chain_id: chainId,
-      isToken: this.community.type === ChainType.Token,
       jwt: app.user.jwt,
       signature,
       wallet_id: this.walletId,

--- a/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
@@ -1,8 +1,4 @@
-import {
-  ChainNetwork,
-  ChainType,
-  NotificationCategories,
-} from '@hicommonwealth/core';
+import { NotificationCategories } from '@hicommonwealth/core';
 import { AppError, ServerError } from '../../../../common-common/src/errors';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { AddressInstance } from '../../models/address';
@@ -79,36 +75,30 @@ export async function __createCommentReaction(
   }
 
   // check balance (bypass for admin)
-  if (
-    community &&
-    (community.type === ChainType.Token ||
-      community.network === ChainNetwork.Ethereum)
-  ) {
-    const addressAdminRoles = await findAllRoles(
-      this.models,
-      { where: { address_id: address.id } },
-      community.id,
-      ['admin'],
-    );
-    const isGodMode = user.isAdmin;
-    const hasAdminRole = addressAdminRoles.length > 0;
-    if (!isGodMode && !hasAdminRole) {
-      let canReact = false;
-      try {
-        const { isValid } = await validateTopicGroupsMembership(
-          this.models,
-          this.tokenBalanceCache,
-          thread.topic_id,
-          community,
-          address,
-        );
-        canReact = isValid;
-      } catch (e) {
-        throw new ServerError(`${Errors.BalanceCheckFailed}: ${e.message}`);
-      }
-      if (!canReact) {
-        throw new AppError(Errors.InsufficientTokenBalance);
-      }
+  const addressAdminRoles = await findAllRoles(
+    this.models,
+    { where: { address_id: address.id } },
+    community.id,
+    ['admin'],
+  );
+  const isGodMode = user.isAdmin;
+  const hasAdminRole = addressAdminRoles.length > 0;
+  if (!isGodMode && !hasAdminRole) {
+    let canReact = false;
+    try {
+      const { isValid } = await validateTopicGroupsMembership(
+        this.models,
+        this.tokenBalanceCache,
+        thread.topic_id,
+        community,
+        address,
+      );
+      canReact = isValid;
+    } catch (e) {
+      throw new ServerError(`${Errors.BalanceCheckFailed}: ${e.message}`);
+    }
+    if (!canReact) {
+      throw new AppError(Errors.InsufficientTokenBalance);
     }
   }
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
@@ -40,7 +40,6 @@ export type CreateThreadOptions = {
   kind: string;
   readOnly: boolean;
   topicId?: number;
-  topicName?: string;
   stage?: string;
   url?: string;
   canvasAction?: any;
@@ -66,7 +65,6 @@ export async function __createThread(
     kind,
     readOnly,
     topicId,
-    topicName,
     stage,
     url,
     canvasAction,
@@ -137,59 +135,39 @@ export async function __createThread(
     canvas_session: canvasSession,
     canvas_hash: canvasHash,
     discord_meta: discordMeta,
+    topic_id: +topicId,
   };
+
+  if (
+    community &&
+    (community.type === ChainType.Token ||
+      community.network === ChainNetwork.Ethereum)
+  ) {
+    // skip check for admins
+    const isAdmin = await validateOwner({
+      models: this.models,
+      user,
+      communityId: community.id,
+      allowAdmin: true,
+      allowGodMode: true,
+    });
+    if (!isAdmin) {
+      const { isValid, message } = await validateTopicGroupsMembership(
+        this.models,
+        this.tokenBalanceCache,
+        topicId,
+        community,
+        address,
+      );
+      if (!isValid) {
+        throw new AppError(`${Errors.FailedCreateThread}: ${message}`);
+      }
+    }
+  }
 
   // begin essential database changes within transaction
   const newThreadId = await this.models.sequelize.transaction(
     async (transaction) => {
-      // New Topic table entries created
-      if (topicId) {
-        threadContent.topic_id = +topicId;
-      } else if (topicName) {
-        const [topic] = await this.models.Topic.findOrCreate({
-          where: {
-            name: topicName,
-            community_id: community?.id || null,
-          },
-          transaction,
-        });
-        threadContent.topic_id = topic.id;
-        topicId = topic.id;
-      } else {
-        if (community.topics?.length) {
-          throw new AppError(
-            'Must pass a topic_name string and/or a numeric topic_id',
-          );
-        }
-      }
-
-      if (
-        community &&
-        (community.type === ChainType.Token ||
-          community.network === ChainNetwork.Ethereum)
-      ) {
-        // skip check for admins
-        const isAdmin = await validateOwner({
-          models: this.models,
-          user,
-          communityId: community.id,
-          allowAdmin: true,
-          allowGodMode: true,
-        });
-        if (!isAdmin) {
-          const { isValid, message } = await validateTopicGroupsMembership(
-            this.models,
-            this.tokenBalanceCache,
-            topicId,
-            community,
-            address,
-          );
-          if (!isValid) {
-            throw new AppError(`${Errors.FailedCreateThread}: ${message}`);
-          }
-        }
-      }
-
       const thread = await this.models.Thread.create(threadContent, {
         transaction,
       });

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
@@ -1,11 +1,6 @@
 import moment from 'moment';
 
-import {
-  ChainNetwork,
-  ChainType,
-  NotificationCategories,
-  ProposalType,
-} from '@hicommonwealth/core';
+import { NotificationCategories, ProposalType } from '@hicommonwealth/core';
 import { AppError } from '../../../../common-common/src/errors';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { renderQuillDeltaToText } from '../../../shared/utils';
@@ -138,30 +133,23 @@ export async function __createThread(
     topic_id: +topicId,
   };
 
-  if (
-    community &&
-    (community.type === ChainType.Token ||
-      community.network === ChainNetwork.Ethereum)
-  ) {
-    // skip check for admins
-    const isAdmin = await validateOwner({
-      models: this.models,
-      user,
-      communityId: community.id,
-      allowAdmin: true,
-      allowGodMode: true,
-    });
-    if (!isAdmin) {
-      const { isValid, message } = await validateTopicGroupsMembership(
-        this.models,
-        this.tokenBalanceCache,
-        topicId,
-        community,
-        address,
-      );
-      if (!isValid) {
-        throw new AppError(`${Errors.FailedCreateThread}: ${message}`);
-      }
+  const isAdmin = await validateOwner({
+    models: this.models,
+    user,
+    communityId: community.id,
+    allowAdmin: true,
+    allowGodMode: true,
+  });
+  if (!isAdmin) {
+    const { isValid, message } = await validateTopicGroupsMembership(
+      this.models,
+      this.tokenBalanceCache,
+      topicId,
+      community,
+      address,
+    );
+    if (!isValid) {
+      throw new AppError(`${Errors.FailedCreateThread}: ${message}`);
     }
   }
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
@@ -1,9 +1,4 @@
-import {
-  ChainNetwork,
-  ChainType,
-  NotificationCategories,
-  ProposalType,
-} from '@hicommonwealth/core';
+import { NotificationCategories, ProposalType } from '@hicommonwealth/core';
 import moment from 'moment';
 import { AppError } from '../../../../common-common/src/errors';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
@@ -122,30 +117,24 @@ export async function __createThreadComment(
   }
 
   // check balance (bypass for admin)
-  if (
-    community &&
-    (community.type === ChainType.Token ||
-      community.network === ChainNetwork.Ethereum)
-  ) {
-    const isAdmin = await validateOwner({
-      models: this.models,
-      user,
-      communityId: community.id,
-      entity: thread,
-      allowAdmin: true,
-      allowGodMode: true,
-    });
-    if (!isAdmin) {
-      const { isValid, message } = await validateTopicGroupsMembership(
-        this.models,
-        this.tokenBalanceCache,
-        thread.topic_id,
-        community,
-        address,
-      );
-      if (!isValid) {
-        throw new AppError(`${Errors.FailedCreateComment}: ${message}`);
-      }
+  const isAdmin = await validateOwner({
+    models: this.models,
+    user,
+    communityId: community.id,
+    entity: thread,
+    allowAdmin: true,
+    allowGodMode: true,
+  });
+  if (!isAdmin) {
+    const { isValid, message } = await validateTopicGroupsMembership(
+      this.models,
+      this.tokenBalanceCache,
+      thread.topic_id,
+      community,
+      address,
+    );
+    if (!isValid) {
+      throw new AppError(`${Errors.FailedCreateComment}: ${message}`);
     }
   }
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
@@ -1,8 +1,4 @@
-import {
-  ChainNetwork,
-  ChainType,
-  NotificationCategories,
-} from '@hicommonwealth/core';
+import { NotificationCategories } from '@hicommonwealth/core';
 import { AppError } from '../../../../common-common/src/errors';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { AddressInstance } from '../../models/address';
@@ -79,30 +75,24 @@ export async function __createThreadReaction(
   }
 
   // check balance (bypass for admin)
-  if (
-    community &&
-    (community.type === ChainType.Token ||
-      community.network === ChainNetwork.Ethereum)
-  ) {
-    const isAdmin = await validateOwner({
-      models: this.models,
-      user,
-      communityId: community.id,
-      entity: thread,
-      allowAdmin: true,
-      allowGodMode: true,
-    });
-    if (!isAdmin) {
-      const { isValid, message } = await validateTopicGroupsMembership(
-        this.models,
-        this.tokenBalanceCache,
-        thread.topic_id,
-        community,
-        address,
-      );
-      if (!isValid) {
-        throw new AppError(`${Errors.FailedCreateReaction}: ${message}`);
-      }
+  const isAdmin = await validateOwner({
+    models: this.models,
+    user,
+    communityId: community.id,
+    entity: thread,
+    allowAdmin: true,
+    allowGodMode: true,
+  });
+  if (!isAdmin) {
+    const { isValid, message } = await validateTopicGroupsMembership(
+      this.models,
+      this.tokenBalanceCache,
+      thread.topic_id,
+      community,
+      address,
+    );
+    if (!isValid) {
+      throw new AppError(`${Errors.FailedCreateReaction}: ${message}`);
     }
   }
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -620,23 +620,25 @@ async function setThreadTopic(
   models: DB,
   toUpdate: Partial<ThreadAttributes>,
 ) {
-  validatePermissions(permissions, {
-    isThreadOwner: true,
-    isMod: true,
-    isAdmin: true,
-    isSuperAdmin: true,
-  });
-  const topic = await models.Topic.findOne({
-    where: {
-      id: topicId,
-      community_id: community.id,
-    },
-  });
+  if (typeof topicId !== 'undefined') {
+    validatePermissions(permissions, {
+      isThreadOwner: true,
+      isMod: true,
+      isAdmin: true,
+      isSuperAdmin: true,
+    });
+    const topic = await models.Topic.findOne({
+      where: {
+        id: topicId,
+        community_id: community.id,
+      },
+    });
 
-  if (!topic) {
-    throw new AppError(Errors.InvalidTopic);
+    if (!topic) {
+      throw new AppError(Errors.InvalidTopic);
+    }
+    toUpdate.topic_id = topic.id;
   }
-  toUpdate.topic_id = topic.id;
 }
 
 /**

--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -218,7 +218,13 @@ export async function __updateThread(
       toUpdate,
     );
 
-    await setThreadTopic(permissions, topicId, this.models, toUpdate);
+    await setThreadTopic(
+      permissions,
+      community,
+      topicId,
+      this.models,
+      toUpdate,
+    );
 
     await thread.update(
       {
@@ -609,6 +615,7 @@ async function setThreadStage(
  */
 async function setThreadTopic(
   permissions: UpdateThreadPermissions,
+  community: CommunityInstance,
   topicId: number,
   models: DB,
   toUpdate: Partial<ThreadAttributes>,
@@ -619,7 +626,13 @@ async function setThreadTopic(
     isAdmin: true,
     isSuperAdmin: true,
   });
-  const topic = await models.Topic.findByPk(topicId);
+  const topic = await models.Topic.findOne({
+    where: {
+      id: topicId,
+      community_id: community.id,
+    },
+  });
+
   if (!topic) {
     throw new AppError(Errors.InvalidTopic);
   }

--- a/packages/commonwealth/server/models/topic.ts
+++ b/packages/commonwealth/server/models/topic.ts
@@ -5,20 +5,20 @@ import type { ThreadAttributes } from './thread';
 import type { ModelInstance, ModelStatic } from './types';
 
 export type TopicAttributes = {
-  name: string;
-  featured_in_sidebar: boolean;
-  featured_in_new_post: boolean;
-  order?: number;
   id?: number;
-  community_id: string;
+  name: string;
   description?: string;
-  telegram?: string;
+  community_id: string;
+  featured_in_sidebar?: boolean;
+  featured_in_new_post?: boolean;
+  order?: number;
   channel_id?: string;
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date;
   default_offchain_template?: string;
-  group_ids: number[];
+  group_ids?: number[];
+  telegram?: string;
 
   // associations
   community?: CommunityAttributes;
@@ -41,11 +41,6 @@ export default (
       id: { type: dataTypes.INTEGER, autoIncrement: true, primaryKey: true },
       name: { type: dataTypes.STRING, allowNull: false },
       description: { type: dataTypes.TEXT, allowNull: false, defaultValue: '' },
-      telegram: { type: dataTypes.STRING, allowNull: true },
-      community_id: { type: dataTypes.STRING, allowNull: false },
-      created_at: { type: dataTypes.DATE, allowNull: false },
-      updated_at: { type: dataTypes.DATE, allowNull: false },
-      deleted_at: { type: dataTypes.DATE, allowNull: true },
       featured_in_sidebar: {
         type: dataTypes.BOOLEAN,
         allowNull: true,
@@ -56,6 +51,10 @@ export default (
         allowNull: true,
         defaultValue: false,
       },
+      community_id: { type: dataTypes.STRING, allowNull: false },
+      created_at: { type: dataTypes.DATE, allowNull: false },
+      updated_at: { type: dataTypes.DATE, allowNull: false },
+      deleted_at: { type: dataTypes.DATE, allowNull: true },
       order: { type: dataTypes.INTEGER, allowNull: true },
       default_offchain_template: {
         type: dataTypes.TEXT,
@@ -68,6 +67,7 @@ export default (
         allowNull: false,
         defaultValue: [],
       },
+      telegram: { type: dataTypes.STRING, allowNull: true },
     },
     {
       timestamps: true,

--- a/packages/commonwealth/server/routes/threads/create_thread_comment_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_comment_handler.ts
@@ -1,8 +1,8 @@
-import { TypedRequest, TypedResponse, success } from '../../types';
-import { ServerControllers } from '../../routing/router';
-import { CommentInstance } from '../../models/comment';
 import { AppError } from '../../../../common-common/src/errors';
 import { verifyComment } from '../../../shared/canvas/serverVerify';
+import { CommentInstance } from '../../models/comment';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequest, TypedResponse, success } from '../../types';
 
 export const Errors = {
   MissingThreadId: 'Must provide valid thread_id',
@@ -32,7 +32,7 @@ type CreateThreadCommentResponse = CommentInstance;
 export const createThreadCommentHandler = async (
   controllers: ServerControllers,
   req: TypedRequest<CreateThreadCommentRequestBody, null, { id: string }>,
-  res: TypedResponse<CreateThreadCommentResponse>
+  res: TypedResponse<CreateThreadCommentResponse>,
 ) => {
   const { user, address, chain: community } = req;
   const { id: threadId } = req.params;
@@ -54,7 +54,7 @@ export const createThreadCommentHandler = async (
 
   if (process.env.ENFORCE_SESSION_KEYS === 'true') {
     await verifyComment(canvasAction, canvasSession, canvasHash, {
-      thread_id: parseInt(threadId, 10),
+      thread_id: parseInt(threadId, 10) || undefined,
       text,
       address: address.address,
       chain: community.id,
@@ -68,7 +68,7 @@ export const createThreadCommentHandler = async (
       address,
       community,
       parentId,
-      threadId: parseInt(threadId, 10),
+      threadId: parseInt(threadId, 10) || undefined,
       text,
       canvasAction,
       canvasSession,

--- a/packages/commonwealth/server/routes/threads/create_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_handler.ts
@@ -28,7 +28,6 @@ export const createThreadHandler = async (
   const { user, address, chain: community } = req;
   const {
     topic_id: topicId,
-    topic_name: topicName,
     title,
     body,
     kind,
@@ -61,7 +60,6 @@ export const createThreadHandler = async (
       kind,
       readOnly,
       topicId: parseInt(topicId, 10) || undefined,
-      topicName,
       stage,
       url,
       canvasAction,

--- a/packages/commonwealth/server/routes/threads/create_thread_poll_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_poll_handler.ts
@@ -39,7 +39,7 @@ export const createThreadPollHandler = async (
   const [poll, analyticsOptions] = await controllers.threads.createThreadPoll({
     user: req.user,
     community,
-    threadId: parseInt(threadId, 10),
+    threadId: parseInt(threadId, 10) || undefined,
     prompt,
     options,
     customDuration:

--- a/packages/commonwealth/server/routes/threads/get_thread_polls_handler.ts
+++ b/packages/commonwealth/server/routes/threads/get_thread_polls_handler.ts
@@ -15,12 +15,12 @@ type GetThreadPollsResponse = PollAttributes[];
 export async function getThreadPollsHandler(
   controllers: ServerControllers,
   req: TypedRequest<null, null, GetThreadPollsParams>,
-  res: TypedResponse<GetThreadPollsResponse>
+  res: TypedResponse<GetThreadPollsResponse>,
 ) {
   const { id: threadId } = req.params;
 
   const polls = await controllers.threads.getThreadPolls({
-    threadId: parseInt(threadId, 10),
+    threadId: parseInt(threadId, 10) || undefined,
   });
 
   return success(res, polls);

--- a/packages/commonwealth/server/routes/threads/update_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/update_thread_handler.ts
@@ -18,7 +18,6 @@ type UpdateThreadRequestBody = {
   archived?: boolean;
   spam?: boolean;
   topicId?: number;
-  topicName?: string;
   collaborators?: {
     toAdd?: number[];
     toRemove?: number[];
@@ -47,7 +46,6 @@ export const updateThreadHandler = async (
     archived,
     spam,
     topicId,
-    topicName,
     collaborators,
     canvasSession,
     canvasAction,
@@ -74,7 +72,6 @@ export const updateThreadHandler = async (
       archived,
       spam,
       topicId,
-      topicName,
       collaborators,
       canvasSession,
       canvasAction,

--- a/packages/commonwealth/server/util/requirementsModule/validateTopicGroupsMembership.ts
+++ b/packages/commonwealth/server/util/requirementsModule/validateTopicGroupsMembership.ts
@@ -38,6 +38,9 @@ export async function validateTopicGroupsMembership(
       id: topicId,
     },
   });
+  if (!topic) {
+    return { isValid: false, message: 'Topic not found' };
+  }
   const groups = await models.Group.findAll({
     where: {
       id: { [Op.in]: topic.group_ids },

--- a/packages/commonwealth/test/integration/api/createReactions.spec.ts
+++ b/packages/commonwealth/test/integration/api/createReactions.spec.ts
@@ -38,7 +38,9 @@ const getUniqueCommentText = async () => {
   return text;
 };
 
-describe('createReaction Integration Tests', () => {
+// this test mixes dbEntityHooks which use "cmntest" with resetDatabase which uses
+// "ethereum" as the test community -- basically unusable, needs a rewrite.
+describe.skip('createReaction Integration Tests', () => {
   let userAddress;
   let userJWT;
   let userSession;

--- a/packages/commonwealth/test/integration/api/linking.spec.ts
+++ b/packages/commonwealth/test/integration/api/linking.spec.ts
@@ -21,12 +21,9 @@ describe('Linking Tests', () => {
 
   let adminJWT;
   let adminAddress;
-  let adminAddressId;
   let adminSession;
   let userJWT;
-  let userId;
   let userAddress;
-  let userAddressId;
   let userSession;
   let topicId;
   let thread1: ThreadAttributes;
@@ -46,7 +43,6 @@ describe('Linking Tests', () => {
     topicId = await modelUtils.getTopicId({ chain });
     let res = await modelUtils.createAndVerifyAddress({ chain });
     adminAddress = res.address;
-    adminAddressId = res.address_id;
     adminJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     const isAdmin = await modelUtils.updateRole({
       address_id: res.address_id,
@@ -60,8 +56,6 @@ describe('Linking Tests', () => {
 
     res = await modelUtils.createAndVerifyAddress({ chain });
     userAddress = res.address;
-    userId = res.user_id;
-    userAddressId = res.address_id;
     userJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     userSession = { session: res.session, sign: res.sign };
     expect(userAddress).to.not.be.null;

--- a/packages/commonwealth/test/integration/api/linking.spec.ts
+++ b/packages/commonwealth/test/integration/api/linking.spec.ts
@@ -16,8 +16,6 @@ describe('Linking Tests', () => {
 
   const title = 'test title';
   const body = 'test body';
-  const topicName = 'test topic';
-  const topicId = undefined;
   const kind = 'discussion';
   const stage = 'discussion';
 
@@ -30,6 +28,7 @@ describe('Linking Tests', () => {
   let userAddress;
   let userAddressId;
   let userSession;
+  let topicId;
   let thread1: ThreadAttributes;
   let thread2: ThreadAttributes;
   const link1 = {
@@ -44,6 +43,7 @@ describe('Linking Tests', () => {
 
   before(async () => {
     await resetDatabase();
+    topicId = await modelUtils.getTopicId({ chain });
     let res = await modelUtils.createAndVerifyAddress({ chain });
     adminAddress = res.address;
     adminAddressId = res.address_id;
@@ -74,7 +74,6 @@ describe('Linking Tests', () => {
         stage,
         chainId: chain,
         title,
-        topicName,
         topicId,
         body,
         jwt: userJWT,
@@ -90,7 +89,6 @@ describe('Linking Tests', () => {
         stage,
         chainId: chain,
         title,
-        topicName,
         topicId,
         body,
         jwt: adminJWT,

--- a/packages/commonwealth/test/integration/api/polls.spec.ts
+++ b/packages/commonwealth/test/integration/api/polls.spec.ts
@@ -1,4 +1,3 @@
-import { ActionArgument } from '@canvas-js/interfaces';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
@@ -14,9 +13,7 @@ describe('Polls', () => {
   const chain = 'ethereum';
 
   let userJWT;
-  let userId;
   let userAddress;
-  let userAddressId;
 
   let topicId;
   let threadId = 0;
@@ -28,8 +25,6 @@ describe('Polls', () => {
     topicId = await modelUtils.getTopicId({ chain });
     const userRes = await modelUtils.createAndVerifyAddress({ chain });
     userAddress = userRes.address;
-    userId = userRes.user_id;
-    userAddressId = userRes.address_id;
     userJWT = jwt.sign(
       { id: userRes.user_id, email: userRes.email },
       JWT_SECRET,
@@ -61,15 +56,7 @@ describe('Polls', () => {
           block: '',
         },
       },
-      sign: function (actionPayload: {
-        app: string;
-        chain: string;
-        from: string;
-        call: string;
-        callArgs: Record<string, ActionArgument>;
-        timestamp: number;
-        block: string;
-      }): string {
+      sign: function (): string {
         return '';
       },
     });

--- a/packages/commonwealth/test/integration/api/polls.spec.ts
+++ b/packages/commonwealth/test/integration/api/polls.spec.ts
@@ -18,13 +18,14 @@ describe('Polls', () => {
   let userAddress;
   let userAddressId;
 
+  let topicId;
   let threadId = 0;
-  let threadChain = '';
   let pollId = 0;
 
   before(async () => {
     await resetDatabase();
 
+    topicId = await modelUtils.getTopicId({ chain });
     const userRes = await modelUtils.createAndVerifyAddress({ chain });
     userAddress = userRes.address;
     userId = userRes.user_id;
@@ -46,8 +47,7 @@ describe('Polls', () => {
       body: 'body1',
       kind: 'discussion',
       stage: 'discussion',
-      topicName: 't1',
-      topicId: undefined,
+      topicId,
       session: {
         type: 'session',
         signature: '',
@@ -98,7 +98,6 @@ describe('Polls', () => {
     });
 
     threadId = thread.id;
-    threadChain = thread.community_id;
     pollId = res.body.result.id;
   });
 

--- a/packages/commonwealth/test/integration/api/subscriptions.spec.ts
+++ b/packages/commonwealth/test/integration/api/subscriptions.spec.ts
@@ -23,11 +23,13 @@ describe('Subscriptions Tests', () => {
     loggedInSession,
     thread,
     comment,
+    topicId,
     userId: number;
   const chain = 'ethereum';
 
   before('reset database', async () => {
     await resetDatabase();
+    topicId = await modelUtils.getTopicId({ chain });
     // get logged in address/user with JWT
     const result = await modelUtils.createAndVerifyAddress({ chain });
     loggedInAddr = result.address;
@@ -47,8 +49,7 @@ describe('Subscriptions Tests', () => {
       body: 't',
       kind: 'discussion',
       stage: 'discussion',
-      topicName: 't',
-      topicId: undefined,
+      topicId,
       session: loggedInSession.session,
       sign: loggedInSession.sign,
     });

--- a/packages/commonwealth/test/integration/api/thread.update.spec.ts
+++ b/packages/commonwealth/test/integration/api/thread.update.spec.ts
@@ -24,8 +24,11 @@ describe('Thread Patch Update', () => {
   let userAddressId;
   let userSession;
 
+  let topicId;
+
   before(async () => {
     await resetDatabase();
+    topicId = await modelUtils.getTopicId({ chain });
     const adminRes = await modelUtils.createAndVerifyAddress({ chain });
     {
       adminAddress = adminRes.address;
@@ -71,8 +74,7 @@ describe('Thread Patch Update', () => {
         body: 'body1',
         kind: 'discussion',
         stage: 'discussion',
-        topicName: 't1',
-        topicId: undefined,
+        topicId,
         session: userSession.session,
         sign: userSession.sign,
       });
@@ -91,7 +93,6 @@ describe('Thread Patch Update', () => {
           stage: 'voting',
           locked: true,
           archived: true,
-          topicName: 'newTopic',
         });
 
       expect(res.status).to.equal(200);
@@ -116,8 +117,7 @@ describe('Thread Patch Update', () => {
         body: 'body2',
         kind: 'discussion',
         stage: 'discussion',
-        topicName: 't2',
-        topicId: undefined,
+        topicId,
         session: userSession.session,
         sign: userSession.sign,
       });
@@ -163,8 +163,7 @@ describe('Thread Patch Update', () => {
         body: 'body2',
         kind: 'discussion',
         stage: 'discussion',
-        topicName: 't2',
-        topicId: undefined,
+        topicId,
         session: userSession.session,
         sign: userSession.sign,
       });

--- a/packages/commonwealth/test/integration/api/thread.update.spec.ts
+++ b/packages/commonwealth/test/integration/api/thread.update.spec.ts
@@ -13,15 +13,10 @@ describe('Thread Patch Update', () => {
   const chain = 'ethereum';
 
   let adminJWT;
-  let adminUserId;
   let adminAddress;
-  let adminAddressId;
-  let adminSession;
 
   let userJWT;
-  let userId;
   let userAddress;
-  let userAddressId;
   let userSession;
 
   let topicId;
@@ -32,8 +27,6 @@ describe('Thread Patch Update', () => {
     const adminRes = await modelUtils.createAndVerifyAddress({ chain });
     {
       adminAddress = adminRes.address;
-      adminUserId = adminRes.user_id;
-      adminAddressId = adminRes.address_id;
       adminJWT = jwt.sign(
         { id: adminRes.user_id, email: adminRes.email },
         JWT_SECRET,
@@ -43,7 +36,6 @@ describe('Thread Patch Update', () => {
         chainOrCommObj: { chain_id: chain },
         role: 'admin',
       });
-      adminSession = { session: adminRes.session, sign: adminRes.sign };
       expect(adminAddress).to.not.be.null;
       expect(adminJWT).to.not.be.null;
       expect(isAdmin).to.not.be.null;
@@ -52,8 +44,6 @@ describe('Thread Patch Update', () => {
     const userRes = await modelUtils.createAndVerifyAddress({ chain });
     {
       userAddress = userRes.address;
-      userId = userRes.user_id;
-      userAddressId = userRes.address_id;
       userJWT = jwt.sign(
         { id: userRes.user_id, email: userRes.email },
         JWT_SECRET,

--- a/packages/commonwealth/test/integration/api/thread.update.spec.ts
+++ b/packages/commonwealth/test/integration/api/thread.update.spec.ts
@@ -77,6 +77,7 @@ describe('Thread Patch Update', () => {
           author_chain: thread.community_id,
           chain: thread.community_id,
           address: userAddress,
+          topicId,
           jwt: userJWT,
           title: 'newTitle',
           body: 'newBody',
@@ -93,7 +94,7 @@ describe('Thread Patch Update', () => {
         body: 'newBody',
         stage: 'voting',
       });
-      expect(res.body.result.topic.name).to.equal('newTopic');
+      // expect(res.body.result.topic.name).to.equal('newTopic');
       expect(res.body.result.locked).to.not.be.null;
       expect(res.body.result.archived).to.not.be.null;
     });
@@ -123,6 +124,7 @@ describe('Thread Patch Update', () => {
             address: userAddress,
             jwt: userJWT,
             pinned: true,
+            topicId,
           });
         expect(res.status).to.equal(400);
       }
@@ -138,6 +140,7 @@ describe('Thread Patch Update', () => {
             address: userAddress,
             jwt: userJWT,
             spam: true,
+            topicId,
           });
         expect(res.status).to.equal(400);
       }
@@ -170,6 +173,7 @@ describe('Thread Patch Update', () => {
             address: adminAddress,
             jwt: adminJWT,
             pinned: true,
+            topicId,
           });
         expect(res.status).to.equal(200);
         expect(res.body.result.pinned).to.be.true;
@@ -187,6 +191,7 @@ describe('Thread Patch Update', () => {
             address: adminAddress,
             jwt: adminJWT,
             spam: true,
+            topicId,
           });
         expect(res.status).to.equal(200);
         expect(!!res.body.result.marked_as_spam_at).to.be.true;

--- a/packages/commonwealth/test/integration/api/threads.spec.ts
+++ b/packages/commonwealth/test/integration/api/threads.spec.ts
@@ -30,8 +30,7 @@ describe('Thread Tests', () => {
   const title = 'test title';
   const body = 'test body';
   const bodyWithMentions = 'test body [@Tagged Member](/edgeware/npRis4Nb)';
-  const topicName = 'test topic';
-  const topicId = undefined;
+  let topicId;
   const kind = 'discussion';
   const stage = 'discussion';
 
@@ -57,6 +56,7 @@ describe('Thread Tests', () => {
 
   before(async () => {
     await resetDatabase();
+    topicId = await modelUtils.getTopicId({ chain });
     let res = await modelUtils.createAndVerifyAddress({ chain });
     adminAddress = res.address;
     adminAddressId = res.address_id;
@@ -99,7 +99,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -118,7 +117,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title: '',
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -139,7 +137,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title: '',
-          topicName,
           topicId,
           body,
           url: 'http://commonwealth.im',
@@ -161,7 +158,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           url: null,
@@ -183,7 +179,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           readOnly,
@@ -208,34 +203,6 @@ describe('Thread Tests', () => {
         expect(cRes.error).not.to.be.null;
       });
 
-      it.skip('should successfully create a thread without a topic name (if the community lacks topics)', async () => {
-        const communityArgs: modelUtils.CommunityArgs = {
-          jwt: adminJWT,
-          id: 'test',
-          name: 'test',
-          creator_address: adminAddress,
-          creator_chain: chain,
-          description: 'test enabled community',
-          default_chain: chain,
-          isAuthenticatedForum: 'false',
-          privacyEnabled: 'false',
-        };
-        const c = await modelUtils.createCommunity(communityArgs);
-        const tRes = await modelUtils.createThread({
-          address: adminAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          body,
-          jwt: adminJWT,
-          session: adminSession.session,
-          sign: adminSession.sign,
-        });
-        expect(tRes.status).to.equal('Success');
-        expect(tRes.result).to.not.be.null;
-      });
-
       it('should create a discussion thread', async () => {
         const res = await modelUtils.createThread({
           address: userAddress,
@@ -243,7 +210,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -281,7 +247,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body: bodyWithMentions,
           jwt: userJWT,
@@ -303,7 +268,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain2,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT2,
@@ -367,7 +331,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -502,7 +465,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: adminJWT,
@@ -656,7 +618,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -725,7 +686,6 @@ describe('Thread Tests', () => {
           jwt: userJWT,
           title,
           body,
-          topicName,
           topicId,
           kind,
           stage,
@@ -764,7 +724,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -818,7 +777,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,
@@ -894,7 +852,6 @@ describe('Thread Tests', () => {
           stage,
           chainId: chain,
           title,
-          topicName,
           topicId,
           body,
           jwt: userJWT,

--- a/packages/commonwealth/test/integration/api/threads.spec.ts
+++ b/packages/commonwealth/test/integration/api/threads.spec.ts
@@ -19,7 +19,8 @@ import { markdownComment } from '../../util/fixtures/markdownComment';
 chai.use(chaiHttp);
 const { expect } = chai;
 
-describe('Thread Tests', () => {
+// @TODO 1/10/24: was not running previously, so set to skip -- needs cleaning
+describe.skip('Thread Tests', () => {
   const chain = 'ethereum';
   const chain2 = 'alex';
   // The createThread util uses the chainId parameter to determine
@@ -76,791 +77,770 @@ describe('Thread Tests', () => {
     userSession2 = { session: res.session, sign: res.sign };
     expect(userAddress2).to.not.be.null;
     expect(userJWT2).to.not.be.null;
+  });
 
-    describe('POST /threads', () => {
-      const readOnly = true;
+  describe('POST /threads', () => {
+    const readOnly = true;
 
-      it('should fail to create a thread without a kind', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind: null,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(tRes).to.not.be.null;
-        expect(tRes.error).to.not.be.null;
-        expect(tRes.error).to.be.equal(CreateThreadErrors.UnsupportedKind);
+    it('should fail to create a thread without a kind', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind: null,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-
-      it('should fail to create a forum thread with an empty title', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title: '',
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(tRes).to.not.be.null;
-        expect(tRes.error).to.not.be.null;
-        expect(tRes.error).to.be.equal(
-          CreateThreadErrors.DiscussionMissingTitle,
-        );
-      });
-
-      it('should fail to create a link thread with an empty title', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind: 'link',
-          stage,
-          chainId: chain,
-          title: '',
-          topicId,
-          body,
-          url: 'http://commonwealth.im',
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(tRes).to.not.be.null;
-        expect(tRes.error).to.not.be.null;
-        expect(tRes.error).to.be.equal(
-          CreateThreadErrors.LinkMissingTitleOrUrl,
-        );
-      });
-
-      it('should fail to create a link thread with an empty URL', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind: 'link',
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          url: null,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(tRes).to.not.be.null;
-        expect(tRes.error).to.not.be.null;
-        expect(tRes.error).to.be.equal(
-          CreateThreadErrors.LinkMissingTitleOrUrl,
-        );
-      });
-
-      it('should fail to create a comment on a readOnly thread', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          readOnly,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        console.log({ tRes });
-        expect(tRes).not.to.be.null;
-        expect(tRes.status).to.be.equal('Success');
-        expect(tRes.result.read_only).to.be.equal(true);
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: tRes.result.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(cRes).not.to.be.null;
-        expect(cRes.error).not.to.be.null;
-      });
-
-      it('should create a discussion thread', async () => {
-        const res = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(res.status).to.equal('Success');
-        expect(res.result).to.not.be.null;
-        expect(res.result.title).to.equal(encodeURIComponent(title));
-        expect(res.result.body).to.equal(encodeURIComponent(body));
-        expect(res.result.Address).to.not.be.null;
-        expect(res.result.Address.address).to.equal(userAddress);
-      });
-
-      it('should fail to create a thread without a topic name (if the community has topics)', async () => {
-        const tRes = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(tRes).to.not.be.null;
-        expect(tRes.error).to.not.be.null;
-      });
-
-      it('should create a thread with mentions to non-existent addresses', async () => {
-        const res = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body: bodyWithMentions,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(res.status).to.equal('Success');
-        expect(res.result).to.not.be.null;
-        expect(res.result.title).to.equal(encodeURIComponent(title));
-        expect(res.result.body).to.equal(encodeURIComponent(bodyWithMentions));
-        expect(res.result.Address).to.not.be.null;
-        expect(res.result.Address.address).to.equal(userAddress);
-      });
-
-      it('Thread Create should fail because address does not have permission', async () => {
-        const res2 = await modelUtils.createThread({
-          address: userAddress2,
-          kind,
-          stage,
-          chainId: chain2,
-          title,
-          topicId,
-          body,
-          jwt: userJWT2,
-          session: userSession2.session,
-          sign: userSession2.sign,
-        });
-        expect(res2.status).not.to.be.equal('Success');
-      });
+      expect(tRes).to.not.be.null;
+      expect(tRes.error).to.not.be.null;
+      expect(tRes.error).to.be.equal(CreateThreadErrors.UnsupportedKind);
     });
 
-    describe('/threads (bulkThreads)', () => {
-      it('should return bulk threads for a public chain', async () => {
-        const res = await chai.request
-          .agent(app)
-          .get('/api/threads')
-          .set('Accept', 'application/json')
-          .query({
-            bulk: true,
-            chain,
-            jwt: adminJWT,
-          });
-        expect(res.body.result).to.not.be.null;
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.be.equal('Success');
+    it('should fail to create a forum thread with an empty title', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title: '',
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-      it('should return bulk threads for a public community', async () => {
-        const res = await chai.request
-          .agent(app)
-          .get('/api/bulkThreads')
-          .set('Accept', 'application/json')
-          .query({
-            chain,
-            jwt: adminJWT,
-          });
-        expect(res.body.result).to.not.be.null;
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.be.equal('Success');
-      });
-      it.skip('should pass as admin of private community', async () => {
-        const communityArgs: modelUtils.CommunityArgs = {
-          jwt: userJWT,
-          isAuthenticatedForum: 'false',
-          privacyEnabled: 'true',
-          id: 'test',
-          name: 'test community',
-          creator_address: userAddress,
-          creator_chain: chain,
-          description: 'test enabled community',
-          default_chain: chain,
-        };
-
-        await modelUtils.createCommunity(communityArgs);
-      });
+      expect(tRes).to.not.be.null;
+      expect(tRes.error).to.not.be.null;
+      expect(tRes.error).to.be.equal(CreateThreadErrors.DiscussionMissingTitle);
     });
 
-    describe('/thread/:id/comments', () => {
-      beforeEach(async () => {
-        const res2 = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(res2.status).to.be.equal('Success');
-        expect(res2.result).to.not.be.null;
-        thread = res2.result;
+    it('should fail to create a link thread with an empty title', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind: 'link',
+        stage,
+        chainId: chain,
+        title: '',
+        topicId,
+        body,
+        url: 'http://commonwealth.im',
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-
-      it('should create a comment for a thread', async () => {
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: thread.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.status).to.equal('Success');
-        expect(cRes.result).to.not.be.null;
-        expect(cRes.result.thread_id).to.equal(thread.id);
-        expect(cRes.result.text).to.equal(markdownComment.text);
-        expect(cRes.result.Address).to.not.be.null;
-        expect(cRes.result.Address.address).to.equal(userAddress);
-      });
-
-      it('should create a comment for a thread with an non-existent mention', async () => {
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: bodyWithMentions,
-          thread_id: thread.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.status).to.equal('Success');
-        expect(cRes.result).to.not.be.null;
-        expect(cRes.result.thread_id).to.equal(thread.id);
-        expect(cRes.result.text).to.equal(bodyWithMentions);
-        expect(cRes.result.Address).to.not.be.null;
-        expect(cRes.result.Address.address).to.equal(userAddress);
-      });
-
-      it('should create a comment reply for a comment', async () => {
-        let cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: thread.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        const parentId = cRes.result.id;
-        cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: thread.id,
-          parentCommentId: `${parentId}`,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.status).to.equal('Success');
-        expect(cRes.result).to.not.be.null;
-        expect(cRes.result.thread_id).to.equal(thread.id);
-        expect(cRes.result.parent_id).to.equal(`${parentId}`);
-        expect(cRes.result.text).to.equal(markdownComment.text);
-        expect(cRes.result.Address).to.not.be.null;
-        expect(cRes.result.Address.address).to.equal(userAddress);
-      });
-
-      it('should fail to create a comment without a thread_id', async () => {
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: null,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.error).to.not.be.null;
-        expect(cRes.error).to.be.equal(CreateCommentErrors.MissingRootId);
-      });
-
-      it('should fail to create a comment without text', async () => {
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: null,
-          thread_id: thread.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.error).to.not.be.null;
-        expect(cRes.error).to.be.equal(CreateCommentErrors.MissingText);
-      });
-
-      it('should fail to create a comment on a non-existent thread', async () => {
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: 'test',
-          thread_id: -1,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-
-        expect(cRes.error).to.not.be.null;
-        expect(cRes.error).to.be.equal(CreateCommentErrors.MissingRootId);
-      });
+      expect(tRes).to.not.be.null;
+      expect(tRes.error).to.not.be.null;
+      expect(tRes.error).to.be.equal(CreateThreadErrors.LinkMissingTitleOrUrl);
     });
 
-    describe('/editThread', () => {
-      beforeEach(async () => {
-        const res2 = await modelUtils.createThread({
-          address: adminAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
+    it('should fail to create a link thread with an empty URL', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind: 'link',
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        url: null,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(tRes).to.not.be.null;
+      expect(tRes.error).to.not.be.null;
+      expect(tRes.error).to.be.equal(CreateThreadErrors.LinkMissingTitleOrUrl);
+    });
+
+    it('should fail to create a comment on a readOnly thread', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        readOnly,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      console.log({ tRes });
+      expect(tRes).not.to.be.null;
+      expect(tRes.status).to.be.equal('Success');
+      expect(tRes.result.read_only).to.be.equal(true);
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: tRes.result.id,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(cRes).not.to.be.null;
+      expect(cRes.error).not.to.be.null;
+    });
+
+    it('should create a discussion thread', async () => {
+      const res = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(res.status).to.equal('Success');
+      expect(res.result).to.not.be.null;
+      expect(res.result.title).to.equal(encodeURIComponent(title));
+      expect(res.result.body).to.equal(encodeURIComponent(body));
+      expect(res.result.Address).to.not.be.null;
+      expect(res.result.Address.address).to.equal(userAddress);
+    });
+
+    it('should fail to create a thread without a topic name (if the community has topics)', async () => {
+      const tRes = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(tRes).to.not.be.null;
+      expect(tRes.error).to.not.be.null;
+    });
+
+    it('should create a thread with mentions to non-existent addresses', async () => {
+      const res = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body: bodyWithMentions,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(res.status).to.equal('Success');
+      expect(res.result).to.not.be.null;
+      expect(res.result.title).to.equal(encodeURIComponent(title));
+      expect(res.result.body).to.equal(encodeURIComponent(bodyWithMentions));
+      expect(res.result.Address).to.not.be.null;
+      expect(res.result.Address.address).to.equal(userAddress);
+    });
+
+    it('Thread Create should fail because address does not have permission', async () => {
+      const res2 = await modelUtils.createThread({
+        address: userAddress2,
+        kind,
+        stage,
+        chainId: chain2,
+        title,
+        topicId,
+        body,
+        jwt: userJWT2,
+        session: userSession2.session,
+        sign: userSession2.sign,
+      });
+      expect(res2.status).not.to.be.equal('Success');
+    });
+  });
+
+  describe('/threads (bulkThreads)', () => {
+    it('should return bulk threads for a public chain', async () => {
+      const res = await chai.request
+        .agent(app)
+        .get('/api/threads')
+        .set('Accept', 'application/json')
+        .query({
+          bulk: true,
+          chain,
           jwt: adminJWT,
-          session: adminSession.session,
-          sign: adminSession.sign,
         });
-        expect(res2.status).to.be.equal('Success');
-        expect(res2.result).to.not.be.null;
-        thread = res2.result;
-      });
+      expect(res.body.result).to.not.be.null;
+      expect(res.body).to.not.be.null;
+      expect(res.body.status).to.be.equal('Success');
+    });
+    it.skip('should pass as admin of private community', async () => {
+      const communityArgs: modelUtils.CommunityArgs = {
+        jwt: userJWT,
+        isAuthenticatedForum: 'false',
+        privacyEnabled: 'true',
+        id: 'test',
+        name: 'test community',
+        creator_address: userAddress,
+        creator_chain: chain,
+        description: 'test enabled community',
+        default_chain: chain,
+      };
 
-      it("should fail to edit an admin's post as a user", async () => {
-        const thread_kind = thread.kind;
-        const thread_stage = thread.stage;
-        const readOnly = false;
-        const res = await chai
-          .request(app)
-          .put('/api/editThread')
-          .set('Accept', 'application/json')
-          .send({
-            chain,
-            address: adminAddress,
-            author_chain: chain,
-            kind: thread_kind,
-            stage: thread_stage,
-            body: thread.body,
-            read_only: readOnly,
-            jwt: userJWT,
-          });
-        expect(res.body.error).to.not.be.null;
-        expect(res.status).to.be.equal(400);
-      });
+      await modelUtils.createCommunity(communityArgs);
+    });
+  });
 
-      it('should fail to edit a thread without passing a thread id', async () => {
-        const thread_kind = thread.kind;
-        const thread_stage = thread.stage;
-        const readOnly = false;
-        const res = await chai
-          .request(app)
-          .put('/api/editThread')
-          .set('Accept', 'application/json')
-          .send({
-            chain,
-            address: adminAddress,
-            author_chain: chain,
-            thread_id: null,
-            kind: thread_kind,
-            stage: thread_stage,
-            body: thread.body,
-            read_only: readOnly,
-            jwt: adminJWT,
-          });
-        expect(res.body.error).to.not.be.null;
-        expect(res.status).to.be.equal(400);
-        expect(res.body.error).to.be.equal(
-          EditThreadHandlerErrors.InvalidThreadID,
-        );
+  describe('/thread/:id/comments', () => {
+    beforeEach(async () => {
+      const res2 = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-
-      it('should fail to edit a thread without passing a body', async () => {
-        const thread_id = thread.id;
-        const thread_kind = thread.kind;
-        const thread_stage = thread.stage;
-        const readOnly = false;
-        const res = await chai
-          .request(app)
-          .put('/api/editThread')
-          .set('Accept', 'application/json')
-          .send({
-            chain,
-            address: adminAddress,
-            author_chain: chain,
-            thread_id,
-            kind: thread_kind,
-            stage: thread_stage,
-            body: null,
-            read_only: readOnly,
-            jwt: adminJWT,
-          });
-        expect(res.body.error).to.not.be.null;
-        expect(res.status).to.be.equal(400);
-        expect(res.body.error).to.be.equal(EditThreadErrors.NoBody);
-      });
-
-      it('should succeed in updating a thread body', async () => {
-        const thread_id = thread.id;
-        const thread_kind = thread.kind;
-        const thread_stage = thread.stage;
-        const newBody = 'new Body';
-        const readOnly = false;
-        const res = await chai.request
-          .agent(app)
-          .put('/api/editThread')
-          .set('Accept', 'application/json')
-          .send({
-            chain,
-            address: adminAddress,
-            author_chain: chain,
-            thread_id,
-            kind: thread_kind,
-            stage: thread_stage,
-            body: newBody,
-            read_only: readOnly,
-            jwt: adminJWT,
-          });
-        expect(res.status).to.be.equal(200);
-        expect(res.body.result.body).to.be.equal(newBody);
-      }).timeout(400000);
-
-      it('should succeed in updating a thread title', async () => {
-        const thread_id = thread.id;
-        const thread_kind = thread.kind;
-        const thread_stage = thread.stage;
-        const newTitle = 'new Title';
-        const readOnly = false;
-        const res = await chai
-          .request(app)
-          .put('/api/editThread')
-          .set('Accept', 'application/json')
-          .send({
-            chain,
-            address: adminAddress,
-            author_chain: chain,
-            thread_id,
-            kind: thread_kind,
-            stage: thread_stage,
-            body: thread.body,
-            title: newTitle,
-            read_only: readOnly,
-            jwt: adminJWT,
-          });
-        expect(res.status).to.be.equal(200);
-        expect(res.body.result.title).to.be.equal(newTitle);
-      });
+      expect(res2.status).to.be.equal('Success');
+      expect(res2.result).to.not.be.null;
+      thread = res2.result;
     });
 
-    describe('/updateThreadPrivacy', () => {
-      let tempThread;
-
-      it('should turn on readonly', async () => {
-        const res1 = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        expect(res1.result).to.not.be.null;
-        tempThread = res1.result;
-        const res = await chai
-          .request(app)
-          .post('/api/updateThreadPrivacy')
-          .set('Accept', 'application/json')
-          .send({
-            thread_id: tempThread.id,
-            read_only: 'true',
-            jwt: userJWT,
-          });
-        expect(res.status).to.be.equal(200);
-        expect(res.body.result.read_only).to.be.true;
+    it('should create a comment for a thread', async () => {
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: thread.id,
+        session: userSession.session,
+        sign: userSession.sign,
       });
 
-      it('should fail to comment on a read_only thread', async () => {
-        // create new user + jwt
-        const res = await modelUtils.createAndVerifyAddress({ chain });
-        const newUserJWT = jwt.sign(
-          { id: res.user_id, email: res.email },
-          JWT_SECRET,
-        );
-        // try to comment and fail
-        const cRes = await modelUtils.createComment({
+      expect(cRes.status).to.equal('Success');
+      expect(cRes.result).to.not.be.null;
+      expect(cRes.result.thread_id).to.equal(thread.id);
+      expect(cRes.result.text).to.equal(markdownComment.text);
+      expect(cRes.result.Address).to.not.be.null;
+      expect(cRes.result.Address.address).to.equal(userAddress);
+    });
+
+    it('should create a comment for a thread with an non-existent mention', async () => {
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: bodyWithMentions,
+        thread_id: thread.id,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+
+      expect(cRes.status).to.equal('Success');
+      expect(cRes.result).to.not.be.null;
+      expect(cRes.result.thread_id).to.equal(thread.id);
+      expect(cRes.result.text).to.equal(bodyWithMentions);
+      expect(cRes.result.Address).to.not.be.null;
+      expect(cRes.result.Address.address).to.equal(userAddress);
+    });
+
+    it('should create a comment reply for a comment', async () => {
+      let cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: thread.id,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      const parentId = cRes.result.id;
+      cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: thread.id,
+        parentCommentId: `${parentId}`,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+
+      expect(cRes.status).to.equal('Success');
+      expect(cRes.result).to.not.be.null;
+      expect(cRes.result.thread_id).to.equal(thread.id);
+      expect(cRes.result.parent_id).to.equal(`${parentId}`);
+      expect(cRes.result.text).to.equal(markdownComment.text);
+      expect(cRes.result.Address).to.not.be.null;
+      expect(cRes.result.Address.address).to.equal(userAddress);
+    });
+
+    it('should fail to create a comment without a thread_id', async () => {
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: null,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+
+      expect(cRes.error).to.not.be.null;
+      expect(cRes.error).to.be.equal(CreateCommentErrors.MissingThreadId);
+    });
+
+    it('should fail to create a comment without text', async () => {
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: null,
+        thread_id: thread.id,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+
+      expect(cRes.error).to.not.be.null;
+      expect(cRes.error).to.be.equal(CreateCommentErrors.MissingText);
+    });
+
+    it('should fail to create a comment on a non-existent thread', async () => {
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: 'test',
+        thread_id: -1,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+
+      expect(cRes.error).to.not.be.null;
+      expect(cRes.error).to.be.equal(CreateCommentErrors.MissingThreadId);
+    });
+  });
+
+  describe('/editThread', () => {
+    beforeEach(async () => {
+      const res2 = await modelUtils.createThread({
+        address: adminAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: adminJWT,
+        session: adminSession.session,
+        sign: adminSession.sign,
+      });
+      expect(res2.status).to.be.equal('Success');
+      expect(res2.result).to.not.be.null;
+      thread = res2.result;
+    });
+
+    it("should fail to edit an admin's post as a user", async () => {
+      const thread_kind = thread.kind;
+      const thread_stage = thread.stage;
+      const readOnly = false;
+      const res = await chai
+        .request(app)
+        .put('/api/editThread')
+        .set('Accept', 'application/json')
+        .send({
           chain,
-          address: res.address,
-          jwt: newUserJWT,
-          text: 'hello world',
+          address: adminAddress,
+          author_chain: chain,
+          kind: thread_kind,
+          stage: thread_stage,
+          body: thread.body,
+          read_only: readOnly,
+          jwt: userJWT,
+        });
+      expect(res.body.error).to.not.be.null;
+      expect(res.status).to.be.equal(400);
+    });
+
+    it('should fail to edit a thread without passing a thread id', async () => {
+      const thread_kind = thread.kind;
+      const thread_stage = thread.stage;
+      const readOnly = false;
+      const res = await chai
+        .request(app)
+        .put('/api/editThread')
+        .set('Accept', 'application/json')
+        .send({
+          chain,
+          address: adminAddress,
+          author_chain: chain,
+          thread_id: null,
+          kind: thread_kind,
+          stage: thread_stage,
+          body: thread.body,
+          read_only: readOnly,
+          jwt: adminJWT,
+        });
+      expect(res.body.error).to.not.be.null;
+      expect(res.status).to.be.equal(400);
+      expect(res.body.error).to.be.equal(
+        EditThreadHandlerErrors.InvalidThreadID,
+      );
+    });
+
+    it('should fail to edit a thread without passing a body', async () => {
+      const thread_id = thread.id;
+      const thread_kind = thread.kind;
+      const thread_stage = thread.stage;
+      const readOnly = false;
+      const res = await chai
+        .request(app)
+        .put('/api/editThread')
+        .set('Accept', 'application/json')
+        .send({
+          chain,
+          address: adminAddress,
+          author_chain: chain,
+          thread_id,
+          kind: thread_kind,
+          stage: thread_stage,
+          body: null,
+          read_only: readOnly,
+          jwt: adminJWT,
+        });
+      expect(res.body.error).to.not.be.null;
+      expect(res.status).to.be.equal(400);
+      expect(res.body.error).to.be.equal(EditThreadErrors.NoBody);
+    });
+
+    it('should succeed in updating a thread body', async () => {
+      const thread_id = thread.id;
+      const thread_kind = thread.kind;
+      const thread_stage = thread.stage;
+      const newBody = 'new Body';
+      const readOnly = false;
+      const res = await chai.request
+        .agent(app)
+        .put('/api/editThread')
+        .set('Accept', 'application/json')
+        .send({
+          chain,
+          address: adminAddress,
+          author_chain: chain,
+          thread_id,
+          kind: thread_kind,
+          stage: thread_stage,
+          body: newBody,
+          read_only: readOnly,
+          jwt: adminJWT,
+        });
+      expect(res.status).to.be.equal(200);
+      expect(res.body.result.body).to.be.equal(newBody);
+    }).timeout(400000);
+
+    it('should succeed in updating a thread title', async () => {
+      const thread_id = thread.id;
+      const thread_kind = thread.kind;
+      const thread_stage = thread.stage;
+      const newTitle = 'new Title';
+      const readOnly = false;
+      const res = await chai
+        .request(app)
+        .put('/api/editThread')
+        .set('Accept', 'application/json')
+        .send({
+          chain,
+          address: adminAddress,
+          author_chain: chain,
+          thread_id,
+          kind: thread_kind,
+          stage: thread_stage,
+          body: thread.body,
+          title: newTitle,
+          read_only: readOnly,
+          jwt: adminJWT,
+        });
+      expect(res.status).to.be.equal(200);
+      expect(res.body.result.title).to.be.equal(newTitle);
+    });
+  });
+
+  describe('/updateThreadPrivacy', () => {
+    let tempThread;
+
+    it('should turn on readonly', async () => {
+      const res1 = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
+      });
+      expect(res1.result).to.not.be.null;
+      tempThread = res1.result;
+      const res = await chai
+        .request(app)
+        .post('/api/updateThreadPrivacy')
+        .set('Accept', 'application/json')
+        .send({
           thread_id: tempThread.id,
-          session: res.session,
-          sign: res.sign,
+          read_only: 'true',
+          jwt: userJWT,
         });
-        expect(cRes.result).to.be.undefined;
-        expect(cRes.error).to.be.equal(
-          CreateCommentErrors.CantCommentOnReadOnly,
-        );
-      });
-
-      it('should turn off readonly as an admin of community', async () => {
-        const res = await chai
-          .request(app)
-          .post('/api/updateThreadPrivacy')
-          .set('Accept', 'application/json')
-          .send({
-            thread_id: tempThread.id,
-            read_only: 'false',
-            jwt: adminJWT,
-          });
-        expect(res.status).to.be.equal(200);
-        expect(res.body.result.read_only).to.be.false;
-      });
+      expect(res.status).to.be.equal(200);
+      expect(res.body.result.read_only).to.be.true;
     });
 
-    describe('/comments/:id', () => {
-      it('should edit a comment', async () => {
-        const text = 'tes text';
-        const tRes = await modelUtils.createThread({
-          chainId: chain,
-          address: userAddress,
-          jwt: userJWT,
-          title,
-          body,
-          topicId,
-          kind,
-          stage,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        const cRes = await modelUtils.createComment({
-          chain,
-          address: userAddress,
-          jwt: userJWT,
-          text: markdownComment.text,
-          thread_id: tRes.result.id,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        const eRes = await modelUtils.editComment({
-          text,
-          jwt: userJWT,
-          comment_id: cRes.result.id,
-          address: userAddress,
-          chain,
-        });
-        expect(eRes).not.to.be.null;
-        expect(eRes.status).to.be.equal('Success');
-        expect(eRes.result).not.to.be.null;
-        expect(eRes.result.chain).to.be.equal(chain);
-        expect(eRes.result.thread_id).to.be.equal(tRes.result.id);
+    it('should fail to comment on a read_only thread', async () => {
+      // create new user + jwt
+      const res = await modelUtils.createAndVerifyAddress({ chain });
+      const newUserJWT = jwt.sign(
+        { id: res.user_id, email: res.email },
+        JWT_SECRET,
+      );
+      // try to comment and fail
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: res.address,
+        jwt: newUserJWT,
+        text: 'hello world',
+        thread_id: tempThread.id,
+        session: res.session,
+        sign: res.sign,
       });
+      expect(cRes.result).to.be.undefined;
+      expect(cRes.error).to.be.equal(CreateCommentErrors.CantCommentOnReadOnly);
     });
 
-    describe('/viewCount', () => {
-      it('should track views on chain', async () => {
-        const threadRes = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
+    it('should turn off readonly as an admin of community', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/updateThreadPrivacy')
+        .set('Accept', 'application/json')
+        .send({
+          thread_id: tempThread.id,
+          read_only: 'false',
+          jwt: adminJWT,
         });
-        const object_id = threadRes.result.id;
-        expect(object_id).to.not.be.null;
-        // should track first view
-        let res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain, object_id });
-        expect(res.status).to.equal(200);
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.equal('Success');
-        expect(res.body.result).to.not.be.null;
-        expect(res.body.result.view_count).to.equal(1);
+      expect(res.status).to.be.equal(200);
+      expect(res.body.result.read_only).to.be.false;
+    });
+  });
 
-        // should ignore second view, same IP
-        res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain, object_id });
-        expect(res.status).to.equal(200);
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.equal('Success');
-        expect(res.body.result).to.not.be.null;
-        expect(res.body.result.view_count).to.equal(1);
-
-        // sleep a second and verify cache invalidation
-        await sleep(1000);
-        res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain, object_id });
-        expect(res.status).to.equal(200);
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.equal('Success');
-        expect(res.body.result).to.not.be.null;
-        expect(res.body.result.view_count).to.equal(2);
+  describe('/comments/:id', () => {
+    it('should edit a comment', async () => {
+      const text = 'tes text';
+      const tRes = await modelUtils.createThread({
+        chainId: chain,
+        address: userAddress,
+        jwt: userJWT,
+        title,
+        body,
+        topicId,
+        kind,
+        stage,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-
-      it('should track views on community', async () => {
-        const threadRes = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        const object_id = threadRes.result.id;
-
-        // should track first view
-        const res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain, object_id });
-        expect(res.status).to.equal(200);
-        expect(res.body).to.not.be.null;
-        expect(res.body.status).to.equal('Success');
-        expect(res.body.result).to.not.be.null;
-        expect(res.body.result.view_count).to.equal(1);
+      const cRes = await modelUtils.createComment({
+        chain,
+        address: userAddress,
+        jwt: userJWT,
+        text: markdownComment.text,
+        thread_id: tRes.result.id,
+        session: userSession.session,
+        sign: userSession.sign,
       });
-
-      it('should not track views without object_id', async () => {
-        const res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain });
-        expect(res.status).to.equal(400);
-        expect(res.body).to.not.be.null;
-        expect(res.body.error).to.equal(ViewCountErrors.NoObjectId);
+      const eRes = await modelUtils.editComment({
+        text,
+        jwt: userJWT,
+        comment_id: cRes.result.id,
+        address: userAddress,
+        chain,
       });
+      expect(eRes).not.to.be.null;
+      expect(eRes.status).to.be.equal('Success');
+      expect(eRes.result).not.to.be.null;
+      expect(eRes.result.chain).to.be.equal(chain);
+      expect(eRes.result.thread_id).to.be.equal(tRes.result.id);
+    });
+  });
 
-      it('should not track views without chain or community', async () => {
-        const res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ object_id: '9999' });
-        expect(res.status).to.equal(400);
-        expect(res.body).to.not.be.null;
-        expect(res.body.error).to.equal(ViewCountErrors.NoChainOrComm);
+  describe('/viewCount', () => {
+    it('should track views on chain', async () => {
+      const threadRes = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
+      const object_id = threadRes.result.id;
+      expect(object_id).to.not.be.null;
+      // should track first view
+      let res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain, object_id });
+      expect(res.status).to.equal(200);
+      expect(res.body).to.not.be.null;
+      expect(res.body.status).to.equal('Success');
+      expect(res.body.result).to.not.be.null;
+      expect(res.body.result.view_count).to.equal(1);
 
-      it('should not track views with invalid chain or community', async () => {
-        const res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain: 'adkgjkjgda', object_id: '9999' });
-        expect(res.status).to.equal(400);
-        expect(res.body).to.not.be.null;
-        expect(res.body.error).to.equal(ViewCountErrors.InvalidChainOrComm);
-      });
+      // should ignore second view, same IP
+      res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain, object_id });
+      expect(res.status).to.equal(200);
+      expect(res.body).to.not.be.null;
+      expect(res.body.status).to.equal('Success');
+      expect(res.body.result).to.not.be.null;
+      expect(res.body.result.view_count).to.equal(1);
 
-      it('should not track views with invalid object_id', async () => {
-        const res = await chai
-          .request(app)
-          .post('/api/viewCount')
-          .set('Accept', 'application/json')
-          .send({ chain, object_id: '9999' });
-        expect(res.status).to.equal(400);
-        expect(res.body).to.not.be.null;
-        expect(res.body.error).to.equal(ViewCountErrors.InvalidThread);
-      });
+      // sleep a second and verify cache invalidation
+      await sleep(1000);
+      res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain, object_id });
+      expect(res.status).to.equal(200);
+      expect(res.body).to.not.be.null;
+      expect(res.body.status).to.equal('Success');
+      expect(res.body.result).to.not.be.null;
+      expect(res.body.result.view_count).to.equal(2);
     });
 
-    describe('/updateThreadPinned route tests', () => {
-      let pinThread;
-      before(async () => {
-        const res = await modelUtils.createThread({
-          address: userAddress,
-          kind,
-          stage,
-          chainId: chain,
-          title,
-          topicId,
-          body,
-          jwt: userJWT,
-          session: userSession.session,
-          sign: userSession.sign,
-        });
-        pinThread = res.result.id;
+    it('should track views on community', async () => {
+      const threadRes = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
+      const object_id = threadRes.result.id;
 
-      it('admin can toggle thread to pinned', async () => {
-        const res2 = await chai
-          .request(app)
-          .post('/api/updateThreadPinned')
-          .set('Accept', 'application/json')
-          .send({ thread_id: pinThread, jwt: adminJWT });
-        expect(res2.body.status).to.be.equal('Success');
-        expect(res2.body.result.pinned).to.be.true;
-      });
+      // should track first view
+      const res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain, object_id });
+      expect(res.status).to.equal(200);
+      expect(res.body).to.not.be.null;
+      expect(res.body.status).to.equal('Success');
+      expect(res.body.result).to.not.be.null;
+      expect(res.body.result.view_count).to.equal(1);
+    });
 
-      it('admin can toggle thread to unpinned', async () => {
-        const res2 = await chai
-          .request(app)
-          .post('/api/updateThreadPinned')
-          .set('Accept', 'application/json')
-          .send({ thread_id: pinThread, jwt: adminJWT });
-        expect(res2.body.status).to.be.equal('Success');
-        expect(res2.body.result.pinned).to.be.false;
+    it('should not track views without object_id', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain });
+      expect(res.status).to.equal(400);
+      expect(res.body).to.not.be.null;
+      expect(res.body.error).to.equal(ViewCountErrors.NoObjectId);
+    });
+
+    it('should not track views without chain or community', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ object_id: '9999' });
+      expect(res.status).to.equal(400);
+      expect(res.body).to.not.be.null;
+      expect(res.body.error).to.equal(ViewCountErrors.NoChainOrComm);
+    });
+
+    it('should not track views with invalid chain or community', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain: 'adkgjkjgda', object_id: '9999' });
+      expect(res.status).to.equal(400);
+      expect(res.body).to.not.be.null;
+      expect(res.body.error).to.equal(ViewCountErrors.InvalidChainOrComm);
+    });
+
+    it('should not track views with invalid object_id', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/viewCount')
+        .set('Accept', 'application/json')
+        .send({ chain, object_id: '9999' });
+      expect(res.status).to.equal(400);
+      expect(res.body).to.not.be.null;
+      expect(res.body.error).to.equal(ViewCountErrors.InvalidThread);
+    });
+  });
+
+  describe('/updateThreadPinned route tests', () => {
+    let pinThread;
+    before(async () => {
+      const res = await modelUtils.createThread({
+        address: userAddress,
+        kind,
+        stage,
+        chainId: chain,
+        title,
+        topicId,
+        body,
+        jwt: userJWT,
+        session: userSession.session,
+        sign: userSession.sign,
       });
+      pinThread = res.result.id;
+    });
+
+    it('admin can toggle thread to pinned', async () => {
+      const res2 = await chai
+        .request(app)
+        .post('/api/updateThreadPinned')
+        .set('Accept', 'application/json')
+        .send({ thread_id: pinThread, jwt: adminJWT });
+      expect(res2.body.status).to.be.equal('Success');
+      expect(res2.body.result.pinned).to.be.true;
+    });
+
+    it('admin can toggle thread to unpinned', async () => {
+      const res2 = await chai
+        .request(app)
+        .post('/api/updateThreadPinned')
+        .set('Accept', 'application/json')
+        .send({ thread_id: pinThread, jwt: adminJWT });
+      expect(res2.body.status).to.be.equal('Success');
+      expect(res2.body.result.pinned).to.be.false;
     });
   });
 });

--- a/packages/commonwealth/test/integration/api/threads.spec.ts
+++ b/packages/commonwealth/test/integration/api/threads.spec.ts
@@ -5,7 +5,6 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
 import jwt from 'jsonwebtoken';
-import moment from 'moment';
 import { JWT_SECRET } from 'server/config';
 import { Errors as CreateThreadErrors } from 'server/controllers/server_threads_methods/create_thread';
 import { Errors as EditThreadErrors } from 'server/controllers/server_threads_methods/update_thread';
@@ -34,22 +33,16 @@ describe('Thread Tests', () => {
   const kind = 'discussion';
   const stage = 'discussion';
 
-  const markdownThread = require('../../util/fixtures/markdownThread');
   let adminJWT;
   let adminAddress;
-  let adminAddressId;
   let adminSession;
 
   let userJWT;
-  let userId;
   let userAddress;
-  let userAddressId;
   let userSession;
 
   let userJWT2;
-  let userId2;
   let userAddress2;
-  let userAddressId2;
   let userSession2;
 
   let thread;
@@ -59,7 +52,6 @@ describe('Thread Tests', () => {
     topicId = await modelUtils.getTopicId({ chain });
     let res = await modelUtils.createAndVerifyAddress({ chain });
     adminAddress = res.address;
-    adminAddressId = res.address_id;
     adminJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     const isAdmin = await modelUtils.updateRole({
       address_id: res.address_id,
@@ -73,8 +65,6 @@ describe('Thread Tests', () => {
 
     res = await modelUtils.createAndVerifyAddress({ chain });
     userAddress = res.address;
-    userId = res.user_id;
-    userAddressId = res.address_id;
     userJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     userSession = { session: res.session, sign: res.sign };
     expect(userAddress).to.not.be.null;
@@ -82,8 +72,6 @@ describe('Thread Tests', () => {
 
     res = await modelUtils.createAndVerifyAddress({ chain: chain2 });
     userAddress2 = res.address;
-    userId2 = res.user_id;
-    userAddressId2 = res.address_id;
     userJWT2 = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
     userSession2 = { session: res.session, sign: res.sign };
     expect(userAddress2).to.not.be.null;
@@ -319,7 +307,7 @@ describe('Thread Tests', () => {
           default_chain: chain,
         };
 
-        const testCommunity = await modelUtils.createCommunity(communityArgs);
+        await modelUtils.createCommunity(communityArgs);
       });
     });
 
@@ -477,11 +465,8 @@ describe('Thread Tests', () => {
       });
 
       it("should fail to edit an admin's post as a user", async () => {
-        const thread_id = thread.id;
         const thread_kind = thread.kind;
         const thread_stage = thread.stage;
-        const recentEdit: any = { timestamp: moment(), body: thread.body };
-        const versionHistory = JSON.stringify(recentEdit);
         const readOnly = false;
         const res = await chai
           .request(app)
@@ -504,8 +489,6 @@ describe('Thread Tests', () => {
       it('should fail to edit a thread without passing a thread id', async () => {
         const thread_kind = thread.kind;
         const thread_stage = thread.stage;
-        const recentEdit: any = { timestamp: moment(), body: thread.body };
-        const versionHistory = JSON.stringify(recentEdit);
         const readOnly = false;
         const res = await chai
           .request(app)
@@ -533,8 +516,6 @@ describe('Thread Tests', () => {
         const thread_id = thread.id;
         const thread_kind = thread.kind;
         const thread_stage = thread.stage;
-        const recentEdit: any = { timestamp: moment(), body: thread.body };
-        const versionHistory = JSON.stringify(recentEdit);
         const readOnly = false;
         const res = await chai
           .request(app)

--- a/packages/commonwealth/test/integration/api/topics.spec.ts
+++ b/packages/commonwealth/test/integration/api/topics.spec.ts
@@ -4,85 +4,22 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import 'chai/register-should';
-import jwt from 'jsonwebtoken';
-import app, { resetDatabase } from '../../../server-test';
-import { JWT_SECRET } from '../../../server/config';
-import * as modelUtils from '../../util/modelUtils';
 import { ApiEndpoints } from 'state/api/config';
+import app, { resetDatabase } from '../../../server-test';
 
 chai.use(chaiHttp);
 const { expect } = chai;
 
 let adminJWT;
-let adminAddress;
-let userJWT;
-let userAddress;
-let topic;
 
 describe('Topic Tests', () => {
   const chain = 'ethereum';
-  const title = 'test title';
-  const body = 'test body';
-  const topicName = 'test topic';
-  const topicId = undefined;
-  const kind = 'discussion';
-  const stage = 'discussion';
 
   before('reset database', async () => {
     await resetDatabase();
-    let res = await modelUtils.createAndVerifyAddress({ chain });
-    adminAddress = res.address;
-    adminJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
-    const isAdmin = await modelUtils.updateRole({
-      address_id: res.address_id,
-      chainOrCommObj: { chain_id: chain },
-      role: 'admin',
-    });
-    expect(adminAddress).to.not.be.null;
-    expect(adminJWT).to.not.be.null;
-    expect(isAdmin).to.not.be.null;
-
-    res = await modelUtils.createAndVerifyAddress({ chain });
-    userAddress = res.address;
-    userJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
-    expect(userAddress).to.not.be.null;
-    expect(userJWT).to.not.be.null;
   });
 
   describe('Bulk Topics', () => {
-    before(async () => {
-      const res = await modelUtils.createAndVerifyAddress({ chain });
-      adminAddress = res.address;
-
-      adminJWT = jwt.sign({ id: res.user_id, email: res.email }, JWT_SECRET);
-      const isAdmin = await modelUtils.updateRole({
-        address_id: res.address_id,
-        chainOrCommObj: { chain_id: chain },
-        role: 'admin',
-      });
-      expect(adminAddress).to.not.be.null;
-      expect(adminJWT).to.not.be.null;
-      expect(isAdmin).to.not.be.null;
-      const res2 = await modelUtils.createThread({
-        chainId: chain,
-        address: adminAddress,
-        jwt: adminJWT,
-        title,
-        body,
-        topicName,
-        topicId,
-        kind,
-        stage,
-        session: res.session,
-        sign: res.sign,
-      });
-      expect(res2.status).to.be.equal('Success');
-      expect(res2.result).to.not.be.null;
-      expect(res2.result.Address).to.not.be.null;
-      expect(res2.result.Address.address).to.equal(adminAddress);
-      topic = res2.result.topic;
-    });
-
     it('Should pass /bulkTopics', async () => {
       const res = await chai.request
         .agent(app)

--- a/packages/commonwealth/test/integration/api/userDashboard.spec.ts
+++ b/packages/commonwealth/test/integration/api/userDashboard.spec.ts
@@ -22,7 +22,6 @@ describe('User Dashboard API', () => {
   // communityId, unlike in non-test thread creation
   const title = 'test title';
   const body = 'test body';
-  const topicName = 'test topic';
   const kind = 'discussion';
 
   let userJWT;
@@ -92,7 +91,6 @@ describe('User Dashboard API', () => {
       body,
       readOnly: false,
       kind,
-      topicName,
       session: userSession2.session,
       sign: userSession2.sign,
     };
@@ -108,7 +106,6 @@ describe('User Dashboard API', () => {
       body,
       readOnly: false,
       kind,
-      topicName,
       session: userSession2.session,
       sign: userSession2.sign,
     };
@@ -205,7 +202,6 @@ describe('User Dashboard API', () => {
           body,
           readOnly: false,
           kind,
-          topicName,
           session: userSession2.session,
           sign: userSession2.sign,
         };

--- a/packages/commonwealth/test/integration/api/userDashboard.spec.ts
+++ b/packages/commonwealth/test/integration/api/userDashboard.spec.ts
@@ -25,7 +25,6 @@ describe('User Dashboard API', () => {
   const kind = 'discussion';
 
   let userJWT;
-  let userSession;
   let userId;
   let userAddress;
   let userAddressId;
@@ -45,7 +44,6 @@ describe('User Dashboard API', () => {
     userAddress = firstUser.address;
     userAddressId = firstUser.address_id;
     userJWT = jwt.sign({ id: userId, email: firstUser.email }, JWT_SECRET);
-    userSession = { session: firstUser.session, sign: firstUser.sign };
     expect(userId).to.not.be.null;
     expect(userAddress).to.not.be.null;
     expect(userAddressId).to.not.be.null;
@@ -76,7 +74,7 @@ describe('User Dashboard API', () => {
     expect(res).to.equal(true);
 
     // sets user-2 to be admin of the alex community
-    let isAdmin = await modelUtils.updateRole({
+    const isAdmin = await modelUtils.updateRole({
       address_id: userAddressId2,
       chainOrCommObj: { chain_id: chain2 },
       role: 'admin',

--- a/packages/commonwealth/test/integration/api/userDashboard.spec.ts
+++ b/packages/commonwealth/test/integration/api/userDashboard.spec.ts
@@ -34,10 +34,14 @@ describe('User Dashboard API', () => {
   let userAddress2;
   let userAddressId2;
   let threadOne;
+  let topicId;
+  let topicId2;
 
   before('Reset database', async () => {
     await resetDatabase();
 
+    topicId = await modelUtils.getTopicId({ chain });
+    topicId2 = await modelUtils.getTopicId({ chain: chain2 });
     // creates 2 ethereum users
     const firstUser = await modelUtils.createAndVerifyAddress({ chain });
     userId = firstUser.user_id;
@@ -91,6 +95,7 @@ describe('User Dashboard API', () => {
       kind,
       session: userSession2.session,
       sign: userSession2.sign,
+      topicId: topicId2,
     };
     threadOne = await modelUtils.createThread(threadOneArgs);
     expect(threadOne.status).to.equal('Success');
@@ -106,6 +111,7 @@ describe('User Dashboard API', () => {
       kind,
       session: userSession2.session,
       sign: userSession2.sign,
+      topicId,
     };
     //
     // // create a thread in both 'ethereum' and 'alex' communities
@@ -202,6 +208,7 @@ describe('User Dashboard API', () => {
           kind,
           session: userSession2.session,
           sign: userSession2.sign,
+          topicId,
         };
         const res = await modelUtils.createThread(threadArgs);
         expect(res.status).to.equal('Success');

--- a/packages/commonwealth/test/integration/api/webhooks.spec.ts
+++ b/packages/commonwealth/test/integration/api/webhooks.spec.ts
@@ -35,21 +35,22 @@ describe('Webhook Tests', () => {
   let loggedInSession;
   let notAdminJWT;
   const chain = 'ethereum';
-  const topicName = 'test';
-  const topicId = 0;
+  let topicId;
 
   before('reset database', async () => {
     await resetDatabase();
   });
 
   beforeEach(async () => {
+    // get topic
+    topicId = await modelUtils.getTopicId({ chain });
     // get logged in address/user with JWT
     let result = await modelUtils.createAndVerifyAddress({ chain });
     loggedInAddr = result.address;
     loggedInSession = { session: result.session, sign: result.sign };
     jwtToken = jwt.sign(
       { id: result.user_id, email: result.email },
-      JWT_SECRET
+      JWT_SECRET,
     );
     await modelUtils.updateRole({
       address_id: result.address_id,
@@ -64,7 +65,7 @@ describe('Webhook Tests', () => {
     loggedInNotAdminAddr = result.address;
     notAdminJWT = jwt.sign(
       { id: result.user_id, email: result.email },
-      JWT_SECRET
+      JWT_SECRET,
     );
   });
 
@@ -208,7 +209,7 @@ describe('Webhook Tests', () => {
             .set('Accept', 'application/json')
             .send({ chain, webhookUrl, auth: true, jwt: jwtToken });
           return webhookUrl;
-        })
+        }),
       );
       expect(urls).to.have.length(5);
       const res = await chai.request
@@ -229,7 +230,7 @@ describe('Webhook Tests', () => {
             .set('Accept', 'application/json')
             .send({ chain, webhookUrl, auth: true, jwt: jwtToken });
           return webhookUrl;
-        })
+        }),
       );
       expect(urls).to.have.length(5);
       const errorRes = await chai.request
@@ -255,7 +256,6 @@ describe('Webhook Tests', () => {
       });
       await modelUtils.createThread({
         chainId: chain,
-        topicName,
         topicId,
         address: loggedInAddr,
         jwt: jwtToken,
@@ -279,7 +279,6 @@ describe('Webhook Tests', () => {
       // expect(res.statusCode).to.be.equal(200);
       await modelUtils.createThread({
         chainId: chain,
-        topicName,
         topicId,
         address: loggedInAddr,
         jwt: jwtToken,

--- a/packages/commonwealth/test/integration/emitNotifications.spec.ts
+++ b/packages/commonwealth/test/integration/emitNotifications.spec.ts
@@ -25,11 +25,8 @@ describe('emitNotifications tests', () => {
   // Therefore, a valid chain MUST be included alongside
   // communityId, unlike in non-test thread creation
   let thread, comment;
-  //reaction;
   const title = 'test title';
-  // const body = 'test body';
   const commentBody = 'test';
-  // const topicName = 'test topic';
   const kind = 'discussion';
 
   let userJWT;

--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -11,6 +11,9 @@ describe('ServerCommentsController', () => {
     it('should create a comment reaction (new reaction)', async () => {
       const sandbox = Sinon.createSandbox();
       const db = {
+        Address: {
+          findAll: async () => [{}], // used in findOneRole
+        },
         Reaction: {
           findOne: sandbox.stub().resolves({
             id: 2,

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
@@ -1351,7 +1351,6 @@ describe('ServerThreadsController', () => {
       const kind = 'discussion';
       const readOnly = false;
       const topicId = 1;
-      const topicName = undefined;
       const title = 'mythread';
       const stage = 'stage';
       const url = 'http://blah';
@@ -1369,7 +1368,6 @@ describe('ServerThreadsController', () => {
           kind,
           readOnly,
           topicId,
-          topicName,
           stage,
           url,
           canvasAction,
@@ -1390,7 +1388,6 @@ describe('ServerThreadsController', () => {
           kind,
           readOnly,
           topicId,
-          topicName,
           stage,
           url,
           canvasAction,

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
@@ -8,6 +8,22 @@ describe('ServerThreadsController', () => {
     it('should create a thread reaction (new reaction)', async () => {
       const sandbox = Sinon.createSandbox();
       const db = {
+        // for findAllRoles
+        Address: {
+          findAll: async () => [
+            {
+              toJSON: () => ({}),
+            },
+          ],
+        },
+        Group: {
+          findAll: async () => [],
+        },
+        Topic: {
+          findOne: async () => ({
+            group_ids: [],
+          }),
+        },
         Reaction: {
           findOne: sandbox.stub().resolves({
             id: 2,
@@ -1295,8 +1311,14 @@ describe('ServerThreadsController', () => {
           },
           query: async () => ({}),
         },
+        Group: {
+          findAll: async () => [],
+        },
         Topic: {
           findOrCreate: async () => ({}),
+          findOne: async () => ({
+            group_ids: [],
+          }),
         },
         Thread: {
           findOne: async () => ({

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.update_thread.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.update_thread.spec.ts
@@ -112,6 +112,11 @@ describe('ServerThreadsController', () => {
             toJSON: () => ({}),
           }),
         },
+        Topic: {
+          findOne: async () => ({
+            id: 1,
+          }),
+        },
         // for findAllRoles
         Address: {
           findAll: async () => [address],

--- a/packages/commonwealth/test/util/modelUtils.ts
+++ b/packages/commonwealth/test/util/modelUtils.ts
@@ -58,7 +58,7 @@ export const getTopicId = async ({ chain }) => {
     .agent(app)
     .get('/api/topics')
     .set('Accept', 'application/json')
-    .send({
+    .query({
       community_id: chain,
     });
   const topicId = res.body.result[0].id;

--- a/packages/commonwealth/test/util/modelUtils.ts
+++ b/packages/commonwealth/test/util/modelUtils.ts
@@ -53,6 +53,18 @@ export const generateEthAddress = () => {
   return { keypair, address };
 };
 
+export const getTopicId = async ({ chain }) => {
+  const res = await chai.request
+    .agent(app)
+    .get('/api/topics')
+    .set('Accept', 'application/json')
+    .send({
+      community_id: chain,
+    });
+  const topicId = res.body.result[0].id;
+  return topicId;
+};
+
 export const createAndVerifyAddress = async ({ chain }, mnemonic = 'Alice') => {
   if (chain === 'ethereum' || chain === 'alex') {
     const wallet_id = 'metamask';
@@ -205,7 +217,6 @@ export interface ThreadArgs {
   stage?: string;
   chainId: string;
   title: string;
-  topicName?: string;
   topicId?: number;
   body?: string;
   url?: string;
@@ -223,7 +234,6 @@ export const createThread = async (
     jwt,
     title,
     body,
-    topicName,
     topicId,
     readOnly,
     kind,
@@ -268,7 +278,6 @@ export const createThread = async (
       title: encodeURIComponent(title),
       body: encodeURIComponent(body),
       kind,
-      topic_name: topicName,
       topic_id: topicId,
       url,
       readOnly: readOnly || false,

--- a/packages/commonwealth/test/util/resetDatabase.ts
+++ b/packages/commonwealth/test/util/resetDatabase.ts
@@ -87,6 +87,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         has_chain_events_listener: false,
         chain_node_id: edgewareNode.id,
       });
+      await models.Topic.create({
+        community_id: 'edgeware',
+        name: 'General',
+      });
       await models.Community.create({
         id: 'ethereum',
         network: ChainNetwork.Ethereum,
@@ -99,6 +103,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         has_chain_events_listener: false,
         chain_node_id: mainnetNode.id,
       });
+      await models.Topic.create({
+        community_id: 'ethereum',
+        name: 'General',
+      });
       const alex = await models.Community.create({
         id: 'alex',
         network: ChainNetwork.ERC20,
@@ -110,6 +118,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         base: ChainBase.Ethereum,
         has_chain_events_listener: false,
         chain_node_id: testnetNode.id,
+      });
+      await models.Topic.create({
+        community_id: 'alex',
+        name: 'General',
       });
       await models.Community.create({
         id: 'osmosis',
@@ -124,6 +136,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         chain_node_id: osmosisNode.id,
         bech32_prefix: 'osmo',
       });
+      await models.Topic.create({
+        community_id: 'osmosis',
+        name: 'General',
+      });
       await models.Community.create({
         id: 'csdk-beta',
         network: ChainNetwork.Osmosis,
@@ -137,6 +153,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         chain_node_id: csdkBetaNode.id,
         bech32_prefix: 'cosmos',
       });
+      await models.Topic.create({
+        community_id: 'csdk-beta',
+        name: 'General',
+      });
       await models.Community.create({
         id: 'csdk',
         network: ChainNetwork.Osmosis,
@@ -149,6 +169,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         has_chain_events_listener: true,
         chain_node_id: csdkV1Node.id,
         bech32_prefix: 'cosmos',
+      });
+      await models.Topic.create({
+        community_id: 'csdk',
+        name: 'General',
       });
       const alexContract = await models.Contract.create({
         address: '0xFab46E002BbF0b4509813474841E0716E6730136',
@@ -173,6 +197,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         has_chain_events_listener: false,
         chain_node_id: mainnetNode.id,
       });
+      await models.Topic.create({
+        community_id: 'yearn',
+        name: 'General',
+      });
       const yearnContract = await models.Contract.create({
         address: '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e',
         token_name: 'yearn',
@@ -196,6 +224,10 @@ export const resetDatabase = (debug = false): Promise<void> => {
         base: ChainBase.Ethereum,
         has_chain_events_listener: false,
         chain_node_id: mainnetNode.id,
+      });
+      await models.Topic.create({
+        community_id: 'sushi',
+        name: 'General',
       });
       const sushiContract = await models.Contract.create({
         address: '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6298 
Closes: #6299 

## Description of Changes
- Removes uses of topicName as legacy method for creating a new topic, per #6298 description.
- Moves Membership check in #6299 out of db transaction.
- Update all tests to no longer rely on undefined topicIds, and explicitly disable some tests which were not running at all previously (looking at you, threads.spec.ts).

## Test Plan
- Hit all routes involved and ensure they all work: createThread, updateThread, createComment, createPoll.

## Deployment Plan
Hotfix for v0.9.0, then cherry-pick onto master.

## Other Considerations
- Need to check all modified routes to ensure provided topicId is actually in provided communityId = is valid.