### PR TITLE
Israel.6871.resize logo remove line

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.scss
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.scss
@@ -8,7 +8,7 @@
   height: $global-header-height;
   justify-content: space-between;
   min-height: $global-header-height;
-  padding: 0 8px;
+  padding: 0 12px;
 
   .header-left.desktop {
     padding-left: 68px;

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -55,7 +55,6 @@ const DesktopHeader = ({
   return (
     <div className="DesktopHeader">
       <div className="header-left">
-        <CWDivider isVertical />
         <CWIconButton
           iconName="commonLogo"
           iconButtonTheme="black"

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -58,7 +58,7 @@ const DesktopHeader = ({
         <CWIconButton
           iconName="commonLogo"
           iconButtonTheme="black"
-          iconSize="xl"
+          iconSize="header"
           onClick={() => {
             if (app.isCustomDomain()) {
               navigate('/', {}, null);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/types.ts
@@ -13,7 +13,8 @@ export type IconSize =
   | 'medium'
   | 'large'
   | 'xl'
-  | 'xxl';
+  | 'xxl'
+  | 'header';
 
 export type IconStyleProps = {
   className?: string;

--- a/packages/commonwealth/client/styles/mixins/icons.scss
+++ b/packages/commonwealth/client/styles/mixins/icons.scss
@@ -4,6 +4,7 @@ $small-icon: 16px;
 $regular-icon: 20px;
 $medium-icon: 24px;
 $large-icon: 32px;
+$header-icon: 36px;
 $xl-icon: 48px;
 $xxl-icon: 60px;
 
@@ -35,6 +36,10 @@ $xxl-icon: 60px;
 
   &.large {
     font-size: $large-icon;
+  }
+
+  &.header {
+    font-size: $header-icon;
   }
 
   &.xl {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6871 

## Description of Changes
- Changed size of logo in header/added new `header` type for header specific logo.
- added more padding to the left of the logo at the request and approval of Jess
- removed the vertical border line that was to the left of the logo in the header 


## Test Plan
-Go to any page and notice that the header no longer has a vertical line to the left of the logo, and that the logo matches the size in the below screenshot

![screen_shot_2024-02-23_at_11 36 45_am_720](https://github.com/hicommonwealth/commonwealth/assets/69872984/db4a82d5-fe94-46d6-ae35-909b45c1adf5)
