### PR TITLE
Added auth guidance modal logic behind feature flag

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useWallets.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useWallets.tsx
@@ -43,6 +43,7 @@ import {
 } from '../views/components/component_kit/helpers';
 import { useBrowserAnalyticsTrack } from './useBrowserAnalyticsTrack';
 import useBrowserWindow from './useBrowserWindow';
+import { useFlag } from './useFlag';
 
 type ProfileRowProps = {
   name: string;
@@ -83,6 +84,7 @@ type IuseWalletProps = {
 
 const useWallets = (walletProps: IuseWalletProps) => {
   const createAccountWithDefaultValues = true;
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   const [avatarUrl, setAvatarUrl] = useState<string>();
   const [address, setAddress] = useState<string>();
   const [activeStep, setActiveStep] = useState<LoginActiveStep>();
@@ -229,6 +231,7 @@ const useWallets = (walletProps: IuseWalletProps) => {
       // then open the user auth type guidance modal
       // else clear state of `shouldOpenGuidanceModalAfterMagicSSORedirect`
       if (
+        userOnboardingEnabled &&
         isAddressNew &&
         !isAttemptingToConnectAddressToCommunity &&
         !app.isLoggedIn()
@@ -607,33 +610,35 @@ const useWallets = (walletProps: IuseWalletProps) => {
     } else {
       const selectedAddress = getAddressFromWallet(wallet);
 
-      // check if address exists
-      const profileAddresses = await fetchProfilesByAddress({
-        currentChainId: '',
-        profileAddresses: [
-          wallet.chain === ChainBase.Substrate
-            ? addressSwapper({
-                address: selectedAddress,
-                currentPrefix: parseInt(
-                  (app.chain as Substrate)?.meta.ss58Prefix,
-                  10,
-                ),
-              })
-            : selectedAddress,
-        ],
-        profileChainIds: [app.activeChainId() ?? wallet.chain],
-        initiateProfilesAfterFetch: false,
-      });
-      const addressExists = profileAddresses?.length > 0;
-      const isAttemptingToConnectAddressToCommunity =
-        app.isLoggedIn() && app.activeChainId();
-      if (
-        !addressExists &&
-        !isAttemptingToConnectAddressToCommunity &&
-        walletProps.onUnrecognizedAddressReceived
-      ) {
-        const shouldContinue = walletProps.onUnrecognizedAddressReceived();
-        if (!shouldContinue) return;
+      if (userOnboardingEnabled) {
+        // check if address exists
+        const profileAddresses = await fetchProfilesByAddress({
+          currentChainId: '',
+          profileAddresses: [
+            wallet.chain === ChainBase.Substrate
+              ? addressSwapper({
+                  address: selectedAddress,
+                  currentPrefix: parseInt(
+                    (app.chain as Substrate)?.meta.ss58Prefix,
+                    10,
+                  ),
+                })
+              : selectedAddress,
+          ],
+          profileChainIds: [app.activeChainId() ?? wallet.chain],
+          initiateProfilesAfterFetch: false,
+        });
+        const addressExists = profileAddresses?.length > 0;
+        const isAttemptingToConnectAddressToCommunity =
+          app.isLoggedIn() && app.activeChainId();
+        if (
+          !addressExists &&
+          !isAttemptingToConnectAddressToCommunity &&
+          walletProps.onUnrecognizedAddressReceived
+        ) {
+          const shouldContinue = walletProps.onUnrecognizedAddressReceived();
+          if (!shouldContinue) return;
+        }
       }
 
       if (walletProps.useSessionKeyLoginFlow) {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -1,4 +1,5 @@
 import { ChainBase, WalletId, WalletSsoSource } from '@hicommonwealth/shared';
+import { useFlag } from 'client/scripts/hooks/useFlag';
 import useWallets from 'client/scripts/hooks/useWallets';
 import app from 'client/scripts/state';
 import useAuthModalStore from 'client/scripts/state/ui/modals/authModal';
@@ -60,6 +61,7 @@ const ModalBase = ({
   onSignInClick,
   onChangeModalType,
 }: ModalBaseProps) => {
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
   const copy = MODAL_COPY[layoutType];
 
   const [activeTabIndex, setActiveTabIndex] = useState<number>(
@@ -197,7 +199,7 @@ const ModalBase = ({
 
   const onAuthMethodSelect = async (option: AuthTypes) => {
     if (option === 'email') {
-      if (layoutType === AuthModalType.SignIn) {
+      if (layoutType === AuthModalType.SignIn && userOnboardingEnabled) {
         setShouldOpenGuidanceModalAfterMagicSSORedirect(true);
       }
 
@@ -218,7 +220,7 @@ const ModalBase = ({
 
     // if any SSO option is selected
     if (activeTabIndex === 1) {
-      if (layoutType === AuthModalType.SignIn) {
+      if (layoutType === AuthModalType.SignIn && userOnboardingEnabled) {
         setShouldOpenGuidanceModalAfterMagicSSORedirect(true);
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7883

## Description of Changes
- Added some logic of #6642 PR, behind the user onboarding feature flag. This was mistakenly not done before in the #7856 PR

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_USER_ONBOARDING_ENABLED`
- Test auth flow with new and old accounts
- Disable `FLAG_USER_ONBOARDING_ENABLED`
- Test auth flow with new and old accounts
- Verify that the new account creation flow is different, and user flow when `FLAG_USER_ONBOARDING_ENABLED` is enabled, doesn't overlap the flow when `FLAG_USER_ONBOARDING_ENABLED` is disabled.

## Deployment Plan
N/A

## Other Considerations
N/A