### PR TITLE
Fix group tags wrap on members page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.scss
@@ -43,6 +43,7 @@
 
   .gating-tags {
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
     align-items: center;
     width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7066

## Description of Changes
Fix group tags wrap on members page

## "How We Fixed It"
N/A

## Test Plan
- Create a group in a community and add multiple topics/tags to that community
- Visit group tabs of the members page and verify that the tags/topics for that group wrap on next line

## Deployment Plan
N/A

## Other Considerations
N/A