### PR TITLE
6733- Fixed changing topic bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalBody/CWModalBody.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalBody/CWModalBody.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 16px;
   padding-inline: 24px;
-  overflow: auto;
+  overflow: inherit;
   max-height: 440px;
 
   // For content that may overflow the parent container (e.g. Dropdowns)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6733 

## Description of Changes
- Fixes overflow css that was causing the dropdown to not work
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added the `inherit` property to css rather than `auto` which caused the regression

## Test Plan
- Go to any thread
- Attempt to change topic
- Ensure you can change topic