### PR TITLE
6723-New Thread Markdown broke

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/useNotionPaste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/useNotionPaste.tsx
@@ -6,33 +6,20 @@ export const useNotionPaste = (setContentDelta, contentDelta, editorRef) => {
       event.preventDefault();
       const editor = editorRef.current?.getEditor();
       const pastedText = event.clipboardData.getData('text/plain');
+
       if (pastedText) {
-        const lines = pastedText.split('\n');
-        const fixedLines = lines.map((line) => {
-          if (line.trim().startsWith('[ ]')) {
-            return `- ${line.trim()}`;
-          }
-          return line;
+        setContentDelta({
+          ops: [
+            {
+              insert: pastedText,
+            },
+          ],
         });
-        const fixedText = fixedLines.join('\n');
-
-        if (fixedText !== contentDelta.ops[0]?.insert) {
-          setContentDelta((prevDelta) => ({
-            ...prevDelta,
-            ops: [
-              ...prevDelta.ops,
-              {
-                insert: fixedText,
-              },
-            ],
-          }));
-
-          //Setting a delay to reset cursor position
-          setTimeout(() => {
-            const newCursorPosition = editor.getLength();
-            editor.setSelection(newCursorPosition, newCursorPosition);
-          }, 10);
-        }
+        setTimeout(() => {
+          const newCursorPosition = editor.getLength();
+          editor.setSelection(newCursorPosition, newCursorPosition);
+        }, 10);
+        return;
       }
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6723

## Description of Changes
- Simplified the `useNotionPaste` hook 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- By removing the check and the manual manipulation of the Quill Delta 
- Was doing too much and causes a check for the delta before it was populated

## Test Plan
1. Goto create thread 
2. Paste the following:
3. Copy this content
```
An h1 header
============

Paragraphs are separated by a blank line.

2nd paragraph. *Italic*, **bold**, and `monospace`. Itemized lists
look like:

  * this one
  * that one
  * the other one

Note that --- not considering the asterisk --- the actual text
content starts at 4-columns in.

> Block quotes are
> written like so.
>
> They can span multiple paragraphs,
> if you like.

Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
in chapters 12--14"). Three dots ... will be converted to an ellipsis.
Unicode is supported. ☺
```
4. Paste this with keyboard (ctrl + v or cmd + v)
5. To ensure no regression do the same with the following Notion MD:
```
- [x]  Click anywhere and just start typing
- [ ]  Hit **/** to see all the types of content you can create - headers, videos, sub pages, etc.
- [ ]  Highlight any text, and use the menu that pops up to **style** *your* ~~writing~~ `however` [you](https://www.notion.so/product) like
- [ ]  See the **⋮⋮** to the left of this checkbox on hover? Click and drag to move this line
- [ ]  Explore the sidebar to your left
```