### PR TITLE
Allows communities to be created

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/createCommunity.ts
@@ -69,8 +69,8 @@ const useCreateCommunityMutation = () => {
       if (data?.result?.admin_address) {
         await linkExistingAddressToChainOrCommunity(
           data.result.admin_address,
-          data.result.role.chain_id,
-          data.result.role.chain_id,
+          data.result.role.community_id,
+          data.result.role.community_id,
         );
       }
 

--- a/packages/commonwealth/server/routes/linkExistingAddressToCommunity.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToCommunity.ts
@@ -24,7 +24,7 @@ const linkExistingAddressToCommunity = async (
   res: Response,
 ) => {
   const userId = req.user.id;
-  const { community } = req;
+  const { community_id } = req.body;
 
   if (!req.body.address) {
     throw new AppError(Errors.NeedAddress);
@@ -32,12 +32,16 @@ const linkExistingAddressToCommunity = async (
   if (!req.user?.id) {
     throw new AppError(Errors.NeedLoggedIn);
   }
-  if (community.id == 'injective') {
+  if (community_id == 'injective') {
     if (req.body.address.slice(0, 3) !== 'inj')
       throw new AppError('Must join with Injective address');
   } else if (req.body.address.slice(0, 3) === 'inj') {
     throw new AppError('Cannot join with an injective address');
   }
+
+  const community = await models.Community.findOne({
+    where: { id: req.body.community_id },
+  });
 
   // check if the original address is verified and is owned by the user
   const originalAddress = await models.Address.scope('withPrivateData').findOne(


### PR DESCRIPTION
## Description

Community creation was succeeding, but `linkAddressToCommunity` was failing. There were some missed C3 changes that left `chain_id` a required param not to be passed to `linkAddressToCommunity`.

User was left with `CommunityIdNotFound` on `linkAddressToCommunity`

## Link to Issue
Closes: #TODO

## Description of Changes
- Renames some variables `chain_id` to `community_id` in `createCommunity`
- Updates `linkAddressToCommunity` as well, correctly reference passed params, adds find Community so `linkAddressToCommunity` works

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- CA. Try to create a new community, succeeded
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 