### PR TITLE
community names are now clickable

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -27,7 +27,13 @@ const SidebarHeader = ({
         }
       />
 
-      <CWText className="header" type="h5">
+      <CWText
+        className="header"
+        type="h5"
+        onClick={() =>
+          navigateToCommunity({ navigate, path: '', chain: app.chain.id })
+        }
+      >
         {app?.chain?.meta?.name || <Skeleton width="70%" />}
       </CWText>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7773 

## Description of Changes
- Community name is now clickable and redirects to the same page as the avatar/icon does
- NOTE: This change was ok'd by Jess and Jared

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added an onClick to the `CWText` 
## Test Plan
-Go to a community you are a part of and click into anything on the sidebar or a thread
-now click the community name and notice that it now redirects to the Discussions page 
