### PR TITLE
changed Base copy in Create Community

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityTypeStep/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityTypeStep/helpers.ts
@@ -8,7 +8,7 @@ export const communityTypeOptions = [
     title: 'BASE',
     isRecommended: true,
     description:
-      'Base in an Ethereum layer 2 network with high TVL and low transaction fees',
+      'Base is an Ethereum Layer 2 network with high TVL and low transaction fees',
   },
   {
     type: CommunityType.Blast,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7702 

## Description of Changes
Changed Base copy in Create Community to "Base is an Ethereum Layer 2..." from "Base in an Ethereum layer 2..."

## Test Plan
-Create a community
-notice new spelling
