### PR TITLE
Fix process exits when unhandled errors are found in production

### DIFF
--- a/libs/core/src/ports/port.ts
+++ b/libs/core/src/ports/port.ts
@@ -33,14 +33,20 @@ const disposers: Disposer[] = [];
  * @param code exit code, defaults to unit testing
  */
 const disposeAndExit = async (code: ExitCode = 'UNIT_TEST'): Promise<void> => {
+  // don't kill process when errors are caught in production
+  if (code === 'ERROR' && process.env.NODE_ENV === 'production') return;
+
+  // call disposers
   await Promise.all(disposers.map((disposer) => disposer()));
   await Promise.all(
-    [...adapters].map(async ([key, adapter]) => {
+    [...adapters].reverse().map(async ([key, adapter]) => {
       console.log('[disposing adapter]', adapter.name || key);
       await adapter.dispose();
     }),
   );
   adapters.clear();
+
+  // exit when not unit testing
   code !== 'UNIT_TEST' && process.exit(code === 'ERROR' ? 1 : 0);
 };
 


### PR DESCRIPTION
The new `ports` implementation kills the process when unhandled exceptions or uncaught rejections are detected. This is a useful feature in a `development` or `qa` environment, allowing us to find bugs quickly... but it shouldn't be used in our production environment (we have a monolithic server, not micro-services that can recover from this).

## Link to Issue
Closes: #TODO

## Description of Changes
- Ignore process level errors when in production
 