### PR TITLE
Fix: Cosmos join community with Magic/New Email

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -449,7 +449,7 @@ export async function handleSocialLoginCallback({
     }
   }
 
-  let authedSessionPayload, authedSignature;
+  let authedSessionPayload, authedSignature, didToken;
   try {
     // Sign a session
     if (isCosmos && desiredChain) {
@@ -463,6 +463,8 @@ export async function handleSocialLoginCallback({
         );
       }
 
+      didToken = await magic.user.generateIdToken({ attachment: magicAddress });
+
       // Request the cosmos chain ID, since this is used by Magic to generate
       // the signed message. The API is already used by the Magic iframe,
       // but they don't expose the results.
@@ -470,7 +472,6 @@ export async function handleSocialLoginCallback({
         `${document.location.origin}/magicCosmosAPI/${desiredChain.id}/node_info`,
       );
       const chainId = nodeInfo.node_info.network;
-
       const timestamp = +new Date();
 
       const signer = { signMessage: magic.cosmos.sign };
@@ -545,6 +546,7 @@ export async function handleSocialLoginCallback({
       username: profileMetadata?.username,
       avatarUrl: profileMetadata?.avatarUrl,
       magicAddress,
+      didToken,
       sessionPayload: authedSessionPayload,
       signature: authedSignature,
       walletSsoSource,

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -351,7 +351,10 @@ export async function startLoginWithMagicLink({
   if (email) {
     // email-based login
     const bearer = await magic.auth.loginWithMagicLink({ email });
-    const address = await handleSocialLoginCallback({ bearer, isEmail: true });
+    const address = await handleSocialLoginCallback({
+      bearer,
+      walletSsoSource: WalletSsoSource.Email,
+    });
     return { bearer, address };
   } else {
     const params = `?redirectTo=${
@@ -406,18 +409,17 @@ export async function handleSocialLoginCallback({
   bearer,
   chain,
   walletSsoSource,
-  isEmail,
 }: {
   bearer?: string;
   chain?: string;
   walletSsoSource?: string;
-  isEmail?: boolean;
 }): Promise<string> {
   // desiredChain may be empty if social login was initialized from
   // a page without a chain, in which case we default to an eth login
   const desiredChain = app.chain?.meta || app.config.chains.getById(chain);
   const isCosmos = desiredChain?.base === ChainBase.CosmosSDK;
   const magic = await constructMagic(isCosmos, desiredChain?.id);
+  const isEmail = walletSsoSource === WalletSsoSource.Email;
 
   // Code up to this line might run multiple times because of extra calls to useEffect().
   // Those runs will be rejected because getRedirectResult purges the browser search param.
@@ -453,25 +455,11 @@ export async function handleSocialLoginCallback({
   try {
     // Sign a session
     if (isCosmos && desiredChain) {
-      // Not every chain prefix will succeed, so Magic defaults to osmo... as the Cosmos prefix
       const bech32Prefix = desiredChain.bech32Prefix;
-      try {
-        magicAddress = await magic.cosmos.changeAddress(bech32Prefix);
-      } catch (err) {
-        console.error(
-          `Error changing address to ${bech32Prefix}. Keeping default cosmos prefix and moving on. Error: ${err}`,
-        );
-      }
 
       didToken = await magic.user.generateIdToken({ attachment: magicAddress });
 
-      // Request the cosmos chain ID, since this is used by Magic to generate
-      // the signed message. The API is already used by the Magic iframe,
-      // but they don't expose the results.
-      const nodeInfo = await $.get(
-        `${document.location.origin}/magicCosmosAPI/${desiredChain.id}/node_info`,
-      );
-      const chainId = nodeInfo.node_info.network;
+      const chainId = 'cosmoshub';
       const timestamp = +new Date();
 
       const signer = { signMessage: magic.cosmos.sign };

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -451,14 +451,11 @@ export async function handleSocialLoginCallback({
     }
   }
 
-  let authedSessionPayload, authedSignature, didToken;
+  let authedSessionPayload, authedSignature;
   try {
     // Sign a session
     if (isCosmos && desiredChain) {
       const bech32Prefix = desiredChain.bech32Prefix;
-
-      didToken = await magic.user.generateIdToken({ attachment: magicAddress });
-
       const chainId = 'cosmoshub';
       const timestamp = +new Date();
 
@@ -534,7 +531,6 @@ export async function handleSocialLoginCallback({
       username: profileMetadata?.username,
       avatarUrl: profileMetadata?.avatarUrl,
       magicAddress,
-      didToken,
       sessionPayload: authedSessionPayload,
       signature: authedSignature,
       walletSsoSource,

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -37,7 +37,7 @@
     "reset-frack-db": "heroku pg:copy commonwealth-beta::CW_READ_DB DATABASE_URL --app commonwealth-frack --confirm commonwealth-frack",
     "send-notification-digest-emails": "SEND_EMAILS=true ts-node -r tsconfig-paths/register server.ts",
     "send-cosmos-notifs": "ts-node -r tsconfig-paths/register server/workers/cosmosGovNotifications/generateCosmosGovNotifications.ts",
-    "start": "ts-node-dev -r tsconfig-paths/register --inspect=0.0.0.0:9229 --max-old-space-size=4096 --respawn --transpile-only server.ts",
+    "start": "ts-node-dev -r tsconfig-paths/register --max-old-space-size=4096 --respawn --transpile-only server.ts",
     "start-evm-ce": "ts-node -r tsconfig-paths/register server/workers/evmChainEvents/startEvmPolling.ts",
     "start-all": "concurrently -p '{name}' -c red,green -n app,consumer 'yarn start' 'yarn start-consumer'",
     "start-android": "npx cap run android",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -37,7 +37,7 @@
     "reset-frack-db": "heroku pg:copy commonwealth-beta::CW_READ_DB DATABASE_URL --app commonwealth-frack --confirm commonwealth-frack",
     "send-notification-digest-emails": "SEND_EMAILS=true ts-node -r tsconfig-paths/register server.ts",
     "send-cosmos-notifs": "ts-node -r tsconfig-paths/register server/workers/cosmosGovNotifications/generateCosmosGovNotifications.ts",
-    "start": "ts-node-dev -r tsconfig-paths/register --max-old-space-size=4096 --respawn --transpile-only server.ts",
+    "start": "ts-node-dev -r tsconfig-paths/register --inspect=0.0.0.0:9229 --max-old-space-size=4096 --respawn --transpile-only server.ts",
     "start-evm-ce": "ts-node -r tsconfig-paths/register server/workers/evmChainEvents/startEvmPolling.ts",
     "start-all": "concurrently -p '{name}' -c red,green -n app,consumer 'yarn start' 'yarn start-consumer'",
     "start-android": "npx cap run android",

--- a/packages/commonwealth/server/migrations/20240126235535-cosmoshub-rpc.js
+++ b/packages/commonwealth/server/migrations/20240126235535-cosmoshub-rpc.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        INSERT INTO "ChainNodes" (name, url, alt_wallet_url, balance_type, cosmos_chain_id, created_at, updated_at) VALUES (
+          'Cosmos Hub',
+          'https://rpc.cosmos.directory/cosmoshub',
+          'https://rest.cosmos.directory/cosmoshub',
+          'cosmos',
+          'cosmoshub',
+           NOW(),
+           NOW()
+        );
+      `,
+        { transaction },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        DELETE FROM "ChainNodes" WHERE cosmos_chain_id = 'cosmoshub';
+      `,
+        { transaction },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -377,7 +377,6 @@ async function magicLoginRoute(
     signature: string;
     sessionPayload?: string; // optional because session keys are feature-flagged
     magicAddress?: string; // optional because session keys are feature-flagged
-    didToken?: string; // optional because currently only used for cosmos
     walletSsoSource: WalletSsoSource;
   }>,
   decodedMagicToken: MagicUser,
@@ -453,17 +452,18 @@ async function magicLoginRoute(
 
     if (chainToJoin) {
       if (isCosmos) {
-        const magicUserMetadataCosmosAddress = magicUserMetadata.wallets?.find(
-          (wallet) => wallet.wallet_type === WalletType.COSMOS,
+        // (magic bug?): magic typing doesn't match data, so we need to cast as any
+        const magicWallets = magicUserMetadata.wallets as any[];
+        const magicUserMetadataCosmosAddress = magicWallets?.find(
+          (wallet: any) =>
+            (wallet as unknown as any).wallet_type === WalletType.COSMOS,
         )?.public_address;
 
-        if (magicUserMetadataCosmosAddress !== req.body.magicAddress) {
+        if (req.body.magicAddress !== magicUserMetadataCosmosAddress) {
           throw new Error(
-            'magicAddress does not match magic user metadata Cosmos address',
+            'user-provided magicAddress does not match magic metadata Cosmos address',
           );
         }
-        // throws if magicAddress does not match signed address in didToken
-        // await magic.token.validate(req.body.didToken, req.body.magicAddress);
 
         generatedAddresses.push({
           address: req.body.magicAddress,

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -409,8 +409,8 @@ async function magicLoginRoute(
   // replay attack check
   const didTokenId = decodedMagicToken.claim.tid; // single-use token id
 
-  // The same didToken is used for potentially two addresses at the same time,
-  // (ex: Eth and Cosmos for Cosmos login)
+  // The same didToken is used for potentially two addresses at the same time
+  // (ex: Eth and cosmos for Cosmos sign-in),
   // but if a single one is found we reject the token replay
   const usedMagicToken = await models.Address.findOne({
     where: {
@@ -421,7 +421,7 @@ async function magicLoginRoute(
   if (usedMagicToken) {
     log.warn('Replay attack detected.');
     throw new Error(
-      `Replay attack detected for user ${decodedMagicToken.publicAddress}}.`,
+      `Replay attack detected for user ${decodedMagicToken.publicAddress}.`,
     );
   }
 

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -455,8 +455,7 @@ async function magicLoginRoute(
         // (magic bug?): magic typing doesn't match data, so we need to cast as any
         const magicWallets = magicUserMetadata.wallets as any[];
         const magicUserMetadataCosmosAddress = magicWallets?.find(
-          (wallet: any) =>
-            (wallet as unknown as any).wallet_type === WalletType.COSMOS,
+          (wallet) => wallet.wallet_type === WalletType.COSMOS,
         )?.public_address;
 
         if (req.body.magicAddress !== magicUserMetadataCosmosAddress) {

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -235,7 +235,7 @@ async function loginExistingMagicUser({
       ssoToken.issued_at = decodedMagicToken.claim.iat;
       ssoToken.updated_at = new Date();
       ssoToken.state_id = decodedMagicToken.claim.tid;
-      await ssoToken.save({ transaction }); // todo
+      await ssoToken.save({ transaction });
       log.trace('SSO TOKEN HANDLED NORMALLY');
     } else {
       // situation for legacy SsoToken instances:

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -49,7 +49,6 @@ type MagicLoginContext = {
 };
 
 const DEFAULT_ETH_CHAIN = 'ethereum';
-const DEFAULT_COSMOS_CHAIN = 'cosmos';
 
 // Creates a trusted address in a community
 async function createMagicAddressInstances(

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -113,7 +113,6 @@ function setupCosmosProxy(
    *  cosmos-api proxies for the magic link iframe
    * - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
    * - POST / for node info
-   * - POST /cosmos.auth.v1beta1.Query/Account for fetching address status (use by magic iframe)
    */
   app.options('/magicCosmosAPI/:chain', (req, res) => {
     res.header('Access-Control-Allow-Origin', 'https://auth.magic.link');

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -108,6 +108,65 @@ function setupCosmosProxy(
       }
     },
   );
+
+  /**
+   *  cosmos-api proxies for the magic link iframe
+   * - GET /node_info for fetching chain status (used by magic iframe, and magic login flow)
+   * - POST / for node info
+   * - POST /cosmos.auth.v1beta1.Query/Account for fetching address status (use by magic iframe)
+   */
+  app.options('/magicCosmosAPI/:chain', (req, res) => {
+    res.header('Access-Control-Allow-Origin', 'https://auth.magic.link');
+    res.header('Access-Control-Allow-Private-Network', 'true');
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, Content-Length, X-Requested-With',
+    );
+    res.sendStatus(200);
+  });
+
+  app.use(
+    '/magicCosmosAPI/:chain/?(node_info)?',
+    bodyParser.text(),
+    async (req, res) => {
+      log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      // always use cosmoshub for simplicity
+      const chainNode = await models.ChainNode.findOne({
+        where: { cosmos_chain_id: 'cosmoshub' },
+      });
+      const targetRestUrl = chainNode?.alt_wallet_url;
+      const targetRpcUrl = chainNode?.url;
+      log.trace(`Found cosmos endpoint: ${targetRestUrl}, ${targetRpcUrl}`);
+
+      try {
+        let response;
+        if (req.method === 'POST') {
+          response = await axios.get(targetRestUrl + '/node_info', {
+            headers: {
+              origin: 'https://commonwealth.im/?magic_login_proxy=true',
+            },
+          });
+        }
+        log.trace(
+          `Got response from endpoint: ${JSON.stringify(
+            response.data,
+            null,
+            2,
+          )}`,
+        );
+
+        // magicCosmosAPI is CORS-approved for the magic iframe
+        res.setHeader('Access-Control-Allow-Origin', 'https://auth.magic.link');
+        res.setHeader('Access-Control-Allow-Methods', '*');
+        res.setHeader('Access-Control-Allow-Headers', 'content-type');
+        return res.send(response.data);
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      }
+    },
+  );
 }
 
 export default setupCosmosProxy;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6230 

## Description of Changes
- Fixes case: Can't join a Cosmos community with a new E-mail address
- Addresses token replay scenarios

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Adds magic-generated cosmos address to User when it matches that from a signed Magic DID token
- Rejects re-used Magic DID tokens

## Test Plan
- CA (click around) tested on local:
  - go to /terra-luna-classic-lunc or /osmosis or /injective
    - Sign in with an email address that hasn't been used for CW yet
    - Expect to sign in successfully and see "Joined" and "Connected" with a chain or `cosmos` address
  - other Magic use cases should be unchanged

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Magic does not yet support ADR-036, so this is another way to validate the cosmos address.
- https://magic.link/docs/api/server-side-sdks/node#getmetadatabypublicaddressandwallet
- https://magic.link/docs/authentication/features/decentralized-id#decentralized-id-token-specification