### PR TITLE
Migrating feature flagging for communityStakes to Unleash

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -3,5 +3,4 @@ export const featureFlags = {
   communityHomepage: process.env.FLAG_COMMUNITY_HOMEPAGE === 'true',
   sidebarToggle: process.env.FLAG_SIDEBAR_TOGGLE === 'true',
   newAdminOnboardingEnabled: process.env.FLAG_NEW_ADMIN_ONBOARDING === 'true',
-  communityStake: process.env.FLAG_COMMUNITY_STAKE === 'true',
 };

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -1,6 +1,6 @@
 import { DefaultPage } from '@hicommonwealth/core';
+import { useFlag } from '@unleash/proxy-client-react';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import { featureFlags } from 'helpers/feature-flags';
 import getLinkType from 'helpers/linkType';
 import React, { useState } from 'react';
 import { slugifyPreserveDashes } from 'shared/utils';
@@ -32,6 +32,7 @@ import {
 } from './validation';
 
 const CommunityProfileForm = () => {
+  const communityStakeEnabled = useFlag('flag.communityStake');
   const communityTagOptions: CommunityTags[] = ['DeFi', 'DAO'];
   const community = app.config.chains.getById(app.activeChainId());
 
@@ -206,7 +207,7 @@ const CommunityProfileForm = () => {
               placeholder="Community URL"
               value={`${window.location.origin}/${communityId}`}
             />
-            {featureFlags.communityStake && (
+            {communityStakeEnabled && (
               <>
                 <CWTextInput
                   disabled

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/CreateCommunity.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/CreateCommunity.tsx
@@ -1,3 +1,4 @@
+import { useFlag } from '@unleash/proxy-client-react';
 import React from 'react';
 
 import CWFormSteps from 'views/components/component_kit/new_designs/CWFormSteps';
@@ -14,6 +15,7 @@ import { CreateCommunityStep, getFormSteps } from './utils';
 import './CreateCommunity.scss';
 
 const CreateCommunity = () => {
+  const communityStakeEnabled = useFlag('flag.communityStake');
   const {
     createCommunityStep,
     selectedCommunity,
@@ -76,7 +78,11 @@ const CreateCommunity = () => {
     <div className="CreateCommunity">
       {!isSuccessStep && (
         <CWFormSteps
-          steps={getFormSteps(createCommunityStep, showCommunityStakeStep)}
+          steps={getFormSteps(
+            createCommunityStep,
+            showCommunityStakeStep,
+            communityStakeEnabled,
+          )}
         />
       )}
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/useCreateCommunity.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/useCreateCommunity.ts
@@ -1,3 +1,4 @@
+import { useFlag } from '@unleash/proxy-client-react';
 import { useState } from 'react';
 
 import { ValidChains } from '@hicommonwealth/chains';
@@ -7,6 +8,7 @@ import { SelectedCommunity } from 'views/components/component_kit/new_designs/CW
 import { CreateCommunityStep, handleChangeStep } from './utils';
 
 const useCreateCommunity = () => {
+  const communityStakeEnabled = useFlag('flag.communityStake');
   const [createCommunityStep, setCreateCommunityStep] =
     useState<CreateCommunityStep>(CreateCommunityStep.CommunityTypeSelection);
   const [selectedCommunity, setSelectedCommunity] = useState<SelectedCommunity>(
@@ -23,6 +25,7 @@ const useCreateCommunity = () => {
       createCommunityStep,
       setCreateCommunityStep,
       showCommunityStakeStep,
+      communityStakeEnabled,
     );
   };
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/utils.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { featureFlags } from 'helpers/feature-flags';
 import { CWFormStepsProps } from 'views/components/component_kit/new_designs/CWFormSteps/CWFormSteps';
 
 export enum CreateCommunityStep {
@@ -13,6 +12,7 @@ export enum CreateCommunityStep {
 export const getFormSteps = (
   createCommunityStep: CreateCommunityStep,
   showCommunityStakeStep: boolean,
+  communityStakeEnabled: boolean,
 ): CWFormStepsProps['steps'] => {
   return [
     {
@@ -31,7 +31,7 @@ export const getFormSteps = (
           ? 'active'
           : 'completed',
     },
-    ...((featureFlags.communityStake && showCommunityStakeStep
+    ...((communityStakeEnabled && showCommunityStakeStep
       ? [
           {
             label: 'Community Stake',
@@ -54,6 +54,7 @@ export const handleChangeStep = (
     React.SetStateAction<CreateCommunityStep>
   >,
   showCommunityStakeStep: boolean,
+  communityStakeEnabled: boolean,
 ) => {
   switch (createCommunityStep) {
     case CreateCommunityStep.CommunityTypeSelection:
@@ -62,7 +63,7 @@ export const handleChangeStep = (
     case CreateCommunityStep.BasicInformation:
       setCreateCommunityStep(
         forward
-          ? featureFlags.communityStake && showCommunityStakeStep
+          ? communityStakeEnabled && showCommunityStakeStep
             ? CreateCommunityStep.CommunityStake
             : CreateCommunityStep.Success
           : CreateCommunityStep.CommunityTypeSelection,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6522

## Description of Changes
- Removes the in memory feature flag for communityStakes
- Adds the unleash feature flag for communityStakes

## Test Plan
With the required API key in environment variables, run through the community stakes flow
- Create a new ethereum community, Make sure chain is set to goerli, after creating see the "Do you want to enable community Stake?" screen