### PR TITLE
#5215 - Add inline horizontal scroll to markdown tables

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -57,8 +57,9 @@
   }
 
   table {
-    width: 100%;
+    display: inline-block;
     overflow-x: auto;
+    max-width: 615px;
     border-spacing: 0;
     border-radius: $border-radius-corners-wider;
     border: 1px solid $neutral-200;
@@ -122,6 +123,11 @@
           border-right: 1px solid $neutral-200;
         }
       }
+    }
+
+    th,
+    td {
+      min-width: 125px;
     }
   }
 


### PR DESCRIPTION
This PR adds a horizontal scroll to markdown tables above a certain width. 

## Link to Issue
Closes: #5215

## Description of Changes
- updates CSS to add inline scroll

## Test Plan
- create a markdown table (quick MD table generator [here](https://www.tablesgenerator.com/markdown_tables))
- check that it has horizontal scrolling when it's above 615px