### PR TITLE
Added stake transaction history UI

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.tsx
@@ -85,7 +85,7 @@ import {
 } from '@tanstack/react-table';
 import { getRelativeTimestamp } from 'client/scripts/helpers/dates';
 import clsx from 'clsx';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { Avatar } from '../../../Avatar';
 import { CWIcon } from '../../cw_icons/cw_icon';
 import { ComponentType } from '../../types';
@@ -93,7 +93,7 @@ import './CWTable.scss';
 
 type ColumnDescriptor = {
   key: string;
-  header: string;
+  header: string | (() => ReactNode);
   numeric: boolean;
   sortable: boolean;
   chronological?: boolean;

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.scss
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.scss
@@ -1,4 +1,23 @@
 @import '../../../../../styles/shared';
 
 .Transactions {
+  .Table {
+    .data-container {
+      vertical-align: middle;
+
+      .etherscanLink {
+        cursor: pointer;
+        color: $neutral-500;
+        text-decoration: none;
+
+        &:focus,
+        &:active,
+        &:hover,
+        &:visited {
+          outline: none;
+          text-decoration: none;
+        }
+      }
+    }
+  }
 }

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
@@ -51,8 +51,7 @@ const columnInfo = [
   },
   {
     key: 'etherscanLink',
-    // TODO: add ReactNode type in CWTable allow list
-    header: (<CWIcon iconName="etherscan" iconSize="regular" />) as any,
+    header: () => <CWIcon iconName="etherscan" iconSize="regular" />,
     numeric: false,
     sortable: false,
   },

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
@@ -1,8 +1,94 @@
 import React from 'react';
+import CommunityInfo from '../common/CommunityInfo';
+import { transactionHistoryData } from '../common/sampleData'; // TODO: get data from API
 import './Transactions.scss';
+import { CWIcon } from '/views/components/component_kit/cw_icons/cw_icon';
+import { CWTable } from '/views/components/component_kit/new_designs/CWTable';
+
+const columnInfo = [
+  {
+    key: 'name',
+    customElementKey: 'community',
+    header: 'Community',
+    numeric: false,
+    sortable: true,
+  },
+  {
+    key: 'address',
+    header: 'Address',
+    numeric: false,
+    sortable: true,
+  },
+  {
+    key: 'action',
+    header: 'Action',
+    numeric: true,
+    sortable: true,
+  },
+  {
+    key: 'stake',
+    header: 'Stake',
+    numeric: true,
+    sortable: true,
+  },
+  {
+    key: 'avgPrice',
+    header: 'Avg. price',
+    numeric: true,
+    sortable: true,
+  },
+  {
+    key: 'totalPrice',
+    header: 'Total price',
+    numeric: true,
+    sortable: true,
+  },
+  {
+    key: 'timestamp',
+    header: 'Timestamp',
+    numeric: true,
+    sortable: true,
+  },
+  {
+    key: 'etherscanLink',
+    // TODO: add ReactNode type in CWTable allow list
+    header: (<CWIcon iconName="etherscan" iconSize="regular" />) as any,
+    numeric: false,
+    sortable: false,
+  },
+];
 
 const Transactions = () => {
-  return <section className="Transactions">Transactions</section>;
+  return (
+    <section className="Transactions">
+      <CWTable
+        columnInfo={columnInfo}
+        rowData={transactionHistoryData.map((tx) => ({
+          ...tx,
+          community: (
+            <CommunityInfo
+              symbol={tx.community.symbol}
+              iconUrl={tx.community.iconUrl}
+              name={tx.community.name}
+              communityId={tx.community.id}
+            />
+          ),
+          etherscanLink: {
+            customElement: (
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href={tx.etherscanLink}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <CWIcon iconName="externalLink" className="etherscanLink" />
+              </a>
+            ),
+          },
+        }))}
+      />
+    </section>
+  );
 };
 
 export { Transactions };

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.scss
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.scss
@@ -1,0 +1,35 @@
+@import '../../../../../../styles/shared';
+
+.CommunityInfo {
+  padding: 0;
+  margin: 0;
+  text-decoration: none;
+  color: initial;
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  cursor: pointer;
+
+  &:focus,
+  &:active,
+  &:hover,
+  &:visited {
+    outline: none;
+    text-decoration: none;
+  }
+
+  .info-container {
+    display: flex;
+    flex-direction: column;
+
+    .symbol {
+      color: $neutral-800 !important;
+    }
+
+    .name {
+      color: $neutral-500 !important;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.tsx
@@ -19,12 +19,7 @@ const CommunityInfo = ({
   communityId = '',
 }: CommunityInfoProps) => {
   return (
-    <Link
-      className="CommunityInfo"
-      target="_blank"
-      rel="noreferrer"
-      to={`/${communityId}`}
-    >
+    <Link className="CommunityInfo" rel="noreferrer" to={`/${communityId}`}>
       <CWCommunityAvatar
         size="medium"
         community={{ iconUrl, name } as ChainInfo}

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/CommunityInfo.tsx
@@ -1,0 +1,44 @@
+import ChainInfo from 'client/scripts/models/ChainInfo';
+import { CWCommunityAvatar } from 'client/scripts/views/components/component_kit/cw_community_avatar';
+import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './CommunityInfo.scss';
+
+type CommunityInfoProps = {
+  name: string;
+  symbol: string;
+  iconUrl: string;
+  communityId: string;
+};
+
+const CommunityInfo = ({
+  name,
+  symbol,
+  iconUrl,
+  communityId = '',
+}: CommunityInfoProps) => {
+  return (
+    <Link
+      className="CommunityInfo"
+      target="_blank"
+      rel="noreferrer"
+      to={`/${communityId}`}
+    >
+      <CWCommunityAvatar
+        size="medium"
+        community={{ iconUrl, name } as ChainInfo}
+      />
+      <div className="info-container">
+        <CWText type="b1" fontWeight="semiBold" className="symbol">
+          {symbol}
+        </CWText>
+        <CWText type="b2" className="name">
+          {name}
+        </CWText>
+      </div>
+    </Link>
+  );
+};
+
+export { CommunityInfo };

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/CommunityInfo/index.ts
@@ -1,0 +1,1 @@
+export { CommunityInfo as default } from './CommunityInfo';

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/sampleData.ts
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/common/sampleData.ts
@@ -1,0 +1,22 @@
+import { buildEtherscanLink } from 'client/scripts/views/modals/ManageCommunityStakeModal/utils';
+
+export const transactionHistoryData = [
+  {
+    community: {
+      id: 'dydx',
+      symbol: 'ABCD',
+      iconUrl:
+        'https://assets.commonwealth.im/eda9d2ee-16b0-4563-a035-5abfef99ace0.jpg',
+      name: 'Comunity name',
+    },
+    address: '0xr407...86RJyz',
+    action: 'Mint',
+    stake: '2',
+    avgPrice: '0.036 ETH',
+    totalPrice: '0.072 ETH',
+    timestamp: '3 weeks ago',
+    etherscanLink: buildEtherscanLink(
+      '0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5',
+    ),
+  },
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6674

## Description of Changes
- Added stake transaction history UI in "my community stake" page

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_MY_COMMUNITY_STAKE_PAGE_ENABLED` in `.env`
- Visit `/myCommunityStake` -> "Transaction History" tab
- Verify you see transaction data filled in.

## Deployment Plan
Enable `FLAG_MY_COMMUNITY_STAKE_PAGE_ENABLED` in after https://github.com/hicommonwealth/commonwealth/issues/6661 is completed

## Other Considerations
N/A