### PR TITLE
Fix buy stake

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/ManageCommunityStakeModal/StakeExchangeForm/StakeExchangeForm.tsx
@@ -130,7 +130,7 @@ const StakeExchangeForm = ({
       const txReceipt = await buyStake({
         amount: numberOfStakeToExchange,
         stakeId: commonProtocol.STAKE_ID,
-        namespace: stakeData?.Chain?.namespace,
+        namespace: stakeData?.Community?.namespace,
         chainRpc,
         walletAddress: selectedAddress?.value,
         ethChainId,
@@ -180,7 +180,7 @@ const StakeExchangeForm = ({
       const txReceipt = await sellStake({
         amount: numberOfStakeToExchange,
         stakeId: commonProtocol.STAKE_ID,
-        namespace: stakeData?.Chain?.namespace,
+        namespace: stakeData?.Community?.namespace,
         chainRpc,
         walletAddress: selectedAddress?.value,
         ethChainId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7820 


## "How We Fixed It"
- before, the response from endpoint `/communityStakes/communityId/stakeId` returned `data.result.Chain.namesapce`. Currently it is returning `data.result.Community.namesapce`. 
- as a fix, changed `Chain` to `Community`

## Test Plan
- try to buy/sell stake from left sidebar or explore page - both should work

