### PR TITLE
changed error message and separated components

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -94,7 +94,7 @@ const ViewSnapshotsProposalPage = lazy(
   () => import('views/pages/view_snapshot_proposal'),
 );
 const NewSnapshotProposalPage = lazy(
-  () => import('views/pages/new_snapshot_proposal'),
+  () => import('views/pages/new_snapshot_proposal/NewSnapshotProposalPage'),
 );
 const AdminPanelPage = lazy(() => import('views/pages/AdminPanel'));
 

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/NewSnapshotProposalPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/NewSnapshotProposalPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NewSnapshotProposalForm } from '../../../views/pages/new_snapshot_proposal/index';
+import { CWText } from '../../components/component_kit/cw_text';
+
+type NewSnapshotProposalPageProps = {
+  snapshotId: string;
+};
+
+const NewSnapshotProposalPage = ({
+  snapshotId,
+}: NewSnapshotProposalPageProps) => {
+  return (
+    <div className="NewSnapshotProposalPage">
+      <CWText type="h3" fontWeight="medium">
+        New Snapshot Proposal
+      </CWText>
+      <NewSnapshotProposalForm snapshotId={snapshotId} />
+    </div>
+  );
+};
+
+export default NewSnapshotProposalPage;

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/NewSnapshotProposalPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/NewSnapshotProposalPage.tsx
@@ -6,7 +6,7 @@ type NewSnapshotProposalPageProps = {
   snapshotId: string;
 };
 
-const NewSnapshotProposalPage = ({
+export const NewSnapshotProposalPage = ({
   snapshotId,
 }: NewSnapshotProposalPageProps) => {
   return (

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/NewSnapshotProposalPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/NewSnapshotProposalPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { NewSnapshotProposalForm } from '../../../views/pages/new_snapshot_proposal/index';
 import { CWText } from '../../components/component_kit/cw_text';
+import { NewSnapshotProposalForm } from './index';
 
 type NewSnapshotProposalPageProps = {
   snapshotId: string;

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -319,3 +319,4 @@ export const NewSnapshotProposalForm = ({
     </div>
   );
 };
+export default NewSnapshotProposalForm;

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -24,10 +24,6 @@ import {
 import { createNewProposal } from './helpers';
 import type { ThreadForm } from './types';
 
-type NewSnapshotProposalPageProps = {
-  snapshotId: string;
-};
-
 type NewSnapshotProposalFormProps = {
   snapshotId: string;
   thread?: Thread;
@@ -90,7 +86,7 @@ export const NewSnapshotProposalForm = ({
         onSave({ id: response.id, snapshot_title: response.title }); // Pass relevant information
       }
     } catch (err) {
-      notifyError(capitalize(err.message));
+      notifyError(capitalize(err.error_description));
     } finally {
       setIsSaving(false);
     }
@@ -300,7 +296,7 @@ export const NewSnapshotProposalForm = ({
           <ReactQuillEditor
             contentDelta={contentDelta}
             setContentDelta={setContentDelta}
-            placeholder={'What is your proposal?'}
+            placeholder="What is your proposal?"
           />
           <div className="footer">
             {onModalClose && (
@@ -323,18 +319,3 @@ export const NewSnapshotProposalForm = ({
     </div>
   );
 };
-
-const NewSnapshotProposalPage = ({
-  snapshotId,
-}: NewSnapshotProposalPageProps) => {
-  return (
-    <div className="NewSnapshotProposalPage">
-      <CWText type="h3" fontWeight="medium">
-        New Snapshot Proposal
-      </CWText>
-      <NewSnapshotProposalForm snapshotId={snapshotId} />
-    </div>
-  );
-};
-
-export default NewSnapshotProposalPage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6485 

## Description of Changes
-Updated error message and separated components to pass tests

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-At first I thought this was a bug in how we were saving the Snapshot address, but in further digging I realized that it was instead a proposal rate limit problem (see screenshot of rate limit). I changed to error message shown to read 'Proposal limit reached' to reflect this instead of simply giving a blank error notice (also see screenshot). 

## Test Plan
This is annoying to test, but if you need to you simply have to create several Snapshot proposals in a row to see the error. 
<img width="766" alt="Screenshot 2024-01-29 at 4 58 09 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/b92c936c-1679-4878-b15a-7ae48badfd35">
<img width="1440" alt="Screenshot 2024-01-29 at 5 13 32 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/acc5376f-b8a7-4661-a0f3-bce9ee7b4e04">
