### PR TITLE
Show Archived Posts

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -103,7 +103,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     if (!isOnArchivePage && !includeArchivedThreads && t.archivedAt)
       return null;
 
-    if (isOnArchivePage && t.archivedAt) return null;
+    if (isOnArchivePage && !t.archivedAt) return null;
 
     return t;
   });


### PR DESCRIPTION
One character fix to show archived posts.

## Link to Issue
Closes: #7344 

## "How We Fixed It"
Filter had a missing ! on `t.archivedAt` ->   

Now: it's if (isOnArchivePage && !t.archivedAt) return null;

## Test Plan
- See archived posts work on sushi community

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 