### PR TITLE
Contest - thread filters & contest cancelling 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Select/Select.scss
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.scss
@@ -51,7 +51,6 @@
     color: $neutral-800 !important;
     font-size: 14px !important;
     line-height: 20px;
-    letter-spacing: 1%;
     font-weight: 400;
     margin-top: 3px;
   }
@@ -70,7 +69,6 @@
   padding: 8px 1px !important;
   background-color: $white;
   border-radius: $border-radius-md !important;
-  overflow-y: auto;
   max-height: 336px;
   margin-top: 4px;
   font-size: 14px !important;
@@ -89,5 +87,15 @@
 
   .IconButton.archiveTrayIcon {
     fill: none;
+  }
+
+  .select-header {
+    text-transform: uppercase;
+    color: $neutral-400;
+    padding: 10px 12px;
+
+    &.divider {
+      border-top: 1px solid $neutral-200;
+    }
   }
 }

--- a/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
@@ -1,6 +1,8 @@
 import ClickAwayListener from '@mui/base/ClickAwayListener';
 import type { Placement } from '@popperjs/core/lib';
+import clsx from 'clsx';
 import React from 'react';
+import { CWText } from 'views/components/component_kit/cw_text';
 import CWPopover, {
   usePopover,
 } from 'views/components/component_kit/new_designs/CWPopover';
