### PR TITLE
#6715 - Bug: Combination of bold, italic, and strikethrough is wonky

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/markdown_formatted_text.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/markdown_formatted_text.tsx
@@ -13,7 +13,7 @@ import { loadScript } from 'helpers';
 import { twitterLinkRegex } from 'helpers/constants';
 import { debounce } from 'lodash';
 import { marked } from 'marked';
-import markedFoodnote from 'marked-footnote';
+import markedFootnote from 'marked-footnote';
 import { markedSmartypants } from 'marked-smartypants';
 import { markedXhtml } from 'marked-xhtml';
 import removeMd from 'remove-markdown';
@@ -49,7 +49,7 @@ marked
     renderer: markdownRenderer,
     gfm: true, // use github flavored markdown
   })
-  .use(markedFoodnote(), markedSmartypants(), markedXhtml());
+  .use(markedFootnote(), markedSmartypants(), markedXhtml());
 
 type MarkdownFormattedTextProps = Omit<QuillRendererProps, 'doc'> & {
   doc: string;

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -176,14 +176,15 @@
     letter-spacing: 0.02em;
   }
 
-  strong {
-    font-weight: 700;
-  }
-
   em,
   del,
   ins {
     font-weight: 400;
+  }
+
+  strong,
+  strong * {
+    font-weight: 700;
   }
 
   blockquote {


### PR DESCRIPTION
The following rendered as expected: `~~***words***~~`. This, however, did not: `***~~words~~***`
This PR updates the styling so that the two render correctly, i.e. italicized, bold, and with a strikethrough.

## Link to Issue
Closes: #6715 

## Description of Changes
- adds necessary css to style tags

## "How We Fixed It"
- updated styling for `strong` tags

## Test Plan
- in our editor, enter `***~~words~~***` and `~~***words***~~`. Confirm in preview that the text has italic, bold, and strikethrough styling
