### PR TITLE
Israel.6660.switch out twitter logos for x

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/linkType.ts
+++ b/packages/commonwealth/client/scripts/helpers/linkType.ts
@@ -3,7 +3,7 @@ const getLinkType = (link: string, defaultValueWhenValidLink = '') => {
     return 'discord';
   if (link.includes('slack.com')) return 'slack';
   if (link.includes('telegram.com')) return 'telegram';
-  if (link.includes('twitter.com')) return 'twitter';
+  if (link.includes('twitter.com')) return 'x (twitter)';
   if (link.includes('github.com')) return 'github';
   if (/^https?:\/\/[^\s/$.?#].[^\s]*$/.test(link))
     return defaultValueWhenValidLink;

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -320,6 +320,7 @@ class ChainInfo {
       discords: [],
       githubs: [],
       telegrams: [],
+      twitters: [],
       elements: [],
       remainingLinks: [],
     };
@@ -335,6 +336,8 @@ class ChainInfo {
           categorizedLinks.telegrams.push(link);
         } else if (link.includes('://matrix.to')) {
           categorizedLinks.elements.push(link);
+        } else if (link.includes('://twitter.com')) {
+          categorizedLinks.twitters.push(link);
         } else {
           categorizedLinks.remainingLinks.push(link);
         }
@@ -348,6 +351,7 @@ export type CategorizedSocialLinks = {
   discords: string[];
   githubs: string[];
   telegrams: string[];
+  twitters: string[];
   elements: string[];
   remainingLinks: string[];
 };

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -155,7 +155,7 @@ const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
               {
                 iconLeft: 'twitterOutline',
                 iconLeftSize: 'regular',
-                label: 'Share on Twitter',
+                label: 'Share on  X (Twitter)',
                 onClick: async () => {
                   if (isThread) {
                     await window.open(

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
@@ -217,6 +217,7 @@ export const iconLookup = {
   twitter: Icons.CWTwitter,
   twitterNew: Icons.CWTwitterNew,
   twitterOutline: withPhosphorIcon(TwitterLogo),
+  twitterX: Icons.CWTwitterX,
   unsubscribe: Icons.CWUnsubscribe,
   upvote: withPhosphorIcon(ArrowFatUp),
   users: withPhosphorIcon(Users),

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
@@ -3216,6 +3216,37 @@ export const CWTwitterNew = (props: IconProps) => {
   );
 };
 
+export const CWTwitterX = (props: IconProps) => {
+  const {
+    className,
+    componentType,
+    disabled,
+    iconButtonTheme,
+    iconSize,
+    selected,
+    ...otherProps
+  } = props;
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={getClasses<IconStyleProps>(
+        { className, disabled, iconButtonTheme, iconSize, selected },
+        componentType,
+      )}
+      {...otherProps}
+    >
+      <path
+        d="M18.8274 2.25H22.1354L14.9084 10.51L23.4104 21.75H16.7534L11.5394 14.933L5.5734 21.75H2.2634L9.9934 12.915L1.8374 2.25H8.6634L13.3764 8.481L18.8274 2.25ZM17.6664 19.77H19.4994L7.6674 4.126H5.7004L17.6664 19.77Z"
+        fill="black"
+      />
+    </svg>
+  );
+};
+
 export const CWUnsubscribe = (props: IconProps) => {
   const {
     className,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_socials.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_socials.tsx
@@ -18,11 +18,11 @@ export const CWSocials = ({ handleInputChange, socials }: SocialsProps) => {
   const [propSocials, setPropSocials] = useState(socials ?? []);
 
   const addInputRow = () => {
-    setPropSocials([...socials, '']);
+    setPropSocials([...propSocials, '']);
   };
 
   const deleteInputRow = (index: number) => {
-    const newSocials = socials.filter((_, i) => i !== index);
+    const newSocials = propSocials.filter((_, i) => i !== index);
     setPropSocials(newSocials);
     handleInputChange(newSocials);
   };
@@ -38,7 +38,7 @@ export const CWSocials = ({ handleInputChange, socials }: SocialsProps) => {
       placeholder = 'https://discord.com/...';
     } else if (social.includes('twitter.com/')) {
       name = 'X (Twitter)';
-      icon = 'twitter';
+      icon = 'twitterX';
       placeholder = 'https://twitter.com/...';
     } else if (social.includes('telegram.org/')) {
       name = 'telegram';
@@ -69,7 +69,7 @@ export const CWSocials = ({ handleInputChange, socials }: SocialsProps) => {
           iconRight={icon}
           placeholder={placeholder}
           onInput={(e) => {
-            const newSocials = [...socials];
+            const newSocials = [...propSocials];
             newSocials[i] = e.target.value;
             setPropSocials(newSocials);
             handleInputChange(newSocials);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_socials.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_socials.tsx
@@ -2,32 +2,32 @@ import React, { useState } from 'react';
 
 import 'components/component_kit/cw_socials.scss';
 
-import { ComponentType } from './types';
+import { CWIconButton } from './cw_icon_button';
+import { CWIcon } from './cw_icons/cw_icon';
+import type { IconName } from './cw_icons/cw_icon_lookup';
 import { CWText } from './cw_text';
 import { CWTextInput } from './cw_text_input';
-import { CWIconButton } from './cw_icon_button';
-import type { IconName } from './cw_icons/cw_icon_lookup';
-import { CWIcon } from './cw_icons/cw_icon';
+import { ComponentType } from './types';
 
 type SocialsProps = {
   socials: string[];
   handleInputChange?: (value: string[]) => void;
 };
 
-export const CWSocials = (props: SocialsProps) => {
-  const [socials, setSocials] = useState(props.socials ?? []);
+export const CWSocials = ({ handleInputChange, socials }: SocialsProps) => {
+  const [propSocials, setPropSocials] = useState(socials ?? []);
 
   const addInputRow = () => {
-    setSocials([...socials, '']);
+    setPropSocials([...socials, '']);
   };
 
   const deleteInputRow = (index: number) => {
     const newSocials = socials.filter((_, i) => i !== index);
-    setSocials(newSocials);
-    props.handleInputChange(newSocials);
+    setPropSocials(newSocials);
+    handleInputChange(newSocials);
   };
 
-  const socialsList = socials?.map((social, i) => {
+  const socialsList = propSocials?.map((social, i) => {
     let name: string;
     let icon: IconName;
     let placeholder: string;
@@ -37,7 +37,7 @@ export const CWSocials = (props: SocialsProps) => {
       icon = 'discord';
       placeholder = 'https://discord.com/...';
     } else if (social.includes('twitter.com/')) {
-      name = 'twitter';
+      name = 'X (Twitter)';
       icon = 'twitter';
       placeholder = 'https://twitter.com/...';
     } else if (social.includes('telegram.org/')) {
@@ -71,8 +71,8 @@ export const CWSocials = (props: SocialsProps) => {
           onInput={(e) => {
             const newSocials = [...socials];
             newSocials[i] = e.target.value;
-            setSocials(newSocials);
-            props.handleInputChange(newSocials);
+            setPropSocials(newSocials);
+            handleInputChange(newSocials);
           }}
         />
         <CWIconButton

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_wallets_list.tsx
@@ -265,7 +265,7 @@ export const CWWalletsList = (props: WalletsListProps) => {
           />
           <CWAuthButton
             type="twitter"
-            label="Twitter"
+            label="X (Twitter)"
             darkMode={darkMode}
             onClick={() =>
               onSocialLogin(

--- a/packages/commonwealth/client/scripts/views/components/share_popover.tsx
+++ b/packages/commonwealth/client/scripts/views/components/share_popover.tsx
@@ -70,7 +70,7 @@ export const SharePopover = ({
         {
           iconLeft: 'twitterOutline',
           iconLeftSize: 'regular',
-          label: 'Share on Twitter',
+          label: 'Share on X (Twitter)',
           onClick: async () => {
             if (!commentId) {
               await window.open(

--- a/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.tsx
@@ -8,7 +8,7 @@ import { CWIcon } from '../component_kit/cw_icons/cw_icon';
 export const ExternalLinksModule = () => {
   if (!app.chain) return;
   const meta = app.chain.meta;
-  const { remainingLinks, discords, elements, telegrams, githubs } =
+  const { remainingLinks, discords, elements, telegrams, githubs, twitters } =
     meta.categorizeSocialLinks();
 
   return (
@@ -34,6 +34,14 @@ export const ExternalLinksModule = () => {
           key={link}
           iconName="telegram"
           className="telegram-link"
+          onClick={() => window.open(link)}
+        />
+      ))}
+      {twitters.map((link) => (
+        <CWIcon
+          key={link}
+          iconName="twitterX"
+          className="twitter-link"
           onClick={() => window.open(link)}
         />
       ))}

--- a/packages/commonwealth/client/scripts/views/components/social_accounts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/social_accounts.tsx
@@ -19,7 +19,7 @@ export const SocialAccounts = (props: SocialAccountsProps) => {
       {email && <SocialAccount link={`mailto:${email}`} iconName="mail" />}
       {socials?.map((social, i) => {
         if (social.includes('twitter')) {
-          return <SocialAccount link={social} iconName="twitter" key={i} />;
+          return <SocialAccount link={social} iconName="twitterX" key={i} />;
         } else if (social.includes('discord')) {
           return <SocialAccount link={social} iconName="discord" key={i} />;
         } else if (social.includes('telegram')) {

--- a/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/SessionRevalidationModal/SessionRevalidationModal.tsx
@@ -125,7 +125,7 @@ const SessionRevalidationModal = ({
           ) : walletSsoSource === WalletSsoSource.Twitter ? (
             <CWAuthButton
               type="twitter"
-              label="Twitter"
+              label="X (Twitter)"
               onClick={() => onSocialLogin(WalletSsoSource.Twitter)}
             />
           ) : connectWithEmail ? (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -250,7 +250,7 @@ const CommunityProfileForm = () => {
             <div className="header">
               <CWText type="h4">Links</CWText>
               <CWText type="b1">
-                Add your Discord, Twitter (X), Telegram, Github, Website, etc.
+                Add your Discord, X (Twitter), Telegram, Github, Website, etc.
               </CWText>
             </div>
             <LinksArray

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -264,7 +264,7 @@ const BasicInformationForm = ({
               </CWText>
             </CWText>
             <CWText type="b1" className="description">
-              Add your Discord, Twitter (X), Telegram, Website, etc.
+              Add your Discord, X (Twitter), Telegram, Website, etc.
             </CWText>
           </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6660 

## Description of Changes
-Updated Twitter icons to X icons and updated button copy. 
-refactored some code 

## Test Plan
- Go to Community Profile page in any community you're an Admin in and add a twitter link to Add social link
- notice the button now reads "X (Twitter)" which matches the copy in our sign in flow
- look at left sidebar at the bottom and confirm that you see an X logo, and that clicking it brings you to the corresponding twitter page in a new tab. 
- go to Edit Profile page and click Add social link
- input a twitter address and notice the X logo at the end of the input
- save those changes
- now go to View Profile and confirm that you now see the X logo on your profile that when clicked brings you to the corresponding twitter page in a new tab.

<img width="430" alt="Screenshot 2024-03-20 at 3 02 50 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/8bfb9e29-2c22-477f-8e31-8082559fe691">
<img width="915" alt="Screenshot 2024-03-20 at 3 02 35 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/4124de2e-845d-493c-9c0f-db55141c0343">
<img width="530" alt="Screenshot 2024-03-20 at 3 01 30 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/5df040af-94f0-4fdc-bd15-4007f0078899">
<img width="838" alt="Screenshot 2024-03-20 at 2 53 23 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/7400861e-d259-4b27-a5cb-1ffd59ba4088">
