### PR TITLE
Add Admin Panel RPC functionality, bugfixes

### DIFF
--- a/packages/commonwealth/client/scripts/stores/NodeStore.ts
+++ b/packages/commonwealth/client/scripts/stores/NodeStore.ts
@@ -14,6 +14,12 @@ class NodeStore extends IdStore<NodeInfo> {
 
     return this._store.find((node) => urlVariants.includes(node.url));
   }
+
+  public getByCosmosChainId(cosmosChainId: string) {
+    if (!cosmosChainId) return undefined;
+
+    return this._store.find((node) => cosmosChainId === node.cosmosChainId);
+  }
 }
 
 export default NodeStore;

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
@@ -8,12 +8,14 @@ export const createChainNode = async ({
   bech32,
   balance_type,
   eth_chain_id,
+  cosmos_chain_id,
 }: {
   url: string;
   name: string;
   bech32: string;
   balance_type: BalanceType;
   eth_chain_id: number;
+  cosmos_chain_id: string;
 }) => {
   return await axios.post(`${app.serverUrl()}/nodes`, {
     url,
@@ -21,6 +23,35 @@ export const createChainNode = async ({
     bech32,
     balance_type,
     eth_chain_id,
+    cosmos_chain_id,
+    jwt: app.user.jwt,
+  });
+};
+
+export const updateChainNode = async ({
+  id,
+  url,
+  name,
+  bech32,
+  balance_type,
+  eth_chain_id,
+  cosmos_chain_id,
+}: {
+  id: number;
+  url: string;
+  name: string;
+  bech32: string;
+  balance_type: BalanceType;
+  eth_chain_id: number;
+  cosmos_chain_id: string;
+}) => {
+  return await axios.put(`${app.serverUrl()}/nodes/${id}`, {
+    url,
+    name,
+    bech32,
+    balance_type,
+    eth_chain_id,
+    cosmos_chain_id,
     jwt: app.user.jwt,
   });
 };

--- a/packages/commonwealth/server/controllers/server_communities_controller.ts
+++ b/packages/commonwealth/server/controllers/server_communities_controller.ts
@@ -45,6 +45,11 @@ import {
   __searchCommunities,
 } from './server_communities_methods/search_communities';
 import {
+  UpdateChainNodeOptions,
+  UpdateChainNodeResult,
+  __updateChainNode,
+} from './server_communities_methods/update_chain_node';
+import {
   UpdateCommunityOptions,
   UpdateCommunityResult,
   __updateCommunity,
@@ -96,6 +101,12 @@ export class ServerCommunitiesController {
     options: CreateChainNodeOptions,
   ): Promise<CreateChainNodeResult> {
     return __createChainNode.call(this, options);
+  }
+
+  async updateChainNode(
+    options: UpdateChainNodeOptions,
+  ): Promise<UpdateChainNodeResult> {
+    return __updateChainNode.call(this, options);
   }
 
   async getRelatedCommunities(

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -63,7 +63,7 @@ export async function __updateCommunity(
     include: [
       {
         model: this.models.ChainNode,
-        attributes: ['url', 'eth_chain_id'],
+        attributes: ['url', 'eth_chain_id', 'cosmos_chain_id'],
       },
     ],
   });

--- a/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
+++ b/packages/commonwealth/server/routes/communities/create_chain_node_handler.ts
@@ -8,6 +8,7 @@ type CreateChainNodeRequestBody = {
   bech32?: string;
   balance_type?: string;
   eth_chain_id?: number;
+  cosmos_chain_id?: string;
 };
 type CreateChainNodeResponse = CreateChainNodeResult;
 
@@ -23,6 +24,7 @@ export const createChainNodeHandler = async (
     bech32: req.body.bech32,
     balanceType: req.body.balance_type,
     eth_chain_id: req.body.eth_chain_id,
+    cosmos_chain_id: req.body.cosmos_chain_id,
   });
   return success(res, results);
 };

--- a/packages/commonwealth/server/routes/communities/update_chain_node_handler.ts
+++ b/packages/commonwealth/server/routes/communities/update_chain_node_handler.ts
@@ -1,0 +1,34 @@
+import { UpdateChainNodeResult } from '../../controllers/server_communities_methods/update_chain_node';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequest, TypedResponse, success } from '../../types';
+
+type UpdateChainNodeRequestBody = {
+  url: string;
+  name?: string;
+  bech32?: string;
+  balance_type?: string;
+  eth_chain_id?: number;
+  cosmos_chain_id?: string;
+};
+type UpdateChainNodeResponse = UpdateChainNodeResult;
+
+export const updateChainNodeHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequest<UpdateChainNodeRequestBody, null, { id: string }>,
+  res: TypedResponse<UpdateChainNodeResponse>,
+) => {
+  const { id } = req.params;
+  const nodeId = parseInt(id, 10) || null;
+
+  const results = await controllers.communities.updateChainNode({
+    id: nodeId,
+    user: req.user,
+    url: req.body.url,
+    name: req.body.name,
+    bech32: req.body.bech32,
+    balanceType: req.body.balance_type,
+    eth_chain_id: req.body.eth_chain_id,
+    cosmos_chain_id: req.body.cosmos_chain_id,
+  });
+  return success(res, results);
+};

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -141,6 +141,7 @@ import { ServerTopicsController } from '../controllers/server_topics_controller'
 import { GENERATE_IMAGE_RATE_LIMIT } from 'server/config';
 import { rateLimiterMiddleware } from 'server/middleware/rateLimiter';
 import { getTopUsersHandler } from 'server/routes/admin/get_top_users_handler';
