### PR TITLE
Notifications model semantics

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -152,7 +152,7 @@ export async function __deleteCommunity(
 
           // notifications + notifications_read (cascade)
           await this.models.Notification.destroy({
-            where: { chain_id: community.id },
+            where: { community_id: community.id },
             transaction: t,
           });
 

--- a/packages/commonwealth/server/migrations/20240111163208-notifications-semantics.js
+++ b/packages/commonwealth/server/migrations/20240111163208-notifications-semantics.js
@@ -1,0 +1,51 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.renameColumn(
+        'Notifications',
+        'chain_id',
+        'community_id',
+        {
+          transaction,
+        },
+      );
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE "Notifications"
+        RENAME CONSTRAINT "Notifications_chain_id_fkey" TO "Notifications_community_id_fkey";
+      `,
+        { transaction },
+      );
+      await queryInterface.removeIndex('Notifications', 'new_chain_event_id', {
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.renameColumn(
+        'Notifications',
+        'community_id',
+        'chain_id',
+        {
+          transaction,
+        },
+      );
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE "Notifications"
+        RENAME CONSTRAINT "Notifications_community_id_fkey" TO "Notifications_chain_id_fkey";
+      `,
+        { transaction },
+      );
+      await queryInterface.addIndex('Notifications', {
+        fields: ['chain_event_id'],
+        name: 'new_chain_event_id',
+        transaction,
+      });
+    });
+  },
+};

--- a/packages/commonwealth/server/models/community.ts
+++ b/packages/commonwealth/server/models/community.ts
@@ -174,7 +174,9 @@ export default (
       foreignKey: 'chain_node_id',
     });
     models.Community.hasMany(models.Address, { foreignKey: 'community_id' });
