### PR TITLE
Divastaking delegate button fix

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -10,7 +10,7 @@ import { matchRoutes, useLocation } from 'react-router-dom';
 import app from 'state';
 import { sidebarStore } from 'state/ui/sidebar';
 import { isWindowSmallInclusive } from '../component_kit/helpers';
-import { verifyCachedToggleTree } from './helpers';
+import { isGovernorCountingSimple, verifyCachedToggleTree } from './helpers';
 import { SidebarSectionGroup } from './sidebar_section';
 import type {
   SectionGroupAttrs,
@@ -64,11 +64,16 @@ export const GovernanceSection = () => {
       app.chain.meta.snapshot?.length);
 
   const isNotOffchain = app.chain?.meta.type !== ChainType.Offchain;
+  const compoundContracts = app.contracts.getByType('compound');
 
   const showCompoundOptions =
     isNotOffchain &&
     app.user.activeAccount &&
-    app.chain?.network === ChainNetwork.Compound;
+    app.chain?.network === ChainNetwork.Compound &&
+    !(
+      compoundContracts.length > 0 &&
+      isGovernorCountingSimple(compoundContracts[0])
+    );
 
   const showSnapshotOptions =
     app.chain?.base === ChainBase.Ethereum &&

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -70,10 +70,8 @@ export const GovernanceSection = () => {
     isNotOffchain &&
     app.user.activeAccount &&
     app.chain?.network === ChainNetwork.Compound &&
-    !(
-      compoundContracts.length > 0 &&
-      isGovernorCountingSimple(compoundContracts[0])
-    );
+    compoundContracts.length > 0 &&
+    !isGovernorCountingSimple(compoundContracts[0]);
 
   const showSnapshotOptions =
     app.chain?.base === ChainBase.Ethereum &&

--- a/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
@@ -12,10 +12,13 @@ function comparisonCustomizer(value1, value2) {
 // Check that our current cached tree is structurally correct
 export function verifyCachedToggleTree(
   treeName: string,
-  toggleTree: ToggleTree
+  toggleTree: ToggleTree,
 ) {
   const cachedTree = JSON.parse(
-    localStorage[`${app.activeChainId()}-${treeName}-toggle-tree`]
+    localStorage[`${app.activeChainId()}-${treeName}-toggle-tree`],
   );
   return _.isEqualWith(cachedTree, toggleTree, comparisonCustomizer);
 }
+
+export const isGovernorCountingSimple = (contract) =>
+  contract.abi.filter((x) => x.name === 'proposalVotes').length > 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6277 

## Description of Changes
- Checks if a contract is a GovernorCountingSimple type by its abi and blocks Delegate button being shown if it is.

## "How We Fixed It"
- Created a small function to check the abi of the current contract in the community

## Test Plan
- Join Divastaking community and check if delegate tab is present