### PR TITLE
xss attempts now filtered from Trending Communities section

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -40,7 +40,7 @@ export const TrendingCommunitiesPreview = () => {
         onClick: () => navigate(`/${community.id}`),
       };
     });
-  console.log('sortedCommunities: ', sortedCommunities);
+
   return (
     <div className="TrendingCommunitiesPreview">
       <CWText type="h4" className="header">

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -12,6 +12,8 @@ export const TrendingCommunitiesPreview = () => {
     .getAll()
     .filter((community) => {
       const name = community.name.toLowerCase();
+      //this filter is meant to not include any de facto communities that are actually xss attempts.
+      //It's a way of keeping the front facing parts of the app clean looking for users
       return (
         !['"', '>', '<'].includes(name[0]) && !['"', '>', '<'].includes(name[1])
       );

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -10,6 +10,12 @@ export const TrendingCommunitiesPreview = () => {
 
   const sortedCommunities = app.config.chains
     .getAll()
+    .filter((community) => {
+      const name = community.name.toLowerCase();
+      return (
+        !['"', '>', '<'].includes(name[0]) && !['"', '>', '<'].includes(name[1])
+      );
+    })
     .sort((a, b) => {
       const threadCountA = app.recentActivity.getCommunityThreadCount(a.id);
       const threadCountB = app.recentActivity.getCommunityThreadCount(b.id);
@@ -34,7 +40,7 @@ export const TrendingCommunitiesPreview = () => {
         onClick: () => navigate(`/${community.id}`),
       };
     });
-
+  console.log('sortedCommunities: ', sortedCommunities);
   return (
     <div className="TrendingCommunitiesPreview">
       <CWText type="h4" className="header">

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -15,7 +15,8 @@ export const TrendingCommunitiesPreview = () => {
       //this filter is meant to not include any de facto communities that are actually xss attempts.
       //It's a way of keeping the front facing parts of the app clean looking for users
       return (
-        !['"', '>', '<'].includes(name[0]) && !['"', '>', '<'].includes(name[1])
+        !['"', '>', '<', "'", '/', '`'].includes(name[0]) &&
+        !['"', '>', '<', "'", '/', '`'].includes(name[1])
       );
     })
     .sort((a, b) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7386 

## Description of Changes
-Added a `.filter()` to look for '"', '<', or '>' in both the first and second letters in a community name. [XSS/Cross Site Scripting](https://brightsec.com/blog/xss-attack/) usually look something like `"><script>alert()</script>` hence the filtering on the first and second letters of the name.

## Test Plan
-go to your dashboard and check to see if there are any communities that have those characters as name[0] or name[1]
