### PR TITLE
1155 NFT URI Endpoint and setter

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/NamespaceFactoryAbi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/NamespaceFactoryAbi.ts
@@ -20,6 +20,11 @@ export const namespaceFactoryAbi = [
         type: 'string',
       },
       {
+        internalType: 'string',
+        name: '_uri',
+        type: 'string',
+      },
+      {
         internalType: 'address',
         name: '_feeManager',
         type: 'address',

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -93,8 +93,9 @@ class NamespaceFactory extends ContractBase {
 
     let txReceipt;
     try {
+      const uri = `commonwealth.im/api/namespaceMetadata/${name}/{id}`;
       txReceipt = await this.contract.methods
-        .deployNamespace(name, feeManager, [])
+        .deployNamespace(name, uri, feeManager, [])
         .send({ from: walletAddress });
     } catch (error) {
       throw new Error('Transaction failed: ' + error);

--- a/packages/commonwealth/server/routes/communities/get_namespace_metadata.ts
+++ b/packages/commonwealth/server/routes/communities/get_namespace_metadata.ts
@@ -1,0 +1,37 @@
+import { AppError } from '@hicommonwealth/core';
+import { DB } from '@hicommonwealth/model';
+import { TypedRequestParams } from 'server/types';
+
+export const getNamespaceMetadata = async (
+  models: DB,
+  req: TypedRequestParams<{ namespace: string; stake_id: string }>,
+  res: any,
+) => {
+  //stake_id will be a 32 byte hex string, convert to number
+  const decodedId = parseInt(req.params.stake_id, 16);
+  const metadata = await models.Community.findOne({
+    where: {
+      namespace: req.params.namespace,
+    },
+    include: [
+      {
+        model: models.CommunityStake,
+        required: true,
+        attributes: ['stake_id'],
+        where: {
+          stake_id: decodedId,
+        },
+      },
+    ],
+    attributes: ['namespace', 'icon_url'],
+  });
+
+  if (!metadata) {
+    throw new AppError('Token metadata does not exist');
+  }
+
+  return res.json({
+    name: `${metadata.namespace} Community Stake`,
+    image: metadata.icon_url,
+  });
+};

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -143,6 +143,7 @@ import { ServerTopicsController } from '../controllers/server_topics_controller'
 import { GENERATE_IMAGE_RATE_LIMIT } from 'server/config';
 import { rateLimiterMiddleware } from 'server/middleware/rateLimiter';
 import { getTopUsersHandler } from 'server/routes/admin/get_top_users_handler';
+import { getNamespaceMetadata } from 'server/routes/communities/get_namespace_metadata';
 import { getStatsHandler } from '../routes/admin/get_stats_handler';
 import { createCommentReactionHandler } from '../routes/comments/create_comment_reaction_handler';
 import { deleteBotCommentHandler } from '../routes/comments/delete_comment_bot_handler';
@@ -379,6 +380,13 @@ function setupRouter(
     'get',
     '/communityStakes/:community_id/:stake_id?',
     getCommunityStakeHandler.bind(this, models, serverControllers),
+  );
+
+  registerRoute(
+    router,
+    'get',
+    '/namespaceMetadata/:namespace/:stake_id',
+    getNamespaceMetadata.bind(this, models),
   );
 
   registerRoute(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6681

## Description of Changes
- Adds endpoint to serve json to public with ERC1155 schema
- Adds uri construction to namespace helper
- updates ABI

## Deployment Plan
<!--- Omit if unneeded -->
1. should be deployed when contract updates have also been deployed

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Will break with current contracts 
- will only work on production as the commonwealth endpoint is hardcoded 