@@ -19,13 +21,26 @@ export type SelectProps = {
   onSelect?: (
     v:
       | string
-      | { id: string | number; value: any; label: string; iconLeft?: IconName },
+      | {
+          id?: string | number;
+          value?: any;
+          label: string;
+          iconLeft?: IconName;
+          type?: 'header' | 'header-divider' | 'contest';
+        },
   ) => any;
   onOpen?: () => {};
   onClose?: () => {};
   options:
     | string[]
-    | { id: string | number; value: any; label: string; iconLeft?: IconName }[];
+    | {
+        id?: string | number;
+        value?: any;
+        label: string;
+        iconLeft?: IconName;
+        type?: 'header' | 'header-divider' | 'contest';
+      }[]
+    | {}[];
   canEditOption?: boolean;
   onOptionEdit?: (
     v: string | { id: string | number; value: any; label: string },
@@ -90,6 +105,24 @@ export const Select = ({
                 const optionLabel = option.label || option;
                 const current = option.value || option;
 
+                if (
+                  option.type === 'header' ||
+                  option.type === 'header-divider'
+                ) {
+                  return (
+                    <CWText
+                      type="caption"
+                      fontWeight="medium"
+                      className={clsx('select-header', {
+                        divider: option.type === 'header-divider',
+                      })}
+                      key={i}
+                    >
+                      {option.label}
+                    </CWText>
+                  );
+                }
+
                 return (
                   <Option
                     key={i}
@@ -103,19 +136,20 @@ export const Select = ({
                     }}
                     isSelected={selected === current}
                     iconLeft={option && option.iconLeft ? option.iconLeft : ''}
-                    {...(canEditOption && {
-                      iconRight: (
-                        <CWIconButton
-                          iconName="write"
-                          iconSize="small"
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            popoverProps.setAnchorEl(null);
-                            onOptionEdit && (await onOptionEdit(option));
-                          }}
-                        />
-                      ),
-                    })}
+                    {...(canEditOption &&
+                      !option.type && {
+                        iconRight: (
+                          <CWIconButton
+                            iconName="write"
+                            iconSize="small"
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              popoverProps.setAnchorEl(null);
+                              onOptionEdit && (await onOptionEdit(option));
+                            }}
+                          />
+                        ),
+                      })}
                     {...(option.value === 'Archived' && {
                       iconRight: (
                         <CWIconButton iconName="archiveTray" iconSize="small" />

--- a/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Select/Select.tsx
@@ -23,7 +23,7 @@ export type SelectProps = {
       | string
       | {
           id?: string | number;
-          value?: any;
+          value?: string;
           label: string;
           iconLeft?: IconName;
           type?: 'header' | 'header-divider' | 'contest';
@@ -35,7 +35,7 @@ export type SelectProps = {
     | string[]
     | {
         id?: string | number;
-        value?: any;
+        value?: string;
         label: string;
         iconLeft?: IconName;
         type?: 'header' | 'header-divider' | 'contest';
@@ -142,10 +142,10 @@ export const Select = ({
                           <CWIconButton
                             iconName="write"
                             iconSize="small"
-                            onClick={async (e) => {
+                            onClick={(e) => {
                               e.stopPropagation();
                               popoverProps.setAnchorEl(null);
-                              onOptionEdit && (await onOptionEdit(option));
+                              onOptionEdit?.(option);
                             }}
                           />
                         ),

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -235,7 +235,7 @@ export const DiscussionSection = ({
 
   for (const topic of topics) {
     if (topic.featuredInSidebar) {
-      const topicInvolvedInActiveContest = true;
+      const topicInvolvedInActiveContest = false;
 
       const discussionSectionGroup: SectionGroupAttrs = {
         title: topic.name,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -1,15 +1,16 @@
+import moment from 'moment';
 import React from 'react';
 
 import { CWCard } from 'views/components/component_kit/cw_card';
 
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
-import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { SharePopover } from 'views/components/share_popover';
+import { openConfirmation } from 'views/modals/confirmation_modal';
 
 import ContestCountdown from '../ContestCountdown';
 
@@ -42,8 +43,24 @@ const ContestCard = ({
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
   const handleCancelContest = () => {
-    // TODO open warning modal
-    console.log('Cancel contest');
+    openConfirmation({
+      title: 'You are about to end your contest',
+      description:
+        'Are you sure you want to cancel your contest? You cannot restart a contest once it has ended.',
+      buttons: [
+        {
+          label: 'Keep contest',
+          buttonType: 'secondary',
+          buttonHeight: 'sm',
+        },
+        {
+          label: 'Cancel contest',
+          buttonType: 'destructive',
+          buttonHeight: 'sm',
+          onClick: () => console.log('cancel contest'),
+        },
+      ],
+    });
   };
 
   const handleEditContest = () => {
@@ -51,17 +68,11 @@ const ContestCard = ({
   };
 
   const handleLeaderboardClick = () => {
-    // Leaderboard Button takes user to the Thread Listing Page, filtered by Contest + sorted by Upvote.
-    // TODO open threads view with proper filter
-    // navigate('/discussions');
-    console.log('navigate to discussions');
+    navigate(`/discussions?featured=mostLikes&contest=${name}`);
   };
 
   const handleWinnersClick = () => {
-    // Previous Winners button takes user to the Thread Listing Page, filtered by Contest.
-    // TODO open threads view with proper filter
-    // navigate('/discussions');
-    console.log('navigate to discussions');
+    navigate(`/discussions?contest=${name}`);
   };
 
   const handleFundClick = () => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -5,7 +5,7 @@ import useForceRerender from 'hooks/useForceRerender';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useEffect, useRef, useState } from 'react';
-import { matchRoutes } from 'react-router-dom';
+import { matchRoutes, useLocation } from 'react-router-dom';
 import app from 'state';
 import { useFetchTopicsQuery } from 'state/api/topics';
 import useEXCEPTION_CASE_threadCountersStore from 'state/ui/thread';
@@ -31,6 +31,7 @@ import {
 import { QuillRenderer } from 'client/scripts/views/components/react_quill_editor/quill_renderer';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import useCommunityStakeStore from 'state/ui/communityStake';
+import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCommunityContests';
 import './HeaderWithFilters.scss';
 
 type HeaderWithFiltersProps = {
@@ -59,7 +60,9 @@ export const HeaderWithFilters = ({
   isOnArchivePage,
 }: HeaderWithFiltersProps) => {
   const communityStakeEnabled = useFlag('communityStake');
+  const contestsEnabled = useFlag('contest');
   const navigate = useCommonNavigate();
+  const location = useLocation();
   const [topicSelectedToEdit, setTopicSelectedToEdit] = useState<Topic>(null);
   const [isDismissStakeBannerModalOpen, setIsDismissStakeBannerModalOpen] =
     useState(false);
@@ -74,6 +77,7 @@ export const HeaderWithFilters = ({
     useEXCEPTION_CASE_threadCountersStore();
   const { stakeEnabled } = useCommunityStake();
   const { dismissBanner, isBannerVisible } = useCommunityStakeStore();
+  const { isContestAvailable, contestsData } = useCommunityContests();
 
   const onFilterResize = () => {
     if (filterRowRef.current) {
@@ -108,6 +112,10 @@ export const HeaderWithFilters = ({
     communityId: app.activeChainId(),
   });
 
+  const urlParams = Object.fromEntries(
+    new URLSearchParams(window.location.search),
+  );
+
   const featuredTopics = (topics || [])
     .filter((t) => t.featuredInSidebar)
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -118,6 +126,13 @@ export const HeaderWithFilters = ({
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const selectedTopic = (topics || []).find((t) => topic && topic === t.name);
+
+  const contestNameOptions = (contestsData || []).map((contest) => ({
+    label: contest?.name,
+    value: contest?.name,
+    id: contest?.contest_address,
+    type: 'contest',
+  }));
 
   const stages = !customStages
     ? [
@@ -136,6 +151,8 @@ export const HeaderWithFilters = ({
     location,
   );
 
+  const matchesContestFilterRoute = urlParams.contest;
+
   const matchesArchivedRoute = matchRoutes(
     [{ path: '/archived' }, { path: ':scope/archived' }],
     location,
@@ -146,9 +163,6 @@ export const HeaderWithFilters = ({
     filterKey = '',
     filterVal = '',
   }) => {
-    const urlParams = Object.fromEntries(
-      new URLSearchParams(window.location.search),
-    );
     urlParams[filterKey] = filterVal;
 
     if (filterVal === '') {
@@ -162,11 +176,30 @@ export const HeaderWithFilters = ({
             .map((x) => `${x}=${urlParams[x]}`)
             .join('&'),
       );
+    } else if (filterKey === 'contest') {
+      navigate(
+        `/discussions?` +
+          Object.keys(urlParams)
+            .map((param) => {
+              if (param === 'stage') {
+                return false;
+              }
+              return `${param}=${urlParams[param]}`;
+            })
+            .filter(Boolean)
+            .join('&'),
+      );
     } else {
       navigate(
         `/discussions${pickedTopic ? `/${pickedTopic}` : ''}?` +
           Object.keys(urlParams)
-            .map((x) => `${x}=${urlParams[x]}`)
+            .map((param) => {
+              if (pickedTopic && (param === 'contest' || param === 'status')) {
+                return false;
+              }
+              return `${param}=${urlParams[param]}`;
+            })
+            .filter(Boolean)
             .join('&'),
       );
     }
@@ -190,6 +223,8 @@ export const HeaderWithFilters = ({
     communityStakeEnabled &&
     stakeEnabled &&
     isBannerVisible(app.activeChainId());
+
+  const contestFiltersVisible = contestsEnabled && isContestAvailable;
 
   return (
     <div className="HeaderWithFilters">
@@ -302,15 +337,32 @@ export const HeaderWithFilters = ({
               {(topics || []).length > 0 && (
                 <Select
                   selected={
+                    matchesContestFilterRoute ||
                     matchesDiscussionsTopicRoute?.[0]?.params?.topic ||
                     'All Topics'
                   }
-                  onSelect={(item: any) =>
-                    onFilterSelect({
-                      pickedTopic: item === 'All Topics' ? '' : item.value,
-                    })
-                  }
+                  onSelect={(item) => {
+                    if (typeof item === 'string') {
+                      // All topics
+                      onFilterSelect({ pickedTopic: '' });
+                      return;
+                    }
+
+                    if (item.type === 'contest') {
+                      onFilterSelect({
+                        filterKey: 'contest',
+                        filterVal: item.value,
+                        pickedTopic: '',
+                      });
+                      return;
+                    }
+
+                    onFilterSelect({ pickedTopic: item.value });
+                  }}
                   options={[
+                    ...(contestFiltersVisible
+                      ? [{ type: 'header', label: 'Topics' }]
+                      : []),
                     {
                       id: 0,
                       label: 'All Topics',
@@ -321,6 +373,12 @@ export const HeaderWithFilters = ({
                       value: t.name,
                       label: t.name,
                     })),
+                    ...(contestFiltersVisible
+                      ? [
+                          { type: 'header-divider', label: 'Contests' },
+                          ...contestNameOptions,
+                        ]
+                      : []),
                   ]}
                   dropdownPosition={rightFiltersDropdownPosition}
                   canEditOption={app.roles?.isAdminOfEntity({
@@ -335,33 +393,65 @@ export const HeaderWithFilters = ({
                   }
                 />
               )}
-              {stagesEnabled && (
+              {matchesContestFilterRoute ? (
                 <Select
-                  selected={selectedStage || 'All Stages'}
+                  selected={urlParams.status || 'all-statuses'}
                   onSelect={(item: any) =>
                     onFilterSelect({
-                      filterKey: 'stage',
-                      filterVal: item.value === 'All Stages' ? '' : item.value,
+                      filterKey: 'status',
+                      filterVal:
+                        item.value === 'all-statuses' ? '' : item.value,
                     })
                   }
                   options={[
                     {
                       id: 0,
-                      label: 'All Stages',
-                      value: 'All Stages',
+                      label: 'Active',
+                      value: 'active',
                     },
-                    ...stages.map((s) => ({
-                      id: s,
-                      value: s,
-                      label: `${threadStageToLabel(s)} ${
-                        s === ThreadStage.Voting
-                          ? totalThreadsInCommunityForVoting
-                          : ''
-                      }`,
-                    })),
+                    {
+                      id: 1,
+                      label: 'Past winners',
+                      value: 'past-winners',
+                    },
+                    {
+                      id: 2,
+                      label: 'All Statuses',
+                      value: 'all-statuses',
+                    },
                   ]}
                   dropdownPosition={rightFiltersDropdownPosition}
                 />
+              ) : (
+                stagesEnabled && (
+                  <Select
+                    selected={selectedStage || 'All Stages'}
+                    onSelect={(item: any) =>
+                      onFilterSelect({
+                        filterKey: 'stage',
+                        filterVal:
+                          item.value === 'All Stages' ? '' : item.value,
+                      })
+                    }
+                    options={[
+                      {
+                        id: 0,
+                        label: 'All Stages',
+                        value: 'All Stages',
+                      },
+                      ...stages.map((s) => ({
+                        id: s,
+                        value: s,
+                        label: `${threadStageToLabel(s)} ${
+                          s === ThreadStage.Voting
+                            ? totalThreadsInCommunityForVoting
+                            : ''
+                        }`,
+                      })),
+                    ]}
+                    dropdownPosition={rightFiltersDropdownPosition}
+                  />
+                )
               )}
               <Select
                 selected={dateRange || ThreadTimelineFilterTypes.AllTime}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -426,11 +426,15 @@ export const HeaderWithFilters = ({
                 stagesEnabled && (
                   <Select
                     selected={selectedStage || 'All Stages'}
-                    onSelect={(item: any) =>
+                    onSelect={(item) =>
                       onFilterSelect({
                         filterKey: 'stage',
                         filterVal:
-                          item.value === 'All Stages' ? '' : item.value,
+                          typeof item !== 'string'
+                            ? item.value === 'All Stages'
+                              ? ''
+                              : item.value
+                            : '',
                       })
                     }
                     options={[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7302 
Closes: #7463 

## Description of Changes
- added confirmation modal when contest is about to be cancelled
- edited Select component to so that it can show headers and dividers in the list. Also prevented edition for items other than topics
- adjusted HeaderWithFilters.tsx 
  -  combined topics dropdown with contest => modified logic so that it can be selected either one or the other
  - combined stages with status => status is only visible when contest filter is selected 


## Test Plan
- it all with mocked data so hard to test it properly
- good thing this is last PR that is "untestable", from the next up it will be possible to test some flows e2e

## Deployment Plan
<!--- Omit if unneeded -->
1. safe to deploy