### PR TITLE
Edit & cancel contest

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/contests/cancelContest.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/cancelContest.ts
@@ -1,7 +1,13 @@
 import { trpc } from 'utils/trpcClient';
 
 const useCancelContestMutation = () => {
-  return trpc.contest.cancelContestMetadata.useMutation();
+  const utils = trpc.useUtils();
+
+  return trpc.contest.cancelContestMetadata.useMutation({
+    onSuccess: async () => {
+      await utils.contest.getAllContests.invalidate();
+    },
+  });
 };
 
 export default useCancelContestMutation;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7822 

## Description of Changes
- this should be merge after #7667 
- handled editing and canceling contests

https://github.com/hicommonwealth/commonwealth/assets/14819225/af2d5032-180a-4417-9dfa-784ae2acc455


## Test Plan
- check test plan from https://github.com/hicommonwealth/commonwealth/pull/7667 to launch the contes first
- as an admin, go to contest list (`Contests` menu item in left sidebar)

CANCELLING 
- click red Cancel contest button
  - contest card should be `ended` with disabled buttons

EDITING
- click black Edit contest button
- you can edit name, image and topics
- click save
- applied changes should be visible in the contest card

## Deployment Plan
<!--- Omit if unneeded -->
1. safe to deploy as it is behind the feature flag
