### PR TITLE
Fix stages bool update logic

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -179,7 +179,8 @@ export async function __updateCommunity(
   if (nonEmptySocialLinks !== undefined && nonEmptySocialLinks.length > 0)
     community.social_links = nonEmptySocialLinks;
   if (hide_projects) community.hide_projects = hide_projects;
-  if (stages_enabled) community.stages_enabled = stages_enabled;
+  if (typeof stages_enabled === 'boolean')
+    community.stages_enabled = stages_enabled;
   if (custom_stages) community.custom_stages = custom_stages;
   if (terms) community.terms = terms;
   if (has_homepage) community.has_homepage = has_homepage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6390

## Description of Changes
Fix stages toggle update logic, in admin community management page

## "How We Fixed It"
By updating API conditional logic for `stages_enabled` param

## Test Plan
1. Go to any community where you are an admin.
1. Try to disable the "Stages" toggle, and save changes.
1. Reload the page, and verify the "Stages" toggle is still enabled/disabled correctly

## Deployment Plan
N/A

## Other Considerations
N/A