### PR TITLE
User-Onboarding: Welcome Onboard Modal - 1. Personal Information Step

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -215,8 +215,9 @@ const useWallets = (walletProps: IuseWalletProps) => {
       });
       setIsMagicLoading(false);
 
-      if (walletProps.onSuccess)
+      if (walletProps.onSuccess) {
         walletProps.onSuccess(magicAddress, isNewlyCreated);
+      }
 
       if (isWindowMediumSmallInclusive(window.innerWidth)) {
         await walletProps?.onModalClose?.();
@@ -254,8 +255,9 @@ const useWallets = (walletProps: IuseWalletProps) => {
       });
       setIsMagicLoading(false);
 
-      if (walletProps.onSuccess)
+      if (walletProps.onSuccess) {
         walletProps.onSuccess(magicAddress, isNewlyCreated);
+      }
 
       if (isWindowMediumSmallInclusive(window.innerWidth)) {
         await walletProps?.onModalClose?.();
@@ -282,6 +284,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
   const onLogInWithAccount = async (
     account: Account,
     exitOnComplete: boolean,
+    newelyCreated = false,
     shouldRedrawApp = true,
   ) => {
     const profile = account.profile;
@@ -312,8 +315,9 @@ const useWallets = (walletProps: IuseWalletProps) => {
 
     if (exitOnComplete) {
       await walletProps?.onModalClose?.();
-      if (walletProps.onSuccess)
-        walletProps.onSuccess(account.address, isNewlyCreated);
+      if (walletProps.onSuccess) {
+        walletProps.onSuccess(account.address, newelyCreated);
+      }
     }
   };
 
@@ -325,7 +329,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
     currentWallet?: IWebWallet<any>,
   ) => {
     if (walletProps.useSessionKeyLoginFlow) {
-      walletProps.onSuccess?.(account.address, isNewlyCreated);
+      walletProps.onSuccess?.(account.address, newlyCreated);
       return;
     }
 
@@ -344,7 +348,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
         sessionPayload,
         signature,
       );
-      await onLogInWithAccount(account, true);
+      await onLogInWithAccount(account, true, newlyCreated);
       return;
     }
 
@@ -382,7 +386,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
           sessionPayload,
           signature,
         );
-        await onLogInWithAccount(account, true);
+        await onLogInWithAccount(account, true, newlyCreated);
       } catch (e) {
         console.log(e);
       }
@@ -397,7 +401,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
           setCachedTimestamp(timestamp);
           setCachedChainId(chainId);
           setCachedSessionPayload(sessionPayload);
-          walletProps.onSuccess?.(account.address, isNewlyCreated);
+          walletProps.onSuccess?.(account.address, newlyCreated);
           setSidebarType('newOrReturning');
           setActiveStep('selectAccountType');
 
@@ -411,7 +415,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
               sessionPayload,
               account,
             );
-            await onSaveProfileInfo(account);
+            await onSaveProfileInfo(account, newlyCreated);
           }
         } catch (e) {
           console.log(e);
@@ -457,7 +461,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
           cachedWalletSignatureToUse,
         );
       }
-      await onLogInWithAccount(primaryAccountToUse, false, false);
+      await onLogInWithAccount(primaryAccountToUse, false, true, false);
       // Important: when we first create an account and verify it, the user id
       // is initially null from api (reloading the page will update it), to correct
       // it we need to get the id from api
@@ -523,7 +527,10 @@ const useWallets = (walletProps: IuseWalletProps) => {
   };
 
   // Handle saving profile information
