### PR TITLE
This is a PoC of migration to workspaces rather than using 'paths'.  …

### DIFF
--- a/libs/adapters/package.json
+++ b/libs/adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hicommonwealth/adapters",
   "private": "true",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "External adapters",
   "files": [
     "build"

--- a/libs/chains/package.json
+++ b/libs/chains/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hicommonwealth/chains",
   "private": "true",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Chain types",
   "files": [
     "build"

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hicommonwealth/core",
   "private": "true",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Core Abstractions and Shared Utilities",
   "files": [
     "build"

--- a/libs/model/package.json
+++ b/libs/model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hicommonwealth/model",
   "private": "true",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Core Model - Server Side",
   "files": [
     "build"

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -218,7 +218,11 @@
     "web3-utils": "1.8.2",
     "yargs": "^17.7.2",
     "zod": "^3.22.4",
-    "zustand": "^4.3.8"
+    "zustand": "^4.3.8",
+    "@hicommonwealth/core": "0.0.0",
+    "@hicommonwealth/chains": "0.0.0",
+    "@hicommonwealth/adapters": "0.0.0",
+    "@hicommonwealth/model": "0.0.0"
   },
   "devDependencies": {}
 }

--- a/packages/commonwealth/tsconfig.json
+++ b/packages/commonwealth/tsconfig.json
@@ -8,7 +8,6 @@
     "outDir": "build",
     "baseUrl": ".",
     "paths": {
-      "@hicommonwealth/*": ["../../libs/*/src"],
       "*": ["./*", "shared/*", "client/scripts/*"]
     }
   },


### PR DESCRIPTION
…It should also speed up the typescript compiler too as we're using the compiler output of hicommonwealth

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7218

This is just a draft PR and it doesn't CLOSE this issue but it does help mitigate it.  We will have some more things to fix first 

We will have to migrate some more code.

## Description of Changes
- Migrates us to yarn workspaces  

## "How We Fixed It"
We just used the package dependency.

## Test Plan
- I'm still concerned about breaking something in prod because we're still a bit fragile but this DOES move us in the right direction towards being more robust as this will work on all loaders including nodejs.
