### PR TITLE
Refactor App for multi-chain CS - Deploy Sepolia-base contracts for QA

### DIFF
--- a/libs/core/src/commonProtocol/chainConfig.ts
+++ b/libs/core/src/commonProtocol/chainConfig.ts
@@ -2,6 +2,7 @@
 export enum ValidChains {
   Base = 8453,
   SepoliaBase = 84532,
+  Sepolia = 11155111,
 }
 
 export const STAKE_ID = 2;
@@ -14,6 +15,11 @@ export const factoryContracts: {
     chainId: number;
   };
 } = {
+  [ValidChains.Sepolia]: {
+    factory: '0xEAB6373E6a722EeC8A65Fd38b014d8B81d5Bc1d4',
+    communityStake: '0xf6C1B02257f0Ac4Af5a1FADd2dA8E37EC5f9E5fd',
+    chainId: 11155111,
+  },
   [ValidChains.SepoliaBase]: {
     factory: '0xD8a357847cABA76133D5f2cB51317D3C74609710',
     communityStake: '0xd097926d8765A7717206559E7d19EECCbBa68c18',

--- a/libs/core/src/commonProtocol/chainConfig.ts
+++ b/libs/core/src/commonProtocol/chainConfig.ts
@@ -1,7 +1,7 @@
 // Chains with deployed namespace factories. As new chains are enabled, add here.
 export enum ValidChains {
-  Sepolia = 11155111,
   Base = 8453,
+  SepoliaBase = 84532,
 }
 
 export const STAKE_ID = 2;
@@ -14,10 +14,10 @@ export const factoryContracts: {
     chainId: number;
   };
 } = {
-  [ValidChains.Sepolia]: {
-    factory: '0xA6f747b38B50B2519dDb7a12e1523d518B6D0FD3',
-    communityStake: '0x377004f12eEE739204D44073F160798235160711',
-    chainId: 11155111,
+  [ValidChains.SepoliaBase]: {
+    factory: '0xD8a357847cABA76133D5f2cB51317D3C74609710',
+    communityStake: '0xd097926d8765A7717206559E7d19EECCbBa68c18',
+    chainId: 84532,
   },
   [ValidChains.Base]: {
     factory: '0xedf43C919f59900C82d963E99d822dA3F95575EA',

--- a/libs/model/src/services/commonProtocol/contractHelpers.ts
+++ b/libs/model/src/services/commonProtocol/contractHelpers.ts
@@ -5,7 +5,6 @@ import {
 } from '@hicommonwealth/core';
 import Web3 from 'web3';
 import { AbiItem } from 'web3-utils';
-import { DB } from '../../models';
 import { getBalances } from '../tokenBalanceCache';
 
 export const getNamespace = async (
@@ -57,17 +56,11 @@ export const getNamespaceBalance = async (
   tokenId: number,
   chain: commonProtocol.ValidChains,
   address: string,
-  model: DB,
+  nodeUrl: string,
 ): Promise<string> => {
   const factoryData = commonProtocol.factoryContracts[chain];
-  const node = await model.ChainNode.findOne({
-    where: {
-      eth_chain_id: factoryData.chainId,
-    },
-    attributes: ['url'],
-  });
-  if (node) {
-    const web3 = new Web3(node.url);
+  if (nodeUrl) {
+    const web3 = new Web3(nodeUrl);
     const activeNamespace = await getNamespace(
       web3,
       namespace,

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -146,15 +146,24 @@ class MetamaskWebWalletController implements IWebWallet<string> {
       } catch (switchError) {
         // This error code indicates that the chain has not been added to MetaMask.
         if (switchError.code === 4902) {
-          const wsRpcUrl = new URL(app.chain.meta.node.url);
+          const wsRpcUrl = app.chain?.meta?.node.url ?? '';
           const rpcUrl =
-            app.chain.meta.node.altWalletUrl || `https://${wsRpcUrl.host}`;
+            app.chain?.meta?.node.altWalletUrl ?? wsRpcUrl
+              ? new URL(wsRpcUrl).host
+              : '';
 
           // TODO: we should cache this data!
           const chains = await $.getJSON('https://chainid.network/chains.json');
           const baseChain = chains.find((c) => c.chainId == chainId);
           const pubRpcUrl = baseChain.rpc.filter((r) => !/\${.*?}/.test(r));
-          const url = rpcUrl.length > 0 ? pubRpcUrl[0] : rpcUrl;
+          // remove duplicate https b/c chain list has a bug in their sepolia endpoint
+          const url =
+            pubRpcUrl.length > 0
+              ? pubRpcUrl[0].replace(/(https:\/\/)+/, 'https://')
+              : rpcUrl;
+          if (url === '') {
+            throw new Error('Could not find rpc for new network');
+          }
           await this._web3.givenProvider.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -215,11 +224,11 @@ class MetamaskWebWalletController implements IWebWallet<string> {
     try {
       // Get current chain ID
       const communityChain = chainId ?? this.getChainId();
-      const chainIdHex = parseInt(communityChain, 10).toString(16);
+      const chainIdHex = `0x${parseInt(communityChain, 10).toString(16)}`;
       try {
         await window.ethereum.request({
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: `0x${chainIdHex}` }],
+          params: [{ chainId: chainIdHex }],
         });
       } catch (error) {
         if (error.code === 4902) {
@@ -228,7 +237,9 @@ class MetamaskWebWalletController implements IWebWallet<string> {
           // Check if the string contains '${' and '}'
           const rpcUrl = baseChain.rpc.filter((r) => !/\${.*?}/.test(r));
           const url =
-            rpcUrl.length > 0 ? rpcUrl[0] : app.chain.meta.node.altWalletUrl;
+            rpcUrl.length > 0
+              ? rpcUrl[0].replace(/(https:\/\/)+/, 'https://')
+              : app.chain.meta.node.altWalletUrl;
           await this._web3.givenProvider.request({
             method: 'wallet_addEthereumChain',
             params: [

--- a/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
@@ -10,6 +10,7 @@ interface BuyStakeProps {
   amount: number;
   chainRpc: string;
   walletAddress: string;
+  ethChainId: number;
 }
 
 const buyStake = async ({
@@ -18,13 +19,12 @@ const buyStake = async ({
   amount,
   chainRpc,
   walletAddress,
+  ethChainId,
 }: BuyStakeProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
@@ -12,13 +12,12 @@ const getBuyPrice = async ({
   stakeId,
   amount,
   chainRpc,
+  ethChainId,
 }: GetBuyPriceProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 
@@ -32,6 +31,7 @@ interface UseGetBuyPriceQueryProps {
   apiEnabled: boolean;
   chainRpc: string;
   keepPreviousData?: boolean;
+  ethChainId: number;
 }
 
 const useGetBuyPriceQuery = ({
@@ -40,6 +40,7 @@ const useGetBuyPriceQuery = ({
   amount,
   apiEnabled,
   chainRpc,
+  ethChainId,
   keepPreviousData = false,
 }: UseGetBuyPriceQueryProps) => {
   return useQuery({
@@ -50,7 +51,8 @@ const useGetBuyPriceQuery = ({
       amount,
       chainRpc,
     ],
-    queryFn: () => getBuyPrice({ namespace, stakeId, amount, chainRpc }),
+    queryFn: () =>
+      getBuyPrice({ namespace, stakeId, amount, chainRpc, ethChainId }),
     enabled: apiEnabled,
     staleTime: GET_BUY_PRICE_STALE_TIME,
     keepPreviousData,

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
@@ -50,6 +50,7 @@ const useGetBuyPriceQuery = ({
       stakeId,
       amount,
       chainRpc,
+      ethChainId,
     ],
     queryFn: () =>
       getBuyPrice({ namespace, stakeId, amount, chainRpc, ethChainId }),

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
@@ -48,6 +48,7 @@ const useGetSellPriceQuery = ({
       stakeId,
       amount,
       chainRpc,
+      ethChainId,
     ],
     queryFn: () =>
       getSellPrice({ namespace, stakeId, amount, chainRpc, ethChainId }),

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
@@ -12,13 +12,12 @@ const getSellPrice = async ({
   stakeId,
   amount,
   chainRpc,
+  ethChainId,
 }: GetSellPriceProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 
@@ -31,6 +30,7 @@ interface UseGetSellPriceQueryProps {
   amount: number;
   apiEnabled: boolean;
   chainRpc: string;
+  ethChainId: number;
 }
 
 const useGetSellPriceQuery = ({
@@ -39,6 +39,7 @@ const useGetSellPriceQuery = ({
   amount,
   apiEnabled,
   chainRpc,
+  ethChainId,
 }: UseGetSellPriceQueryProps) => {
   return useQuery({
     queryKey: [
@@ -48,7 +49,8 @@ const useGetSellPriceQuery = ({
       amount,
       chainRpc,
     ],
-    queryFn: () => getSellPrice({ namespace, stakeId, amount, chainRpc }),
+    queryFn: () =>
+      getSellPrice({ namespace, stakeId, amount, chainRpc, ethChainId }),
     enabled: apiEnabled,
     staleTime: GET_SELL_PRICE_STALE_TIME,
   });

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
@@ -13,13 +13,12 @@ type GetUserEthBalanceProps = Omit<
 const getUserEthBalance = async ({
   chainRpc,
   walletAddress,
+  ethChainId,
 }: GetUserEthBalanceProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 
@@ -30,16 +29,18 @@ interface UseGetUserEthBalanceQueryProps {
   chainRpc: string;
   walletAddress: string;
   apiEnabled: boolean;
+  ethChainId: number;
 }
 
 const useGetUserEthBalanceQuery = ({
   chainRpc,
   walletAddress,
   apiEnabled,
+  ethChainId,
 }: UseGetUserEthBalanceQueryProps) => {
   return useQuery({
     queryKey: [ContractMethods.GET_USER_ETH_BALANCE, chainRpc, walletAddress],
-    queryFn: () => getUserEthBalance({ chainRpc, walletAddress }),
+    queryFn: () => getUserEthBalance({ chainRpc, walletAddress, ethChainId }),
     staleTime: GET_USER_ETH_BALANCE_STALE_TIME,
     enabled: apiEnabled,
   });

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
@@ -39,7 +39,12 @@ const useGetUserEthBalanceQuery = ({
   ethChainId,
 }: UseGetUserEthBalanceQueryProps) => {
   return useQuery({
-    queryKey: [ContractMethods.GET_USER_ETH_BALANCE, chainRpc, walletAddress],
+    queryKey: [
+      ContractMethods.GET_USER_ETH_BALANCE,
+      chainRpc,
+      walletAddress,
+      ethChainId,
+    ],
     queryFn: () => getUserEthBalance({ chainRpc, walletAddress, ethChainId }),
     staleTime: GET_USER_ETH_BALANCE_STALE_TIME,
     enabled: apiEnabled,

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
@@ -15,13 +15,12 @@ const getUserStakeBalance = async ({
   stakeId,
   chainRpc,
   walletAddress,
+  ethChainId,
 }: GetUserStakeBalanceProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 
@@ -39,6 +38,7 @@ interface UseGetUserStakeBalanceQueryProps {
   chainRpc: string;
   walletAddress: string;
   keepPreviousData?: boolean;
+  ethChainId: number;
 }
 
 const useGetUserStakeBalanceQuery = ({
@@ -48,6 +48,7 @@ const useGetUserStakeBalanceQuery = ({
   chainRpc,
   walletAddress,
   keepPreviousData = false,
+  ethChainId,
 }: UseGetUserStakeBalanceQueryProps) => {
   return useQuery({
     queryKey: [
@@ -58,7 +59,13 @@ const useGetUserStakeBalanceQuery = ({
       walletAddress,
     ],
     queryFn: () =>
-      getUserStakeBalance({ namespace, stakeId, chainRpc, walletAddress }),
+      getUserStakeBalance({
+        namespace,
+        stakeId,
+        chainRpc,
+        walletAddress,
+        ethChainId,
+      }),
     staleTime: GET_USER_STAKE_BALANCE_STALE_TIME,
     enabled: apiEnabled,
     keepPreviousData,

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
@@ -57,6 +57,7 @@ const useGetUserStakeBalanceQuery = ({
       stakeId,
       chainRpc,
       walletAddress,
+      ethChainId,
     ],
     queryFn: () =>
       getUserStakeBalance({

--- a/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
@@ -10,6 +10,7 @@ interface SellStakeProps {
   amount: number;
   chainRpc: string;
   walletAddress: string;
+  ethChainId: number;
 }
 
 const sellStake = async ({
@@ -18,13 +19,12 @@ const sellStake = async ({
   amount,
   chainRpc,
   walletAddress,
+  ethChainId,
 }: SellStakeProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
-    commonProtocol.factoryContracts[
-      commonProtocol.ValidChains.Base
-    ].communityStake,
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory,
+    commonProtocol.factoryContracts[ethChainId].communityStake,
+    commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
   );
 

--- a/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
+++ b/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
@@ -26,6 +26,7 @@ const useCommunityStake = (props: UseCommunityStakeProps = {}) => {
   const activeCommunityId = app?.chain?.id;
   const activeCommunityNamespace = app?.chain?.meta?.namespace;
   const chainRpc = app?.chain?.meta?.ChainNode?.url;
+  const ethChainId = app?.chain?.meta?.ChainNode?.ethChainId;
   const activeAccountAddress = app?.user?.activeAccount?.address;
 
   const { isInitialLoading: communityStakeLoading, data: stakeResponse } =
@@ -55,6 +56,7 @@ const useCommunityStake = (props: UseCommunityStakeProps = {}) => {
     chainRpc,
     walletAddress: walletAddress || activeAccountAddress,
     keepPreviousData: true,
+    ethChainId,
   });
 
   const { isInitialLoading: buyPriceDataLoading, data: buyPriceData } =
@@ -64,6 +66,7 @@ const useCommunityStake = (props: UseCommunityStakeProps = {}) => {
       amount: Number(userStakeBalanceData),
       apiEnabled: apiEnabled && !isNaN(Number(userStakeBalanceData)),
       chainRpc,
+      ethChainId,
       keepPreviousData: true,
     });
 

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -69,6 +69,7 @@ const StakeExchangeForm = ({
   onSetNumberOfStakeToExchange,
 }: StakeExchangeFormProps) => {
   const chainRpc = app?.chain?.meta?.ChainNode?.url;
+  const ethChainId = app?.chain?.meta?.ChainNode?.ethChainId;
   const activeAccountAddress = app?.user?.activeAccount?.address;
 
   const {
@@ -112,6 +113,7 @@ const StakeExchangeForm = ({
         namespace: stakeData?.Chain?.namespace,
         chainRpc,
         walletAddress: selectedAddress?.value,
+        ethChainId,
       });
 
       onSetSuccessTransactionHash(txReceipt?.transactionHash);
@@ -139,6 +141,7 @@ const StakeExchangeForm = ({
         namespace: stakeData?.Chain?.namespace,
         chainRpc,
         walletAddress: selectedAddress?.value,
+        ethChainId,
       });
 
       onSetSuccessTransactionHash(txReceipt?.transactionHash);

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/hooks/useStakeExchange.ts
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/hooks/useStakeExchange.ts
@@ -21,12 +21,14 @@ const useStakeExchange = ({
 }: UseStakeExchangeProps) => {
   const activeCommunityNamespace = app?.chain?.meta?.namespace;
   const chainRpc = app?.chain?.meta?.ChainNode?.url;
+  const ethChainId = app?.chain?.meta?.ChainNode?.ethChainId;
 
   const { data: userEthBalance, isLoading: userEthBalanceLoading } =
     useGetUserEthBalanceQuery({
       chainRpc,
       walletAddress: address,
       apiEnabled: !!address,
+      ethChainId,
     });
 
   const { data: buyPriceData } = useGetBuyPriceQuery({
@@ -35,6 +37,7 @@ const useStakeExchange = ({
     amount: numberOfStakeToExchange,
     apiEnabled: mode === 'buy' && !!address,
     chainRpc,
+    ethChainId,
   });
 
   const { data: sellPriceData } = useGetSellPriceQuery({
@@ -43,6 +46,7 @@ const useStakeExchange = ({
     amount: numberOfStakeToExchange,
     apiEnabled: mode === 'sell',
     chainRpc,
+    ethChainId,
   });
 
   const { data: ethUsdRateData } = useFetchEthUsdRateQuery();

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/CommunityStakeStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/CommunityStakeStep.tsx
@@ -37,6 +37,7 @@ const CommunityStakeStep = ({
           goToSuccessStep={goToSuccessStep}
           onOptInEnablingStake={handleOptInEnablingStake}
           communityStakeData={communityStakeData}
+          chainId={chainId}
         />
       ) : (
         <SignStakeTransactions

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/EnableStake/EnableStake.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/EnableStake/EnableStake.tsx
@@ -17,10 +17,11 @@ const EnableStake = ({
   goToSuccessStep,
   onOptInEnablingStake,
   communityStakeData,
+  chainId,
 }: EnableStakeProps) => {
   const [namespaceError, setNamespaceError] = useState('');
 
-  const { namespaceFactory } = useNamespaceFactory();
+  const { namespaceFactory } = useNamespaceFactory(parseInt(chainId));
 
   const clearNamespaceError = () => {
     setNamespaceError('');

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useLaunchCommunityStake.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useLaunchCommunityStake.tsx
@@ -28,7 +28,7 @@ const useLaunchCommunityStake = ({
   const [launchStakeData, setLaunchStakeData] =
     useState<ActionState>(defaultActionState);
 
-  const { namespaceFactory } = useNamespaceFactory();
+  const { namespaceFactory } = useNamespaceFactory(parseInt(chainId));
   const { mutateAsync: updateCommunityStake } = useUpdateCommunityStake();
 
   const { trackAnalytics } = useBrowserAnalyticsTrack<BaseMixpanelPayload>({

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
@@ -27,7 +27,7 @@ const useReserveCommunityNamespace = ({
   const [reserveNamespaceData, setReserveNamespaceData] =
     useState<ActionState>(defaultActionState);
 
-  const { namespaceFactory } = useNamespaceFactory();
+  const { namespaceFactory } = useNamespaceFactory(parseInt(chainId));
   const { mutateAsync: updateCommunity } = useUpdateCommunityMutation();
 
   const { trackAnalytics } = useBrowserAnalyticsTrack<BaseMixpanelPayload>({

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/types.ts
@@ -23,6 +23,7 @@ export interface EnableStakeProps {
   goToSuccessStep: () => void;
   onOptInEnablingStake: ({ namespace, symbol }: StakeData) => void;
   communityStakeData: StakeData;
+  chainId: string;
 }
 
 export const defaultActionState: ActionState = {

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/useNamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/useNamespaceFactory.ts
@@ -2,12 +2,12 @@ import { commonProtocol } from '@hicommonwealth/core';
 import NamespaceFactory from 'helpers/ContractHelpers/NamespaceFactory';
 import app from 'state';
 
-const useNamespaceFactory = () => {
+const useNamespaceFactory = (ethChainId: number) => {
   const goerliFactoryAddress =
-    commonProtocol.factoryContracts[commonProtocol.ValidChains.Base].factory;
+    commonProtocol.factoryContracts[ethChainId].factory;
   const chainRpc = app.config.nodes
     .getAll()
-    .find((node) => node.ethChainId === commonProtocol.ValidChains.Base)?.url;
+    .find((node) => node.ethChainId === ethChainId)?.url;
   const namespaceFactory = new NamespaceFactory(goerliFactoryAddress, chainRpc);
 
   return { namespaceFactory };

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/useCreateCommunity.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/useCreateCommunity.ts
@@ -42,7 +42,9 @@ const useCreateCommunity = () => {
   ].includes(createCommunityStep);
   const isEthereumMainnetSelected =
     // selectedChainId === ETHEREUM_MAINNET_ID ||
-    selectedChainId === String(commonProtocol.ValidChains.Base);
+    Object.values(commonProtocol.ValidChains).includes(
+      parseInt(selectedChainId),
+    );
   const showCommunityStakeStep =
     isValidStepToShowCommunityStakeFormStep &&
     selectedCommunity.type === 'ethereum' &&

--- a/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
@@ -125,13 +125,16 @@ export async function __createCommentReaction(
       if (!community) {
         throw new AppError(Errors.CommunityNotFound);
       }
+      const node = await this.models.ChainNode.findByPk(
+        community.chain_node_id,
+      );
       const stakeBalance =
         await commonProtocolService.contractHelpers.getNamespaceBalance(
           community.namespace,
           stake.stake_id,
-          commonProtocol.ValidChains.Base,
+          node.eth_chain_id,
           address.address,
-          this.models,
+          node.url,
         );
       calculatedVotingWeight = commonProtocol.calculateVoteWeight(
         stakeBalance,

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
@@ -113,13 +113,16 @@ export async function __createThreadReaction(
       if (!community) {
         throw new AppError(Errors.CommunityNotFound);
       }
+      const node = await this.models.ChainNode.findByPk(
+        community.chain_node_id,
+      );
       const stakeBalance =
         await commonProtocolService.contractHelpers.getNamespaceBalance(
           community.namespace,
           stake.stake_id,
-          commonProtocol.ValidChains.Base,
+          node.eth_chain_id,
           address.address,
-          this.models,
+          node.url,
         );
       calculatedVotingWeight = commonProtocol.calculateVoteWeight(
         stakeBalance,

--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -76,6 +76,12 @@ describe('ServerCommentsController', () => {
             namespace: 'cake',
           }),
         },
+        ChainNode: {
+          findByPk: async () => ({
+            eth_chain_id: 8453,
+            url: 'test.com',
+          }),
+        },
       };
       const banCache = BAN_CACHE_MOCK_FN('ethereum');
 

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
@@ -72,10 +72,17 @@ describe('ServerThreadsController', () => {
             vote_weight: 1,
           }),
         },
+
         Community: {
           findByPk: async () => ({
             id: 'ethereum',
             namespace: 'cake',
+          }),
+        },
+        ChainNode: {
+          findByPk: async () => ({
+            eth_chain_id: 8453,
+            url: 'test.com',
           }),
         },
         sequelize: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6876

## Description of Changes
- allows CS and namespace creation for any chainNode with an `eth_chain_id` matching `validChains` in `chainConfig.ts`
    - In the future enabling a new chain will simply involve deploying and adding addresses here. No changes to platform or frontend req.
- Refactor all usage of hardcoded base contracts to use the selected validChain enabled community chain data + rpc
- Fixes chain switching when chain is not in metamask 

## Test Plan
- Run the base-sepolia chainNode query
- get some base-sepolia by bridging sepolia here: https://sepolia-bridge.base.org/deposit
- Select base-sepolia and deploy a community, ensuring wallet switches and deploys on base-sepolia
- test buy/sell etc(note fiat denominated values wont work on testnet as the tokens have no value) 

-suggest to test regular base flow at least once as well 

## Deployment Plan
<!--- Omit if unneeded -->
1. Run the following query, filling in the base-sepolia rpc key from alchemy 
```
INSERT INTO public."ChainNodes" (url, eth_chain_id, alt_wallet_url, balance_type, name)
VALUES ('https://base-sepolia.g.alchemy.com/v2/{API_KEY}', 84532, 'https://base-sepolia.g.alchemy.com/v2/{API_KEY}', 'ethereum', 'Base-Sepolia');

```

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Note that this technically makes base-sepolia available to all users as we're treating it like other testnets in create community 