### PR TITLE
snapshot now shows proper amount in message

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
+++ b/packages/commonwealth/client/scripts/helpers/snapshot_utils.ts
@@ -301,7 +301,7 @@ export async function getMultipleSpaces(space: string): Promise<SnapshotSpace> {
 }
 
 export async function getMultipleSpacesById(
-  id_in: Array<string>
+  id_in: Array<string>,
 ): Promise<Array<SnapshotSpace>> {
   await getApolloClient();
   const spaceObj = await apolloClient.query({
@@ -315,7 +315,7 @@ export async function getMultipleSpacesById(
 }
 
 export async function getProposal(
-  id: string
+  id: string,
 ): Promise<{ title: string; space: string }> {
   await getApolloClient();
   const proposalObj = await apolloClient.query({
@@ -343,7 +343,7 @@ export async function getProposals(space: string): Promise<SnapshotProposal[]> {
 }
 
 export async function getVotes(
-  proposalHash: string
+  proposalHash: string,
 ): Promise<SnapshotProposalVote[]> {
   await getApolloClient();
   const response = await apolloClient.query({
@@ -382,7 +382,7 @@ export async function getScore(space: SnapshotSpace, address: string) {
     space.id,
     space.strategies,
     space.network,
-    [address]
+    [address],
     // Snapshot.utils.getProvider(space.network),
   );
 }
@@ -402,7 +402,7 @@ export type VoteResults = {
 
 export async function getResults(
   space: SnapshotSpace,
-  proposal: SnapshotProposal
+  proposal: SnapshotProposal,
 ): Promise<VoteResults> {
   try {
     let votes = await getVotes(proposal.id);
@@ -418,13 +418,13 @@ export async function getResults(
             strategies,
             space.network,
             votes.map((vote) => vote.voter),
-            parseInt(proposal.snapshot, 10)
+            parseInt(proposal.snapshot, 10),
             // provider,
           );
           votes = votes
             .map((vote: any) => {
               vote.scores = strategies.map(
-                (strategy, i) => scores[i][vote.voter] || 0
+                (strategy, i) => scores[i][vote.voter] || 0,
               );
               vote.balance = vote.scores.reduce((a, b: any) => a + b, 0);
               return vote;
@@ -448,7 +448,7 @@ export async function getResults(
     const votingClass = new snapshot.utils.voting[proposal.type](
       proposal,
       votes,
-      strategies
+      strategies,
     );
     const results = {
       resultsByVoteBalance: votingClass.getScores(),
@@ -471,11 +471,11 @@ export type Power = {
 export async function getPower(
   space: SnapshotSpace,
   proposal: SnapshotProposal,
-  address: string
+  address: string,
 ): Promise<Power> {
   const snapshot = await SnapshotLazyLoader.getSnapshot();
   const blockNumber = await snapshot.utils.getBlockNumber(
-    snapshot.utils.getProvider(space.network)
+    snapshot.utils.getProvider(space.network),
   );
   const blockTag =
     +proposal.snapshot > blockNumber ? 'latest' : +proposal.snapshot;
@@ -485,11 +485,11 @@ export async function getPower(
       proposal.strategies,
       space.network,
       [address],
-      blockTag
+      blockTag,
       // Snapshot.utils.getProvider(space.network),
     );
   const summedScores = scores.map((score) =>
-    Object.values(score).reduce((a, b) => a + b, 0)
+    Object.values(score).reduce((a, b) => a + b, 0),
   );
   return {
     scores: summedScores,

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -225,7 +225,7 @@ export const NewSnapshotProposalForm = ({
           )}
           {showScoreWarning ? (
             <CWText>
-              You need to have a minimum of {space.filters.minScore}{' '}
+              You need to have a minimum of {space.validation.params.minScore}{' '}
               {space.symbol} in order to submit a proposal.
             </CWText>
           ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6111 

## Description of Changes
-When a user tries to create a proposal on Snapshot without having the minimum amount for that space, the message on Common now corresponds with the message/amount that is seen on Snapshot.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the message to display `space.validation.params.minScore`

## Test Plan
- Make sure you have a Snapshot space saved in Integrations. If you don't have one you can use mangrove.eth
- go to a thread or create one and connect a Snapshot
- notice that it now reads to be a certain amount, rather than the default 0. 
- If you would like more confirmation that the amounts match up, you can go to the Snapshot space on Snapshot and try to make a proposal there, and compare the two messages. Try here on Mangrove DAO https://snapshot.org/#/mangrove.eth

<img width="711" alt="Screenshot 2024-03-07 at 9 56 57 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/cf60e3e7-7bf4-4e8f-8b91-e231b453e24d">
<img width="1396" alt="Screenshot 2024-03-07 at 9 57 25 AM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/2a69cefd-b788-42ad-a189-fecd42554a5a">
