### PR TITLE
Fix sign-in request branch case for mobile devices when signing in with mobile wallets

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -641,7 +641,16 @@ const useWallets = (walletProps: IuseWalletProps) => {
         setSignerAccount(signingAccount);
         setIsNewlyCreated(newlyCreated);
         setIsLinkingOnMobile(isLinkingWallet);
-        setActiveStep('redirectToSign');
+        if (featureFlags.newSignInModal) {
+          onAccountVerified(
+            signingAccount,
+            newlyCreated,
+            isLinkingWallet,
+            wallet,
+          );
+        } else {
+          setActiveStep('redirectToSign');
+        }
       } else {
         onAccountVerified(
           signingAccount,
@@ -724,7 +733,11 @@ const useWallets = (walletProps: IuseWalletProps) => {
       if (setSignerAccount) setSignerAccount(account);
       if (setIsNewlyCreated) setIsNewlyCreated(false);
       if (setIsLinkingOnMobile) setIsLinkingOnMobile(false);
-      setActiveStep('redirectToSign');
+      if (featureFlags.newSignInModal) {
+        onAccountVerified(account, false, false);
+      } else {
+        setActiveStep('redirectToSign');
+      }
       return;
     } else {
       onAccountVerified(account, false, false);

--- a/packages/commonwealth/client/scripts/views/pages/landing/header.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/landing/header.tsx
@@ -61,8 +61,9 @@ export const Header = ({ onLogin }: HeaderProps) => {
         />
       ) : (
         <AuthModal
-          onClose={() => setIsAuthModalOpen(false)}
+          onSuccess={onLogin}
           isOpen={isAuthModalOpen}
+          onClose={() => setIsAuthModalOpen(false)}
         />
       )}
     </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6703

## Description of Changes
- Fixes mobile wallet login signature verification in mobile devices.

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_NEW_SIGN_IN_MODAL` in `.env`
- On mobile install a wallet (ex: metamask)
- Visit the app on local network/ip (ex: IP of your host machine where app is running + port, and use it on a mobile device on which you are testing, -> `192.168.1.2:8080`)
- Try to login with Wallet Connect and chose Metamask from the wallets list, verify that login works as follows


https://github.com/hicommonwealth/commonwealth/assets/51641047/1c744530-a23d-47cb-8ac0-1624bce83edc


## Deployment Plan
N/A

## Other Considerations
Should go in with mobile sign-in revamp.