### PR TITLE
Fixed version history for proposal pages

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -201,7 +201,7 @@ export const CWContentPage = ({
         archivedAt={thread?.archivedAt}
         isHot={isHot(thread)}
         profile={thread?.profile}
-        versionHistory={thread.versionHistory}
+        versionHistory={thread?.versionHistory}
         changeContentText={setThreadBody}
       />
     </div>


### PR DESCRIPTION
## Link to Issue
Closes: #7557 

## Description of Changes
- Since proposal page also went through CWContentPage, we needed to optionally get the threads version_history (proposal pages don't have version history).

## Test Plan
- Navigate to a proposal page like http://localhost:8080/dydx/snapshot/dydxgov.eth/0x937e3d2c0a39d980d782d953ec5ceeeee74656282374810fac74dc07f37e3942 Make sure it doesn't break the app
