### PR TITLE
Fix query in stakeholder script

### DIFF
--- a/packages/scripts/src/generate-stakeholder-groups/index.ts
+++ b/packages/scripts/src/generate-stakeholder-groups/index.ts
@@ -3,7 +3,7 @@ import { Community, models } from '@hicommonwealth/model';
 import { Op } from 'sequelize';
 
 async function main() {
-  const stakedCommunitiesWithGroups = await models.Community.findAll({
+  const stakedCommunities = await models.Community.findAll({
     where: {
       ...(process.env.COMMUNITY_ID && { id: process.env.COMMUNITY_ID }),
       namespace: {
@@ -11,11 +11,6 @@ async function main() {
       },
     },
     include: [
-      {
-        model: models.Group,
-        as: 'groups',
-        required: true,
-      },
       {
         model: models.CommunityStake,
         as: 'CommunityStakes',
@@ -25,7 +20,7 @@ async function main() {
   });
 
   // generate stakeholder group for each staked community
-  for (const c of stakedCommunitiesWithGroups) {
+  for (const c of stakedCommunities) {
     if ((c.CommunityStakes || []).length > 0) {
       const { groups, created } = await command(
         Community.GenerateStakeholderGroups(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7336

## Description of Changes
- Removed constraint in stakeholder groups query that caused the script to only affect communities that had groups. Now the script affects all staked communities regardless of if they already have groups or not.

## "How We Fixed It"
- Remove include requirement for groups

## Test Plan
- Go to a staked community without any groups
- Run `yarn generate-stakeholder-groups`
- Confirm that the community now has 1 stakeholder group

## Deployment Plan
Run `yarn generate-stakeholder-group` in QA/prod

## Other Considerations
Will create FF to change script into migration