### PR TITLE
Emit thread upvoted event to outbox

### DIFF
--- a/libs/core/src/integration/events.schemas.ts
+++ b/libs/core/src/integration/events.schemas.ts
@@ -2,12 +2,13 @@ import {
   Comment,
   ETHERS_BIG_NUMBER,
   EVM_ADDRESS,
+  Reaction,
   Thread,
 } from '@hicommonwealth/schemas';
 import { z } from 'zod';
 
 export const ThreadCreated = Thread;
-export const ThreadUpvoted = z.object({}); // TODO: use Reaction schema
+export const ThreadUpvoted = Reaction;
 export const CommentCreated = Comment;
 export const GroupCreated = z.object({
   groupId: z.string(),

--- a/libs/core/src/integration/events.schemas.ts
+++ b/libs/core/src/integration/events.schemas.ts
@@ -7,6 +7,7 @@ import {
 import { z } from 'zod';
 
 export const ThreadCreated = Thread;
+export const ThreadUpvoted = z.object({}); // TODO: use Reaction schema
 export const CommentCreated = Comment;
 export const GroupCreated = z.object({
   groupId: z.string(),

--- a/libs/core/src/integration/events.ts
+++ b/libs/core/src/integration/events.ts
@@ -10,6 +10,7 @@ export enum EventNames {
   GroupCreated = 'GroupCreated',
   SnapshotProposalCreated = 'SnapshotProposalCreated',
   ThreadCreated = 'ThreadCreated',
+  ThreadUpvoted = 'ThreadUpvoted',
   UserMentioned = 'UserMentioned',
 
   // Contests

--- a/libs/core/src/integration/outbox.schema.ts
+++ b/libs/core/src/integration/outbox.schema.ts
@@ -43,6 +43,12 @@ export const Outbox = z.union([
     .merge(BaseOutboxProperties),
   z
     .object({
+      event_name: z.literal(EventNames.ThreadUpvoted),
+      event_payload: events.ThreadUpvoted,
+    })
+    .merge(BaseOutboxProperties),
+  z
+    .object({
       event_name: z.literal(EventNames.DiscordMessageCreated),
       event_payload: events.DiscordMessageCreated,
     })

--- a/libs/model/src/models/reaction.ts
+++ b/libs/model/src/models/reaction.ts
@@ -80,7 +80,10 @@ export default (sequelize: Sequelize.Sequelize) =>
                     [
                       {
                         event_name: EventNames.ThreadUpvoted,
-                        event_payload: reaction.get({ plain: true }),
+                        event_payload: {
+                          ...reaction.get({ plain: true }),
+                          reaction: 'like',
+                        },
                       },
                     ],
                     options.transaction,

--- a/libs/model/src/models/reaction.ts
+++ b/libs/model/src/models/reaction.ts
@@ -1,7 +1,8 @@
-import { stats } from '@hicommonwealth/core';
+import { EventNames, stats } from '@hicommonwealth/core';
 import { logger } from '@hicommonwealth/logging';
 import Sequelize from 'sequelize';
 import { fileURLToPath } from 'url';
+import { emitEvent } from '../utils';
 import type { AddressAttributes } from './address';
 import type { CommunityAttributes } from './community';
 import type { ModelInstance, ModelStatic } from './types';
@@ -57,7 +58,7 @@ export default (sequelize: Sequelize.Sequelize) =>
         afterCreate: async (reaction: ReactionInstance, options) => {
           let thread_id = reaction.thread_id;
           const comment_id = reaction.comment_id;
-          const { Thread, Comment } = sequelize.models;
+          const { Thread, Comment, Outbox } = sequelize.models;
           try {
             if (thread_id) {
               const thread = await Thread.findOne({
@@ -73,6 +74,16 @@ export default (sequelize: Sequelize.Sequelize) =>
                     transaction: options.transaction,
                   });
                 }
+                await emitEvent(
+                  Outbox,
+                  [
+                    {
+                      event_name: EventNames.ThreadUpvoted,
+                      event_payload: reaction.get({ plain: true }),
+                    },
+                  ],
+                  options.transaction,
+                );
                 stats().increment('cw.hook.reaction-count', {
                   thread_id: String(thread_id),
                 });

--- a/libs/model/src/models/reaction.ts
+++ b/libs/model/src/models/reaction.ts
@@ -74,16 +74,18 @@ export default (sequelize: Sequelize.Sequelize) =>
                     transaction: options.transaction,
                   });
                 }
-                await emitEvent(
-                  Outbox,
-                  [
-                    {
-                      event_name: EventNames.ThreadUpvoted,
-                      event_payload: reaction.get({ plain: true }),
-                    },
-                  ],
-                  options.transaction,
-                );
+                if (reaction.reaction === 'like') {
+                  await emitEvent(
+                    Outbox,
+                    [
+                      {
+                        event_name: EventNames.ThreadUpvoted,
+                        event_payload: reaction.get({ plain: true }),
+                      },
+                    ],
+                    options.transaction,
+                  );
+                }
                 stats().increment('cw.hook.reaction-count', {
                   thread_id: String(thread_id),
                 });

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -38,6 +38,10 @@ type EmitEventValues =
   | {
       event_name: EventNames.SnapshotProposalCreated;
       event_payload: z.infer<typeof events.SnapshotProposalCreated>;
+    }
+  | {
+      event_name: EventNames.ThreadUpvoted;
+      event_payload: any; // TODO: set to events.ThreadUpvoted
     };
 
 // Load with env var?

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -41,7 +41,7 @@ type EmitEventValues =
     }
   | {
       event_name: EventNames.ThreadUpvoted;
-      event_payload: any; // TODO: set to events.ThreadUpvoted
+      event_payload: z.infer<typeof events.ThreadUpvoted>;
     };
 
 // Load with env var?

--- a/libs/model/test/reaction/reaction-lifecycle.spec.ts
+++ b/libs/model/test/reaction/reaction-lifecycle.spec.ts
@@ -1,0 +1,83 @@
+import { dispose } from '@hicommonwealth/core';
+import { models } from '@hicommonwealth/model';
+import { expect } from 'chai';
+import { bootstrap_testing, seed } from 'model/src/tester';
+
+describe('Reactions lifecycle', () => {
+  const addressId = 555;
+  const communityId = 'eee';
+  const threadId = 999;
+
+  before(async () => {
+    await bootstrap_testing();
+    const [chain] = await seed('ChainNode', { contracts: [] });
+    const [user] = await seed(
+      'User',
+      {
+        isAdmin: false,
+        selected_community_id: undefined,
+      },
+      //{ mock: true, log: true },
+    );
+    const [community] = await seed(
+      'Community',
+      {
+        id: communityId,
+        chain_node_id: chain!.id,
+        discord_config_id: undefined,
+        Addresses: [
+          {
+            id: addressId,
+            user_id: user?.id,
+            role: 'admin',
+            profile_id: undefined,
+          },
+        ],
+        // CommunityStakes: [],
+        topics: [],
+        // groups: [],
+        // contest_managers: [],
+      },
+      //{ mock: true, log: true },
+    );
+    await seed(
+      'Thread',
+      {
+        community_id: community?.id,
+        Address: community?.Addresses?.at(0),
+        id: threadId,
+        address_id: community?.Addresses?.at(0)?.id,
+        topic_id: undefined,
+        deleted_at: undefined, // so we can find it!
+      },
+      //{ mock: true, log: true },
+    );
+  });
+  after(async () => {
+    await dispose()();
+  });
+
+  it('should create an outbox entry when a thread is liked', async () => {
+    await models.Reaction.create({
+      community_id: communityId,
+      address_id: addressId,
+      thread_id: threadId,
+      reaction: 'like',
+      canvas_action: '',
+      canvas_session: '',
+      canvas_hash: '',
+      calculated_voting_weight: 0,
+    });
+
+    const lastOutboxEntry = await models.Outbox.findOne({
+      order: [['created_at', 'DESC']],
+    });
+    expect(lastOutboxEntry!.event_name).to.eq('ThreadUpvoted');
+    expect(lastOutboxEntry!.event_payload).to.contain({
+      community_id: communityId,
+      address_id: addressId,
+      thread_id: threadId,
+      reaction: 'like',
+    });
+  });
+});

--- a/libs/schemas/src/entities/index.ts
+++ b/libs/schemas/src/entities/index.ts
@@ -4,6 +4,7 @@ export * from './contest-manager.schemas';
 export * from './contract.schemas';
 export * from './group.schemas';
 export * from './notification.schemas';
+export * from './reaction.schemas';
 export * from './snapshot.schemas';
 export * from './stake.schemas';
 export * from './thread.schemas';

--- a/libs/schemas/src/entities/reaction.schemas.ts
+++ b/libs/schemas/src/entities/reaction.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { PG_INT } from '../utils';
+
+// TODO: use this as single source of truth for model?
+export const Reaction = z.object({
+  id: PG_INT.optional(),
+  community_id: z.string().max(255),
+  address_id: PG_INT,
+  reaction: z.enum(['like']),
+  created_at: z.date().optional(),
+  updated_at: z.date().optional(),
+  thread_id: PG_INT.optional(),
+  comment_id: PG_INT.optional(),
+  proposal_id: z.number().max(255).optional(),
+  canvas_action: z.any().optional(),
+  canvas_session: z.any().optional(),
+  canvas_hash: z.string().max(255).optional(),
+  calculated_voting_weight: PG_INT.optional(),
+});

--- a/libs/schemas/src/index.ts
+++ b/libs/schemas/src/index.ts
@@ -9,6 +9,7 @@ export type Aggregates = Extract<
   | 'NotificationCategory'
   | 'Subscription'
   | 'Thread'
+  | 'Reaction'
   | 'User'
   | 'StakeTransaction'
   | 'SubscriptionPreference'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7727

## Description of Changes
- In the `afterCreate` hook of the `Reaction` model, it now emits the event to the outbox (only for threads, and only if it's a like)

## Test Plan
- Unit test