### PR TITLE
Added feature flag for homepage directing to dashboard

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -20,6 +20,7 @@ export const featureFlags = {
   newAdminOnboarding: buildFlag(process.env.FLAG_NEW_ADMIN_ONBOARDING),
   communityStake: buildFlag(process.env.FLAG_COMMUNITY_STAKE),
   newSignInModal: buildFlag(process.env.FLAG_NEW_SIGN_IN_MODAL),
+  rootDomainRebrand: buildFlag(process.env.ROOT_DOMAIN_REBRAND),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -20,7 +20,7 @@ export const featureFlags = {
   newAdminOnboarding: buildFlag(process.env.FLAG_NEW_ADMIN_ONBOARDING),
   communityStake: buildFlag(process.env.FLAG_COMMUNITY_STAKE),
   newSignInModal: buildFlag(process.env.FLAG_NEW_SIGN_IN_MODAL),
-  rootDomainRebrand: buildFlag(process.env.ROOT_DOMAIN_REBRAND),
+  rootDomainRebrand: buildFlag(process.env.FLAG_ROOT_DOMAIN_REBRAND),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -106,15 +106,26 @@ const CommonDomainRoutes = ({
   proposalTemplatesEnabled,
   newAdminOnboardingEnabled,
   communityHomepageEnabled,
+  rootDomainRebrandEnabled,
 }: RouteFeatureFlags) => [
-  <Route
-    key="/"
-    path="/"
-    element={withLayout(LandingPage, {
-      scoped: false,
-      type: 'blank',
-    })}
-  />,
+  ...(rootDomainRebrandEnabled
+    ? [
+        <Route
+          key="/"
+          path="/"
+          element={withLayout(DashboardPage, { type: 'common' })}
+        />,
+      ]
+    : [
+        <Route
+          key="/"
+          path="/"
+          element={withLayout(LandingPage, {
+            scoped: false,
+            type: 'blank',
+          })}
+        />,
+      ]),
   <Route
     key="/createCommunity"
     path="/createCommunity"

--- a/packages/commonwealth/client/scripts/navigation/Router.tsx
+++ b/packages/commonwealth/client/scripts/navigation/Router.tsx
@@ -15,6 +15,7 @@ export type RouteFeatureFlags = {
   proposalTemplatesEnabled: boolean;
   newAdminOnboardingEnabled: boolean;
   communityHomepageEnabled: boolean;
+  rootDomainRebrandEnabled: boolean;
 };
 
 const Router = (customDomain: string) => {
@@ -28,13 +29,18 @@ const Router = (customDomain: string) => {
     false,
   );
   const communityHomepageEnabled = client.getBooleanValue(
-    'communityHomepageEnabled',
+    'communityHomepage',
+    false,
+  );
+  const rootDomainRebrandEnabled = client.getBooleanValue(
+    'rootDomainRebrand',
     false,
   );
   const flags = {
     proposalTemplatesEnabled,
     newAdminOnboardingEnabled,
     communityHomepageEnabled,
+    rootDomainRebrandEnabled,
   };
 
   return createBrowserRouter(

--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -81,8 +81,8 @@ module.exports = {
       ),
     }),
     new webpack.DefinePlugin({
-      'process.env.ROOT_DOMAIN_REBRAND': JSON.stringify(
-        process.env.ROOT_DOMAIN_REBRAND,
+      'process.env.FLAG_ROOT_DOMAIN_REBRAND': JSON.stringify(
+        process.env.FLAG_ROOT_DOMAIN_REBRAND,
       ),
     }),
     new HtmlWebpackPlugin({

--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -80,6 +80,11 @@ module.exports = {
         process.env.FLAG_COMMUNITY_STAKE,
       ),
     }),
+    new webpack.DefinePlugin({
+      'process.env.ROOT_DOMAIN_REBRAND': JSON.stringify(
+        process.env.ROOT_DOMAIN_REBRAND,
+      ),
+    }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../client/index.html'),
       attributes: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6534

## Description of Changes
- Makes the root domain direct to the user dashboard

## Test Plan
- Add `ROOT_DOMAIN_REBRAND=true` to your .env and go to localhost:8080. It redirects to the /dashboard/global
- Go to some other page, click on the top left icon, it will redirect to /dashboard/global

## Deployment Plan
1. Ideally this goes in with the unleash feature flagging. Then we can "flip the switch" as suggested in the ticket
