### PR TITLE
Fix email call callback

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -136,7 +136,7 @@ const SessionRevalidationModal = ({
                   label="email address"
                   placeholder="your-email@email.com"
                   onInput={(e) => setEmail(e.target.value)}
-                  onenterkey={onEmailLogin}
+                  onenterkey={async () => await onEmailLogin()}
                 />
               ) : (
                 <CWSpinner />

--- a/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_desktop.tsx
@@ -107,13 +107,13 @@ export const LoginDesktop = ({
                   placeholder="Email address"
                   className="login-email-field"
                   onInput={handleSetEmail}
-                  onenterkey={onEmailLogin}
+                  onenterkey={async () => await onEmailLogin()}
                 />
                 <div className="buttons-row email-form-buttons">
                   <CWButton
                     label="Sign in with Magic"
                     className="wallet-magic-btn"
-                    onClick={onEmailLogin}
+                    onClick={async () => await onEmailLogin()}
                   />
                   <CWButton
                     iconLeft="arrowLeft"

--- a/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/login/login_mobile.tsx
@@ -179,14 +179,14 @@ export const LoginMobile = ({
                   placeholder="Email address"
                   className="login-email-field"
                   onInput={handleSetEmail}
-                  onenterkey={onEmailLogin}
+                  onenterkey={async () => await onEmailLogin()}
                 />
                 <div className="buttons-row email-form-buttons">
                   <CWButton
                     label="Sign in with Magic"
                     buttonType="secondary-blue"
                     className="wallet-magic-btn"
-                    onClick={onEmailLogin}
+                    onClick={async () => await onEmailLogin()}
                   />
                   <CWButton
                     iconLeft="arrowLeft"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6806

## Description of Changes
- Fixes the `onEmailLogin` login call in old login modal.

## "How We Fixed It"
The `onEmailLogin` callback will not receive HTML synthetic events which were breaking login

## Test Plan
- Login with any email
- Verify it works

## Deployment Plan
N/A

## Other Considerations
N/A