### PR TITLE
Fixed the added breadcrumb issue in admin

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
@@ -125,14 +125,6 @@ export const generateBreadcrumbs = (
       label = 'Discussions';
     }
 
-    if (
-      pathSegments[pathSegments.length - 1] === 'contract' ||
-      (['manage', 'analytics', 'contracts'].includes(pathSegments[1]) &&
-        index === 0)
-    ) {
-      label = 'Admin Capabilities';
-    }
-
     // Handles the unique logic of the discussions section
     if (
       !locationPath.includes('new/discussion') &&
@@ -166,6 +158,19 @@ export const generateBreadcrumbs = (
       }
       if (pathSegments.length > 3) {
         pathSegments.splice(2, 2);
+      }
+    }
+
+    if (
+      pathSegments[pathSegments.length - 1] === 'contract' ||
+      (['manage', 'analytics', 'contracts'].includes(pathSegments[1]) &&
+        index === 0)
+    ) {
+      label = 'Admin Capabilities';
+      isParent = true;
+
+      if (pathSegments.length > 1 && pathSegments[1] === 'manage') {
+        pathSegments.splice(0, 1);
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6491 

## Description of Changes
- Fixes issue where there was a middle not needed breadcrumb in Admin

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added a check where it would splice the breadcrumb array

## Test Plan
Create community (or open community where are you admin)
Navigate to Admins & Moderator page
In breadcrumb click on manage
Observe that it is fixed, should only have two tiers of breadcrumbs
