### PR TITLE
Added safari specific styles to fix content height

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/browser.ts
+++ b/packages/commonwealth/client/scripts/helpers/browser.ts
@@ -1,0 +1,24 @@
+import { BrowserTypes, parseUserAgent } from 'react-device-detect';
+
+type BrowserInfo = {
+  name: typeof BrowserTypes & 'Unknown';
+  version: string;
+  isMobile: boolean;
+};
+
+/**
+ * Detects the browsers vender i.e google/safari etc, version number i.e 12.5, and if the browser
+ * is used in mobile device or web platform.
+ * This is different from detecting the rendering engine i.e chromium/spider-monkey/webkit etc
+ */
+export const getBrowserInfo = (): BrowserInfo => {
+  const userAgent = parseUserAgent(navigator.userAgent);
+
+  const browserInfo: BrowserInfo = {
+    name: userAgent?.browser?.name || 'Unknown',
+    version: userAgent?.browser?.version || 'Unknown',
+    isMobile: /Mobi/.test(userAgent), // mobile browsers have `Mobi` in user agent string
+  };
+
+  return browserInfo;
+};

--- a/packages/commonwealth/client/scripts/index.tsx
+++ b/packages/commonwealth/client/scripts/index.tsx
@@ -1,15 +1,29 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
-import 'normalize.css'; // reset
-import 'shared.scss';
 import 'index.scss';
-import '../../static/fonts/fonts.css';
+import 'normalize.css'; // reset
 import 'react-toastify/dist/ReactToastify.css';
+import 'shared.scss';
+import '../../static/fonts/fonts.css';
 
 import App from './App';
+import { getBrowserInfo } from './helpers/browser';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(<App />);
+
+// add browser info as classlist to body tag, ex: class="{browser}_{platform}_{version}"
+const browserInfo = getBrowserInfo();
+const sanitizedName = browserInfo.name
+  .toLowerCase()
+  .split(' ')
+  .join('_')
+  .trim();
+document.body.classList.add(
+  `${sanitizedName}_${browserInfo.isMobile ? 'mobile' : 'web'}_${
+    browserInfo.version
+  }`,
+);

--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -21,6 +21,7 @@ body {
   &[class^='safari_'][class*='13.'],
   &[class^='safari_'][class*='14.'],
   &[class^='safari_'][class*='15.'],
+  &[class^='safari_'][class*='16.0'],
   &[class^='safari_'][class*='16.1'],
   &[class^='safari_'][class*='16.2'],
   &[class^='safari_'][class*='16.3'] {

--- a/packages/commonwealth/client/styles/index.scss
+++ b/packages/commonwealth/client/styles/index.scss
@@ -13,6 +13,19 @@ body {
   //Prevents overscroll on macOS
   position: fixed;
   overflow: hidden;
+
+  // Target safari versions from 12.x to 16.3 which don't support the `dvh`
+  // unit, here 12.x is chosen as arbitrary lower limit (released in 2015)
+  // see https://caniuse.com/?search=dvh%20 for reference
+  &[class^='safari_'][class*='12.'],
+  &[class^='safari_'][class*='13.'],
+  &[class^='safari_'][class*='14.'],
+  &[class^='safari_'][class*='15.'],
+  &[class^='safari_'][class*='16.1'],
+  &[class^='safari_'][class*='16.2'],
+  &[class^='safari_'][class*='16.3'] {
+    height: 100vh;
+  }
 }
 
 #root {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6986

## Description of Changes
Adds safari-specific styles to fix content height on certain versions (<=16.3) that don't support the `dvh` unit. I used `12.x` as the lowest supported safari version, as it dates back to 2015 (release year), we can update this if required.

See [here](https://caniuse.com/?search=dvh%20)
<img width="495" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/49c9f22f-942d-40b3-a8d6-2cb9f89c7e74">

See [here](https://en.wikipedia.org/wiki/Safari_(web_browser))
<img width="647" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/51641047/19a7638d-b8bb-46e0-a91d-74a8eb00b2c3">


## "How We Fixed It"
N/A

## Test Plan
Pre-req: Test on safari versions < 16.3 (released around 2022)

- Visit any page that has content height less than window height, ex: https://commonwealth.im/terra-luna-classic-lunc/discussions
- Verify that page height is not cut-off

## Deployment Plan
N/A

## Other Considerations
N/A