### PR TITLE
Fix: Cosmos join community with Magic

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -324,7 +324,7 @@ async function constructMagic(isCosmos: boolean, chain?: string) {
           new OAuthExtension(),
           new CosmosExtension({
             // Magic has a strict cross-origin policy that restricts rpcs to whitelisted URLs,
-            // so make sure this is whitelisted in Magic dashboard.
+            // so we proxy the Cosmos RPC through the server
             rpcUrl: `${document.location.origin}/magicCosmosAPI/${chain}`,
           }),
         ],

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -324,7 +324,7 @@ async function constructMagic(isCosmos: boolean, chain?: string) {
           new OAuthExtension(),
           new CosmosExtension({
             // Magic has a strict cross-origin policy that restricts rpcs to whitelisted URLs,
-            // so make sure cosmoshub's ChainNode url is whitelisted in Magic dashboard.
+            // so make sure this is whitelisted in Magic dashboard.
             rpcUrl: `${document.location.origin}/magicCosmosAPI/${chain}`,
           }),
         ],

--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -85,7 +85,7 @@ export async function signSessionWithMagic(
 ) {
   const idOrPrefix =
     walletChain === ChainBase.CosmosSDK
-      ? app.chain?.meta.bech32Prefix || 'cosmos'
+      ? 'cosmos'
       : app.chain?.meta.node?.ethChainId || 1;
   const canvasChainId = chainBaseToCanvasChainId(walletChain, idOrPrefix);
   const sessionPublicAddress = await app.sessions.getOrCreateAddress(

--- a/packages/commonwealth/client/scripts/helpers/canvas.ts
+++ b/packages/commonwealth/client/scripts/helpers/canvas.ts
@@ -55,6 +55,7 @@ export const verify = async ({
           `Invalid signature: signature did not match ${signaturePattern}`,
         );
       }
+      // eslint-disable-next-line no-unused-vars
       const [_, domain, nonce, signatureData] = signaturePatternMatch;
       const siweMessage = createSiweMessage(sessionPayload, domain, nonce);
 

--- a/packages/commonwealth/client/scripts/helpers/canvas.ts
+++ b/packages/commonwealth/client/scripts/helpers/canvas.ts
@@ -55,7 +55,7 @@ export const verify = async ({
           `Invalid signature: signature did not match ${signaturePattern}`,
         );
       }
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [_, domain, nonce, signatureData] = signaturePatternMatch;
       const siweMessage = createSiweMessage(sessionPayload, domain, nonce);
 

--- a/packages/commonwealth/client/scripts/helpers/canvas.ts
+++ b/packages/commonwealth/client/scripts/helpers/canvas.ts
@@ -1,13 +1,13 @@
 import type { Action, Session } from '@canvas-js/interfaces';
 
 import {
-  createSiweMessage,
-  getEIP712SignableAction,
-} from '../../../shared/adapters/chain/ethereum/keys';
-import {
   getADR036SignableAction,
   getADR036SignableSession,
 } from '../../../shared/adapters/chain/cosmos/keys';
+import {
+  createSiweMessage,
+  getEIP712SignableAction,
+} from '../../../shared/adapters/chain/ethereum/keys';
 
 // TODO: verify payload is not expired
 export const verify = async ({
@@ -42,7 +42,7 @@ export const verify = async ({
         domain as any,
         types,
         message,
-        signature
+        signature,
       );
       return recoveredAddr.toLowerCase() === actionSignerAddress.toLowerCase();
     } else {
@@ -52,7 +52,7 @@ export const verify = async ({
       const signaturePatternMatch = signaturePattern.exec(signature);
       if (signaturePatternMatch === null) {
         throw new Error(
-          `Invalid signature: signature did not match ${signaturePattern}`
+          `Invalid signature: signature did not match ${signaturePattern}`,
         );
       }
       const [_, domain, nonce, signatureData] = signaturePatternMatch;
@@ -60,7 +60,7 @@ export const verify = async ({
 
       const recoveredAddress = ethersUtils.verifyMessage(
         siweMessage,
-        signatureData
+        signatureData,
       );
       return (
         recoveredAddress.toLowerCase() === session.payload.from.toLowerCase()
@@ -81,24 +81,24 @@ export const verify = async ({
       const canvas = await import('@canvas-js/interfaces');
       const prefix = cosmEncoding.fromBech32(sessionPayload.from).prefix;
       const signDocDigest = new cosmCrypto.Sha256(
-        Buffer.from(canvas.serializeSessionPayload(sessionPayload))
+        Buffer.from(canvas.serializeSessionPayload(sessionPayload)),
       ).digest();
       // decode "{ pub_key, signature }" to an object with { pubkey, signature }
       const { pubkey, signature: decodedSignature } = cosmAmino.decodeSignature(
-        JSON.parse(signature)
+        JSON.parse(signature),
       );
       const secpSignature =
         cosmCrypto.Secp256k1Signature.fromFixedLength(decodedSignature);
       const valid = await cosmCrypto.Secp256k1.verifySignature(
         secpSignature,
         signDocDigest,
-        pubkey
+        pubkey,
       );
       if (
         payload.from !==
         cosmEncoding.toBech32(
           prefix,
-          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey)
+          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey),
         )
       )
         return false;
@@ -109,7 +109,7 @@ export const verify = async ({
       const ethUtil = await import('ethereumjs-util');
       const canvas = await import('@canvas-js/interfaces');
       const msgHash = ethUtil.hashPersonalMessage(
-        Buffer.from(canvas.serializeSessionPayload(sessionPayload))
+        Buffer.from(canvas.serializeSessionPayload(sessionPayload)),
       );
       const ethSignatureParams = ethUtil.fromRpcSig(signature.trim());
       // recover the eth signature, then convert to cosmos address
@@ -117,18 +117,18 @@ export const verify = async ({
         msgHash,
         ethSignatureParams.v,
         ethSignatureParams.r,
-        ethSignatureParams.s
+        ethSignatureParams.s,
       );
       const lowercaseAddress = ethUtil.bufferToHex(
-        ethUtil.publicToAddress(publicKey)
+        ethUtil.publicToAddress(publicKey),
       );
       const bech32AddrBuf = ethUtil.Address.fromString(
-        lowercaseAddress.toString()
+        lowercaseAddress.toString(),
       ).toBuffer();
       const { prefix } = bech32.bech32.decode(payload.from);
       const bech32Address = bech32.bech32.encode(
         prefix,
-        bech32.bech32.toWords(bech32AddrBuf)
+        bech32.bech32.toWords(bech32AddrBuf),
       );
       const valid = payload.from === bech32Address;
       return valid;
@@ -137,48 +137,48 @@ export const verify = async ({
     if (action) {
       const signDocPayload = await getADR036SignableAction(
         actionPayload,
-        actionSignerAddress
+        actionSignerAddress,
       );
       const signDocDigest = new cosmCrypto.Sha256(
-        cosmAmino.serializeSignDoc(signDocPayload)
+        cosmAmino.serializeSignDoc(signDocPayload),
       ).digest();
       const prefix = 'cosmos'; // not: fromBech32(payload.from).prefix;
       const extendedSecp256k1Signature =
         cosmCrypto.ExtendedSecp256k1Signature.fromFixedLength(
-          Buffer.from(signature, 'hex')
+          Buffer.from(signature, 'hex'),
         );
       const pubkey = cosmCrypto.Secp256k1.compressPubkey(
         cosmCrypto.Secp256k1.recoverPubkey(
           extendedSecp256k1Signature,
-          signDocDigest
-        )
+          signDocDigest,
+        ),
       );
       return (
         actionSignerAddress ===
         cosmEncoding.toBech32(
           prefix,
-          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey)
+          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey),
         )
       );
     } else {
       const canvas = await import('@canvas-js/interfaces');
       const signDocPayload = await getADR036SignableSession(
         Buffer.from(canvas.serializeSessionPayload(sessionPayload)),
-        payload.from
+        payload.from,
       );
       const signDocDigest = new cosmCrypto.Sha256(
-        cosmAmino.serializeSignDoc(signDocPayload)
+        cosmAmino.serializeSignDoc(signDocPayload),
       ).digest();
       const prefix = cosmEncoding.fromBech32(payload.from).prefix;
       // decode "{ pub_key, signature }" to an object with { pubkey, signature }
       const { pubkey, signature: decodedSignature } = cosmAmino.decodeSignature(
-        JSON.parse(signature)
+        JSON.parse(signature),
       );
       if (
         payload.from !==
         cosmEncoding.toBech32(
           prefix,
-          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey)
+          cosmAmino.rawSecp256k1PubkeyToRawAddress(pubkey),
         )
       )
         return false;
@@ -187,7 +187,7 @@ export const verify = async ({
       const valid = await cosmCrypto.Secp256k1.verifySignature(
         secpSignature,
         signDocDigest,
-        pubkey
+        pubkey,
       );
       return valid;
     }
@@ -202,12 +202,12 @@ export const verify = async ({
     const message = new TextEncoder().encode(stringPayload);
     const signatureBytes = bs58.decode(signature);
     const signerPublicKeyBytes = bs58.decode(
-      action ? actionSignerAddress : payload.from
+      action ? actionSignerAddress : payload.from,
     );
     const valid = nacl.sign.detached.verify(
       message,
       signatureBytes,
-      signerPublicKeyBytes
+      signerPublicKeyBytes,
     );
     return valid;
   } else if (payload.chain === 'near') {
@@ -224,7 +224,7 @@ export const verify = async ({
       const valid = nacl.sign.detached.verify(
         message,
         signatureBytes,
-        publicKey.data
+        publicKey.data,
       );
       return valid;
     } else if (session) {
@@ -239,13 +239,13 @@ export const verify = async ({
         JSON.parse(signature);
       // encoded in client/scripts/controllers/chain/near/account.ts
       const publicKey = nearlib.PublicKey.fromString(
-        bs58.encode(Buffer.from(publicKeyEncoded, 'base64'))
+        bs58.encode(Buffer.from(publicKeyEncoded, 'base64')),
       );
       const signatureBytes = Buffer.from(signatureEncoded, 'base64');
       const valid = nacl.sign.detached.verify(
         message,
         signatureBytes,
-        publicKey.data
+        publicKey.data,
       );
       return valid;
     }
@@ -259,12 +259,12 @@ export const verify = async ({
     const message = new TextEncoder().encode(stringPayload);
     const signatureBytes = new Buffer(
       action ? signature : signature.slice(2),
-      'hex'
+      'hex',
     );
     const valid = polkadotUtil.signatureVerify(
       message,
       signatureBytes,
-      action ? actionSignerAddress : payload.from
+      action ? actionSignerAddress : payload.from,
     ).isValid;
     return valid;
   } else {

--- a/packages/commonwealth/client/scripts/views/pages/finish_social_login.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/finish_social_login.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { useCommonNavigate } from 'navigation/helpers';
-import { PageLoading } from 'views/pages/loading';
-import ErrorPage from 'views/pages/error';
 import { handleSocialLoginCallback } from 'controllers/app/login';
+import { useCommonNavigate } from 'navigation/helpers';
+import React, { useEffect, useState } from 'react';
 import app, { initAppState } from 'state';
+import ErrorPage from 'views/pages/error';
+import { PageLoading } from 'views/pages/loading';
 
 const validate = async (setRoute) => {
   const params = new URLSearchParams(window.location.search);

--- a/packages/commonwealth/server/migrations/20240123200556-cosmos-rpc.js
+++ b/packages/commonwealth/server/migrations/20240123200556-cosmos-rpc.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        INSERT INTO "ChainNodes" (name, url, alt_wallet_url, balance_type, cosmos_chain_id, created_at, updated_at) VALUES (
+          'Cosmos Hub',
+          'https://rpc.cosmos.directory/cosmoshub',
+          'https://rest.cosmos.directory/cosmoshub',
+          'cosmos',
+          'cosmoshub',
+           NOW(),
+           NOW()
+        );
+      `,
+        { transaction },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        DELETE FROM "ChainNodes" WHERE cosmos_chain_id = 'cosmoshub';
+      `,
+        { transaction },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -417,7 +417,7 @@ async function magicLoginRoute(
           },
         ],
       });
-      log.info(
+      log.trace(
         `DECODED LOGGED IN USER: ${JSON.stringify(loggedInUser, null, 2)}`,
       );
       if (!loggedInUser) {
@@ -431,7 +431,6 @@ async function magicLoginRoute(
   const magicUserMetadata = await magic.users.getMetadataByIssuer(
     decodedMagicToken.issuer,
   );
-
   log.trace(
     `MAGIC USER METADATA: ${JSON.stringify(magicUserMetadata, null, 2)}`,
   );

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -109,7 +109,7 @@ function setupCosmosProxy(app: Express, models: DB) {
   // - POST / for node info
   // - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
   // - GET /auth/accounts/:address for fetching address status (use by magic iframe)
-  app.options('/magicCosmosAPI/:chain', (req, res, next) => {
+  app.options('/magicCosmosAPI/:chain', (req, res) => {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Private-Network', 'true');
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
@@ -143,19 +143,6 @@ function setupCosmosProxy(app: Express, models: DB) {
             req.body.method === 'abci_query' &&
             req.body.params.path === '/cosmos.auth.v1beta1.Query/Account'
           ) {
-            const hexToStr = (hex) =>
-              String.fromCharCode(
-                ...hex.match(/.{1,2}/g).map((c) => parseInt(c, 16)),
-              )
-                .replace('-', '')
-                .replace(/\n/g, '');
-
-            // TODO: validate?
-            const cosmosAddress = hexToStr(req.body.params.data);
-
-            // magicCosmosAPI is CORS-approved for the magic iframe
-            res.setHeader('Access-Control-Allow-Origin', '*');
-
             // TODO: stub out value, get block height
             response = {
               data: JSON.stringify({
@@ -168,8 +155,8 @@ function setupCosmosProxy(app: Express, models: DB) {
                     info: '',
                     index: '0',
                     key: null,
-                    value:
-                      'ClcKIC9jb3Ntb3MuYXV0aC52MWJldGExLkJhc2VBY2NvdW50EjMKLWNvc21vczFyYXpsM2gyZWo0dDZrbmVqOGttd2R2Y2xraGV0ZHVyemp6Z211Yxjih20=',
+                    value: `ClcKIC9jb3Ntb3MuYXV0aC52MWJldGExLkJhc2VBY2NvdW50EjMKLWNvc
+                    21vczFyYXpsM2gyZWo0dDZrbmVqOGttd2R2Y2xraGV0ZHVyemp6Z211Yxjih20=`,
                     proofOps: null,
                     height: '17101151',
                     codespace: '',

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -105,10 +105,12 @@ function setupCosmosProxy(app: Express, models: DB) {
     },
   );
 
-  // cosmos-api proxies for the magic link iframe
-  // - POST / for node info
-  // - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
-  // - GET /auth/accounts/:address for fetching address status (use by magic iframe)
+  /**
+   *  cosmos-api proxies for the magic link iframe
+   * - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
+   * - POST / for node info
+   * - POST /cosmos.auth.v1beta1.Query/Account for fetching address status (use by magic iframe)
+   */
   app.options('/magicCosmosAPI/:chain', (req, res) => {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Private-Network', 'true');
@@ -123,12 +125,9 @@ function setupCosmosProxy(app: Express, models: DB) {
   app.use(
     '/magicCosmosAPI/:chain/?(node_info)?',
     bodyParser.text(),
-    cacheDecorator.cacheMiddleware(
-      defaultCacheDuration,
-      lookupKeyDurationInReq,
-    ),
     async (req, res) => {
       log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      // always use cosmoshub for simplicity
       const chainNode = await models.ChainNode.findOne({
         where: { cosmos_chain_id: 'cosmoshub' },
       });

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -104,6 +104,113 @@ function setupCosmosProxy(app: Express, models: DB) {
       }
     },
   );
+
+  // cosmos-api proxies for the magic link iframe
+  // - POST / for node info
+  // - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
+  // - GET /auth/accounts/:address for fetching address status (use by magic iframe)
+  app.options('/magicCosmosAPI/:chain', (req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Private-Network', 'true');
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, Content-Length, X-Requested-With',
+    );
+    res.sendStatus(200);
+  });
+
+  app.use(
+    '/magicCosmosAPI/:chain/?(node_info)?',
+    bodyParser.text(),
+    cacheDecorator.cacheMiddleware(
+      defaultCacheDuration,
+      lookupKeyDurationInReq,
+    ),
+    async (req, res) => {
+      log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      const chainNode = await models.ChainNode.findOne({
+        where: { cosmos_chain_id: 'cosmoshub' },
+      });
+      const targetRestUrl = chainNode?.alt_wallet_url;
+      const targetRpcUrl = chainNode?.url;
+      log.trace(`Found cosmos endpoint: ${targetRestUrl}, ${targetRpcUrl}`);
+
+      try {
+        let response;
+        if (req.method === 'POST') {
+          if (
+            req.body.method === 'abci_query' &&
+            req.body.params.path === '/cosmos.auth.v1beta1.Query/Account'
+          ) {
+            const hexToStr = (hex) =>
+              String.fromCharCode(
+                ...hex.match(/.{1,2}/g).map((c) => parseInt(c, 16)),
+              )
+                .replace('-', '')
+                .replace(/\n/g, '');
+
+            // TODO: validate?
+            const cosmosAddress = hexToStr(req.body.params.data);
+
+            // magicCosmosAPI is CORS-approved for the magic iframe
+            res.setHeader('Access-Control-Allow-Origin', '*');
+
+            // TODO: stub out value, get block height
+            response = {
+              data: JSON.stringify({
+                jsonrpc: '2.0',
+                id: req.body.id,
+                result: {
+                  response: {
+                    code: 0,
+                    log: '',
+                    info: '',
+                    index: '0',
+                    key: null,
+                    value:
+                      'ClcKIC9jb3Ntb3MuYXV0aC52MWJldGExLkJhc2VBY2NvdW50EjMKLWNvc21vczFyYXpsM2gyZWo0dDZrbmVqOGttd2R2Y2xraGV0ZHVyemp6Z211Yxjih20=',
+                    proofOps: null,
+                    height: '17101151',
+                    codespace: '',
+                  },
+                },
+              }),
+            };
+            res.setHeader('Content-Type', 'application/json');
+          } else {
+            response = await axios.post(targetRpcUrl, req.body, {
+              headers: {
+                origin: 'https://commonwealth.im/?magic_login_proxy=true',
+              },
+            });
+          }
+        } else {
+          response = await axios.get(targetRestUrl + '/node_info', {
+            headers: {
+              origin: 'https://commonwealth.im/?magic_login_proxy=true',
+            },
+          });
+        }
+        log.trace(
+          `Got response from endpoint: ${JSON.stringify(
+            response.data,
+            null,
+            2,
+          )}`,
+        );
+
+        // magicCosmosAPI is CORS-approved for the magic iframe
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', '*');
+        res.setHeader('Access-Control-Allow-Headers', 'content-type');
+        return res.send(response.data);
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      }
+    },
+  );
 }
 
 export default setupCosmosProxy;

--- a/packages/commonwealth/shared/adapters/chain/cosmos/keys.ts
+++ b/packages/commonwealth/shared/adapters/chain/cosmos/keys.ts
@@ -1,8 +1,8 @@
 // Cosmos cannot sign arbitrary blobs, but they can sign transactions. So, as a hack around that,
 // we insert our account registration token into a proposal message, and then verify against the
 // generated signature. But first we need the message to insert.
-import type { AminoMsg, StdFee, StdSignDoc } from '@cosmjs/amino';
 import type { ActionPayload } from '@canvas-js/interfaces';
+import type { AminoMsg, StdFee, StdSignDoc } from '@cosmjs/amino';
 import { configure as configureStableStringify } from 'safe-stable-stringify';
 
 const sortedStringify = configureStableStringify({
@@ -14,7 +14,7 @@ const sortedStringify = configureStableStringify({
 
 export const getADR036SignableAction = async (
   actionPayload: ActionPayload,
-  address: string
+  address: string,
 ): Promise<StdSignDoc> => {
   const accountNumber = 0;
   const sequence = 0;
@@ -39,7 +39,7 @@ export const getADR036SignableAction = async (
     chainId,
     memo,
     accountNumber,
-    sequence
+    sequence,
   );
   return signDoc;
 };
@@ -47,7 +47,7 @@ export const getADR036SignableAction = async (
 export const getADR036SignableSession = async (
   token: Uint8Array,
   address: string,
-  chainId = ''
+  chainId = '',
 ): Promise<StdSignDoc> => {
   const accountNumber = 0;
   const sequence = 0;
@@ -72,7 +72,7 @@ export const getADR036SignableSession = async (
     chainId,
     memo,
     accountNumber,
-    sequence
+    sequence,
   );
   return signDoc;
 };

--- a/packages/commonwealth/shared/canvas/chainMappings.ts
+++ b/packages/commonwealth/shared/canvas/chainMappings.ts
@@ -36,12 +36,12 @@ export function caip2ToChainBase(caip2: string): ChainBase {
 
 export function chainBaseToCanvasChainId(
   chainBase: ChainBase,
-  idOrPrefix: string | number,
+  idOrPrefix?: string | number,
 ): string {
   // The Canvas chain id is a stringified ETH chain ID, or Cosmos bech32 prefix, or equivalent.
   if (chainBase === ChainBase.CosmosSDK) {
-    // Temporarily locked to cosmoshub-1, since we don't have the live chain ID for cosmos chains
-    return 'cosmoshub-1';
+    // Temporarily locked to cosmoshub-4, since we don't have the live chain ID for cosmos chains
+    return 'cosmoshub-4';
   } else if (chainBase === ChainBase.Ethereum) {
     return idOrPrefix.toString();
   } else if (chainBase === ChainBase.NEAR) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3944,16 +3944,16 @@
     "@lit-labs/ssr-dom-shim" "^1.0.0"
 
 "@magic-ext/cosmos@^12.1.3":
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/@magic-ext/cosmos/-/cosmos-12.1.3.tgz#4e7eed788d0611129cd6aeafa3d334a64623a1fd"
-  integrity sha512-tsCKMF+GTMd9jfdhm6VN9zXR/XrIoTzpa8Y0j74iFGiISm8PyHfyT4Sp+Y5KXP6E29dOBCaZfslK/rzHpn0SHA==
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/@magic-ext/cosmos/-/cosmos-12.4.0.tgz#9ceed13209aa56ae6b744fc42e3fbd798310ae45"
+  integrity sha512-WfLlUzkKVfqO9vv+h8fA7z/KAcBL6tbLjSPHZCr8WbBUL/Me86Pmx8g8Zftb19oaGmYM+XkPVli7h20zBRE2oA==
 
 "@magic-ext/oauth@^11.1.1":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@magic-ext/oauth/-/oauth-11.2.0.tgz#21b5d8f7a58463f324db2d7315f065fcec3c2046"
-  integrity sha512-F308JC5+dVOutsLtBJBdPshDGPOlchAlcedJoqcBie/NBr8VRq0eI3+cRWcvz6LFHnn6nD83g5FIOYS1C8X4KA==
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@magic-ext/oauth/-/oauth-11.4.0.tgz#a14df3195d3936c5626a21efa55113b0806ff555"
+  integrity sha512-BDgQolLq6ck5JkFFH0eIs81NOaMQYmr/p4wBrRdxwBBIQtYg3FF5qLPsOoppdEO7BifNhrEKKWkyNzH//Eafmw==
   dependencies:
-    "@magic-sdk/types" "^15.2.0"
+    "@magic-sdk/types" "^15.4.0"
 
 "@magic-sdk/admin@^0.1.0-beta.8":
   version "0.1.0-beta.10"
@@ -3966,38 +3966,33 @@
     node-fetch "^2.6.0"
 
 "@magic-sdk/admin@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-1.10.0.tgz#9c5e17f65fe136ba670446e2513d64f80e1544fe"
-  integrity sha512-byPp3DPpGyl+/71zN7lyKlLFEJuP944hI0NArHkJkCDsZBcSZ+6X3T9ipetnKz8MM2eCVTQB+HkYeNDd9lct2Q==
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-1.10.1.tgz#f8881928a9ee49816008ef7e51dcd1217fdef74b"
+  integrity sha512-Ju+HoXJPEkFOTf52TMAO4L0+CXPthlGSJIjV+D5xvvhcab3Ddm6ykMzApoF9i3p7K/MM06SmS+SMM9z6b4JRQg==
   dependencies:
     "@types/atob" "^2.1.2"
     atob "^2.1.2"
     ethereum-cryptography "^1.0.1"
     node-fetch "^2.6.0"
 
-"@magic-sdk/commons@^13.1.3":
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/commons/-/commons-13.1.3.tgz#c7a60970f1e8fb67b6e3ad8b0668c3135fff728b"
-  integrity sha512-4cdQz81G/W3TjxnR1YAlKQslXr1BpyAjmv+VbhtrUzcIAJGKZXFQ8hbpkOPauK5qc+isHJPbEQ2Qj/BNn0R7Sg==
+"@magic-sdk/commons@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/commons/-/commons-13.4.0.tgz#6217fd8e7346f5029c7c584d98578c36d26ec3db"
+  integrity sha512-F6XG0r0XEZmGB8OTPNFrRz6IgDhb39YxUrG2n/4hajb0vJuA28QjoexG/d7f6Rklvxq9oIBR1wMuqUzGs3oSnA==
 
-"@magic-sdk/provider@^17.1.3":
-  version "17.1.3"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/provider/-/provider-17.1.3.tgz#a5e708b0385c7b0d9b5d75523c9e7a39fffd7a54"
-  integrity sha512-1Bhu09EQmeNtBu4LwsYxaXOtbPvDRlzyMqCOlVls3pz1O0JZNoVGuDe4RBH4nLS6+3kTIIpyh+iAz4MLaVctnA==
+"@magic-sdk/provider@^17.4.0":
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/provider/-/provider-17.4.0.tgz#f22174899f36664fcebd47781b3c497479abe671"
+  integrity sha512-DvroR5qCumGtS8TY8wr/4bI9bvkUD222ghbNTsu9MFAgybksc6/ARUX8ttjFZVQXMIIe07PpZroxnxI+ih5mlA==
   dependencies:
-    "@magic-sdk/types" "^15.1.3"
+    "@magic-sdk/types" "^15.4.0"
     eventemitter3 "^4.0.4"
     web3-core "1.5.2"
 
-"@magic-sdk/types@^15.1.3":
-  version "15.1.3"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/types/-/types-15.1.3.tgz#57f8c814e5b8a9a16349e13b19cb981e69dc6671"
-  integrity sha512-ee0pIHoJkm3BX3WiunJYdQwqP0PNK46Rnelhc7RYq+pG46SuWAUGrJo2dzT7+RYJNo7dRqKNnVJ/WahPSLvkuQ==
-
-"@magic-sdk/types@^15.2.0":
-  version "15.2.0"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/types/-/types-15.2.0.tgz#b0f1fa352b2cdbd4b1ba2a3666407900e41fc311"
-  integrity sha512-oS6yShBsBWWhTsEZtEPqJ2cY+b/7iQlqh36eeySKlWFPXQXbakTx20Tbr6CI0svFWQNDgX240hfHbyF2PRClxQ==
+"@magic-sdk/types@^15.4.0":
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/types/-/types-15.8.0.tgz#d54dc8221bb0f69c74ff96d486535ce150c2c04b"
+  integrity sha512-xLQsBAg2JXUn39dRfZW6Z3LUT50qz/3pg6R658oVBr4LbJd/L8iAR0zCRmjLLNXzfYm1RkJYZWuHaxjJgKlkSA==
 
 "@metamask/detect-provider@^2.0.0":
   version "2.0.0"
@@ -5393,9 +5388,9 @@
     "@types/node" "*"
 
 "@types/atob@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
-  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.4.tgz#50bb756a99bbdba6995f2d10a134d21a881323b3"
+  integrity sha512-FisOhG87cCFqzCgq6FUtSYsTMOHCB/p28zJbSN1QBo4ZGJfg9PEhMjdIV++NDeOnloUUe0Gz6jwBV+L1Ac00Mw==
 
 "@types/better-sqlite3@^7.6.4":
   version "7.6.4"
@@ -7678,7 +7673,7 @@ at-least-node@^1.0.0:
 
 atob@^2.1.2:
   version "2.1.2"
-  resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 atomic-sleep@^1.0.0:
@@ -15648,13 +15643,13 @@ ltgt@~2.2.0:
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
 
 magic-sdk@^17.1.4:
-  version "17.1.4"
-  resolved "https://registry.yarnpkg.com/magic-sdk/-/magic-sdk-17.1.4.tgz#353fcbbca06e462d896058c8ca7f4108c3b6244e"
-  integrity sha512-VNRVIEiC+RH2l8U3XGMrJiPhTA7bpfen7cEqe25p/jCl6fPXxd9ISN1ZJN5ypj2KO8obbllY0evgkm6UgDi5zg==
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/magic-sdk/-/magic-sdk-17.4.0.tgz#ed5a71c1308b484b2e7615eb39d10194907ac6ed"
+  integrity sha512-oIsj0D01pSDhiuscZ4KCUcT07pWlg2+wsqZHzs5IAYbd1d4PM6+ZvYjTeob9W0Cl5FB8NNE0W8GUumvTd4fqqA==
   dependencies:
-    "@magic-sdk/commons" "^13.1.3"
-    "@magic-sdk/provider" "^17.1.3"
-    "@magic-sdk/types" "^15.1.3"
+    "@magic-sdk/commons" "^13.4.0"
+    "@magic-sdk/provider" "^17.4.0"
+    "@magic-sdk/types" "^15.4.0"
     localforage "^1.7.4"
 
 make-dir@^2.0.0, make-dir@^2.1.0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6230 

## Description of Changes
- Fixes case: Can't join a Cosmos community with a new E-mail address

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Uses cosmoshub for all Cosmos-Magic: `cosmos1...` addresses are valid for joining Cosmos communities
- `magicCosmosAPI` proxy handles magic calls

## Test Plan
- CA (click around) tested on local:
  - go to /terra-luna-classic-lunc or /osmosis or /injective
  - Sign in with an email address that hasn't been used for CW yet
  - Expect to sign in successfully and see "Joined" and "Connected" with a `cosmos..` address

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 