### PR TITLE
6731-deleting thread causes error

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/confirmation_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/confirmation_modal.tsx
@@ -89,7 +89,9 @@ export const openConfirmation = (props: OpenConfirmationProps) => {
   const removeModal = () => {
     root.unmount();
     target.remove();
-    props.onClose();
+    if (typeof props.onClose === 'function') {
+      props.onClose();
+    }
   };
 
   root = createRoot(target);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6731 

## Description of Changes
- Added a function check to the `onClose()` prop on the `openConfirmation` modal
- Confirmed no regression with components that use the `onClose()` prop

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- The error was `Uncaught TypeError: props.onClose is not a function` by adding the type check it prevents this error when the optional prop is omitted 

## Test Plan
- Go to a thread
- Attempt to delete
- Ensure it deletes correctly