### PR TITLE
ban address modal no longer opens thread

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.tsx
@@ -12,7 +12,7 @@ interface CWModalProps {
   content: React.ReactNode;
   isFullScreen?: boolean;
   size?: ModalSize;
-  onClose: () => void;
+  onClose: (e: any) => void;
   open: boolean;
   className?: string;
   rootClassName?: string;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalHeader/CWModalHeader.tsx
@@ -20,6 +20,11 @@ const CWModalHeader: FC<CWModalHeaderProps> = ({
   icon,
   onModalClose,
 }) => {
+  const handleModalClose = (e) => {
+    e.stopPropagation();
+    onModalClose();
+  };
+
   return (
     <div className="CWModalHeader">
       <div className="ModalHeader">
@@ -39,7 +44,7 @@ const CWModalHeader: FC<CWModalHeaderProps> = ({
             </CWText>
           ) : null}
         </div>
-        <X className="close-icon" onClick={onModalClose} size={24} />
+        <X className="close-icon" onClick={handleModalClose} size={24} />
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -77,11 +77,6 @@ export const User = ({
       (r) => r.address === userAddress && r.address_chain === userCommunityId,
     );
 
-  const handleCloseModal = (e) => {
-    e.stopPropagation();
-    setIsModalOpen(false);
-  };
-
   const roleTags = (
     <>
       {shouldShowRole && roleInCommunity && (
@@ -235,7 +230,10 @@ export const User = ({
       <CWModal
         size="small"
         content={
-          <BanUserModal address={userAddress} onModalClose={handleCloseModal} />
+          <BanUserModal
+            address={userAddress}
+            onModalClose={() => setIsModalOpen(false)}
+          />
         }
         onClose={() => setIsModalOpen(false)}
         open={isModalOpen}

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -77,6 +77,11 @@ export const User = ({
       (r) => r.address === userAddress && r.address_chain === userCommunityId,
     );
 
+  const handleCloseModal = (e) => {
+    e.stopPropagation();
+    setIsModalOpen(false);
+  };
+
   const roleTags = (
     <>
       {shouldShowRole && roleInCommunity && (
@@ -230,10 +235,7 @@ export const User = ({
       <CWModal
         size="small"
         content={
-          <BanUserModal
-            address={userAddress}
-            onModalClose={() => setIsModalOpen(false)}
-          />
+          <BanUserModal address={userAddress} onModalClose={handleCloseModal} />
         }
         onClose={() => setIsModalOpen(false)}
         open={isModalOpen}

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -235,7 +235,10 @@ export const User = ({
             onModalClose={() => setIsModalOpen(false)}
           />
         }
-        onClose={() => setIsModalOpen(false)}
+        onClose={(e) => {
+          e.stopPropagation();
+          setIsModalOpen(false);
+        }}
         open={isModalOpen}
       />
     </>

--- a/packages/commonwealth/client/scripts/views/modals/ban_user_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ban_user_modal.tsx
@@ -25,6 +25,11 @@ export const BanUserModal = ({ address, onModalClose }: BanUserModalAttrs) => {
     address: address,
   });
 
+  const handleModalClose = (e) => {
+    e.stopPropagation();
+    onModalClose();
+  };
+
   const onBanConfirmation = async () => {
     // ZAK TODO: Update Banned User Table with userProfile
     if (!address) {
@@ -62,7 +67,7 @@ export const BanUserModal = ({ address, onModalClose }: BanUserModalAttrs) => {
           label="Cancel"
           buttonType="secondary"
           buttonHeight="sm"
-          onClick={onModalClose}
+          onClick={handleModalClose}
         />
         <CWButton
           label="Ban Address"

--- a/packages/commonwealth/client/scripts/views/modals/ban_user_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ban_user_modal.tsx
@@ -30,7 +30,7 @@ export const BanUserModal = ({ address, onModalClose }: BanUserModalAttrs) => {
     onModalClose();
   };
 
-  const onBanConfirmation = async () => {
+  const onBanConfirmation = async (event) => {
     // ZAK TODO: Update Banned User Table with userProfile
     if (!address) {
       notifyError('CW Data error');
@@ -38,14 +38,14 @@ export const BanUserModal = ({ address, onModalClose }: BanUserModalAttrs) => {
     }
 
     try {
+      handleModalClose(event);
       await banUser({
         address,
         chainId: app.activeChainId(),
       });
-      onModalClose();
       notifySuccess('Banned Address');
-    } catch (e) {
-      notifyError(e.response.data.error);
+    } catch (err) {
+      notifyError(err.response.data.error);
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7029 

## Description of Changes
-When a user clicks Cancel or the X button to close the Ban Address modal, it no longer opens a thread

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-stopped the propagation of a click event so that the parent element (the thread) wouldn't be opened. Added `e.stopPropagation();` and refactored an onClick 
## Test Plan
- Go to All Discussions and hover over the author's name on a thread until the popover appears
- click Ban Address button
- In Ban Address modal click Cancel or X
- -notice that you are no longer directed to that thread but instead stay on All Discussions
