### PR TITLE
Use base64 for Terra Station signing at sign-in.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/terra_station_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/terra_station_web_wallet.ts
@@ -90,7 +90,9 @@ class TerraStationWebWalletController implements IWebWallet<TerraAddress> {
 
     try {
       const signBytesResult = await window.station.signBytes(
-        Buffer.from(canvas.serializeSessionPayload(canvasSessionPayload)),
+        Buffer.from(
+          canvas.serializeSessionPayload(canvasSessionPayload),
+        ).toString('base64'),
       );
 
       result = signBytesResult;


### PR DESCRIPTION
## Link to Issue
Closes: #7244 

## Description of Changes
- Encodes string as base64 to fix broken Terra signing. Try signing in on /terra community.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
Targeting 1.2.3.