### PR TITLE
Fix connect address callback

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -115,7 +115,7 @@ const DesktopHeader = ({
 
         {isLoggedIn && (
           <UserDropdown
-            onAuthModalOpen={() => onAuthModalOpen}
+            onAuthModalOpen={() => onAuthModalOpen()}
             onRevalidationModalData={onRevalidationModalData}
           />
         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7805

## Description of Changes
Fixed the callback that opens auth modal to connect multiple addresses

## "How We Fixed It"
In recent changes we missed a pair of parenthesis `( )` which was not triggering a callback needed for connecting multiple addresses.

## Test Plan
- Visit any community
- Try to connect multiple address
- Verify you are able to connect multiple addresses

## Deployment Plan
N/A

## Other Considerations
N/A