### PR TITLE
#6716 - Bug: Editor - Font sizing for numbered lists and links is incorrect

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.scss
@@ -55,22 +55,6 @@
     gap: 16px;
 
     .comment-text {
-      div,
-      p {
-        font-size: 16px !important;
-        line-height: 24px !important;
-        /* identical to box height, or 143% */
-        letter-spacing: 0.16px !important;
-      }
-      h1 {
-        font-size: 24px !important;
-      }
-      h2 {
-        font-size: 20px !important;
-      }
-    }
-
-    .comment-text {
       padding-left: 8px;
     }
 


### PR DESCRIPTION
The sources of the incorrect font-sizing are:
1. creating lists used to wrap the list item contents in paragraph tags 
2. styling on the parent class `.comment-text` that wraps the rendered Markdown. 

The first issue has been handled by @lzach83 in a previous commit. The second issue is handled here, i.e. the conflicting styling is removed entirely since styles for markdown content are handled in `markdown_formatted_text.tsx`. 

## Link to Issue
Closes: #6716 

## Description of Changes
- removes styles that conflict with existing styles for rendered markdown text