### PR TITLE
Improved getBulkThreads query

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -50,14 +50,6 @@ interface FetchActiveThreadsProps extends CommonProps {
   topicsPerThread?: number;
 }
 
-export const featuredFilterQueryMap = {
-  newest: 'createdAt:desc',
-  oldest: 'createdAt:asc',
-  mostLikes: 'numberOfLikes:desc',
-  mostComments: 'numberOfComments:desc',
-  latestActivity: 'latestActivity:desc',
-};
-
 const useDateCursor = ({
   dateRange,
 }: {
@@ -145,9 +137,7 @@ const fetchBulkThreads = (props) => {
           }),
           ...(props.fromDate && { from_date: props.fromDate }),
           to_date: props.toDate,
-          orderBy:
-            featuredFilterQueryMap[props.orderBy] ||
-            featuredFilterQueryMap.newest,
+          orderBy: props.orderBy || 'newest',
           ...(props.isOnArchivePage && { archived: true }),
         },
       },

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -6,7 +6,6 @@ import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { getProposalUrlPath } from 'identifiers';
 import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
 import useFetchThreadsQuery, {
-  featuredFilterQueryMap,
   useDateCursor,
 } from 'state/api/threads/fetchThreads';
 import useEXCEPTION_CASE_threadCountersStore from 'state/ui/thread';
@@ -85,8 +84,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       topicId,
       stage: stageName ?? undefined,
       includePinnedThreads: true,
-      ...(featuredFilterQueryMap[featuredFilter] && {
-        orderBy: featuredFilterQueryMap[featuredFilter],
+      ...(featuredFilter && {
+        orderBy: featuredFilter,
       }),
       toDate: dateCursor.toDate,
       fromDate: dateCursor.fromDate,

--- a/packages/commonwealth/server/migrations/20240404092312-profile-user-id-index.js
+++ b/packages/commonwealth/server/migrations/20240404092312-profile-user-id-index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('Profiles', { fields: ['user_id'] });
+    await queryInterface.addIndex('Reactions', { fields: ['thread_id'] });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Profiles', 'profiles_user_id');
+    await queryInterface.removeIndex('Reactions', 'reactions_thread_id');
+  },
+};


### PR DESCRIPTION
faster then regular bulk threads (excluding speedups from indexing):

old query on master: https://explain.dalibo.com/plan/97d8edade87ad5g0
new query on this PR: https://explain.dalibo.com/plan/45375dh9h26e9c3f

## Link to Issue
Closes: #TODO

## Description of Changes
- Improves GetBulkThreads query
- Adds indexes to the columns that were being sequential scanned before.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 