### PR TITLE
Fix archived page for custom domains

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -72,7 +72,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   });
 
   const isOnArchivePage =
-    location.pathname === `/${app.activeChainId()}/archived`;
+    location.pathname ===
+    (app.isCustomDomain() ? `/archived` : `/${app.activeChainId()}/archived`);
 
   const { fetchNextPage, data, isInitialLoading, hasNextPage } =
     useFetchThreadsQuery({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7060

## Description of Changes
- Fixes archived community page for custom domains

## "How We Fixed It"
By checking for custom domain in the archived page display logic.

## Test Plan
- Open the app in a custom domain setup
- Visit `/archived` page
- Verify you see the archived threads

## Deployment Plan
N/A

## Other Considerations
N/A