### PR TITLE
Followup enhancements on community profile and integrations screen

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AdminOnboardingSlider/AdminOnboardingSlider.tsx
@@ -1,4 +1,5 @@
 import { featureFlags } from 'helpers/feature-flags';
+import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useState } from 'react';
 import app from 'state';
@@ -16,6 +17,8 @@ import './AdminOnboardingSlider.scss';
 import { DismissModal } from './DismissModal';
 
 export const AdminOnboardingSlider = () => {
+  useUserActiveAccount();
+
   const community = app.config.chains.getById(app.activeChainId());
   const integrations = {
     snapshot: community?.snapshot?.length > 0,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_toggle.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_toggle.tsx
@@ -51,7 +51,7 @@ export const CWToggle = (props: ToggleProps) => {
   const formFieldContext =
     hookToForm && name ? formContext.register(name) : ({} as any);
   const [formCheckedStatus, setFormCheckedStatus] = useState(
-    formContext?.getValues?.(name),
+    hookToForm && name && formContext?.getValues?.(name),
   );
 
   return (
@@ -69,14 +69,15 @@ export const CWToggle = (props: ToggleProps) => {
       <input
         type="checkbox"
         {...params}
-        {...(formFieldContext && {
-          ...formFieldContext,
-          onChange: async (e) => {
-            setFormCheckedStatus(e.target.checked);
-            formFieldContext.onChange(e);
-            await params?.onChange?.(e);
-          },
-        })}
+        {...(hookToForm &&
+          name && {
+            ...formFieldContext,
+            onChange: async (e) => {
+              setFormCheckedStatus(e.target.checked);
+              formFieldContext.onChange(e);
+              await params?.onChange?.(e);
+            },
+          })}
         className="toggle-input"
       />
       <div className="slider" />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -59,21 +59,12 @@ const CommunityProfileForm = () => {
     useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [initialLinks, setInitialLinks] = useState(
-    (community.socialLinks || []).length > 0
-      ? community.socialLinks.map((link) => ({
-          value: link,
-          canUpdate: true,
-          canDelete: true,
-          error: '',
-        }))
-      : [
-          {
-            value: '',
-            canUpdate: true,
-            canDelete: false,
-            error: '',
-          },
-        ],
+    (community.socialLinks || []).map((link) => ({
+      value: link,
+      canUpdate: true,
+      canDelete: true,
+      error: '',
+    })),
   );
 
   const {
@@ -398,6 +389,10 @@ const CommunityProfileForm = () => {
               }
               onClick={() => {
                 reset();
+                setNameFieldDisabledState({
+                  isDisabled: true,
+                  canDisable: true,
+                });
                 setLinks(initialLinks);
                 setSelectedCommunityTags(currentCommunityTags);
               }}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/CustomTOS/CustomTOS.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/CustomTOS/CustomTOS.tsx
@@ -11,7 +11,7 @@ import './CustomTOS.scss';
 const CustomTOS = () => {
   const [community] = useState(app.config.chains.getById(app.activeChainId()));
   const [terms, setTerms] = useState({
-    value: community.terms,
+    value: community.terms || '',
     error: '',
   });
   const [isSaving, setIsSaving] = useState(false);
@@ -20,11 +20,13 @@ const CustomTOS = () => {
     const value = event?.target?.value?.trim() || '';
     let error = '';
 
-    try {
-      linkValidationSchema.parse(value);
-    } catch (e: any) {
-      const zodError = e as ZodError;
-      error = zodError.errors[0].message;
+    if (value) {
+      try {
+        linkValidationSchema.parse(value);
+      } catch (e: any) {
+        const zodError = e as ZodError;
+        error = zodError.errors[0].message;
+      }
     }
 
     setTerms({ error, value });

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Directory/Directory.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Directory/Directory.scss
@@ -19,13 +19,13 @@
 
   .b1 {
     color: $neutral-500 !important;
+    padding-bottom: 12px;
   }
 
   .chains {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding-top: 12px;
 
     .cta-button-container {
       width: fit-content;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Discord/Discord.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Discord/Discord.tsx
@@ -109,7 +109,9 @@ const Discord = () => {
           <p>
             You can merge content from Discord directly into your community by
             connecting the Commonbot.{' '}
-            <a href="https://example.com">Learn more</a>
+            <a href="https://docs.commonwealth.im/commonwealth/bridged-discord-forum-bot">
+              Learn more
+            </a>
           </p>
         </CWText>
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Webhooks/Webhooks.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Webhooks/Webhooks.tsx
@@ -96,7 +96,7 @@ const Webhooks = () => {
         `Failed to create ${pluralizeWithoutNumberPrefix(
           webhooksToCreate.length,
           'webhook',
-        )}}!`,
+        )}!`,
       );
     } finally {
       setLinks(
@@ -156,7 +156,10 @@ const Webhooks = () => {
             <p>
               Slack, Discord, and Telegram webhooks are supported. For more
               information and examples for setting these up, please view our{' '}
-              <a href="https://example.com">documentation</a>.
+              <a href="https://docs.commonwealth.im/commonwealth/for-admins-and-mods/capabilities/webhooks">
+                documentation
+              </a>
+              .
             </p>
           </CWText>
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/common/CommunityManagementLayout/CommunityManagementLayout.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/common/CommunityManagementLayout/CommunityManagementLayout.tsx
@@ -1,3 +1,4 @@
+import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import React, { ReactNode } from 'react';
 import app from 'state';
 import Permissions from 'utils/Permissions';
@@ -22,8 +23,10 @@ const CommunityManagementLayout = ({
   children,
   featureHint,
 }: CommunityManagementLayout) => {
+  useUserActiveAccount();
+
   if (
-    !app?.user?.activeAccount?.address ||
+    !app.isLoggedIn() ||
     !(Permissions.isSiteAdmin() || Permissions.isCommunityAdmin())
   ) {
     return <PageNotFound />;

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/discord-callback.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/discord-callback.tsx
@@ -11,8 +11,8 @@ const DiscordCallbackPage = () => {
   const [failed, setFailed] = useState(false);
   const [failureMessage, setFailureMessage] = useState<string>('');
   const redirectPath = featureFlags.newAdminOnboardingEnabled
-    ? '/manage/integrations'
-    : '/manage';
+    ? 'manage/integrations'
+    : 'manage';
 
   const setBotConfig = useCallback(
     async (state: string, guildId: string) => {

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -184,7 +184,7 @@ export async function __updateCommunity(
   if (typeof stages_enabled === 'boolean')
     community.stages_enabled = stages_enabled;
   if (custom_stages) community.custom_stages = custom_stages;
-  if (terms) community.terms = terms;
+  if (typeof terms === 'string') community.terms = terms;
   if (has_homepage) community.has_homepage = has_homepage;
   if (default_page) {
     if (!has_homepage) {

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -183,7 +183,8 @@ export async function __updateCommunity(
   if (hide_projects) community.hide_projects = hide_projects;
   if (typeof stages_enabled === 'boolean')
     community.stages_enabled = stages_enabled;
-  if (custom_stages) community.custom_stages = custom_stages;
+  if (typeof custom_stages === 'string')
+    community.custom_stages = custom_stages;
   if (typeof terms === 'string') community.terms = terms;
   if (has_homepage) community.has_homepage = has_homepage;
   if (default_page) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6405

## Description of Changes
Community profile page -> `/:communityName/manage/profile`
Community integrations page -> `/:communityName/manage/integrations`

- Updated blog links for discord and webhooks on the community integrations screen
- When on the community profile or integrations screen and re-authenticating (logout/login), the correct page state will be shown i.e when logout or not admin "Page not found", when login and admin, it will render the correct page
- Fix CWToggle from breaking page when it is not hooked to CWForm via the `hookToForm` prop
- Fix API to allow admin to remove the TOS link from the community.
- Fix API to allow admin to remove the custom stages from the community.
- Now relocking the Community name field on the community profile page, after the "Reset Changes" button is clicked.
<img width="742" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/273ff247-0987-4f13-844e-0837c179d87b">

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_NEW_ADMIN_ONBOARDING` in `.env` i.e `FLAG_NEW_ADMIN_ONBOARDING=true`
- Go to any community where you are an admin.
- Visit the community profile or integrations screen. Logout and verify that you see the "Page not found" message. Now login and verify that you see the correct page UI.
- Visit community integrations page, and check these links (blue one's) are correct, aka for discord bot - https://docs.commonwealth.im/commonwealth/bridged-discord-forum-bot, for webhooks https://docs.commonwealth.im/commonwealth/for-admins-and-mods/capabilities/webhooks

<img width="742" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/dbd6e338-2292-4129-832d-562907934a96">

On the community profile page
- check that toggling this "CWToggle" doesn't break the page (plz connect discord bot to test it)
<img width="750" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/6793b34f-7e8f-4851-a6c0-110d46abea01">

- remove the TOS link and save changes. Refresh the page and verify that changes are saved correctly.
- remove the custom stages (pre-req: you have enabled Stages toggle and added custom stages) and save changes. Refresh the page and verify that changes are saved correctly.
- Unlock the name field, then change name value (don't save changes yet), click on reset changes button and verify the name field is locked again.



## Deployment Plan
N/A

## Other Considerations
This needs to go in with the other Admin onboarding tickets.