### PR TITLE
#6481 - Drawer Refinements

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.scss
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.scss
@@ -2,8 +2,6 @@
 
 .ViewUpvotesDrawer {
   .Drawer.upvote-drawer {
-    top: 56px !important;
-
     @include extraSmall {
       top: 48px !important;
 
@@ -17,10 +15,12 @@
     }
 
     .drawer-actions {
+      position: sticky;
+      top: 0;
       display: flex;
       gap: 8px;
       align-items: center;
-      padding: 16px 56px 12px 56px;
+      padding: 16px 56px 12px 25px;
 
       @include extraSmall {
         gap: 4px;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWDrawer/CWDrawer.scss
@@ -1,7 +1,6 @@
 @import '../../../../../../styles/shared.scss';
 
 .Drawer {
-  padding-bottom: 46px;
   overflow: auto;
 
   &.bottom-drawer {


### PR DESCRIPTION
This PR adds a couple improvements to the drawer component.

## Link to Issue
Closes: #6481

## Description of Changes
- positions the close-drawer trigger (i.e. the double caret icon button) at the top of the drawer
- the drawer now takes up the full height of the window

## Test Plan
- navigate to the discussions page or the view thread page and click on 'View Upvotes'
- confirm that the drawer takes up the height of the window
- confirm that, when you scroll, the drawer trigger remains at the top of the drawer