### PR TITLE
replace drawer close trigger with icon button

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.scss
@@ -9,10 +9,6 @@
     gap: 8px;
     align-items: center;
     padding: 16px 56px 12px 56px;
-
-    .Icon {
-      cursor: pointer;
-    }
   }
 
   .content-container {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.tsx
@@ -2,9 +2,9 @@ import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import React, { ComponentProps } from 'react';
 import Drawer from 'react-modern-drawer';
 import 'react-modern-drawer/dist/index.css';
-import { CWIcon } from '../../cw_icons/cw_icon';
 import { CWText } from '../../cw_text';
 import { ComponentType } from '../../types';
+import CWIconButton from '../CWIconButton';
 import './CWDrawer.scss';
 
 type CWDrawerProps = Omit<ComponentProps<typeof Drawer>, 'direction'> & {
@@ -36,10 +36,10 @@ export const CWDrawer = ({
       style={{ top: '56px' }}
     >
       <div className="drawer-actions">
-        <CWIcon
+        <CWIconButton
           iconName="caretDoubleRight"
           onClick={onClose}
-          iconSize="small"
+          buttonSize="sm"
         />
       </div>
       <div className="content-container">


### PR DESCRIPTION
Replaces trigger to close drawer with icon-only button.

## Link to Issue
Closes: #6519 

## Description of Changes
- drawer trigger is now icon only button 

## Test Plan
- click on 'View Upvotes' beneath a thread or comment
- confirm that trigger to close drawer is a button 