### PR TITLE
patch to handle v1 chains that return nextKey as string

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/utils-v1.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/gov/v1/utils-v1.ts
@@ -28,8 +28,14 @@ export const fetchProposalsByStatusV1 = async (
       });
 
     let nextKey = pagination?.next_key;
+
     while (nextKey?.length > 0) {
-      // console.log(nextKey);
+      // TODO: temp fix to handle chains that return nextKey as a string instead of Uint8Array
+      // Our v1 API needs to handle this better. To be addressed in #6610
+      if (typeof nextKey === 'string') {
+        nextKey = new Uint8Array(Buffer.from(nextKey, 'base64'));
+      }
+
       const { proposals, pagination: nextPage } =
         await lcd.cosmos.gov.v1.proposals({
           proposalStatus: status,
@@ -37,8 +43,8 @@ export const fetchProposalsByStatusV1 = async (
           depositor: '',
           pagination: {
             key: nextKey,
-            limit: null,
-            offset: null,
+            limit: undefined,
+            offset: undefined,
             countTotal: true,
             reverse: true,
           },

--- a/packages/commonwealth/server/workers/cosmosGovNotifications/proposalFetching/v1ProposalFetching.ts
+++ b/packages/commonwealth/server/workers/cosmosGovNotifications/proposalFetching/v1ProposalFetching.ts
@@ -40,6 +40,12 @@ export async function fetchLatestCosmosProposalV1(
         }
       } else nextKey = pagination.next_key;
     }
+
+    // TODO: temp fix to handle chains that return nextKey as a string instead of Uint8Array
+    // Our v1 API needs to handle this better. To be addressed in #6610
+    if (typeof nextKey === 'string') {
+      nextKey = new Uint8Array(Buffer.from(nextKey, 'base64'));
+    }
   } while (uint8ArrayToNumberBE(nextKey) > 0);
 
   if (finalProposalsPage.length > 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6609 

## Description of Changes
- makes sure paginated proposal types load properly for UX (a gov v1 chain)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- If pagination.next_key is a string, this converts it to the expected uint8array

## Test Plan
- CA (click around) tested on local and frack:
  - http://localhost:8080/ux/proposals
  - expect over 140 proposals to load.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 