### PR TITLE
Fix discussion page crash.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -39,10 +39,11 @@ export const ReactionButton = ({
   const newSignInModalEnabled = useFlag('newSignInModal');
   const [isAuthModalOpen, setIsAuthModalOpen] = useState<boolean>(false);
   const reactors = thread?.associatedReactions?.map((t) => t.address);
-  const reactionWeightsSum = thread?.associatedReactions.reduce(
-    (acc, curr) => acc + (curr.voting_weight || 1),
-    0,
-  );
+  const reactionWeightsSum =
+    thread?.associatedReactions?.reduce(
+      (acc, curr) => acc + (curr.voting_weight || 1),
+      0,
+    ) || 0;
   const activeAddress = app.user.activeAccount?.address;
   const thisUserReaction = thread?.associatedReactions?.filter(
     (r) => r.address === activeAddress,


### PR DESCRIPTION
## Link to Issue
Closes: #6909 

## Description of Changes
- Fixes discussion page crash.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Adds null check to handle case where thread has no reactions.

## Test Plan
- Navigate to a community's discussions page -- ensure it loads correctly.
- Ensure stake arithmetic is correct if enabled.
