### PR TITLE
#6432 - Drawer not closing on click outside element

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -79,12 +79,7 @@ export const ThreadOptions = ({
 
   return (
     <>
-      <div
-        className="ThreadOptions"
-        onClick={(e) => {
-          e.preventDefault();
-        }}
-      >
+      <div className="ThreadOptions">
         <div className="options-container">
           {!upvoteDrawerBtnBelow && <ViewThreadUpvotesDrawer thread={thread} />}
 


### PR DESCRIPTION
Currently, after you open a drawer, clicking outside of it does not close it. This PR allows the user to use either the close-drawer button or click outside of the drawer to hide it.

## Link to Issue
Closes: #6432 

## Description of Changes
- removes call to `preventDefault` on `div` holding thread options

## "How We Fixed It"
The absence of the `preventDefault` does not change the behavior of the buttons within it. 

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 