### PR TITLE
quill editor is now inside snapshot modal

### DIFF
--- a/packages/commonwealth/client/styles/pages/new_snapshot_proposal.scss
+++ b/packages/commonwealth/client/styles/pages/new_snapshot_proposal.scss
@@ -25,6 +25,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow: auto;
 
   .proposal-loading {
     width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6927 

## Description of Changes
-Quill editor is now scrollable inside the snapshot modal

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `overflow: auto;` to `.NewSnapshotProposalForm`

## Test Plan
-create a thread or go to one that doesn't have a snapshot connected to it
-create a snapshot
-notice that the editor is now scrollable inside the modal

https://github.com/hicommonwealth/commonwealth/assets/69872984/eeb09db2-5817-478e-8a21-e71eb9c9c8e5

