### PR TITLE
added snapshot link value in breadcrumbs/utils

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
@@ -78,6 +78,7 @@ export const generateBreadcrumbs = (
         //Match the header on the snapshots page
         pathSegments.splice(index + 1, 1);
         pathSegments[index] = 'snapshots';
+        link = 'snapshots';
         break;
       case 'proposal':
         link = 'proposals';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7141 

## Description of Changes
-A user with a custom domain is now able to access snapshot proposals without seeing an error. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- added `link = "snapshots"` to switch case inside `Breadcrumbs/utils.tsx`
## Test Plan
- go to http://localhost:8080/snapshot/1inch.eth and notice that there is no longer a split error. 
