### PR TITLE
Fixes Z-Index for CWModal

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.scss
@@ -2,7 +2,7 @@
 
 .MuiModal-root {
   position: fixed;
-  z-index: 80;
+  z-index: 80000;
   right: 0;
   bottom: 0;
   top: 0;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.scss
@@ -2,7 +2,7 @@
 
 .MuiModal-root {
   position: fixed;
-  z-index: 80000;
+  z-index: 80;
   right: 0;
   bottom: 0;
   top: 0;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModal.tsx
@@ -17,6 +17,7 @@ interface CWModalProps {
   className?: string;
   rootClassName?: string;
   visibleOverflow?: boolean;
+  zIndex?: number;
 }
 
 // Backdrop is needed for modal clickaway events
@@ -41,6 +42,7 @@ const CWModal: FC<CWModalProps> = ({
   rootClassName,
   className,
   visibleOverflow,
+  zIndex,
 }) => (
   <ModalUnstyled
     open={open}
@@ -48,6 +50,7 @@ const CWModal: FC<CWModalProps> = ({
     slots={{ backdrop: Backdrop }}
     disableEnforceFocus
     className={rootClassName}
+    style={{ zIndex: zIndex || null }}
   >
     <div
       className={`${getClasses(

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/CWPopover.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/CWPopover.tsx
@@ -102,7 +102,6 @@ const CWPopover = ({
   return (
     <PopperUnstyled
       id={id}
-      style={{ zIndex: 'unset' }}
       open={open}
       anchorEl={anchorEl}
       disablePortal={disablePortal}

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -249,7 +249,7 @@ export const User = ({
     <div
       className="user-popover-wrapper"
       onMouseEnter={popoverProps.handleInteraction}
-      // onMouseLeave={popoverProps.handleInteraction}
+      onMouseLeave={popoverProps.handleInteraction}
     >
       {userFinal}
       {profile && (

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -229,6 +229,7 @@ export const User = ({
       )}
       <CWModal
         size="small"
+        zIndex={10001}
         content={
           <BanUserModal
             address={userAddress}
@@ -248,7 +249,7 @@ export const User = ({
     <div
       className="user-popover-wrapper"
       onMouseEnter={popoverProps.handleInteraction}
-      onMouseLeave={popoverProps.handleInteraction}
+      // onMouseLeave={popoverProps.handleInteraction}
     >
       {userFinal}
       {profile && (

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.scss
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.scss
@@ -34,7 +34,7 @@
   .community-preview-cards-collection {
     display: flex;
     flex-direction: column;
-    z-index: auto;
+    z-index: 10;
 
     @include mediumSmallInclusive {
       flex-direction: row;

--- a/packages/commonwealth/client/styles/components/user/user.scss
+++ b/packages/commonwealth/client/styles/components/user/user.scss
@@ -72,7 +72,7 @@
   white-space: nowrap;
   align-items: center;
 
-  >a {
+  > a {
     // reset link styles
 
     &,
@@ -171,7 +171,7 @@
 
     a {
       text-decoration: none !important;
-      color: $neutral-800  !important;
+      color: $neutral-800 !important;
     }
 
     a:hover {
@@ -181,7 +181,7 @@
 
   .user-address,
   .user-chain {
-    color: $neutral-500  !important;
+    color: $neutral-500 !important;
   }
 
   .role-tag {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7164 (technically closes #6705 and #7069)

## Description of Changes
- Made the z-index an obnoxiously large number to always be on top

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- In the `CWModal.scss` updated the `z-index: 80` to a much larger `z-index: 80000` to be higher than the popover's z-index of `10000`

## Test Plan
- On homepage, make sure the sign out drop down is visible and does not go behind the sidebar
- Make sure the top right button's popovers are visible
- Be an admin
- Go to all-discussions
- Hover over a name and click ban-address
- Ensure the bottom is _always_ above the popover
