### PR TITLE
magic ghost fix

### DIFF
--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -570,7 +570,8 @@ async function magicLoginRoute(
 
   if (
     !existingUserInstance &&
-    magicUserMetadata.oauthProvider === 'email' &&
+    (!magicUserMetadata.oauthProvider ||
+      magicUserMetadata.oauthProvider === 'email') &&
     magicUserMetadata.email
   ) {
     // if unable to locate a magic user by address, attempt to locate by email.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7063

## Description of Changes
- Fixes magic ghost account bug

## "How We Fixed It"
- Update conditional to allow null oauth provider (which is sometimes the case when using magic login)

## Test Plan
```sql

--  Pick a user ID
SELECT id, user_id FROM "Addresses" WHERE ghost_address = true;

--  Confirm only 1 address shows and it's the ghost address
SELECT id, ghost_address FROM "Addresses" WHERE user_id = <USER_ID>;

--  Check user
SELECT * FROM "Users" where id = <USER_ID>;

-- Update user to your email (must be unique, never used)
UPDATE "Users" SET email = 'ryan+test338@common.xyz' WHERE id = <USER_ID>;

-- Login with email

-- Confirm that there are now at least 2 addresses shown, with at least 1 being a non-ghost address
SELECT id, ghost_address FROM "Addresses" WHERE user_id = 49053;
```

## Deployment Plan
N/A

## Other Considerations
N/A