### PR TITLE
Establish ADR template

### DIFF
--- a/knowledge_base/ADRs/001-Hexagonal-Architecture-Style.md
+++ b/knowledge_base/ADRs/001-Hexagonal-Architecture-Style.md
@@ -1,12 +1,10 @@
 # ADR 001: Hexagonal Architecture Style
 
-Implementing hexagonal architecture will give us greater flexibility, testability, and maintainability.
+Implementing hexagonal architecture gives us greater flexibility, testability, and maintainability.
 
 ## Status
 
 Proposed: 240112 by Roger Torres (@Rotorsoft)
-
-Accepted:
 
 ## Context
 

--- a/knowledge_base/ADRs/001-Hexagonal-Architecture-Style.md
+++ b/knowledge_base/ADRs/001-Hexagonal-Architecture-Style.md
@@ -1,10 +1,11 @@
 # ADR 001: Hexagonal Architecture Style
 
-Date: 2024-01-12
+Implementing hexagonal architecture will give us greater flexibility, testability, and maintainability.
 
 ## Status
 
-Proposed: @Rotorsoft 20240112
+Proposed: 240112 by Roger Torres (@Rotorsoft)
+
 Accepted:
 
 ## Context
@@ -41,4 +42,4 @@ While Hexagonal Architecture provides many benefits, it also introduces some com
 
 - [Alistair Cockburn, "Hexagonal Architecture"](https://alistair.cockburn.us/hexagonal-architecture)
 - [Roman Glushach, "Hexagonal Architecture: The Secret to Scalable and Maintainable Code for Modern Software"](https://medium.com/@romanglushach/hexagonal-architecture-the-secret-to-scalable-and-maintainable-code-for-modern-software-d345fdb47347)
-- [Spike PR - Logging port and adapter](https://github.com/hicommonwealth/commonwealth/pull/6345)
+- [Spike PR #6345: Logging port and adapter](https://github.com/hicommonwealth/commonwealth/pull/6345)

--- a/knowledge_base/ADRs/_ADR-Template.md
+++ b/knowledge_base/ADRs/_ADR-Template.md
@@ -1,0 +1,29 @@
+# ADR XXX: Title
+
+Brief summary of the decision.
+
+## Status
+
+Proposed: YYMMDD by Full Name (@github_handle)
+
+Accepted/Rejected: YYMMDD by Full Name (@github_handle)
+
+## Context
+
+What background information is necessary to understand why the decision was made? What problems are solved or goals accomplished?
+
+## Decision
+
+What decision was ultimately made?
+
+## Rationale
+
+Why was the decision made? Comparison with alternative solutions may be useful.
+
+## Consequences
+
+What are the outcomes of the decision, both desirable and undesirable? (No such thing as a free lunch.)
+
+## References
+
+- [GitHub ADR Organization Homepage](https://adr.github.io/)


### PR DESCRIPTION
In #6345, @Rotorsoft established a new ADR (Architectural Decision Record) system for documenting significant codebase design choices.

This branch formalizes the template introduced in #6345, and also makes some minor amendments to ADR001 to bring it in line with codebase style.

## Link to Issue
Links to, but keeps open: #4800

## Description of Changes

- Creation of `_ADR_Template.md` 
- Changes to ADR001
    - Changes datestamp format
    - Removes a datestamp viewed as redundant
    - Adds an executive summary