### PR TITLE
Remove dev dependencies from libs

### DIFF
--- a/libs/chains/package.json
+++ b/libs/chains/package.json
@@ -36,11 +36,9 @@
     "@ethersproject/units": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@osmonauts/lcd": "^0.10.0",
-    "ethers": "5.7.2"
-  },
-  "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@typechain/ethers-v5": "^6.0.0",
+    "ethers": "5.7.2",
     "hardhat": "^2.3.0",
     "hardhat-typechain": "^0.3.5",
     "ts-generator": "^0.1.1",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -22,9 +22,7 @@
   "dependencies": {
     "pino": "^8.19.0",
     "pino-http": "^9.0.0",
-    "pino-http-print": "^3.1.0"
-  },
-  "devDependencies": {
+    "pino-http-print": "^3.1.0",
     "pino-pretty": "^10.3.1"
   }
 }

--- a/libs/model/package.json
+++ b/libs/model/package.json
@@ -20,6 +20,8 @@
     "test": "yarn build && NODE_OPTIONS='--import tsx/esm' NODE_ENV=test mocha 'test/**/*.spec.ts'"
   },
   "dependencies": {
+    "@anatine/zod-mock": "^3.13.3",
+    "@faker-js/faker": "^8.4.1",
     "@hicommonwealth/core": "*",
     "@hicommonwealth/chains": "*",
     "@hicommonwealth/schemas": "*",
@@ -28,18 +30,13 @@
     "@cosmjs/stargate": "^0.31.3",
     "@cosmjs/tendermint-rpc": "^0.31.3",
     "node-object-hash": "^3.0.0",
+    "mocha-steps": "^1.3.0",
     "pg": "^8.11.3",
     "sequelize": "^6.32.1",
+    "umzug": "^3.7.0",
     "web3": "1.8.2",
     "web3-core": "1.8.2",
     "web3-utils": "1.8.2",
     "zod": "^3.22.4"
-  },
-  "devDependencies": {
-    "@anatine/zod-mock": "^3.13.3",
-    "@faker-js/faker": "^8.4.1",
-    "mocha-steps": "^1.3.0",
-    "tsx": "^4.7.2",
-    "umzug": "^3.7.0"
   }
 }

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -18,6 +18,5 @@
     "clean": "rm -rf build && find . -type f -name '*.tsbuildinfo' -exec rm {} +",
     "check-types": "tsc --noEmit",
     "test": "echo No tests for @hicommonwealth/shared"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hekoru removes dev dependencies, breaking builds

## Link to Issue
Closes: #TODO

## Description of Changes
- Removes all dev deps from libs until we find a better way to isolate dev mode
 