### PR TITLE
Refresh 'buy stake' button on user login on global explore

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/communities.tsx
@@ -3,6 +3,7 @@ import {
   ChainNetwork,
   CommunityCategoryType,
 } from '@hicommonwealth/shared';
+import useUserLoggedIn from 'client/scripts/hooks/useUserLoggedIn';
 import { useManageCommunityStakeModalStore } from 'client/scripts/state/ui/modals';
 import numeral from 'numeral';
 import 'pages/communities.scss';
@@ -59,6 +60,7 @@ const getInitialFilterMap = (): Record<string, unknown> => {
 const STAKE_FILTER_KEY = 'Stake';
 
 const CommunitiesPage = () => {
+  useUserLoggedIn();
   const [filterMap, setFilterMap] = React.useState<Record<string, unknown>>(
     getInitialFilterMap(),
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7480

## Description of Changes
Now when user login's on global explore page, we refresh the `Buy Stake` button state on community cards.

## "How We Fixed It"
N/A

## Test Plan
- Visit `/communities`
- Logout
- Filter stake enabled communities
- Notice the `Buy stake` button is disabled
- Login
- Verify the `Buy stake` button is enabled

## Deployment Plan
N/A

## Other Considerations
N/A