### PR TITLE
Allow imports without file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,10 @@
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-webpack": "^0.12.1",
+    "eslint-plugin-diff": "^2.0.3",
+    "eslint-plugin-functional": "^6.1.1",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "faker": "^4.1.0",
@@ -161,15 +164,15 @@
     "webpack-deduplication-plugin": "^0.0.8",
     "webpack-dev-middleware": "^5.3.3",
     "webpack-hot-middleware": "^2.25.2",
-    "webpack-merge": "^5.8.0",
-    "eslint-plugin-diff": "^2.0.3",
-    "eslint-plugin-functional": "^6.1.1",
-    "eslint-plugin-promise": "^6.1.1"
+    "webpack-merge": "^5.8.0"
   },
   "optionalDependencies": {
     "esbuild-darwin-64": "^0.15.12"
   },
   "engines": {
     "node": "20.x"
+  },
+  "dependencies": {
+    "extensionless": "^1.9.6"
   }
 }

--- a/packages/commonwealth/Procfile
+++ b/packages/commonwealth/Procfile
@@ -1,5 +1,5 @@
-web: cd packages/commonwealth && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) node --experimental-specifier-resolution=node --enable-source-maps ./build/server.js
-consumer: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/commonwealthConsumer/commonwealthConsumer.js
-evm-ce: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/evmChainEvents/startEvmPolling.js
-message-relayer: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/messageRelayer/messageRelayer.js
+web: cd packages/commonwealth && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) node --import=extensionless/register --enable-source-maps ./build/server.js
+consumer: cd packages/commonwealth && node --import=extensionless/register --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/commonwealthConsumer/commonwealthConsumer.js
+evm-ce: cd packages/commonwealth && node --import=extensionless/register --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/evmChainEvents/startEvmPolling.js
+message-relayer: cd packages/commonwealth && node --import=extensionless/register --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/messageRelayer/messageRelayer.js
 release: cd packages/commonwealth && npx sequelize-cli db:migrate --config server/sequelize.json

--- a/packages/commonwealth/Procfile
+++ b/packages/commonwealth/Procfile
@@ -1,5 +1,5 @@
-web: cd packages/commonwealth && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) node --enable-source-maps ./build/server.js
-consumer: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/commonwealthConsumer/commonwealthConsumer.js
-evm-ce: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/evmChainEvents/startEvmPolling.js
-message-relayer: cd packages/commonwealth && node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/messageRelayer/messageRelayer.js
+web: cd packages/commonwealth && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=$(../../scripts/get-max-old-space-size.sh) node --experimental-specifier-resolution=node --enable-source-maps ./build/server.js
+consumer: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/commonwealthConsumer/commonwealthConsumer.js
+evm-ce: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/evmChainEvents/startEvmPolling.js
+message-relayer: cd packages/commonwealth && node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/messageRelayer/messageRelayer.js
 release: cd packages/commonwealth && npx sequelize-cli db:migrate --config server/sequelize.json

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "add-component-showcase": "tsx ./scripts/add-component-showcase.ts",
-    "archive-outbox": "node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/scripts/archive-outbox.js",
+    "archive-outbox": "node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/scripts/archive-outbox.js",
     "build": "tsc -b ./tsconfig.build.json && tsc-alias -p ./tsconfig.build.json",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
@@ -34,7 +34,7 @@
     "reset-frack-db": "heroku pg:copy commonwealth-beta::HEROKU_POSTGRESQL_MAROON_URL DATABASE_URL --app commonwealth-frack --confirm commonwealth-frack",
     "resize-large-images": "tsx  ./scripts/resizeImages.ts",
     "send-notification-digest-emails": "SEND_EMAILS=true tsx  server.ts",
-    "send-cosmos-notifs": "node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/cosmosGovNotifications/generateCosmosGovNotifications.js",
+    "send-cosmos-notifs": "node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/cosmosGovNotifications/generateCosmosGovNotifications.js",
     "set-super-admin": "chmod u+x scripts/set-super-admin.sh && ./scripts/set-super-admin.sh",
     "start": "tsx watch --max-old-space-size=4096 server.ts",
     "start-evm-ce": "tsx  server/workers/evmChainEvents/startEvmPolling.ts",

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "add-component-showcase": "tsx ./scripts/add-component-showcase.ts",
-    "archive-outbox": "node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/scripts/archive-outbox.js",
+    "archive-outbox": "node --import=extensionless/register --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/scripts/archive-outbox.js",
     "build": "tsc -b ./tsconfig.build.json && tsc-alias -p ./tsconfig.build.json",
     "clean": "rm -rf build",
     "check-types": "tsc --noEmit",
@@ -34,7 +34,7 @@
     "reset-frack-db": "heroku pg:copy commonwealth-beta::HEROKU_POSTGRESQL_MAROON_URL DATABASE_URL --app commonwealth-frack --confirm commonwealth-frack",
     "resize-large-images": "tsx  ./scripts/resizeImages.ts",
     "send-notification-digest-emails": "SEND_EMAILS=true tsx  server.ts",
-    "send-cosmos-notifs": "node --experimental-specifier-resolution=node --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/cosmosGovNotifications/generateCosmosGovNotifications.js",
+    "send-cosmos-notifs": "node --import=extensionless/register --max-old-space-size=$(../../scripts/get-max-old-space-size.sh) build/server/workers/cosmosGovNotifications/generateCosmosGovNotifications.js",
     "set-super-admin": "chmod u+x scripts/set-super-admin.sh && ./scripts/set-super-admin.sh",
     "start": "tsx watch --max-old-space-size=4096 server.ts",
     "start-evm-ce": "tsx  server/workers/evmChainEvents/startEvmPolling.ts",

