### PR TITLE
Fix social links updation when links are equal to 0

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -176,7 +176,7 @@ export async function __updateCommunity(
   if (icon_url) community.icon_url = icon_url;
   if (active !== undefined) community.active = active;
   if (type) community.type = type;
-  if (nonEmptySocialLinks !== undefined && nonEmptySocialLinks.length > 0)
+  if (nonEmptySocialLinks !== undefined && nonEmptySocialLinks.length >= 0)
     community.social_links = nonEmptySocialLinks;
   if (hide_projects) community.hide_projects = hide_projects;
   if (stages_enabled) community.stages_enabled = stages_enabled;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6391

## Description of Changes
- Fixes social links update, when links are equal to 0

## "How We Fixed It"
N/A

## Test Plan
- Go to any community where you are an admin
- From the manage community page, removal all social links and update
- Refresh the page and verify that all social links are removed

## Deployment Plan
N/A

## Other Considerations
N/A