### PR TITLE
Cosmos: include rawLog in UI TX error

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/cosmos/chain.ts
@@ -246,7 +246,7 @@ class CosmosChain implements IChainModule<CosmosToken, CosmosAccount> {
       );
       console.log(result);
       if (cosm.isDeliverTxFailure(result)) {
-        throw new Error('TX execution failed.');
+        throw new Error(`TX execution failed: ${result?.rawLog}`);
       } else if (cosm.isDeliverTxSuccess(result)) {
         const txHash = result.transactionHash;
         const txResult = await this._tmClient.tx({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7151 

## Description of Changes
- Gives user the error message from a failed onchain transaction
<img width="668" alt="Screenshot 2024-03-15 at 11 04 49 AM" src="https://github.com/hicommonwealth/commonwealth/assets/9438198/6a86e9a9-c5cd-485c-8afc-5f8435b5d0cc">

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- added error "rawlog" to "Tx Failed" banner message 


## Test Plan
- CA (click around) tested on local:
  - (requires STARS balance in keplr wallet - as in screenshot above)
  - sign into /stargaze
  - create onchain proposal with insufficient balance of STARS
  - expect to see context of error, as in image above

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
