### PR TITLE
Add custom domain task to site admin panel.

### DIFF
--- a/knowledge_base/Custom-Domains.md
+++ b/knowledge_base/Custom-Domains.md
@@ -5,7 +5,6 @@
 - [Local Testing](#local-testing)
 - [Staging Testing](#staging-testing)
 - [Heroku](#heroku)
-- [Airplane (default method for prod)](#airplane-default-method-for-prod)
 - [Workflow](#workflow)
 - [External Dependencies](#external-dependencies)
 - [Change Log](#change-log)
@@ -40,31 +39,17 @@ Go to <https://whateveryouwant.com> and verify that it loads as expected (you mi
 ## Heroku
 
 1. Go to Heroku > settings > custom domain section
-1. get [whatever].herokudns.com ⇒ then "use wherever"
-1. (must) wait for ACM status to be “ready or green check”
-1. if that’s taking a while, just delete the record, and re add it (the use Let’s Encrypt)
-1. it may take some time
-
-## Airplane (default method for prod)
-
-Airplane has a [task](https://app.airplane.dev/runbooks/rbk20220809zm9b1vxoi7e) set up to automate the process of adding a custom domain in 3 stages.
-
-1. Updates the Chain entry to reflect the new custom domain.
-2. Hit heroku /domains endpoint, which spins up a DNS target and is returned to the airplane user. At this step, the DNS target must be shared with the customer and a confirmation that they have added a CNAME record must be obtained.
-3. Refreshes the Heroku ACM via the heroku CLI. This is manually performed after step 2 is complete.
-
-## Workflow
-
-1. A DNS target is made for the custom domain in heroku.
-2. The domain is put in the "Chains" table under the custom_domain column
-3. When a client makes a request to the custom domain, our customDomainRoutes.tsx routes paths to not need the scope, passes scope into the component
+1. Get [whatever].herokudns.com ⇒ then "use wherever". Communicate this with the external client, who must configure it on their side.
+1. Wait for ACM status to be “ready or green check”, once configured on external client's DNS provider.
+1. If that’s taking a while, just delete the record, and re add it (the use Let’s Encrypt).
+1. Once completed, use the admin panel to add the custom domain to the community.
 
 ## External Dependencies
 
 When adding a new custom domain, ensure you update the following external whitelists:
 
 - For Login: magic.link
-- For Chain Data: alchemy.com (ETH mainnet) or quicknode.com (BSC, Fantom)
+- For Chain Data: alchemy.com (ETH mainnet only)
 
 ## Change Log
 

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 import app from 'state';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import UpdateCommunityIdTask from 'views/pages/AdminPanel/UpdateCommunityIdTask';
+import UpdateCustomDomainTask from 'views/pages/AdminPanel/UpdateCustomDomainTask';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWText } from '../../components/component_kit/cw_text';
 import Analytics from './Analytics';
@@ -31,6 +32,7 @@ const AdminPanelPage = () => {
         <CWDivider />
         <CWText type="h2">Site Admin Tasks</CWText>
         <DeleteChainTask />
+        <UpdateCustomDomainTask />
         <UpdateCommunityIdTask />
         <DownloadMembersListTask />
         <RPCEndpointTask />

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/UpdateCustomDomainTask.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/UpdateCustomDomainTask.tsx
@@ -1,0 +1,139 @@
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import React, { useState } from 'react';
+import app from 'state';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { ValidationStatus } from 'views/components/component_kit/cw_validation_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { updateCommunityCustomDomain } from 'views/pages/AdminPanel/utils';
+import { CWTextInput } from '../../components/component_kit/cw_text_input';
+import { openConfirmation } from '../../modals/confirmation_modal';
+
+const UpdateCustomDomainTask = () => {
+  const [communityId, setCommunityId] = useState<string>('');
+  const [communityIdValidated, setCommunityIdValidated] =
+    useState<boolean>(false);
+  const [customDomain, setCustomDomain] = useState<string>('');
+  const [customDomainValidated, setCustomDomainValidated] =
+    useState<boolean>(false);
+
+  const openConfirmationModal = () => {
+    openConfirmation({
+      title: 'Update Custom Domain',
+      // eslint-disable-next-line max-len
+      description: `Are you sure you want to update ${communityId}'s custom domain to ${customDomain}? Please ensure engineering has been contacted prior to making this change.`,
+      buttons: [
+        {
+          label: 'Update',
+          buttonType: 'destructive',
+          buttonHeight: 'sm',
+          onClick: () => {
+            void (async () => {
+              try {
+                await updateCommunityCustomDomain({
+                  community_id: communityId,
+                  custom_domain: customDomain,
+                });
+                setCommunityId('');
+                setCustomDomain('');
+                notifySuccess('Custom domain updated');
+              } catch (e) {
+                notifyError('Error updating custom domain');
+                console.error(e);
+              }
+            })();
+          },
+        },
+        {
+          label: 'Cancel',
+          buttonType: 'secondary',
+          buttonHeight: 'sm',
+        },
+      ],
+    });
+  };
+
+  const validateCommunityFn = (
+    value: string,
+  ): [ValidationStatus, string] | [] => {
+    const communityExists = app.config.chains.getById(value);
+    if (!communityExists) {
+      setCommunityIdValidated(false);
+      return ['failure', 'Community not found'];
+    }
+    setCommunityIdValidated(true);
+    return [];
+  };
+
+  const validateCustomDomain = (
+    value: string,
+  ): [ValidationStatus, string] | [] => {
+    const validCustomDomainUrl = new RegExp(
+      '^(([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}$',
+    );
+    // TODO: enhance this validation to ensure a tighter format (no dangling paths)
+    if (!validCustomDomainUrl.test(value)) {
+      setCustomDomainValidated(false);
+      return ['failure', 'Invalid URL (try removing the http prefix)'];
+    }
+
+    // there's probably a better way to remove prefixes for duplicate finding purposes
+    const existingCustomDomain = app.config.chains
+      .getAll()
+      .find(
+        (community) =>
+          community.customDomain &&
+          community.customDomain
+            .replace('https://', '')
+            .replace('http://', '') === value,
+      );
+    if (existingCustomDomain) {
+      setCustomDomainValidated(false);
+      return [
+        'failure',
+        `Custom domain in use by community '${existingCustomDomain.id}'`,
+      ];
+    }
+    setCustomDomainValidated(true);
+    return [];
+  };
+
+  return (
+    <div className="TaskGroup">
+      <CWText type="h4">Update Custom Domain</CWText>
+      <CWText type="caption">
+        Update a communities custom domain url. Contact engineering before
+        changing, and for custom domain removals.
+      </CWText>
+      <div className="TaskRow">
+        <CWTextInput
+          value={communityId}
+          label="Community Id"
+          onInput={(e) => {
+            setCommunityId(e.target.value);
+            if (e.target.value.length === 0) setCommunityIdValidated(false);
+          }}
+          inputValidationFn={(value) => validateCommunityFn(value)}
+          placeholder="dydx"
+        />
+        <CWTextInput
+          value={customDomain}
+          label="Custom Domain URL"
+          onInput={(e) => {
+            setCustomDomain(e.target.value);
+            if (e.target.value.length === 0) setCustomDomainValidated(false);
+          }}
+          inputValidationFn={(value) => validateCustomDomain(value)}
+          placeholder="my.customdomain.com"
+        />
+        <CWButton
+          label="Update"
+          className="TaskButton"
+          disabled={!customDomainValidated || !communityIdValidated}
+          onClick={openConfirmationModal}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default UpdateCustomDomainTask;

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/utils.ts
@@ -73,6 +73,20 @@ export const updateCommunityId = async ({ community_id, new_community_id }) => {
   });
 };
 
+export const updateCommunityCustomDomain = async ({
+  community_id,
+  custom_domain,
+}: {
+  community_id: string;
+  custom_domain: string;
+}) => {
+  await axios.patch(`${app.serverUrl()}/communities/${community_id}`, {
+    jwt: app.user.jwt,
+    id: community_id,
+    custom_domain,
+  });
+};
+
 export const updateSiteAdmin = async ({
   address,
   siteAdmin,

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -18,6 +18,7 @@ export const Errors = {
   NotLoggedIn: 'Not signed in',
   NoCommunityId: 'Must provide community ID',
   ReservedId: 'The id is reserved and cannot be used',
+  CantChangeCustomDomain: 'Custom domain change not permitted',
   CantChangeNetwork: 'Cannot change community network',
   NotAdmin: 'Not an admin',
   NoCommunityFound: 'Community not found',
@@ -260,11 +261,14 @@ export async function __updateCommunity(
   // is left un-updated? Is there a better approach?
   community.default_summary_view = default_summary_view || false;
 
-  // Under our current security policy, custom domains must be set by trusted
-  // administrators only. Otherwise an attacker could configure a custom domain and
-  // use the code they run to steal login tokens for arbitrary users.
-  //
-  // chain.custom_domain = custom_domain;
+  // Only permit site admins to update custom domain field on communities, as it requires
+  // external configuration (via heroku + whitelists).
+  // Currently does not permit unsetting the custom domain; must be done manually.
+  if (user.isAdmin && custom_domain) {
+    community.custom_domain = custom_domain;
+  } else if (custom_domain && custom_domain !== community.custom_domain) {
+    throw new AppError(Errors.CantChangeCustomDomain);
+  }
 
   await community.save();
 

--- a/packages/commonwealth/test/util/modelUtils.ts
+++ b/packages/commonwealth/test/util/modelUtils.ts
@@ -157,6 +157,10 @@ export interface JoinCommunityArgs {
   originChain: string;
 }
 
+export interface SetSiteAdminArgs {
+  user_id: number;
+}
+
 const sortedStringify = configureStableStringify({
   bigint: false,
   circularValue: Error,
@@ -216,6 +220,7 @@ export type ModelSeeder = {
   ) => Promise<NotificationSubscription>;
   createCommunity: (args: CommunityArgs) => Promise<CommunityAttributes>;
   joinCommunity: (args: JoinCommunityArgs) => Promise<boolean>;
+  setSiteAdmin: (args: SetSiteAdminArgs) => Promise<boolean>;
 };
 
 export const modelSeeder = (app: Application, models: DB): ModelSeeder => ({
@@ -788,6 +793,24 @@ export const modelSeeder = (app: Application, models: DB): ModelSeeder => ({
       return false;
     }
 
+    return true;
+  },
+
+  setSiteAdmin: async (args: SetSiteAdminArgs) => {
+    const { user_id } = args;
+    const user = await models.User.findOne({ where: { id: user_id } });
+    if (!user) {
+      console.error('User not found');
+      return false;
+    }
+    user.isAdmin = true;
+    try {
+      await user.save();
+    } catch (e) {
+      console.error('Failed to set user as site admin');
+      console.error(e);
+      return false;
+    }
     return true;
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7676 
Closes: #7675 

## Description of Changes
- Adds site admin task which allows a site admin to update a community's custom domain.
  - Added task in UI to expose forms for site admin.
  - Updated the update_community route to permit custom domain change iff requester is site admin.
- Updated documentation surrounding custom domains.

## Test Plan
- Integration test to confirm site admins can update custom_domain and non-site-admins cannot.
- Manually confirmed success on admin panel:
  - Community field should only validate if community exists.
  - URL field should only validate if hostname sans url AND domain not used by any other community (not enforced on platform side, but since it's site admin only, the discrepancy is not a major concern).
  - Submitting should update the `custom_domain` field on community and ONLY that field (NB: the custom domain wont start working automatically -- need to ensure it's in heroku + whitelisted on magic + alchemy as well, but this makes one piece easier).
