### PR TITLE
Markdown-only proposal description editor

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/cosmos_proposal_form.tsx
@@ -9,6 +9,7 @@ import {
 import { CosmosToken } from 'controllers/chain/cosmos/types';
 import type { Any as ProtobufAny } from 'cosmjs-types/google/protobuf/any';
 import { useCommonNavigate } from 'navigation/helpers';
+import { DeltaStatic } from 'quill';
 import React, { useState } from 'react';
 import app from 'state';
 import {
@@ -24,15 +25,21 @@ import { Skeleton } from '../../components/Skeleton';
 import { CWButton } from '../../components/component_kit/cw_button';
 import { CWLabel } from '../../components/component_kit/cw_label';
 import { CWRadioGroup } from '../../components/component_kit/cw_radio_group';
-import { CWTextArea } from '../../components/component_kit/cw_text_area';
 import { CWTextInput } from '../../components/component_kit/cw_text_input';
+import {
+  ReactQuillEditor,
+  createDeltaFromText,
+  getTextFromDelta,
+} from '../../components/react_quill_editor';
 
 export const CosmosProposalForm = () => {
   const [cosmosProposalType, setCosmosProposalType] = useState<
     'textProposal' | 'communitySpend'
   >('textProposal');
   const [deposit, setDeposit] = useState<number>(0);
-  const [description, setDescription] = useState<string>('');
+  const [descriptionDelta, setDescriptionDelta] = useState<DeltaStatic>(
+    createDeltaFromText(''),
+  );
   const [payoutAmount, setPayoutAmount] = useState<number>(0);
   const [recipient, setRecipient] = useState<string>('');
   const [title, setTitle] = useState<string>('');
@@ -62,6 +69,7 @@ export const CosmosProposalForm = () => {
       deposit,
       meta?.decimals,
     );
+    const description = getTextFromDelta(descriptionDelta);
 
     const _deposit = deposit
       ? new CosmosToken(
@@ -126,15 +134,14 @@ export const CosmosProposalForm = () => {
           setTitle(e.target.value);
         }}
       />
-      <CWTextArea
-        label="Description"
-        placeholder="Enter a description"
-        onInput={(e) => {
-          setDescription(e.target.value);
-        }}
-        value={description}
-        resizeWithText
-      />
+      <div>
+        <CWLabel label="Description" />
+        <ReactQuillEditor
+          placeholder="Enter a description"
+          contentDelta={descriptionDelta}
+          setContentDelta={setDescriptionDelta}
+        />
+      </div>
       {isLoadingDepositParams ? (
         <Skeleton className="TextInput" style={{ height: 62 }} />
       ) : (

--- a/packages/commonwealth/client/styles/pages/new_proposal/index.scss
+++ b/packages/commonwealth/client/styles/pages/new_proposal/index.scss
@@ -6,7 +6,7 @@
   gap: 16px;
   flex: 1;
   padding: 24px;
-  max-width: 432px;
+  max-width: 476px;
 
   @include smallInclusive {
     padding: 16px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6635 

## Description of Changes
- Makes Cosmos Onchain Proposal description input markdown-only
- slightly widens form to make editor toolbar fit in one line

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Tested by copying some proposal markdown content from past [Juno summaries](https://wallet.keplr.app/chains/juno?tab=governance)

## Test Plan
- CA (click around) tested on local:
  - http://localhost:8080/csdk-beta/new/proposal. or /csdk
  - sign in with ["shared account"](https://github.com/hicommonwealth/commonwealth/blob/master/knowledge_base/Devnet.md#manually-testing-transactions-on-the-csdk-or-csdk-beta-sandbox-community) 
  - copy/paste any markdown, or type a description in markdown 
  - Check preview to make sure it looks good
  - Send Transaction -> (Keplr: set TX Fee to zero, confirm)
  - Expect resulting proposal page to look like Preview

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- I noticed juno proposals have \n newline characters a lot. Our editor doesn't support that, but the Preview window should resolve any confusion