### PR TITLE
Fix thread fetch when x(20) recent threads are archived

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -140,7 +140,7 @@ export async function __getBulkThreads(
           ${communityId ? ` AND t.community_id = $community_id` : ''}
           ${topicId ? ` AND t.topic_id = $topic_id ` : ''}
           ${stage ? ` AND t.stage = $stage ` : ''}
-          ${archived ? ` AND t.archived_at IS NOT NULL ` : ''}
+          ${` AND t.archived_at IS ${archived ? 'NOT' : ''} NULL `}
           AND (${includePinnedThreads ? 't.pinned = true OR' : ''}
           (COALESCE(t.last_commented_on, t.created_at) < $to_date AND t.pinned = false))
           GROUP BY (t.id, t.max_notif_id, t.comment_count,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6998

## Description of Changes
- Updated API to return un-archived threads on discussion pages

## "How We Fixed It"
N/A

## Test Plan
- Visit any community (with admin account)
- Go to archive page of the community, note the archived threads number (count)
- Go to any other topic page, mark 20+ threads as archived and reload the page, verify you see new threads popup (if there are any more)
- Go to archive page again, verify the updated archived threads number (count), verify that it adds up.

## Deployment Plan
N/A

## Other Considerations
N/A