### PR TITLE
Israel.6448.admins moderators refinement

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/members/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/members/index.ts
@@ -1,3 +1,5 @@
 import useFetchAdminQuery from './fetchAdmin';
+import removeRole from './removeRole';
+import upgradeRoles from './upgradeRoles';
 
-export { useFetchAdminQuery };
+export { removeRole, upgradeRoles, useFetchAdminQuery };

--- a/packages/commonwealth/client/scripts/state/api/members/removeRole.ts
+++ b/packages/commonwealth/client/scripts/state/api/members/removeRole.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { notifyError } from 'controllers/app/notifications';
+import app from 'state';
+import RoleInfo from '../../../models/RoleInfo';
+
+type RemoveRoleProps = {
+  role: RoleInfo;
+  onRoleUpdate: (oldRole: RoleInfo, newRole: RoleInfo) => void;
+};
+
+const removeRole = async ({ role, onRoleUpdate }: RemoveRoleProps) => {
+  const communityObj = { chain: app.activeChainId() };
+
+  try {
+    const res = await axios.post(`${app.serverUrl()}/upgradeMember`, {
+      ...communityObj,
+      new_role: 'member',
+      address: role.Address.address,
+      jwt: app.user.jwt,
+    });
+
+    if (res.data.status !== 'Success') {
+      throw new Error(`Got unsuccessful status: ${res.data.status}`);
+    }
+
+    const newRole = res.data.result;
+    onRoleUpdate(role, newRole);
+  } catch (err) {
+    const errMsg = err.response?.data?.error || 'Failed to alter role.';
+    notifyError(errMsg);
+  }
+};
+
+export default removeRole;

--- a/packages/commonwealth/client/scripts/state/api/members/upgradeRoles.ts
+++ b/packages/commonwealth/client/scripts/state/api/members/upgradeRoles.ts
@@ -1,0 +1,35 @@
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import $ from 'jquery';
+import app from 'state';
+import type RoleInfo from '../../../models/RoleInfo';
+
+type UpgradeRolesProps = {
+  onRoleUpdate: (oldRole: RoleInfo, newRole: RoleInfo) => void;
+  newRole: string;
+  _user;
+};
+
+const upgradeRoles = async ({
+  onRoleUpdate,
+  _user,
+  newRole,
+}: UpgradeRolesProps) => {
+  const communityObj = { chain: app.activeChainId() };
+
+  $.post(`${app.serverUrl()}/upgradeMember`, {
+    new_role: newRole,
+    address: _user.Address.address,
+    ...communityObj,
+    jwt: app.user.jwt,
+  }).then((r) => {
+    if (r.status === 'Success') {
+      notifySuccess('Member upgraded');
+    } else {
+      notifyError('Upgrade failed');
+    }
+
+    onRoleUpdate(_user, r.result);
+  });
+};
+
+export default upgradeRoles;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_radio_button.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_radio_button.tsx
@@ -49,7 +49,7 @@ export const CWRadioButton = (props: RadioButtonProps) => {
           checked,
           disabled,
         },
-        ComponentType.RadioButton
+        ComponentType.RadioButton,
       )}
     >
       <input className="radio-input" {...params} />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
@@ -2,14 +2,12 @@ import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
 import useFetchAdminQuery from 'state/api/members/fetchAdmin';
 import { useDebounce } from 'usehooks-ts';
-import { CWText } from 'views/components/component_kit/cw_text';
 import {
   APIOrderBy,
   APIOrderDirection,
 } from '../../../../../scripts/helpers/constants';
 import useSearchProfilesQuery from '../../../../../scripts/state/api/profiles/searchProfiles';
 import RoleInfo from '../../../../models/RoleInfo';
-import { ComponentType } from '../../../components/component_kit/types';
 import { UpgradeRolesForm } from '../../../pages/manage_community/upgrade_roles_form';
 import { ManageRoles } from '../../manage_community/manage_roles';
 import CommunityManagementLayout from '../common/CommunityManagementLayout';
