### PR TITLE
added individual mixpanel calls to buy stake and sell stake

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -1,8 +1,12 @@
+import { commonProtocol } from '@hicommonwealth/core';
 import clsx from 'clsx';
+import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import React from 'react';
 import { isMobile } from 'react-device-detect';
-
-import { commonProtocol } from '@hicommonwealth/core';
+import {
+  BaseMixpanelPayload,
+  MixpanelCommunityStakeEvent,
+} from 'shared/analytics/types';
 import app from 'state';
 import {
   useBuyStakeMutation,
@@ -24,7 +28,6 @@ import CWPopover, {
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { MessageRow } from 'views/components/component_kit/new_designs/CWTextInput/MessageRow';
 import { CWButton } from 'views/components/component_kit/new_designs/cw_button';
-
 import { useStakeExchange } from '../hooks';
 import {
   ManageCommunityStakeModalMode,
@@ -94,6 +97,10 @@ const StakeExchangeForm = ({
 
   const isBuyMode = mode === 'buy';
 
+  const { trackAnalytics } = useBrowserAnalyticsTrack<BaseMixpanelPayload>({
+    onAction: true,
+  });
+
   const handleBuy = async () => {
     try {
       onSetModalState(ManageCommunityStakeModalState.Loading);
@@ -108,6 +115,13 @@ const StakeExchangeForm = ({
 
       onSetSuccessTransactionHash(txReceipt?.transactionHash);
       onSetModalState(ManageCommunityStakeModalState.Success);
+
+      trackAnalytics({
+        event: MixpanelCommunityStakeEvent.STAKE_BOUGHT,
+        community: app.activeChainId(),
+        userId: app.user.activeAccount.profile.id,
+        userAddress: selectedAddress?.value,
+      });
     } catch (err) {
       console.log('Error buying: ', err);
       onSetModalState(ManageCommunityStakeModalState.Failure);
@@ -128,6 +142,13 @@ const StakeExchangeForm = ({
 
       onSetSuccessTransactionHash(txReceipt?.transactionHash);
       onSetModalState(ManageCommunityStakeModalState.Success);
+
+      trackAnalytics({
+        event: MixpanelCommunityStakeEvent.STAKE_SOLD,
+        community: app.activeChainId(),
+        userId: app.user.activeAccount.profile.id,
+        userAddress: selectedAddress?.value,
+      });
     } catch (err) {
       console.log('Error selling: ', err);
       onSetModalState(ManageCommunityStakeModalState.Failure);

--- a/packages/commonwealth/shared/analytics/types.ts
+++ b/packages/commonwealth/shared/analytics/types.ts
@@ -33,6 +33,11 @@ export const enum MixpanelCommunityInteractionEvent {
   DIRECTORY_PAGE_DISABLED = 'Directory Page Disabled',
 }
 
+export const enum MixpanelCommunityStakeEvent {
+  STAKE_BOUGHT = 'Stake Bought',
+  STAKE_SOLD = 'Stake Sold',
+}
+
 export const enum MixpanelLoginEvent {
   LOGIN = 'Login',
   LOGIN_COMPLETED = 'Login Completed',
@@ -73,6 +78,7 @@ export type MixpanelEvents =
   | MixpanelLoginEvent
   | MixpanelUserSignupEvent
   | MixpanelCommunityCreationEvent
+  | MixpanelCommunityStakeEvent
   | MixpanelPageViewEvent
   | MixpanelCommunityInteractionEvent
   | MixpanelSnapshotEvents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6734 

## Description of Changes
- Adds Mixpanel calls for when a user buys stake and sells stake

## Test Plan
-Create a community or go to a community that currently has stake enabled. 
-Buy Stake and then go to Mixpanel dashboard and confirm that "Stake Bought" is logged
-Sell Stake and then go to Mixpanel dashboard and confirm that "Stake Sold" is logged

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- NOTE: I left a comment on the original ticket, but adding a Mixpanel call to the Manage Stake functionality is not applicable because Manage Stake was part of previous iteration and doesn't exist. This was cleared by Harris. 