### PR TITLE
Hotfix sending app errors to rollbar

### DIFF
--- a/libs/adapters/src/utils/setupErrorHandlers.ts
+++ b/libs/adapters/src/utils/setupErrorHandlers.ts
@@ -1,12 +1,6 @@
 import { AppError, ServerError, logger } from '@hicommonwealth/core';
 import type { Express, Request, Response } from 'express';
 
-class ExpressError extends Error {
-  constructor(public error: Error, public req: Request) {
-    super(error.message);
-  }
-}
-
 // Handle server and application errors.
 // 401 Unauthorized errors are handled by Express' middleware and returned
 // before this handler. Errors that hit the final condition should be either
@@ -26,19 +20,22 @@ export const setupErrorHandlers = (app: Express) => {
   // Handle our ServerErrors (500), AppErrors (400), or unknown errors.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((error, req, res: Response, next) => {
-    log.error(error.message, new ExpressError(error, req));
+    error.req = req;
     if (error instanceof ServerError) {
+      log.error(error.message, error);
       res.status(error.status).send({
         status: error.status,
         // Use external facing error message
         error: 'Server error, please try again later.',
       });
     } else if (error instanceof AppError) {
+      log.warn(error.message, error); // just warn, to avoid overloading rollbar with bots and attacks
       res.status(error.status).send({
         status: error.status,
         error: error.message,
       });
     } else {
+      log.error(error.message, error);
       res.status(500);
       res.json({
         status: error.status,


### PR DESCRIPTION
We've been hit with a wave of application errors (AppError 400) following a recent community migration for comment fetching. It looks like a bot is at play here.

We have a policy to send all error (and fatal) logs over to the `rollbar` service to keep tabs on the system's well-being.

To tackle this issue, we're tweaking the logging settings to categorize app errors as warnings instead of errors. This should help weed out any bot or attack from cluttering up the logs.