### PR TITLE
Fix the eslint diff branch on master.

### DIFF
--- a/packages/commonwealth/.eslintrc-diff.js
+++ b/packages/commonwealth/.eslintrc-diff.js
@@ -12,7 +12,7 @@ const path = require('path');
  * git push origin my_branch
  *
  */
-process.env.ESLINT_PLUGIN_DIFF_COMMIT = 'origin/MASTER_CIRCA_2024_03_21';
+process.env.ESLINT_PLUGIN_DIFF_COMMIT = 'origin/MASTER_CIRCA_2024_03_26';
 
 const ENABLE_ESLINT_DIFF_PLUGIN =
   process.env.ENABLE_ESLINT_DIFF_PLUGIN || 'true';


### PR DESCRIPTION
Quick fix for eslint-diff on master. I merged it and I forgot to change the branch name to yesterday and it caught a bug that we committed to master around promises.

This doesn't fix the bug but it does allow master to integrate properly again.  