### PR TITLE
User-Onboarding: Suggest communities that match user preferences on JoinCommunityStep

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
@@ -1,13 +1,15 @@
 import { ChainNetwork } from '@hicommonwealth/shared';
-import ChainInfo from 'client/scripts/models/ChainInfo';
-import app from 'client/scripts/state';
 import Permissions from 'client/scripts/utils/Permissions';
-import useJoinCommunity from 'client/scripts/views/components/SublayoutHeader/useJoinCommunity';
+import ChainInfo from 'models/ChainInfo';
 import React, { useEffect, useRef, useState } from 'react';
+import app from 'state';
+import { useFetchSelfProfileQuery } from 'state/api/profiles';
+import useJoinCommunity from 'views/components/SublayoutHeader/useJoinCommunity';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { JoinCommunityCard } from './JoinCommunityCard';
 import './JoinCommunityStep.scss';
+import { findSuggestedCommunities } from './helpers';
 
 type JoinCommunityStepProps = {
   onComplete: () => void;
@@ -19,25 +21,29 @@ const JoinCommunityStep = ({ onComplete }: JoinCommunityStepProps) => {
     { community: ChainInfo; isJoined: boolean }[]
   >([]);
   const userAddress = useRef(app?.user?.addresses?.[0]);
+  const areCommunitiesSuggested = useRef(false);
+
+  const { data: profile, isLoading: isLoadingProfile } =
+    useFetchSelfProfileQuery({
+      apiCallEnabled: true,
+    });
 
   useEffect(() => {
-    const userChainNetwork = userAddress?.current?.profile
-      ?.chain as ChainNetwork;
-
-    // get 4 suggested communities based on the user's selected wallet
-    const chains = [...app.config.chains.getAll()]
-      .filter((chain) => chain.network === userChainNetwork)
-      .sort((a, b) => b.addressCount - a.addressCount)
-      .sort((a, b) => b.threadCount - a.threadCount)
-      .slice(0, 4);
-
-    setSuggestedCommunities(
-      chains.map((chain) => ({
-        community: chain,
-        isJoined: Permissions.isCommunityMember(chain.id),
-      })),
-    );
-  }, []);
+    if (!isLoadingProfile && profile && !areCommunitiesSuggested.current) {
+      const suggestions = findSuggestedCommunities({
+        maxCommunitiesToFind: 4,
+        userChainNetwork: userAddress?.current?.profile?.chain as ChainNetwork,
+        userPreferenceTags: (profile?.tags || []).map((t) => t.name),
+      });
+      setSuggestedCommunities(
+        suggestions.map((chain) => ({
+          community: chain,
+          isJoined: Permissions.isCommunityMember(chain.id),
+        })),
+      );
+      areCommunitiesSuggested.current = true;
+    }
+  }, [isLoadingProfile, profile]);
 
   const handleCommunityJoin = (community: ChainInfo) => {
     linkSpecificAddressToSpecificCommunity({

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/helpers.ts
@@ -1,0 +1,94 @@
+import { ChainNetwork, CommunityCategoryType } from '@hicommonwealth/shared';
+import ChainInfo from 'models/ChainInfo';
+import app from 'state';
+import { getCommunityTags } from 'views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/helpers';
+
+type FindSuggestedCommunitiesProps = {
+  userChainNetwork: ChainNetwork;
+  userPreferenceTags: string[];
+  maxCommunitiesToFind: number;
+};
+
+// TODO: this method should be deprecated after https://github.com/hicommonwealth/commonwealth/issues/7835
+const getAllCommunityTags = (community: ChainInfo): string[] => {
+  const deprecatedTags = getCommunityTags(community.id);
+  const aggregatedTags = [
+    // filter out `defi` and `dao` tags from newer `CommunityTags` array
+    ...community.CommunityTags.filter(
+      (t) =>
+        ![
+          CommunityCategoryType.DeFi.toLowerCase(),
+          CommunityCategoryType.DeFi.toLowerCase(),
+        ].includes(t.name.toLowerCase()),
+    ).map((t) => t.name),
+  ];
+  // add `defi`, `dao` tags from older community category map
+  deprecatedTags.DeFi && aggregatedTags.push(CommunityCategoryType.DeFi);
+  deprecatedTags.DAO && aggregatedTags.push(CommunityCategoryType.DAO);
+  return aggregatedTags;
+};
+
+export const findSuggestedCommunities = ({
+  userChainNetwork,
+  userPreferenceTags,
+  maxCommunitiesToFind,
+}: FindSuggestedCommunitiesProps): ChainInfo[] => {
+  // this map will hold both the communities that match user preferences and the ones that don't
+  const communityPreferenceMap: {
+    [key in string]: ChainInfo[];
+  } = {
+    communitiesMatchingUserPreferences: [],
+    communitiesNotMatchingUserPreferences: [],
+  };
+
+  // 1. filter communities that match user wallet chain network
+  // 2. then sort them by the count of members (from higher to lower)
+  // 3. then sort them by the count of threads (from higher to lower)
+  // 4. then seperate them into 2 groups, communities that match user preferences and those that don't
+  [...app.config.chains.getAll()]
+    .filter((community) => community.network === userChainNetwork)
+    .sort((a, b) => b.addressCount - a.addressCount)
+    .sort((a, b) => b.threadCount - a.threadCount)
+    .map((community) => {
+      const aggregatedCommunityTags = getAllCommunityTags(community);
+
+      // We dont want this community here
+      // 1. if there are no tags
+      // 2. if the community tags don't overlap user preference tags
+      if (
+        aggregatedCommunityTags.length === 0 ||
+        !userPreferenceTags.some((tag) => aggregatedCommunityTags.includes(tag))
+      ) {
+        communityPreferenceMap.communitiesNotMatchingUserPreferences.push(
+          community,
+        );
+      } else {
+        communityPreferenceMap.communitiesMatchingUserPreferences.push(
+          community,
+        );
+      }
+
+      return community;
+    });
+
+  const {
+    communitiesMatchingUserPreferences,
+    communitiesNotMatchingUserPreferences,
+  } = communityPreferenceMap;
+
+  // get upto `maxCommunitiesToFind` count of communities from the preference map.
+  let suggestedCommunities = communitiesMatchingUserPreferences.slice(
+    0,
+    maxCommunitiesToFind,
+  );
+  // if there aren't `maxCommunitiesToFind` count of communities that match user preferences
+  // then get the remaining communities from the communities map that doesn't match user preferences
+  if (suggestedCommunities.length < maxCommunitiesToFind) {
+    const remainingCount = maxCommunitiesToFind - suggestedCommunities.length;
+    suggestedCommunities = suggestedCommunities.concat(
+      communitiesNotMatchingUserPreferences.slice(0, remainingCount),
+    );
+  }
+
+  return suggestedCommunities;
+};

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/helpers.ts
@@ -1,17 +1,20 @@
 import { CommunityCategoryType } from '@hicommonwealth/shared';
 import app from 'state';
 
-export const getCommunityTags = (community: string) => {
+type CommunityTags = {
+  [tag in CommunityCategoryType]: boolean;
+};
+
+// TODO: this method should be deprecated after https://github.com/hicommonwealth/commonwealth/issues/7835
+export const getCommunityTags = (community: string): CommunityTags => {
   const chainToCategoriesMap: {
     [community: string]: CommunityCategoryType[];
   } = app.config.chainCategoryMap;
 
-  const types = Object.keys(CommunityCategoryType);
-  const selectedTags = {};
-
-  for (const type of types) {
-    selectedTags[type] = false;
-  }
+  const selectedTags = {
+    [CommunityCategoryType.DeFi]: false,
+    [CommunityCategoryType.DAO]: false,
+  };
 
   if (chainToCategoriesMap[community]) {
     for (const tag of chainToCategoriesMap[community]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7198

## Description of Changes
1. Updated the JoinCommunity step of the welcome onboard modal to suggest communities that match user preferences
2. If there aren't enough (atm we use 4) communities that match user preferences, then we fill the gap by add communities that match other criteria, like the same chain base as user address and higher member and threads count.

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_USER_ONBOARDING_ENABLED`
- As super admin, add certain tags to some communities (be sure to remember them as it would help later on)
- Now create a new account, and wait for the welcome modal to appear.
- Complete the first step in the welcome onboard model
- In the 2nd step, choose preference tags, in the next step, communities will be suggested based on these tags.
- On step 3 aka Join Communities, verify you see correctly suggested communities, i.e. those that match the preferences you set (also keep in mind the edge case when there aren't enough communities that match user preferences, see point `2` in description above for more details)

## Deployment Plan
N/A

## Other Considerations
N/A