@@ -140,11 +138,8 @@ const AdminsAndModerators = () => {
             roledata={mods}
             onRoleUpdate={handleRoleUpdate}
           />
-          <CWText type="caption" className={ComponentType.Label}>
-            Members
-          </CWText>
-
           <UpgradeRolesForm
+            label="Members"
             roleData={roleData}
             onRoleUpdate={handleRoleUpdate}
             searchTerm={searchTerm}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/common/CommunityManagementLayout/CommunityManagementLayout.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/common/CommunityManagementLayout/CommunityManagementLayout.scss
@@ -32,7 +32,6 @@
     .admins-moderators {
       display: flex;
       flex-direction: column;
-      gap: 32px;
       width: 100%;
     }
 

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/manage_roles.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/manage_roles.tsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { notifyError } from 'controllers/app/notifications';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/manage_community/manage_roles.scss';
 import React from 'react';
 import app from 'state';
+import removeRole from 'state/api/members/removeRole';
 import { User } from 'views/components/user/user';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { useFlag } from '../../../hooks/useFlag';
@@ -24,29 +24,6 @@ export const ManageRoles = ({
 }: ManageRoleRowProps) => {
   const newAdminOnboardingEnabled = useFlag('newAdminOnboarding');
   const navigate = useCommonNavigate();
-
-  const communityObj = { chain: app.activeChainId() };
-
-  const removeRole = async (role: RoleInfo) => {
-    try {
-      const res = await axios.post(`${app.serverUrl()}/upgradeMember`, {
-        ...communityObj,
-        new_role: 'member',
-        address: role.Address.address,
-        jwt: app.user.jwt,
-      });
-
-      if (res.data.status !== 'Success') {
-        throw new Error(`Got unsuccessful status: ${res.data.status}`);
-      }
-
-      const newRole = res.data.result;
-      onRoleUpdate(role, newRole);
-    } catch (err) {
-      const errMsg = err.response?.data?.error || 'Failed to alter role.';
-      notifyError(errMsg);
-    }
-  };
 
   const handleDeleteRole = async (role: RoleInfo) => {
     const isSelf =
@@ -109,7 +86,7 @@ export const ManageRoles = ({
           buttonType: 'destructive',
           buttonHeight: 'sm',
           onClick: async () => {
-            await removeRole(role);
+            await removeRole({ role, onRoleUpdate });
             if (isLosingAdminPermissions) {
               navigate(newAdminOnboardingEnabled ? '/manage/moderators' : '/');
             }

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -77,6 +77,31 @@ export const UpgradeRolesForm = ({
     setRadioButtons(updatedRadioButtons);
   };
 
+  const handleUpgrade = () => {
+    const indexOfName = nonAdminNames.indexOf(user);
+
+    const _user = nonAdmins[indexOfName];
+
+    const newRole =
+      role === 'Admin' ? 'admin' : role === 'Moderator' ? 'moderator' : '';
+
+    $.post(`${app.serverUrl()}/upgradeMember`, {
+      new_role: newRole,
+      address: _user.Address.address,
+      ...communityObj,
+      jwt: app.user.jwt,
+    }).then((r) => {
+      if (r.status === 'Success') {
+        notifySuccess('Member upgraded');
+      } else {
+        notifyError('Upgrade failed');
+      }
+
+      onRoleUpdate(_user, r.result);
+    });
+    zeroOutRadioButtons();
+  };
+
   return (
     <div>
       <CWLabel label={label} />
@@ -132,34 +157,7 @@ export const UpgradeRolesForm = ({
           <CWButton
             label="Upgrade Member"
             disabled={!role || !user}
-            onClick={() => {
-              const indexOfName = nonAdminNames.indexOf(user);
-
-              const _user = nonAdmins[indexOfName];
-
-              const newRole =
-                role === 'Admin'
-                  ? 'admin'
-                  : role === 'Moderator'
-                  ? 'moderator'
-                  : '';
-
-              $.post(`${app.serverUrl()}/upgradeMember`, {
-                new_role: newRole,
-                address: _user.Address.address,
-                ...communityObj,
-                jwt: app.user.jwt,
-              }).then((r) => {
-                if (r.status === 'Success') {
-                  notifySuccess('Member upgraded');
-                } else {
-                  notifyError('Upgrade failed');
-                }
-
-                onRoleUpdate(_user, r.result);
-              });
-              zeroOutRadioButtons();
-            }}
+            onClick={handleUpgrade}
           />
         </div>
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/manage_community/upgrade_roles_form.tsx
@@ -7,11 +7,13 @@ import React, { useMemo, useState } from 'react';
 import app from 'state';
 import { useFlag } from '../../../hooks/useFlag';
 import type RoleInfo from '../../../models/RoleInfo';
+import { CWLabel } from '../../components/component_kit/cw_label';
 import { CWRadioGroup } from '../../components/component_kit/cw_radio_group';
 import { CWButton } from '../../components/component_kit/new_designs/cw_button';
 import { CWRadioButton } from '../../components/component_kit/new_designs/cw_radio_button';
 import { MembersSearchBar } from '../../components/members_search_bar';
 type UpgradeRolesFormProps = {
+  label?: string;
   onRoleUpdate: (oldRole: RoleInfo, newRole: RoleInfo) => void;
   roleData: RoleInfo[];
   searchTerm: string;
@@ -19,6 +21,7 @@ type UpgradeRolesFormProps = {
 };
 
 export const UpgradeRolesForm = ({
+  label,
   onRoleUpdate,
   roleData,
   searchTerm,
@@ -75,87 +78,90 @@ export const UpgradeRolesForm = ({
   };
 
   return (
-    <div className="UpgradeRolesForm">
-      <MembersSearchBar
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        communityName={app.activeChainId()}
-      />
-      <div className="members-container">
-        <CWRadioGroup
-          name="members/mods"
-          options={options}
-          toggledOption={user}
-          onChange={(e) => {
-            setUser(e.target.value);
-          }}
+    <div>
+      <CWLabel label={label} />
+      <div className="UpgradeRolesForm">
+        <MembersSearchBar
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          communityName={app.activeChainId()}
         />
-      </div>
-      <div className="upgrade-buttons-container">
-        {newAdminOnboardingEnabled ? (
-          <>
-            {newAdminOnboardingEnabledOptions.map((o, i) => {
-              return (
-                <div key={i}>
-                  <CWRadioButton
-                    key={i}
-                    checked={radioButtons[i].checked}
-                    name="roles"
-                    onChange={(e) => {
-                      setRole(e.target.value);
-                      handleRadioButtonChange(i + 1);
-                    }}
-                    value={o.value}
-                  />
-                </div>
-              );
-            })}
-          </>
-        ) : (
+        <div className="members-container">
           <CWRadioGroup
-            name="roles"
-            options={[
-              { label: 'Admin', value: 'Admin' },
-              { label: 'Moderator', value: 'Moderator' },
-            ]}
-            toggledOption={role}
+            name="members/mods"
+            options={options}
+            toggledOption={user}
             onChange={(e) => {
-              setRole(e.target.value);
+              setUser(e.target.value);
             }}
           />
-        )}
-        <CWButton
-          label="Upgrade Member"
-          disabled={!role || !user}
-          onClick={() => {
-            const indexOfName = nonAdminNames.indexOf(user);
+        </div>
+        <div className="upgrade-buttons-container">
+          {newAdminOnboardingEnabled ? (
+            <>
+              {newAdminOnboardingEnabledOptions.map((o, i) => {
+                return (
+                  <div key={i}>
+                    <CWRadioButton
+                      key={i}
+                      checked={radioButtons[i].checked}
+                      name="roles"
+                      onChange={(e) => {
+                        setRole(e.target.value);
+                        handleRadioButtonChange(i + 1);
+                      }}
+                      value={o.value}
+                    />
+                  </div>
+                );
+              })}
+            </>
+          ) : (
+            <CWRadioGroup
+              name="roles"
+              options={[
+                { label: 'Admin', value: 'Admin' },
+                { label: 'Moderator', value: 'Moderator' },
+              ]}
+              toggledOption={role}
+              onChange={(e) => {
+                setRole(e.target.value);
+              }}
+            />
+          )}
+          <CWButton
+            label="Upgrade Member"
+            disabled={!role || !user}
+            onClick={() => {
+              const indexOfName = nonAdminNames.indexOf(user);
 
-            const _user = nonAdmins[indexOfName];
+              const _user = nonAdmins[indexOfName];
 
-            const newRole =
-              role === 'Admin'
-                ? 'admin'
-                : role === 'Moderator'
-                ? 'moderator'
-                : '';
+              const newRole =
+                role === 'Admin'
+                  ? 'admin'
+                  : role === 'Moderator'
+                  ? 'moderator'
+                  : '';
 
-            $.post(`${app.serverUrl()}/upgradeMember`, {
-              new_role: newRole,
-              address: _user.Address.address,
-              ...communityObj,
-              jwt: app.user.jwt,
-            }).then((r) => {
-              if (r.status === 'Success') {
-                notifySuccess('Member upgraded');
-              } else {
-                notifyError('Upgrade failed');
-              }
+              $.post(`${app.serverUrl()}/upgradeMember`, {
+                new_role: newRole,
+                address: _user.Address.address,
+                ...communityObj,
+                jwt: app.user.jwt,
+              }).then((r) => {
+                if (r.status === 'Success') {
+                  notifySuccess('Member upgraded');
+                } else {
+                  notifyError('Upgrade failed');
+                }
 
-              onRoleUpdate(_user, r.result);
-            });
-            zeroOutRadioButtons();
-          }}
-        />
+                onRoleUpdate(_user, r.result);
+              });
+              zeroOutRadioButtons();
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/commonwealth/client/styles/pages/manage_community/manage_roles.scss
+++ b/packages/commonwealth/client/styles/pages/manage_community/manage_roles.scss
@@ -28,6 +28,9 @@
           color: $neutral-600;
         }
       }
+      &:hover {
+        background-color: $neutral-100;
+      }
     }
   }
 }

--- a/packages/commonwealth/client/styles/pages/manage_community/upgrade_roles_form.scss
+++ b/packages/commonwealth/client/styles/pages/manage_community/upgrade_roles_form.scss
@@ -21,6 +21,6 @@
   .upgrade-buttons-container {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 12px;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6448 

## Description of Changes
- Allows user to now see all members of a large group 
- shows refined design to stay in line with design standards

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-refactored use `useSearchProfilesQuery` to use `fetchNextPage` to allow the user to see all members of a large group
-refactored `removeRole` and `upgradeRoles` into their own hooks
-refactored components to have label props, allowing component to adhere to design standards
-added styling for when hovering over Admins and Moderators lists for better ux/ui

## Test Plan
- make sure you have FLAG_NEW_ADMIN_ONBOARDING=true in .env
- go to a community where you're an admin, or make yourself an admin, preferably in a larger community (Ethereum or Dydx)
- go to Admins and Moderators in Admin Capabilities
- click around and make sure you can upgrade a user, remove a user, and search for a user. 
