### PR TITLE
changed error message for Metamask reject on create snapshot

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -86,7 +86,9 @@ export const NewSnapshotProposalForm = ({
         onSave({ id: response.id, snapshot_title: response.title }); // Pass relevant information
       }
     } catch (err) {
-      notifyError(capitalize(err.error_description));
+      err.code === 'ACTION_REJECTED'
+        ? notifyError('User rejected signing')
+        : notifyError(capitalize(err.error_description));
     } finally {
       setIsSaving(false);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6487 

## Description of Changes
-An error of 'User rejected signing' is now shown when a user clicks Reject in Metamask while creating a snapshot. This is to replace default err showing all the wallet and snapshot info

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Changed the logic in the catch to look for a specific error code, and if found to throw a specific error. 
-NOTE: I wrote the error handling this way because it is difficult to access the Metamask RPC error object, so I improvised to look for the err.code instead

## Test Plan
-make sure you have a snapshot address saved. If not you can use this one commonspacetester.eth
-create a snapshot
-fill out the info to activate the Publish button, click that
-in Metamask modal click Reject
-notice that the error 'User rejected signing' is shown.
NOTE: To my knowledge this only works with Metamask. I will create more tickets to show different errors if this bug is present while using any other wallet. 


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-

https://github.com/hicommonwealth/commonwealth/assets/69872984/20a183c7-89d5-4e5d-927a-0d3910647fd9

