### PR TITLE
Add base, avax, optimism migration

### DIFF
--- a/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
+++ b/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
@@ -1,0 +1,53 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const baseChainNode = {
+      url: 'https://base-mainnet.g.alchemy.com/v2/LZsi0DyfEpBVHfLxQsmt04IO7iBdanh_',
+      eth_chain_id: 8453,
+      alt_wallet_url:
+        'https://base-mainnet.g.alchemy.com/v2/LZsi0DyfEpBVHfLxQsmt04IO7iBdanh_',
+      balance_type: 'ethereum',
+      name: 'Base',
+    };
+
+    const optimismChainNode = {
+      url: 'https://opt-mainnet.g.alchemy.com/v2/QsmtYU6oC36UeqsSAfG5VS9NM6x6cggn',
+      eth_chain_id: 10,
+      alt_wallet_url:
+        'https://opt-mainnet.g.alchemy.com/v2/QsmtYU6oC36UeqsSAfG5VS9NM6x6cggn',
+      balance_type: 'ethereum',
+      name: 'Optimism',
+    };
+
+    const avaxChainNode = {
+      url: 'https://api.avax.network/ext/bc/C/rpc',
+      eth_chain_id: 43114,
+      alt_wallet_url: 'https://api.avax.network/ext/bc/C/rpc',
+      balance_type: 'ethereum',
+      name: 'Avalanche',
+    };
+
+    queryInterface.bulkInsert('ChainNodes', [
+      baseChainNode,
+      optimismChainNode,
+      avaxChainNode,
+    ]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const conditions = {
+      [Sequelize.Op.or]: [
+        {
+          url: 'https://base-mainnet.g.alchemy.com/v2/LZsi0DyfEpBVHfLxQsmt04IO7iBdanh_',
+        },
+        {
+          url: 'https://opt-mainnet.g.alchemy.com/v2/QsmtYU6oC36UeqsSAfG5VS9NM6x6cggn',
+        },
+        { url: 'https://api.avax.network/ext/bc/C/rpc' },
+      ],
+    };
+
+    return queryInterface.bulkDelete('ChainNodes', conditions, { transaction });
+  },
+};

--- a/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
+++ b/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
@@ -28,7 +28,7 @@ module.exports = {
       name: 'Avalanche',
     };
 
-    queryInterface.bulkInsert('ChainNodes', [
+    await queryInterface.bulkInsert('ChainNodes', [
       baseChainNode,
       optimismChainNode,
       avaxChainNode,

--- a/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
+++ b/packages/commonwealth/server/migrations/20240110174904-avax-base-optimism-chainNodes.js
@@ -48,6 +48,6 @@ module.exports = {
       ],
     };
 
-    return queryInterface.bulkDelete('ChainNodes', conditions, { transaction });
+    return queryInterface.bulkDelete('ChainNodes', conditions);
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5675 
## Description of Changes
- Adds migration to add three new chains
- Will be included in create community and groups now

## Test Plan
- Run migration
- Confirm base, avax, optimism are available in create community and groups
- confirm group/community can be created
- 
## Deployment Plan
<!--- Omit if unneeded -->
1. run migration
2. New alchemy app to be created with `private_url` updated post merge

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Alchemy has nodes for base and optimism, but not avax so used an avax public node. Could have rate limits etc 