--- a/packages/discord-bot/Procfile
+++ b/packages/discord-bot/Procfile
@@ -1,2 +1,2 @@
-listener: node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-listener/discordListener.js
-consumer: node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-consumer/discordConsumer.js
+listener: node --experimental-specifier-resolution=node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-listener/discordListener.js
+consumer: node --experimental-specifier-resolution=node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-consumer/discordConsumer.js

--- a/packages/discord-bot/Procfile
+++ b/packages/discord-bot/Procfile
@@ -1,2 +1,2 @@
-listener: node --experimental-specifier-resolution=node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-listener/discordListener.js
-consumer: node --experimental-specifier-resolution=node --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-consumer/discordConsumer.js
+listener: node --import=extensionless/register --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-listener/discordListener.js
+consumer: node --import=extensionless/register --max_old_space_size=$(./scripts/get-max-old-space-size.sh) packages/discord-bot/build/discord-consumer/discordConsumer.js

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -9,8 +9,8 @@
     "dev": "concurrently -n watcher,listener,consumer -c red,green,yellow 'tsc -b -w' 'yarn start' 'yarn start-consumer'",
     "start": "tsx src/discord-listener/discordListener.ts",
     "start-consumer": "tsx src/discord-consumer/discordConsumer.ts",
-    "start-prod-consumer": "node --experimental-specifier-resolution=node build/discord-consumer/discordConsumer.js",
-    "start-prod-listener": "node --experimental-specifier-resolution=node build/discord-listener/discordListener.js",
+    "start-prod-consumer": "node --import=extensionless/register build/discord-consumer/discordConsumer.js",
+    "start-prod-listener": "node --import=extensionless/register build/discord-listener/discordListener.js",
     "switch-staging-app": "chmod u+x scripts/switch-discobot-staging-env.sh && ./scripts/switch-discobot-staging-env.sh",
     "test": "NODE_OPTIONS='--import tsx/esm' NODE_ENV=test mocha './test/**/*.spec.ts'"
   },

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -9,8 +9,8 @@
     "dev": "concurrently -n watcher,listener,consumer -c red,green,yellow 'tsc -b -w' 'yarn start' 'yarn start-consumer'",
     "start": "tsx src/discord-listener/discordListener.ts",
     "start-consumer": "tsx src/discord-consumer/discordConsumer.ts",
-    "start-prod-consumer": "node build/discord-consumer/discordConsumer.js",
-    "start-prod-listener": "node build/discord-listener/discordListener.js",
+    "start-prod-consumer": "node --experimental-specifier-resolution=node build/discord-consumer/discordConsumer.js",
+    "start-prod-listener": "node --experimental-specifier-resolution=node build/discord-listener/discordListener.js",
     "switch-staging-app": "chmod u+x scripts/switch-discobot-staging-env.sh && ./scripts/switch-discobot-staging-env.sh",
     "test": "NODE_OPTIONS='--import tsx/esm' NODE_ENV=test mocha './test/**/*.spec.ts'"
   },

--- a/packages/snapshot-listener/Procfile
+++ b/packages/snapshot-listener/Procfile
@@ -1,1 +1,1 @@
-web: node --max_old_space_size=$(../../scripts/get-max-old-space-size.sh) packages/snapshot-listener/build/index.js
+web: node --experimental-specifier-resolution=node --max_old_space_size=$(../../scripts/get-max-old-space-size.sh) packages/snapshot-listener/build/index.js

--- a/packages/snapshot-listener/Procfile
+++ b/packages/snapshot-listener/Procfile
@@ -1,1 +1,1 @@
-web: node --experimental-specifier-resolution=node --max_old_space_size=$(../../scripts/get-max-old-space-size.sh) packages/snapshot-listener/build/index.js
+web: node --import=extensionless/register --max_old_space_size=$(../../scripts/get-max-old-space-size.sh) packages/snapshot-listener/build/index.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -12401,6 +12401,11 @@ extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+extensionless@^1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/extensionless/-/extensionless-1.9.6.tgz#250178a90bcd188699b81570039ae5a17c7dd3bd"
+  integrity sha512-40F6zThJu1MxaT1A1pJ/2SHlU1BPYYnQNHt0j2ZlPuxxm2ddMcNc1D7uS/LGc4K3VwMEMaZLkCdHWaKk0LnQXA==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"


### PR DESCRIPTION
Closes #7646.

Allows direct invocations using `node` to work under ESM.

ESM requires that imports are written with a `.js ` extension at the end:
```
import fetchNewSnapshotProposal from './utils/fetchSnapshot.js';
// not: import fetchNewSnapshotProposal from './utils/fetchSnapshot';

export * from './utils/index.js';
// not: export * from './utils';
```

We probably don't want to rewrite all imports across the codebase right now. Up through Node v18, a possible workaround was to use --experimental-specifier-resolution=node when invoking `node`, but now that we're on Node v20, this requires an alternative loader to work around.

This PR adds the `extensionless` loader to package.json and uses it everywhere a command or Procfile invokes node directly (instead of through tsx, etc).

## Link to Issue
Issue reported by @timolegros and @ilijabojanovic.

## Test Plan
```
// from packages/commonwealth
yarn archive-outbox
yarn send-cosmos-notifs

// from packages/discord-bot
yarn start-prod-consumer
yarn start-prod-listener

// also run procfile commands in:
packages/commonwealth/Procfile
packages/discord-bot/Procfile
packages/snapshot-listener/Procfile
```

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 