### PR TITLE
Add missing await and fix banner null check.

### DIFF
--- a/packages/commonwealth/server/routes/updateBanner.ts
+++ b/packages/commonwealth/server/routes/updateBanner.ts
@@ -34,7 +34,7 @@ const updateBanner = async (
     throw new AppError(UpdateBannerErrors.NoPermission);
   }
 
-  const { banner_text } = req.body || { banner_text: '' };
+  const banner_text = req.body?.banner_text || '';
 
   // find or create
   const [banner] = await models.CommunityBanner.findOrCreate({
@@ -49,7 +49,7 @@ const updateBanner = async (
   if (banner_text !== banner.banner_text) {
     // update if need be
     banner.banner_text = banner_text;
-    banner.save();
+    await banner.save();
   }
   return success(res, banner.toJSON());
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6378

## Description of Changes
- Adds missing await to the `save()` function on the banner object.
- Fixes the default-to-empty-string logic to avoid setting to "null" when banner is unset.

## Test Plan
- Go to community where you are admin.
- Set a banner text in the admin panel. Confirm it is set.
- Remove the banner text in the admin panel. Confirm it is unset.
