### PR TITLE
Prototype analytics policy

### DIFF
--- a/libs/adapters/src/trpc/index.ts
+++ b/libs/adapters/src/trpc/index.ts
@@ -126,7 +126,7 @@ export const event = <T, S extends EventSchemas>(
     .meta({
       openapi: {
         method: 'POST',
-        path: `/${factory.name}`,
+        path: `/${tag.toLowerCase()}/${factory.name}`,
         tags: [tag],
       },
     })
@@ -152,7 +152,11 @@ export const query = <T, P extends ZodObject<any>>(
   const md = factory();
   return trpc.procedure
     .meta({
-      openapi: { method: 'GET', path: `/${factory.name}`, tags: [Tag.Query] },
+      openapi: {
+        method: 'GET',
+        path: `/${Tag.Query.toLowerCase()}/${factory.name}`,
+        tags: [Tag.Query],
+      },
       protect: md.secure,
     })
     .input(md.schema.extend({ address_id: z.string().optional() }))

--- a/libs/core/src/framework/index.ts
+++ b/libs/core/src/framework/index.ts
@@ -1,3 +1,4 @@
 export * from './command';
+export * from './event';
 export * from './query';
 export * from './types';

--- a/libs/core/src/schemas/events.schemas.ts
+++ b/libs/core/src/schemas/events.schemas.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 export const schemas = {
   ThreadCreated: z.object({ thread: z.string() }),
   CommentCreated: z.object({ comment: z.string() }),
+  GroupCreated: z.object({
+    groupId: z.string(),
+    userId: z.string(),
+  }),
 };
 
 export type Events = keyof typeof schemas;

--- a/packages/commonwealth/server/routes/ddd/community.ts
+++ b/packages/commonwealth/server/routes/ddd/community.ts
@@ -2,7 +2,7 @@ import { express, trpc } from '@hicommonwealth/adapters';
 import { Community } from '@hicommonwealth/model';
 import { Router } from 'express';
 import passport from 'passport';
-import { MixpanelCommunityInteractionEvent } from 'shared/analytics/types';
+import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 
 export const expressRouter = Router();
 expressRouter.get(
@@ -26,5 +26,5 @@ export const trpcRouter = trpc.router({
   getStake: trpc.query(Community.GetCommunityStake),
   setStake: trpc.command(Community.SetCommunityStake, trpc.Tag.Community),
   createGroup: trpc.command(Community.CreateGroup, trpc.Tag.Community),
-  // TODO: integrate via events: analyticsMiddleware(MixpanelCommunityInteractionEvent.CREATE_GROUP),
+  // TODO: integrate via async analytics policy: analyticsMiddleware(MixpanelCommunityInteractionEvent.CREATE_GROUP),
 });

--- a/packages/commonwealth/server/routes/ddd/index.ts
+++ b/packages/commonwealth/server/routes/ddd/index.ts
@@ -24,7 +24,7 @@ const trpcRouter = trpc.router({
  */
 router.get('/trpc/openapi.json', (req, res) => {
   const baseUrl = req.protocol + '://' + req.get('host') + '/ddd/trpc';
-  res.set('Cache-Control', `public, max-age=${5 * 60 * 1000}`);
+  res.set('Cache-Control', 'public, max-age=300');
   return res.json(
     trpc.toOpenApiDocument(trpcRouter, {
       title: 'Common API',

--- a/packages/commonwealth/server/routes/ddd/index.ts
+++ b/packages/commonwealth/server/routes/ddd/index.ts
@@ -2,6 +2,7 @@ import { express, trpc } from '@hicommonwealth/adapters';
 import { Router } from 'express';
 import swaggerUi from 'swagger-ui-express';
 import * as community from './community';
+import * as integrations from './integrations';
 
 /**
  * Express router
@@ -13,7 +14,10 @@ router.use(express.errorMiddleware);
 /**
  * tRPC router
  */
-const trpcRouter = trpc.router({ community: community.trpcRouter });
+const trpcRouter = trpc.router({
+  community: community.trpcRouter,
+  integrations: integrations.trpcRouter,
+});
 
 /**
  * OpenAPI spec

--- a/packages/commonwealth/server/routes/ddd/integrations.ts
+++ b/packages/commonwealth/server/routes/ddd/integrations.ts
@@ -1,0 +1,28 @@
+import { trpc } from '@hicommonwealth/adapters';
+import {
+  analytics,
+  events,
+  type EventSchemas,
+  type PolicyMetadata,
+} from '@hicommonwealth/core';
+import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
+
+const schemas: EventSchemas = {
+  GroupCreated: events.schemas.GroupCreated,
+};
+
+const Analytics: () => PolicyMetadata<never, typeof schemas> = () => ({
+  schemas,
+  body: {
+    GroupCreated: async ({ name, payload }) => {
+      analytics().track(MixpanelCommunityInteractionEvent.CREATE_GROUP, {
+        name,
+        ...payload,
+      });
+    },
+  },
+});
+
+export const trpcRouter = trpc.router({
+  analytics: trpc.event(Analytics, trpc.Tag.Integration),
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See ticket - this is a prototype we can follow to implement all integration policies. 

## Link to Issue
Closes: #6948 

## Description of Changes
- Adds trpc event adapter
- Implement sample analytics policy
- Adds GroupCreated event to list of domain events (strong typed)
- Route policy 

## Next Steps
- Configure RabbitMQ to push events to analytics policy - #6730 is a blocker
- Identify all commands emitting the domain events we are sending to analytics panel
- Refactor commands to decouple analytics from logic

 