### PR TITLE
Update reaction weight calculation

### DIFF
--- a/libs/core/src/commonProtocol/utils.ts
+++ b/libs/core/src/commonProtocol/utils.ts
@@ -2,5 +2,6 @@ export const calculateVoteWeight = (
   stakeBalance: string,
   voteWeight: number,
 ) => {
-  return parseInt(stakeBalance, 10) * voteWeight || 1;
+  // all community members get 1 weight by default
+  return 1 + parseInt(stakeBalance, 10) * voteWeight;
 };

--- a/libs/model/src/models/comment.ts
+++ b/libs/model/src/models/comment.ts
@@ -88,7 +88,8 @@ export default (
       },
       reaction_weights_sum: {
         type: dataTypes.INTEGER,
-        allowNull: true,
+        allowNull: false,
+        defaultValue: 0,
       },
     },
     {

--- a/libs/model/src/models/thread.ts
+++ b/libs/model/src/models/thread.ts
@@ -148,7 +148,8 @@ export default (
       },
       reaction_weights_sum: {
         type: dataTypes.INTEGER,
-        allowNull: true,
+        allowNull: false,
+        defaultValue: 0,
       },
       comment_count: {
         type: dataTypes.INTEGER,

--- a/packages/commonwealth/server/migrations/20240214183918-reaction-weights-sum-not-null.js
+++ b/packages/commonwealth/server/migrations/20240214183918-reaction-weights-sum-not-null.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.bulkUpdate(
+        'Threads',
+        { reaction_weights_sum: 0 },
+        { reaction_weights_sum: null },
+        { transaction },
+      );
+      await queryInterface.bulkUpdate(
+        'Comments',
+        { reaction_weights_sum: 0 },
+        { reaction_weights_sum: null },
+        { transaction },
+      );
+
+      await queryInterface.changeColumn(
+        'Threads',
+        'reaction_weights_sum',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          defaultValue: 0,
+        },
+        { transaction },
+      );
+
+      await queryInterface.changeColumn(
+        'Comments',
+        'reaction_weights_sum',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          defaultValue: 0,
+        },
+        { transaction },
+      );
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.changeColumn(
+        'Threads',
+        'reaction_weights_sum',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          defaultValue: null,
+        },
+        { transaction },
+      );
+
+      await queryInterface.changeColumn(
+        'Comments',
+        'reaction_weights_sum',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          defaultValue: null,
+        },
+        { transaction },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/test/integration/api/createReactions.spec.ts
+++ b/packages/commonwealth/test/integration/api/createReactions.spec.ts
@@ -10,8 +10,6 @@ import * as modelUtils from '../../util/modelUtils';
 
 const { JWT_SECRET } = Config;
 
