### PR TITLE
Change stake modal to text input

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -152,7 +152,9 @@ class MetamaskWebWalletController implements IWebWallet<string> {
 
           // TODO: we should cache this data!
           const chains = await $.getJSON('https://chainid.network/chains.json');
-          const baseChain = chains.find((c) => c.chainId === chainId);
+          const baseChain = chains.find((c) => c.chainId == chainId);
+          const pubRpcUrl = baseChain.rpc.filter((r) => !/\${.*?}/.test(r));
+          const url = rpcUrl.length > 0 ? pubRpcUrl[0] : rpcUrl;
           await this._web3.givenProvider.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -160,7 +162,7 @@ class MetamaskWebWalletController implements IWebWallet<string> {
                 chainId: chainIdHex,
                 chainName: baseChain.name,
                 nativeCurrency: baseChain.nativeCurrency,
-                rpcUrls: [rpcUrl],
+                rpcUrls: [url],
               },
             ],
           });
@@ -222,7 +224,7 @@ class MetamaskWebWalletController implements IWebWallet<string> {
       } catch (error) {
         if (error.code === 4902) {
           const chains = await $.getJSON('https://chainid.network/chains.json');
-          const baseChain = chains.find((c) => c.chainId === communityChain);
+          const baseChain = chains.find((c) => c.chainId == communityChain);
           // Check if the string contains '${' and '}'
           const rpcUrl = baseChain.rpc.filter((r) => !/\${.*?}/.test(r));
           const url =

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
@@ -119,7 +119,12 @@ class CommunityStakes extends ContractBase {
     try {
       txReceipt = await this.contract.methods
         .buyStake(namespaceAddress, id, amount)
-        .send({ value: totalPrice, from: walletAddress });
+        .send({
+          value: totalPrice,
+          from: walletAddress,
+          maxPriorityFeePerGas: null,
+          maxFeePerGas: null,
+        });
       try {
         await this.web3.givenProvider.request({
           method: 'wallet_watchAsset',
@@ -162,7 +167,11 @@ class CommunityStakes extends ContractBase {
     try {
       txReceipt = await this.contract.methods
         .sellStake(namespaceAddress, id.toString(), amount.toString())
-        .send({ from: walletAddress });
+        .send({
+          from: walletAddress,
+          maxPriorityFeePerGas: null,
+          maxFeePerGas: null,
+        });
     } catch {
       throw new Error('Transaction failed');
     }

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -101,7 +101,11 @@ class NamespaceFactory extends ContractBase {
       const uri = `${window.location.origin}/api/namespaceMetadata/${name}/{id}`;
       txReceipt = await this.contract.methods
         .deployNamespace(name, uri, feeManager, [])
-        .send({ from: walletAddress });
+        .send({
+          from: walletAddress,
+          maxPriorityFeePerGas: null,
+          maxFeePerGas: null,
+        });
     } catch (error) {
       throw new Error('Transaction failed: ' + error);
     }
@@ -138,7 +142,11 @@ class NamespaceFactory extends ContractBase {
           100000000,
           0,
         )
-        .send({ from: walletAddress });
+        .send({
+          from: walletAddress,
+          maxPriorityFeePerGas: null,
+          maxFeePerGas: null,
+        });
     } catch {
       throw new Error('Transaction failed');
     }

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
@@ -9,6 +9,8 @@
   }
 
   .CWModalBody {
+    overflow: auto;
+
     @include heightSmallInclusive {
       max-height: 300px;
     }
@@ -85,21 +87,27 @@
         align-items: center;
 
         @include smallInclusive {
-          gap: 25px;
+          gap: 0;
         }
 
-        .number {
-          font-size: 29px;
-          background: transparent;
-          font-weight: bold;
-          text-align: center;
-          width: 5ch;
-          border-color: transparent;
-          transition: width 0.2s ease-in-out;
-        }
+        .number-container {
+          .input-and-icon-container {
+            width: unset;
 
-        .number.expanded {
-          width: 8ch;
+            .number {
+              font-size: 29px;
+              background: transparent;
+              font-weight: bold;
+              text-align: center;
+              width: 5ch;
+              border-color: transparent;
+              transition: width 0.2s ease-in-out;
+
+              &.expanded {
+                width: 8ch;
+              }
+            }
+          }
         }
       }
     }
@@ -114,6 +122,7 @@
 
       .label {
         color: $neutral-400;
+        min-width: 90px;
       }
     }
   }
@@ -146,6 +155,11 @@
   .total-cost-row {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+
+    .left-side {
+      min-width: 70px;
+    }
 
     .Text {
       color: $neutral-500;

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
@@ -98,12 +98,8 @@
           transition: width 0.2s ease-in-out;
         }
 
-        .number.expand1 {
+        .number.expanded {
           width: 8ch;
-        }
-
-        .number.expand2 {
-          width: 11ch;
         }
       }
     }

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
@@ -81,7 +81,7 @@
 
       .stake-selector {
         display: flex;
-        gap: 50px;
+        gap: 25px;
         align-items: center;
 
         @include smallInclusive {
@@ -90,8 +90,20 @@
 
         .number {
           font-size: 29px;
-          min-width: 34px;
-          justify-content: center;
+          background: transparent;
+          font-weight: bold;
+          text-align: center;
+          width: 5ch;
+          border-color: transparent;
+          transition: width 0.2s ease-in-out;
+        }
+
+        .number.expand1 {
+          width: 8ch;
+        }
+
+        .number.expand2 {
+          width: 11ch;
         }
       }
     }

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -22,6 +22,7 @@ import CWPopover, {
   usePopover,
 } from 'views/components/component_kit/new_designs/CWPopover';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
+import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import { MessageRow } from 'views/components/component_kit/new_designs/CWTextInput/MessageRow';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
 
@@ -36,7 +37,6 @@ import {
   CustomAddressOptionElement,
 } from './CustomAddressOption';
 
-import { CWTextInput } from 'client/scripts/views/components/component_kit/new_designs/CWTextInput';
 import './StakeExchangeForm.scss';
 
 type OptionDropdown = {
@@ -203,13 +203,6 @@ const StakeExchangeForm = ({
     ? false
     : numberOfStakeToExchange >= stakeBalance;
 
-  const inputClassExpanded =
-    numberOfStakeToExchange?.toString().length > 6
-      ? 'number expand2'
-      : numberOfStakeToExchange?.toString().length > 3
-      ? 'number expand1'
-      : 'number';
-
   return (
     <div className="StakeExchangeForm">
       <CWModalBody>
@@ -287,9 +280,7 @@ const StakeExchangeForm = ({
                 inputClassName={clsx('number', {
                   expanded: numberOfStakeToExchange?.toString().length > 3,
                 })}
-                containerClassName={clsx('number', {
-                  expanded: numberOfStakeToExchange?.toString().length > 3,
-                })}
+                containerClassName="number-container"
               />
               <CWCircleButton
                 buttonType="secondary"
@@ -387,7 +378,9 @@ const StakeExchangeForm = ({
         </div>
 
         <div className="total-cost-row">
-          <CWText type="caption">{isBuyMode ? 'Total cost' : 'Net'}</CWText>
+          <div className="left-side">
+            <CWText type="caption">{isBuyMode ? 'Total cost' : 'Net'}</CWText>
+          </div>
           {isUsdPriceLoading ? (
             <Skeleton className="price-skeleton" />
           ) : (

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -36,6 +36,7 @@ import {
   CustomAddressOptionElement,
 } from './CustomAddressOption';
 
+import { CWTextInput } from 'client/scripts/views/components/component_kit/cw_text_input';
 import './StakeExchangeForm.scss';
 
 type OptionDropdown = {
@@ -76,7 +77,7 @@ const StakeExchangeForm = ({
   } = useStakeExchange({
     mode,
     address: selectedAddress?.value,
-    numberOfStakeToExchange,
+    numberOfStakeToExchange: numberOfStakeToExchange ?? 0,
   });
 
   const { stakeBalance, stakeValue, currentVoteWeight, stakeData } =
@@ -86,7 +87,7 @@ const StakeExchangeForm = ({
   const { mutateAsync: sellStake } = useSellStakeMutation();
 
   const expectedVoteWeight = commonProtocol.calculateVoteWeight(
-    String(numberOfStakeToExchange),
+    numberOfStakeToExchange ? String(numberOfStakeToExchange) : '0',
     stakeData?.vote_weight,
   );
 
@@ -149,9 +150,15 @@ const StakeExchangeForm = ({
     onSetNumberOfStakeToExchange((prevState) => prevState + 1);
   };
 
-  const insufficientFunds =
-    isBuyMode &&
-    parseFloat(userEthBalance) < parseFloat(buyPriceData?.totalPrice);
+  const handleInput = (e) => {
+    onSetNumberOfStakeToExchange(
+      e.target.value === '' ? null : parseInt(e.target.value),
+    );
+  };
+
+  const insufficientFunds = isBuyMode
+    ? parseFloat(userEthBalance) < parseFloat(buyPriceData?.totalPrice)
+    : numberOfStakeToExchange > stakeBalance;
 
   const ctaDisabled = isBuyMode
     ? insufficientFunds || numberOfStakeToExchange <= 0 || !selectedAddress
@@ -190,6 +197,13 @@ const StakeExchangeForm = ({
   const plusDisabled = isBuyMode
     ? false
     : numberOfStakeToExchange >= stakeBalance;
+
+  const inputClassExpanded =
+    numberOfStakeToExchange?.toString().length > 6
+      ? 'number expand2'
+      : numberOfStakeToExchange?.toString().length > 3
+      ? 'number expand1'
+      : 'number';
 
   return (
     <div className="StakeExchangeForm">
@@ -262,9 +276,11 @@ const StakeExchangeForm = ({
                 onClick={handleMinus}
                 disabled={minusDisabled}
               />
-              <CWText type="h3" fontWeight="bold" className="number">
-                {numberOfStakeToExchange}
-              </CWText>
+              <CWTextInput
+                onInput={handleInput}
+                value={numberOfStakeToExchange}
+                inputClassName={inputClassExpanded ?? 'number'}
+              />
               <CWCircleButton
                 buttonType="secondary"
                 iconName="plus"

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -36,7 +36,7 @@ import {
   CustomAddressOptionElement,
 } from './CustomAddressOption';
 
-import { CWTextInput } from 'client/scripts/views/components/component_kit/cw_text_input';
+import { CWTextInput } from 'client/scripts/views/components/component_kit/new_designs/CWTextInput';
 import './StakeExchangeForm.scss';
 
 type OptionDropdown = {
@@ -284,7 +284,12 @@ const StakeExchangeForm = ({
               <CWTextInput
                 onInput={handleInput}
                 value={numberOfStakeToExchange}
-                inputClassName={inputClassExpanded ?? 'number'}
+                inputClassName={clsx('number', {
+                  expanded: numberOfStakeToExchange?.toString().length > 3,
+                })}
+                containerClassName={clsx('number', {
+                  expanded: numberOfStakeToExchange?.toString().length > 3,
+                })}
               />
               <CWCircleButton
                 buttonType="secondary"

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -153,9 +153,12 @@ const StakeExchangeForm = ({
   const handleInput = (e) => {
     const inputValue = e.target.value;
     const numericValue = inputValue.replace(/[^0-9]/g, '');
-    onSetNumberOfStakeToExchange(
-      !numericValue || inputValue === '' ? null : parseInt(numericValue),
-    );
+    const parsed = parseInt(numericValue);
+    if (parsed < 1000000) {
+      onSetNumberOfStakeToExchange(parsed);
+    } else if (inputValue === '') {
+      onSetNumberOfStakeToExchange(0);
+    }
   };
 
   const insufficientFunds = isBuyMode

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -151,8 +151,10 @@ const StakeExchangeForm = ({
   };
 
   const handleInput = (e) => {
+    const inputValue = e.target.value;
+    const numericValue = inputValue.replace(/[^0-9]/g, '');
     onSetNumberOfStakeToExchange(
-      e.target.value === '' ? null : parseInt(e.target.value),
+      !numericValue || inputValue === '' ? null : parseInt(numericValue),
     );
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6766 

## Description of Changes
https://www.loom.com/share/61e1cc9e926f44228becc4195b310bb2
- Converts stake amound from text to input
- updates style for text input
- adds dynamic character size for input

-bonus: includes an optimization for suggested gas in txs + add base as a network fix 

## Test Plan
- Click buy stake, input amount via input
- test + and -
- attempt again on sell flow

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- supports max characters of 8, this is far beyond any likely affordable eth amount