### PR TITLE
Added param validation to GET threads

### DIFF
--- a/libs/model/src/thread/GetThread.query.ts
+++ b/libs/model/src/thread/GetThread.query.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const GetThreadsParamsSchema = z.object({
+  community_id: z.string(),
+  bulk: z.coerce.boolean().default(false),
+  thread_ids: z.coerce.number().int().array().optional(),
+  active: z.string().optional(),
+  search: z.string().optional(),
+});
+
+export const GetBulkThreadsParamsSchema = z.object({
+  topic_id: z.coerce.number().int().optional(),
+  includePinnedThreads: z.coerce.boolean().optional(),
+  limit: z.coerce.number().int().optional(),
+  page: z.coerce.number().int().optional(),
+  archived: z.coerce.boolean().optional(),
+  stage: z.string().optional(),
+  orderBy: z.string().optional(),
+  from_date: z.string().optional(),
+  to_date: z.string().optional(),
+});
+
+export type GetThreadsParams = z.infer<typeof GetThreadsParamsSchema>;

--- a/libs/model/src/thread/index.ts
+++ b/libs/model/src/thread/index.ts
@@ -1,1 +1,2 @@
 export * from './CreateThread.command';
+export * from './GetThread.query';

--- a/packages/commonwealth/server/routes/threads/get_threads_handler.ts
+++ b/packages/commonwealth/server/routes/threads/get_threads_handler.ts
@@ -70,13 +70,9 @@ export const getThreadsHandler = async (
 
   // get threads by IDs
   if (thread_ids) {
-    const threadIds = thread_ids.map((id) => parseInt(id, 10));
-    for (const id of threadIds) {
-      if (isNaN(id)) {
-        throw new AppError(Errors.InvalidThreadId);
-      }
-    }
-    const threads = await controllers.threads.getThreadsByIds({ threadIds });
+    const threads = await controllers.threads.getThreadsByIds({
+      threadIds: thread_ids,
+    });
     return success(res, threads);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6566

## Description of Changes
- Adds Param validation for GET threads. This early exits with a 4xx error instead of failing in the handler with a 5xx error on bad params.

## Test Plan
- Navigated to dydx/discussions
- Clicked on a few topics, made sure they worked correctly
- Used the search bar in the community, made sure it worked correctly
- In the above steps ensure that no errors are thrown
- Used a bad request with chain=dydx instead of community_id=dydx. Made sure it threw a 4xx error.