### PR TITLE
#6579 - Vote Weights Are Reflected in Upvote Counts

### DIFF
--- a/packages/commonwealth/client/scripts/models/Comment.ts
+++ b/packages/commonwealth/client/scripts/models/Comment.ts
@@ -13,6 +13,7 @@ export class Comment<T extends IUniqueId> {
   public readonly text: string;
   public readonly plaintext: string;
   public readonly reactions: Reaction[];
+  public reactionWeightsSum: number;
   public readonly id: number;
   public readonly createdAt: momentType.Moment;
   public readonly authorChain?: string;
@@ -40,6 +41,7 @@ export class Comment<T extends IUniqueId> {
     parent_id,
     plaintext,
     reactions,
+    reaction_weights_sum,
     created_at,
     deleted_at,
     authorChain,
@@ -92,6 +94,7 @@ export class Comment<T extends IUniqueId> {
     this.canvasSession = canvas_session;
     this.canvasHash = canvas_hash;
     this.reactions = (reactions || []).map((r) => new Reaction(r));
+    this.reactionWeightsSum = reaction_weights_sum;
     this.rootThread = thread_id;
     this.discord_meta = discord_meta;
   }

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -163,6 +163,7 @@ export class Thread implements IUniqueId {
   public readonly hasPoll: boolean;
   public numberOfComments: number;
   public associatedReactions: AssociatedReaction[];
+  public reactionWeightsSum: number;
   public links: Link[];
   public readonly discord_meta: any;
   public readonly latestActivity: Moment;
@@ -200,6 +201,7 @@ export class Thread implements IUniqueId {
     reactionType,
     reactionTimestamps,
     reactionWeights,
+    reaction_weights_sum,
     addressesReacted,
     canvasAction,
     canvasSession,
@@ -238,6 +240,7 @@ export class Thread implements IUniqueId {
     reactionType: any[]; // TODO: fix type
     reactionTimestamps: string[];
     reactionWeights: number[];
+    reaction_weights_sum: number;
     version_history: any[]; // TODO: fix type
     Address: any; // TODO: fix type
     discord_meta?: any;
@@ -276,6 +279,7 @@ export class Thread implements IUniqueId {
     this.links = links || [];
     this.discord_meta = discord_meta;
     this.versionHistory = processVersionHistory(version_history);
+    this.reactionWeightsSum = reaction_weights_sum;
     this.associatedReactions = processAssociatedReactions(
       reactions,
       reactionIds,

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -63,7 +63,7 @@ export const CommentReactionButton = ({
   const hasReacted = !!(comment.reactions || []).find(
     (x) => x?.author === activeAddress,
   );
-  const likes = comment.reactionWeightsSum;
+  const likes = comment.reactionWeightsSum || comment.reactions.length;
 
   const handleVoteClick = async (e) => {
     e.stopPropagation();

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -63,7 +63,7 @@ export const CommentReactionButton = ({
   const hasReacted = !!(comment.reactions || []).find(
     (x) => x?.author === activeAddress,
   );
-  const likes = (comment.reactions || []).length;
+  const likes = comment.reactionWeightsSum;
 
   const handleVoteClick = async (e) => {
     e.stopPropagation();

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
@@ -28,7 +28,7 @@ export const ViewCommentUpvotesDrawer = ({
       avatarUrl: profile.avatarUrl,
       address: profile.address,
       updated_at: reactor?.updatedAt,
-      voting_weight: reactor?.calculatedVotingWeight || 0,
+      voting_weight: reactor?.calculatedVotingWeight || 1,
     };
   });
 

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
@@ -28,7 +28,7 @@ export const ViewThreadUpvotesDrawer = ({
       avatarUrl: profile.avatarUrl,
       address: profile.address,
       updated_at: reactor?.updated_at,
-      voting_weight: reactor?.voting_weight || 0,
+      voting_weight: reactor?.voting_weight || 1,
     };
   });
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -117,7 +117,7 @@ export const ReactionButton = ({
     <>
       {size === 'small' ? (
         <CWUpvoteSmall
-          voteCount={thread.reactionWeightsSum}
+          voteCount={thread.reactionWeightsSum || reactors.length}
           disabled={disabled}
           isThreadArchived={!!thread.archivedAt}
           selected={hasReacted}
@@ -131,7 +131,7 @@ export const ReactionButton = ({
         <TooltipWrapper disabled={disabled} text={tooltipText}>
           <CWUpvote
             onClick={handleVoteClick}
-            voteCount={thread.reactionWeightsSum}
+            voteCount={thread.reactionWeightsSum || reactors.length}
             disabled={disabled}
             active={hasReacted}
           />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -143,7 +143,7 @@ export const ReactionButton = ({
         >
           <CWUpvote
             onClick={handleVoteClick}
-            voteCount={thread.reactionWeightsSum}
+            voteCount={thread.reactionWeightsSum || reactors.length}
             disabled={disabled}
             active={hasReacted}
           />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -117,7 +117,7 @@ export const ReactionButton = ({
     <>
       {size === 'small' ? (
         <CWUpvoteSmall
-          voteCount={reactors.length}
+          voteCount={thread.reactionWeightsSum}
           disabled={disabled}
           isThreadArchived={!!thread.archivedAt}
           selected={hasReacted}
@@ -131,7 +131,7 @@ export const ReactionButton = ({
         <TooltipWrapper disabled={disabled} text={tooltipText}>
           <CWUpvote
             onClick={handleVoteClick}
-            voteCount={reactors.length}
+            voteCount={thread.reactionWeightsSum}
             disabled={disabled}
             active={hasReacted}
           />
@@ -143,7 +143,7 @@ export const ReactionButton = ({
         >
           <CWUpvote
             onClick={handleVoteClick}
-            voteCount={reactors.length}
+            voteCount={thread.reactionWeightsSum}
             disabled={disabled}
             active={hasReacted}
           />


### PR DESCRIPTION
This PR changes the display of upvotes so that users see a sum of weighted votes instead of a count of the number of users who have upvoted a piece of content.

## Link to Issue
Closes: #6579

## Description of Changes
- changes vote count from reactor count to weighted sum

## Test Plan
- set REACTION_WEIGHT_OVERRIDE to a number
- check that it is reflected in the upvote counts
