### PR TITLE
Fix first login for polkadot wallet

### DIFF
--- a/packages/commonwealth/server/util/verifySessionSignature.ts
+++ b/packages/commonwealth/server/util/verifySessionSignature.ts
@@ -80,6 +80,10 @@ const verifySessionSignature = async (
     //
     // substrate address handling
     //
+
+    // Import @polkadot/keyring twice, since the first import might fail invisibly
+    // because of conflicting package versions, causing signerKeyring.verify to fail.
+    await import('@polkadot/keyring');
     const polkadot = await import('@polkadot/keyring');
     const address = polkadot.decodeAddress(addressModel.address);
     const keyringOptions: KeyringOptions = { type: 'sr25519' };


### PR DESCRIPTION
Polkadot logins may fail on the first try, because polkadot-js tries to check for conflicting versions
and invisibly mis-imports some subpackages, causing signature verification to fail.

Since Polkadot is a lower priority chain/wallet to support, this PR doesn't try to look up the root cause
and instead just imports the polkadot library twice using `await import()`.

To QA, check that the first login fails (but second login succeeds) using polkadot-js on master, and
then check that the first login succeeds on this branch.

## Link to Issue
n/a

## Description of Changes
- Import @polkadot-js/keyring twice, and don't use the first import.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Login with polkadot-js as described above

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 