### PR TITLE
"Choose File" button and text now centered on PWA

### DIFF
--- a/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
@@ -46,8 +46,10 @@
     }
 
     .pseudo-input {
-      max-height: 0;
-      max-width: 0;
+      width: 240px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .attach-btn {
@@ -55,7 +57,6 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-
       padding: 16px;
       color: $neutral-400;
 

--- a/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_cover_image_uploader.scss
@@ -46,7 +46,7 @@
     }
 
     .pseudo-input {
-      width: 240px;
+      width: 220px;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7108 

## Description of Changes
Centered "Choose File" button and default text

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added styling to input tag
## Test Plan
-In the PWA, create a new community
-click through until you get to the section that asks you to drag/generate/upload a file
-notice that the "Choose File" and the default text is now centered

![IMG_4145](https://github.com/hicommonwealth/commonwealth/assets/69872984/2cf8dfdb-9773-4fcf-ac05-84d2ce462151)


