### PR TITLE
Update members filter to support individual group filters

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
@@ -27,6 +27,7 @@ interface SearchProfilesProps {
   includeRoles: boolean;
   includeMembershipTypes?: 'in-group' | 'not-in-group';
   includeGroupIds?: boolean;
+  membersInGroup?: number;
   enabled?: boolean;
 }
 
@@ -39,6 +40,7 @@ const searchProfiles = async ({
   orderDirection,
   includeMembershipTypes,
   includeGroupIds,
+  membersInGroup,
   includeRoles,
 }: SearchProfilesProps & { pageParam: number }) => {
   const {
@@ -59,6 +61,7 @@ const searchProfiles = async ({
         include_roles: includeRoles,
         ...(includeMembershipTypes && { memberships: includeMembershipTypes }),
         ...(includeGroupIds && { include_group_ids: includeGroupIds }),
+        ...(membersInGroup && { members_in_group_id: membersInGroup }),
       },
     },
   );
@@ -74,6 +77,7 @@ const useSearchProfilesQuery = ({
   includeRoles,
   includeGroupIds,
   includeMembershipTypes,
+  membersInGroup,
   enabled = true,
 }: SearchProfilesProps) => {
   const key = [
@@ -85,6 +89,7 @@ const useSearchProfilesQuery = ({
       includeRoles,
       includeGroupIds,
       includeMembershipTypes,
+      membersInGroup,
     },
   ];
   return useInfiniteQuery(
@@ -100,6 +105,7 @@ const useSearchProfilesQuery = ({
         includeMembershipTypes,
         includeGroupIds,
         includeRoles,
+        membersInGroup,
       }),
     {
       getNextPageParam: (lastPage) => {

--- a/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
@@ -25,9 +25,8 @@ interface SearchProfilesProps {
   orderBy: APIOrderBy;
   orderDirection: APIOrderDirection;
   includeRoles: boolean;
-  includeMembershipTypes?: 'in-group' | 'not-in-group';
+  includeMembershipTypes?: 'in-group' | `in-group:${string}` | 'not-in-group';
   includeGroupIds?: boolean;
-  membersInGroup?: number;
   enabled?: boolean;
 }
 
@@ -40,7 +39,6 @@ const searchProfiles = async ({
   orderDirection,
   includeMembershipTypes,
   includeGroupIds,
-  membersInGroup,
   includeRoles,
 }: SearchProfilesProps & { pageParam: number }) => {
   const {
@@ -61,7 +59,6 @@ const searchProfiles = async ({
         include_roles: includeRoles,
         ...(includeMembershipTypes && { memberships: includeMembershipTypes }),
         ...(includeGroupIds && { include_group_ids: includeGroupIds }),
-        ...(membersInGroup && { members_in_group_id: membersInGroup }),
       },
     },
   );
@@ -77,7 +74,6 @@ const useSearchProfilesQuery = ({
   includeRoles,
   includeGroupIds,
   includeMembershipTypes,
-  membersInGroup,
   enabled = true,
 }: SearchProfilesProps) => {
   const key = [
@@ -89,7 +85,6 @@ const useSearchProfilesQuery = ({
       includeRoles,
       includeGroupIds,
       includeMembershipTypes,
-      membersInGroup,
     },
   ];
   return useInfiniteQuery(
@@ -105,7 +100,6 @@ const useSearchProfilesQuery = ({
         includeMembershipTypes,
         includeGroupIds,
         includeRoles,
-        membersInGroup,
       }),
     {
       getNextPageParam: (lastPage) => {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
@@ -69,14 +69,14 @@
       }
     }
 
-  .cwsl__indicators {
-    cursor: pointer;
-    
-    &.searchable {
-      [class$='-control'] {
-        cursor: text !important;
+    .cwsl__indicators {
+      cursor: pointer;
+
+      &.searchable {
+        [class$='-control'] {
+          cursor: text !important;
+        }
       }
-    }
 
       .cwsl__indicator-separator {
         display: none;
@@ -96,6 +96,15 @@
         @include scrollbarStyles;
         overflow: auto;
         padding: 8px;
+
+        .cwsl__group {
+          padding-bottom: 0;
+
+          .cwsl__group-heading {
+            text-transform: uppercase;
+            font-size: 12px;
+          }
+        }
 
         .cwsl__option {
           border: 0;

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.scss
@@ -79,11 +79,16 @@
           margin-left: 0;
         }
       }
-    }
 
-    .select-dropdown {
-      button {
-        width: 100%;
+      .CWSelectList {
+        min-width: 144px;
+
+        .cwsl__menu {
+          min-width: 200px;
+          margin-right: auto;
+          right: 0;
+          left: auto;
+        }
       }
     }
   }

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -89,11 +89,10 @@ const CommunityMembersPage = () => {
     ...(searchFilters.groupFilter === 'Ungrouped' && {
       includeMembershipTypes: 'not-in-group',
     }),
-    ...(!['All groups', 'Ungrouped'].includes(
-      `${searchFilters.groupFilter}`,
-    ) && {
-      membersInGroup: parseInt(`${searchFilters.groupFilter}`),
-    }),
+    ...(!['All groups', 'Ungrouped'].includes(`${searchFilters.groupFilter}`) &&
+      searchFilters.groupFilter && {
+        includeMembershipTypes: `in-group:${searchFilters.groupFilter}`,
+      }),
   });
 
   const { data: groups } = useFetchGroupsQuery({

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/CommunityMembersPage.tsx
@@ -15,11 +15,11 @@ import { SearchProfilesResponse } from 'state/api/profiles/searchProfiles';
 import useGroupMutationBannerStore from 'state/ui/group';
 import { useDebounce } from 'usehooks-ts';
 import Permissions from 'utils/Permissions';
-import { Select } from 'views/components/Select';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { getClasses } from 'views/components/component_kit/helpers';
 import CWBanner from 'views/components/component_kit/new_designs/CWBanner';
+import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import {
   CWTab,
   CWTabsRow,
@@ -33,18 +33,14 @@ import {
 import './CommunityMembersPage.scss';
 import GroupsSection from './GroupsSection';
 import MembersSection from './MembersSection';
-import { GroupCategory, MembershipFilter, SearchFilters } from './index.types';
+import { BaseGroupFilter, SearchFilters } from './index.types';
 
 const TABS = [
   { value: 'all-members', label: 'All members' },
   { value: 'groups', label: 'Groups' },
 ];
 
-const GROUP_AND_MEMBER_FILTERS: GroupCategory[] = [
-  'All groups',
-  'In group',
-  'Not in group',
-];
+const GROUP_AND_MEMBER_FILTERS: BaseGroupFilter[] = ['All groups', 'Ungrouped'];
 
 const CommunityMembersPage = () => {
   useUserActiveAccount();
@@ -54,7 +50,7 @@ const CommunityMembersPage = () => {
   const [selectedTab, setSelectedTab] = useState(TABS[0].value);
   const [searchFilters, setSearchFilters] = useState<SearchFilters>({
     searchText: '',
-    category: GROUP_AND_MEMBER_FILTERS[0],
+    groupFilter: GROUP_AND_MEMBER_FILTERS[0],
   });
   const {
     shouldShowGroupMutationBannerForCommunities,
@@ -90,11 +86,13 @@ const CommunityMembersPage = () => {
     includeRoles: true,
     includeGroupIds: true,
     enabled: app?.user?.activeAccount?.address ? !!memberships : true,
-    ...(searchFilters.category !== 'All groups' && {
-      includeMembershipTypes: searchFilters.category
-        .split(' ')
-        .join('-')
-        .toLowerCase() as MembershipFilter,
+    ...(searchFilters.groupFilter === 'Ungrouped' && {
+      includeMembershipTypes: 'not-in-group',
+    }),
+    ...(!['All groups', 'Ungrouped'].includes(
+      `${searchFilters.groupFilter}`,
+    ) && {
+      membersInGroup: parseInt(`${searchFilters.groupFilter}`),
     }),
   });
 
@@ -103,6 +101,30 @@ const CommunityMembersPage = () => {
     includeTopics: true,
     enabled: app?.user?.activeAccount?.address ? !!memberships : true,
   });
+
+  const filterOptions = useMemo(
+    () => [
+      {
+        // base filters
+        label: 'Filters',
+        options: GROUP_AND_MEMBER_FILTERS.map((x) => ({
+          id: x,
+          label: x,
+          value: x,
+        })),
+      },
+      {
+        // filters by group name
+        label: 'Groups',
+        options: (groups || []).map((group) => ({
+          id: group.id,
+          label: group.name,
+          value: group.id,
+        })),
+      },
+    ],
+    [groups],
+  );
 
   const formattedMembers = useMemo(() => {
     if (!members?.pages?.length) {
@@ -163,13 +185,11 @@ const CommunityMembersPage = () => {
               .includes(searchFilters.searchText.toLowerCase())
           : true,
       )
-      .filter((group) =>
-        searchFilters.category === 'All groups'
-          ? true
-          : searchFilters.category === 'In group'
-          ? group.isJoined
-          : !group.isJoined,
-      );
+      .filter((group) => {
+        if (searchFilters.groupFilter === 'All groups') return true;
+        if (searchFilters.groupFilter === 'Ungrouped') return !group.isJoined;
+        return group.id === parseInt(`${searchFilters.groupFilter}`);
+      });
 
     const clonedFilteredGroups = [...filteredGroupsArr];
 
@@ -303,17 +323,19 @@ const CommunityMembersPage = () => {
               <CWText type="b2" fontWeight="bold" className="filter-text">
                 Filter
               </CWText>
-              <Select
-                containerClassname="select-dropdown"
-                options={GROUP_AND_MEMBER_FILTERS.map((x) => ({
-                  id: x,
-                  label: x,
-                  value: x,
-                }))}
-                selected={searchFilters.category}
-                dropdownPosition="bottom-end"
-                onSelect={(item: any) => {
-                  setSearchFilters((g) => ({ ...g, category: item.value }));
+              <CWSelectList
+                isSearchable={false}
+                isClearable={false}
+                options={filterOptions}
+                value={[
+                  ...filterOptions[0].options,
+                  ...filterOptions[1].options,
+                ].find((option) => option.value === searchFilters.groupFilter)}
+                onChange={(option) => {
+                  setSearchFilters((g) => ({
+                    ...g,
+                    groupFilter: option.value,
+                  }));
                 }}
               />
             </div>

--- a/packages/commonwealth/client/scripts/views/pages/Community/Members/index.types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Community/Members/index.types.ts
@@ -1,8 +1,6 @@
-export type GroupCategory = 'All groups' | 'In group' | 'Not in group';
+export type BaseGroupFilter = 'All groups' | 'Ungrouped';
 
 export type SearchFilters = {
   searchText?: string;
-  category?: GroupCategory;
+  groupFilter?: BaseGroupFilter | number; // or the group id represented by number
 };
-
-export type MembershipFilter = 'in-group' | 'not-in-group';

--- a/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
+++ b/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
@@ -22,6 +22,7 @@ type SearchCommentsRequestParams = {
   include_roles?: string;
   memberships?: string;
   include_group_ids?: string;
+  members_in_group_id?: number;
 } & PaginationQueryParams;
 
 type SearchCommentsResponse = SearchProfilesResult;
@@ -51,6 +52,7 @@ export const searchProfilesHandler = async (
     orderDirection: options.order_direction as any,
     memberships: options.memberships,
     includeGroupIds: options.include_group_ids === 'true',
+    membersInGroupId: options.members_in_group_id,
   });
 
   return success(res, profileSearchResults);

--- a/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
+++ b/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
@@ -1,5 +1,8 @@
 import { AppError } from '@hicommonwealth/adapters';
-import { SearchProfilesResult } from 'server/controllers/server_profiles_methods/search_profiles';
+import {
+  MembershipFilters,
+  SearchProfilesResult,
+} from 'server/controllers/server_profiles_methods/search_profiles';
 import { ALL_COMMUNITIES } from '../../middleware/databaseValidationService';
 import { ServerControllers } from '../../routing/router';
 import {
@@ -20,9 +23,8 @@ type SearchCommentsRequestParams = {
   search: string;
   community_id?: string;
   include_roles?: string;
-  memberships?: string;
+  memberships?: MembershipFilters;
   include_group_ids?: string;
-  members_in_group_id?: number;
 } & PaginationQueryParams;
 
 type SearchCommentsResponse = SearchProfilesResult;
@@ -52,7 +54,6 @@ export const searchProfilesHandler = async (
     orderDirection: options.order_direction as any,
     memberships: options.memberships,
     includeGroupIds: options.include_group_ids === 'true',
-    membersInGroupId: options.members_in_group_id,
   });
 
   return success(res, profileSearchResults);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6142

## Description of Changes
- Updated members dropdown filter to filter by individual group name
- Updated `/profiles` API, added a new query param `membersInGroupId` to get all members belonging to that group

## "How We Fixed It"
N/A

## Test Plan
- Visit any community you are an admin of, or make yourself admin of any community (try to test in a community with a lot of members)
- Create new groups if there arent any existing ones
- From both the "Members" and "Groups" tab, use the group filter. Try out different options and verify you see the correct results.

## Deployment Plan
N/A

## Other Considerations
API not tested. I was having some issues with group membership calculations in local setup.