### PR TITLE
#6036 - Markdown Support Pt. 2: The Reckoning

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -151,6 +151,10 @@
     }
   }
 
+  dl {
+    margin: revert;
+  }
+
   mark {
     background-color: $primary-50;
   }


### PR DESCRIPTION
The work in this PR adds styles for and confirms functionality for features in this list:

- Inline Typography:
  - [x] subscript
  - [x] superscript
- Tables
  - [x] [Custom set Alignment](https://www.markdownguide.org/extended-syntax/#alignment)
- [ ] Footnotes
- List
  - [x] Definition Lists

Note that the list above includes footnotes. Implementing footnotes requires upgrading our current markdown parser by several major versions, so we're leaving that work to ticket #6338. Please ignore footnotes for this review.

## Link to Issue
Closes: #6036 

## Description of Changes
* see above list

## Test Plan
- input markdown for the features in the list above and check that they look/work as expected (note that superscript/subscript are implemented using the <sub>/<sup> syntax, not the ~/^ syntax particular to Markdown Extra)

## Other Considerations
- #6338 will handle footnote functionality 