### PR TITLE
Fix undefined value when buying stake

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -131,7 +131,7 @@ const StakeExchangeForm = ({
         chainRpc,
         walletAddress: selectedAddress?.value,
         ethChainId,
-        ...(community.ChainNode.ethChainId && {
+        ...(community?.ChainNode?.ethChainId && {
           chainId: `${community.ChainNode.ethChainId}`,
         }),
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7493

## Description of Changes
Fixes undefined object key call when buying stake from community page

## "How We Fixed It"
N/A

## Test Plan
1. Go to https://qa.commonwealth.im/
2. Sign in
3. Create community with stake
4. On side bar click to buy stake
5. Verify you can buy stake

## Deployment Plan
N/A

## Other Considerations
N/A