### PR TITLE
#6818 - Show Success Banner On Topic Update

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -18,6 +18,7 @@ import {
 import { CWButton } from '../components/component_kit/new_designs/cw_button';
 import { openConfirmation } from './confirmation_modal';
 
+import { notifySuccess } from 'client/scripts/controllers/app/notifications';
 import '../../../styles/modals/edit_topic_modal.scss';
 
 type EditTopicModalProps = {
@@ -68,6 +69,7 @@ export const EditTopicModal = ({
       await editTopic({ topic: new Topic(topicInfo) });
       if (noRedirect) {
         onModalClose();
+        notifySuccess('Topic updated!');
       } else {
         navigate(`/discussions/${encodeURI(name.toString().trim())}`);
       }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/ManageTopicsSection/ManageTopicsSection.tsx
@@ -1,4 +1,7 @@
-import { notifyError } from 'client/scripts/controllers/app/notifications';
+import {
+  notifyError,
+  notifySuccess,
+} from 'client/scripts/controllers/app/notifications';
 import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import type Topic from 'client/scripts/models/Topic';
 import app from 'client/scripts/state';
@@ -76,8 +79,9 @@ export const ManageTopicsSection = () => {
   const handleSave = async () => {
     try {
       await updateFeaturedTopicsOrder({ featuredTopics: featuredTopics });
+      notifySuccess('Topic order updated!');
     } catch (err) {
-      notifyError('Failed to update order');
+      notifyError('Failed to update topic order');
     }
   };
 


### PR DESCRIPTION
If a topic is updated on the admin topics page, under the 'Manage Topics' tab, the user should see a success banner when a topic is successfully updated (including when a featured topic is re-ordered)

## Link to Issue
Closes: #6818 

## Description of Changes
- displays success banners on successful save

## Test Plan
- navigate to the Topics page under the Admin Capabilities submenu and go to the Manage Topics tab. 
- re-order the topics and click 'Save Changes'. You should see a success banner.
- select the pencil icon next to a topic name to edit it. Update the topic and click 'Save Changes'. You should see a success banner. 
