### PR TITLE
Fix zindex for explore page auth modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -34,6 +34,7 @@ const UserDashboard = (props: UserDashboardProps) => {
   const { isWindowExtraSmall } = useBrowserWindow({});
   useStickyHeader({
     elementId: 'dashboard-header',
+    zIndex: 500,
     stickyBehaviourEnabled: !!isWindowExtraSmall,
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7027

## Description of Changes
Adds a lower CSS `z-index` value of the `For You` tab section on dashboard page

## "How We Fixed It"
By adding a lower `z-index` for the `For you` section in the dashboard page

## Test Plan
- Visit `/dashboard/for-you` and logout
- Click on sign-in and observe the sign-in modal
- Verify the modal doesn't show UI elements of the For You page within it

## Deployment Plan
N/A

## Other Considerations
N/A