### PR TITLE
[Docs Improvement] Update Ways of Working with new tag information

### DIFF
--- a/knowledge_base/Custom-Domains.md
+++ b/knowledge_base/Custom-Domains.md
@@ -53,7 +53,8 @@ When adding a new custom domain, ensure you update the following external whitel
 
 ## Change Log
 
+- 240503: Updated by Jake Naviasky with post-Airplane instructions for adding domains to Heroku (#7679).
 - 240415: Flagged by Graham Johnson as possibly obsolete in light of abandoning Airplane.
-- 230515: Updated with Staging Testing section by Kurtis Assad
-- 230321: Updated with Airplane section by Alex Young
-- 230227: Authored by Jake Naviaski.
+- 230515: Updated with Staging Testing section by Kurtis Assad.
+- 230321: Updated with Airplane section by Alex Young.
+- 230227: Authored by Jake Naviasky.

--- a/knowledge_base/Ways-Of-Working.md
+++ b/knowledge_base/Ways-Of-Working.md
@@ -91,6 +91,12 @@ NB. Points != Time! Points are an estimate of complexity, not time. Having said 
 
 Points may always be increased mid-implementation, but a justification must be provided. Moreover, the original point estimation _must_ be left as a tag, rather than deleted.
 
+#### Tags
+
+The tag syntax `Sn` (e.g. `S1`, `S2`) refers to the sprint cycle `n` the work is scoped to. If a ticket rolls over to the next sprint cycle, we add that next cycle's tag without removing the prior cycle tag. (Similar to our handling of point estimations.)
+
+Documentation work (both tickets and pull requests) must receive a `documentation` tag.
+
 ### Branches
 
 Branches should be prefixed with an issue number, then the contributor's name, followed by a short descriptive tag e.g. `5007.john-doe.update-sidebar-layout`.

--- a/knowledge_base/_README.md
+++ b/knowledge_base/_README.md
@@ -51,6 +51,12 @@ Significant updates to knowledge base entries should be manually listed in a giv
 
 At least for the duration of 2023, as we implement this new system, any PR that updates or contributes to our knowledge base should tag @gdjohnson (the documentarian) on GitHub.
 
+### Tickets and PRs
+
+Substantial documentation work (both tickets and pull requests) must receive a `documentation` tag. The PR title should begin with `[Docs Improvement]`. The documentarian should be added as a reviewer.
+
+The #4800 general documentation ticket can be used as a linked issue for minor fixes and improvements.
+
 ### Inline Documentation
 
 We use a combination of TSDoc and comments for inline documentation. For more information, see our [Code Style Inline Documentation](./Code-Style.md#inline-documentation) section.

--- a/knowledge_base/_README.md
+++ b/knowledge_base/_README.md
@@ -49,7 +49,7 @@ Similarly, whenever a PR introduces new codebase functionality where either...
 
 Significant updates to knowledge base entries should be manually listed in a given entry's change log; see the [Change Log](#change-log) sub-entry for guidelines and context. All entries should follow the [Documentation Language](#documentation-language) guidelines.
 
-At least for the duration of 2023, as we implement this new system, any PR that updates or contributes to our knowledge base should tag @gdjohnson (the documentarian) on GitHub.
+As we implement this new system in 2024, any PR that updates or contributes to our knowledge base should tag @gdjohnson (the documentarian) on GitHub.
 
 ### Tickets and PRs
 


### PR DESCRIPTION
This branch documents our use of the `Sn` (S1, S2...) tag syntax and the `documentation` tag.

It also updates the Custom Domains change log for record-keeping.

## Link to Issue
Closes: #7706 