+import { updateChainNodeHandler } from 'server/routes/communities/update_chain_node_handler';
 import { getStatsHandler } from '../routes/admin/get_stats_handler';
 import { createCommentReactionHandler } from '../routes/comments/create_comment_reaction_handler';
 import { deleteBotCommentHandler } from '../routes/comments/delete_comment_bot_handler';
@@ -353,6 +354,13 @@ function setupRouter(
     '/nodes',
     passport.authenticate('jwt', { session: false }),
     createChainNodeHandler.bind(this, serverControllers),
+  );
+  registerRoute(
+    router,
+    'put',
+    '/nodes/:id',
+    passport.authenticate('jwt', { session: false }),
+    updateChainNodeHandler.bind(this, serverControllers),
   );
   registerRoute(
     router,

--- a/packages/commonwealth/test/integration/api/chainNodes.spec.ts
+++ b/packages/commonwealth/test/integration/api/chainNodes.spec.ts
@@ -160,4 +160,81 @@ describe('ChainNode Tests', () => {
       1,
     );
   });
+
+  it('Updates a ChainNode from community controller', async () => {
+    it('EVM', async () => {
+      const eth_chain_id = 123;
+      const controller = new ServerCommunitiesController(models, null);
+
+      const [createdNode] = await models.ChainNode.findOrCreate({
+        where: {
+          eth_chain_id,
+          balance_type: BalanceType.Ethereum,
+          name: 'Ethereum1',
+          url: 'https://eth-mainnet.g.com/2',
+        },
+      });
+
+      const user: UserInstance = buildUser({
+        models,
+        userAttributes: { email: '', id: 1, isAdmin: true },
+      }) as UserInstance;
+
+      await controller.updateChainNode({
+        id: createdNode.id,
+        user,
+        url: 'https://eth-mainnet.g.com/3',
+        name: 'Ethereum3',
+        eth_chain_id,
+      });
+
+      const updatedNode = await models.ChainNode.findOne({
+        where: { eth_chain_id },
+      });
+      assert.equal(updatedNode.url, 'https://eth-mainnet.g.com/3');
+      assert.equal(updatedNode.name, 'Ethereum3');
+      assert.equal(updatedNode.balance_type, 'ethereum');
+      assert.equal(updatedNode.eth_chain_id, 123);
+    });
+    it('Cosmos', async () => {
+      const cosmos_chain_id = 'osmosiz';
+      const controller = new ServerCommunitiesController(models, null);
+      const user: UserInstance = buildUser({
+        models,
+        userAttributes: { email: '', id: 1, isAdmin: true },
+      }) as UserInstance;
+
+      assert.equal(
+        await models.ChainNode.count({
+          where: { cosmos_chain_id },
+        }),
+        0,
+      );
+
+      const [createdNode] = await models.ChainNode.findOrCreate({
+        where: {
+          cosmos_chain_id,
+          balance_type: BalanceType.Cosmos,
+          name: 'Osmosis',
+          url: 'https://osmosis-mainnet.g.com/2',
+        },
+      });
+
+      await controller.updateChainNode({
+        id: createdNode.id,
+        user,
+        url: 'https://cosmos-mainnet.g.com/4',
+        name: 'mmm',
+        cosmos_chain_id,
+      });
+
+      const updatedNode = await models.ChainNode.findOne({
+        where: { cosmos_chain_id },
+      });
+      assert.equal(updatedNode.url, 'https://cosmos-mainnet.g.com/4');
+      assert.equal(updatedNode.name, 'mmm');
+      assert.equal(updatedNode.balance_type, 'cosmos');
+      assert.equal(updatedNode.cosmos_chain_id, 'osmosiz');
+    });
+  });
 });

--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -53,6 +53,11 @@ module.exports = {
       'process.env.COSMOS_GOV_V1': JSON.stringify(process.env.COSMOS_GOV_V1),
     }),
     new webpack.DefinePlugin({
+      'process.env.COSMOS_REGISTRY_API': JSON.stringify(
+        process.env.COSMOS_REGISTRY_API,
+      ),
+    }),
+    new webpack.DefinePlugin({
       'process.env.FLAG_COMMUNITY_HOMEPAGE': JSON.stringify(
         process.env.FLAG_COMMUNITY_HOMEPAGE,
       ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6658 
Closes: #6732 

## Description of Changes
- Updates /admin-panel RPC functionality:
  - Can add a ChainNode without needing a community
  - Only allows endpoint update if community is of type `chain`
- Fixes duplicate node creation

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Adds updateChainNode functionality
- Requires cosmos_chain_id if Cosmos

## Test Plan
- Unit tested updateChainNode
- CA (click around) tested on local:
- Update flow:
  - create a new community (evm or cosmos)
  - as a super-admin, go to /admin-panel -> "Switch/Add RPC Endpoint"
  - enter a non-existent community ID: Expect validation message "Community not found"
  - enter your new community ID: Expect validation message "Community is not a chain"
  - enter a Cosmos community (ie "osmosis") and set balance type to "cosmos": Expect an input for "cosmos chain id"
  - Select osmosis and update to a valid URL: expect Update button to be enabled
  - Click Update: expect success message
- Create flow:
  - Leave community ID blank
  - Set balance type to "cosmos": Expect an input for "cosmos chain id"
  - Select a non-existent chain (ie "meme") and add a valid RPC URL: expect Create button to be enabled
  - Click Create: expect success

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 