### PR TITLE
Add more stats to admin page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/Analytics.tsx
@@ -18,6 +18,8 @@ type Stats = {
   numProposalVotesLastMonth: number;
   numMembersLastMonth: number;
   numGroupsLastMonth: number;
+  averageAddressesPerCommunity: number;
+  populatedCommunities: number;
 };
 
 const Analytics = () => {
@@ -150,6 +152,22 @@ const Analytics = () => {
                 <CWText fontWeight="medium">Total New Groups</CWText>
                 <CWText className="StatValue">
                   {globalStats?.numGroupsLastMonth}
+                </CWText>
+              </div>
+              <div className="Stat">
+                <CWText fontWeight="medium">
+                  Average Addresses Per Community
+                </CWText>
+                <CWText className="StatValue">
+                  {Math.round(globalStats?.averageAddressesPerCommunity)}
+                </CWText>
+              </div>
+              <div className="Stat">
+                <CWText fontWeight="medium">
+                  {'Total Communities with > 2 addresses'}
+                </CWText>
+                <CWText className="StatValue">
+                  {Math.round(globalStats?.populatedCommunities)}
                 </CWText>
               </div>
             </div>

--- a/packages/commonwealth/server/controllers/server_admin_methods/get_stats.ts
+++ b/packages/commonwealth/server/controllers/server_admin_methods/get_stats.ts
@@ -114,20 +114,20 @@ export async function __getStats(
           SELECT "Communities".id, "Communities".name, COUNT("Addresses".id) as address_count
           FROM "Communities"
           JOIN "Addresses" ON "Addresses".community_id = "Communities".id
-          GROUP BY "Communities".id, "Communities".name
-      ) as address_counts;
+          GROUP BY "Communities".id
+      ) as _;
     `,
       { type: QueryTypes.SELECT },
     ),
     this.models.sequelize.query<{ result: number }>(
       `
-        SELECT COUNT(*) as result FROM (
-          SELECT DISTINCT("Communities".id)
+        SELECT COUNT(communities_count) as result FROM (
+          SELECT "Communities".id
           FROM "Communities"
           JOIN "Addresses" ON "Addresses".community_id = "Communities".id
-          GROUP BY "Communities".id, "Communities".name
+          GROUP BY "Communities".id
           HAVING COUNT("Addresses".id) > 2
-        ) as _;
+        ) as communities_count;
       `,
       { type: QueryTypes.SELECT },
     ),

--- a/packages/commonwealth/server/controllers/server_admin_methods/get_stats.ts
+++ b/packages/commonwealth/server/controllers/server_admin_methods/get_stats.ts
@@ -111,7 +111,7 @@ export async function __getStats(
       `
       SELECT AVG(address_count) as result
       FROM (
-          SELECT "Communities".id, "Communities".name, COUNT("Addresses".id) as address_count
+          SELECT "Communities".id, COUNT("Addresses".id) as address_count
           FROM "Communities"
           JOIN "Addresses" ON "Addresses".community_id = "Communities".id
           GROUP BY "Communities".id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6198

## Description of Changes
- Adds stat for average addresses per community
- Adds stat for total communities with > 2 addresses

## Test Plan
- Go to http://localhost:8080/admin-panel
- Confirm that it shows average addresses per community + total communities w/ > 2 addresses

## Deployment Plan
N/A

## Other Considerations
- The average computed by SQL (current implementation) is different than the average computed by dividing [total addresses / total communities]