### PR TITLE
Added wallet address filtering for stake transactions history

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/MyCommunityStake.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/MyCommunityStake.tsx
@@ -1,5 +1,7 @@
+import { formatAddressShort } from 'helpers';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import React, { useState } from 'react';
+import app from 'state';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWSelectList } from '../../components/component_kit/new_designs/CWSelectList';
@@ -15,20 +17,30 @@ import Transactions from './Transactions';
 import { FilterOptions } from './types';
 
 const TABS = ['My stake', 'Transaction history'] as const;
-
-const FILTERS = {
-  ALL_ADDRESSES: 'All addresses',
-} as const;
+const BASE_ADDRESS_FILTER = {
+  label: 'All addresses',
+  value: '',
+};
 
 const MyCommunityStake = () => {
   const { isLoggedIn } = useUserLoggedIn();
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
-  const [activeFilter, setActiveFilter] = useState<any>(FILTERS.ALL_ADDRESSES);
   const [filterOptions, setFilterOptions] = useState<FilterOptions>({
     searchText: '',
+    selectedAddress: BASE_ADDRESS_FILTER,
   });
 
   if (!isLoggedIn) return <PageNotFound />;
+
+  const ADDRESS_FILTERS = [
+    BASE_ADDRESS_FILTER,
+    ...[...new Set((app?.user?.addresses || []).map((x) => x.address))].map(
+      (address) => ({
+        label: formatAddressShort(address, 5, 6),
+        value: address,
+      }),
+    ),
+  ];
 
   return (
     <section className="MyCommunityStake">
@@ -56,12 +68,14 @@ const MyCommunityStake = () => {
           <CWSelectList
             isSearchable={false}
             isClearable={false}
-            options={Object.values(FILTERS).map((filter) => ({
-              value: filter,
-              label: filter,
-            }))}
-            value={{ label: activeFilter, value: activeFilter }}
-            onChange={(option) => setActiveFilter(option.value)}
+            options={ADDRESS_FILTERS}
+            value={filterOptions.selectedAddress}
+            onChange={(option) =>
+              setFilterOptions((filters) => ({
+                ...filters,
+                selectedAddress: option,
+              }))
+            }
           />
         </div>
       </section>

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Transactions/Transactions.tsx
@@ -69,7 +69,7 @@ const Transactions = ({ filterOptions }: TransactionsProps) => {
   useEffect(() => {
     let tempFilteredData = [...transactionHistoryData];
 
-    // check if community name and symbol contains 'searchText'
+    // filter by community name and symbol
     if (filterOptions.searchText) {
       tempFilteredData = tempFilteredData.filter((tx) =>
         (tx.community.symbol + tx.community.name)
@@ -78,8 +78,17 @@ const Transactions = ({ filterOptions }: TransactionsProps) => {
       );
     }
 
+    // filter by selected address
+    if (filterOptions?.selectedAddress?.value) {
+      tempFilteredData = tempFilteredData.filter(
+        (tx) =>
+          tx.address.toLowerCase() ===
+          filterOptions.selectedAddress.value.toLowerCase(),
+      );
+    }
+
     setFilteredTransactionHistoryData(tempFilteredData);
-  }, [filterOptions.searchText]);
+  }, [filterOptions]);
 
   return (
     <section className="Transactions">

--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/types.ts
@@ -1,3 +1,4 @@
 export type FilterOptions = {
   searchText?: string;
+  selectedAddress?: { label: string; value: string };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6677

## Description of Changes
- Added wallet address filtering for stake transactions history tab
 
## "How We Fixed It"
N/A

## Test Plan
Pre-req: Connect multiple addresses to a single account in any community

- Enable `FLAG_MY_COMMUNITY_STAKE_PAGE_ENABLED` in `.env`
- Visit `/myCommunityStake` -> "Transaction History" tab
- Verify you see multiple addresses in the address filter dropdown and you can select those options (ATM the sample data won't show any filtered results since user wallet addresses and those from the sample data won't match)

## Deployment Plan
N/A

## Other Considerations
N/A