### PR TITLE
Fix production webserver runner for ESM

### DIFF
--- a/packages/commonwealth/server/util/requirementsModule/validateRequirements.ts
+++ b/packages/commonwealth/server/util/requirementsModule/validateRequirements.ts
@@ -1,6 +1,9 @@
 import { Requirement } from '@hicommonwealth/shared';
 import Ajv from 'ajv';
-import requirementsSchema from './requirementsSchema_v1.json';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const requirementsSchema = require('./requirementsSchema_v1.json');
 
 const Errors = {
   InvalidRequirements: 'Invalid requirements',

--- a/packages/commonwealth/tsconfig.json
+++ b/packages/commonwealth/tsconfig.json
@@ -11,6 +11,14 @@
       "*": ["./*", "shared/*", "client/scripts/*"]
     }
   },
+  "tsc-alias": {
+    "replacers": {
+      "webpack": {
+        "enabled": true,
+        "file": "./webpackReplacer.cjs"
+      }
+    }
+  },
   "include": [
     "client",
     "globals.d.ts",

--- a/packages/commonwealth/webpackReplacer.cjs
+++ b/packages/commonwealth/webpackReplacer.cjs
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+exports.default = ({ orig, file }) => {
+  if (
+    file.endsWith('setupWebpackDevServer.js') ||
+    file.endsWith('webpack.dev.config.mjs') ||
+    file.endsWith('webpack.base.config.mjs')
+  ) {
+    if (orig === "from '../webpack'" || orig === "from '../../webpack'") {
+      return "from 'webpack'";
+    }
+  }
+  return orig;
+};


### PR DESCRIPTION
Closes #7710.

Addresses two issues that only show up when using `node` to run the built package:

- We include a `*` path inside `tsconfig.json:compilerOptions.paths` inside packages/commonwealth. We really shouldn't do this - I think I added it back in 2020 and never got around to cleaning it up. One of the effects is that this causes webpack to be treated as a relative import, and rewritten as `../../webpack`.
  - We should remove the `*` path inside tsconfig but that would require overhauling all imports across the codebase. 
  - Instead, this adds a replacer module to `tsc-alias` which we're already running in `yarn build` right now, that rewrites ../../webpack or ../webpack inside the two files where this happens.
- Additionally, fixes import for .json file in production.

## Test Plan
- [x] Start the webserver using the `web` command in the Procfile in packages/commonwealth
- [x] Test other build commands/tasks inside packages/commonwealth
- [x] Test login with Metamask to make sure that any async imports there are working

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 