### PR TITLE
[Sign-in Revamp]: Email Sign-in UI + Implementation

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -177,10 +177,13 @@ const useWallets = (walletProps: IuseWalletProps) => {
   }, []);
 
   // Handles Magic Link Login
-  const onEmailLogin = async () => {
+  const onEmailLogin = async (emailToUse = '') => {
+    const tempEmailToUse = emailToUse || email;
+    setEmail(tempEmailToUse);
+
     setIsMagicLoading(true);
 
-    if (!email) {
+    if (!tempEmailToUse) {
       notifyError('Please enter a valid email address.');
       setIsMagicLoading(false);
       return;
@@ -189,7 +192,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
     try {
       const isCosmos = app.chain?.base === ChainBase.CosmosSDK;
       const { address: magicAddress } = await startLoginWithMagicLink({
-        email,
+        email: tempEmailToUse,
         isCosmos,
         redirectTo: document.location.pathname + document.location.search,
         chain: app.chain?.id,

--- a/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.scss
@@ -5,29 +5,63 @@
   align-items: center;
   gap: 16px;
   border-radius: 6px;
-  border: 2px solid $neutral-200;
   padding: 16px;
   width: 100%;
   outline: none !important;
   cursor: pointer;
-  background-color: white;
 
-  &:not(:disabled) {
-    &:focus-within,
-    &:focus,
-    &:active {
-      border: 2px solid $primary-200 !important;
-      outline: none !important;
+  &.rounded {
+    border-radius: 16px;
+  }
+
+  &.light {
+    background-color: white;
+    border: 2px solid $neutral-200;
+
+    &:not(:disabled) {
+      &:focus-within,
+      &:focus,
+      &:active {
+        border: 2px solid $primary-200 !important;
+        outline: none !important;
+      }
+    }
+
+    &:disabled {
+      background-color: $neutral-100 !important;
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      background-color: $neutral-25;
     }
   }
 
-  &:disabled {
-    background-color: $neutral-100 !important;
-    cursor: not-allowed;
-  }
+  &.dark {
+    background-color: #1e1f1f;
+    border: transparent;
 
-  &:hover {
-    background-color: $neutral-25;
+    &:not(:disabled) {
+      &:focus-within,
+      &:focus,
+      &:active {
+        border: transparent !important;
+        outline: none !important;
+      }
+    }
+
+    &:disabled {
+      background-color: $neutral-800 !important;
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      background-color: $neutral-900;
+    }
+
+    .Text {
+      color: white;
+    }
   }
 
   .icon {

--- a/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.tsx
@@ -13,6 +13,9 @@ const AuthButton = ({
   onClick,
   className = '',
   disabled = false,
+  showDescription = true,
+  rounded = false,
+  variant = 'light',
 }: AuthButtonProps) => {
   const auth = AUTH_TYPES[type];
   const IconComp = auth.icon.isCustom ? CWCustomIcon : CWIcon;
@@ -21,7 +24,7 @@ const AuthButton = ({
     <button
       disabled={disabled}
       onClick={disabled ? null : onClick}
-      className={clsx('AuthButton', className)}
+      className={clsx('AuthButton', variant, rounded && 'rounded', className)}
     >
       <IconComp className="icon" iconName={auth.icon.name as any} />
 
@@ -30,7 +33,7 @@ const AuthButton = ({
           {auth.label}
         </CWText>
 
-        {auth?.description && (
+        {auth?.description && showDescription && (
           <CWTag
             type="stage"
             label={auth.description.text}

--- a/packages/commonwealth/client/scripts/views/components/AuthButton/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/AuthButton/types.ts
@@ -35,4 +35,7 @@ export type AuthButtonProps = {
   onClick?: () => any;
   className?: string;
   disabled?: boolean;
+  showDescription?: boolean;
+  rounded?: boolean;
+  variant?: 'light' | 'dark';
 };

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
@@ -4,7 +4,11 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import app from 'state';
 import AuthButton from '../../components/AuthButton';
-import { AuthTypes, AuthWallets } from '../../components/AuthButton/types';
+import {
+  AuthTypes,
+  AuthWallets,
+  EVMWallets,
+} from '../../components/AuthButton/types';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import {
@@ -17,6 +21,7 @@ import {
   CWTabsRow,
 } from '../../components/component_kit/new_designs/CWTabs';
 import './AuthModal.scss';
+import { EVMWalletsSubModal } from './EVMWalletsSubModal';
 import { EmailForm } from './EmailForm';
 import { AuthModalProps, AuthModalTabs } from './types';
 
@@ -27,11 +32,14 @@ const AuthModal = ({
   showWalletsFor,
 }: AuthModalProps) => {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
+  const [isEVMWalletsModalVisible, setIsEVMWalletsModalVisible] =
+    useState(false);
   const [isAuthenticatingWithEmail, setIsAuthenticatingWithEmail] =
     useState(false);
 
   const handleClose = async () => {
     setIsAuthenticatingWithEmail(false);
+    setIsEVMWalletsModalVisible(false);
     await onClose();
   };
 
@@ -46,6 +54,9 @@ const AuthModal = ({
     onSuccess,
   });
 
+  const evmWallets = (wallets || [])
+    .filter((wallet) => wallet.chain == ChainBase.Ethereum)
+    .map((wallet) => wallet.name) as EVMWallets[];
   const cosmosWallets = (wallets || [])
     .filter((wallet) => wallet.chain === ChainBase.CosmosSDK)
     .map((wallet) => wallet.name);
@@ -96,11 +107,13 @@ const AuthModal = ({
 
     // if any wallet option is selected
     if (activeTabIndex === 0) {
-      await onWalletSelect(
-        wallets.find(
-          (wallet) => wallet.name.toLowerCase() === option.toLowerCase(),
-        ),
-      );
+      // if wallet connect option is selected, open the EVM wallet list modal
+      if (option === 'walletconnect' && !isEVMWalletsModalVisible) {
+        setIsEVMWalletsModalVisible(true);
+        return;
+      }
+
+      await onWalletSelect(wallets.find((wallet) => wallet.name === option));
     }
 
     // if any SSO option is selected
@@ -113,82 +126,91 @@ const AuthModal = ({
   };
 
   return (
-    <CWModal
-      open={isOpen}
-      onClose={handleClose}
-      size="medium"
-      content={
-        <section className="AuthModal">
-          <CWIcon
-            iconName="close"
-            onClick={handleClose}
-            className="close-btn"
-          />
+    <>
+      <CWModal
+        open={isOpen}
+        onClose={handleClose}
+        size="medium"
+        content={
+          <section className="AuthModal">
+            <CWIcon
+              iconName="close"
+              onClick={handleClose}
+              className="close-btn"
+            />
 
-          <img src="/static/img/branding/common-logo.svg" className="logo" />
+            <img src="/static/img/branding/common-logo.svg" className="logo" />
 
-          <CWText type="h2" className="header" isCentered>
-            Sign into Common
-          </CWText>
+            <CWText type="h2" className="header" isCentered>
+              Sign into Common
+            </CWText>
 
-          <CWModalBody className="content">
-            <CWTabsRow className="tabs">
-              {tabsList.map((tab, index) => (
-                <CWTab
-                  key={tab.name}
-                  label={tab.name}
-                  isDisabled={isMagicLoading}
-                  isSelected={tabsList[activeTabIndex].name === tab.name}
-                  onClick={() => setActiveTabIndex(index)}
-                />
-              ))}
-            </CWTabsRow>
+            <CWModalBody className="content">
+              <CWTabsRow className="tabs">
+                {tabsList.map((tab, index) => (
+                  <CWTab
+                    key={tab.name}
+                    label={tab.name}
+                    isDisabled={isMagicLoading}
+                    isSelected={tabsList[activeTabIndex].name === tab.name}
+                    onClick={() => setActiveTabIndex(index)}
+                  />
+                ))}
+              </CWTabsRow>
 
-            <section className="auth-options">
-              {/* On the wallets tab, if no wallet is found, show "No wallets Found" */}
-              {activeTabIndex === 0 &&
-                tabsList[activeTabIndex].options.length === 0 && (
-                  <AuthButton type="NO_WALLETS_FOUND" />
-                )}
+              <section className="auth-options">
+                {/* On the wallets tab, if no wallet is found, show "No wallets Found" */}
+                {activeTabIndex === 0 &&
+                  tabsList[activeTabIndex].options.length === 0 && (
+                    <AuthButton type="NO_WALLETS_FOUND" />
+                  )}
 
-              {/*
+                {/*
                 If email option is selected don't render SSO's list,
                 else render wallets/SSO's list based on activeTabIndex
               */}
-              {(activeTabIndex === 0 ||
-                (activeTabIndex === 1 && !isAuthenticatingWithEmail)) &&
-                tabsList[activeTabIndex].options.map((option, key) => (
-                  <AuthButton
-                    key={key}
-                    type={option}
-                    disabled={isMagicLoading}
-                    onClick={async () => await onAuthMethodSelect(option)}
+                {(activeTabIndex === 0 ||
+                  (activeTabIndex === 1 && !isAuthenticatingWithEmail)) &&
+                  tabsList[activeTabIndex].options.map((option, key) => (
+                    <AuthButton
+                      key={key}
+                      type={option}
+                      disabled={isMagicLoading}
+                      onClick={async () => await onAuthMethodSelect(option)}
+                    />
+                  ))}
+
+                {/* If email option is selected from the SSO's list, show email form */}
+                {activeTabIndex === 1 && isAuthenticatingWithEmail && (
+                  <EmailForm
+                    isLoading={isMagicLoading}
+                    onCancel={() => setIsAuthenticatingWithEmail(false)}
+                    onSubmit={async ({ email }) => await onEmailLogin(email)}
                   />
-                ))}
+                )}
+              </section>
+            </CWModalBody>
 
-              {/* If email option is selected from the SSO's list, show email form */}
-              {activeTabIndex === 1 && isAuthenticatingWithEmail && (
-                <EmailForm
-                  isLoading={isMagicLoading}
-                  onCancel={() => setIsAuthenticatingWithEmail(false)}
-                  onSubmit={async ({ email }) => await onEmailLogin(email)}
-                />
-              )}
-            </section>
-          </CWModalBody>
-
-          <CWModalFooter className="footer">
-            <CWText isCentered>
-              By connecting to Common you agree to our&nbsp;
-              <br />
-              <Link to="/terms">Terms of Service</Link>
-              &nbsp;and&nbsp;
-              <Link to="/privacy">Privacy Policy</Link>
-            </CWText>
-          </CWModalFooter>
-        </section>
-      }
-    />
+            <CWModalFooter className="footer">
+              <CWText isCentered>
+                By connecting to Common you agree to our&nbsp;
+                <br />
+                <Link to="/terms">Terms of Service</Link>
+                &nbsp;and&nbsp;
+                <Link to="/privacy">Privacy Policy</Link>
+              </CWText>
+            </CWModalFooter>
+          </section>
+        }
+      />
+      <EVMWalletsSubModal
+        availableWallets={evmWallets}
+        isOpen={isEVMWalletsModalVisible}
+        onClose={() => setIsEVMWalletsModalVisible(false)}
+        onWalletSelect={async (option) => await onAuthMethodSelect(option)}
+        disabled={isMagicLoading}
+      />
+    </>
   );
 };
 

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/EVMWalletsSubModal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/EVMWalletsSubModal.scss
@@ -1,0 +1,50 @@
+@import '../../../../../styles/shared';
+
+.EVMWalletsSubModal {
+  background-color: black;
+
+  .CWModal {
+    border-radius: 24px;
+    box-shadow: none;
+    background: transparent;
+  }
+
+  .container {
+    background-color: #191a1a;
+    color: white !important;
+    border-radius: 24px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: 370px;
+    padding: 24px 12px;
+    gap: 24px;
+
+    @include extraSmall {
+      min-width: auto;
+    }
+
+    .header {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 16px;
+      padding: 0 24px;
+
+      .Text {
+        color: white !important;
+      }
+
+      .Icon {
+        cursor: pointer;
+      }
+    }
+
+    .evm-wallet-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      width: 100%;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/EVMWalletsSubModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/EVMWalletsSubModal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import AuthButton from 'views/components/AuthButton';
+import { EVMWallets } from 'views/components/AuthButton/types';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWIcon } from '../../../components/component_kit/cw_icons/cw_icon';
+import { CWModal } from '../../../components/component_kit/new_designs/CWModal';
+import './EVMWalletsSubModal.scss';
+
+type EVMWalletsSubModalProps = {
+  isOpen: boolean;
+  onClose: () => any;
+  disabled?: boolean;
+  availableWallets?: EVMWallets[];
+  onWalletSelect?: (wallet: EVMWallets) => any;
+};
+
+const EVMWalletsSubModal = ({
+  isOpen,
+  onClose,
+  disabled,
+  availableWallets,
+  onWalletSelect,
+}: EVMWalletsSubModalProps) => {
+  return (
+    <CWModal
+      rootClassName="EVMWalletsSubModal"
+      open={isOpen}
+      onClose={onClose}
+      content={
+        <section className="container">
+          <div className="header">
+            <CWIcon iconName="help" />
+            <CWText type="h3" className="header" isCentered>
+              Connect Wallet
+            </CWText>
+            <CWIcon iconName="close" onClick={onClose} />
+          </div>
+
+          <section className="evm-wallet-list">
+            {availableWallets.map((wallet) => (
+              <AuthButton
+                key={wallet}
+                type={wallet}
+                rounded
+                variant="dark"
+                showDescription={false}
+                onClick={async () => await onWalletSelect(wallet)}
+                disabled={disabled}
+              />
+            ))}
+          </section>
+        </section>
+      }
+    />
+  );
+};
+
+export { EVMWalletsSubModal };

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EVMWalletsSubModal/index.ts
@@ -1,0 +1,1 @@
+export { EVMWalletsSubModal } from './EVMWalletsSubModal';

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.scss
@@ -1,0 +1,29 @@
+@import '../../../../../styles/shared';
+
+.EmailForm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  padding: 0 4px;
+
+  .LoadingSpinner {
+    margin: auto;
+  }
+
+  .action-btns {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+
+    .btn-border {
+      margin: 0 !important;
+
+      &:focus-within {
+        border-width: 1px !important;
+        padding: 0px !important;
+      }
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.scss
@@ -20,6 +20,14 @@
     .btn-border {
       margin: 0 !important;
 
+      @include extraSmall {
+        width: 100% !important;
+
+        button {
+          width: 100% !important;
+        }
+      }
+
       &:focus-within {
         border-width: 1px !important;
         padding: 0px !important;

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.tsx
@@ -19,32 +19,35 @@ const EmailForm = ({ onSubmit, onCancel, isLoading }: EmailFormProps) => {
       validationSchema={emailValidationSchema}
       onSubmit={!isLoading ? onSubmit : () => {}}
     >
-      <CWTextInput
-        fullWidth
-        hookToForm
-        name="email"
-        label="Email address"
-        placeholder="Email address"
-      />
-
-      {isLoading && <CWLoadingSpinner />}
-
-      <div className="action-btns">
-        <CWButton
-          type="button"
-          onClick={onCancel}
-          buttonType="tertiary"
-          label="Back to sign in options"
-          disabled={isLoading}
-        />
-        <CWButton
-          type="submit"
-          buttonWidth="wide"
-          buttonType="primary"
-          label="Sign in with Magic"
-          disabled={isLoading}
-        />
-      </div>
+      {isLoading ? (
+        <CWLoadingSpinner />
+      ) : (
+        <>
+          <CWTextInput
+            fullWidth
+            hookToForm
+            name="email"
+            label="Email address"
+            placeholder="Email address"
+          />
+          <div className="action-btns">
+            <CWButton
+              type="button"
+              onClick={onCancel}
+              buttonType="tertiary"
+              label="Back to sign in options"
+              disabled={isLoading}
+            />
+            <CWButton
+              type="submit"
+              buttonWidth="wide"
+              buttonType="primary"
+              label="Sign in with Magic"
+              disabled={isLoading}
+            />
+          </div>
+        </>
+      )}
     </CWForm>
   );
 };

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/EmailForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import CWLoadingSpinner from 'views/components/component_kit/new_designs/CWLoadingSpinner';
+import { CWForm } from '../../../components/component_kit/new_designs/CWForm';
+import { CWTextInput } from '../../../components/component_kit/new_designs/CWTextInput';
+import { CWButton } from '../../../components/component_kit/new_designs/cw_button';
+import './EmailForm.scss';
+import { emailValidationSchema } from './validation';
+
+type EmailFormProps = {
+  onCancel: () => any;
+  onSubmit: (values: { email: string }) => any;
+  isLoading?: boolean;
+};
+
+const EmailForm = ({ onSubmit, onCancel, isLoading }: EmailFormProps) => {
+  return (
+    <CWForm
+      className="EmailForm"
+      validationSchema={emailValidationSchema}
+      onSubmit={!isLoading ? onSubmit : () => {}}
+    >
+      <CWTextInput
+        fullWidth
+        hookToForm
+        name="email"
+        label="Email address"
+        placeholder="Email address"
+      />
+
+      {isLoading && <CWLoadingSpinner />}
+
+      <div className="action-btns">
+        <CWButton
+          type="button"
+          onClick={onCancel}
+          buttonType="tertiary"
+          label="Back to sign in options"
+          disabled={isLoading}
+        />
+        <CWButton
+          type="submit"
+          buttonWidth="wide"
+          buttonType="primary"
+          label="Sign in with Magic"
+          disabled={isLoading}
+        />
+      </div>
+    </CWForm>
+  );
+};
+
+export { EmailForm };

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/index.ts
@@ -1,0 +1,1 @@
+export { EmailForm } from './EmailForm';

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/EmailForm/validation.ts
@@ -1,0 +1,10 @@
+import { VALIDATION_MESSAGES } from 'client/scripts/helpers/formValidationMessages';
+import { z } from 'zod';
+
+const emailValidationSchema = z.object({
+  email: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .email({ message: VALIDATION_MESSAGES.INVALID_INPUT }),
+});
+
+export { emailValidationSchema };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6386

## Description of Changes
- Adds new Email login form (with validations) in AuthModal with auth implementation
- Disables all other auth options when any type of authentication is in progress.

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_NEW_SIGN_IN_MODAL` in .env
- Logout and visit any page
- Open the login modal -> 'Email or Social' tab and press the 'Email' option
- CA (click around) and verify that form submit, cancel, and modal tab buttons work correctly
- Verify that Email form validation works correctly (enter incorrect email and try to submit)
- Enter a valid email and try to login, verify it logs you in correctly
- While the email authentication is in progress, verify that email form submit buttons and modal tabs are disabled

## Deployment Plan
Part of https://github.com/hicommonwealth/commonwealth/milestone/38

## Other Considerations
`FLAG_NEW_SIGN_IN_MODAL` should not be enabled in prod yet.