### PR TITLE
Updated Group banner text and moved it to the members page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/TopicGatingHelpMessage/TopicGatingHelpMessage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/TopicGatingHelpMessage/TopicGatingHelpMessage.tsx
@@ -1,8 +1,28 @@
 import React from 'react';
 import { CWText } from 'views/components/component_kit/cw_text';
+import { useFlag } from '../../../../../hooks/useFlag';
 import './TopicGatingHelpMessage.scss';
 
 const TopicGatingHelpMessage = () => {
+  const allowlistEnabled = useFlag('allowlist');
+
+  if (allowlistEnabled) {
+    return (
+      <section className="TopicGatingHelpMessage">
+        <CWText type="h4" fontWeight="semiBold" className="header-text">
+          How does gating a group impact my community?
+        </CWText>
+        <CWText type="b2">
+          Enabling groups allows admins to created gated discussion topics.
+          Non-group members can still view the gated topics but will not be able
+          to create threads, upvote, or comment on threads within the gated
+          topic(s). You can always create another group with different
+          requirements and add any topics to gate, including previously gated
+          topics.
+        </CWText>
+      </section>
+    );
+  }
   return (
     <section className="TopicGatingHelpMessage">
       <CWText type="h4" fontWeight="semiBold" className="header-text">

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/GroupForm.tsx
@@ -15,6 +15,7 @@ import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextIn
 import { MessageRow } from 'views/components/component_kit/new_designs/CWTextInput/MessageRow';
 import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
 import { ZodError, ZodObject } from 'zod';
+import { useFlag } from '../../../../../../hooks/useFlag';
 import {
   AMOUNT_CONDITIONS,
   ERC_SPECIFICATIONS,
@@ -136,6 +137,7 @@ const GroupForm = ({
   initialValues = {},
   onDelete = () => {},
 }: GroupFormProps) => {
+  const allowlistEnabled = useFlag('allowlist');
   const navigate = useCommonNavigate();
   const { data: topics } = useFetchTopicsQuery({
     communityId: app.activeChainId(),
@@ -562,9 +564,8 @@ const GroupForm = ({
             </section>
           </section>
 
-          {(formType === 'create' || formType === 'edit') && (
-            <TopicGatingHelpMessage />
-          )}
+          {(formType === 'create' || formType === 'edit') &&
+            !allowlistEnabled && <TopicGatingHelpMessage />}
 
           {/* Form action buttons */}
           <div className="action-buttons">

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -33,6 +33,7 @@ import {
   MixpanelPageViewEvent,
   MixpanelPageViewEventPayload,
 } from '../../../../../../shared/analytics/types';
+import { useFlag } from '../../../../hooks/useFlag';
 import './CommunityMembersPage.scss';
 import GroupsSection from './GroupsSection';
 import MembersSection from './MembersSection';
@@ -46,6 +47,7 @@ const TABS = [
 const GROUP_AND_MEMBER_FILTERS: BaseGroupFilter[] = ['All groups', 'Ungrouped'];
 
 const CommunityMembersPage = () => {
+  const allowlistEnabled = useFlag('allowlist');
   useUserActiveAccount();
   const location = useLocation();
   const navigate = useCommonNavigate();
@@ -337,7 +339,9 @@ const CommunityMembersPage = () => {
           )}
 
         {/* Filter section */}
-        {selectedTab === TABS[1].value && groups?.length === 0 ? (
+        {selectedTab === TABS[1].value &&
+        groups?.length === 0 &&
+        !allowlistEnabled ? (
           <></>
         ) : (
           <section

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupsSection.tsx
@@ -5,6 +5,8 @@ import app from 'state';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { useFlag } from '../../../../../hooks/useFlag';
+import TopicGatingHelpMessage from '../../Groups/TopicGatingHelpMessage/index';
 import { chainTypes, requirementTypes } from '../../common/constants';
 import { convertRequirementAmountFromWeiToTokens } from '../../common/helpers';
 import GroupCard from './GroupCard';
@@ -21,11 +23,13 @@ const GroupsSection = ({
   canManageGroups,
   hasNoGroups,
 }: GroupSectionProps) => {
+  const allowlistEnabled = useFlag('allowlist');
   const navigate = useCommonNavigate();
 
   return (
     <section className="GroupsSection">
-      {hasNoGroups && (
+      {hasNoGroups && allowlistEnabled && <TopicGatingHelpMessage />}
+      {hasNoGroups && !allowlistEnabled && (
         <div className="empty-groups-container">
           <CWIcon iconName="members" iconSize="xxl" className="members-icon" />
           <CWText type="h4" className="header">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7128

## Description of Changes
- as title
- Note this only works when FLAG_ALLOWLIST=true (The feature flag is set)

## Test Plan
### Make sure unchanged when .env not set
- Go to members page for some community you are an admin of, make sure it looks the same as the old members page:
<img width="1086" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/d5edf027-bdf6-4d9f-a515-ce362a36d807">
- Go to create a group, make sure banner still exists:
<img width="1117" alt="image" src="https://github.com/hicommonwealth/commonwealth/assets/14794654/de49f156-f4f8-4e85-9bc1-99d82195a4a4">

### Make sure changes work when .env is set
- In .env set FLAG_ALLOWLIST=true
- Go to members page, check that it looks like in the attached ticket
- Go to the groups page, make sure that the banner at the bottom is not there
- Create a group, make sure the banner in the members page dissapears