### PR TITLE
Fix Phantom wallet login for tsx

### DIFF
--- a/packages/commonwealth/server/util/verifySessionSignature.ts
+++ b/packages/commonwealth/server/util/verifySessionSignature.ts
@@ -293,7 +293,8 @@ const verifySessionSignature = async (
     //
 
     // both in base64 encoding
-    const nacl = await import('tweetnacl');
+    const nacl = (await import('tweetnacl')).default;
+    console.log('nacl', nacl);
     const { signature: sigObj, publicKey } = JSON.parse(signatureString);
 
     isValid = nacl.sign.detached.verify(
@@ -310,7 +311,7 @@ const verifySessionSignature = async (
     try {
       const decodedAddress = bs58.decode(addressModel.address);
       if (decodedAddress.length === 32) {
-        const nacl = await import('tweetnacl');
+        const nacl = (await import('tweetnacl')).default;
         isValid = nacl.sign.detached.verify(
           Buffer.from(sortedStringify(canvasSessionPayload)),
           bs58.decode(signatureString),

--- a/packages/commonwealth/server/util/verifySessionSignature.ts
+++ b/packages/commonwealth/server/util/verifySessionSignature.ts
@@ -294,7 +294,6 @@ const verifySessionSignature = async (
 
     // both in base64 encoding
     const nacl = (await import('tweetnacl')).default;
-    console.log('nacl', nacl);
     const { signature: sigObj, publicKey } = JSON.parse(signatureString);
 
     isValid = nacl.sign.detached.verify(


### PR DESCRIPTION
Fix session signature verification for Solana.

Root cause: `tsx` treats default imports slightly differently. TypeScript doesn't identify this because it's an asynchronous import.

## Link to Issue
Closes: n/a

## Description of Changes
- Use .default for import

## "How We Fixed It"


## Test Plan
- Test by Solana login
- CI, typecheck, lint

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 