### PR TITLE
Switch to `ALLOWED_EVENTS`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ env:
   ROLLBAR_ENV: 'GitHubCI'
   NODE_ENV: 'test'
   TEST_WITHOUT_LOGS: 'true'
-  ALLOWED_EVENTS: 'ChainEventCreated,SnapshotProposalCreated'
+  ALLOWED_EVENTS: 'ChainEventCreated,SnapshotProposalCreated,ThreadUpvoted'
 
 on:
   pull_request:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ env:
   ROLLBAR_ENV: 'GitHubCI'
   NODE_ENV: 'test'
   TEST_WITHOUT_LOGS: 'true'
+  ALLOWED_EVENTS: 'ChainEventCreated,SnapshotProposalCreated'
 
 on:
   pull_request:

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -45,8 +45,8 @@ type EmitEventValues =
     };
 
 // Load with env var?
-const DISALLOWED_EVENTS = process.env.DISALLOWED_EVENTS
-  ? process.env.DISALLOWED_EVENTS.split(',')
+const ALLOWED_EVENTS = process.env.ALLOWED_EVENTS
+  ? process.env.ALLOWED_EVENTS.split(',')
   : [];
 
 /**
@@ -63,13 +63,17 @@ export async function emitEvent(
 ) {
   const records: Array<EmitEventValues> = [];
   for (const event of values) {
-    if (!DISALLOWED_EVENTS.includes(event.event_name)) {
+    if (ALLOWED_EVENTS.includes(event.event_name)) {
       records.push(event);
     } else {
-      log.warn('Event not inserted into outbox!', {
-        event_name: event.event_name,
-        disallowed_events: DISALLOWED_EVENTS,
-      });
+      log.warn(
+        `Event not inserted into outbox! ` +
+          `Add ${event.event_name} to the ALLOWED_EVENTS env var to enable emitting this event.`,
+        {
+          event_name: event.event_name,
+          allowed_events: ALLOWED_EVENTS,
+        },
+      );
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7797 

## Description of Changes
- Switches `DISALLOWED_EVENTS` to `ALLOWED_EVENTS` to improve devX

## Test Plan
- Remove `DISALLOWED_EVENTS` and `ALLOWED_EVENTS` from env var
- Start the Commonwealth server
- Create a thread + comment (should complete successfully)

## Deployment Plan
<!--- Omit if unneeded -->
1. Set `ALLOWED_EVENTS=ChainEventCreated,SnapshotProposalCreated` in all Heroku environments

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 