-    models.Community.hasMany(models.Notification, { foreignKey: 'chain_id' });
+    models.Community.hasMany(models.Notification, {
+      foreignKey: 'community_id',
+    });
     models.Community.hasMany(models.Topic, {
       as: 'topics',
       foreignKey: 'community_id',

--- a/packages/commonwealth/server/models/notification.ts
+++ b/packages/commonwealth/server/models/notification.ts
@@ -42,8 +42,7 @@ export default (
       notification_data: { type: dataTypes.TEXT, allowNull: false },
       chain_event_id: { type: dataTypes.INTEGER, allowNull: true },
       entity_id: { type: dataTypes.INTEGER, allowNull: true },
-      // eslint-disable-next-line max-len
-      community_id: { type: dataTypes.STRING, allowNull: true }, // for backwards compatibility of threads associated with OffchainCommunities rather than a proper chain
+      community_id: { type: dataTypes.STRING, allowNull: true },
       category_id: { type: dataTypes.STRING, allowNull: false },
       thread_id: { type: dataTypes.INTEGER, allowNull: true },
     },

--- a/packages/commonwealth/server/models/notification.ts
+++ b/packages/commonwealth/server/models/notification.ts
@@ -15,7 +15,7 @@ const log = loggerFactory.getLogger(formatFilename(__filename));
 export type NotificationAttributes = {
   id: number;
   notification_data: string;
-  chain_id?: string;
+  community_id?: string;
   category_id: string;
   chain_event_id?: number;
   entity_id: number;
@@ -43,7 +43,7 @@ export default (
       chain_event_id: { type: dataTypes.INTEGER, allowNull: true },
       entity_id: { type: dataTypes.INTEGER, allowNull: true },
       // eslint-disable-next-line max-len
-      chain_id: { type: dataTypes.STRING, allowNull: true }, // for backwards compatibility of threads associated with OffchainCommunities rather than a proper chain
+      community_id: { type: dataTypes.STRING, allowNull: true }, // for backwards compatibility of threads associated with OffchainCommunities rather than a proper chain
       category_id: { type: dataTypes.STRING, allowNull: false },
       thread_id: { type: dataTypes.INTEGER, allowNull: true },
     },
@@ -82,7 +82,10 @@ export default (
       underscored: true,
       createdAt: 'created_at',
       updatedAt: 'updated_at',
-      indexes: [{ fields: ['chain_event_id'], prefix: 'new' }],
+      indexes: [
+        { fields: ['chain_event_id'], unique: true },
+        { fields: ['thread_id'] },
+      ],
     },
   );
 
@@ -97,7 +100,7 @@ export default (
       targetKey: 'name',
     });
     models.Notification.belongsTo(models.Community, {
-      foreignKey: 'chain_id',
+      foreignKey: 'community_id',
       targetKey: 'id',
     });
     models.Notification.belongsTo(models.Thread, {

--- a/packages/commonwealth/server/scripts/emitTestNotification.ts
+++ b/packages/commonwealth/server/scripts/emitTestNotification.ts
@@ -122,7 +122,7 @@ async function getExistingNotifications(
     existingNotifications = await models.Notification.findAll({
       where: {
         category_id: NotificationCategories.ChainEvent,
-        chain_id: chainId,
+        community_id: chainId,
       },
       order: Sequelize.literal(`RANDOM()`),
       limit: 1,
@@ -167,7 +167,7 @@ async function setupNotification(
     const existingCeMockNotif = await models.Notification.findAll({
       where: {
         category_id: NotificationCategories.ChainEvent,
-        chain_id: chainId,
+        community_id: chainId,
         chain_event_id: mockNotif.id || null,
         [Sequelize.Op.and]: [
           Sequelize.literal(

--- a/packages/commonwealth/server/util/emitNotifications.ts
+++ b/packages/commonwealth/server/util/emitNotifications.ts
@@ -123,13 +123,13 @@ export default async function emitNotifications(
         notification_data: JSON.stringify(chainEvent),
         chain_event_id: chainEvent.id,
         category_id: 'chain-event',
-        chain_id: chainEvent.chain,
+        community_id: chainEvent.chain,
       });
     } else {
       notification = await models.Notification.create({
         notification_data: JSON.stringify(notification_data),
         category_id,
-        chain_id: (<IForumNotificationData>notification_data).chain_id,
+        community_id: (<IForumNotificationData>notification_data).chain_id,
         thread_id:
           Number((<IForumNotificationData>notification_data).thread_id) ||
           undefined,

--- a/packages/commonwealth/server/workers/cosmosGovNotifications/util.ts
+++ b/packages/commonwealth/server/workers/cosmosGovNotifications/util.ts
@@ -44,23 +44,23 @@ export async function fetchCosmosNotifChains(models: DB) {
 
 export async function fetchLatestNotifProposalIds(
   models: DB,
-  chainIds: string[],
+  communityIds: string[],
 ): Promise<Record<string, number>> {
-  if (chainIds.length === 0) return {};
+  if (communityIds.length === 0) return {};
 
   const result = (await models.sequelize.query(
     `
     SELECT
-    chain_id, MAX(notification_data::jsonb -> 'event_data' ->> 'id') as proposal_id
+    community_id, MAX(notification_data::jsonb -> 'event_data' ->> 'id') as proposal_id
     FROM "Notifications"
-    WHERE category_id = 'chain-event' AND chain_id IN (?)
-    GROUP BY chain_id;
+    WHERE category_id = 'chain-event' AND community_id IN (?)
+    GROUP BY community_id;
   `,
-    { raw: true, type: 'SELECT', replacements: [chainIds] },
-  )) as { chain_id: string; proposal_id: string }[];
+    { raw: true, type: 'SELECT', replacements: [communityIds] },
+  )) as { community_id: string; proposal_id: string }[];
 
   return result.reduce(
-    (acc, item) => ({ ...acc, [item.chain_id]: +item.proposal_id }),
+    (acc, item) => ({ ...acc, [item.community_id]: +item.proposal_id }),
     {},
   );
 }

--- a/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
+++ b/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
@@ -49,7 +49,7 @@ async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-describe('EVM Chain Events End to End Tests', () => {
+describe.only('EVM Chain Events End to End Tests', () => {
   const sandbox = sinon.createSandbox();
   let clock: sinon.SinonFakeTimers;
   let propCreatedResult: { block: number; proposalId: string };
@@ -120,7 +120,7 @@ describe('EVM Chain Events End to End Tests', () => {
     const notifications = await models.Notification.findAll();
     expect(notifications.length).to.equal(1);
     const notification = notifications[0].toJSON();
-    expect(notification).to.have.own.property('chain_id', testChainId);
+    expect(notification).to.have.own.property('community_id', testChainId);
     expect(notification).to.have.own.property(
       'category_id',
       NotificationCategories.ChainEvent,

--- a/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
+++ b/packages/commonwealth/test/devnet/evm/evmChainEvents/startEvmPolling.spec.ts
@@ -49,7 +49,7 @@ async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-describe.only('EVM Chain Events End to End Tests', () => {
+describe('EVM Chain Events End to End Tests', () => {
   const sandbox = sinon.createSandbox();
   let clock: sinon.SinonFakeTimers;
   let propCreatedResult: { block: number; proposalId: string };

--- a/packages/commonwealth/test/e2e/hooks/e2eDbEntityHooks.spec.ts
+++ b/packages/commonwealth/test/e2e/hooks/e2eDbEntityHooks.spec.ts
@@ -127,7 +127,7 @@ export async function clearTestEntities() {
       where: {
         [Op.or]: [
           { thread_id: { [Op.lt]: 0 } },
-          { chain_id: { [Op.in]: chainsToDelete.map((c) => c['id']) } },
+          { community_id: { [Op.in]: chainsToDelete.map((c) => c['id']) } },
         ],
       },
       force: true,

--- a/packages/commonwealth/test/integration/api/notifications.spec.ts
+++ b/packages/commonwealth/test/integration/api/notifications.spec.ts
@@ -48,19 +48,19 @@ describe('Notification Routes Tests', () => {
 
     notification = await models.Notification.create({
       category_id: NotificationCategories.NewThread,
-      chain_id: chain,
+      community_id: chain,
       notification_data: '',
     });
 
     notificationTwo = await models.Notification.create({
       category_id: NotificationCategories.NewThread,
-      chain_id: chain,
+      community_id: chain,
       notification_data: '',
     });
 
     notificationThree = await models.Notification.create({
       category_id: NotificationCategories.ChainEvent,
-      chain_id: chain,
+      community_id: chain,
       notification_data: '',
     });
 
@@ -185,7 +185,7 @@ describe('Notification Routes Tests', () => {
     it('should pass when notification id is a string instead of an array', async () => {
       const notif = await models.Notification.create({
         category_id: NotificationCategories.NewThread,
-        chain_id: chain,
+        community_id: chain,
         notification_data: '',
       });
 

--- a/packages/commonwealth/test/integration/cosmosGovNotifGenerator.spec.ts
+++ b/packages/commonwealth/test/integration/cosmosGovNotifGenerator.spec.ts
@@ -48,7 +48,7 @@ async function createFakeProposalNotification(
   };
   await models.Notification.create({
     category_id: 'chain-event',
-    chain_id: chainId,
+    community_id: chainId,
     notification_data: JSON.stringify(notifData),
   });
 
@@ -387,7 +387,7 @@ describe('Cosmos Governance Notification Generator', () => {
       const v1Beta1ExistingNotifPropId = 36;
       await models.Notification.create({
         category_id: 'chain-event',
-        chain_id: 'kyve',
+        community_id: 'kyve',
         notification_data: JSON.stringify({
           event_data: {
             id: v1ExistingNotifPropId,
@@ -397,7 +397,7 @@ describe('Cosmos Governance Notification Generator', () => {
 
       await models.Notification.create({
         category_id: 'chain-event',
-        chain_id: 'osmosis',
+        community_id: 'osmosis',
         notification_data: JSON.stringify({
           event_data: {
             id: v1Beta1ExistingNotifPropId,

--- a/packages/commonwealth/test/integration/databaseCleaner.spec.ts
+++ b/packages/commonwealth/test/integration/databaseCleaner.spec.ts
@@ -158,14 +158,14 @@ describe('DatabaseCleaner Tests', () => {
       await models.Notification.create({
         notification_data: 'testing',
         created_at: hundredDaysAgo,
-        chain_id: 'ethereum',
+        community_id: 'ethereum',
         category_id: 'new-thread-creation',
       });
 
       // create new notification
       await models.Notification.create({
         notification_data: 'testing',
-        chain_id: 'ethereum',
+        community_id: 'ethereum',
         created_at: eightyEightDaysAgo,
         category_id: 'new-thread-creation',
       });

--- a/packages/commonwealth/test/integration/emitNotifications.spec.ts
+++ b/packages/commonwealth/test/integration/emitNotifications.spec.ts
@@ -134,7 +134,7 @@ describe('emitNotifications tests', () => {
 
       const notif = await models.Notification.findOne({
         where: {
-          chain_id: chain,
+          community_id: chain,
           category_id: NotificationCategories.NewThread,
           thread_id: thread.id,
         },
@@ -190,7 +190,7 @@ describe('emitNotifications tests', () => {
 
       const notif = await models.Notification.findOne({
         where: {
-          chain_id: chain,
+          community_id: chain,
           category_id: NotificationCategories.NewComment,
         },
       });
@@ -249,7 +249,7 @@ describe('emitNotifications tests', () => {
 
       const notif = await models.Notification.findOne({
         where: {
-          chain_id: chain,
+          community_id: chain,
           category_id: NotificationCategories.NewReaction,
           thread_id: thread.id,
         },
@@ -440,7 +440,7 @@ describe('emitNotifications tests', () => {
 
       const notif = await models.Notification.findOne({
         where: {
-          chain_id: chain,
+          community_id: chain,
           category_id: NotificationCategories.ChainEvent,
           chain_event_id: chainEventId,
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5355
Closes: #3779 

## Description of Changes
- Updates `Notifications.chain_id` to `Notifications.community_id` (and all references)

## Test Plan
- [x] Generate a notification in a community and then delete the community
- [x] Generate thread + comment notifications using 2 accounts
- [x] Emit a test chain-event notification using: `yarn emit-notification -c aave -w [wallet-address]`
- [x] Click on a notification
- [x] Mark all notifications as read

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 