### PR TITLE
Linked Discussions now links to discussions

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/proposal_header_links.tsx
@@ -48,7 +48,11 @@ type SnapshotThreadLinkProps = {
 };
 
 export const SnapshotThreadLink = ({ thread }: SnapshotThreadLinkProps) => {
-  const proposalLink = getProposalUrlPath(ProposalType.Thread, thread.id, true);
+  const proposalLink = getProposalUrlPath(
+    ProposalType.Thread,
+    thread.id,
+    false,
+  );
 
   return (
     <div className="HeaderLink">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7753  

## Description of Changes
-fixed the broken link when clicking Linked Discussions in Snapshot proposal

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
**-NOTE: The original ticket had 3 different bugs.**
1. Linked Discussions link with Snapshot Proposal was broken. That has been fixed within this PR
2. In the original ticket it was incorrectly reported that the Proposals tab wasn't showing up under the Governance section in the sidebar for LinksDAO, but the actual problem was that Snapshots wasn't showing under Governance, despite that community having previous Snapshot proposals. Because other similar communities such as 1inch had their Snapshots shown, Zak and I determined that it was because (for whatever reason) LinksDAO did not have their Snapshot space listed in Integrations. We went god mode and inserted it back in for them. Now Snapshots are able to be seen under Governance on prod for LinksDAO
3. There is a known bug that attributes proposals to being made 54 years ago. It's a UNIX default bug that already has a ticket. It will be dealt with separately and soon. 

## Test Plan
-go to LinksDAO community
-confirm you can see Snapshots under Governance
-click into Snapshots
-click into [Proposal #17]: LinksDAO Scottish Golf Course Purchase
-click Linked Discussions link
-confirm that you are back to the thread

