### PR TITLE
CW20 gating

### DIFF
--- a/libs/core/src/requirements-types.ts
+++ b/libs/core/src/requirements-types.ts
@@ -20,7 +20,7 @@ export type CosmosSource = {
 };
 
 export type CosmosContractSource = {
-  source_type: BalanceSourceType.CW721;
+  source_type: BalanceSourceType.CW20 | BalanceSourceType.CW721;
   cosmos_chain_id: string;
   contract_address: string;
 };
@@ -50,5 +50,6 @@ export enum BalanceSourceType {
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',
   CosmosNative = 'cosmos_native',
+  CW20 = 'cw20',
   CW721 = 'cw721',
 }

--- a/libs/core/src/schemas/group.schemas.ts
+++ b/libs/core/src/schemas/group.schemas.ts
@@ -28,7 +28,7 @@ const CosmosSource = z.object({
 });
 
 const CosmosContractSource = z.object({
-  source_type: z.enum([BalanceSourceType.CW721]),
+  source_type: z.enum([BalanceSourceType.CW721, BalanceSourceType.CW20]),
   cosmos_chain_id: z.string(),
   contract_address: z.string(),
 });

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -119,6 +119,7 @@ export enum ChainNetwork {
   ERC20 = 'erc20',
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',
+  CW20 = 'cw20',
   CW721 = 'cw721',
   Clover = 'clover',
   HydraDX = 'hydradx',
@@ -133,6 +134,7 @@ export enum ChainNetwork {
   Kava = 'kava',
   Kyve = 'kyve',
   Stargaze = 'stargaze',
+  Cosmos = 'cosmos',
 }
 
 export enum BalanceType {

--- a/libs/model/src/services/tokenBalanceCache/providers/cacheBalances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/cacheBalances.ts
@@ -79,6 +79,7 @@ function buildCacheKey(options: GetBalancesOptions, address: string): string {
       );
     case BalanceSourceType.CosmosNative:
       return `${options.sourceOptions.cosmosChainId}_${address}`;
+    case BalanceSourceType.CW20:
     case BalanceSourceType.CW721:
       return (
         `${options.sourceOptions.cosmosChainId}_` +

--- a/libs/model/src/services/tokenBalanceCache/providers/getCosmosBalances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/getCosmosBalances.ts
@@ -4,6 +4,7 @@ import { models } from '../../../database';
 import { Balances, GetCosmosBalancesOptions } from '../types';
 import { cacheBalances, getCachedBalances } from './cacheBalances';
 import { __getCosmosNativeBalances } from './get_cosmos_balances';
+import { __getCw20Balances } from './get_cw20_balances';
 import { __getCw721Balances } from './get_cw721_balances';
 
 const log = logger().getLogger(__filename);
@@ -58,6 +59,14 @@ export async function getCosmosBalances(
       freshBalances = await __getCosmosNativeBalances({
         chainNode,
         addresses: validatedAddresses,
+        batchSize: options.batchSize,
+      });
+      break;
+    case BalanceSourceType.CW20:
+      freshBalances = await __getCw20Balances({
+        chainNode,
+        addresses: validatedAddresses,
+        contractAddress: options.sourceOptions.contractAddress,
         batchSize: options.batchSize,
       });
       break;

--- a/libs/model/src/services/tokenBalanceCache/providers/get_cw20_balances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/get_cw20_balances.ts
@@ -1,0 +1,99 @@
+import { WasmExtension, setupWasmExtension } from '@cosmjs/cosmwasm-stargate';
+import { QueryClient } from '@cosmjs/stargate';
+import { logger } from '@hicommonwealth/core';
+import { ChainNodeInstance } from '../../../models/chain_node';
+import { Balances } from '../types';
+import { getTendermintClient } from '../util';
+
+const log = logger().getLogger(__filename);
+
+export type GetCw20BalancesOptions = {
+  chainNode: ChainNodeInstance;
+  addresses: string[];
+  contractAddress: string;
+  batchSize?: number;
+};
+
+export async function __getCw20Balances(
+  options: GetCw20BalancesOptions,
+): Promise<Balances> {
+  if (options.addresses.length === 0) return {};
+  const tmClient = await getTendermintClient({
+    chainNode: options.chainNode,
+    batchSize: options.batchSize,
+  });
+
+  const api = QueryClient.withExtensions(tmClient, setupWasmExtension);
+
+  if (options.addresses.length > 1) {
+    return await getOffChainBatchCw20Balances(
+      api,
+      options.contractAddress,
+      options.addresses,
+    );
+  } else {
+    return await getCw20Balance(
+      api,
+      options.addresses[0],
+      options.contractAddress,
+    );
+  }
+}
+
+export async function getOffChainBatchCw20Balances(
+  api: QueryClient & WasmExtension,
+  contractAddress: string,
+  addresses: string[],
+): Promise<Balances> {
+  const balancePromises = [];
+  for (const address of addresses) {
+    const key = { balance: { address } };
+    balancePromises.push(
+      api.wasm.queryContractSmart(contractAddress?.toLowerCase(), key),
+    );
+  }
+
+  // this looks like we are parallellizing all the balance queries but
+  // that is not the case. The HttpBatchClient defined above handles
+  // the queuing and batching of requests all the queries are not
+  // actually in parallel
+  const promiseResults = await Promise.allSettled<Balances>(balancePromises);
+
+  const result: Balances = {};
+  addresses.forEach((a, i) => {
+    const balanceResult = promiseResults[i];
+    if (balanceResult?.status === 'rejected') {
+      log.error(
+        `Failed to get balance for address ${a}:
+        ${balanceResult.reason}`,
+      );
+    } else {
+      result[a] = balanceResult?.value?.balance?.toString();
+    }
+  });
+  return result;
+}
+
+async function getCw20Balance(
+  api: QueryClient & WasmExtension,
+  ownerAddress: string,
+  contactAddress: string,
+): Promise<Balances> {
+  try {
+    const key = { balance: { address: ownerAddress } };
+    const result = await api.wasm.queryContractSmart(
+      contactAddress?.toLowerCase(),
+      key,
+    );
+
+    return {
+      [ownerAddress]: result?.balance?.toString(),
+    };
+  } catch (e) {
+    log.error(
+      `Failed to get balance for address ${ownerAddress}`,
+      e instanceof Error ? e : undefined,
+    );
+    return {};
+  }
+}

--- a/libs/model/src/services/tokenBalanceCache/tokenBalanceCache.ts
+++ b/libs/model/src/services/tokenBalanceCache/tokenBalanceCache.ts
@@ -25,6 +25,7 @@ export async function getBalances(
   try {
     if (
       options.balanceSourceType === BalanceSourceType.CosmosNative ||
+      options.balanceSourceType === BalanceSourceType.CW20 ||
       options.balanceSourceType === BalanceSourceType.CW721
     ) {
       balances = await getCosmosBalances(options, ttl);

--- a/libs/model/src/services/tokenBalanceCache/types.ts
+++ b/libs/model/src/services/tokenBalanceCache/types.ts
@@ -57,6 +57,13 @@ type GetCosmosNativeBalanceOptions = GetCosmosBalancesBase & {
   balanceSourceType: BalanceSourceType.CosmosNative;
 };
 
+export type GetCw20BalanceOptions = GetCosmosBalancesBase & {
+  balanceSourceType: BalanceSourceType.CW20;
+  sourceOptions: {
+    contractAddress: string;
+  };
+};
+
 export type GetCw721BalanceOptions = GetCosmosBalancesBase & {
   balanceSourceType: BalanceSourceType.CW721;
   sourceOptions: {
@@ -75,6 +82,11 @@ export type GetEvmBalancesOptions =
 
 export type GetCosmosBalancesOptions =
   | GetCosmosNativeBalanceOptions
+  | GetCw20BalanceOptions
+  | GetCw721BalanceOptions;
+
+export type GetCwBalancesOptions =
+  | GetCw20BalanceOptions
   | GetCw721BalanceOptions;
 
 export type GetBalancesOptions =

--- a/packages/commonwealth/client/scripts/models/Group.ts
+++ b/packages/commonwealth/client/scripts/models/Group.ts
@@ -13,8 +13,9 @@ interface APIResponseFormat {
         | 'erc20'
         | 'erc721'
         | 'erc1155'
-        | 'cosmos_native'
         | 'eth_native'
+        | 'cosmos_native'
+        | 'cw20'
         | 'cw721';
       evm_chain_id?: number;
       cosmos_chain_id?: number;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/RequirementSubForm/RequirementSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/RequirementSubForm/RequirementSubForm.tsx
@@ -28,13 +28,15 @@ const RequirementSubForm = ({
   const is1155Requirement = requirementType === ERC_SPECIFICATIONS.ERC_1155;
   const isCosmosRequirement =
     requirementType === TOKENS.COSMOS_TOKEN ||
-    requirementType === CW_SPECIFICATIONS.CW_721;
+    requirementType === CW_SPECIFICATIONS.CW_721 ||
+    requirementType === CW_SPECIFICATIONS.CW_20;
   const helperTextForAmount = {
     [TOKENS.EVM_TOKEN]: 'Using 18 decimal precision',
     [TOKENS.COSMOS_TOKEN]: 'Using 6 decimal precision',
     [ERC_SPECIFICATIONS.ERC_20]: 'Using 18 decimal precision',
     [ERC_SPECIFICATIONS.ERC_721]: '',
     [CW_SPECIFICATIONS.CW_721]: '',
+    [CW_SPECIFICATIONS.CW_20]: 'Using 6 decimal precision',
   };
 
   useEffect(() => {
@@ -58,8 +60,10 @@ const RequirementSubForm = ({
           options={requirementTypes
             .filter((x) =>
               app.chain.base === ChainBase.CosmosSDK
-                ? x.value === TOKENS.COSMOS_TOKEN ||
-                  x.value === CW_SPECIFICATIONS.CW_721
+                ? [
+                    TOKENS.COSMOS_TOKEN,
+                    ...Object.values(CW_SPECIFICATIONS),
+                  ].includes(x.value)
                 : [
                     TOKENS.EVM_TOKEN,
                     ...Object.values(ERC_SPECIFICATIONS),

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/helpers/index.ts
@@ -58,7 +58,8 @@ export const makeGroupDataBaseAPIPayload = (
     // for cosmos base
     if (
       x.requirementType === TOKENS.COSMOS_TOKEN ||
-      x.requirementType === CW_SPECIFICATIONS.CW_721
+      x.requirementType === CW_SPECIFICATIONS.CW_721 ||
+      x.requirementType === CW_SPECIFICATIONS.CW_20
     ) {
       payload.requirements.push({
         rule: 'threshold',

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/common/constants.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/common/constants.ts
@@ -13,6 +13,7 @@ export const ERC_SPECIFICATIONS = {
 
 export const CW_SPECIFICATIONS = {
   CW_721: 'cw721',
+  CW_20: 'cw20',
 };
 
 export const BLOCKCHAINS = {
@@ -31,6 +32,7 @@ export const AMOUNT_CONDITIONS = {
 
 export const requirementTypes = [
   { value: TOKENS.COSMOS_TOKEN, label: 'Cosmos base tokens' },
+  { value: CW_SPECIFICATIONS.CW_20, label: 'CW-20' },
   { value: CW_SPECIFICATIONS.CW_721, label: 'CW-721' },
   { value: ERC_SPECIFICATIONS.ERC_20, label: 'ERC-20' },
   { value: ERC_SPECIFICATIONS.ERC_721, label: 'ERC-721' },

--- a/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
+++ b/packages/commonwealth/server/util/requirementsModule/makeGetBalancesOptions.ts
@@ -9,7 +9,7 @@ import {
   AddressAttributes,
   GetBalancesOptions,
   GetCosmosBalancesOptions,
-  GetCw721BalanceOptions,
+  GetCwBalancesOptions,
   GetErc1155BalanceOptions,
   GetErcBalanceOptions,
   GetEthNativeBalanceOptions,
@@ -128,11 +128,12 @@ export function makeGetBalancesOptions(
             break;
           }
           // CosmosContractSource
+          case BalanceSourceType.CW20:
           case BalanceSourceType.CW721: {
             const castedSource = requirement.data
               .source as CosmosContractSource;
             const existingOptions = allOptions.find((opt) => {
-              const castedOpt = opt as GetCw721BalanceOptions;
+              const castedOpt = opt as GetCwBalancesOptions;
               return (
                 castedOpt.balanceSourceType === castedSource.source_type &&
                 castedOpt.sourceOptions.cosmosChainId ===
@@ -143,7 +144,7 @@ export function makeGetBalancesOptions(
             });
             if (!existingOptions) {
               allOptions.push({
-                balanceSourceType: BalanceSourceType.CW721,
+                balanceSourceType: castedSource.source_type as any,
                 sourceOptions: {
                   contractAddress: castedSource.contract_address,
                   cosmosChainId: castedSource.cosmos_chain_id,

--- a/packages/commonwealth/server/util/requirementsModule/requirementsSchema_v1.json
+++ b/packages/commonwealth/server/util/requirementsModule/requirementsSchema_v1.json
@@ -56,7 +56,7 @@
       "properties": {
         "source_type": {
           "type": "string",
-          "enum": ["cw721"]
+          "enum": ["cw20", "cw721"]
         },
         "cosmos_chain_id": {
           "type": "string"

--- a/packages/commonwealth/server/util/requirementsModule/validateGroupMembership.ts
+++ b/packages/commonwealth/server/util/requirementsModule/validateGroupMembership.ts
@@ -129,6 +129,12 @@ function _thresholdCheck(
         chainId = thresholdData.source.cosmos_chain_id;
         break;
       }
+      case 'cw20': {
+        balanceSourceType = BalanceSourceType.CW20;
+        contractAddress = thresholdData.source.contract_address;
+        chainId = thresholdData.source.cosmos_chain_id;
+        break;
+      }
       case 'cw721': {
         balanceSourceType = BalanceSourceType.CW721;
         contractAddress = thresholdData.source.contract_address;
@@ -159,6 +165,7 @@ function _thresholdCheck(
             return b.options.sourceOptions.evmChainId.toString() === chainId;
           case BalanceSourceType.CosmosNative:
             return b.options.sourceOptions.cosmosChainId.toString() === chainId;
+          case BalanceSourceType.CW20:
           case BalanceSourceType.CW721:
             return (
               b.options.sourceOptions.contractAddress == contractAddress &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6634 

## Description of Changes
- Adds CW20 tokens as a groups/gating option


## Test Plan
- Added tests in devnet suite for fetching and TBC
- CA (click around) tested on local and frack:
  - sign in with the [shared devnet address](https://github.com/hicommonwealth/commonwealth/blob/master/knowledge_base/Devnet.md#manually-testing-transactions-on-the-csdk-or-csdk-beta-sandbox-community), which I have set up with 2 WYND tokens for testing
  - create a Cosmos community
  - Create a group with requirement:
    - CW-20 
    - Chain: Juno
    - Contract Address: `juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9` (WYND token)
    - More than: 1000000
  - To test negative case:
    - Sign out, change wallets in Keplr, sign in to same community
  - http://localhost:8080/{communityID}/members
  - Expect to see the first account tagged with the group, and the second to not be tagged.


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This works for a standard native CW20 case: a contract address on a specific chain. There are some other cases which will not work with the standard cosmjs query we are using here, such as:

  - IBC-CW20, ex: WYND which has been migrated to Osmosis: `ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3`
  - [Token Factory](https://github.com/CosmosContracts/juno/tree/main/x/tokenfactory#token-factory): `factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn`

Ticket: #7026 
