### PR TITLE
Code split out web3 bundles

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/LazyCommunityStakes.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/LazyCommunityStakes.ts
@@ -1,0 +1,3 @@
+export async function lazyLoadCommunityStakes() {
+  return (await import('./CommunityStakes')).default;
+}

--- a/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
@@ -1,8 +1,8 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useMutation } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods, queryClient } from 'state/api/config';
 import { setActiveAccountOnTransactionSuccess } from 'views/modals/ManageCommunityStakeModal/utils';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 interface BuyStakeProps {
   namespace: string;
@@ -19,6 +19,7 @@ const buyStake = async ({
   chainRpc,
   walletAddress,
 }: BuyStakeProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
@@ -1,7 +1,7 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useQuery } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods } from 'state/api/config';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 const GET_BUY_PRICE_STALE_TIME = 2 * 1_000; // 2 sec
 
@@ -13,6 +13,7 @@ const getBuyPrice = async ({
   amount,
   chainRpc,
 }: GetBuyPriceProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
@@ -1,7 +1,7 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useQuery } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods } from 'state/api/config';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 const GET_SELL_PRICE_STALE_TIME = 2 * 1_000; // 2 sec
 
@@ -13,6 +13,7 @@ const getSellPrice = async ({
   amount,
   chainRpc,
 }: GetSellPriceProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
@@ -1,7 +1,7 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useQuery } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods } from 'state/api/config';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 const GET_USER_ETH_BALANCE_STALE_TIME = 60 * 1_000; // 1 min
 
@@ -14,6 +14,7 @@ const getUserEthBalance = async ({
   chainRpc,
   walletAddress,
 }: GetUserEthBalanceProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
@@ -1,7 +1,7 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useQuery } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods } from 'state/api/config';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 const GET_USER_STAKE_BALANCE_STALE_TIME = 5 * 1_000; // 5 sec
 
@@ -16,6 +16,7 @@ const getUserStakeBalance = async ({
   chainRpc,
   walletAddress,
 }: GetUserStakeBalanceProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia

--- a/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
@@ -1,8 +1,8 @@
 import { commonProtocol } from '@hicommonwealth/core';
 import { useMutation } from '@tanstack/react-query';
-import CommunityStakes from 'helpers/ContractHelpers/CommunityStakes';
 import { ContractMethods, queryClient } from 'state/api/config';
 import { setActiveAccountOnTransactionSuccess } from 'views/modals/ManageCommunityStakeModal/utils';
+import { lazyLoadCommunityStakes } from '../../../helpers/ContractHelpers/LazyCommunityStakes';
 
 interface SellStakeProps {
   namespace: string;
@@ -19,6 +19,7 @@ const sellStake = async ({
   chainRpc,
   walletAddress,
 }: SellStakeProps) => {
+  const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[
       commonProtocol.ValidChains.Sepolia


### PR DESCRIPTION
## Link to Issue
Closes: #6624

## Description of Changes
- Lazily load all CommunityStakes usages

## stats
Before:
<img width="1394" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/9123bf48-f212-47d4-939c-8bdfa4d418b1">

After:
<img width="1415" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/bea08662-1ac4-4967-bb7a-858edeb58f15">



## Other considerations
This should not be viewed as a complete solution. It is only a bandaid fix on the main problem which is the ease of adding bloat to Layout.tsx. We need to establish a frontend pattern so that we don't run into this issue again.

This bandaid fix is bad in practice because it reduces code readability, but will be necessary to cut out ~30% of our initial bundle size.