### PR TITLE
#6510: Update Editor Component UI - Toolbar Headers, Text Formatting 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -1,22 +1,23 @@
-import React, { MutableRefObject, useMemo } from 'react';
-import ReactQuill from 'react-quill';
-import { renderToolbarIcon, SerializableDeltaStatic } from './utils';
-import { DeltaStatic } from 'quill';
-import clsx from 'clsx';
 import {
-  TextHOne,
-  TextHTwo,
-  TextB,
-  TextItalic,
-  TextStrikethrough,
-  LinkSimple,
   Code,
-  Quotes,
   Image,
-  ListNumbers,
+  LinkSimple,
   ListBullets,
   ListChecks,
+  ListNumbers,
+  Quotes,
+  TextB,
+  TextHOne,
+  TextHThree,
+  TextHTwo,
+  TextItalic,
+  TextStrikethrough,
 } from '@phosphor-icons/react';
+import clsx from 'clsx';
+import { DeltaStatic } from 'quill';
+import React, { MutableRefObject, useMemo } from 'react';
+import ReactQuill from 'react-quill';
+import { SerializableDeltaStatic, renderToolbarIcon } from './utils';
 
 import 'components/react_quill/react_quill_editor.scss';
 
@@ -28,6 +29,7 @@ Object.assign(quillIcons, {
   header: {
     1: renderToolbarIcon(TextHOne),
     2: renderToolbarIcon(TextHTwo),
+    3: renderToolbarIcon(TextHThree),
   },
   bold: renderToolbarIcon(TextB),
   italic: renderToolbarIcon(TextItalic),
@@ -71,6 +73,7 @@ export const CustomQuillToolbar = ({
       <div className="section">
         <button className="ql-header" value={1} />
         <button className="ql-header" value={2} />
+        <button className="ql-header" value={3} />
       </div>
       <div className="section">
         <button className="ql-bold"></button>
@@ -131,7 +134,7 @@ export const useMarkdownToolbarHandlers = ({
       editor.deleteText(selection.index, selection.length);
       editor.insertText(
         selection.index,
-        `${markdownChars}${text.trim()}${markdownChars}`
+        `${markdownChars}${text.trim()}${markdownChars}`,
       );
       setContentDelta({
         ...editor.getContents(),
@@ -152,7 +155,7 @@ export const useMarkdownToolbarHandlers = ({
       }
       const start = selection.index;
       const prefix = start === 0 ? '' : '\n';
-      const hashChar = headerValue === '2' ? '##' : '#';
+      const hashChar = '#'.repeat(parseInt(headerValue));
       editor.insertText(start, `${prefix}${hashChar} `);
       setContentDelta({
         ...editor.getContents(),


### PR DESCRIPTION
This PR adds the H3 header to the quill editor toolbar. 

## Link to Issue
Closes: #6510 

## Description of Changes
- allow users to create H3 headers

## Test Plan
- go to the create thread page
- click on the H3 icon in the editor toolbar. You should see 3 hashes appear in the editor. 

## Other Considerations
- Follow-up ticket: #6598 (for positioning the cursor between formatting characters when no text is selected) 