### PR TITLE
Remove email based magic linking.

### DIFF
--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -135,8 +135,10 @@ async function createNewMagicUser({
     const newUser = await models.User.createWithProfile(
       models,
       {
-        email: magicUserMetadata.email || null,
-        emailVerified: true,
+        // never use emails from magic, even for "email" login -- magic maintains the mapping
+        // of emails/socials -> addresses, and we rely ONLY on the address as a canonical piece
+        // of login information.
+        email: null,
       },
       { transaction },
     );
@@ -536,37 +538,25 @@ async function magicLoginRoute(
   // attempt to locate an existing magic user by canonical address.
   // this is the properly modern method of identifying users, as it conforms to
   // the DID standard.
-  let existingUserInstance = await models.User.scope('withPrivateData').findOne(
-    {
-      include: [
-        {
-          model: models.Address,
-          where: {
-            wallet_id: WalletId.Magic,
-            address: canonicalAddress,
-            verified: { [Op.ne]: null },
-          },
-          required: true,
+  const existingUserInstance = await models.User.scope(
+    'withPrivateData',
+  ).findOne({
+    include: [
+      {
+        model: models.Address,
+        where: {
+          wallet_id: WalletId.Magic,
+          address: canonicalAddress,
+          verified: { [Op.ne]: null },
         },
-        {
-          model: models.Profile,
-        },
-      ],
-    },
-  );
-  if (!existingUserInstance && magicUserMetadata.email) {
-    // if unable to locate a magic user by address, attempt to locate by email.
-    // only legacy users (pre-magic or magic but with broken assumptions) should
-    // trigger this case, as it was formerly canonical.
-    existingUserInstance = await models.User.scope('withPrivateData').findOne({
-      where: { email: magicUserMetadata.email },
-      include: [
-        {
-          model: models.Profile,
-        },
-      ],
-    });
-  }
+        required: true,
+      },
+      {
+        model: models.Profile,
+      },
+    ],
+  });
+
   log.trace(
     `EXISTING USER INSTANCE: ${JSON.stringify(existingUserInstance, null, 2)}`,
   );


### PR DESCRIPTION
## Link to Issue
Closes: #6885 

## Description of Changes
- Removes email-based linking of new magic accounts to each other. Now addresses alone will determine the canonical magic user. Existing links should function as normal.

## Test Plan
- confirm that "email" login and "google" login do not enter user into same account, even if using same email.
- confirm that "connect a new address" + adding social does produce an account that can be accessed with both social and original login method.