### PR TITLE
Add reaction timestamp and reaction weights to bulk threads query

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -84,7 +84,7 @@ export async function __getBulkThreads(
         threads.read_only, threads.body, threads.stage, threads.discord_meta,
         threads.has_poll, threads.plaintext,
         threads.url, threads.pinned, COALESCE(threads.number_of_comments,0) as threads_number_of_comments,
-        threads.reaction_ids, threads.reaction_type, threads.addresses_reacted, COALESCE(threads.total_likes, 0)
+        threads.reaction_ids, threads.reaction_timestamps, threads.reaction_weights, threads.reaction_type, threads.addresses_reacted, COALESCE(threads.total_likes, 0)
           as threads_total_likes,
         threads.reaction_weights_sum,
         threads.links as links,
@@ -102,7 +102,7 @@ export async function __getBulkThreads(
           t.updated_at AS thread_updated,
           t.locked_at AS thread_locked,
           t.community_id AS thread_chain, t.read_only, t.body, t.discord_meta, t.comment_count AS number_of_comments,
-          reactions.reaction_ids, reactions.reaction_type, reactions.addresses_reacted, t.reaction_count AS total_likes,
+          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type, reactions.addresses_reacted, t.reaction_count AS total_likes,
           t.reaction_weights_sum,
           t.has_poll,
           t.plaintext,
@@ -120,7 +120,9 @@ export async function __getBulkThreads(
             SELECT thread_id,
             STRING_AGG(ad.address::text, ',') AS addresses_reacted,
             STRING_AGG(r.reaction::text, ',') AS reaction_type,
-            STRING_AGG(r.id::text, ',') AS reaction_ids
+            STRING_AGG(r.id::text, ',') AS reaction_ids,
+            STRING_AGG(r.created_at::text, ',') AS reaction_timestamps,
+            STRING_AGG(COALESCE(r.calculated_voting_weight::text, '0'), ',') AS reaction_weights
             FROM "Reactions" as r
             JOIN "Threads" t2
             ON r.thread_id = t2.id and t2.community_id = $community_id ${
@@ -140,7 +142,7 @@ export async function __getBulkThreads(
           AND (${includePinnedThreads ? 't.pinned = true OR' : ''}
           (COALESCE(t.last_commented_on, t.created_at) < $to_date AND t.pinned = false))
           GROUP BY (t.id, t.max_notif_id, t.comment_count,
-          reactions.reaction_ids, reactions.reaction_type, reactions.addresses_reacted)
+          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type, reactions.addresses_reacted)
           ORDER BY t.pinned DESC, t.max_notif_id DESC
         ) threads
       ON threads.address_id = addr.id
@@ -207,6 +209,12 @@ export async function __getBulkThreads(
       },
       numberOfComments: t.threads_number_of_comments,
       reactionIds: t.reaction_ids ? t.reaction_ids.split(',') : [],
+      reactionTimestamps: t.reaction_timestamps
+        ? t.reaction_timestamps.split(',')
+        : [],
+      reactionWeights: t.reaction_weights
+        ? t.reaction_weights.split(',').map((n) => parseInt(n, 10))
+        : [],
       reaction_weights_sum: t.reaction_weights_sum,
       addressesReacted: t.addresses_reacted
         ? t.addresses_reacted.split(',')

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -84,7 +84,8 @@ export async function __getBulkThreads(
         threads.read_only, threads.body, threads.stage, threads.discord_meta,
         threads.has_poll, threads.plaintext,
         threads.url, threads.pinned, COALESCE(threads.number_of_comments,0) as threads_number_of_comments,
-        threads.reaction_ids, threads.reaction_timestamps, threads.reaction_weights, threads.reaction_type, threads.addresses_reacted, COALESCE(threads.total_likes, 0)
+        threads.reaction_ids, threads.reaction_timestamps, threads.reaction_weights, threads.reaction_type,
+        threads.addresses_reacted, COALESCE(threads.total_likes, 0)
           as threads_total_likes,
         threads.reaction_weights_sum,
         threads.links as links,
@@ -102,7 +103,8 @@ export async function __getBulkThreads(
           t.updated_at AS thread_updated,
           t.locked_at AS thread_locked,
           t.community_id AS thread_chain, t.read_only, t.body, t.discord_meta, t.comment_count AS number_of_comments,
-          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type, reactions.addresses_reacted, t.reaction_count AS total_likes,
+          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type,
+          reactions.addresses_reacted, t.reaction_count AS total_likes,
           t.reaction_weights_sum,
           t.has_poll,
           t.plaintext,
@@ -142,7 +144,8 @@ export async function __getBulkThreads(
           AND (${includePinnedThreads ? 't.pinned = true OR' : ''}
           (COALESCE(t.last_commented_on, t.created_at) < $to_date AND t.pinned = false))
           GROUP BY (t.id, t.max_notif_id, t.comment_count,
-          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type, reactions.addresses_reacted)
+          reactions.reaction_ids, reactions.reaction_timestamps, reactions.reaction_weights, reactions.reaction_type,
+          reactions.addresses_reacted)
           ORDER BY t.pinned DESC, t.max_notif_id DESC
         ) threads
       ON threads.address_id = addr.id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6459 

## Description of Changes
- Adds `reactionTimestamps` and `reactionWeights` to the bulk threads payload so that UI can render weighted reactions

## Test Plan
- Set env `REACTION_WEIGHT_OVERRIDE=300`
- Go to http://localhost:8080/ethereum/discussions
- Add a like to the first thread in the list
- Check the Chrome/Brave network tab and check the payload for the bulk threads route– confirm that the first element of the payload shows the `reactionTimestamps` and `reactionWeights` fields
- Confirm that the `reactionWeights` field contains `300`

## Deployment Plan
N/A

## Other Considerations
N/A