### PR TITLE
Fix community categories payload in status route

### DIFF
--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -58,7 +58,8 @@ const getCommunityStatus = async (models: DB) => {
   } = {};
   for (const community of communities) {
     if (community.category !== null) {
-      [community.id] = community.category as CommunityCategoryType[];
+      communityCategories[community.id] =
+        community.category as CommunityCategoryType[];
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7225

## Description of Changes
- Fixes typo which made `communityCategories` empty in the /status route

## Test Plan
- CA test
  - Go to http://localhost:8080/communities
  - Click the Defi/DAO tags to filter communities– confirm that items show up for each category

## Deployment Plan
N/A

## Other Considerations
N/A