### PR TITLE
Filter out ExpressJS client errors

### DIFF
--- a/libs/adapters/src/utils/setupErrorHandlers.ts
+++ b/libs/adapters/src/utils/setupErrorHandlers.ts
@@ -46,14 +46,22 @@ export const setupErrorHandlers = (app: Express) => {
         error: error.message,
       });
     } else {
-      log.error(error.message, error, reqContext);
-      res.status(500);
-      res.json({
-        status: error.status,
-        error:
-          error.message ||
-          'Server error, unknown error thrown. Please try again later.',
-      });
+      if (error?.status < 500) {
+        log.warn(error.message || '', error, reqContext);
+        res.status(error.status);
+        res.json({
+          error,
+        });
+      } else {
+        log.error(error.message, error, reqContext);
+        res.status(500);
+        res.json({
+          status: error.status || 500,
+          error:
+            error.message ||
+            'Server error, unknown error thrown. Please try again later.',
+        });
+      }
     }
   });
 };

--- a/libs/adapters/src/utils/setupErrorHandlers.ts
+++ b/libs/adapters/src/utils/setupErrorHandlers.ts
@@ -47,7 +47,7 @@ export const setupErrorHandlers = (app: Express) => {
       });
     } else {
       if (error?.status < 500) {
-        log.warn(error.message || '', error, reqContext);
+        log.warn(error.message || 'Unknown client error', error, reqContext);
         res.status(error.status);
         res.json({
           error,

--- a/libs/adapters/src/utils/setupErrorHandlers.ts
+++ b/libs/adapters/src/utils/setupErrorHandlers.ts
@@ -50,6 +50,7 @@ export const setupErrorHandlers = (app: Express) => {
         log.warn(error.message || 'Unknown client error', error, reqContext);
         res.status(error.status);
         res.json({
+          status: error.status,
           error,
         });
       } else {

--- a/libs/adapters/src/utils/setupErrorHandlers.ts
+++ b/libs/adapters/src/utils/setupErrorHandlers.ts
@@ -54,7 +54,7 @@ export const setupErrorHandlers = (app: Express) => {
         });
       } else {
         log.error(error.message, error, reqContext);
-        res.status(500);
+        res.status(error.status || 500);
         res.json({
           status: error.status || 500,
           error:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6174 

## Description of Changes
- If an error already has `error.status` defined and it is less than 500 log a warning instead of an error

## Test Plan
- Make a request that causes a 400 error such as URI error:
  `curl --request GET 'http://localhost:8080/u/carnation/%c0%ae/WEB-INF/web.xml'`
  - This should return a 400 error not a 500
- Trigger a 500 error e.g. add `throw new Error('test')` to `status.ts`

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 