### PR TITLE
update DB rules for extended sessions

### DIFF
--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -109,7 +109,7 @@ async function main() {
     db: models.sequelize,
     tableName: 'Sessions',
     checkExpirationInterval: 15 * 60 * 1000, // Clean up expired sessions every 15 minutes
-    expiration: 7 * 24 * 60 * 60 * 1000, // Set session expiration to 7 days
+    expiration: 14 * 24 * 60 * 60 * 1000, // Set session expiration to 7 days
   });
 
   sessionStore.sync();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5428 

## Description of Changes
- Updates Session length in magic dashboard to 14 days
- Updated Sessions model expiration to 14 days

## Test Plan
- Test sign in with magic 
- Test sign in with other wallets w/ a fresh session
- Check sessions table to ensure expiry is T + 14
