### PR TITLE
Added 'My Community Stake' option in profile dropdown

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -16,6 +16,7 @@ import {
   toggleDarkMode,
 } from 'views/components/component_kit/cw_toggle';
 
+import { OpenFeature } from '@openfeature/web-sdk';
 import UserMenuItem from './UserMenuItem';
 import useCheckAuthenticatedAddresses from './useCheckAuthenticatedAddresses';
 
@@ -111,6 +112,12 @@ const useUserMenuItems = ({
     },
   );
 
+  const client = OpenFeature.getClient();
+  const myCommunityStakePageEnabled = client.getBooleanValue(
+    'myCommunityStakePageEnabled',
+    false,
+  );
+
   return [
     ...(app.user.activeAccounts.length > 0
       ? ([
@@ -144,6 +151,15 @@ const useUserMenuItems = ({
       label: 'Edit profile',
       onClick: () => navigate(`/profile/edit`, {}, null),
     },
+    ...(myCommunityStakePageEnabled
+      ? [
+          {
+            type: 'default',
+            label: 'My community stake',
+            onClick: () => navigate(`/myCommunityStake`, {}, null),
+          },
+        ]
+      : []),
     {
       type: 'default',
       label: 'Notifications',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6668

## Description of Changes
- Added 'My community stake' option in profile dropdown

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_MY_COMMUNITY_STAKE_PAGE_ENABLED` in `.env`
- Open profile dropdown, verify you see the 'My community stake' option
- Click on that option and verify you get redirected to `/myCommunityStake` page
- 
## Deployment Plan
N/A

## Other Considerations
N/A