### PR TITLE
changed min height of pixels in cw banner to be 49 and not 48

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/cw_banner.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_banner.scss
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 48px;
+  min-height: 49px;
   box-sizing: border-box;
   padding: 8px 16px 8px 192px;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6524 

## Description of Changes
Banner now matches height with element to the left of it. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-- changed `min-height` to 49px, not 48px in `cw_banner.scss`
## Test Plan
-find a community that has a terms of service banner
-notice that the banner bottom border now matches up with the the border of the element to the left of it. 

<img width="1090" alt="Screenshot 2024-02-08 at 3 52 43 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/cfd58edc-68ef-47e7-83d5-6fa9fbaaa425">
