### PR TITLE
Fix wallet sign in

### DIFF
--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -294,7 +294,7 @@ function setupRouter(
     router,
     'post',
     '/getAddressStatus',
-    databaseValidationService.validateAuthor,
+    passport.authenticate('jwt', { session: false }),
     getAddressStatus.bind(this, models),
   );
   registerRoute(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6991

## Description of Changes
- Fixes wallet sign in by updating the `getAddressStatus` route middleware

## "How We Fixed It"
The `getAddressStatus` route was recently updated to use the wrong middleware. The correct middleware is the passport authenticate middleware because the route requires access to `req.user` and not `req.address`.

## Test Plan
- CA Test
  - Attempt to create a community
  - Click "Connect new wallet"
  - Click "Wallet Connect"
  - Should successfully allow sign in

## Deployment Plan
N/A

## Other Considerations
N/A