### PR TITLE
Delete + Redirect community fixes

### DIFF
--- a/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/delete_community.ts
@@ -118,6 +118,10 @@ export async function __deleteCommunity(
           );
 
           const models = [
+            this.models.CommunitySnapshotSpaces,
+            this.models.CommunityStake,
+            this.models.DiscordBotConfig,
+            this.models.Ban,
             this.models.Reaction,
             this.models.Comment,
             this.models.Topic,
@@ -137,6 +141,7 @@ export async function __deleteCommunity(
           for (const model of models) {
             await (model as ModelStatic<any>).destroy({
               where: { community_id: community.id },
+              force: true,
               transaction: t,
             });
           }

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community_id.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community_id.ts
@@ -103,6 +103,18 @@ export async function __updateCommunityId(
       );
     }
 
+    await this.models.Template.update(
+      {
+        created_for_community: new_community_id,
+      },
+      {
+        where: {
+          created_for_community: community_id,
+        },
+        transaction,
+      },
+    );
+
     await this.models.User.update(
       {
         selected_community_id: new_community_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6970

## Description of Changes
- Simplified delete community logic
- Added delete records for `Template`, `CommunitySnapshotSpaces`, `CommunityStakes`, `DiscordBotConfigs`, and `Bans`
- Added `Template.created_for_community` update to redirect transaction
- Added force (hard) delete -> soft-deletion on `Threads`, `Comments`, `Topics` will not be respected

## "How We Fixed It"
Added `Template.created_for_community` update to redirect transaction

## Test Plan
- Delete community `common`
- Rename community `cmn-protocol` to `common`
- Delete `dydx`, `common`, and `osmosis`