-Sinon.stub(Config, 'REACTION_WEIGHT_OVERRIDE').value('300');
-
 chai.use(chaiHttp);
 
 const deleteReaction = async (reactionId, jwtToken, userAddress) => {
@@ -50,6 +48,7 @@ describe('createReaction Integration Tests', () => {
   let threadId: number;
 
   before(async () => {
+    Sinon.stub(Config, 'REACTION_WEIGHT_OVERRIDE').value('300');
     await tester.seedDb();
 
     const res = await modelUtils.createAndVerifyAddress({ chain: communityId });
@@ -99,6 +98,10 @@ describe('createReaction Integration Tests', () => {
       },
     });
     threadId = thread.id;
+  });
+
+  after(() => {
+    Sinon.restore();
   });
 
   it('should create comment reactions and verify comment reaction count', async () => {

--- a/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
+++ b/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
@@ -26,6 +26,8 @@ describe('Reaction vote weight', () => {
 
   let user: UserInstance | null = null;
   let address: AddressInstance | null = null;
+  let community: CommunityInstance | null = null;
+  let topic: TopicInstance | null = null;
 
   const createThread = async () => {
     const t = await threadsController.createThread({
@@ -50,9 +52,6 @@ describe('Reaction vote weight', () => {
     });
     return c[0];
   };
-
-  let community: CommunityInstance | null = null;
-  let topic: TopicInstance | null = null;
 
   before(async () => {
     await tester.seedDb();
@@ -87,6 +86,10 @@ describe('Reaction vote weight', () => {
     );
   });
 
+  afterEach(() => {
+    Sinon.restore();
+  });
+
   it('should set thread reaction vote weight and thread vote sum correctly', async () => {
     Sinon.stub(contractHelpers, 'getNamespaceBalance').resolves('50');
     const thread = await createThread();
@@ -100,7 +103,6 @@ describe('Reaction vote weight', () => {
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
     const t = await models.Thread.findByPk(thread.id);
     expect(t.reaction_weights_sum).to.eq(expectedWeight);
-    Sinon.restore();
   });
 
   it('should set comment reaction vote weight and comment vote sum correctly', async () => {
@@ -117,7 +119,6 @@ describe('Reaction vote weight', () => {
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
     const c = await models.Comment.findByPk(comment.id);
     expect(c.reaction_weights_sum).to.eq(expectedWeight);
-    Sinon.restore();
   });
 
   it('should set thread reaction vote weight to min 1', async () => {
@@ -131,7 +132,6 @@ describe('Reaction vote weight', () => {
     });
     const expectedWeight = 1;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
-    Sinon.restore();
   });
 
   it('should set comment reaction vote weight to min 1', async () => {
@@ -146,6 +146,5 @@ describe('Reaction vote weight', () => {
     });
     const expectedWeight = 1;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
-    Sinon.restore();
   });
 });

--- a/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
+++ b/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
@@ -1,0 +1,93 @@
+import {
+  AddressInstance,
+  CommunityInstance,
+  ThreadAttributes,
+  TopicInstance,
+  UserInstance,
+  models,
+  tester,
+} from '@hicommonwealth/model';
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { ServerThreadsController } from 'server/controllers/server_threads_controller';
+import BanCache from 'server/util/banCheckCache';
+import Sinon from 'sinon';
+import { createAndVerifyAddress } from 'test/util/modelUtils';
+import { contractHelpers } from '../../../../../libs/model/src/services/commonProtocol';
+
+Sinon.stub(contractHelpers, 'getNamespaceBalance').resolves('50');
+
+chai.use(chaiHttp);
+
+const mockBanCache = {
+  checkBan: async () => [true, null],
+} as any as BanCache;
+
+describe('Reaction vote weight', () => {
+  const threadsController = new ServerThreadsController(models, mockBanCache);
+  let user: UserInstance | null = null;
+  let address: AddressInstance | null = null;
+  let thread: ThreadAttributes | null = null;
+  let community: CommunityInstance | null = null;
+  let topic: TopicInstance | null = null;
+
+  before(async () => {
+    await tester.seedDb();
+
+    const userRes = await createAndVerifyAddress({
+      chain: 'ethereum',
+    });
+    user = await models.User.findByPk(userRes.user_id);
+    address = await models.Address.findByPk(userRes.address_id);
+    community = await models.Community.findByPk('ethereum');
+    topic = await models.Topic.findOne({
+      where: {
+        community_id: 'ethereum',
+      },
+    });
+
+    expect(user).not.to.be.null;
+    expect(address).not.to.be.null;
+    expect(community.id).to.eq('ethereum');
+    expect(topic).not.to.be.null;
+
+    // existing ethereum seed data
+    await models.CommunityStake.update(
+      {
+        vote_weight: 200,
+      },
+      {
+        where: {
+          stake_id: 1,
+        },
+      },
+    );
+
+    const t = await threadsController.createThread({
+      user,
+      address,
+      community,
+      topicId: topic.id,
+      title: 'Hey',
+      body: 'Cool',
+      kind: 'discussion',
+      readOnly: false,
+    });
+    thread = t[0];
+  });
+
+  it('should set reaction vote weight and thread vote sum correctly', async () => {
+    const [reaction] = await threadsController.createThreadReaction({
+      user,
+      address,
+      reaction: 'like',
+      threadId: thread.id,
+    });
+    const expectedWeight = 1 + 50 * 200;
+    expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
+    const [t] = await threadsController.getThreadsByIds({
+      threadIds: [thread.id],
+    });
+    expect(t.reaction_weights_sum).to.eq(expectedWeight);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6583 

## Description of Changes
- Updates reaction vote weight to be `1 + (stakeBalance * voteWeight)`, giving all community members a minimum of 1 vote weight, regardless of how much stake is owned
- Adds migration to make thread/comment reaction weights sum non-nullable default 0 so that the post-create hook increment always works
- Adds integration test

## Test Plan
- CA test
  - Disable the `REACTION_WEIGHT_OVERRIDE` env if using it
  - Run migration
  - On a community with staking enabled– with the user owning 0 stake – create a thread reaction
    - Confirm that 1 vote is added
    - Add stake for the user
    - Vote again on the same thread
      - Confirm that vote is greater than 1

## Deployment Plan
N/A

## Other Considerations
N/A