### PR TITLE
Updated necessary requirements selector

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.scss
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.scss
@@ -27,15 +27,14 @@
         align-items: center;
         gap: 8px;
 
-        .input {
-          .input-and-icon-container {
-            width: 45px !important;
-          }
+        .CWSelectList {
+          .SelectList {
+            padding: 4px 10px !important;
+            min-height: auto;
 
-          &.failure {
-            .input-and-icon-container > input {
-              border-color: $rorange-600 !important;
-              background-color: $white !important;
+            .cwsl__option {
+              text-align: center;
+              padding: 2px 16px !important;
             }
           }
         }

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/GroupForm.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable react/no-multi-comp */
 import { useCommonNavigate } from 'navigation/helpers';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
 import { useFetchGroupsQuery } from 'state/api/groups';
 import { useFetchTopicsQuery } from 'state/api/topics';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTextArea } from 'views/components/component_kit/cw_text_area';
-import { getClasses } from 'views/components/component_kit/helpers';
 import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
@@ -25,14 +24,12 @@ import TopicGatingHelpMessage from '../../TopicGatingHelpMessage';
 import './GroupForm.scss';
 import RequirementSubForm from './RequirementSubForm';
 import {
-  CWRequirementsLabelInputFieldState,
   FormSubmitValues,
   GroupFormProps,
   RequirementSubFormsState,
   RequirementSubType,
 } from './index.types';
 import {
-  VALIDATION_MESSAGES,
   groupValidationSchema,
   requirementSubFormValidationSchema,
 } from './validations';
@@ -43,7 +40,7 @@ const REQUIREMENTS_TO_FULFILL = {
 };
 
 type CWRequirementsRadioButtonProps = {
-  inputError?: string;
+  maxRequirements: number;
   inputValue: string;
   isSelected: boolean;
   onSelect: () => any;
@@ -51,36 +48,45 @@ type CWRequirementsRadioButtonProps = {
 };
 
 const CWRequirementsRadioButton = ({
-  inputError,
+  maxRequirements = 1,
   inputValue,
   isSelected,
   onSelect,
   onInputValueChange,
 }: CWRequirementsRadioButtonProps) => {
-  const inputRef = useRef();
+  const options = useMemo(
+    () =>
+      Array.from({ length: maxRequirements }).map((_, index) => ({
+        label: `${index + 1}`,
+        value: `${index + 1}`,
+      })),
+    [maxRequirements],
+  );
+
+  const value = useMemo(() => {
+    if (inputValue) {
+      return {
+        label: inputValue,
+        value: inputValue,
+      };
+    }
+
+    return options[0];
+  }, [inputValue, options]);
 
   const Label = (
     <span className="requirements-radio-btn-label">
-      At least{' '}
-      {
-        <CWTextInput
-          disabled={!isSelected}
-          inputRef={inputRef}
-          containerClassName={getClasses<{ failure?: boolean }>(
-            { failure: !!inputError },
-            'input',
-          )}
-          value={inputValue}
-          onInput={(e) => {
-            const value = e.target?.value?.trim();
-            // Only allow numbers
-            if (!/[^0-9]/g.test(value)) {
-              onInputValueChange(e.target?.value?.trim());
-            }
-          }}
-        />
-      }{' '}
-      # of all requirements
+      Minimum number of conditions to join{' '}
+      <CWSelectList
+        isDisabled={!isSelected}
+        isSearchable={false}
+        isClearable={false}
+        options={options}
+        value={value}
+        onChange={(selectedOption) => {
+          onInputValueChange(`${selectedOption.value}`);
+        }}
+      />
     </span>
   );
 
@@ -94,18 +100,9 @@ const CWRequirementsRadioButton = ({
         onChange={(e) => {
           if (e.target.checked) {
             onSelect();
-            setTimeout(() =>
-              (inputRef?.current as HTMLInputElement)?.focus?.(),
-            );
           }
         }}
       />
-      {isSelected && (
-        <CWText type="caption" className="requirements-radio-btn-helper-text">
-          Number must be less than or equal to number of requirements added and
-          cannot be 0.
-        </CWText>
-      )}
     </>
   );
 };
@@ -159,8 +156,8 @@ const GroupForm = ({
     initialValues?.requirementsToFulfill &&
       initialValues?.requirementsToFulfill !== 'ALL',
   );
-  const [cwRequiremenetsLabelInputField, setCwRequiremenetsLabelInputField] =
-    useState<CWRequirementsLabelInputFieldState>({ value: '1', error: '' });
+  const [cwRequiremenetsLabelInputValue, setCwRequiremenetsLabelInputValue] =
+    useState<string>('1');
   const [requirementSubForms, setRequirementSubForms] = useState<
     RequirementSubFormsState[]
   >([
@@ -210,10 +207,9 @@ const GroupForm = ({
       initialValues.requirementsToFulfill !==
         REQUIREMENTS_TO_FULFILL.ALL_REQUIREMENTS
     ) {
-      setCwRequiremenetsLabelInputField({
-        ...cwRequiremenetsLabelInputField,
-        value: `${initialValues.requirementsToFulfill}`,
-      });
+      setCwRequiremenetsLabelInputValue(
+        `${initialValues.requirementsToFulfill}`,
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -342,68 +338,19 @@ const GroupForm = ({
     return !!updatedSubForms.find((x) => Object.keys(x.errors).length > 0);
   };
 
-  const validateCustomRequirementsRadioLabelValue = useCallback(
-    (value: string): boolean | number => {
-      // If radio label input has no value
-      if (!value) {
-        setCwRequiremenetsLabelInputField((prevVal) => ({
-          ...prevVal,
-          error: VALIDATION_MESSAGES.NO_INPUT,
-        }));
-        return false;
-      }
-
-      // If radio label input has invalid value
-      const requirementsToFulfill = parseInt(value || '');
-      if (
-        !requirementsToFulfill ||
-        requirementsToFulfill < 1 ||
-        requirementsToFulfill > MAX_REQUIREMENTS ||
-        requirementsToFulfill > requirementSubForms.length
-      ) {
-        setCwRequiremenetsLabelInputField((prevVal) => ({
-          ...prevVal,
-          error: VALIDATION_MESSAGES.INVALID_INPUT,
-        }));
-        return false;
-      }
-
-      return requirementsToFulfill; // return a number indicating the number of requirements to fulfill
-    },
-    [requirementSubForms.length],
-  );
-
-  useEffect(() => {
-    if (isSelectedCustomRequirementsToFulfillOption) {
-      validateCustomRequirementsRadioLabelValue(
-        cwRequiremenetsLabelInputField.value,
-      );
-    }
-  }, [
-    cwRequiremenetsLabelInputField.value,
-    isSelectedCustomRequirementsToFulfillOption,
-    validateCustomRequirementsRadioLabelValue,
-  ]);
-
   const handleSubmit = async (values: FormSubmitValues) => {
     const hasSubFormErrors = validateSubForms();
-    if (hasSubFormErrors || cwRequiremenetsLabelInputField.error) {
+    if (hasSubFormErrors) {
       return;
     }
 
     // Custom validation for the radio with input label
     let requirementsToFulfill: any = values.requirementsToFulfill;
-    setCwRequiremenetsLabelInputField({
-      ...cwRequiremenetsLabelInputField,
-      error: '',
-    });
+    setCwRequiremenetsLabelInputValue(cwRequiremenetsLabelInputValue);
     if (
       values.requirementsToFulfill === REQUIREMENTS_TO_FULFILL.N_REQUIREMENTS
     ) {
-      requirementsToFulfill = validateCustomRequirementsRadioLabelValue(
-        cwRequiremenetsLabelInputField.value,
-      );
-      if (!requirementsToFulfill) return;
+      requirementsToFulfill = parseInt(cwRequiremenetsLabelInputValue);
     }
 
     const formValues = {
@@ -542,36 +489,27 @@ const GroupForm = ({
                   onChange={(e) => {
                     if (e.target.checked) {
                       setIsSelectedCustomRequirementsToFulfillOption(false);
-                      setCwRequiremenetsLabelInputField((prevVal) => ({
-                        ...prevVal,
-                        error: '',
-                      }));
                     }
                   }}
                 />
 
                 <CWRequirementsRadioButton
-                  inputError={cwRequiremenetsLabelInputField.error}
-                  inputValue={cwRequiremenetsLabelInputField.value}
+                  maxRequirements={requirementSubForms.length}
+                  inputValue={cwRequiremenetsLabelInputValue}
                   isSelected={isSelectedCustomRequirementsToFulfillOption}
                   onSelect={() =>
                     setIsSelectedCustomRequirementsToFulfillOption(true)
                   }
                   onInputValueChange={(value) => {
-                    setCwRequiremenetsLabelInputField({
-                      value,
-                      error: '',
-                    });
+                    setCwRequiremenetsLabelInputValue(value);
                   }}
                 />
 
-                {(formState?.errors?.requirementsToFulfill?.message ||
-                  cwRequiremenetsLabelInputField.error) && (
+                {formState?.errors?.requirementsToFulfill?.message && (
                   <MessageRow
                     hasFeedback
                     statusMessage={
-                      formState?.errors?.requirementsToFulfill?.message ||
-                      cwRequiremenetsLabelInputField.error
+                      formState?.errors?.requirementsToFulfill?.message
                     }
                     validationStatus="failure"
                   />

--- a/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/index.types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Groups/common/GroupForm/index.types.ts
@@ -4,11 +4,6 @@ export type RequirementSubFormsState = {
   errors?: RequirementSubType;
 };
 
-export type CWRequirementsLabelInputFieldState = {
-  value: string;
-  error: string;
-};
-
 export type RequirementSubType = {
   requirementType?: string;
   requirementContractAddress?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6143

## Description of Changes
- Updated copy for necessary requirements selector in group form
- Updated input in necessary requirements from text input to dropdown selector

Note: the second checkbox here (now referring to as "custom necessary requirements checkbox")

<img width="493" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/8cc881c1-6729-4778-98a5-17559cb6bbc7">


## "How We Fixed It"
N/A

## Test Plan
- Visit any community in which you are an admin
- Navigate to Create Group (or Edit Group) page

While in the group form
- Verify that when the "custom necessary requirements checkbox" is not selected, its dropdown is disabled
- Verify that adding sub-requirements updates the "custom necessary requirements checkbox" dropdown options
- Verify that when updating a group, the "custom necessary requirements checkbox" takes value from the existing group config, if the value was < max requirements.

## Deployment Plan
N/A

## Other Considerations
N/A