### PR TITLE
Fix negative vote weight and stake

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Stakes/Stakes.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MyCommunityStake/Stakes/Stakes.tsx
@@ -92,7 +92,7 @@ const Stakes = ({ transactions }: TransactionsProps) => {
             ?.name || '',
         )}`,
       }))
-      .filter((transaction) => transaction.stake);
+      .filter((transaction) => transaction.stake > 0);
   })();
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
The aggregate filter that removed negative transactions wasn't looking for `< 0` values, this pr adds a check for that.

## "How We Fixed It"
N/A

## Test Plan
- Buy some stakes in a community and sell all of them
- Visit `/myCommunityStakes` -> "Stakes" tab, and verify you see no negative transactions

## Deployment Plan
N/A

## Other Considerations
N/A