### PR TITLE
6693- Fixed replacing lists and odd spacing

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -191,7 +191,7 @@ export const useMarkdownToolbarHandlers = ({
   };
 
   const createListHandler = () => {
-    return (value) => {
+    return (value: string) => {
       const editor = editorRef?.current?.getEditor();
       if (!editor) {
         return;

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -232,7 +232,7 @@ export const useMarkdownToolbarHandlers = ({
             updatedLine = `${prefix} ${updatedLine}`;
           }
 
-          return updatedLine;
+          return updatedLine.replace(/\s{2,}/, ' ');
         })
         .join('\n');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6693 

## Description of Changes
- Fixes an issue where if you have a current list and want to change list types it would just append to the front instead of replacing the list
- In lists this also fixes the odd spacing where when you copied the string it would apply extra \n in between 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Edited `createListHandler` to check if there's a previous prefix and append/replace with the new one
- Trim the ends of the strings in order to eliminate the odd spacing in the lists

## Test Plan
- Go to create a thread or comment 
- Highlight and create a list
- then switch between all of the lists
- Copy the contents
- Paste somewhere and ensure the spacing is correct
