### PR TITLE
Use dedicated common_test db instance to execute unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 *.postgres
 *.rabbitmq
 redis-data
+**/.nyc_output

--- a/libs/adapters/package.json
+++ b/libs/adapters/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
-    "test": "ts-mocha '__tests__/**/*.spec.ts'"
+    "test": "NODE_ENV=test ts-mocha '__tests__/**/*.spec.ts'"
   },
   "dependencies": {
     "amqplib": "^0.10.3",

--- a/libs/chains/package.json
+++ b/libs/chains/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
-    "test": "ts-mocha '__tests__/**/*.spec.ts'"
+    "test": "NODE_ENV=test ts-mocha '__tests__/**/*.spec.ts'"
   },
   "dependencies": {
     "@canvas-js/interfaces": "0.5.0-alpha4",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
-    "test": "ts-mocha '__tests__/**/*.spec.ts'"
+    "test": "NODE_ENV=test ts-mocha '__tests__/**/*.spec.ts'"
   },
   "dependencies": {
     "zod": "^3.22.4"

--- a/libs/core/src/ports/index.ts
+++ b/libs/core/src/ports/index.ts
@@ -3,6 +3,7 @@ import { port } from './port';
 
 export * from './enums';
 export * from './interfaces';
+export * from './port';
 
 /**
  * Logger port factory

--- a/libs/model/__tests__/community/CommunityStake.spec.ts
+++ b/libs/model/__tests__/community/CommunityStake.spec.ts
@@ -3,6 +3,7 @@ import {
   InvalidActor,
   InvalidState,
   command,
+  dispose,
   query,
 } from '@hicommonwealth/core';
 import chai, { expect } from 'chai';
@@ -28,6 +29,10 @@ describe('Community stake', () => {
 
   before(async () => {
     await seedDb();
+  });
+
+  after(async () => {
+    await dispose()();
   });
 
   it('should fail set when community namespace not configured', () => {

--- a/libs/model/package.json
+++ b/libs/model/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
-    "test": "ts-mocha '__tests__/**/*.spec.ts'"
+    "test": "NODE_ENV=test ts-mocha '__tests__/**/*.spec.ts'"
   },
   "dependencies": {
     "@cosmjs/stargate": "^0.31.3",

--- a/libs/model/src/database.ts
+++ b/libs/model/src/database.ts
@@ -42,11 +42,14 @@ import WebhookFactory from './models/webhook';
 
 const log = logger().getLogger(__filename);
 
-export const DATABASE_URI = process.env.USES_DOCKER_DB
-  ? 'postgresql://commonwealth:edgeware@postgres/commonwealth' // this is because url will be hidden in CI.yaml
-  : !process.env.DATABASE_URL || process.env.NODE_ENV === 'development'
-  ? 'postgresql://commonwealth:edgeware@localhost/commonwealth'
-  : process.env.DATABASE_URL;
+export const DATABASE_URI =
+  process.env.NODE_ENV === 'test'
+    ? 'postgresql://commonwealth:edgeware@localhost/common_test'
+    : process.env.USES_DOCKER_DB
+    ? 'postgresql://commonwealth:edgeware@postgres/commonwealth' // this is because url will be hidden in CI.yaml
+    : !process.env.DATABASE_URL || process.env.NODE_ENV === 'development'
+    ? 'postgresql://commonwealth:edgeware@localhost/commonwealth'
+    : process.env.DATABASE_URL;
 
 export const sequelize = new Sequelize(DATABASE_URI, {
   // disable string operators (https://github.com/sequelize/sequelize/issues/8417)
@@ -119,7 +122,6 @@ const _models: Models = {
   CommunityStake: CommunityStakeFactory(sequelize, DataTypes),
 };
 
-// TODO: use port/adaper pattern to test in-memory
 export const models: DB = {
   sequelize,
   Sequelize,

--- a/libs/model/src/test/seedDb.ts
+++ b/libs/model/src/test/seedDb.ts
@@ -4,14 +4,42 @@ import {
   ChainNetwork,
   ChainType,
   NotificationCategories,
+  dispose,
   logger,
 } from '@hicommonwealth/core';
-import { ChainNodeAttributes, models } from '..';
+import { QueryTypes, Sequelize } from 'sequelize';
+import type { ChainNodeAttributes } from '../models/chain_node';
+
+const checkDb = async () => {
+  let sequelize: Sequelize | undefined = undefined;
+  try {
+    sequelize = new Sequelize('postgresql://commonwealth:edgeware@localhost');
+    const testdbname = 'common_test';
+    const [{ count }] = await sequelize.query<{ count: number }>(
+      `SELECT COUNT(*) FROM pg_database WHERE datname = '${testdbname}'`,
+      { type: QueryTypes.SELECT },
+    );
+    if (!+count) await sequelize.query(`CREATE DATABASE ${testdbname};`);
+  } catch (error) {
+    console.error('Error creating test db:', error);
+  } finally {
+    sequelize && sequelize.close();
+  }
+};
 
 export const seedDb = async (debug = false): Promise<void> => {
   const log = logger().getLogger(__filename);
-  if (debug) log.info('Resetting database...');
+  if (debug) log.info('Seeding test db...');
   try {
+    await checkDb();
+
+    // connect and seed
+    const { models } = await import('..');
+    // dispose sequelize connection before exit
+    dispose(async () => {
+      models.sequelize.close().catch((_) => {});
+    });
+
     await models.sequelize.sync({ force: true });
     log.info('done syncing.');
     if (debug) log.info('Initializing default models...');

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -49,7 +49,7 @@
     "test-integration-util": "NODE_ENV=test nyc ts-mocha ./test/integration/*.spec.ts",
     "test-select": "NODE_ENV=test nyc ts-mocha",
     "test-suite": "NODE_ENV=test nyc ts-mocha './test/**/*.spec.ts'",
-    "unit-test": "NODE_ENV=test FEATURE_FLAG_GROUP_CHECK_ENABLED=true ts-mocha './test/unit/**/*.spec.ts'",
+    "unit-test": "NODE_ENV=test ts-mocha './test/unit/seed_hack.spec.ts' && NODE_ENV=test FEATURE_FLAG_GROUP_CHECK_ENABLED=true ts-mocha './test/unit/**/*.spec.ts'",
     "unit-test:watch": "NODE_ENV=test ts-mocha --opts test/mocha-dev.opts './test/unit/**/*.spec.ts' -w --watch-files '**/*.ts'",
     "wait-server": "chmod +x ./scripts/wait-server.sh && ./scripts/wait-server.sh",
     "refresh-all-memberships": "npx ts-node -r tsconfig-paths/register -T ./scripts/refresh-all-memberships.ts",

--- a/packages/commonwealth/test/unit/seed_hack.spec.ts
+++ b/packages/commonwealth/test/unit/seed_hack.spec.ts
@@ -1,0 +1,18 @@
+import { dispose } from '@hicommonwealth/core';
+import { tester } from '@hicommonwealth/model';
+import { expect } from 'chai';
+
+describe('Hack to seed test db before other unit tests', () => {
+  before(async () => {
+    await tester.seedDb();
+  });
+  after(async () => {
+    await dispose()();
+  });
+
+  it('should seed', async () => {
+    const { models } = await import('@hicommonwealth/model');
+    const communities = await models.Community.findAll();
+    expect(communities.length).to.be.greaterThan(0);
+  });
+});

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -17,5 +17,5 @@ yarn workspaces run check-types
 # run unit tests
 # this should be: yarn workspaces run test
 # this should be added to CI: yarn workspace @hicommonwealth/adapters test
-NODE_ENV=test yarn workspace @hicommonwealth/model test
-NODE_ENV=test yarn workspace commonwealth unit-test
+yarn workspace @hicommonwealth/model test
+yarn workspace commonwealth unit-test


### PR DESCRIPTION
See ticket details

## Link to Issue
Closes: #6619

## Description of Changes
- Creates instance when not found
- Connects models to test instance when NODE_ENV=test
- Uses dispose()() utility to encapsulate disposing resources in unit tests
 