### PR TITLE
Fix /groups 400 on community members page

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/groups/fetchGroups.ts
+++ b/packages/commonwealth/client/scripts/state/api/groups/fetchGroups.ts
@@ -17,6 +17,13 @@ const fetchGroups = async ({
   // includeMembers = false,
   includeTopics = false,
 }: FetchGroupsProps): Promise<Group[]> => {
+  // HACK:
+  // This returns early when communityId is falsy
+  // ideal solution would be to make the `enabled` prop of `useQuery`
+  // work, but for some reason, it messes up on the /members page.
+  // This early return however doesn't seem to messup cache on current page.
+  if (!communityId) return;
+
   const response = await axios.get(
     `${app.serverUrl()}${ApiEndpoints.FETCH_GROUPS}`,
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6351

## Description of Changes
Add an early return to check for null `communityId` when calling `/groups`

## "How We Fixed It"
N/A

## Test Plan
- Create a community
- Visit the members page
- Verify there are no failing requests to `/groups`

## Deployment Plan
N/A

## Other Considerations
N/A