### PR TITLE
Add missing await to existing user magic flow.

### DIFF
--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -101,7 +101,7 @@ async function createMagicAddressInstances(
       addressInstance.wallet_sso_source === null
     ) {
       addressInstance.wallet_sso_source = walletSsoSource;
-      addressInstance.save({ transaction: t });
+      await addressInstance.save({ transaction: t });
     }
     addressInstances.push(addressInstance);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6376 

## Description of Changes
- Adds missing await to `save()` to prevent database transaction error on magic link login to existing user.

## Test Plan
- Navigate to a community you've logged in before on with a specific email via Magic Google auth (or other form of auth), i.e. where you already have an account configured.
- Follow sign-in flow all the way through via Magic and ensure it completes the /finishsociallogin redirect successfully (should be seamless).
