### PR TITLE
Fixed double webhook error

### DIFF
--- a/packages/commonwealth/server/util/webhooks/dispatchWebhook.ts
+++ b/packages/commonwealth/server/util/webhooks/dispatchWebhook.ts
@@ -36,6 +36,15 @@ export async function dispatchWebhooks(
     return;
   }
 
+  if (
+    notification.categoryId === NotificationCategories.NewComment &&
+    notification.data?.parent_comment_id
+  ) {
+    // If parent comment exists we don't want to send a webhook.
+    // Otherwise we will duplicate send a webhook for every reply to a comment.
+    return;
+  }
+
   if (!webhooks) {
     webhooks = await fetchWebhooks(notification);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solves the divastaking discord bug where double notifications were being sent for comments.

Closes: #5994 

## Description of Changes
- Added a return for webhook dispatch for notifications that have a parent id

## "How We Fixed It"
Added a return for webhook dispatch for notifications that have a parent id

## Test Plan
- Test commenting on a custom community and see if notification was being dispatched to webhooks more than 1 time on a reply comment.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 