### PR TITLE
Refactor: remove repetition in Canvas code

### DIFF
--- a/libs/model/src/models/comment.ts
+++ b/libs/model/src/models/comment.ts
@@ -4,7 +4,12 @@ import type { DataTypes } from 'sequelize';
 import type { AddressAttributes } from './address';
 import type { CommunityAttributes } from './community';
 import { ThreadAttributes } from './thread';
-import type { ModelInstance, ModelStatic } from './types';
+import {
+  canvasModelSequelizeColumns,
+  type CanvasModelAttributes,
+  type ModelInstance,
+  type ModelStatic,
+} from './types';
 
 const log = logger().getLogger(__filename);
 
@@ -17,10 +22,6 @@ export type CommentAttributes = {
   community_id: string;
   parent_id?: string;
   version_history?: string[];
-
-  canvas_action: string;
-  canvas_session: string;
-  canvas_hash: string;
 
   created_at?: Date;
   updated_at?: Date;
@@ -36,7 +37,7 @@ export type CommentAttributes = {
   //counts
   reaction_count: number;
   reaction_weights_sum: number;
-};
+} & CanvasModelAttributes;
 
 export type CommentInstance = ModelInstance<CommentAttributes>;
 
@@ -70,9 +71,8 @@ export default (
         allowNull: false,
       },
       // signed data
-      canvas_action: { type: dataTypes.JSONB, allowNull: true },
-      canvas_session: { type: dataTypes.JSONB, allowNull: true },
-      canvas_hash: { type: dataTypes.STRING, allowNull: true },
+      ...canvasModelSequelizeColumns(dataTypes),
+
       // timestamps
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },

--- a/libs/model/src/models/reaction.ts
+++ b/libs/model/src/models/reaction.ts
@@ -3,7 +3,12 @@ import type * as Sequelize from 'sequelize';
 import type { DataTypes } from 'sequelize';
 import type { AddressAttributes } from './address';
 import type { CommunityAttributes } from './community';
-import type { ModelInstance, ModelStatic } from './types';
+import {
+  canvasModelSequelizeColumns,
+  type CanvasModelAttributes,
+  type ModelInstance,
+  type ModelStatic,
+} from './types';
 
 const log = logger().getLogger(__filename);
 
@@ -18,16 +23,12 @@ export type ReactionAttributes = {
 
   calculated_voting_weight: number;
 
-  canvas_action: string;
-  canvas_session: string;
-  canvas_hash: string;
-
   created_at?: Date;
   updated_at?: Date;
 
   Chain?: CommunityAttributes;
   Address?: AddressAttributes;
-};
+} & CanvasModelAttributes;
 
 export type ReactionInstance = ModelInstance<ReactionAttributes>;
 
