### PR TITLE
Prevent unknown thread crash on proposal page.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -195,7 +195,7 @@ export const CWContentPage = ({
         threadStage={stageLabel}
         archivedAt={thread?.archivedAt}
         isHot={isHot(thread)}
-        profile={thread.profile}
+        profile={thread?.profile}
       />
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -126,7 +126,7 @@ export const ThreadCard = ({
               })}
               discord_meta={thread.discord_meta}
               archivedAt={thread.archivedAt}
-              profile={thread.profile}
+              profile={thread?.profile}
             />
             <div className="content-header-icons">
               {thread.pinned && <CWIcon iconName="pin" />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7236 

## Description of Changes
- Prevents crash on proposal page, per ticket description.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Added null check for `thread` on components that reference `.profile`, as property is optional.

## Test Plan
- Visit http://localhost:8080/dydx/proposal/16-bridging-the-community-and-rewards-treasuries locally and verify crash against master. Verify no longer crashes on this branch.
