### PR TITLE
changed logo to not show white background on dark mode

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
@@ -950,7 +950,7 @@ export const CWCommonLogo = (props: IconProps) => {
       {...otherProps}
     >
       <g clipPath="url(#clip0_234_14690)">
-        <rect width="32" height="32" fill="white" />
+        <rect width="32" height="32" fill="none" />
         <g style={{ mixBlendMode: 'multiply' }}>
           <ellipse cx="16" cy="10.215" rx="9.645" ry="9.645" fill="#0079CC" />
         </g>
@@ -975,7 +975,7 @@ export const CWCommonLogo = (props: IconProps) => {
       </g>
       <defs>
         <clipPath id="clip0_234_14690">
-          <rect width="32" height="32" fill="white" />
+          <rect width="32" height="32" fill="none" />
         </clipPath>
       </defs>
     </svg>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6969 

## Description of Changes
- changed logo to not show a white background on dark mode

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the value from `fill="white"` to `fill="none"` in `cw_icons.tsx`

## Test Plan
-go to dashboard and change to dark mode
-notice there is no more white background behind logo

<img width="829" alt="Screenshot 2024-03-05 at 11 27 50 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/73c06ff9-df12-4bf2-a24d-6ab7d3770b91">
