### PR TITLE
#6422 - Add Non-Featured Topics to Manage Topics Page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.scss
@@ -15,12 +15,25 @@
   gap: 24px;
 
   .content {
-    .featured-topic-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .featured-topic-list,
+    .regular-topic-list {
       display: flex;
       flex-direction: column;
-      height: 320px;
+      height: 400px;
+      gap: 8px;
 
       @include visibleScrollbar(light);
+
+      .header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
 
       .topic-row {
         @include topicRowStyles;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.scss
@@ -19,11 +19,22 @@
     flex-direction: column;
     gap: 16px;
 
+    .featured-topic-list {
+      height: 400px;
+    }
+
+    .regular-topic-list {
+      max-height: 400px;
+
+      .topic-list-container {
+        overflow-y: auto;
+      }
+    }
+
     .featured-topic-list,
     .regular-topic-list {
       display: flex;
       flex-direction: column;
-      height: 400px;
       gap: 8px;
 
       @include visibleScrollbar(light);

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
@@ -7,6 +7,7 @@ import {
   useUpdateFeaturedTopicsOrderMutation,
 } from 'client/scripts/state/api/topics';
 import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
+import CWIconButton from 'client/scripts/views/components/component_kit/new_designs/CWIconButton';
 import { CWModal } from 'client/scripts/views/components/component_kit/new_designs/CWModal';
 import { CWButton } from 'client/scripts/views/components/component_kit/new_designs/cw_button';
 import { EditTopicModal } from 'client/scripts/views/modals/edit_topic_modal';
@@ -18,6 +19,24 @@ export const ManageTopicsSection = () => {
   const getFilteredTopics = (rawTopics: Topic[]): Topic[] => {
     const topics = rawTopics
       .filter((topic) => topic.featuredInSidebar)
+      .map((topic) => ({ ...topic } as Topic));
+
+    if (!topics.length) return [];
+
+    if (!topics[0].order) {
+      return [...topics]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .reduce((acc, curr, index) => {
+          return [...acc, { ...curr, order: index + 1 }];
+        }, []);
+    } else {
+      return [...topics].sort((a, b) => a.order - b.order);
+    }
+  };
+
+  const getRegularTopics = (rawTopics: Topic[]): Topic[] => {
+    const topics = rawTopics
+      .filter((topic) => !topic.featuredInSidebar)
       .map((topic) => ({ ...topic } as Topic));
 
     if (!topics.length) return [];
@@ -46,6 +65,10 @@ export const ManageTopicsSection = () => {
     getFilteredTopics(rawTopics),
   );
 
+  const [regularTopics, setRegularTopics] = useState<Topic[]>(() =>
+    getRegularTopics(rawTopics),
+  );
+
   const [topicSelectedToEdit, setTopicSelectedToEdit] = useState<Topic>(null);
 
   const handleSave = async () => {
@@ -62,12 +85,20 @@ export const ManageTopicsSection = () => {
 
   useEffect(() => {
     setTopics(getFilteredTopics(rawTopics));
+    setRegularTopics(getRegularTopics(rawTopics));
   }, [rawTopics]);
 
   return (
     <div className="ManageTopicsSection">
       <div className="content">
         <div className="featured-topic-list">
+          <div className="header">
+            <CWText type="h4">Featured Topics</CWText>
+            <CWText type="b1">
+              Manage the topics that appear in the sidebar of your community
+            </CWText>
+          </div>
+
           {topics.length ? (
             <DraggableTopicsList
               topics={topics}
@@ -76,6 +107,35 @@ export const ManageTopicsSection = () => {
             />
           ) : (
             <CWText>No Topics to Reorder</CWText>
+          )}
+        </div>
+
+        <div className="regular-topic-list">
+          <div className="header">
+            <CWText type="h4">Other Topics</CWText>
+            <CWText type="b1">
+              Manage the topics that appear in the discussion filter dropdown
+            </CWText>
+          </div>
+
+          {regularTopics.length ? (
+            regularTopics.map((regTopic, index) => (
+              <div key={index} className="topic-row">
+                <CWText>
+                  {regTopic.name}
+                  <CWIconButton
+                    iconName="pencil"
+                    buttonSize="sm"
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      setTopicSelectedToEdit(regTopic);
+                    }}
+                  />
+                </CWText>
+              </div>
+            ))
+          ) : (
+            <CWText>No Topics to View</CWText>
           )}
         </div>
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
@@ -16,7 +16,7 @@ import React, { useEffect, useState } from 'react';
 import './ManageTopicsSection.scss';
 
 export const ManageTopicsSection = () => {
-  const getFilteredTopics = (rawTopics: Topic[]): Topic[] => {
+  const getFeaturedTopics = (rawTopics: Topic[]): Topic[] => {
     const topics = rawTopics
       .filter((topic) => topic.featuredInSidebar)
       .map((topic) => ({ ...topic } as Topic));
@@ -61,8 +61,8 @@ export const ManageTopicsSection = () => {
   const { mutateAsync: updateFeaturedTopicsOrder } =
     useUpdateFeaturedTopicsOrderMutation();
 
-  const [topics, setTopics] = useState<Topic[]>(() =>
-    getFilteredTopics(rawTopics),
+  const [featuredTopics, setFeaturedTopics] = useState<Topic[]>(() =>
+    getFeaturedTopics(rawTopics),
   );
 
   const [regularTopics, setRegularTopics] = useState<Topic[]>(() =>
@@ -73,18 +73,18 @@ export const ManageTopicsSection = () => {
 
   const handleSave = async () => {
     try {
-      await updateFeaturedTopicsOrder({ featuredTopics: topics });
+      await updateFeaturedTopicsOrder({ featuredTopics: featuredTopics });
     } catch (err) {
       notifyError('Failed to update order');
     }
   };
 
   const handleReversion = () => {
-    setTopics(getFilteredTopics(rawTopics));
+    setFeaturedTopics(getFeaturedTopics(rawTopics));
   };
 
   useEffect(() => {
-    setTopics(getFilteredTopics(rawTopics));
+    setFeaturedTopics(getFeaturedTopics(rawTopics));
     setRegularTopics(getRegularTopics(rawTopics));
   }, [rawTopics]);
 
@@ -99,10 +99,10 @@ export const ManageTopicsSection = () => {
             </CWText>
           </div>
 
-          {topics.length ? (
+          {featuredTopics.length ? (
             <DraggableTopicsList
-              topics={topics}
-              setTopics={setTopics}
+              topics={featuredTopics}
+              setTopics={setFeaturedTopics}
               onEdit={setTopicSelectedToEdit}
             />
           ) : (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
@@ -118,25 +118,27 @@ export const ManageTopicsSection = () => {
             </CWText>
           </div>
 
-          {regularTopics.length ? (
-            regularTopics.map((regTopic, index) => (
-              <div key={index} className="topic-row">
-                <CWText>
-                  {regTopic.name}
-                  <CWIconButton
-                    iconName="pencil"
-                    buttonSize="sm"
-                    onClick={async (e) => {
-                      e.stopPropagation();
-                      setTopicSelectedToEdit(regTopic);
-                    }}
-                  />
-                </CWText>
-              </div>
-            ))
-          ) : (
-            <CWText>No Topics to View</CWText>
-          )}
+          <div className="topic-list-container">
+            {regularTopics.length ? (
+              regularTopics.map((regTopic, index) => (
+                <div key={index} className="topic-row">
+                  <CWText>
+                    {regTopic.name}
+                    <CWIconButton
+                      iconName="pencil"
+                      buttonSize="sm"
+                      onClick={async (e) => {
+                        e.stopPropagation();
+                        setTopicSelectedToEdit(regTopic);
+                      }}
+                    />
+                  </CWText>
+                </div>
+              ))
+            ) : (
+              <CWText>No Topics to View</CWText>
+            )}
+          </div>
         </div>
       </div>
       <div className="actions">


### PR DESCRIPTION
This PR adds a section for non-featured topics to the 'Manage Topics' page.

## Link to Issue
Closes: #6422 

## Description of Changes
- On the Topics page (under Admin Capabilities submenu), under the 'Manage Topics' tab, a section for non-featured topics has been added

## Test Plan
- make sure you are an admin
- navigate to the Topics page (see the Admin Capabilities submenu), then the Manage Topics tab
- make sure that you can see and can edit non-featured topics
