### PR TITLE
Fix profile bio quill bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.tsx
@@ -130,7 +130,7 @@ export const deserializeDelta = (str: string): DeltaStatic => {
   try {
     if (typeof str !== 'string') {
       // empty richtext delta
-      return createDeltaFromText('', false);
+      return createDeltaFromText('', true);
     }
     // is richtext delta object
     const delta: DeltaStatic = JSON.parse(str);

--- a/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
+++ b/packages/commonwealth/test/unit/react_quill_editor/utils.spec.ts
@@ -111,11 +111,11 @@ describe('react quill editor unit tests', () => {
     });
 
     it('should deserialize a string (richtext) to DeltaStatic - bad input case', () => {
-      // bad input should return an empty richtext delta
+      // bad input should return an empty richtext delta with markdown true
       const original = null;
       const expectedOutput = {
         ops: [{ insert: '' }],
-        ___isMarkdown: false,
+        ___isMarkdown: true,
       } as SerializableDeltaStatic;
       const result = deserializeDelta(original);
       assert.deepEqual(result, expectedOutput);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7267

## Description of Changes
- Fixes bug where saving a profile with empty bio would render the quill JSON as raw text

## "How We Fixed It"
- Updated the `deserializeDelta` function to set markdown to `true` by default if the input text is null– this makes the quill editor properly render the delta when the bio is saved as null.

## Test Plan
- Unit test is updated to reflect markdown as the default 
- CA test
  - In local DB, set your profile `profile_name` and `bio` to `NULL`
  - Go to the profile page, edit ONLY the display name, then save– it should redirect to profile view page
  - Go back to the profile edit page– confirm that the text displays properly and not as a quill JSON string

## Deployment Plan
N/A

## Other Considerations
N/A