### PR TITLE
User-Onboarding: New Auth Buttons

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useStickyHeader.ts
+++ b/packages/commonwealth/client/scripts/hooks/useStickyHeader.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 type StickyHeaderProps = {
   elementId: string;
   zIndex?: number;
+  top?: number;
   stickyBehaviourEnabled?: boolean;
 };
 
@@ -11,6 +12,7 @@ type StickyHeaderProps = {
 const useStickyHeader = ({
   elementId,
   zIndex = 999,
+  top = 0,
   stickyBehaviourEnabled = true,
 }: StickyHeaderProps) => {
   useEffect(() => {
@@ -19,7 +21,7 @@ const useStickyHeader = ({
     const updateStickyBehaviour = (isSticky = false) => {
       if (stickyElement?.style) {
         stickyElement.style.position = isSticky ? 'sticky' : 'initial';
-        stickyElement.style.top = isSticky ? '0' : 'initial';
+        stickyElement.style.top = isSticky ? `${top}px` : 'initial';
         stickyElement.style.zIndex = isSticky ? `${zIndex}` : 'initial';
       }
     };
@@ -32,7 +34,7 @@ const useStickyHeader = ({
         const stickyElementPos = stickyElement.getBoundingClientRect();
         // checks if user scroll past this element
         const hasTabsSectionReachedTop =
-          stickyElementPos.top - stickyElementPos.height <= 0;
+          stickyElementPos.top - top - stickyElementPos.height <= 0;
         updateStickyBehaviour(hasTabsSectionReachedTop);
       }
     };
@@ -44,7 +46,7 @@ const useStickyHeader = ({
     return () => {
       window.removeEventListener('wheel', listener);
     };
-  }, [stickyBehaviourEnabled, elementId, zIndex]);
+  }, [stickyBehaviourEnabled, elementId, zIndex, top]);
 };
 
 export default useStickyHeader;

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -19,7 +19,7 @@ import { SublayoutBanners } from './SublayoutBanners';
 import { AdminOnboardingSlider } from './components/AdminOnboardingSlider';
 import { Breadcrumbs } from './components/Breadcrumbs';
 import MobileNavigation from './components/MobileNavigation';
-import { CWButton } from './components/component_kit/new_designs/CWButton';
+import AuthButtons from './components/SublayoutHeader/AuthButtons';
 import CollapsableSidebarButton from './components/sidebar/CollapsableSidebarButton';
 import { AuthModal, AuthModalType } from './modals/AuthModal';
 import { WelcomeOnboardModal } from './modals/WelcomeOnboardModal';
@@ -167,19 +167,9 @@ const Sublayout = ({
               })}
               id="mobile-auth-buttons"
             >
-              <CWButton
-                buttonType="secondary"
-                label="Create account"
-                buttonWidth="full"
-                disabled={location.pathname.includes('/finishsociallogin')}
-                onClick={() => setAuthModalType('create-account')}
-              />
-              <CWButton
-                buttonType="primary"
-                label="Sign in"
-                buttonWidth="full"
-                disabled={location.pathname.includes('/finishsociallogin')}
-                onClick={() => setAuthModalType('sign-in')}
+              <AuthButtons
+                fullWidthButtons
+                onButtonClick={(selectedType) => setAuthModalType(selectedType)}
               />
             </div>
             {!routesWithoutGenericBreadcrumbs && <Breadcrumbs />}

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -18,7 +18,9 @@ import { SublayoutBanners } from './SublayoutBanners';
 import { AdminOnboardingSlider } from './components/AdminOnboardingSlider';
 import { Breadcrumbs } from './components/Breadcrumbs';
 import MobileNavigation from './components/MobileNavigation';
+import { CWButton } from './components/component_kit/new_designs/CWButton';
 import CollapsableSidebarButton from './components/sidebar/CollapsableSidebarButton';
+import { AuthModal, AuthModalType } from './modals/AuthModal';
 import { WelcomeOnboardModal } from './modals/WelcomeOnboardModal';
 
 type SublayoutProps = {
@@ -35,6 +37,7 @@ const Sublayout = ({
   const forceRerender = useForceRerender();
   const { menuVisible, setMenu, menuName } = useSidebarStore();
   const [resizing, setResizing] = useState(false);
+  const [authModalType, setAuthModalType] = useState<AuthModalType>();
   const { isWindowSmallInclusive, isWindowExtraSmall } = useBrowserWindow({
     onResize: () => setResizing(true),
     resizeListenerUpdateDeps: [resizing],
@@ -120,6 +123,14 @@ const Sublayout = ({
       <SublayoutHeader
         onMobile={isWindowExtraSmall}
         isInsideCommunity={isInsideCommunity}
+        onAuthModalOpen={(modalType) =>
+          setAuthModalType(modalType || 'sign-in')
+        }
+      />
+      <AuthModal
+        type={authModalType}
+        onClose={() => setAuthModalType(undefined)}
+        isOpen={!!authModalType}
       />
       <div className="sidebar-and-body-container">
         <Sidebar
@@ -143,6 +154,27 @@ const Sublayout = ({
           <SublayoutBanners banner={banner} chain={chain} terms={terms} />
 
           <div className="Body">
+            <div
+              className={clsx('mobile-auth-buttons', {
+                isVisible:
+                  !isLoggedIn && userOnboardingEnabled && isWindowExtraSmall,
+              })}
+            >
+              <CWButton
+                buttonType="secondary"
+                label="Create account"
+                buttonWidth="full"
+                disabled={location.pathname.includes('/finishsociallogin')}
+                onClick={() => setAuthModalType('create-account')}
+              />
+              <CWButton
+                buttonType="primary"
+                label="Sign in"
+                buttonWidth="full"
+                disabled={location.pathname.includes('/finishsociallogin')}
+                onClick={() => setAuthModalType('sign-in')}
+              />
+            </div>
             {!routesWithoutGenericBreadcrumbs && <Breadcrumbs />}
             {isInsideCommunity && <AdminOnboardingSlider />}
             {children}

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -34,6 +34,7 @@ const Sublayout = ({
   hideFooter = true,
   isInsideCommunity,
 }: SublayoutProps) => {
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   const { isLoggedIn } = useUserLoggedIn();
   const forceRerender = useForceRerender();
   const { menuVisible, setMenu, menuName } = useSidebarStore();
@@ -41,7 +42,7 @@ const Sublayout = ({
   const [authModalType, setAuthModalType] = useState<AuthModalType>();
   useStickyHeader({
     elementId: 'mobile-auth-buttons',
-    stickyBehaviourEnabled: true,
+    stickyBehaviourEnabled: userOnboardingEnabled,
     zIndex: 70,
   });
   const { isWindowSmallInclusive, isWindowExtraSmall } = useBrowserWindow({
@@ -51,7 +52,6 @@ const Sublayout = ({
 
   const { isWelcomeOnboardModalOpen, setIsWelcomeOnboardModalOpen } =
     useWelcomeOnboardModal();
-  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
 
   useNecessaryEffect(() => {
     if (isLoggedIn && userOnboardingEnabled && !isWelcomeOnboardModalOpen) {

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -11,6 +11,7 @@ import { SublayoutHeader } from 'views/components/SublayoutHeader';
 import { Sidebar } from 'views/components/sidebar';
 import { useFlag } from '../hooks/useFlag';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
+import useStickyHeader from '../hooks/useStickyHeader';
 import useUserLoggedIn from '../hooks/useUserLoggedIn';
 import { useWelcomeOnboardModal } from '../state/ui/modals';
 import { Footer } from './Footer';
@@ -38,6 +39,11 @@ const Sublayout = ({
   const { menuVisible, setMenu, menuName } = useSidebarStore();
   const [resizing, setResizing] = useState(false);
   const [authModalType, setAuthModalType] = useState<AuthModalType>();
+  useStickyHeader({
+    elementId: 'mobile-auth-buttons',
+    stickyBehaviourEnabled: true,
+    zIndex: 70,
+  });
   const { isWindowSmallInclusive, isWindowExtraSmall } = useBrowserWindow({
     onResize: () => setResizing(true),
     resizeListenerUpdateDeps: [resizing],
@@ -159,6 +165,7 @@ const Sublayout = ({
                 isVisible:
                   !isLoggedIn && userOnboardingEnabled && isWindowExtraSmall,
               })}
+              id="mobile-auth-buttons"
             >
               <CWButton
                 buttonType="secondary"

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/AuthButtons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/AuthButtons.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { AuthModalType } from '../../modals/AuthModal';
+import { CWButton } from '../component_kit/new_designs/CWButton';
+
+type AuthButtonsProps = {
+  onButtonClick: (selectedFlow: AuthModalType) => void;
+  fullWidthButtons?: boolean;
+  smallHeightButtons?: boolean;
+};
+
+const AuthButtons = ({
+  onButtonClick,
+  fullWidthButtons = false,
+  smallHeightButtons = false,
+}: AuthButtonsProps) => {
+  const isDisabled = location.pathname.includes('/finishsociallogin');
+
+  return (
+    <>
+      <CWButton
+        buttonType="secondary"
+        label="Create account"
+        {...(smallHeightButtons && {
+          buttonHeight: 'sm',
+        })}
+        buttonWidth={fullWidthButtons ? 'full' : 'narrow'}
+        disabled={isDisabled}
+        onClick={() => onButtonClick('create-account')}
+      />
+      <CWButton
+        buttonType="primary"
+        label="Sign in"
+        {...(smallHeightButtons && {
+          buttonHeight: 'sm',
+        })}
+        buttonWidth={fullWidthButtons ? 'full' : 'narrow'}
+        disabled={isDisabled}
+        onClick={() => onButtonClick('sign-in')}
+      />
+    </>
+  );
+};
+
+export default AuthButtons;

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -19,6 +19,7 @@ import { NotificationsMenuPopover } from 'views/menus/notifications_menu';
 import UserDropdown from './UserDropdown';
 
 import { useFlag } from 'client/scripts/hooks/useFlag';
+import AuthButtons from 'client/scripts/views/components/SublayoutHeader/AuthButtons';
 import { AuthModalType } from 'client/scripts/views/modals/AuthModal';
 import './DesktopHeader.scss';
 
@@ -122,24 +123,10 @@ const DesktopHeader = ({
         {!isLoggedIn && (
           <>
             {userOnboardingEnabled ? (
-              <>
-                <CWButton
-                  buttonType="secondary"
-                  buttonHeight="sm"
-                  label="Create account"
-                  buttonWidth="narrow"
-                  disabled={location.pathname.includes('/finishsociallogin')}
-                  onClick={() => onAuthModalOpen('create-account')}
-                />
-                <CWButton
-                  buttonType="primary"
-                  buttonHeight="sm"
-                  label="Sign in"
-                  buttonWidth="narrow"
-                  disabled={location.pathname.includes('/finishsociallogin')}
-                  onClick={() => onAuthModalOpen()}
-                />
-              </>
+              <AuthButtons
+                smallHeightButtons
+                onButtonClick={(selectedType) => onAuthModalOpen(selectedType)}
+              />
             ) : (
               <CWButton
                 buttonType="primary"

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -18,11 +18,13 @@ import { NotificationsMenuPopover } from 'views/menus/notifications_menu';
 
 import UserDropdown from './UserDropdown';
 
+import { useFlag } from 'client/scripts/hooks/useFlag';
+import { AuthModalType } from 'client/scripts/views/modals/AuthModal';
 import './DesktopHeader.scss';
 
 interface DesktopHeaderProps {
   onMobile: boolean;
-  onAuthModalOpen: () => void;
+  onAuthModalOpen: (modalType?: AuthModalType) => void;
   onRevalidationModalData: ({
     walletSsoSource,
     walletAddress,
@@ -39,6 +41,7 @@ const DesktopHeader = ({
   onRevalidationModalData,
   onFeedbackModalOpen,
 }: DesktopHeaderProps) => {
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   const navigate = useCommonNavigate();
   const { isLoggedIn } = useUserLoggedIn();
   const { menuVisible, setMenu, menuName, setUserToggledVisibility } =
@@ -111,20 +114,43 @@ const DesktopHeader = ({
 
         {isLoggedIn && (
           <UserDropdown
-            onAuthModalOpen={onAuthModalOpen}
+            onAuthModalOpen={() => onAuthModalOpen}
             onRevalidationModalData={onRevalidationModalData}
           />
         )}
 
         {!isLoggedIn && (
-          <CWButton
-            buttonType="primary"
-            buttonHeight="sm"
-            label="Sign in"
-            buttonWidth="wide"
-            disabled={location.pathname.includes('/finishsociallogin')}
-            onClick={onAuthModalOpen}
-          />
+          <>
+            {userOnboardingEnabled ? (
+              <>
+                <CWButton
+                  buttonType="secondary"
+                  buttonHeight="sm"
+                  label="Create account"
+                  buttonWidth="narrow"
+                  disabled={location.pathname.includes('/finishsociallogin')}
+                  onClick={() => onAuthModalOpen('create-account')}
+                />
+                <CWButton
+                  buttonType="primary"
+                  buttonHeight="sm"
+                  label="Sign in"
+                  buttonWidth="narrow"
+                  disabled={location.pathname.includes('/finishsociallogin')}
+                  onClick={() => onAuthModalOpen()}
+                />
+              </>
+            ) : (
+              <CWButton
+                buttonType="primary"
+                buttonHeight="sm"
+                label="Sign in"
+                buttonWidth="wide"
+                disabled={location.pathname.includes('/finishsociallogin')}
+                onClick={() => onAuthModalOpen()}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/UserDropdown/UserDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/UserDropdown/UserDropdown.tsx
@@ -12,7 +12,7 @@ import useUserMenuItems from '../../useUserMenuItems';
 import './UserDropdown.scss';
 
 interface UserDropdownProps {
-  onAuthModalOpen: (open: boolean) => void;
+  onAuthModalOpen: () => void;
   onRevalidationModalData: ({
     walletSsoSource,
     walletAddress,

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/MobileHeader/MobileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/MobileHeader/MobileHeader.tsx
@@ -18,12 +18,14 @@ import MobileSearchModal from 'views/modals/MobileSearchModal';
 
 import useUserMenuItems from '../useUserMenuItems';
 
+import { useFlag } from 'client/scripts/hooks/useFlag';
+import { AuthModalType } from 'client/scripts/views/modals/AuthModal';
 import './MobileHeader.scss';
 
 interface MobileHeaderProps {
   onMobile: boolean;
   isInsideCommunity: boolean;
-  onAuthModalOpen: (open: boolean) => void;
+  onAuthModalOpen: (modalType?: AuthModalType) => void;
   onRevalidationModalData: ({
     walletSsoSource,
     walletAddress,
@@ -41,6 +43,7 @@ const MobileHeader = ({
   onRevalidationModalData,
   onFeedbackModalOpen,
 }: MobileHeaderProps) => {
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   const [isUserDrawerOpen, setIsUserDrawerOpen] = useState(false);
   const [isModalOpen, isSetModalOpen] = useState(false);
   const { isLoggedIn } = useUserLoggedIn();
@@ -107,12 +110,14 @@ const MobileHeader = ({
                 userCommunityId={user?.community?.id}
               />
             </div>
+          ) : userOnboardingEnabled ? (
+            <></>
           ) : (
             <CWButton
               label="Sign in"
               buttonHeight="sm"
               disabled={location.pathname.includes('/finishsociallogin')}
-              onClick={() => onAuthModalOpen(true)}
+              onClick={() => onAuthModalOpen()}
             />
           )}
         </div>

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/SublayoutHeader.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { WalletSsoSource } from '@hicommonwealth/shared';
 import useSidebarStore from 'state/ui/sidebar';
 import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
-import { AuthModal } from 'views/modals/AuthModal';
+import { AuthModalType } from 'views/modals/AuthModal';
 import SessionRevalidationModal from 'views/modals/SessionRevalidationModal';
 import { FeedbackModal } from 'views/modals/feedback_modal';
 
@@ -13,15 +13,16 @@ import MobileHeader from './MobileHeader';
 type SublayoutHeaderProps = {
   onMobile: boolean;
   isInsideCommunity: boolean;
+  onAuthModalOpen: (modalType: AuthModalType) => void;
 };
 
 export const SublayoutHeader = ({
   onMobile,
   isInsideCommunity,
+  onAuthModalOpen,
 }: SublayoutHeaderProps) => {
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
   const { menuVisible, setRecentlyUpdatedVisibility } = useSidebarStore();
-  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [revalidationModalData, setRevalidationModalData] = useState<{
     walletSsoSource: WalletSsoSource;
     walletAddress: string;
@@ -36,7 +37,7 @@ export const SublayoutHeader = ({
       {onMobile ? (
         <MobileHeader
           onMobile={onMobile}
-          onAuthModalOpen={() => setIsAuthModalOpen(true)}
+          onAuthModalOpen={onAuthModalOpen}
           isInsideCommunity={isInsideCommunity}
           onRevalidationModalData={setRevalidationModalData}
           onFeedbackModalOpen={() => setIsFeedbackModalOpen(true)}
@@ -44,7 +45,7 @@ export const SublayoutHeader = ({
       ) : (
         <DesktopHeader
           onMobile={onMobile}
-          onAuthModalOpen={() => setIsAuthModalOpen(true)}
+          onAuthModalOpen={onAuthModalOpen}
           onRevalidationModalData={setRevalidationModalData}
           onFeedbackModalOpen={() => setIsFeedbackModalOpen(true)}
         />
@@ -57,10 +58,6 @@ export const SublayoutHeader = ({
         }
         onClose={() => setIsFeedbackModalOpen(false)}
         open={isFeedbackModalOpen}
-      />
-      <AuthModal
-        onClose={() => setIsAuthModalOpen(false)}
-        isOpen={isAuthModalOpen}
       />
       <CWModal
         size="medium"

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -45,7 +45,7 @@ export const handleLogout = async () => {
 };
 
 interface UseUserMenuItemsProps {
-  onAuthModalOpen: (open: boolean) => void;
+  onAuthModalOpen: () => void;
   onRevalidationModalData: ({
     walletSsoSource,
     walletAddress,
@@ -185,7 +185,7 @@ const useUserMenuItems = ({
             type: 'default',
             label: 'Connect a new address',
             onClick: () => {
-              onAuthModalOpen(true);
+              onAuthModalOpen();
               onAddressItemClick?.();
             },
           },

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/index.ts
@@ -1,1 +1,2 @@
 export { AuthModal } from './AuthModal';
+export { AuthModalType } from './types';

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/types.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/types.ts
@@ -19,8 +19,10 @@ export type ModalVariantProps = {
   onSignInClick?: () => void;
 };
 
+export type AuthModalType = 'create-account' | 'sign-in';
+
 export type ModalBaseProps = {
-  layoutType: 'create-account' | 'sign-in';
+  layoutType: AuthModalType;
   hideDescription?: boolean;
   customBody?: ReactNode;
   showAuthenticationOptionsFor?: ('wallets' | 'sso')[];
@@ -29,5 +31,5 @@ export type ModalBaseProps = {
 
 export type AuthModalProps = {
   isOpen: boolean;
-  type?: 'create-account' | 'sign-in';
+  type?: AuthModalType;
 } & ModalVariantProps;

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -1,3 +1,4 @@
+import { useFlag } from 'client/scripts/hooks/useFlag';
 import { notifyInfo } from 'controllers/app/notifications';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import useBrowserWindow from 'hooks/useBrowserWindow';
@@ -33,9 +34,12 @@ const UserDashboard = (props: UserDashboardProps) => {
   const { type } = props;
   const { isLoggedIn } = useUserLoggedIn();
   const { isWindowExtraSmall } = useBrowserWindow({});
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   useStickyHeader({
     elementId: 'dashboard-header',
     zIndex: 70,
+    // To account for new authentication buttons, shown in small screen sizes
+    top: !isLoggedIn && userOnboardingEnabled ? 68 : 0,
     stickyBehaviourEnabled: !!isWindowExtraSmall,
   });
 

--- a/packages/commonwealth/client/styles/Sublayout.scss
+++ b/packages/commonwealth/client/styles/Sublayout.scss
@@ -77,6 +77,26 @@
         height: 100%;
         overflow-y: auto;
         width: 100%;
+
+        .mobile-auth-buttons {
+          display: none !important;
+          grid-template-columns: 1fr 1fr;
+          gap: 16px;
+          width: 100%;
+          padding: 16px;
+          padding-bottom: 8px;
+          margin-bottom: -8px;
+          background-color: white;
+
+          &.isVisible {
+            display: grid !important;
+          }
+
+          .btn-border {
+            margin: 0 !important;
+            padding: 0 !important;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7718

## Description of Changes
- Added auth button and their trigger flows for user-onboarding
- Made auth buttons on mobile sticky and responsive to screen resizes

## "How We Fixed It"
N/A

## Test Plan
- Logout
- Enable `FLAG_USER_ONBOARDING_ENABLED`
- On the desktop screen, verify you see the `Create account` and `Sign in` buttons in the header, clicking on each one will open separate account authentication flows
- On the mobile screen
  - verify you see auth buttons under the header
  - verify that auth buttons are sticky
  - visit `/dashboard/global`, scroll the page, and verify that sticky elements position themselves as "sticky" in order, ex: the auth buttons div should be the first sticky div, and the dashboard section toggle row (`For You`/`Chain Events`/`Global`) should be the second sticky div, and both of them won't overlap.
  - verify that resizing the page doesn't break sticky behavior.

## Deployment Plan
N/A

## Other Considerations
N/A