### PR TITLE
Add allowlist to GetMembers query

### DIFF
--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -28,6 +28,8 @@ export const GetCommunityMembers = {
         z.literal('in-group'),
         z.string().regex(/^in-group:\d+$/, 'in-group with a number'),
         z.literal('not-in-group'),
+        z.literal('in-group:allowlisted'),
+        z.literal('in-group:not-allowlisted'),
       ])
       .optional(),
     include_group_ids: z.coerce.boolean().optional(),

--- a/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
+++ b/packages/commonwealth/server/controllers/server_groups_methods/create_group.ts
@@ -34,7 +34,6 @@ export type CreateGroupOptions = {
   metadata: z.infer<typeof GroupMetadata>;
   requirements: Requirement[];
   topics?: number[];
-  allowList?: number[];
   systemManaged?: boolean;
   transaction?: Transaction;
 };

--- a/packages/commonwealth/server/routes/groups/create_group_handler.ts
+++ b/packages/commonwealth/server/routes/groups/create_group_handler.ts
@@ -30,7 +30,6 @@ export const createGroupHandler = async (
       }),
       requirements: z.array(z.any()), // validated in controller
       topics: z.array(z.number()).optional(),
-      allowList: z.array(z.number()).default([]),
     }),
   });
   const validationResult = schema.safeParse(req);
@@ -38,7 +37,7 @@ export const createGroupHandler = async (
     throw new AppError(JSON.stringify(validationResult.error));
   }
   const {
-    body: { metadata, requirements, topics, allowList },
+    body: { metadata, requirements, topics },
   } = validationResult.data;
 
   const [group, analyticsOptions] = await controllers.groups.createGroup({
@@ -47,7 +46,6 @@ export const createGroupHandler = async (
     metadata: metadata as Required<typeof metadata>,
     requirements,
     topics,
-    allowList,
   });
 
   // Warning: keep for now, but should be a debounced async integration policy that get's triggered by creation events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7131

## Description of Changes
- Removes unnecesary extra fields from create_group
- Adds logic for filtering members by allow list or not in allow list

## Test Plan
- Checkout this PR:
https://github.com/hicommonwealth/commonwealth/pull/7748
- Create a group and add members to it through the allowlist check box on:
http://localhost:8080/{community_id}/members/groups/create
- Go back to creating a group, click on the dropdown and filter by allowlist and then unallowlist.

Allowlist should filter all addresses that have at least one allowlisted group
UnAllowlist should filter all addresses without an allowlisted group.
 