### PR TITLE
bugfix address comparison in namespace validation 

### DIFF
--- a/libs/model/src/services/commonProtocol/newNamespaceValidator.ts
+++ b/libs/model/src/services/commonProtocol/newNamespaceValidator.ts
@@ -63,7 +63,7 @@ export const validateNamespace = async (
     factoryData.factory,
   );
 
-  if (activeNamespace !== txReceipt.logs[0].address) {
+  if (activeNamespace.toLowerCase() !== txReceipt.logs[0].address) {
     throw new AppError('Invalid tx hash for namespace creation');
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7818

## Description of Changes
- Fixes string comparison issue after web3.js upgrade 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- web3.js returns different checksum vs lower case values for logs and function returns. This normalizes the addresses 
- note test other functions as well(config Community stake

## Test Plan
- Deploy a community and configure stake

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 