-  const onSaveProfileInfo = async (currentPrimaryAccount?: Account) => {
+  const onSaveProfileInfo = async (
+    currentPrimaryAccount?: Account,
+    newelyCreated?: boolean,
+  ) => {
     const primaryAccountToUse = currentPrimaryAccount || primaryAccount;
 
     try {
@@ -537,11 +544,12 @@ const useWallets = (walletProps: IuseWalletProps) => {
         // we should trigger a redraw emit manually
         NewProfilesController.Instance.isFetched.emit('redraw');
       }
-      if (walletProps.onSuccess)
+      if (walletProps.onSuccess) {
         walletProps.onSuccess(
           primaryAccountToUse.profile.address,
-          isNewlyCreated,
+          newelyCreated,
         );
+      }
       app.loginStateEmitter.emit('redraw'); // redraw app state when fully onboarded with new account
       await walletProps?.onModalClose?.();
     } catch (e) {
@@ -663,9 +671,9 @@ const useWallets = (walletProps: IuseWalletProps) => {
         validationBlockInfo,
       );
 
+      setIsNewlyCreated(newlyCreated);
       if (isMobile) {
         setSignerAccount(signingAccount);
-        setIsNewlyCreated(newlyCreated);
         setIsLinkingOnMobile(isLinkingWallet);
         setActiveStep('redirectToSign');
       } else {

--- a/packages/commonwealth/client/scripts/state/ui/modals/index.ts
+++ b/packages/commonwealth/client/scripts/state/ui/modals/index.ts
@@ -1,4 +1,9 @@
 import useManageCommunityStakeModalStore from './manageCommunityStakeModal';
 import useNewTopicModalStore from './newTopicModal';
+import useWelcomeOnboardModal from './welcomeOnboardModal';
 
-export { useManageCommunityStakeModalStore, useNewTopicModalStore };
+export {
+  useManageCommunityStakeModalStore,
+  useNewTopicModalStore,
+  useWelcomeOnboardModal,
+};

--- a/packages/commonwealth/client/scripts/state/ui/modals/welcomeOnboardModal.ts
+++ b/packages/commonwealth/client/scripts/state/ui/modals/welcomeOnboardModal.ts
@@ -1,0 +1,26 @@
+import { createBoundedUseStore } from 'state/ui/utils';
+import { devtools } from 'zustand/middleware';
+import { createStore } from 'zustand/vanilla';
+
+interface WelcomeOnboardModalProps {
+  isWelcomeOnboardModalOpen: boolean;
+  setIsWelcomeOnboardModalOpen: (isOpen: boolean) => any;
+}
+
+export const welcomeOnboardModal = createStore<WelcomeOnboardModalProps>()(
+  devtools((set) => ({
+    isWelcomeOnboardModalOpen: false,
+    setIsWelcomeOnboardModalOpen: (isOpen) => {
+      set((state) => {
+        return {
+          ...state,
+          isWelcomeOnboardModalOpen: isOpen,
+        };
+      });
+    },
+  })),
+);
+
+const useWelcomeOnboardModal = createBoundedUseStore(welcomeOnboardModal);
+
+export default useWelcomeOnboardModal;

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -9,6 +9,8 @@ import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { SublayoutHeader } from 'views/components/SublayoutHeader';
 import { Sidebar } from 'views/components/sidebar';
+import { useFlag } from '../hooks/useFlag';
+import { useWelcomeOnboardModal } from '../state/ui/modals';
 import { Footer } from './Footer';
 import { SublayoutBanners } from './SublayoutBanners';
 import { AdminOnboardingSlider } from './components/AdminOnboardingSlider';
@@ -16,6 +18,7 @@ import { Breadcrumbs } from './components/Breadcrumbs';
 import MobileNavigation from './components/MobileNavigation';
 import { UserSurveyGrowl } from './components/UserSurveyGrowl/UserSurveyGrowl';
 import CollapsableSidebarButton from './components/sidebar/CollapsableSidebarButton';
+import { WelcomeOnboardModal } from './modals/WelcomeOnboardModal';
 
 type SublayoutProps = {
   hideFooter?: boolean;
@@ -34,6 +37,10 @@ const Sublayout = ({
     onResize: () => setResizing(true),
     resizeListenerUpdateDeps: [resizing],
   });
+
+  const { isWelcomeOnboardModalOpen, setIsWelcomeOnboardModalOpen } =
+    useWelcomeOnboardModal();
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
 
   const location = useLocation();
 
@@ -118,6 +125,14 @@ const Sublayout = ({
           </div>
         </div>
         <UserSurveyGrowl />
+        {userOnboardingEnabled && (
+          <WelcomeOnboardModal
+            isOpen={isWelcomeOnboardModalOpen}
+            onClose={() =>
+              setIsWelcomeOnboardModalOpen(!isWelcomeOnboardModalOpen)
+            }
+          />
+        )}
       </div>
       {isWindowExtraSmall && <MobileNavigation />}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_checkbox.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_checkbox.tsx
@@ -5,6 +5,7 @@ import { CWText } from './cw_text';
 import { getClasses } from './helpers';
 
 import clsx from 'clsx';
+import { useFormContext } from 'react-hook-form';
 import type { BaseStyleProps } from './types';
 import { ComponentType } from './types';
 
@@ -15,14 +16,22 @@ type CheckboxStyleProps = {
   indeterminate?: boolean;
 } & BaseStyleProps;
 
+type CheckboxFormValidationProps = {
+  name?: string;
+  hookToForm?: boolean;
+};
+
 type CheckboxProps = {
   groupName?: string;
   onChange?: (e?: any) => void;
   labelClassName?: string;
 } & CheckboxType &
-  CheckboxStyleProps;
+  CheckboxStyleProps &
+  CheckboxFormValidationProps;
 
 export const CWCheckbox = ({
+  name,
+  hookToForm,
   className,
   disabled = false,
   indeterminate = false,
@@ -33,12 +42,22 @@ export const CWCheckbox = ({
   labelClassName,
 }: CheckboxProps) => {
   const params = {
+    name,
     disabled,
     onChange,
     checked,
     type: 'checkbox',
     value,
   };
+
+  const formContext = useFormContext();
+  const formFieldContext = hookToForm
+    ? formContext.register(name)
+    : ({} as any);
+
+  // TODO: this message is not needed now, but when its needed it should be coming from the radio group
+  // const formFieldErrorMessage =
+  //   hookToForm && (formContext?.formState?.errors?.[name]?.message as string);
 
   return (
     <label
@@ -53,7 +72,15 @@ export const CWCheckbox = ({
       )}
     >
       <div className="check">
-        <input className="checkbox-input" {...params} />
+        <input
+          className={clsx('checkbox-input', { disabled })}
+          {...params}
+          {...formFieldContext}
+          onChange={async (e) => {
+            hookToForm && name && (await formFieldContext?.onChange(e));
+            await onChange?.(e);
+          }}
+        />
         <div className="checkbox-control" />
       </div>
       <CWText className={clsx('checkbox-label', labelClassName)}>

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
@@ -1,3 +1,5 @@
+import { useFlag } from 'client/scripts/hooks/useFlag';
+import { useWelcomeOnboardModal } from 'client/scripts/state/ui/modals';
 import React, { useEffect, useState } from 'react';
 import { CWModal } from '../../components/component_kit/new_designs/CWModal';
 import './AuthModal.scss';
@@ -15,6 +17,9 @@ const AuthModal = ({
 }: AuthModalProps) => {
   const [modalType, setModalType] = useState(type);
 
+  const { setIsWelcomeOnboardModalOpen } = useWelcomeOnboardModal();
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
+
   useEffect(() => {
     // reset `modalType` state whenever modal is opened
     isOpen && setModalType(type);
@@ -29,6 +34,16 @@ const AuthModal = ({
     onSignInClick();
   };
 
+  const handleSuccess = (isNewlyCreated) => {
+    if (userOnboardingEnabled && isNewlyCreated) {
+      // using timeout to make the modal transition smooth
+      setTimeout(() => {
+        setIsWelcomeOnboardModalOpen(true);
+      }, 1000);
+    }
+    onSuccess(isNewlyCreated);
+  };
+
   return (
     <CWModal
       key={type}
@@ -40,13 +55,14 @@ const AuthModal = ({
         modalType === 'sign-in' ? (
           <SignInModal
             onClose={onClose}
-            onSuccess={onSuccess}
+            onSuccess={handleSuccess}
             showWalletsFor={showWalletsFor}
             onSignInClick={handleOnSignInClick}
           />
         ) : (
           <CreateAccountModal
             onClose={onClose}
+            onSuccess={handleSuccess}
             onSignInClick={handleOnSignInClick}
           />
         )

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.scss
@@ -1,0 +1,45 @@
+@import '../../../../styles/shared.scss';
+
+.WelcomeOnboardModal {
+  overflow-y: scroll;
+  position: relative;
+
+  .content {
+    .close-btn {
+      position: absolute;
+      right: 0;
+      top: 16px;
+      margin-right: 16px;
+      cursor: pointer;
+
+      &.disabled {
+        cursor: not-allowed !important;
+        pointer-events: painted;
+      }
+    }
+
+    padding: 48px;
+
+    @include extraSmall {
+      padding: 32px;
+    }
+
+    .progress {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 8px;
+      padding-bottom: 18px;
+
+      span {
+        width: 100%;
+        height: 6px;
+        border-radius: 5px;
+        background-color: $neutral-200;
+
+        &.completed {
+          background-color: $primary-600 !important;
+        }
+      }
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import React, { useState } from 'react';
+import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
+import { CWText } from '../../components/component_kit/cw_text';
+import { CWModal } from '../../components/component_kit/new_designs/CWModal';
+import './WelcomeOnboardModal.scss';
+
+type WelcomeOnboardModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
+  const [activeStep] = useState(1);
+
+  return (
+    <CWModal
+      open={isOpen}
+      onClose={onClose}
+      size="medium"
+      className="WelcomeOnboardModal"
+      content={
+        <section className="content">
+          <CWIcon
+            iconName="close"
+            onClick={onClose}
+            className="close-btn"
+            disabled={activeStep === 1}
+          />
+          <CWText type="h2">Welcome to Common!</CWText>
+          <div className="progress">
+            <span className={clsx({ completed: activeStep > 0 })} />
+            <span className={clsx({ completed: activeStep > 1 })} />
+            <span className={clsx({ completed: activeStep > 2 })} />
+          </div>
+        </section>
+      }
+    />
+  );
+};
+
+export { WelcomeOnboardModal };

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -4,6 +4,7 @@ import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWModal } from '../../components/component_kit/new_designs/CWModal';
 import './WelcomeOnboardModal.scss';
+import { PersonalInformationStep } from './steps/PersonalInformationStep';
 
 type WelcomeOnboardModalProps = {
   isOpen: boolean;
@@ -11,19 +12,26 @@ type WelcomeOnboardModalProps = {
 };
 
 const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
-  const [activeStep] = useState(1);
+  const [activeStep, setActiveStep] = useState(1);
+
+  const handleClose = () => {
+    // we require the user's to add their usernames.
+    if (activeStep === 1) return;
+
+    onClose();
+  };
 
   return (
     <CWModal
       open={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       size="medium"
       className="WelcomeOnboardModal"
       content={
         <section className="content">
           <CWIcon
             iconName="close"
-            onClick={onClose}
+            onClick={handleClose}
             className="close-btn"
             disabled={activeStep === 1}
           />
@@ -33,6 +41,9 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
             <span className={clsx({ completed: activeStep > 1 })} />
             <span className={clsx({ completed: activeStep > 2 })} />
           </div>
+          {activeStep === 1 && (
+            <PersonalInformationStep onComplete={() => setActiveStep(2)} />
+          )}
         </section>
       }
     />

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/index.ts
@@ -1,0 +1,1 @@
+export { WelcomeOnboardModal } from './WelcomeOnboardModal';

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.scss
@@ -1,0 +1,57 @@
+@import '../../../../../../styles/shared.scss';
+
+.PersonalInformationStep {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 16px;
+
+  .h4 {
+    color: $neutral-600;
+    .b1 {
+      color: $neutral-500;
+    }
+  }
+
+  .username-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .random-generate-btn {
+      padding: 0;
+      margin: 0;
+      margin-left: auto;
+
+      button {
+        padding-top: 0;
+        padding-bottom: 0;
+      }
+
+      &:focus,
+      &:focus-within {
+        border-color: transparent !important;
+      }
+    }
+  }
+
+  .notification-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+
+  .footer {
+    display: block;
+
+    a,
+    a:visited,
+    a:active,
+    a:hover {
+      color: $primary-600;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
+import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import { z } from 'zod';
+import './PersonalInformationStep.scss';
+import { personalInformationFormValidation } from './validations';
+
+type PersonalInformationStepProps = {
+  onComplete: () => void;
+};
+
+const PersonalInformationStep = ({
+  onComplete,
+}: PersonalInformationStepProps) => {
+  const [emailBoundCheckboxKey, setEmailBoundCheckboxKey] = useState(1);
+
+  const handleSubmit = async () => {
+    onComplete();
+  };
+
+  const handleWatch = (
+    values: z.infer<typeof personalInformationFormValidation>,
+  ) => {
+    // if user enables an email bounded checkbox, we reset the checkbox
+    // when user clears the email field, as email is required for those
+    // bounded checkboxes
+    if (values.email.trim() === '') {
+      setEmailBoundCheckboxKey((key) => key + 1);
+    }
+  };
+
+  return (
+    <CWForm
+      className="PersonalInformationStep"
+      validationSchema={personalInformationFormValidation}
+      initialValues={{
+        enableAccountNotifications: false,
+        enableProductUpdates: false,
+      }}
+      onSubmit={handleSubmit}
+      onWatch={handleWatch}
+    >
+      {({ formState, watch }) => (
+        <>
+          <div className="username-section">
+            <CWTextInput
+              fullWidth
+              placeholder="Enter your user name"
+              label={
+                <CWText type="h4" fontWeight="semiBold">
+                  Enter a username&nbsp;<CWText type="b1">(required)</CWText>
+                </CWText>
+              }
+              name="username"
+              hookToForm
+            />
+            <CWButton
+              label="Generate random username"
+              buttonType="tertiary"
+              buttonHeight="sm"
+              type="button"
+              containerClassName="random-generate-btn"
+            />
+          </div>
+
+          <CWTextInput
+            fullWidth
+            placeholder="Add an email address"
+            label={
+              <CWText type="h4" fontWeight="semiBold">
+                Add an email address&nbsp;<CWText type="b1">(optional)</CWText>
+              </CWText>
+            }
+            name="email"
+            hookToForm
+          />
+
+          <div className="notification-section">
+            <CWCheckbox
+              key={emailBoundCheckboxKey}
+              name="enableAccountNotifications"
+              hookToForm
+              label="Send me notifications about my account"
+              disabled={watch('email')?.trim() === '' || !formState.isDirty}
+            />
+            <CWCheckbox
+              key={emailBoundCheckboxKey + 1}
+              name="enableProductUpdates"
+              hookToForm
+              label="Send me product updates and news"
+              disabled={watch('email')?.trim() === '' || !formState.isDirty}
+            />
+          </div>
+
+          <CWButton
+            label="Next"
+            buttonWidth="full"
+            type="submit"
+            disabled={!formState.isDirty}
+          />
+
+          <CWText isCentered className="footer">
+            We will never share your contact information with third party
+            services.
+            <br />
+            For questions please review our&nbsp;
+            <Link to="/privacy">Privacy Policy</Link>
+          </CWText>
+        </>
+      )}
+    </CWForm>
+  );
+};
+
+export { PersonalInformationStep };

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/index.ts
@@ -1,0 +1,1 @@
+export { PersonalInformationStep } from './PersonalInformationStep';

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/validations.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/validations.ts
@@ -1,0 +1,14 @@
+import { VALIDATION_MESSAGES } from 'client/scripts/helpers/formValidationMessages';
+import z from 'zod';
+
+export const personalInformationFormValidation = z.object({
+  username: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  email: z.union([
+    z.literal(''),
+    z.string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT }).email(),
+  ]),
+  enableAccountNotifications: z.boolean(),
+  enableProductUpdates: z.boolean(),
+});

--- a/packages/commonwealth/client/styles/components/component_kit/cw_checkbox.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_checkbox.scss
@@ -5,6 +5,11 @@
   align-items: center;
   cursor: pointer;
 
+  &.disabled {
+    pointer-events: painted;
+    cursor: not-allowed;
+  }
+
   .check {
     position: relative;
     height: 17px;
@@ -48,6 +53,11 @@
       border-color: #fff;
       content: '';
       z-index: 10000;
+    }
+
+    input[type='checkbox']:disabled + .checkbox-control:after {
+      cursor: not-allowed;
+      background-color: $neutral-50;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6645

## Description of Changes
- Added Welcome Onboard Modal, which is shown after a new user creates an account
- Added Personal Information Step in welcome onboard modal, this step requires the user to provide their username before this modal can be closed
- Added form validation and negative logical checks to the Personal Information Step
- Updated Checkbox to work with CWForm
- Fixed `useWallets` logic where new wallet signups, were not triggering the `isNewlyCreated` flag

## "How We Fixed It"
N/A

## Test Plan

- Enable `FLAG_USER_ONBOARDING_ENABLED` in `.env`.
- Add `type='create-account'` to `<AuthModal/>` instance in `SubLayoutHeader.tsx` or apply this diff
```diff
diff --git a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx
index 4564d26340..c58647b700 100644
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx
@@ -59,6 +59,7 @@ export const SublayoutHeader = ({
         open={isFeedbackModalOpen}
       />
       <AuthModal
+        type='create-account'
         onClose={() => setIsAuthModalOpen(false)}
         isOpen={isAuthModalOpen}
       />

```
open the modal and create a new web3 wallet account, verify you see the `Welcome to Common` modal after a new account is created.
- Verify you see the first step enabled in the welcome onboard modal
- Verify that you can save, username and email in the first step 
- Verify that you can't close the modal until you complete the first step
- Since we `useWallets` logic was changed, verify that you can still create new account by the regular `<AuthModal/>`

## Deployment Plan
N/A

## Other Considerations
N/A