### PR TITLE
Fixed cursor bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -103,11 +103,22 @@ export const useMarkdownToolbarHandlers = ({
         return;
       }
       const text = editor.getText(selection.index, selection.length);
+      const betweenCharacters = editor.getText(
+        selection.index,
+        selection.length / 2,
+      );
+
       editor.deleteText(selection.index, selection.length);
       editor.insertText(
         selection.index,
         `${markdownChars}${text.trim()}${markdownChars}`,
       );
+
+      editor.setSelection(
+        selection.index + markdownChars.length,
+        selection.length,
+      );
+
       setContentDelta({
         ...editor.getContents(),
         ___isMarkdown: true,

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/toolbar.tsx
@@ -103,10 +103,6 @@ export const useMarkdownToolbarHandlers = ({
         return;
       }
       const text = editor.getText(selection.index, selection.length);
-      const betweenCharacters = editor.getText(
-        selection.index,
-        selection.length / 2,
-      );
 
       editor.deleteText(selection.index, selection.length);
       editor.insertText(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #6614 #6598 

## Description of Changes
- Added a selection to split the selected markdown character

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added a `setSelection` to reset cursor position

## Test Plan
- Create a thread or comment
- Press any of the block or markdown characters in the toolbar
- Ensure cursor is correctly position in between the characters