### PR TITLE
Fixed creation account function calls

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 
 import 'pages/login/login_desktop.scss';
 
+import { CWAddress } from 'views/components/component_kit/cw_address';
+import { CWAvatarUsernameInput } from 'views/components/component_kit/cw_avatar_username_input';
+import { CWButton } from 'views/components/component_kit/cw_button';
+import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
+import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import {
   CWProfileRow,
   CWProfilesList,
 } from 'views/components/component_kit/cw_profiles_list';
-import { CWAddress } from 'views/components/component_kit/cw_address';
-import { CWAvatarUsernameInput } from 'views/components/component_kit/cw_avatar_username_input';
-import { CWButton } from 'views/components/component_kit/cw_button';
-import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWSpinner } from 'views/components/component_kit/cw_spinner';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { CWWalletsList } from 'views/components/component_kit/cw_wallets_list';
-import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 
 import { LoginBoilerplate } from './login_boilerplate';
 import { LoginDesktopSidebar } from './login_desktop_sidebar';
@@ -154,7 +154,10 @@ export const LoginDesktop = ({
               onAvatarChangeHandler={handleSetAvatar}
               onUsernameChangeHandler={handleSetUsername}
             />
-            <CWButton label="Finish" onClick={onSaveProfileInfo} />
+            <CWButton
+              label="Finish"
+              onClick={async () => await onSaveProfileInfo()}
+            />
           </div>
         )}
 

--- a/packages/commonwealth/client/scripts/views/pages/login/login_desktop_sidebar.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_desktop_sidebar.tsx
@@ -97,7 +97,9 @@ export const LoginDesktopSidebar = ({
           <CWText type="h4" fontWeight="semiBold" className="header-text">
             New or Returning?
           </CWText>
-          <CWAccountCreationButton onClick={onCreateNewAccount} />
+          <CWAccountCreationButton
+            onClick={async () => await onCreateNewAccount()}
+          />
           <CWAccountCreationButton
             creationType="linkAccount"
             onClick={onLinkExistingAccount}

--- a/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
@@ -147,7 +147,10 @@ export const LoginMobile = ({
               onUsernameChangeHandler={handleSetUsername}
               orientation="vertical"
             />
-            <CWButton label="Finish" onClick={onSaveProfileInfo} />
+            <CWButton
+              label="Finish"
+              onClick={async () => await onSaveProfileInfo()}
+            />
           </div>
         )}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6760

## Description of Changes
The `onSaveProfileInfo` and `onCreateNewAccount` were receiving click events when called from HTML elements in the login modal, this broke the account creation step in the old modal. 

Now we correctly call `onSaveProfileInfo` and `onCreateNewAccount` in the old login modal.

## "How We Fixed It"
By correctly calling `onSaveProfileInfo` and `onCreateNewAccount`

## Test Plan
- Clear DB
- Visit any page of the app
- Login with any wallet
- Verify that you can successfully create a new account.

## Deployment Plan
N/A

## Other Considerations
N/A