### PR TITLE
Fixed price history logic

### DIFF
--- a/libs/model/src/community/GetStakeHistoricalPrice.query.ts
+++ b/libs/model/src/community/GetStakeHistoricalPrice.query.ts
@@ -16,11 +16,11 @@ export const GetStakeHistoricalPrice: Query<
         SELECT s.community_id, (s.stake_price / s.stake_amount::REAL)::TEXT as old_price
         FROM "StakeTransactions" s
         INNER JOIN (
-            SELECT community_id, MAX(timestamp) AS latest_timestamp
+            SELECT community_id, MIN(timestamp) AS latest_timestamp
             FROM "StakeTransactions"
             WHERE stake_id = :stake_id
             AND stake_direction = 'buy'
-            AND timestamp <= :past_date_epoch
+            AND timestamp >= :past_date_epoch
             ${community_id ? 'AND community_id = :community_id' : ''}
             GROUP BY community_id
         ) AS latest ON s.community_id = latest.community_id AND s.timestamp = latest.latest_timestamp

--- a/libs/model/src/community/GetStakeHistoricalPrice.query.ts
+++ b/libs/model/src/community/GetStakeHistoricalPrice.query.ts
@@ -16,14 +16,14 @@ export const GetStakeHistoricalPrice: Query<
         SELECT s.community_id, (s.stake_price / s.stake_amount::REAL)::TEXT as old_price
         FROM "StakeTransactions" s
         INNER JOIN (
-            SELECT community_id, MIN(timestamp) AS latest_timestamp
+            SELECT community_id, MIN(timestamp) AS earliest_timestamp
             FROM "StakeTransactions"
             WHERE stake_id = :stake_id
             AND stake_direction = 'buy'
             AND timestamp >= :past_date_epoch
             ${community_id ? 'AND community_id = :community_id' : ''}
             GROUP BY community_id
-        ) AS latest ON s.community_id = latest.community_id AND s.timestamp = latest.latest_timestamp
+        ) AS latest ON s.community_id = latest.community_id AND s.timestamp = latest.earliest_timestamp
       `,
       {
         replacements: { past_date_epoch, community_id, stake_id },

--- a/libs/model/test/community/stake-historical-price.spec.ts
+++ b/libs/model/test/community/stake-historical-price.spec.ts
@@ -95,6 +95,6 @@ describe('Stake Historical Price', () => {
         community_id,
       },
     });
-    expect(results[0].old_price).to.equal('10');
+    expect(results[0].old_price).to.equal('88');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: hotifx

## Description of Changes
- Price history was calculated wrong, it should be the first timestamp within the 24 hour period, but instead it was being calculated as the last timestamp after the 24 hour period.

## Test Plan
- Have only one transaction, make sure it was > 24 hours ago, for example timestamp can be 100. This price should not be taken into account, meaning that the price change for the community should be 0%.
- For example:
```
insert into "StakeTransactions" values ('0x1234567891234567891234567891234567891234567891234567891234567811', 'zaks-community', 2, '', 10, 1000000000000000, 'buy', 100);
```
- Go to /communities
- Check zak's-community, ensure price change is 0%
