### PR TITLE
fixed Moderator field persistence bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
@@ -22,10 +22,13 @@ const AdminsAndModerators = () => {
 
   const debouncedSearchTerm = useDebounce<string>(searchTerm, 500);
 
-  const { data: { admins: returnedAdmins, mods: returnedMods } = {} } =
-    useFetchAdminQuery({
-      communityId: app.activeChainId(),
-    });
+  const {
+    data: { admins: returnedAdmins, mods: returnedMods } = {},
+    isLoading: isFetchAdminQueryLoading,
+    refetch: refetchAdminData,
+  } = useFetchAdminQuery({
+    communityId: app.activeChainId(),
+  });
 
   const { data: searchResults, refetch } = useSearchProfilesQuery({
     communityId: app.activeChainId(),
@@ -35,6 +38,7 @@ const AdminsAndModerators = () => {
     orderDirection: APIOrderDirection.Desc,
     includeRoles: true,
   });
+
   const roleData = useMemo(() => {
     if (!searchResults?.pages?.length) {
       return [];
@@ -50,13 +54,13 @@ const AdminsAndModerators = () => {
   }, [searchResults]);
 
   useEffect(() => {
-    if (returnedAdmins && returnedAdmins.length > 0) {
+    if (!isFetchAdminQueryLoading && returnedAdmins.length > 0) {
       setAdmins(returnedAdmins);
     }
-    if (returnedMods && returnedMods.length > 0) {
+    if (!isFetchAdminQueryLoading && returnedMods.length > 0) {
       setMods(returnedMods);
     }
-  }, [returnedAdmins, returnedMods]);
+  }, [returnedAdmins, returnedMods, isFetchAdminQueryLoading]);
 
   const handleRoleUpdate = (oldRole, newRole) => {
     // newRole doesn't have the Address property that oldRole has,
@@ -108,6 +112,7 @@ const AdminsAndModerators = () => {
       }
     }
     refetch();
+    refetchAdminData();
   };
 
   return (
@@ -121,28 +126,32 @@ const AdminsAndModerators = () => {
         moderators can only make changes to content by locking and deleting.`,
       }}
     >
-      <section className="admins-moderators">
-        <ManageRoles
-          label="Admins"
-          roledata={admins}
-          onRoleUpdate={handleRoleUpdate}
-        />
-        <ManageRoles
-          label="Moderators"
-          roledata={mods}
-          onRoleUpdate={handleRoleUpdate}
-        />
-        <CWText type="caption" className={ComponentType.Label}>
-          Members
-        </CWText>
+      {isFetchAdminQueryLoading ? (
+        <p>Loading admins and moderators...</p>
+      ) : (
+        <section className="admins-moderators">
+          <ManageRoles
+            label="Admins"
+            roledata={admins}
+            onRoleUpdate={handleRoleUpdate}
+          />
+          <ManageRoles
+            label="Moderators"
+            roledata={mods}
+            onRoleUpdate={handleRoleUpdate}
+          />
+          <CWText type="caption" className={ComponentType.Label}>
+            Members
+          </CWText>
 
-        <UpgradeRolesForm
-          roleData={roleData}
-          onRoleUpdate={handleRoleUpdate}
-          searchTerm={searchTerm}
-          setSearchTerm={setSearchTerm}
-        />
-      </section>
+          <UpgradeRolesForm
+            roleData={roleData}
+            onRoleUpdate={handleRoleUpdate}
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+          />
+        </section>
+      )}
     </CommunityManagementLayout>
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -31,6 +31,14 @@ export const UpgradeRolesForm = ({
     { id: 2, checked: false },
   ]);
 
+  const zeroOutRadioButtons = () => {
+    const zeroedOutRadioButtons = radioButtons.map((radioButton) => ({
+      ...radioButton,
+      checked: false,
+    }));
+    setRadioButtons(zeroedOutRadioButtons);
+  };
+
   const nonAdmins: RoleInfo[] = roleData.filter((_role) => {
     return (
       _role.permission === AccessLevel.Member ||
@@ -144,6 +152,7 @@ export const UpgradeRolesForm = ({
 
               onRoleUpdate(_user, r.result);
             });
+            zeroOutRadioButtons();
           }}
         />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6454 

## Description of Changes
If user is promoted to Moderator and then demoted, their name does not persist in the Moderators field after navigating away from and back to the Admins and Moderators page. 
I also added in a little flair to clear out the radio buttons when Upgrade Button is pressed. This changed was sanctioned by both Jared Bell and @mzparacha 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Added a loading state and a refetch method to get admins and mods on page mount

## Test Plan
-go to a community where you are an admin and there are multiple members
-click into Admins and Moderators
-promote a user to Moderator, then revoke that
-navigate away from this page then back to it
-notice that user is no longer in the Moderators field. 


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->

https://github.com/hicommonwealth/commonwealth/assets/69872984/b9221ab0-8073-4e2d-b85c-8bd01715cbca

