### PR TITLE
Sidebar buttons not clickable fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.scss
@@ -7,11 +7,15 @@
     overflow: hidden;
     z-index: 5;
     transition: 0.2s linear;
+    pointer-events: none;
+
+    &.collapsed {
+      pointer-events: auto;
+    }
 
     &.expanded {
       width: 290px;
       transition: 0.2s linear;
-      pointer-events: none;
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.tsx
@@ -23,6 +23,7 @@ export const CollapsableSidebarButton = ({
       <div
         className={clsx('hover-box', {
           expanded: isInsideCommunity && menuVisible,
+          collapsed: !menuVisible,
         })}
       >
         <CWIconButton


### PR DESCRIPTION
Fix for regression of functionality due to collapsable sidebar button PR:
https://github.com/hicommonwealth/commonwealth/pull/6492

## Link to Issue
Closes: #6615

## Description of Changes
- Makes the hover box only cover the collapsable button when collapsed. This ensures that we are still able to click the buttons (not blocked by the hover-box)

## Test Plan
- on unscoped page, make sure that the create community button in the sidebar still works when the sidebar is expanded.