### PR TITLE
Fixed failing e2e test

### DIFF
--- a/packages/commonwealth/test/e2e/mature/landing.spec.ts
+++ b/packages/commonwealth/test/e2e/mature/landing.spec.ts
@@ -44,11 +44,11 @@ test.describe('Commonwealth Homepage', () => {
     const landingChunkRegex =
       /client_scripts_views_pages_landing_index_tsx\.[a-fA-F0-9]+\.chunk\.js$/;
     expect(loadedJsBundles[loadedJsBundles.length - 1]).toMatch(
-      landingChunkRegex
+      landingChunkRegex,
     );
 
     await page.waitForTimeout(100);
-    expect(loadedJsBundles.length).toEqual(4);
+    expect(loadedJsBundles.length).toEqual(5);
     expect(apiCalls.length).toEqual(4); // domain, status, chains, nodes
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6337

## Description of Changes
- Fixes test

## Other Considerations
The current problem is in colors.scss. In this file we have `:export { ....`. Webpack does not know how to handle code splitting this, and as a result pulls in this file and all dependencies (only 10kb) into every webpage. I have tried many things to fix this with no success:

- changed fast-sass-loader -> sass-loader
- Tried to lazy import this scss file from Colors.showcase.tsx
- Tried updating all our webpack loaders (esbuild-loader, file-loader, ...)

Without this export, there is no way to dynamically get all the colors inside the scss at runtime, so it needs to be there. As a result I have left it and just updated the test to expect that extra 10kb file.