### PR TITLE
7315-customDomainCrash

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { useCommonNavigate } from 'navigation/helpers';
+import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import app from 'state';
@@ -13,6 +13,8 @@ export const Breadcrumbs = () => {
   const navigate = useCommonNavigate();
 
   const getThreadId = location.pathname.match(/\/(\d+)-/);
+
+  console.log(app.chain);
 
   const { data: linkedThreads } = useGetThreadsByIdQuery({
     chainId: app.activeChainId(),
@@ -55,6 +57,7 @@ export const Breadcrumbs = () => {
     location.pathname,
     profileId,
     navigate,
+    app.isCustomDomain() ? getScopePrefix() : undefined,
     currentDiscussion,
   );
 

--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
+import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import app from 'state';
@@ -14,13 +14,12 @@ export const Breadcrumbs = () => {
 
   const getThreadId = location.pathname.match(/\/(\d+)-/);
 
-  console.log(app.chain);
-
   const { data: linkedThreads } = useGetThreadsByIdQuery({
     chainId: app.activeChainId(),
     ids: [getThreadId && Number(getThreadId[1])],
     apiCallEnabled:
-      location.pathname.split('/')[1].toLowerCase() === 'discussion', //Only call when in discussion pages prevents unnecessary calls.
+      // Only call when in discussion pages prevents unnecessary calls.
+      location.pathname.split('/')[1].toLowerCase() === 'discussion',
   });
 
   const user = app?.user?.addresses?.[0];
@@ -57,7 +56,7 @@ export const Breadcrumbs = () => {
     location.pathname,
     profileId,
     navigate,
-    app.isCustomDomain() ? getScopePrefix() : undefined,
+    app.isCustomDomain() ? app.activeChainId() : undefined,
     currentDiscussion,
   );
 

--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
@@ -54,7 +54,7 @@ export const generateBreadcrumbs = (
   let isParent: boolean;
 
   if (customDomain) {
-    locationPath = `${customDomain}/${locationPath}`;
+    locationPath = `${customDomain}${locationPath}`;
   }
 
   const pathSegments = locationPath
@@ -73,12 +73,7 @@ export const generateBreadcrumbs = (
         link = `profile/id/${profileId}`;
         break;
       case 'members':
-        if (
-          pathSegments[index] === 'members' &&
-          pathSegments[index + 1] === 'update'
-        ) {
-          link = 'members';
-        }
+        link = 'members';
         break;
       case 'snapshot':
         //Match the header on the snapshots page

--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
@@ -46,11 +46,17 @@ export const generateBreadcrumbs = (
   locationPath: string,
   profileId: number,
   navigate: (val: To) => void,
+  customDomain: string,
   currentDiscussion?: currentDiscussion,
 ) => {
   let link: string;
   let label: string;
   let isParent: boolean;
+
+  if (customDomain) {
+    locationPath = `${customDomain}/${locationPath}`;
+  }
+
   const pathSegments = locationPath
     .split('/')
     .filter((segment) => segment.length > 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7315 

## Description of Changes
- Fixes crash on members page on custom domains, by adding in custom domains to recreate the location string as if we were not on a custom domain.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Custom domain logic added to breadcrumbs. Also: #7020 added a missing case to a switch statement on the members page, which caused a crash when visited.

## Test Plan
- Ensure members page loads on custom domains.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Hotfix for v1.2.4.