### PR TITLE
7032 - Added border to stake selector

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.scss
@@ -102,6 +102,7 @@
               width: 5ch;
               border-color: transparent;
               transition: width 0.2s ease-in-out;
+              border: 1px solid $neutral-200;
 
               &.expanded {
                 width: 8ch;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7032 

## Description of Changes
- Added a border around the number input
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added `border: 1px solid $neutral-200;` to the text input

## Test Plan
- Create a new community with staking
- Open the buy/sell modal
- Observe


[figma](https://www.figma.com/file/omZZrndm6Phbk1rOU4IKhS/Stake-V1-Fast-Follows?type=design&node-id=368-46804&mode=design&t=z4wO2amEH5G8Dm7H-0)