### PR TITLE
enable merge_group CI..

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ env:
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
... one off

## Description of Changes
- enables running CI on merge groups per: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
