### PR TITLE
Added environment variable to set unleash environment

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -33,7 +33,7 @@ const unleashConfig = {
   url: process.env.UNLEASH_FRONTEND_SERVER_URL,
   clientKey: process.env.UNLEASH_FRONTEND_API_TOKEN,
   refreshInterval: 120,
-  appName: 'commonwealth-web',
+  appName: process.env.HEROKU_APP_NAME,
 };
 
 export const openFeatureProvider = process.env.UNLEASH_FRONTEND_API_TOKEN

--- a/packages/commonwealth/webpack/webpack.base.config.js
+++ b/packages/commonwealth/webpack/webpack.base.config.js
@@ -103,6 +103,11 @@ module.exports = {
         process.env.UNLEASH_FRONTEND_API_TOKEN,
       ),
     }),
+    new webpack.DefinePlugin({
+      'process.env.HEROKU_APP_NAME': JSON.stringify(
+        process.env.HEROKU_APP_NAME,
+      ),
+    }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../client/index.html'),
       attributes: {


### PR DESCRIPTION
Makes an environment variable determine which appName unleash provides, which allows us to change which flags to have on/off on different environments.

## Link to Issue
Closes: #6830

## Description of Changes
- Sets unleashConfig.appName to HEROKU_APP_NAME.

## Test Plan
- In env, have UNLEASH_FRONTEND_SERVER_URL, UNLEASH_FRONTEND_API_TOKEN set in order to use the unleash provider.
- In .env, set HEROKU_APP_NAME=commonwealth-frick, change unleash config so that communityStake is set only for frick. Make sure that communityStake works. When HEROKU_APP_NAME=commonwelath-frack, make sure that communityStake does not show.
