### PR TITLE
Fix snapshots validation and links array component

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/LinksArray/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/LinksArray/types.ts
@@ -42,5 +42,5 @@ export type LinksArrayProps = {
 
 export type LinksArrayHookProps = {
   initialLinks: Link[];
-  linkValidation?: z.ZodEffects<z.ZodString, string, string> | z.ZodString;
+  linkValidation?: z.ZodTypeAny;
 };

--- a/packages/commonwealth/client/scripts/views/components/LinksArray/useLinksArray.tsx
+++ b/packages/commonwealth/client/scripts/views/components/LinksArray/useLinksArray.tsx
@@ -41,10 +41,6 @@ const useLinksArray = ({
   };
 
   const onLinkUpdatedAtIndex = (updatedLink: Link, index: number) => {
-    const splitLink = updatedLink.value.split('/');
-    const sanitizedLink = splitLink[splitLink.length - 1];
-    updatedLink.value = sanitizedLink;
-
     const updatedLinks = [...links];
     updatedLinks[index] = {
       ...updatedLink,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/Snapshots.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/Snapshots.tsx
@@ -1,6 +1,7 @@
 import { notifySuccess } from 'controllers/app/notifications';
 import React, { useState } from 'react';
 import app from 'state';
+import _ from 'underscore';
 import { LinksArray, useLinksArray } from 'views/components/LinksArray';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
@@ -33,7 +34,18 @@ const Snapshots = () => {
     if (!areLinksValid()) return;
 
     try {
-      const newSnapshots = [...new Set(snapshots.map((x) => x.value))];
+      // get unique snapshot names from links (if any value in array was link)
+      const newSnapshots = [
+        ...new Set(
+          snapshots
+            .map((x) => x.value)
+            .map((link) => {
+              const splitLink = link.split('/');
+              const sanitizedLink = splitLink[splitLink.length - 1];
+              return sanitizedLink;
+            }),
+        ),
+      ];
       await community.updateChainData({
         snapshot: newSnapshots,
       });
@@ -80,7 +92,12 @@ const Snapshots = () => {
         <CWButton
           buttonType="secondary"
           label="Save Changes"
-          disabled={snapshots.length === community.snapshot.length}
+          disabled={_.isEqual(
+            [...snapshots.map((x) => x.value.trim())].sort((a, b) =>
+              a.localeCompare(b),
+            ),
+            [...(community.snapshot || [])].sort((a, b) => a.localeCompare(b)),
+          )}
           onClick={onSaveChanges}
         />
       ) : (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
@@ -1,13 +1,19 @@
 import z from 'zod';
 
-const snapshotValidationSchema = z.string().refine(
-  (space) => {
-    const extension = space.slice(space.length - 4);
-    return extension === '.eth' || extension === '.xyz';
-  },
-  {
-    message: 'Snapshot name must be in the form of *.eth or *.xyz',
-  },
-);
+const snapshotNameSchema = z.string().regex(/^[a-zA-Z0-9-.]+\.((xyz)|(eth))$/, {
+  message: 'Snapshot must be valid, and end in *.eth or *.xyz',
+});
+const snapshotLinkSchema = z
+  .string()
+  .regex(
+    /^https:\/\/(\w+\.)?snapshot\.org\/#\/[a-zA-Z0-9-.]+\.((xyz)|(eth))$/,
+    {
+      message: 'Snapshot link be valid, and end in *.eth or *.xyz',
+    },
+  );
+const snapshotValidationSchema = z.union([
+  snapshotNameSchema,
+  snapshotLinkSchema,
+]);
 
 export { snapshotValidationSchema };

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Webhooks/Webhooks.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Webhooks/Webhooks.tsx
@@ -12,6 +12,7 @@ import {
   useEditWebhookMutation,
   useFetchWebhooksQuery,
 } from 'state/api/webhooks';
+import _ from 'underscore';
 import { LinksArray, useLinksArray } from 'views/components/LinksArray';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
@@ -197,7 +198,14 @@ const Webhooks = () => {
           <CWButton
             buttonType="secondary"
             label="Save Changes"
-            disabled={webhooks.length === existingWebhooks.length}
+            disabled={_.isEqual(
+              [...(webhooks || []).map((x) => x.value.trim())].sort((a, b) =>
+                a.localeCompare(b),
+              ),
+              [...(existingWebhooks || []).map((x) => x.url.trim())].sort(
+                (a, b) => a.localeCompare(b),
+              ),
+            )}
             onClick={onSaveChanges}
           />
         ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6593

## Description of Changes
- Adds proper validation to snapshots component, with support for snapshot name and link
- Fixed all instances of `<LinksArray/>` comp where it would break when entering `/`

## "How We Fixed It"
N/A

## Test Plan
- Go to `/manage/integrations` page of any community where you are an admin
- In the snapshots section, verify that snapshot validation works correctly
  - A valid snapshot link should be accepted without errors, example: `https://demo.snapshot.org/#/ninjaturtles.eth`, `https://testnet.snapshot.org/#/ninjaturtles.eth` and `https://snapshot.org/#/ninjaturtles.xyz` should work, while `https://demo.snapshot.org/ninjaturtles.eth`, `https://snapshot.com/ninjaturtles.eth` should give error
  - A valid snapshot name should be accepted without errors, example: `ninjaturtles.eth`, `flyaway.eth`, `xyz.xyz` should work, while `ninjaturtles.eth1` and `ninjaturtles.1xyz` should give errors

## Deployment Plan
N/A

## Other Considerations
N/A