### PR TITLE
page now scrolls to editor when Reply is clicked

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -48,6 +48,7 @@ type CommentCardProps = {
   // Spam
   isSpam?: boolean;
   onSpamToggle?: () => any;
+  scrollToElement?: () => any;
   canToggleSpam?: boolean;
   // actual comment
   comment: Comment<any>;
@@ -77,6 +78,7 @@ export const CommentCard = ({
   // spam
   isSpam,
   onSpamToggle,
+  scrollToElement,
   canToggleSpam,
   // actual comment
   comment,
@@ -216,6 +218,7 @@ export const CommentCard = ({
                   onClick={async (e) => {
                     e.preventDefault();
                     e.stopPropagation();
+                    scrollToElement();
                     await onReply();
                   }}
                 />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -5,7 +5,7 @@ import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { CommentsFeaturedFilterTypes } from 'models/types';
 import type { DeltaStatic } from 'quill';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import app from 'state';
 import {
   useDeleteCommentMutation,
@@ -147,6 +147,16 @@ export const CommentTree = ({
     fromDiscordBot,
     isLoggedIn,
   });
+
+  const scrollToRef = useRef(null);
+
+  const scrollToElement = () => {
+    if (scrollToRef.current) {
+      scrollToRef.current.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const handleIsReplying = (isReplying: boolean, id?: number) => {
@@ -444,6 +454,7 @@ export const CommentTree = ({
                   </div>
                 )}
                 <CommentCard
+                  scrollToElement={scrollToElement}
                   disabledActionsTooltipText={disabledActionsTooltipText}
                   isThreadArchived={!!thread.archivedAt}
                   canReply={
@@ -485,6 +496,7 @@ export const CommentTree = ({
                   comment={comment}
                 />
               </div>
+              <div ref={scrollToRef}></div>
               {isReplying && parentCommentId === comment.id && (
                 <CreateComment
                   handleIsReplying={handleIsReplying}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6259 

## Description of Changes
-Added functionality for the page to scroll to the editor when Reply is clicked

## Test Plan
- Go to a thread where you can reply
- click Reply button
- notice screen opens an editor and now scrolls to the editor

https://github.com/hicommonwealth/commonwealth/assets/69872984/376b76f1-a7be-41cc-96db-6e6d48453b80


