### PR TITLE
Allow profile bio markdown.

### DIFF
--- a/packages/commonwealth/server/routes/updateNewProfile.ts
+++ b/packages/commonwealth/server/routes/updateNewProfile.ts
@@ -45,7 +45,7 @@ const updateNewProfile = async (
     req.body;
 
   let { bio } = req.body;
-  bio = sanitizeQuillText(bio, true);
+  bio = sanitizeQuillText(bio);
 
   if (profile.user_id !== req.user.id) {
     return next(new Error(Errors.NotAuthorized));


### PR DESCRIPTION
## Link to Issue
Closes: #7088

## Description of Changes
- Permits profile bio to be in markdown rather than enforcing Quill formatted text.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Removed `noEncode = true` in sanitizeQuillText for Profile bio updates, which enforced Quill-formatted text.

## Test Plan
- Attempt to edit a profile. It should succeed.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
Targeting hotfix: 1.2.2-3.