### PR TITLE
Fix CWCoverImageUploader default value state

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -1,6 +1,6 @@
 import 'components/component_kit/cw_cover_image_uploader.scss';
 import $ from 'jquery';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import app from 'state';
 import { replaceBucketWithCDN } from '../../../helpers/awsHelpers';
@@ -99,14 +99,7 @@ export const CWCoverImageUploader = ({
   useNecessaryEffect(() => {
     if (defaultFormContext.value && !defaultFormContext.isSet) {
       canResetValue.current = false;
-      const currentImageBehavior = !imageBehavior
-        ? ImageBehavior.Fill
-        : imageBehavior;
-      if (currentImageBehavior !== ImageBehavior.Circle) {
-        attachButton.current.style.display = 'none';
-      } else {
-        attachButton.current.style.display = 'flex';
-      }
+      attachButton.current.style.display = 'flex';
 
       setImageURL(defaultFormContext.value);
       setImageBehavior(ImageBehavior.Circle);
@@ -309,15 +302,18 @@ export const CWCoverImageUploader = ({
 
   const isFillImage = imageBehavior === ImageBehavior.Fill;
 
-  const backgroundStyles = {
-    backgroundImage:
-      imageURL && defaultImageBehaviour !== ImageBehavior.Circle
-        ? `url(${imageURL})`
-        : 'none',
-    backgroundSize: isFillImage ? 'cover' : '100px',
-    backgroundRepeat: isFillImage ? 'no-repeat' : 'repeat',
-    backgroundPosition: isFillImage ? 'center' : '0 0',
-  };
+  const backgroundStyles = useMemo(
+    () => ({
+      backgroundImage:
+        imageURL && defaultImageBehaviour !== ImageBehavior.Circle
+          ? `url(${imageURL})`
+          : 'none',
+      backgroundSize: isFillImage ? 'cover' : '100px',
+      backgroundRepeat: isFillImage ? 'no-repeat' : 'repeat',
+      backgroundPosition: isFillImage ? 'center' : '0 0',
+    }),
+    [imageURL, defaultImageBehaviour, isFillImage],
+  );
 
   return (
     <div className="CoverImageUploader">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6411

## Description of Changes
- Fixes default form value state for CWCoverImageUploader

## "How We Fixed It"
N/A

## Test Plan
- As a site admin, visit `/:communityid/manage/profile` page of any community
- Verify that the community image section is loading correctly with the community image
<img width="1005" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/dc2a15e6-40c8-4f0c-ae45-f41bf66416be">


## Deployment Plan
Needs to go in with the Admin-onboarding milestone

## Other Considerations
N/A