### PR TITLE
Modified community stake db schema

### DIFF
--- a/libs/model/src/models/community_stake.ts
+++ b/libs/model/src/models/community_stake.ts
@@ -23,15 +23,14 @@ export default (
   const CommunityStake = <CommunityStakeModelStatic>sequelize.define(
     'CommunityStakes',
     {
+      id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
       community_id: {
         type: dataTypes.STRING,
         allowNull: false,
-        primaryKey: true,
       },
       stake_id: {
         type: dataTypes.INTEGER,
         allowNull: false,
-        primaryKey: true,
       },
       stake_token: { type: dataTypes.STRING, allowNull: false },
       vote_weight: { type: dataTypes.INTEGER, allowNull: false },

--- a/libs/model/src/models/stake_transaction.ts
+++ b/libs/model/src/models/stake_transaction.ts
@@ -51,16 +51,5 @@ export default (
     },
   );
 
-  StakeTransaction.associate = (models) => {
-    models.StakeTransaction.belongsTo(models.CommunityStake, {
-      foreignKey: 'community_id',
-      targetKey: 'community_id',
-    });
-    models.StakeTransaction.belongsTo(models.CommunityStake, {
-      foreignKey: 'stake_id',
-      targetKey: 'stake_id',
-    });
-  };
-
   return StakeTransaction;
 };

--- a/packages/commonwealth/server/migrations/20240403150608-community-stake-surrogate-pk.js
+++ b/packages/commonwealth/server/migrations/20240403150608-community-stake-surrogate-pk.js
@@ -1,0 +1,64 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeConstraint(
+        'StakeTransactions',
+        'fk_stake_transactions_community_stakes',
+        { transaction: t },
+      );
+
+      await queryInterface.removeConstraint(
+        'CommunityStakes',
+        'CommunityStakes_pkey',
+        { transaction: t },
+      );
+
+      await queryInterface.removeConstraint(
+        'CommunityStakes',
+        'CommunityStakes_community_id_fkey',
+        { transaction: t },
+      );
+
+      await queryInterface.addColumn(
+        'CommunityStakes',
+        'id',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          autoIncrement: true,
+          primaryKey: true,
+        },
+        { transaction: t },
+      );
+
+      await queryInterface.addIndex('CommunityStakes', ['community_id'], {
+        transaction: t,
+      });
+      await queryInterface.addIndex('CommunityStakes', ['stake_id'], {
+        transaction: t,
+      });
+
+      await queryInterface.addConstraint('CommunityStakes', {
+        fields: ['community_id'],
+        type: 'foreign key',
+        name: 'CommunityStake_community_id_fkey',
+        references: {
+          table: 'Communities',
+          field: 'id',
+        },
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
## Link to Issue
Closes: #7347

## Description of Changes
- Adds an auto incrementing surrogate id for CommunityStakes and removes the composite primary key

Before migration:
<img width="1144" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/ec61e334-4299-4670-aee2-be46e5d88236">

After:
<img width="1048" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/11984da0-4790-40da-9977-7ccc85539e6e">


Note that the StakeTransaction table also loses its Foreign key constraint on CommunityStakes. This is to avoid the composite foreign key which Sequelize does not support and the root cause of the CI failure.

## Test Plan
- CI passes