### PR TITLE
Fix page crash when account.address doesn't exist

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -282,7 +282,7 @@ export class Thread implements IUniqueId {
     address_last_active: string;
     associatedReactions?: AssociatedReaction[];
   }) {
-    this.author = Address.address;
+    this.author = Address?.address;
     this.title = getDecodedString(title);
     this.body = getDecodedString(body);
     this.plaintext = plaintext;
@@ -293,7 +293,7 @@ export class Thread implements IUniqueId {
     this.topic = topic?.id ? new Topic({ ...(topic || {}) } as any) : null;
     this.kind = kind;
     this.stage = stage;
-    this.authorCommunity = Address.community_id;
+    this.authorCommunity = Address?.community_id;
     this.pinned = pinned;
     this.url = url;
     this.communityId = community_id;
@@ -334,13 +334,13 @@ export class Thread implements IUniqueId {
       ? moment(last_commented_on)
       : moment(created_at);
 
-    if (Address.User) {
+    if (Address?.User) {
       this.profile = addressToUserProfile(Address);
     } else {
       this.profile = {
         id: profile_id,
         name: profile_name,
-        address: Address.address,
+        address: Address?.address,
         lastActive: address_last_active,
         avatarUrl: avatar_url ?? undefined,
       };

--- a/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
@@ -53,7 +53,8 @@ export const CommentEditor = ({
           >
             <User
               userAddress={author?.address}
-              userCommunityId={author?.community.id}
+              userCommunityId={author?.community?.id}
+              shouldShowAsDeleted={!author?.address && !author?.community?.id}
               shouldHideAvatar
               shouldLinkProfile
             />

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/helpers.tsx
@@ -23,7 +23,8 @@ export const getDisplayedReactorsForPopup = ({
           <CWText noWrap>
             <User
               userAddress={reactorAddress}
-              userCommunityId={app.chain.id}
+              userCommunityId={app?.chain?.id}
+              shouldShowAsDeleted={!reactorAddress && !app?.chain?.id}
               shouldLinkProfile
             />
           </CWText>

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
@@ -36,7 +36,7 @@ export const ViewCommentUpvotesDrawer = ({
       contentBody={comment.text}
       header="Comment upvotes"
       reactorData={reactorData}
-      author={app.chain.accounts.get(comment.author)}
+      author={comment?.author ? app.chain.accounts.get(comment?.author) : null}
       publishDate={comment.createdAt}
     />
   );

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
@@ -36,7 +36,7 @@ export const ViewThreadUpvotesDrawer = ({
       contentBody={thread.body}
       header="Thread upvotes"
       reactorData={reactorData}
-      author={app.chain.accounts.get(thread.author)}
+      author={thread?.author ? app.chain.accounts.get(thread?.author) : null}
       publishDate={thread.createdAt}
     />
   );

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
@@ -106,7 +106,7 @@ export const ViewUpvotesDrawer = ({
     }
   };
 
-  const profile = author['profile']
+  const profile = author?.['profile']
     ? {
         avatarUrl: author['profile'].avatarUrl,
         lastActive: author['profile'].lastActive,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_sidebar_menu.tsx
@@ -115,8 +115,14 @@ export const CWSidebarMenuItem = (props: CWSidebarMenuItemProps) => {
             <User
               avatarSize={18}
               shouldShowAvatarOnly
-              userAddress={roles[0].address}
-              userCommunityId={roles[0].address_chain || roles[0].community_id}
+              userAddress={roles?.[0]?.address}
+              userCommunityId={
+                roles?.[0]?.address_chain || roles?.[0]?.community_id
+              }
+              shouldShowAsDeleted={
+                !roles?.[0]?.address &&
+                !(roles?.[0]?.address_chain || roles?.[0]?.community_id)
+              }
             />
             <div
               className={isStarred ? 'star-filled' : 'star-empty'}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarMemberPreviewRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarMemberPreviewRow.tsx
@@ -31,6 +31,7 @@ export const SearchBarMemberPreviewRow: FC<SearchBarMemberPreviewRowProps> = ({
       <User
         userAddress={address}
         userCommunityId={community_id}
+        shouldShowAsDeleted={!address && !community_id}
         shouldLinkProfile
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarThreadPreviewRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarThreadPreviewRow.tsx
@@ -36,8 +36,11 @@ export const SearchBarThreadPreviewRow: FC<SearchBarThreadPreviewRowProps> = ({
     <div className="SearchBarThreadPreviewRow" onClick={handleClick}>
       <div className="header-row">
         <User
-          userCommunityId={searchResult.community_id}
-          userAddress={searchResult.address}
+          userCommunityId={searchResult?.community_id}
+          userAddress={searchResult?.address}
+          shouldShowAsDeleted={
+            !searchResult?.community_id && !searchResult?.address
+          }
         />
         <CWText className="last-updated-text">•</CWText>
         <CWText type="caption" className="last-updated-text">

--- a/packages/commonwealth/client/scripts/views/components/proposals/aave_proposal_card_detail.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/aave_proposal_card_detail.tsx
@@ -60,9 +60,17 @@ export const AaveProposalCardDetail = (props: AaveProposalCardDetailProps) => {
             </CWText>
           ) : (
             <User
-              userAddress={proposal.author.address}
+              userAddress={proposal?.author?.address}
               userCommunityId={
-                proposal.author.community?.id || proposal.author.profile?.chain
+                proposal?.author?.community?.id ||
+                proposal?.author?.profile?.chain
+              }
+              shouldShowAsDeleted={
+                !proposal?.author?.address &&
+                !(
+                  proposal?.author?.community?.id ||
+                  proposal?.author?.profile?.chain
+                )
               }
               shouldHideAvatar
               shouldLinkProfile

--- a/packages/commonwealth/client/scripts/views/components/proposals/vote_listing.tsx
+++ b/packages/commonwealth/client/scripts/views/components/proposals/vote_listing.tsx
@@ -83,8 +83,11 @@ export const VoteListing = (props: VoteListingProps) => {
   }) => {
     return (
       <User
-        userAddress={voter.address}
-        userCommunityId={voter.community?.id || voter.profile?.chain}
+        userAddress={voter?.address}
+        userCommunityId={voter?.community?.id || voter?.profile?.chain}
+        shouldShowAsDeleted={
+          voter?.address && !(voter?.community?.id || voter?.profile?.chain)
+        }
         shouldLinkProfile
         shouldShowPopover={shouldShowPopover}
       />

--- a/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_collaborators_modal.tsx
@@ -130,8 +130,11 @@ export const EditCollaboratorsModal = ({
                   }
                 >
                   <User
-                    userAddress={c.Address.address}
-                    userCommunityId={c.community_id}
+                    userAddress={c?.Address?.address}
+                    userCommunityId={c?.community_id}
+                    shouldShowAsDeleted={
+                      !c?.Address?.address && !c?.community_id
+                    }
                   />
                 </div>
               ))
@@ -151,8 +154,9 @@ export const EditCollaboratorsModal = ({
               {collaborators.map((c, i) => (
                 <div key={i} className="collaborator-row">
                   <User
-                    userAddress={c.address}
-                    userCommunityId={c.community_id}
+                    userAddress={c?.address}
+                    userCommunityId={c?.community_id}
+                    shouldShowAsDeleted={!c?.address && !c?.community_id}
                   />
                   <CWIconButton
                     iconName="close"

--- a/packages/commonwealth/client/scripts/views/modals/offchain_voting_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/offchain_voting_modal.tsx
@@ -47,8 +47,9 @@ export const OffchainVotingModal = (props: OffchainVotingModalProps) => {
               <User
                 shouldShowPopover
                 shouldLinkProfile
-                userAddress={vote.address}
-                userCommunityId={vote.authorCommunityId}
+                userAddress={vote?.address}
+                userCommunityId={vote?.authorCommunityId}
+                shouldShowAsDeleted={!vote?.address && !vote?.authorCommunityId}
               />
             </div>
             <div className="offchain-poll-voter-choice">{vote.option}</div>

--- a/packages/commonwealth/client/scripts/views/modals/view_template_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/view_template_modal.tsx
@@ -24,7 +24,9 @@ const ViewTemplateModal = ({
   template: Template;
   onClose: () => void;
 }) => {
-  const creator: Account = app.chain.accounts.get(template.createdBy);
+  const creator: Account = template?.createdBy
+    ? app.chain.accounts.get(template?.createdBy)
+    : null;
 
   return (
     <div className="ViewTemplateModal">
@@ -33,8 +35,12 @@ const ViewTemplateModal = ({
         <div className="CreationRow">
           <CWText type="b2">By</CWText>
           <User
-            userAddress={creator.address}
-            userCommunityId={creator.community?.id || creator?.profile?.chain}
+            userAddress={creator?.address}
+            userCommunityId={creator?.community?.id || creator?.profile?.chain}
+            shouldShowAsDeleted={
+              !creator?.address &&
+              !(creator?.community?.id || creator?.profile?.chain)
+            }
             shouldShowAddressWithDisplayName
           />
           <CWText type="b2">•</CWText>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.tsx
@@ -141,8 +141,9 @@ export const ManageRoles = ({
           return (
             <div className="role-row" key={addr.id}>
               <User
-                userAddress={addr.address}
-                userCommunityId={role.community_id}
+                userAddress={addr?.address}
+                userCommunityId={role?.community_id}
+                shouldShowAsDeleted={!addr?.address && !role?.community_id}
                 shouldShowPopover
                 shouldLinkProfile
                 shouldHideAvatar

--- a/packages/commonwealth/client/scripts/views/pages/contracts/contract_template_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/contracts/contract_template_card.tsx
@@ -100,7 +100,9 @@ export const ContractTemplateCard = ({
     });
   };
 
-  const enabler = app.chain.accounts.get(templateInfo.enabledBy);
+  const enabler = templateInfo?.enabledBy
+    ? app.chain.accounts.get(templateInfo?.enabledBy)
+    : null;
   const enabledOn = moment(templateInfo.enabledAt).format('MM/DD/YY');
 
   return (
@@ -141,9 +143,13 @@ export const ContractTemplateCard = ({
                 </CWText>
                 <div className="enabledby-row">
                   <User
-                    userAddress={enabler.address}
+                    userAddress={enabler?.address}
                     userCommunityId={
-                      enabler.community?.id || enabler?.profile?.chain
+                      enabler?.community?.id || enabler?.profile?.chain
+                    }
+                    shouldShowAsDeleted={
+                      !enabler?.address &&
+                      !(enabler?.community?.id || enabler?.profile?.chain)
                     }
                     shouldShowAddressWithDisplayName
                   />

--- a/packages/commonwealth/client/scripts/views/pages/contracts/template_display_tab.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/contracts/template_display_tab.tsx
@@ -90,7 +90,9 @@ export const TemplateDisplayTab = ({
         </div>
         {templates.length > 0 ? (
           templates.map((template, index) => {
-            const creator: Account = app.chain.accounts.get(template.createdBy);
+            const creator: Account = template?.createdBy
+              ? app.chain.accounts.get(template?.createdBy)
+              : null;
             return (
               <div className="table-row" key={index}>
                 <div className="table-column">
@@ -98,9 +100,13 @@ export const TemplateDisplayTab = ({
                 </div>
                 <div className="table-column">
                   <User
-                    userAddress={creator.address}
+                    userAddress={creator?.address}
                     userCommunityId={
-                      creator.community?.id || creator?.profile?.chain
+                      creator?.community?.id || creator?.profile?.chain
+                    }
+                    shouldShowAsDeleted={
+                      !creator?.address &&
+                      !(creator?.community?.id || creator?.profile?.chain)
                     }
                     shouldShowAddressWithDisplayName
                   />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -84,7 +84,9 @@ export const CommentCard = ({
 }: CommentCardProps) => {
   const commentBody = deserializeDelta(editDraft || comment.text);
   const [commentDelta, setCommentDelta] = useState<DeltaStatic>(commentBody);
-  const author = app.chain.accounts.get(comment.author);
+  const author = comment?.author
+    ? app.chain.accounts.get(comment?.author)
+    : null;
 
   const [isCanvasVerifyModalVisible, setIsCanvasVerifyDataModalVisible] =
     useState<boolean>(false);
@@ -129,8 +131,8 @@ export const CommentCard = ({
           <span>[deleted]</span>
         ) : (
           <AuthorAndPublishInfo
-            authorAddress={author.address}
-            authorCommunityId={author.community?.id || author?.profile?.chain}
+            authorAddress={author?.address}
+            authorCommunityId={author?.community?.id || author?.profile?.chain}
             publishDate={comment.createdAt}
             discord_meta={comment.discord_meta}
             popoverPlacement="top"

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -87,6 +87,7 @@ export const AuthorAndPublishInfo = ({
         userCommunityId={authorCommunityId}
         shouldShowPopover
         shouldLinkProfile
+        shouldShowAsDeleted={!authorAddress && !authorCommunityId}
         shouldShowAddressWithDisplayName={
           fromDiscordBot ? false : showUserAddressWithInfo
         }

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/aave_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/aave_proposal_form.tsx
@@ -124,8 +124,12 @@ export const AaveProposalForm = () => {
       <div className="row-with-label">
         <CWLabel label="Proposer (you)" />
         <User
-          userAddress={author.address}
-          userCommunityId={author.community?.id || author.profile?.chain}
+          userAddress={author?.address}
+          userCommunityId={author?.community?.id || author?.profile?.chain}
+          shouldShowAsDeleted={
+            !author?.address &&
+            !(author?.community?.id || author?.profile?.chain)
+          }
           shouldLinkProfile
           shouldShowPopover
           shouldShowAddressWithDisplayName

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/compound_proposal_form.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/compound_proposal_form.tsx
@@ -101,8 +101,12 @@ export const CompoundProposalForm = () => {
       <div className="row-with-label">
         <CWLabel label="Proposer (you)" />
         <User
-          userAddress={author.address}
-          userCommunityId={author.community?.id || author.profile?.chain}
+          userAddress={author?.address}
+          userCommunityId={author?.community?.id || author?.profile?.chain}
+          shouldShowAsDeleted={
+            !author?.address &&
+            !(author?.community?.id || author?.profile?.chain)
+          }
           shouldLinkProfile
           shouldShowPopover
           shouldShowAddressWithDisplayName

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/helper_components.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/helper_components.tsx
@@ -76,8 +76,12 @@ const getTextRows = (
           >
             <User
               shouldHideAvatar
-              userAddress={subscription.Comment.author}
-              userCommunityId={subscription.Comment.communityId}
+              userAddress={subscription?.Comment?.author}
+              userCommunityId={subscription?.Comment?.communityId}
+              shouldShowAsDeleted={
+                !subscription?.Comment?.author &&
+                !subscription?.Comment?.communityId
+              }
             />
             &apos;
           </CWText>

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/index.tsx
@@ -471,15 +471,23 @@ const NotificationSettingsPage = () => {
                           if (sub.Thread?.communityId) {
                             return (
                               <User
-                                userAddress={sub.Thread.author}
-                                userCommunityId={sub.Thread.communityId}
+                                userAddress={sub?.Thread?.author}
+                                userCommunityId={sub?.Thread?.communityId}
+                                shouldShowAsDeleted={
+                                  !sub?.Thread?.author &&
+                                  !sub?.Thread?.communityId
+                                }
                               />
                             );
                           } else if (sub.Comment?.communityId) {
                             return (
                               <User
-                                userAddress={sub.Comment.author}
-                                userCommunityId={sub.Comment.communityId}
+                                userAddress={sub?.Comment?.author}
+                                userCommunityId={sub?.Comment?.communityId}
+                                shouldShowAsDeleted={
+                                  !sub?.Comment?.author &&
+                                  !sub?.Comment?.communityId
+                                }
                               />
                             );
                           } else {

--- a/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/helpers.tsx
@@ -42,6 +42,7 @@ const getNotificationFields = (category, data: IForumNotificationData) => {
     <User
       userAddress={author_address}
       userCommunityId={author_community_id}
+      shouldShowAsDeleted={!author_address && !author_community_id}
       shouldHideAvatar
     />
   );
@@ -148,6 +149,7 @@ export const getBatchNotificationFields = (
     <User
       userAddress={author_address}
       userCommunityId={author_community_id}
+      shouldShowAsDeleted={!author_address && !author_community_id}
       shouldHideAvatar
     />
   );

--- a/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
@@ -79,7 +79,9 @@ export const TopicSummaryRow = ({
             `${thread.identifier}-${slugify(thread.title)}`,
           );
 
-          const user = app.chain.accounts.get(thread.author);
+          const user = thread?.author
+            ? app.chain.accounts.get(thread?.author)
+            : null;
 
           const isStageDefault = isDefaultStage(thread.stage);
           const isTagsRowVisible = thread.stage && !isStageDefault;
@@ -100,9 +102,13 @@ export const TopicSummaryRow = ({
                 <div className="row-top">
                   <div className="user-and-date-row">
                     <User
-                      userAddress={user.address}
+                      userAddress={user?.address}
                       userCommunityId={
-                        user.community?.id || user.profile?.chain
+                        user?.community?.id || user.profile?.chain
+                      }
+                      shouldShowAsDeleted={
+                        !user?.address &&
+                        !(user?.community?.id || user.profile?.chain)
                       }
                       shouldShowAddressWithDisplayName
                       shouldLinkProfile

--- a/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
@@ -63,8 +63,9 @@ const ThreadResultRow = ({
         </CWText>
         <div className="search-results-thread-subtitle">
           <User
-            userAddress={thread.address}
-            userCommunityId={thread.address_chain}
+            userAddress={thread?.address}
+            userCommunityId={thread?.address_chain}
+            shouldShowAsDeleted={!thread?.address && !thread?.address_chain}
           />
           <CWText className="created-at">
             {moment(thread.created_at).fromNow()}
@@ -140,6 +141,9 @@ const ReplyResultRow = ({
           <User
             userAddress={comment.address}
             userCommunityId={comment.address_community_id}
+            shouldShowAsDeleted={
+              !comment?.address && !comment?.address_community_id
+            }
           />
           <CWText className="created-at">
             {moment(comment.created_at).fromNow()}
@@ -240,6 +244,7 @@ const MemberResultRow = ({ addr, setRoute }: MemberResultRowProps) => {
       <User
         userAddress={address}
         userCommunityId={community_id}
+        shouldShowAsDeleted={!address && !community_id}
         shouldShowRole
         shouldLinkProfile
         avatarSize={32}

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
@@ -66,6 +66,7 @@ export const UserDashboardRowTop = (props: UserDashboardRowTopProps) => {
       <User
         userAddress={author_address}
         userCommunityId={author_community_id}
+        shouldShowAsDeleted={!author_address && !author_community_id}
         shouldLinkProfile
         avatarSize={32}
       />

--- a/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/snapshot_information_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/snapshot_information_card.tsx
@@ -75,14 +75,14 @@ export const SnapshotInformationCard = ({
               value={
                 app.chain ? (
                   <User
-                    userAddress={proposal.author}
+                    userAddress={proposal?.author}
                     userCommunityId={app.activeChainId()}
                     shouldHideAvatar
                     shouldLinkProfile
                     shouldShowPopover
                   />
                 ) : (
-                  proposal.author
+                  proposal?.author || 'Deleted'
                 )
               }
             />

--- a/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/snapshot_votes_table.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_snapshot_proposal/snapshot_votes_table.tsx
@@ -60,16 +60,15 @@ export const SnapshotVotesTable = (props: SnapshotVotesTableProps) => {
           <div key={vote.id} className="vote-row">
             {app.chain ? (
               <User
-                userAddress={vote.voter}
+                userAddress={vote?.voter}
                 userCommunityId={app.activeChainId()}
                 shouldLinkProfile
                 shouldShowPopover
               />
             ) : (
-              <CWText className="column-text">{`${vote.voter.slice(
-                0,
-                15,
-              )}...`}</CWText>
+              <CWText className="column-text">
+                {`${vote?.voter?.slice?.(0, 15)}...` || 'Deleted'}
+              </CWText>
             )}
             <CWText className="column-text" noWrap>
               {choices[vote.choice - 1]}

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -410,7 +410,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             )
           }
           isEditing={isEditingBody}
-          author={app.chain.accounts.get(thread.author)}
+          author={
+            thread?.author ? app.chain.accounts.get(thread?.author) : null
+          }
           discord_meta={thread.discord_meta}
           collaborators={thread.collaborators}
           createdAt={thread.createdAt}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7590

## Description of Changes
- Fixes page crashes when `.Account / .Address` instance doesn't exist for a user address

## "How We Fixed It"
Utilizing Null checks and fallback username for user profiles.

## Test Plan
- Join any community (com1) with 2 addresses (as separate accounts)
- [Testing threads] With Address 1, create a thread (t1)
- With Address 2, comment (cmt1) on that thread (t1)
- With Address 1, go to edit profile and remove the address linked to the community (com1).
- With Address 1, visit the thread (t1) - verify you see `Deleted` in place of the Address 1's username and the page doesn't crash
- Now visit every place where this thread (t1) could have been shown (ex: `/dashboard`, `/:scope/overview`, `/:scope/discussion/:thread-topic`, `/:scope/discussion/:thread-link`) and verify you see consistent behaviour -> `'Deleted' in place of the Address 1's username and the page doesn't crash`
- Now with address 1, join that community (com1) again and verify you see the actual username again instead of `Deleted` in every place where the thread (t1) would have been shown and the page again doesn't crash
- [Testing Comments] From address 2, delete the address linked to the community (com1) from the edit profile page
- From address 1, visit every place the comment (cmt1) for thread (t1) would have been shown (ex: `/:scope/discussion/:thread-link` and the upvotes drawer on that page), and verify you see `Deleted` in place of the Address 2's username and the page doesn't crash
- Now from address 2, join the community (com1) again, and visit every place where its comment (cmt1) on thread (t1) would have been shown, and verify that the actual username is displayed instead of `Deleted` and the page doesn't crash



## Deployment Plan
N/A

## Other Considerations
N/A