@@ -49,9 +50,7 @@ export default (
       reaction: { type: dataTypes.STRING, allowNull: false },
       calculated_voting_weight: { type: dataTypes.INTEGER, allowNull: true },
       // signed data
-      canvas_action: { type: dataTypes.JSONB, allowNull: true },
-      canvas_session: { type: dataTypes.JSONB, allowNull: true },
-      canvas_hash: { type: dataTypes.STRING, allowNull: true },
+      ...canvasModelSequelizeColumns(dataTypes),
     },
     {
       hooks: {

--- a/libs/model/src/models/thread.ts
+++ b/libs/model/src/models/thread.ts
@@ -5,7 +5,12 @@ import type { AddressAttributes } from './address';
 import type { CommunityAttributes } from './community';
 import { NotificationAttributes } from './notification';
 import type { TopicAttributes } from './topic';
-import type { ModelInstance, ModelStatic } from './types';
+import {
+  canvasModelSequelizeColumns,
+  type CanvasModelAttributes,
+  type ModelInstance,
+  type ModelStatic,
+} from './types';
 
 export enum LinkSource {
   Snapshot = 'snapshot',
@@ -41,10 +46,6 @@ export type ThreadAttributes = {
 
   has_poll?: boolean;
 
-  canvas_action: string;
-  canvas_session: string;
-  canvas_hash: string;
-
   created_at?: Date;
   updated_at?: Date;
   last_edited?: Date;
@@ -69,7 +70,7 @@ export type ThreadAttributes = {
 
   //notifications
   max_notif_id: number;
-};
+} & CanvasModelAttributes;
 
 export type ThreadInstance = ModelInstance<ThreadAttributes> & {
   // no mixins used
@@ -124,9 +125,7 @@ export default (
       has_poll: { type: dataTypes.BOOLEAN, allowNull: true },
 
       // signed data
-      canvas_action: { type: dataTypes.JSONB, allowNull: true },
-      canvas_session: { type: dataTypes.JSONB, allowNull: true },
-      canvas_hash: { type: dataTypes.STRING, allowNull: true },
+      ...canvasModelSequelizeColumns(dataTypes),
       // timestamps
       created_at: { type: dataTypes.DATE, allowNull: false },
       updated_at: { type: dataTypes.DATE, allowNull: false },

--- a/libs/model/src/models/types.ts
+++ b/libs/model/src/models/types.ts
@@ -1,4 +1,4 @@
-import type { BuildOptions, Model } from 'sequelize';
+import type { BuildOptions, DataTypes, Model } from 'sequelize';
 import type { DB } from '.';
 
 export type ModelInstance<Attrs extends Record<string, unknown>> =
@@ -7,3 +7,15 @@ export type ModelInstance<Attrs extends Record<string, unknown>> =
 export type ModelStatic<T extends Model> = typeof Model & {
   associate: (models: DB) => void;
 } & { new (values?: Record<string, unknown>, options?: BuildOptions): T };
+
+export type CanvasModelAttributes = {
+  canvas_action: string;
+  canvas_session: string;
+  canvas_hash: string;
+};
+
+export const canvasModelSequelizeColumns = (dataTypes: typeof DataTypes) => ({
+  canvas_action: { type: dataTypes.JSONB, allowNull: true },
+  canvas_session: { type: dataTypes.JSONB, allowNull: true },
+  canvas_hash: { type: dataTypes.STRING, allowNull: true },
+});

--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -6,6 +6,7 @@ import { createSiweMessage } from 'adapters/chain/ethereum/keys';
 import { chainBaseToCanvasChainId, createCanvasSessionPayload } from 'canvas';
 
 import { ChainBase, WalletSsoSource } from '@hicommonwealth/core';
+import { serializeCanvasSignedData } from 'shared/canvas/types';
 import app from 'state';
 import Account from '../../models/Account';
 import IWebWallet from '../../models/IWebWallet';
@@ -227,18 +228,14 @@ class SessionsController {
       return { session: '', action: '', hash: '' };
     }
 
-    const { session, action, hash } = await controller.sign(
+    const signResult = await controller.sign(
       canvasChainId,
       address,
       call,
       args,
     );
 
-    return {
-      session: JSON.stringify(session),
-      action: JSON.stringify(action),
-      hash,
-    };
+    return serializeCanvasSignedData(signResult);
   }
 
   // Public signer methods

--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -6,7 +6,7 @@ import { createSiweMessage } from 'adapters/chain/ethereum/keys';
 import { chainBaseToCanvasChainId, createCanvasSessionPayload } from 'canvas';
 
 import { ChainBase, WalletSsoSource } from '@hicommonwealth/core';
-import { serializeCanvasSignedData } from 'shared/canvas/types';
+import { CanvasSignedData } from 'shared/canvas/types';
 import app from 'state';
 import Account from '../../models/Account';
 import IWebWallet from '../../models/IWebWallet';
@@ -189,7 +189,7 @@ class SessionsController {
     address: string,
     call: string,
     args: Record<string, ActionArgument>,
-  ): Promise<{ session: string; action: string; hash: string }> {
+  ): Promise<CanvasSignedData> {
     const chainBase = app.chain?.base;
 
     // Try to infer Chain ID from the currently active chain. Note that
@@ -225,17 +225,10 @@ class SessionsController {
     }
 
     if (!hasAuthenticatedSession) {
-      return { session: '', action: '', hash: '' };
+      return;
     }
 
-    const signResult = await controller.sign(
-      canvasChainId,
-      address,
-      call,
-      args,
-    );
-
-    return serializeCanvasSignedData(signResult);
+    return await controller.sign(canvasChainId, address, call, args);
   }
 
   // Public signer methods

--- a/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import Comment from 'models/Comment';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
 import { updateThreadInAllCaches } from '../threads/helpers/cache';
@@ -22,11 +23,7 @@ const createComment = async ({
   unescapedText,
   parentCommentId = null,
 }: CreateCommentProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signComment(address, {
+  const serializedCanvasSignedData = await app.sessions.signComment(address, {
     thread_id: threadId,
     body: unescapedText,
     parent_comment_id: parentCommentId,
@@ -41,9 +38,7 @@ const createComment = async ({
       parent_id: parentCommentId,
       text: encodeURIComponent(unescapedText),
       jwt: app.user.jwt,
-      canvas_action: action,
-      canvas_session: session,
-      canvas_hash: hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     },
   );
 

--- a/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
@@ -23,7 +23,7 @@ const createComment = async ({
   unescapedText,
   parentCommentId = null,
 }: CreateCommentProps) => {
-  const serializedCanvasSignedData = await app.sessions.signComment(address, {
+  const canvasSignedData = await app.sessions.signComment(address, {
     thread_id: threadId,
     body: unescapedText,
     parent_comment_id: parentCommentId,
@@ -38,7 +38,7 @@ const createComment = async ({
       parent_id: parentCommentId,
       text: encodeURIComponent(unescapedText),
       jwt: app.user.jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     },
   );
 

--- a/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import Reaction from 'models/Reaction';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
 import useFetchCommentsQuery from './fetchComments';
@@ -19,14 +20,13 @@ const createReaction = async ({
   communityId,
   commentId,
 }: CreateReactionProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signCommentReaction(address, {
-    comment_id: commentId,
-    like: reactionType === 'like',
-  });
+  const serializedCanvasSignedData = await app.sessions.signCommentReaction(
+    address,
+    {
+      comment_id: commentId,
+      like: reactionType === 'like',
+    },
+  );
 
   return await axios.post(
     `${app.serverUrl()}/comments/${commentId}/reactions`,
@@ -36,9 +36,7 @@ const createReaction = async ({
       address,
       reaction: reactionType,
       jwt: app.user.jwt,
-      canvas_action: action,
-      canvas_session: session,
-      canvas_hash: hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
       comment_id: commentId,
     },
   );

--- a/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
@@ -20,13 +20,10 @@ const createReaction = async ({
   communityId,
   commentId,
 }: CreateReactionProps) => {
-  const serializedCanvasSignedData = await app.sessions.signCommentReaction(
-    address,
-    {
-      comment_id: commentId,
-      like: reactionType === 'like',
-    },
-  );
+  const canvasSignedData = await app.sessions.signCommentReaction(address, {
+    comment_id: commentId,
+    like: reactionType === 'like',
+  });
 
   return await axios.post(
     `${app.serverUrl()}/comments/${commentId}/reactions`,
@@ -36,7 +33,7 @@ const createReaction = async ({
       address,
       reaction: reactionType,
       jwt: app.user.jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
       comment_id: commentId,
     },
   );

--- a/packages/commonwealth/client/scripts/state/api/comments/deleteComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/deleteComment.ts
@@ -20,7 +20,7 @@ const deleteComment = async ({
   commentId,
   canvasHash,
 }: DeleteCommentProps) => {
-  const serializedCanvasSignedData = await app.sessions.signDeleteComment(
+  const canvasSignedData = await app.sessions.signDeleteComment(
     app.user.activeAccount.address,
     {
       comment_id: canvasHash,
@@ -46,7 +46,7 @@ const deleteComment = async ({
       text: '[deleted]',
       plaintext: '[deleted]',
       versionHistory: [],
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     },
   };
 };

--- a/packages/commonwealth/client/scripts/state/api/comments/deleteComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/deleteComment.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
 import { updateThreadInAllCaches } from '../threads/helpers/cache';
@@ -19,13 +20,12 @@ const deleteComment = async ({
   commentId,
   canvasHash,
 }: DeleteCommentProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signDeleteComment(app.user.activeAccount.address, {
-    comment_id: canvasHash,
-  });
+  const serializedCanvasSignedData = await app.sessions.signDeleteComment(
+    app.user.activeAccount.address,
+    {
+      comment_id: canvasHash,
+    },
+  );
 
   await axios.delete(`${app.serverUrl()}/comments/${commentId}`, {
     data: {
@@ -46,9 +46,7 @@ const deleteComment = async ({
       text: '[deleted]',
       plaintext: '[deleted]',
       versionHistory: [],
-      canvas_action: action,
-      canvas_session: session,
-      canvas_hash: hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     },
   };
 };

--- a/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
@@ -18,10 +18,12 @@ const deleteReaction = async ({
   canvasHash,
   reactionId,
 }: DeleteReactionProps) => {
-  const serializedCanvasSignedData =
-    await app.sessions.signDeleteCommentReaction(address, {
+  const canvasSignedData = await app.sessions.signDeleteCommentReaction(
+    address,
+    {
       comment_id: canvasHash,
-    });
+    },
+  );
   return await axios
     .delete(`${app.serverUrl()}/reactions/${reactionId}`, {
       data: {
@@ -29,7 +31,7 @@ const deleteReaction = async ({
         address: address,
         community_id: communityId,
         jwt: app.user.jwt,
-        ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+        ...toCanvasSignedDataApiArgs(canvasSignedData),
       },
     })
     .then((r) => ({

--- a/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/deleteReaction.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
 import useFetchCommentsQuery from './fetchComments';
@@ -17,13 +18,10 @@ const deleteReaction = async ({
   canvasHash,
   reactionId,
 }: DeleteReactionProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signDeleteCommentReaction(address, {
-    comment_id: canvasHash,
-  });
+  const serializedCanvasSignedData =
+    await app.sessions.signDeleteCommentReaction(address, {
+      comment_id: canvasHash,
+    });
   return await axios
     .delete(`${app.serverUrl()}/reactions/${reactionId}`, {
       data: {
@@ -31,9 +29,7 @@ const deleteReaction = async ({
         address: address,
         community_id: communityId,
         jwt: app.user.jwt,
-        canvas_action: action,
-        canvas_session: session,
-        canvas_hash: hash,
+        ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
       },
     })
     .then((r) => ({

--- a/packages/commonwealth/client/scripts/state/api/comments/editComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/editComment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import Comment from 'models/Comment';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { ApiEndpoints } from 'state/api/config';
 import useFetchCommentsQuery from './fetchComments';
@@ -22,15 +23,14 @@ const editComment = async ({
   commentId,
   updatedBody,
 }: EditCommentProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signComment(app.user.activeAccount.address, {
-    thread_id: threadId,
-    body: updatedBody,
-    parent_comment_id: parentCommentId,
-  });
+  const serializedCanvasSignedData = await app.sessions.signComment(
+    app.user.activeAccount.address,
+    {
+      thread_id: threadId,
+      body: updatedBody,
+      parent_comment_id: parentCommentId,
+    },
+  );
 
   const response = await axios.patch(
     `${app.serverUrl()}/comments/${commentId}`,
@@ -41,9 +41,7 @@ const editComment = async ({
       community_id: communityId,
       body: encodeURIComponent(updatedBody),
       jwt: app.user.jwt,
-      canvas_action: action,
-      canvas_session: session,
-      canvas_hash: hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     },
   );
 

--- a/packages/commonwealth/client/scripts/state/api/comments/editComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/editComment.ts
@@ -23,7 +23,7 @@ const editComment = async ({
   commentId,
   updatedBody,
 }: EditCommentProps) => {
-  const serializedCanvasSignedData = await app.sessions.signComment(
+  const canvasSignedData = await app.sessions.signComment(
     app.user.activeAccount.address,
     {
       thread_id: threadId,
@@ -41,7 +41,7 @@ const editComment = async ({
       community_id: communityId,
       body: encodeURIComponent(updatedBody),
       jwt: app.user.jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     },
   );
 

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -18,13 +18,10 @@ const createReaction = async ({
   reactionType = 'like',
   threadId,
 }: CreateReactionProps) => {
-  const serializedCanvasSignedData = await app.sessions.signThreadReaction(
-    address,
-    {
-      thread_id: threadId,
-      like: reactionType === 'like',
-    },
-  );
+  const canvasSignedData = await app.sessions.signThreadReaction(address, {
+    thread_id: threadId,
+    like: reactionType === 'like',
+  });
 
   return await axios.post(`${app.serverUrl()}/threads/${threadId}/reactions`, {
     author_community_id: app.user.activeAccount.community.id,
@@ -33,7 +30,7 @@ const createReaction = async ({
     address,
     reaction: reactionType,
     jwt: app.user.jwt,
-    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+    ...toCanvasSignedDataApiArgs(canvasSignedData),
   });
 };
 

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { updateThreadInAllCaches } from './helpers/cache';
 
@@ -17,14 +18,13 @@ const createReaction = async ({
   reactionType = 'like',
   threadId,
 }: CreateReactionProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signThreadReaction(address, {
-    thread_id: threadId,
-    like: reactionType === 'like',
-  });
+  const serializedCanvasSignedData = await app.sessions.signThreadReaction(
+    address,
+    {
+      thread_id: threadId,
+      like: reactionType === 'like',
+    },
+  );
 
   return await axios.post(`${app.serverUrl()}/threads/${threadId}/reactions`, {
     author_community_id: app.user.activeAccount.community.id,
@@ -33,9 +33,7 @@ const createReaction = async ({
     address,
     reaction: reactionType,
     jwt: app.user.jwt,
-    canvas_action: action,
-    canvas_session: session,
-    canvas_hash: hash,
+    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
   });
 };
 

--- a/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
@@ -4,6 +4,7 @@ import MinimumProfile from 'models/MinimumProfile';
 import Thread from 'models/Thread';
 import Topic from 'models/Topic';
 import { ThreadStage } from 'models/types';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { EXCEPTION_CASE_threadCountersStore } from '../../ui/thread';
 import { addThreadInAllCaches } from './helpers/cache';
@@ -33,11 +34,7 @@ const createThread = async ({
   readOnly,
   authorProfile,
 }: CreateThreadProps): Promise<Thread> => {
-  const {
-    action = null,
-    session = null,
-    hash = null,
-  } = await app.sessions.signThread(address, {
+  const serializedCanvasSignedData = await app.sessions.signThread(address, {
     community: chainId,
     title,
     body,
@@ -59,9 +56,7 @@ const createThread = async ({
     url,
     readOnly,
     jwt: app.user.jwt,
-    canvas_action: action,
-    canvas_session: session,
-    canvas_hash: hash,
+    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
   });
 
   return new Thread(response.data.result);

--- a/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
@@ -34,7 +34,7 @@ const createThread = async ({
   readOnly,
   authorProfile,
 }: CreateThreadProps): Promise<Thread> => {
-  const serializedCanvasSignedData = await app.sessions.signThread(address, {
+  const canvasSignedData = await app.sessions.signThread(address, {
     community: chainId,
     title,
     body,
@@ -56,7 +56,7 @@ const createThread = async ({
     url,
     readOnly,
     jwt: app.user.jwt,
-    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+    ...toCanvasSignedDataApiArgs(canvasSignedData),
   });
 
   return new Thread(response.data.result);

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -20,10 +20,12 @@ const deleteReaction = async ({
   reactionId,
   threadId,
 }: DeleteReactionProps) => {
-  const serializedCanvasSignedData =
-    await app.sessions.signDeleteThreadReaction(address, {
+  const canvasSignedData = await app.sessions.signDeleteThreadReaction(
+    address,
+    {
       thread_id: threadId,
-    });
+    },
+  );
 
   const response = await axios.delete(
     `${app.serverUrl()}/reactions/${reactionId}`,
@@ -33,7 +35,7 @@ const deleteReaction = async ({
         address: address,
         community_id: app.chain.id,
         jwt: app.user.jwt,
-        ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+        ...toCanvasSignedDataApiArgs(canvasSignedData),
       },
     },
   );

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { updateThreadInAllCaches } from './helpers/cache';
 
@@ -19,13 +20,10 @@ const deleteReaction = async ({
   reactionId,
   threadId,
 }: DeleteReactionProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signDeleteThreadReaction(address, {
-    thread_id: threadId,
-  });
+  const serializedCanvasSignedData =
+    await app.sessions.signDeleteThreadReaction(address, {
+      thread_id: threadId,
+    });
 
   const response = await axios.delete(
     `${app.serverUrl()}/reactions/${reactionId}`,
@@ -35,9 +33,7 @@ const deleteReaction = async ({
         address: address,
         community_id: app.chain.id,
         jwt: app.user.jwt,
-        canvas_action: action,
-        canvas_session: session,
-        canvas_hash: hash,
+        ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
       },
     },
   );

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { ThreadStage } from 'models/types';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { EXCEPTION_CASE_threadCountersStore } from '../../ui/thread';
 import { removeThreadFromAllCaches } from './helpers/cache';
@@ -16,13 +17,12 @@ const deleteThread = async ({
   threadId,
   address,
 }: DeleteThreadProps) => {
-  const {
-    session = null,
-    action = null,
-    hash = null,
-  } = await app.sessions.signDeleteThread(address, {
-    thread_id: threadId,
-  });
+  const serializedCanvasSignedData = await app.sessions.signDeleteThread(
+    address,
+    {
+      thread_id: threadId,
+    },
+  );
 
   return await axios.delete(`${app.serverUrl()}/threads/${threadId}`, {
     data: {
@@ -30,9 +30,7 @@ const deleteThread = async ({
       community_id: chainId,
       address: address,
       jwt: app.user.jwt,
-      canvas_action: action,
-      canvas_session: session,
-      canvas_hash: hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     },
   });
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
@@ -17,12 +17,9 @@ const deleteThread = async ({
   threadId,
   address,
 }: DeleteThreadProps) => {
-  const serializedCanvasSignedData = await app.sessions.signDeleteThread(
-    address,
-    {
-      thread_id: threadId,
-    },
-  );
+  const canvasSignedData = await app.sessions.signDeleteThread(address, {
+    thread_id: threadId,
+  });
 
   return await axios.delete(`${app.serverUrl()}/threads/${threadId}`, {
     data: {
@@ -30,7 +27,7 @@ const deleteThread = async ({
       community_id: chainId,
       address: address,
       jwt: app.user.jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     },
   });
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
@@ -63,7 +63,7 @@ const editThread = async ({
   // for editing thread collaborators
   collaborators,
 }: EditThreadProps): Promise<Thread> => {
-  const serializedCanvasSignedData = await app.sessions.signThread(address, {
+  const canvasSignedData = await app.sessions.signThread(address, {
     community: app.activeChainId(),
     title: newTitle,
     body: newBody,
@@ -96,7 +96,7 @@ const editThread = async ({
     ...(topicId !== undefined && { topicId }),
     // for editing thread collaborators
     ...(collaborators !== undefined && { collaborators }),
-    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+    ...toCanvasSignedDataApiArgs(canvasSignedData),
   });
 
   return new Thread(response.data.result);

--- a/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import MinimumProfile from 'models/MinimumProfile';
 import Thread from 'models/Thread';
 import { ThreadStage } from 'models/types';
+import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import {
   updateThreadInAllCaches,
@@ -62,11 +63,7 @@ const editThread = async ({
   // for editing thread collaborators
   collaborators,
 }: EditThreadProps): Promise<Thread> => {
-  const {
-    action = null,
-    session = null,
-    hash = null,
-  } = await app.sessions.signThread(address, {
+  const serializedCanvasSignedData = await app.sessions.signThread(address, {
     community: app.activeChainId(),
     title: newTitle,
     body: newBody,
@@ -99,9 +96,7 @@ const editThread = async ({
     ...(topicId !== undefined && { topicId }),
     // for editing thread collaborators
     ...(collaborators !== undefined && { collaborators }),
-    canvas_action: action,
-    canvas_session: session,
-    canvas_hash: hash,
+    ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
   });
 
   return new Thread(response.data.result);

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
@@ -43,9 +43,9 @@ export type CreateThreadOptions = {
   topicId?: number;
   stage?: string;
   url?: string;
-  canvasAction?: any;
-  canvasSession?: any;
-  canvasHash?: any;
+  canvasAction?: string;
+  canvasSession?: string;
+  canvasHash?: string;
   discordMeta?: any;
 };
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
@@ -43,9 +43,9 @@ export type CreateThreadCommentOptions = {
   parentId: number;
   threadId: number;
   text: string;
-  canvasAction?: any;
-  canvasSession?: any;
-  canvasHash?: any;
+  canvasAction?: string;
+  canvasSession?: string;
+  canvasHash?: string;
   discordMeta?: any;
 };
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
@@ -32,9 +32,9 @@ export type CreateThreadReactionOptions = {
   address: AddressInstance;
   reaction: string;
   threadId: number;
-  canvasAction?: any;
-  canvasSession?: any;
-  canvasHash?: any;
+  canvasAction?: string;
+  canvasSession?: string;
+  canvasHash?: string;
 };
 
 export type CreateThreadReactionResult = [

--- a/packages/commonwealth/server/routes/comments/create_comment_reaction_handler.ts
+++ b/packages/commonwealth/server/routes/comments/create_comment_reaction_handler.ts
@@ -14,9 +14,6 @@ const Errors = {
 type CreateCommentReactionRequestParams = { id: string };
 type CreateCommentReactionRequestBody = {
   reaction: string;
-  canvas_action?: any;
-  canvas_session?: any;
-  canvas_hash?: any;
 };
 type CreateCommentReactionResponse = ReactionAttributes;
 
@@ -48,16 +45,17 @@ export const createCommentReactionHandler = async (
     commentId,
   };
 
-  if (process.env.ENFORCE_SESSION_KEYS === 'true') {
-    if (isCanvasSignedDataApiArgs(req.body)) {
+  if (isCanvasSignedDataApiArgs(req.body)) {
+    commentReactionFields.canvasAction = req.body.canvas_action;
+    commentReactionFields.canvasSession = req.body.canvas_session;
+    commentReactionFields.canvasHash = req.body.canvas_hash;
+
+    if (process.env.ENFORCE_SESSION_KEYS === 'true') {
       await verifyReaction(req.body, {
         comment_id: commentId,
         address: address.address,
         value: reaction,
       });
-      commentReactionFields.canvasAction = req.body.canvas_action;
-      commentReactionFields.canvasSession = req.body.canvas_session;
-      commentReactionFields.canvasHash = req.body.canvas_hash;
     }
   }
 

--- a/packages/commonwealth/server/routes/threads/create_thread_comment_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_comment_handler.ts
@@ -24,9 +24,6 @@ type CreateThreadCommentRequestBody = {
   parent_id;
   thread_id;
   text;
-  canvas_action;
-  canvas_session;
-  canvas_hash;
   discord_meta;
 };
 type CreateThreadCommentResponse = CommentInstance;
@@ -56,17 +53,18 @@ export const createThreadCommentHandler = async (
     discordMeta: discord_meta,
   };
 
-  if (process.env.ENFORCE_SESSION_KEYS === 'true') {
-    if (isCanvasSignedDataApiArgs(req.body)) {
+  if (isCanvasSignedDataApiArgs(req.body)) {
+    threadCommentFields.canvasAction = req.body.canvas_action;
+    threadCommentFields.canvasSession = req.body.canvas_session;
+    threadCommentFields.canvasHash = req.body.canvas_hash;
+
+    if (process.env.ENFORCE_SESSION_KEYS === 'true') {
       await verifyComment(req.body, {
         thread_id: parseInt(threadId, 10) || undefined,
         text,
         address: address.address,
         parent_comment_id: parentId,
       });
-      threadCommentFields.canvasAction = req.body.canvas_action;
-      threadCommentFields.canvasSession = req.body.canvas_session;
-      threadCommentFields.canvasHash = req.body.canvas_hash;
     }
   }
 

--- a/packages/commonwealth/server/routes/threads/create_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_handler.ts
@@ -36,9 +36,6 @@ export const createThreadHandler = async (
     stage,
     url,
     readOnly,
-    canvas_action: canvasAction,
-    canvas_session: canvasSession,
-    canvas_hash: canvasHash,
     discord_meta,
   } = req.body;
 
@@ -58,7 +55,7 @@ export const createThreadHandler = async (
 
   if (process.env.ENFORCE_SESSION_KEYS === 'true') {
     if (isCanvasSignedDataApiArgs(req.body)) {
-      await verifyThread(canvasAction, canvasSession, canvasHash, {
+      await verifyThread(req.body, {
         title,
         body,
         address: address.address,

--- a/packages/commonwealth/server/routes/threads/create_thread_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_handler.ts
@@ -15,9 +15,6 @@ type CreateThreadRequestBody = {
   stage: string;
   url?: string;
   readOnly: boolean;
-  canvas_action?: any;
-  canvas_session?: any;
-  canvas_hash?: any;
   discord_meta?: IDiscordMeta;
 };
 type CreateThreadResponse = ThreadAttributes;
@@ -53,8 +50,12 @@ export const createThreadHandler = async (
     discordMeta: discord_meta,
   };
 
-  if (process.env.ENFORCE_SESSION_KEYS === 'true') {
-    if (isCanvasSignedDataApiArgs(req.body)) {
+  if (isCanvasSignedDataApiArgs(req.body)) {
+    threadFields.canvasAction = req.body.canvas_action;
+    threadFields.canvasSession = req.body.canvas_session;
+    threadFields.canvasHash = req.body.canvas_hash;
+
+    if (process.env.ENFORCE_SESSION_KEYS === 'true') {
       await verifyThread(req.body, {
         title,
         body,
@@ -62,9 +63,6 @@ export const createThreadHandler = async (
         community: community.id,
         topic: topicId ? parseInt(topicId, 10) : null,
       });
-      threadFields.canvasAction = req.body.canvas_action;
-      threadFields.canvasSession = req.body.canvas_session;
-      threadFields.canvasHash = req.body.canvas_hash;
     }
   }
 

--- a/packages/commonwealth/server/routes/threads/create_thread_reaction_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_reaction_handler.ts
@@ -1,5 +1,6 @@
 import { AppError } from '@hicommonwealth/core';
 import { ReactionAttributes } from '@hicommonwealth/model';
+import { isCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import { verifyReaction } from '../../../shared/canvas/serverVerify';
 import { ServerControllers } from '../../routing/router';
 import { TypedRequest, TypedResponse, success } from '../../types';
@@ -45,11 +46,13 @@ export const createThreadReactionHandler = async (
   }
 
   if (process.env.ENFORCE_SESSION_KEYS === 'true') {
-    await verifyReaction(canvasAction, canvasSession, canvasHash, {
-      thread_id: threadId,
-      address: address.address,
-      value: reaction,
-    });
+    if (isCanvasSignedDataApiArgs(req.body)) {
+      await verifyReaction(req.body, {
+        thread_id: threadId,
+        address: address.address,
+        value: reaction,
+      });
+    }
   }
 
   // create thread reaction

--- a/packages/commonwealth/server/routes/threads/create_thread_reaction_handler.ts
+++ b/packages/commonwealth/server/routes/threads/create_thread_reaction_handler.ts
@@ -14,9 +14,6 @@ const Errors = {
 type CreateThreadReactionRequestParams = { id: string };
 type CreateThreadReactionRequestBody = {
   reaction: string;
-  canvas_action?: any;
-  canvas_session?: any;
-  canvas_hash?: any;
 };
 type CreateThreadReactionResponse = ReactionAttributes;
 
@@ -48,16 +45,18 @@ export const createThreadReactionHandler = async (
     threadId,
   };
 
-  if (process.env.ENFORCE_SESSION_KEYS === 'true') {
-    if (isCanvasSignedDataApiArgs(req.body)) {
+  if (isCanvasSignedDataApiArgs(req.body)) {
+    // Only save the canvas fields if they are given and they are strings
+    reactionFields.canvasAction = req.body.canvas_action;
+    reactionFields.canvasSession = req.body.canvas_session;
+    reactionFields.canvasHash = req.body.canvas_hash;
+
+    if (process.env.ENFORCE_SESSION_KEYS === 'true') {
       await verifyReaction(req.body, {
         thread_id: threadId,
         address: address.address,
         value: reaction,
       });
-      reactionFields.canvasAction = req.body.canvas_action;
-      reactionFields.canvasSession = req.body.canvas_session;
-      reactionFields.canvasHash = req.body.canvas_hash;
     }
   }
 

--- a/packages/commonwealth/shared/canvas/serverVerify.ts
+++ b/packages/commonwealth/shared/canvas/serverVerify.ts
@@ -60,20 +60,9 @@ export const verifyComment = async (args: CanvasSignedDataApiArgs, fields) => {
   // assertMatches(chainBaseToCanvasChain(chain), action.payload.chain)
 };
 
-export const verifyThread = async (
-  canvas_action,
-  canvas_session,
-  canvas_hash,
-  fields,
-) => {
-  if (
-    canvas_action === undefined &&
-    canvas_session === undefined &&
-    canvas_hash === undefined
-  )
-    return;
+export const verifyThread = async (args: CanvasSignedDataApiArgs, fields) => {
   const { title, body, address, community, link, topic } = fields;
-  const { action } = await verifyUnpack(canvas_action, canvas_session);
+  const { action } = await verifyUnpack(args);
 
   assertMatches(action.payload.call, 'thread', 'thread', 'call');
   assertMatches(

--- a/packages/commonwealth/shared/canvas/serverVerify.ts
+++ b/packages/commonwealth/shared/canvas/serverVerify.ts
@@ -1,3 +1,4 @@
+import { CanvasSignedDataApiArgs, fromCanvasSignedDataApiArgs } from './types';
 import { verify } from './verify';
 
 function assert(condition: unknown, message?: string): asserts condition {
@@ -18,10 +19,10 @@ function assertMatches(a, b, obj: string, field: string) {
 // Skip io-ts validation since it produces an import error even though
 // we're already using an async import, and because we're upgrading
 // to the new Canvas packages soon anyway.
-const verifyUnpack = async (canvas_action, canvas_session) => {
+const verifyUnpack = async (args: CanvasSignedDataApiArgs) => {
+  const { action, session } = fromCanvasSignedDataApiArgs(args);
+  // TODO:
   // const { actionType, sessionType } = await import('@canvas-js/core/codecs');
-  const action = canvas_action && JSON.parse(canvas_action);
-  const session = canvas_session && JSON.parse(canvas_session);
   // assert(actionType.is(action), 'Invalid signed action (typecheck)');
   // assert(sessionType.is(session), 'Invalid signed session (typecheck)');
   const [verifiedAction, verifiedSession] = await Promise.all([
@@ -100,20 +101,9 @@ export const verifyThread = async (
   // assertMatches(chainBaseToCanvasChain(chain), action.payload.chain)
 };
 
-export const verifyReaction = async (
-  canvas_action,
-  canvas_session,
-  canvas_hash,
-  fields,
-) => {
-  if (
-    canvas_action === undefined &&
-    canvas_session === undefined &&
-    canvas_hash === undefined
-  )
-    return;
+export const verifyReaction = async (args: CanvasSignedDataApiArgs, fields) => {
   const { thread_id, comment_id, proposal_id, address, value } = fields;
-  const { action } = await verifyUnpack(canvas_action, canvas_session);
+  const { action } = await verifyUnpack(args);
   assert(
     (action.payload.call === 'reactThread' &&
       thread_id === action.payload.callArgs.thread_id &&

--- a/packages/commonwealth/shared/canvas/serverVerify.ts
+++ b/packages/commonwealth/shared/canvas/serverVerify.ts
@@ -38,20 +38,9 @@ const verifyUnpack = async (args: CanvasSignedDataApiArgs) => {
   return { action, session };
 };
 
-export const verifyComment = async (
-  canvas_action,
-  canvas_session,
-  canvas_hash,
-  fields,
-) => {
-  if (
-    canvas_action === undefined &&
-    canvas_session === undefined &&
-    canvas_hash === undefined
-  )
-    return;
+export const verifyComment = async (args: CanvasSignedDataApiArgs, fields) => {
   const { thread_id, text, address, parent_comment_id } = fields;
-  const { action } = await verifyUnpack(canvas_action, canvas_session);
+  const { action } = await verifyUnpack(args);
 
   assertMatches(action.payload.call, 'comment', 'comment', 'call');
   assertMatches(

--- a/packages/commonwealth/shared/canvas/types.ts
+++ b/packages/commonwealth/shared/canvas/types.ts
@@ -23,12 +23,19 @@ const sortedStringify = configureStableStringify({
 
 export const toCanvasSignedDataApiArgs = (
   data: undefined | CanvasSignedData,
-): CanvasSignedDataApiArgs => ({
-  canvas_action: sortedStringify(data.action),
-  canvas_session: sortedStringify(data.session),
-  // hash is already a string so it doesn't need to be serialized
-  canvas_hash: data.hash,
-});
+): CanvasSignedDataApiArgs => {
+  // ignore undefined data
+  if (data === undefined) {
+    return;
+  }
+
+  return {
+    canvas_action: sortedStringify(data.action),
+    canvas_session: sortedStringify(data.session),
+    // hash is already a string so it doesn't need to be serialized
+    canvas_hash: data.hash,
+  };
+};
 
 export type CanvasSignedDataApiArgs = {
   canvas_action: string;

--- a/packages/commonwealth/shared/canvas/types.ts
+++ b/packages/commonwealth/shared/canvas/types.ts
@@ -1,0 +1,45 @@
+import { Action, Session } from '@canvas-js/interfaces';
+import { configure as configureStableStringify } from 'safe-stable-stringify';
+
+export type CanvasSignedData = {
+  action: Action;
+  session: Session;
+  hash: string;
+};
+
+// maybe these fields should be called canvas_action, canvas_session, canvas_hash?
+export type SerializedCanvasSignedData = {
+  action: string;
+  session: string;
+  hash: string;
+};
+
+const sortedStringify = configureStableStringify({
+  bigint: false,
+  circularValue: Error,
+  strict: true,
+  deterministic: true,
+});
+
+export const serializeCanvasSignedData = (
+  data: CanvasSignedData,
+): SerializedCanvasSignedData => ({
+  session: sortedStringify(data.session),
+  action: sortedStringify(data.action),
+  // hash is already a string so it doesn't need to be serialized
+  hash: data.hash,
+});
+
+export type CanvasSignedDataApiArgs = {
+  canvas_action: string;
+  canvas_session: string;
+  canvas_hash: string;
+};
+
+export const toCanvasSignedDataApiArgs = (
+  data: SerializedCanvasSignedData,
+): CanvasSignedDataApiArgs => ({
+  canvas_action: data.action,
+  canvas_session: data.session,
+  canvas_hash: data.hash,
+});

--- a/packages/commonwealth/shared/canvas/types.ts
+++ b/packages/commonwealth/shared/canvas/types.ts
@@ -43,3 +43,49 @@ export const toCanvasSignedDataApiArgs = (
   canvas_session: data.session,
   canvas_hash: data.hash,
 });
+
+export const fromCanvasSignedDataApiArgs = (
+  data: CanvasSignedDataApiArgs,
+): CanvasSignedData => {
+  // try to deserialize
+  return {
+    action: JSON.parse(data.canvas_action),
+    session: JSON.parse(data.canvas_session),
+    hash: data.canvas_hash,
+  };
+};
+
+export const isCanvasSignedDataApiArgs = (
+  args: any,
+): args is CanvasSignedDataApiArgs => {
+  /**
+   * There are three canvas signed data arguments: action, session and hash
+   * The input is valid if either all three are present or all three are absent
+   */
+
+  if (
+    args.canvas_action === undefined &&
+    args.canvas_session === undefined &&
+    args.canvas_hash === undefined
+  ) {
+    return false;
+  }
+
+  if (
+    args.canvas_action === undefined ||
+    args.canvas_session === undefined ||
+    args.canvas_hash === undefined
+  ) {
+    throw new Error('Missing canvas signed data');
+  }
+
+  if (
+    typeof args.canvas_action !== 'string' ||
+    typeof args.canvas_session !== 'string' ||
+    typeof args.canvas_hash !== 'string'
+  ) {
+    throw new Error('Canvas signed data fields should be strings (if present)');
+  }
+
+  return true;
+};

--- a/packages/commonwealth/shared/canvas/types.ts
+++ b/packages/commonwealth/shared/canvas/types.ts
@@ -21,13 +21,13 @@ const sortedStringify = configureStableStringify({
   deterministic: true,
 });
 
-export const serializeCanvasSignedData = (
-  data: CanvasSignedData,
-): SerializedCanvasSignedData => ({
-  session: sortedStringify(data.session),
-  action: sortedStringify(data.action),
+export const toCanvasSignedDataApiArgs = (
+  data: undefined | CanvasSignedData,
+): CanvasSignedDataApiArgs => ({
+  canvas_action: sortedStringify(data.action),
+  canvas_session: sortedStringify(data.session),
   // hash is already a string so it doesn't need to be serialized
-  hash: data.hash,
+  canvas_hash: data.hash,
 });
 
 export type CanvasSignedDataApiArgs = {
@@ -35,14 +35,6 @@ export type CanvasSignedDataApiArgs = {
   canvas_session: string;
   canvas_hash: string;
 };
-
-export const toCanvasSignedDataApiArgs = (
-  data: SerializedCanvasSignedData,
-): CanvasSignedDataApiArgs => ({
-  canvas_action: data.action,
-  canvas_session: data.session,
-  canvas_hash: data.hash,
-});
 
 export const fromCanvasSignedDataApiArgs = (
   data: CanvasSignedDataApiArgs,

--- a/packages/commonwealth/test/util/modelUtils.ts
+++ b/packages/commonwealth/test/util/modelUtils.ts
@@ -23,6 +23,10 @@ import * as siwe from 'siwe';
 import { createRole, findOneRole } from '../../server/util/roles';
 
 import { createCanvasSessionPayload } from '../../shared/canvas';
+import {
+  serializeCanvasSignedData,
+  toCanvasSignedDataApiArgs,
+} from '../../shared/canvas/types';
 
 import type { Role } from '@hicommonwealth/model';
 import { models } from '@hicommonwealth/model';
@@ -267,9 +271,12 @@ export const createThread = async (
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const canvas_session = sortedStringify(session);
-  const canvas_action = sortedStringify(action);
-  const canvas_hash = ''; // getActionHash(action)
+
+  const serializedCanvasSignedData = serializeCanvasSignedData({
+    session,
+    action,
+    hash: '',
+  });
 
   const res = await chai.request
     .agent(app)
@@ -286,9 +293,7 @@ export const createThread = async (
       url,
       readOnly: readOnly || false,
       jwt,
-      canvas_action,
-      canvas_session,
-      canvas_hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     });
   return res.body;
 };
@@ -374,9 +379,11 @@ export const createComment = async (args: CommentArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const canvas_session = sortedStringify(session);
-  const canvas_action = sortedStringify(action);
-  const canvas_hash = ''; // getActionHash(action)
+  const serializedCanvasSignedData = serializeCanvasSignedData({
+    session,
+    action,
+    hash: '',
+  });
   // TODO
 
   const res = await chai.request
@@ -390,9 +397,7 @@ export const createComment = async (args: CommentArgs) => {
       parent_id: parentCommentId,
       text,
       jwt,
-      canvas_action,
-      canvas_session,
-      canvas_hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     });
   return res.body;
 };
@@ -463,9 +468,12 @@ export const createReaction = async (args: CreateReactionArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const canvas_session = sortedStringify(session);
-  const canvas_action = sortedStringify(action);
-  const canvas_hash = ''; // getActionHash(action)
+  const serializedCanvasSignedData = serializeCanvasSignedData({
+    session,
+    action,
+    hash: '',
+  });
+
   // TODO
 
   const res = await chai.request
@@ -480,9 +488,7 @@ export const createReaction = async (args: CreateReactionArgs) => {
       author_chain,
       jwt,
       thread_id,
-      canvas_session,
-      canvas_action,
-      canvas_hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     });
   return res.body;
 };
@@ -525,9 +531,11 @@ export const createThreadReaction = async (args: CreateThreadReactionArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const canvas_session = sortedStringify(session);
-  const canvas_action = sortedStringify(action);
-  const canvas_hash = ''; // getActionHash(action)
+  const serializedCanvasSignedData = serializeCanvasSignedData({
+    session,
+    action,
+    hash: '',
+  });
   // TODO
 
   const res = await chai.request
@@ -541,9 +549,7 @@ export const createThreadReaction = async (args: CreateThreadReactionArgs) => {
       author_chain,
       jwt,
       thread_id,
-      canvas_session,
-      canvas_action,
-      canvas_hash,
+      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
     });
   return res.body;
 };

--- a/packages/commonwealth/test/util/modelUtils.ts
+++ b/packages/commonwealth/test/util/modelUtils.ts
@@ -23,10 +23,7 @@ import * as siwe from 'siwe';
 import { createRole, findOneRole } from '../../server/util/roles';
 
 import { createCanvasSessionPayload } from '../../shared/canvas';
-import {
-  serializeCanvasSignedData,
-  toCanvasSignedDataApiArgs,
-} from '../../shared/canvas/types';
+import { toCanvasSignedDataApiArgs } from '../../shared/canvas/types';
 
 import type { Role } from '@hicommonwealth/model';
 import { models } from '@hicommonwealth/model';
@@ -272,11 +269,11 @@ export const createThread = async (
     signature: sign(actionPayload),
   };
 
-  const serializedCanvasSignedData = serializeCanvasSignedData({
+  const canvasSignedData = {
     session,
     action,
     hash: '',
-  });
+  };
 
   const res = await chai.request
     .agent(app)
@@ -293,7 +290,7 @@ export const createThread = async (
       url,
       readOnly: readOnly || false,
       jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     });
   return res.body;
 };
@@ -379,11 +376,11 @@ export const createComment = async (args: CommentArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const serializedCanvasSignedData = serializeCanvasSignedData({
+  const canvasSignedData = {
     session,
     action,
     hash: '',
-  });
+  };
   // TODO
 
   const res = await chai.request
@@ -397,7 +394,7 @@ export const createComment = async (args: CommentArgs) => {
       parent_id: parentCommentId,
       text,
       jwt,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     });
   return res.body;
 };
@@ -468,11 +465,11 @@ export const createReaction = async (args: CreateReactionArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const serializedCanvasSignedData = serializeCanvasSignedData({
+  const canvasSignedData = {
     session,
     action,
     hash: '',
-  });
+  };
 
   // TODO
 
@@ -488,7 +485,7 @@ export const createReaction = async (args: CreateReactionArgs) => {
       author_chain,
       jwt,
       thread_id,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     });
   return res.body;
 };
@@ -531,11 +528,11 @@ export const createThreadReaction = async (args: CreateThreadReactionArgs) => {
     session: session.payload.sessionAddress,
     signature: sign(actionPayload),
   };
-  const serializedCanvasSignedData = serializeCanvasSignedData({
+  const canvasSignedData = {
     session,
     action,
     hash: '',
-  });
+  };
   // TODO
 
   const res = await chai.request
@@ -549,7 +546,7 @@ export const createThreadReaction = async (args: CreateThreadReactionArgs) => {
       author_chain,
       jwt,
       thread_id,
-      ...toCanvasSignedDataApiArgs(serializedCanvasSignedData),
+      ...toCanvasSignedDataApiArgs(canvasSignedData),
     });
   return res.body;
 };


### PR DESCRIPTION
The objective of this PR is to refactor the existing code to have fewer references to the fields we are sending that relate to verifying actions with Canvas. We are going to make some changes to this data in a subsequent PR but it would be much cleaner to get this change merged first. This mostly involves making some new types that describe the Canvas fields and writing some functions that convert between them, that can then be used throughout the app instead of having lots of duplicated code.

This PR does not change any of the external interfaces or the intended behaviour of any of our endpoints, or require any tests to be updated. I'm trying to do this in a way where the later PR that makes the actual functional changes is not too big.

## Test Plan
- Ensure CI tests are all still passing
- Manual QA - log in with a crypto wallet, post a thread, post a comment and react to a thread and a comment. These should work as before.

Manual QA steps: 

with ENFORCE_SESSION_KEYS not set:

log in with metamask
- [x] create a thread
- [x] create a comment
- [x] react to a thread
- [x] react to a comment

with ENFORCE_SESSION_KEYS=true set:
log in with metamask
- [x] create a thread
- [x] create a comment
- [x] react to a thread
- [x] react to a comment