### PR TITLE
snapshot message now changes when space is changed in dropdown

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import type Thread from '../../models/Thread';
 import app from '../../state';
-import { NewSnapshotProposalForm } from '../pages/new_snapshot_proposal';
 import { CWDropdown } from '../components/component_kit/cw_dropdown';
 import {
   CWModalBody,
   CWModalHeader,
 } from '../components/component_kit/new_designs/CWModal';
+import { NewSnapshotProposalForm } from '../pages/new_snapshot_proposal';
 
 import '../../../styles/modals/new_snapshot_proposal_modal.scss';
 
@@ -23,8 +23,15 @@ export const NewSnapshotProposalModal = ({
   onModalClose,
 }: NewSnapshotProposalModalProps) => {
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(
-    null
+    null,
   );
+  const handleSelect = (item) => {
+    setSelectedSnapshotId(item.value);
+    const init = async () => {
+      await app.snapshot.init(item.value);
+    };
+    init();
+  };
 
   const snapshotOptions = useMemo(
     () =>
@@ -32,9 +39,9 @@ export const NewSnapshotProposalModal = ({
         value: snapshot,
         label: snapshot,
       })) || [],
-    []
+    [],
   );
-
+  console.log('snapshotOptions', snapshotOptions);
   useEffect(() => {
     if (snapshotOptions.length > 0) {
       setSelectedSnapshotId(snapshotOptions[0].value);
@@ -50,7 +57,8 @@ export const NewSnapshotProposalModal = ({
             <CWDropdown
               label="Select Snapshot Space"
               options={snapshotOptions}
-              onSelect={(item) => setSelectedSnapshotId(item.value)}
+              // onSelect={(item) => setSelectedSnapshotId(item.value)}
+              onSelect={handleSelect}
             />
             {selectedSnapshotId && (
               <NewSnapshotProposalForm

--- a/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
@@ -25,12 +25,9 @@ export const NewSnapshotProposalModal = ({
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(
     null,
   );
-  const handleSelect = (item) => {
+  const handleSelect = async (item) => {
     setSelectedSnapshotId(item.value);
-    const init = async () => {
-      await app.snapshot.init(item.value);
-    };
-    init();
+    await app.snapshot.init(item.value);
   };
 
   const snapshotOptions = useMemo(

--- a/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
@@ -41,7 +41,7 @@ export const NewSnapshotProposalModal = ({
       })) || [],
     [],
   );
-  console.log('snapshotOptions', snapshotOptions);
+
   useEffect(() => {
     if (snapshotOptions.length > 0) {
       setSelectedSnapshotId(snapshotOptions[0].value);

--- a/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.tsx
@@ -57,7 +57,6 @@ export const NewSnapshotProposalModal = ({
             <CWDropdown
               label="Select Snapshot Space"
               options={snapshotOptions}
-              // onSelect={(item) => setSelectedSnapshotId(item.value)}
               onSelect={handleSelect}
             />
             {selectedSnapshotId && (

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/SnapshotProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/SnapshotProposalCard.tsx
@@ -16,8 +16,11 @@ type SnapshotProposalCardProps = {
   showSkeleton?: boolean;
 };
 
-export const SnapshotProposalCard = (props: SnapshotProposalCardProps) => {
-  const { proposal, snapshotId } = props;
+export const SnapshotProposalCard = ({
+  showSkeleton,
+  snapshotId,
+  proposal,
+}: SnapshotProposalCardProps) => {
   const navigate = useCommonNavigate();
 
   const proposalLink = `/snapshot/${snapshotId}/${proposal.id}`;
@@ -25,7 +28,7 @@ export const SnapshotProposalCard = (props: SnapshotProposalCardProps) => {
   const time = moment(+proposal.end * 1000);
   const now = moment();
 
-  if (props.showSkeleton) return <SnapshotProposalCardSkeleton />;
+  if (showSkeleton) return <SnapshotProposalCardSkeleton />;
 
   // TODO: display proposal.scores and proposal.scores_total on card
   return (

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/SnapshotProposalCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposals/SnapshotProposalCard.tsx
@@ -25,7 +25,7 @@ export const SnapshotProposalCard = (props: SnapshotProposalCardProps) => {
   const time = moment(+proposal.end * 1000);
   const now = moment();
 
-  if (props.showSkeleton) return <SnapshotProposalCardSkeleton />
+  if (props.showSkeleton) return <SnapshotProposalCardSkeleton />;
 
   // TODO: display proposal.scores and proposal.scores_total on card
   return (
@@ -48,7 +48,7 @@ export const SnapshotProposalCard = (props: SnapshotProposalCardProps) => {
       <div className="proposal-card-metadata">
         <ProposalTag
           label={`${proposal.ipfs.slice(0, 6)}...${proposal.ipfs.slice(
-            proposal.ipfs.length - 6
+            proposal.ipfs.length - 6,
           )}`}
         />
         <CWText title={proposal.title} fontWeight="semiBold" noWrap>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6488 

## Description of Changes
- Switching Snapshot spaces in modal now shows correct corresponding snapshot message

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added an `app.snapshot.init()` call to when the dropdown value is changed

## Test Plan
-make sure you have more than one snapshot space saved in Integrations. You can use shellprotocol.eth and commonspacetester.eth if you don't have spaces.
-go to a thread and add a Snapshot
-switch the snapshot spaces in the dropdown within the modal
-notice that the corresponding messages now change when the value is changed. 

https://github.com/hicommonwealth/commonwealth/assets/69872984/6619bdd3-5b78-4b0a-a529-2bbd83928177


