### PR TITLE
NewCommunityCard now redirects to createCommunity instead of typeform

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/CommunityCard/NewCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CommunityCard/NewCommunityCard.tsx
@@ -1,9 +1,11 @@
+import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import { CWCard } from '../component_kit/cw_card';
 import { CWText } from '../component_kit/cw_text';
 import './NewCommunityCard.scss';
 
 export const NewCommunityCard = () => {
+  const navigate = useCommonNavigate();
   return (
     <CWCard
       elevation="elevation-2"
@@ -11,7 +13,7 @@ export const NewCommunityCard = () => {
       className="new-community-card"
       onClick={(e) => {
         e.preventDefault();
-        document.location = 'https://hicommonwealth.typeform.com/to/cRP27Rp5';
+        navigate('/createCommunity', {}, null);
       }}
     >
       <div className="new-community-card-body">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7253 

## Description of Changes
-clicking on "Create a new community"/NewCommunityCard now redirects to `createCommunity` and not to a typeform

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added a `navigate('/createCommunity')` to the onClick
## Test Plan
-Go to Explore Communities
-find the NewCommunityCard inside the list, clicking Solana usually works to find it easily
-click that card
-notice the page is now directed to `createCommunity`
