### PR TITLE
Return proper 404 for invalid API routes

### DIFF
--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -1309,7 +1309,7 @@ function setupRouter(
   app.use(endpoint, router);
 
   app.use(methodNotAllowedMiddleware());
-  app.use('/api/*', function (req, res, next) {
+  app.use('/api/*', function (_req, res) {
     res.status(404);
     return failure(res, 'Not Found');
   });

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -182,6 +182,7 @@ import { getTopicsHandler } from '../routes/topics/get_topics_handler';
 import { updateTopicChannelHandler } from '../routes/topics/update_topic_channel_handler';
 import { updateTopicHandler } from '../routes/topics/update_topic_handler';
 import { updateTopicsOrderHandler } from '../routes/topics/update_topics_order_handler';
+import { failure } from '../types';
 
 export type ServerControllers = {
   threads: ServerThreadsController;
@@ -1308,6 +1309,10 @@ function setupRouter(
   app.use(endpoint, router);
 
   app.use(methodNotAllowedMiddleware());
+  app.use('/api/*', function (req, res, next) {
+    res.status(404);
+    return failure(res, 'Not Found');
+  });
 }
 
 export default setupRouter;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #3852 

## Description of Changes
- Adds a catch-all `/api/*` middleware that returns a 404 error to the API router

## Test Plan
- Start the local API
- Run `curl -X GET --location "http://localhost:8080/api/status2"`
- Should return a proper 404 error
- Now go with your browser go to any non-existent thread page e.g. http://localhost:8080/common/discussion/91239193-hello
  - It should load most of the UI but give a warning that the page is not visible.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 