### PR TITLE
Switch appropriate wallet network when buying stake on global explore

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
@@ -12,14 +12,25 @@ class CommunityStakes extends ContractBase {
   namespaceFactoryAddress: string;
   namespaceFactory: NamespaceFactory;
   addressCache = { address: '0x0', name: '' };
+  chainId?: string;
 
-  constructor(contractAddress: string, factoryAddress: string, rpc: string) {
+  constructor(
+    contractAddress: string,
+    factoryAddress: string,
+    rpc: string,
+    chainId?: string,
+  ) {
     super(contractAddress, communityStakesAbi, rpc);
     this.namespaceFactoryAddress = factoryAddress;
+    this.chainId = chainId;
   }
 
   async initialize(withWallet: boolean = false): Promise<void> {
-    await super.initialize(withWallet);
+    if (this.chainId) {
+      await super.initialize(withWallet, this.chainId);
+    } else {
+      await super.initialize(withWallet);
+    }
     this.namespaceFactory = new NamespaceFactory(
       this.namespaceFactoryAddress,
       this.rpc,

--- a/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
@@ -11,6 +11,7 @@ interface BuyStakeProps {
   chainRpc: string;
   walletAddress: string;
   ethChainId: number;
+  chainId?: string;
 }
 
 const buyStake = async ({
@@ -20,12 +21,14 @@ const buyStake = async ({
   chainRpc,
   walletAddress,
   ethChainId,
+  chainId,
 }: BuyStakeProps) => {
   const CommunityStakes = await lazyLoadCommunityStakes();
   const communityStakes = new CommunityStakes(
     commonProtocol.factoryContracts[ethChainId].communityStake,
     commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
+    chainId,
   );
 
   return await communityStakes.buyStake(

--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -131,6 +131,9 @@ const StakeExchangeForm = ({
         chainRpc,
         walletAddress: selectedAddress?.value,
         ethChainId,
+        ...(community.ChainNode.ethChainId && {
+          chainId: `${community.ChainNode.ethChainId}`,
+        }),
       });
 
       await createStakeTransaction.mutateAsync({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7430

## Description of Changes
Now when the user tries to buy the stake from global explore, we switch the user's wallet to the appropriate network based on the base chain of the community card (the community where the user wants to buy stake) on the global explore page.

## "How We Fixed It"
N/A

## Test Plan
- Visit global explore page, and filter stake communities
- Now find a community where you would like to buy stake
- Open your wallet and switch to any network that is different from the community that you are trying to buy stake in -- example: if you want to buy stake in `Ethereum (base)` community, then switch to any other network like Sepolia, Mainnet etc.
- Now click on the `Buy stake` button, try to buy some stake and verify it works.

## Deployment Plan
N/A

## Other Considerations
n/a