### PR TITLE
Fix page break for admin

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/useSidebarTreeToggle.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/useSidebarTreeToggle.tsx
@@ -27,7 +27,7 @@ const useSidebarTreeToggle = ({
   localStorageKey,
 }: SidebarTreeToggleProps) => {
   const toggledTreeState = useMemo(
-    () => JSON.parse(localStorage[localStorageKey]),
+    () => JSON.parse(localStorage[localStorageKey] || `{}`),
     [localStorageKey],
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6366

## Description of Changes
Fixes page crash for admin when creating a new community.

## "How We Fixed It"
By adding a default case for parsing admin tree toggle state from the app-level storage. Page was crashing when tree toggle state was `undefined`

## Test Plan
- Login
- Create a new community
- Redirect to that community
- Verify that page doesn't crash

## Deployment Plan
N/A

## Other Considerations
N/A