### PR TITLE
Cosmos node liveness

### DIFF
--- a/knowledge_base/Environment-Variables.md
+++ b/knowledge_base/Environment-Variables.md
@@ -17,6 +17,7 @@ If you add a new environment variable, you must add documentation here. Please d
 - [CHAIN_PORT](#chain_port)
 - [CLOUDAMQP_URL](#cloudamqp_url)
 - [COSMOS_GOV_V1](#cosmos_gov_v1)
+- [COSMOS_PROXY_REFERER](#cosmos_proxy_referer)
 - [COSMOS_REGISTRY_API](#cosmos_registry_api)
 - [CW_BOT_KEY](#cw_bot_key)
 - [DATABASE_CLEAN_HOUR](#database_clean_hour)
@@ -40,6 +41,7 @@ If you add a new environment variable, you must add documentation here. Please d
 - [ETH_ALCHEMY_API_KEY](#eth_alchemy_api_key)
 - [ETH_RPC](#eth_rpc)
 - [ETHERSCAN_JS_API_KEY](#etherscan_js_api_key)
+- [FALLBACK_NODE_DURATION_S](#fallback_node_duration_s)
 - [FLAG_COMMUNITY_HOMEPAGE](#flag_community_homepage)
 - [FLAG_PROPOSAL_TEMPLATES](#flag_proposal_templates)
 - [HEROKU_APP_NAME](#heroku_app_name)
@@ -110,6 +112,14 @@ Required in production. The URI of our RabbitMQ instance. This value is usually 
 ## COSMOS_GOV_V1
 
 Comma-separated list (e.g. "kyve,csdk") of Cosmos chains using v1 (not v1beta1). As of 231212, this should be `kyve,csdk,csdk-v1,quicksilver-protocol,juno,regen` by default.
+
+Owner: Mark Hagelberg.
+
+## COSMOS_PROXY_REFERER
+
+Optional.
+A whitelist Referer header that will prevent us getting rate-limited by the [proxy maintainers](https://github.com/cosmos/chain-registry/).
+Only used for cosmosAPI requests.
 
 Owner: Mark Hagelberg.
 
@@ -214,6 +224,12 @@ Owner: Ian Rowan
 ## ETHERSCAN_JS_API_KEY
 
 API key for Ethereum data.
+
+## FALLBACK_NODE_DURATION_S
+
+Optional. Defaults to 5 minutes (300 seconds).
+This is number, in seconds. It configures the length of time we will use a community-maintained public endpoint if a given ChainNode fails.
+After this time, the server will try the original DB endpoint again.
 
 ## FLAG_COMMUNITY_HOMEPAGE
 

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -242,3 +242,8 @@ export type ChainEventNotification = {
 };
 
 export type AnalyticsOptions = Record<string, any>;
+
+export enum NodeHealth {
+  Failed = 'failed',
+  Healthy = 'healthy',
+}

--- a/libs/model/src/models/chain_node.ts
+++ b/libs/model/src/models/chain_node.ts
@@ -1,4 +1,4 @@
-import type { BalanceType } from '@hicommonwealth/core';
+import type { BalanceType, NodeHealth } from '@hicommonwealth/core';
 import type * as Sequelize from 'sequelize'; // must use "* as" to avoid scope errors
 import type { DataTypes } from 'sequelize';
 import type { ModelInstance, ModelStatic } from './types';
@@ -15,6 +15,8 @@ export type ChainNodeAttributes = {
   ss58?: number;
   name: string;
   description?: string;
+  health?: NodeHealth;
+  updated_at?: Date;
 };
 
 export type ChainNodeInstance = ModelInstance<ChainNodeAttributes>;
@@ -41,6 +43,7 @@ export default (
       balance_type: { type: dataTypes.STRING, allowNull: false },
       name: { type: dataTypes.STRING, allowNull: false },
       description: { type: dataTypes.TEXT, allowNull: true },
+      health: { type: dataTypes.STRING, allowNull: true },
       ss58: { type: dataTypes.INTEGER, allowNull: true },
       bech32: { type: dataTypes.STRING, allowNull: true },
       created_at: { type: dataTypes.DATE, allowNull: false },

--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -112,7 +112,7 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
 
     if (chain?.cosmosGovernanceVersion === 'v1') {
       try {
-        const lcdUrl = `${window.location.origin}/cosmosLCD/${chain.id}`;
+        const lcdUrl = `${window.location.origin}/cosmosAPI/v1/${chain.id}`;
         console.log(`Starting LCD API at ${lcdUrl}...`);
         const lcd = await getLCDClient(lcdUrl);
         this._lcd = lcd;
@@ -206,7 +206,7 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
 
       client = await EthSigningClient(
         {
-          restUrl: `${window.location.origin}/cosmosLCD/${dbId}`,
+          restUrl: `${window.location.origin}/cosmosAPI/v1/${dbId}`,
           chainId,
           path: dbId,
         },

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -92,18 +92,14 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
 
   public async initApi(): Promise<void> {
     this._apiInitialized = true;
-    console.log(
-      `Started API for ${this.meta.id} on node: ${this.meta.node?.url}.`,
-    );
+    console.log(`Started API for ${this.meta.id}.`);
   }
 
   public async initData(): Promise<void> {
     this._loaded = true;
     this.app.chainModuleReady.emit('ready');
     this.app.isModuleReady = true;
-    console.log(
-      `Loaded data for ${this.meta.id} on node: ${this.meta.node?.url}.`,
-    );
+    console.log(`Loaded data for ${this.meta.id}.`);
   }
 
   public async deinit(): Promise<void> {

--- a/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchCosmosProposalMetadata.ts
+++ b/packages/commonwealth/client/scripts/state/api/proposals/cosmos/fetchCosmosProposalMetadata.ts
@@ -20,9 +20,6 @@ const fetchCosmosProposalMetadata = async (
 
     if (!isIPFSFile) {
       // TODO: fetch non-ipfs files. https://github.com/hicommonwealth/commonwealth/issues/4233
-      console.error(
-        `Non-IPFS metadata fetching is not yet implemented. Did not fetch ${fileURI}.`,
-      );
       return {};
     }
 

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_chain_node.ts
@@ -7,6 +7,8 @@ export const Errors = {
   ChainNodeExists: 'Chain Node already exists',
   NotAdmin: 'Not an admin',
   ChainIdNaN: 'eth_chain_id is required on ethereum Chain Nodes',
+  NeedCosmosChainId:
+    'cosmos_chain_id is a string, required on Cosmos Chain Nodes',
 };
 
 export type CreateChainNodeOptions = {
@@ -38,6 +40,12 @@ export async function __createChainNode(
 
   if (balanceType === 'ethereum' && typeof eth_chain_id !== 'number') {
     throw new AppError(Errors.ChainIdNaN);
+  }
+  if (
+    balanceType === BalanceType.Cosmos &&
+    typeof cosmos_chain_id !== 'string'
+  ) {
+    throw new AppError(Errors.NeedCosmosChainId);
   }
 
   let where;

--- a/packages/commonwealth/server/migrations/20240206190420-node-state.js
+++ b/packages/commonwealth/server/migrations/20240206190420-node-state.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'ChainNodes',
+        'health',
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        {
+          transaction: t,
+        },
+      );
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('ChainNodes', 'health', {
+        transaction: t,
+      });
+    });
+  },
+};

--- a/packages/commonwealth/server/util/cosmosProxy.ts
+++ b/packages/commonwealth/server/util/cosmosProxy.ts
@@ -2,7 +2,7 @@ import {
   CacheDecorator,
   lookupKeyDurationInReq,
 } from '@hicommonwealth/adapters';
-import { AppError, logger } from '@hicommonwealth/core';
+import { AppError, NodeHealth, logger } from '@hicommonwealth/core';
 import { DB } from '@hicommonwealth/model';
 import axios from 'axios';
 import bodyParser from 'body-parser';
@@ -14,7 +14,11 @@ import {
 } from './cosmosCache';
 
 const log = logger().getLogger(__filename);
-const defaultCacheDuration = 60 * 10; // 10 minutes
+const DEFAULT_CACHE_DURATION = 60 * 10; // 10 minutes
+const FALLBACK_NODE_DURATION = +process.env.FALLBACK_NODE_DURATION_S || 300; // 5 min
+const Errors = {
+  NeedCosmosChainId: 'cosmos_chain_id is required',
+};
 
 function setupCosmosProxy(
   app: Express,
@@ -27,26 +31,65 @@ function setupCosmosProxy(
     bodyParser.text(),
     calcCosmosRPCCacheKeyDuration,
     cacheDecorator.cacheMiddleware(
-      defaultCacheDuration,
+      DEFAULT_CACHE_DURATION,
       lookupKeyDurationInReq,
     ),
     async function cosmosProxy(req, res) {
       log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      let cosmos_chain_id, chainNodeUrl, previouslyFailed;
       try {
-        log.trace(`Querying cosmos endpoint for chain: ${req.params.chain}`);
+        const chainParam = req.params.chain;
         const chain = await models.Community.findOne({
-          where: { id: req.params.chain },
+          where: { id: chainParam },
           include: models.ChainNode,
         });
         if (!chain) {
-          throw new AppError('Invalid chain');
+          throw new AppError(`Invalid chain: ${chainParam}`);
         }
-        log.trace(`Found cosmos endpoint: ${chain.ChainNode.url}`);
-        const response = await axios.post(chain.ChainNode.url, req.body, {
-          headers: {
-            origin: 'https://commonwealth.im',
-          },
-        });
+
+        let response;
+        const chainNode = chain.ChainNode;
+        chainNodeUrl = chainNode?.url?.trim();
+        let useProxy = !chainNodeUrl;
+        cosmos_chain_id = chainNode?.cosmos_chain_id;
+        previouslyFailed = chainNode?.health === NodeHealth.Failed;
+        if (previouslyFailed) {
+          const lastUpdate = chainNode?.updated_at?.getTime();
+          const healthPauseTimeout = new Date(
+            lastUpdate + FALLBACK_NODE_DURATION,
+          );
+          useProxy = previouslyFailed && new Date() > healthPauseTimeout;
+        }
+
+        if (chainNodeUrl && !useProxy) {
+          log.trace(`Found cosmos endpoint: ${chainNodeUrl}`);
+          response = await axios
+            .post(chainNodeUrl, req.body, {
+              headers: {
+                origin: 'https://commonwealth.im',
+              },
+            })
+            .catch(async (err) => {
+              log.trace(`Error: ${err.message}`);
+              await flagFailedNode(
+                previouslyFailed,
+                cosmos_chain_id,
+                chainNodeUrl,
+                err,
+              );
+              return queryExternalProxy(req, cosmos_chain_id, 'rpc');
+            });
+
+          await flagHealthyNode(
+            response,
+            previouslyFailed,
+            cosmos_chain_id,
+            chainNodeUrl,
+          );
+        } else {
+          response = await queryExternalProxy(req, cosmos_chain_id, 'rpc');
+        }
+
         log.trace(
           `Got response from endpoint: ${JSON.stringify(
             response.data,
@@ -54,59 +97,195 @@ function setupCosmosProxy(
             2,
           )}`,
         );
+
         return res.send(response.data);
       } catch (err) {
-        res.status(500).json({ message: err.message });
+        await flagFailedNode(
+          previouslyFailed,
+          cosmos_chain_id,
+          chainNodeUrl,
+          err,
+        );
+        res.status(500).json({
+          message: err.message,
+        });
       }
     },
   );
 
-  // for gov v1 queries.
+  /**
+   *  For Cosmos REST requests, we use the alt_wallet_url which is an LCD enpdpoint.
+   *  Used for Cosmos chains that use v1 of the gov module.
+   */
   app.use(
-    '/cosmosLCD/:chain',
+    '/cosmosAPI/v1/:chain',
     bodyParser.text(),
     calcCosmosLCDCacheKeyDuration,
     cacheDecorator.cacheMiddleware(
-      defaultCacheDuration,
+      DEFAULT_CACHE_DURATION,
       lookupKeyDurationInReq,
     ),
     async function cosmosProxy(req, res) {
-      log.trace(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      log.info(`Got request: ${JSON.stringify(req.body, null, 2)}`);
+      let cosmos_chain_id, chainNodeRestUrl, previouslyFailed;
       try {
-        log.trace(`Querying cosmos endpoint for chain: ${req.params.chain}`);
+        const chainParam = req.params.chain;
         const chain = await models.Community.findOne({
-          where: { id: req.params.chain },
+          where: { id: chainParam },
           include: models.ChainNode,
         });
         if (!chain) {
-          throw new AppError('Invalid chain');
+          throw new AppError(`Invalid chain: ${chainParam}`);
         }
-        const targetUrl = chain.ChainNode?.alt_wallet_url;
-        if (!targetUrl) {
-          throw new AppError('No LCD endpoint found');
-        }
-        log.trace(`Found cosmos endpoint: ${targetUrl}`);
-        const rewrite = req.originalUrl.replace(req.baseUrl, targetUrl);
-        const body = _.isEmpty(req.body) ? null : req.body;
 
-        const response = await axios.post(rewrite, body, {
-          headers: {
-            origin: 'https://commonwealth.im',
-          },
-        });
-        log.trace(
-          `Got response from endpoint: ${JSON.stringify(
-            response.data,
-            null,
-            2,
-          )}`,
-        );
+        let response;
+        const chainNode = chain.ChainNode;
+        cosmos_chain_id = chainNode?.cosmos_chain_id;
+        chainNodeRestUrl = chainNode?.alt_wallet_url?.trim();
+        let useProxy = !chainNodeRestUrl;
+        previouslyFailed = chainNode?.health === NodeHealth.Failed;
+
+        if (previouslyFailed) {
+          const lastUpdate = chainNode?.updated_at?.getTime();
+          const healthPauseTimeout = new Date(
+            lastUpdate + FALLBACK_NODE_DURATION,
+          );
+          useProxy = previouslyFailed && new Date() > healthPauseTimeout;
+        }
+
+        if (chainNodeRestUrl && !useProxy) {
+          log.trace(`Found cosmos endpoint: ${chainNodeRestUrl}`);
+          const rewrite = req.originalUrl.replace(
+            req.baseUrl,
+            chainNodeRestUrl,
+          );
+          const body = _.isEmpty(req.body) ? null : req.body;
+
+          response = await axios
+            .post(rewrite, body, {
+              headers: {
+                origin: 'https://commonwealth.im',
+              },
+            })
+            .catch(async (err) => {
+              log.trace(`Error: ${err.message}`);
+              await flagFailedNode(
+                previouslyFailed,
+                cosmos_chain_id,
+                chainNodeRestUrl,
+                err,
+              );
+              return queryExternalProxy(req, cosmos_chain_id, 'rest');
+            });
+
+          await flagHealthyNode(
+            response,
+            previouslyFailed,
+            cosmos_chain_id,
+            chainNodeRestUrl,
+          );
+        } else {
+          response = await queryExternalProxy(req, cosmos_chain_id, 'rest');
+        }
+
+        log.trace(`Got response: ${JSON.stringify(response.data, null, 2)}`);
         return res.send(response.data);
       } catch (err) {
-        res.status(500).json({ message: err.message });
+        await flagFailedNode(
+          previouslyFailed,
+          cosmos_chain_id,
+          chainNodeRestUrl,
+          err,
+        );
+        res.status(500).json({
+          message: err.message,
+        });
       }
     },
   );
+
+  /**
+   * When a request fails for any reason, we try the cosmos.directory proxy.
+   * If that also fails, it is not a node problem, but probably a request problem.
+   * Also used if no preferred node is in our DB.
+   */
+  const queryExternalProxy = async (
+    req,
+    cosmos_chain_id: string,
+    web_protocol: 'rpc' | 'rest',
+  ) => {
+    if (!cosmos_chain_id) {
+      throw new AppError(Errors.NeedCosmosChainId);
+    }
+    const proxyUrl = `https://${web_protocol}.cosmos.directory/${cosmos_chain_id}`;
+    const rewrite = rewriteUrl(req, proxyUrl, web_protocol);
+    const body = _.isEmpty(req.body) ? null : req.body;
+    log.trace(`Querying proxy: ${proxyUrl}`);
+
+    const response = await axios.post(rewrite, body, {
+      headers: {
+        origin: 'https://commonwealth.im',
+        Referer: process.env.COSMOS_PROXY_REFERER || 'https://commonwealth.im',
+      },
+    });
+    return response;
+  };
+
+  const rewriteUrl = (req, proxyUrl: string, web_protocol: 'rpc' | 'rest') => {
+    if (web_protocol === 'rpc') {
+      return req.originalUrl.replace(req.originalUrl, proxyUrl);
+    } else if (web_protocol === 'rest') {
+      return req.originalUrl.replace(req.baseUrl, proxyUrl);
+    }
+    return '';
+  };
+
+  const flagFailedNode = async (
+    previouslyFailed: boolean,
+    cosmos_chain_id: string,
+    failedUrl: string,
+    error?: any,
+  ) => {
+    if (error?.message === Errors.NeedCosmosChainId) return; // not a health issue
+    if (previouslyFailed) return; // no need to hit db again
+    if (!cosmos_chain_id) {
+      throw new AppError(Errors.NeedCosmosChainId);
+    }
+
+    const failedChainNode = await models.ChainNode.findOne({
+      where: { cosmos_chain_id },
+    });
+    if (!failedChainNode) return;
+
+    failedChainNode.health = NodeHealth.Failed;
+    await failedChainNode.save();
+    log.trace(
+      `Problem with endpoint ${failedUrl}.
+       Marking node as 'failed' for ${FALLBACK_NODE_DURATION} seconds.
+      ${JSON.stringify(error)}`,
+    );
+  };
+
+  const flagHealthyNode = async (
+    response,
+    previouslyFailed: boolean,
+    cosmos_chain_id: string,
+    dbUrl: string,
+  ) => {
+    // update if the request was successfully made to the DB URL
+    // and the node was previously marked as failed
+    if (dbUrl?.includes(response.request.host) && previouslyFailed) {
+      if (!cosmos_chain_id) {
+        throw new AppError(Errors.NeedCosmosChainId);
+      }
+      const healthyChainNode = await models.ChainNode.findOne({
+        where: { cosmos_chain_id },
+      });
+      if (!healthyChainNode) return;
+      healthyChainNode.health = NodeHealth.Healthy;
+      await healthyChainNode.save();
+    }
+  };
 
   /**
    *  cosmos-api proxies for the magic link iframe

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxEthermint.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxEthermint.spec.ts
@@ -83,7 +83,7 @@ describe('Proposal Transaction Tests - ethermint chain (evmos-dev-ci)', () => {
   let rpc: CosmosApiType;
   let signerAddr: string;
   const rpcUrl = `http://localhost:8080/cosmosAPI/${id}`;
-  const lcdUrl = `http://localhost:8080/cosmosLCD/${id}`;
+  const lcdUrl = `http://localhost:8080/cosmosAPI/v1/${id}`;
 
   before(async () => {
     const tm = await getTMClient(rpcUrl);

--- a/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/proposalTxV1.spec.ts
@@ -30,7 +30,7 @@ const { expect, assert } = chai;
 
 const idV1 = 'csdk-v1'; // V1 CI devnet
 const rpcUrl = `http://localhost:8080/cosmosAPI/${idV1}`;
-const lcdUrl = `http://localhost:8080/cosmosLCD/${idV1}`;
+const lcdUrl = `http://localhost:8080/cosmosAPI/v1/${idV1}`;
 
 describe('Proposal Transaction Tests - gov v1 chain using cosmJs signer (csdk-v1)', () => {
   let lcd: LCD;

--- a/packages/commonwealth/test/e2e/e2eStateful/proposals.spec.ts
+++ b/packages/commonwealth/test/e2e/e2eStateful/proposals.spec.ts
@@ -1,3 +1,4 @@
+import { models } from '@hicommonwealth/model';
 import { expect, test } from '@playwright/test';
 
 test.describe.configure({ mode: 'parallel' });
@@ -17,148 +18,272 @@ test.describe('Community proposals page', () => {
     expect(innerText).toEqual('Active');
   };
 
+  const closeBanner = async ({ page }) => {
+    const banner = await page.$$('.Growl');
+    if (banner?.[0]) {
+      const closeButton = await banner[0].$('.closeButton');
+      await closeButton?.click();
+    }
+  };
+
   const inactiveProposalCardsTest = async ({ page }, expectedMinimumCount) => {
     await waitForCompletedProposals({ page });
-    const inactiveCardsContainer = await page
-      .locator('.CardsCollection .cards')
-      .nth(1);
+    const inactiveCardsCollection = await page.$$('.CardsCollection');
+    const inactiveCardsContainer = await inactiveCardsCollection?.[1];
+    const inactiveCardsSpinner = await inactiveCardsContainer?.$(
+      '.LoadingSpinner',
+    );
+    await inactiveCardsSpinner?.waitForElementState('hidden');
+    const inactiveCards = await inactiveCardsContainer?.$('.cards');
 
-    const cardCount = await inactiveCardsContainer
-      .locator('.ProposalCard')
-      .count();
-    await expect(cardCount).toBeGreaterThanOrEqual(expectedMinimumCount);
+    await expect(async () => {
+      const cardCount = await inactiveCards.$$eval(
+        '.ProposalCard',
+        (cards) => cards.length,
+      );
+      expect(cardCount).toBeGreaterThanOrEqual(expectedMinimumCount);
+    }).toPass();
   };
 
   const waitForCompletedProposals = async ({ page }) => {
     // these are lazy-loaded after page init
-    await page.waitForSelector('.CardsCollection:nth-of-type(2)');
-    const collection = await page.locator('.CardsCollection:nth-of-type(2)');
-    await collection.locator('.cards .LoadingSpinner');
-    const p = await collection
-      .locator('.cards .ProposalCard .proposal-card-metadata')
-      .first();
-    await p.waitFor({ state: 'visible', timeout: 60000 });
+    // await page.waitForSelector('.CardsCollection:nth-of-type(2)');
+    // const collection = await page.locator('.CardsCollection:nth-of-type(2)');
+    // await collection.locator('.cards .LoadingSpinner');
+    // const p = await collection
+    //   .locator('.cards .ProposalCard .proposal-card-metadata')
+    //   .first();
+    // await p.waitFor({ state: 'visible', timeout: 60000 });
+
+    await page.waitForSelector('.CardsCollection');
+    const collections = await page.$$('.CardsCollection');
+    const inactive = collections[1];
+    await inactive?.$('.cards .LoadingSpinner');
+    await inactive?.$$('.cards .ProposalCard .proposal-card-metadata');
+    const spinner = await inactive?.$('.LoadingSpinner');
+    await spinner?.waitForElementState('hidden');
+  };
+
+  const waitForIpfsRequests = async ({ page }) => {
+    const ipfsRe = /http:\/\/localhost:8080\/api\/ipfsProxy\?hash=*/;
+
+    await page.waitForResponse(ipfsRe, { timeout: 10000 }).catch(() => {
+      console.log('no ipfs requests');
+    });
   };
 
   const allProposalCardsHaveTitles = async ({ page }) => {
     await waitForCompletedProposals({ page });
-    const activeCardsContainer = await page
-      .locator('.CardsCollection .cards')
-      .nth(0);
-    const inactiveCardsContainer = await page
-      .locator('.CardsCollection .cards')
-      .nth(1);
+    const collections = await page.$$('.CardsCollection');
+    const activeCardsContainer = await collections[0]?.$('.cards');
+    const inactiveCardsContainer = await collections[1]?.$('.cards');
 
-    const activeCardTitles = await activeCardsContainer
-      .locator('.ProposalCard .Text.b1.semiBold.noWrap')
-      .all();
-    const inactiveCardTitles = await inactiveCardsContainer
-      .locator('.ProposalCard .Text.b1.semiBold.noWrap')
-      .all();
-    const cardTitles = [...activeCardTitles, ...inactiveCardTitles];
+    await expect(async () => {
+      const activeCardTitles = await activeCardsContainer?.$$(
+        '.ProposalCard .Text.b1.semiBold.noWrap',
+      );
+      const inactiveCardTitles = await inactiveCardsContainer?.$$(
+        '.ProposalCard .Text.b1.semiBold.noWrap',
+      );
 
-    expect(cardTitles.length).toBeGreaterThan(0);
+      const cardTitles = [...activeCardTitles, ...inactiveCardTitles];
+      expect(cardTitles.length).toBeGreaterThan(0);
 
-    for (const title of cardTitles) {
-      await title.waitFor({ state: 'visible', timeout: 60000 });
-      const titleText = await title.innerText();
-      expect(titleText).toBeTruthy();
-      expect(titleText.length).toBeGreaterThan(0);
-    }
+      for (const title of cardTitles) {
+        const titleText = await title.innerText();
+        expect(titleText).toBeTruthy();
+        expect(titleText.length).toBeGreaterThan(0);
+      }
+    }).toPass();
   };
 
-  const inactiveProposalPageTest = async ({ page }) => {
+  const inactiveProposalPageTest = async ({ page }, isV1?: boolean) => {
     test.setTimeout(70000);
+    await page.waitForSelector('.CardsCollection .cards');
+    if (isV1) await waitForIpfsRequests({ page });
+
+    await closeBanner({ page });
     await waitForCompletedProposals({ page });
-    const inactiveCardsContainer = await page
-      .locator('.CardsCollection .cards')
-      .nth(1);
+    const cardsContainers = await page.$$('.CardsCollection .cards');
+    const inactiveCardsContainer = await cardsContainers?.[1];
 
-    const firstCard = await inactiveCardsContainer
-      .locator('.ProposalCard')
-      .first();
+    const proposals = await inactiveCardsContainer?.$$('.ProposalCard');
 
-    const title = await firstCard
-      .locator('.Text.b1.semiBold.noWrap')
-      .first()
-      .innerText();
+    const firstProposal = proposals[proposals.length - 1];
+    if (isV1) {
+      await waitForIpfsRequests({ page });
+      await waitForIpfsRequests({ page });
+    }
+
+    const title = await firstProposal?.$('.Text.b1.semiBold.noWrap');
+    const expectedTitle = await title?.innerText();
 
     const navigationPromise = page.waitForNavigation();
-    firstCard.click();
+    await firstProposal?.click({ force: true });
 
     await navigationPromise;
-    await inactiveProposalPageAssertions({ page, expectedTitle: title });
+    const pageSpinner = await page.$('.LoadingSpinner');
+    await pageSpinner?.waitForElementState('hidden');
+    await inactiveProposalPageAssertions({ page, expectedTitle });
   };
 
   const inactiveProposalPageAssertions = async ({
     page,
     expectedTitle,
+    isV1,
   }: {
     page: any;
     expectedTitle?: string;
+    isV1?: boolean;
   }) => {
     await page.waitForSelector('.ContentPage', {
-      timeout: 60000,
+      timeout: 30000,
     });
-    const content = await page.locator('.main-body-container');
+    await closeBanner({ page });
+    if (isV1) await waitForIpfsRequests({ page });
 
-    const header = await content.locator('.header .h3').first();
-    const headerText = await header.innerText();
-    const statusText = await content
-      .locator('.onchain-status-text')
-      .first()
-      .innerText();
-    const description = await content
-      .locator('.MarkdownFormattedText')
-      .first()
-      .innerHTML();
-    const voteResult = await content
-      .locator('.VotingResult')
-      .first()
-      .innerHTML();
+    const skeleton = await page.$(
+      '.ContentPage .main-body-container .react-loading-skeleton',
+    );
+    await skeleton?.waitForElementState('hidden');
+
+    const content = await page.$('.ContentPage .main-body-container');
+    await content.waitForElementState('stable');
+
+    const status = await content.$('.onchain-status-text');
+    await status?.waitForElementState('visible');
+    const statusText = await status?.innerText();
+    const header = await content.$('.header .title');
+    const headerText = await header?.innerText();
+    const description = await content.$('.MarkdownFormattedText');
+    const descText = await description?.innerText();
+    const votingResult = await content.$('.VotingResult');
+    const voteResult = await votingResult?.innerText();
 
     expect(headerText).toBeTruthy();
     expect(headerText.length).toBeGreaterThan(0);
     if (expectedTitle) expect(headerText).toEqual(expectedTitle);
     expect(statusText).toBeTruthy();
-    expect(description).toBeTruthy();
+    expect(descText).toBeTruthy();
     expect(voteResult).toBeTruthy();
   };
 
   // now the test runs:
   test.describe('kyve (gov v1)', () => {
-    const proposalsPageUrl = `http://localhost:8080/kyve/proposals`;
-    test('Active header loads', async ({ page }) => {
-      await page.goto(proposalsPageUrl);
-      await headerTest({ page });
+    const chain = 'kyve';
+    const proposalsPageUrl = `http://localhost:8080/${chain}/proposals`;
+    let originalRPCEndpoint;
+    let originalRESTEndpoint;
+    test.beforeAll(async () => {
+      const chainNode = await models.ChainNode.findOne({
+        where: { cosmos_chain_id: chain },
+      });
+      originalRPCEndpoint = chainNode.url;
+      originalRESTEndpoint = chainNode.alt_wallet_url;
     });
-    test('Inactive proposal cards load', async ({ page }) => {
-      await page.goto(proposalsPageUrl);
-      await inactiveProposalCardsTest({ page }, 5); // as of commit, should never be less than 5
+    test.describe('Using provided URL', () => {
+      test('Active header loads', async ({ page }) => {
+        await page.goto(proposalsPageUrl);
+        await headerTest({ page });
+      });
+      test('Inactive proposal cards load', async ({ page }) => {
+        await page.goto(proposalsPageUrl);
+        await inactiveProposalCardsTest({ page }, 23); // as of commit, should never be less than 23
+      });
+      test('Inactive proposal page loads from Proposal Card click', async ({
+        page,
+      }) => {
+        await page.goto(proposalsPageUrl);
+        await inactiveProposalPageTest({ page }, true);
+      });
+      test('Inactive proposal page loads on direct URL', async ({ page }) => {
+        await page.goto(`http://localhost:8080/kyve/proposal/5`);
+        await inactiveProposalPageAssertions({ page, isV1: true });
+      });
+      test('All proposal cards have titles', async ({ page }) => {
+        await page.goto(proposalsPageUrl);
+        await allProposalCardsHaveTitles({ page });
+      });
     });
-    test('Inactive proposal page loads from Proposal Card click', async ({
-      page,
-    }) => {
-      await page.goto(proposalsPageUrl);
-      await inactiveProposalPageTest({ page });
-    });
-    test('Inactive proposal page loads on direct URL', async ({ page }) => {
-      await page.goto(`http://localhost:8080/kyve/proposal/5`);
-      await inactiveProposalPageAssertions({ page });
-    });
-    test('All proposal cards have titles', async ({ page }) => {
-      await page.goto(proposalsPageUrl);
-      await allProposalCardsHaveTitles({ page });
+
+    test.describe('Using fallback proxy', () => {
+      test.describe('When chain node fails', () => {
+        test.beforeAll(async () => {
+          await models.ChainNode.update(
+            {
+              alt_wallet_url: `nonsense${Math.random()}`,
+              url: `shouldfail${Math.random()}`,
+            },
+            { where: { cosmos_chain_id: chain } },
+          );
+        });
+        test('Proposals load', async ({ page }) => {
+          await page.goto(proposalsPageUrl);
+          await inactiveProposalCardsTest({ page }, 23);
+        });
+        test('Inactive proposal page loads ', async ({ page }) => {
+          await page.goto(`http://localhost:8080/${chain}/proposal/5`);
+          await page.waitForSelector('.LoadingSpinner');
+          await inactiveProposalPageAssertions({ page, isV1: true });
+        });
+        test.afterAll(async () => {
+          await models.ChainNode.update(
+            {
+              url: originalRPCEndpoint,
+              alt_wallet_url: originalRESTEndpoint,
+            },
+            { where: { cosmos_chain_id: chain } },
+          );
+        });
+      });
     });
   });
-  test.describe('osmosis (gov v1beta1)', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto(`http://localhost:8080/osmosis/proposals`);
+
+  test.describe('stargaze (gov v1beta1)', () => {
+    const chain = 'stargaze';
+    const proposalsPageUrl = `http://localhost:8080/${chain}/proposals`;
+    let originalRPCEndpoint;
+    test.describe('Using provided URL', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.goto(proposalsPageUrl);
+      });
+      test('Active header loads', headerTest);
+      test('Inactive proposal cards load', ({ page }) =>
+        inactiveProposalCardsTest({ page }, 200)); // as of commit, should never be less than 200
+      test('Inactive proposal page loads', ({ page }) =>
+        inactiveProposalPageTest({ page }));
+      test('All proposal cards have titles', allProposalCardsHaveTitles);
     });
-    test('Active header loads', headerTest);
-    test('Inactive proposal cards load', ({ page }) =>
-      inactiveProposalCardsTest({ page }, 79)); // as of commit, should never be less than 79
-    test('Inactive proposal page loads', inactiveProposalPageTest);
-    test('All proposal cards have titles', allProposalCardsHaveTitles);
+
+    test.describe('Using fallback proxy', () => {
+      test.describe('When chain node fails', () => {
+        test.beforeAll(async () => {
+          await models.ChainNode.update(
+            {
+              alt_wallet_url: `nonsense${Math.random()}`,
+              url: `shouldfail${Math.random()}`,
+            },
+            { where: { cosmos_chain_id: chain } },
+          );
+        });
+        test('Proposals load', async ({ page }) => {
+          await page.goto(proposalsPageUrl);
+          await inactiveProposalCardsTest({ page }, 200);
+        });
+        test('Inactive proposal page loads ', async ({ page }) => {
+          await page.goto(`http://localhost:8080/${chain}/proposal/5`);
+          await page.waitForSelector('.LoadingSpinner');
+          await inactiveProposalPageAssertions({ page });
+        });
+        test.afterAll(async () => {
+          await models.ChainNode.update(
+            {
+              url: originalRPCEndpoint,
+            },
+            { where: { cosmos_chain_id: chain } },
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
+++ b/packages/commonwealth/test/integration/api/cosmosCache.spec.ts
@@ -14,8 +14,10 @@ import {
   cosmosRPCKey,
 } from 'server/util/cosmosCache';
 import app, { cacheDecorator, redisCache } from '../../../server-test';
-const v1beta1ChainId = 'csdk-beta';
-const v1ChainId = 'csdk';
+const V1BETA1_CHAIN_ID = 'csdk-beta';
+const V1_CHAIN_ID = 'csdk';
+const V1BETA1_API = `/cosmosAPI`;
+const V1_API = `/cosmosAPI/v1`;
 
 chai.use(chaiHttp);
 const expect = chai.expect;
@@ -51,7 +53,7 @@ describe('Cosmos Cache', () => {
   describe('cosmosAPI', () => {
     async function makeRPCRequest(
       body,
-      path = `/cosmosAPI/${v1beta1ChainId}`,
+      path = `/cosmosAPI/${V1BETA1_CHAIN_ID}`,
       headers = {
         'content-type': 'text/plain;charset=UTF-8',
         'accept-language': 'en-US,en;q=0.9',
@@ -69,7 +71,7 @@ describe('Cosmos Cache', () => {
 
     function rpcTestKeyAndDuration(body, expectedKey, expectedDuration) {
       const request = {
-        originalUrl: `/cosmosAPI/${v1beta1ChainId}`,
+        originalUrl: `${V1BETA1_API}/${V1BETA1_CHAIN_ID}`,
       };
       const key = cosmosRPCKey(request, body);
       const duration = cosmosRPCDuration(body);
@@ -83,7 +85,7 @@ describe('Cosmos Cache', () => {
       expectedDuration: number,
     ) => {
       const request = {
-        originalUrl: `/cosmosAPI/${v1beta1ChainId}`,
+        originalUrl: `${V1BETA1_API}/${V1BETA1_CHAIN_ID}`,
       };
       const params = {
         path: '/cosmos.gov.v1beta1.Query/Proposals',
@@ -97,7 +99,7 @@ describe('Cosmos Cache', () => {
         params: params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_{"path":"/cosmos.gov.v1beta1.Query/Proposals","data":"${proposalStatus}","prove":false}`;
 
       const key = cosmosRPCKey(request, body);
       expect(key).to.be.equal(expectedKey);
@@ -143,7 +145,7 @@ describe('Cosmos Cache', () => {
         },
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Proposal","data":"08b502","prove":false}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_{"path":"/cosmos.gov.v1beta1.Query/Proposal","data":"08b502","prove":false}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 7);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -161,7 +163,7 @@ describe('Cosmos Cache', () => {
         params: params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_{"path":"/cosmos.gov.v1beta1.Query/Votes","data":"08b502","prove":false}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_{"path":"/cosmos.gov.v1beta1.Query/Votes","data":"08b502","prove":false}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -179,7 +181,7 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${params.path}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_${params.path}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -197,7 +199,7 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${JSON.stringify(
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_${JSON.stringify(
         params,
       )}`;
 
@@ -217,7 +219,7 @@ describe('Cosmos Cache', () => {
         params,
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${params.path}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_${params.path}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 60 * 60 * 24 * 5);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -230,7 +232,7 @@ describe('Cosmos Cache', () => {
         params: {},
       };
       const bodyString = JSON.stringify(body);
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${bodyString}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_${bodyString}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);
@@ -244,19 +246,19 @@ describe('Cosmos Cache', () => {
       };
       const bodyString = JSON.stringify(body);
 
-      const expectedKey = `/cosmosAPI/${v1beta1ChainId}_${bodyString}`;
+      const expectedKey = `${V1BETA1_API}/${V1BETA1_CHAIN_ID}_${bodyString}`;
 
       rpcTestKeyAndDuration(body, expectedKey, 6);
       await rpcTestIsCached(bodyString, expectedKey);
     });
   }).timeout(5000);
 
-  describe('cosmosLCD', () => {
+  describe('cosmosAPI/v1', () => {
     const lcdProposalsCacheExpectedTest = async (
       proposalStatus: string,
       expectedDuration: number,
     ) => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/proposals?proposal_status=${proposalStatus}&voter=&depositor=`;
       lcdTestDuration(expectedDuration, url, {
         proposal_status: proposalStatus,
       });
@@ -267,7 +269,7 @@ describe('Cosmos Cache', () => {
       param: string,
       expectedDuration: number,
     ) => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/params/${param}`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/params/${param}`;
       lcdTestDuration(expectedDuration, url);
       await lcdTestIsCached(url);
     };
@@ -295,19 +297,19 @@ describe('Cosmos Cache', () => {
     }
 
     it('should have 7-day duration for an an individual proposal', async () => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/proposals/1`;
       lcdTestDuration(60 * 60 * 24 * 7, url);
     });
     it("should have 6-second duration for an an individual proposal's live votes", async () => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/votes`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/proposals/1/votes`;
       lcdTestDuration(6, url);
     });
     it("should have 6-second duration for an individual proposal's live tally", async () => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/tally`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/proposals/1/tally`;
       lcdTestDuration(6, url);
     });
     it("should have 6-second duration for an individual proposal's live deposits", async () => {
-      const url = `/cosmosLCD/${v1ChainId}/cosmos/gov/v1/proposals/1/deposits`;
+      const url = `${V1_API}/${V1_CHAIN_ID}/cosmos/gov/v1/proposals/1/deposits`;
       lcdTestDuration(6, url);
     });
     it('should cache deposit period proposals', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #5157 

## Description of Changes
- Creates a fallback strategy for failing Cosmos nodes
- Adds a `health` column to ChainNodes
- Renames cosmosLCD to cosmosAPI/v1
   
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- If a chain node fails, we try the community proxy endpoint provided by cosmos.directory
- For a given period (default 5 minutes), we continue to use the proxy (using health flag and last_updated)

## Test Plan
- Add playwright tests to demonstrate node-failure case (local only)
- Devnet tests will run in CI
- CA (click around) tested on local:
  - http://localhost:8080/ux/discussions/proposals -> Note loaded proposals
  - Set your local db to a failing node for /ux:
```
update "ChainNodes" set alt_wallet_url = 'willfail' where cosmos_chain_id = 'ux';
update "ChainNodes" set url = 'willalsofail' where cosmos_chain_id = 'ux';
```
  - http://localhost:8080/ux/discussions/proposals again -> Expect proposals to still load

## Deployment Plan
<!--- Omit if unneeded -->
1.  Optional env vars added for configuration. Not needed for deployment, although we may want to update the proxy referer when a whitelist header is agreed upon.
`COSMOS_PROXY_REFERER`
`FALLBACK_NODE_DURATION_S` in seconds (defaults to 300 if not provided)

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- if #6097 is merged first, we will want to make some adjustments to this PR.