### PR TITLE
Removed `FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED`

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -26,9 +26,6 @@ const featureFlags = {
   proposalTemplates: buildFlag(process.env.FLAG_PROPOSAL_TEMPLATES),
   communityHomepage: buildFlag(process.env.FLAG_COMMUNITY_HOMEPAGE),
   communityStake: buildFlag(process.env.FLAG_COMMUNITY_STAKE),
-  existingCommunityStakeIntegrationEnabled: buildFlag(
-    process.env.FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED,
-  ),
   userOnboardingEnabled: buildFlag(process.env.FLAG_USER_ONBOARDING_ENABLED),
   knockInAppNotifications: buildFlag(
     process.env.FLAG_KNOCK_IN_APP_NOTIFICATIONS,

--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -116,7 +116,6 @@ const CommonDomainRoutes = ({
   proposalTemplatesEnabled,
   communityHomepageEnabled,
   contestEnabled,
-  existingCommunityStakeIntegrationEnabled,
 }: RouteFeatureFlags) => [
   <Route
     key="/"
@@ -434,17 +433,13 @@ const CommonDomainRoutes = ({
       scoped: true,
     })}
   />,
-  ...(existingCommunityStakeIntegrationEnabled
-    ? [
-        <Route
-          key="/:scope/manage/integrations/stake"
-          path="/:scope/manage/integrations/stake"
-          element={withLayout(CommunityStakeIntegration, {
-            scoped: true,
-          })}
-        />,
-      ]
-    : []),
+  <Route
+    key="/:scope/manage/integrations/stake"
+    path="/:scope/manage/integrations/stake"
+    element={withLayout(CommunityStakeIntegration, {
+      scoped: true,
+    })}
+  />,
   <Route
     key="/:scope/manage/topics"
     path="/:scope/manage/topics"

--- a/packages/commonwealth/client/scripts/navigation/CustomDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CustomDomainRoutes.tsx
@@ -109,7 +109,6 @@ const ProfilePageRedirect = lazy(() => import('views/pages/profile_redirect'));
 const CustomDomainRoutes = ({
   proposalTemplatesEnabled,
   contestEnabled,
-  existingCommunityStakeIntegrationEnabled,
 }: RouteFeatureFlags) => {
   return [
     <Route
@@ -351,17 +350,13 @@ const CustomDomainRoutes = ({
         scoped: true,
       })}
     />,
-    ...(existingCommunityStakeIntegrationEnabled
-      ? [
-          <Route
-            key="/manage/integrations/stake"
-            path="/manage/integrations/stake"
-            element={withLayout(CommunityStakeIntegration, {
-              scoped: true,
-            })}
-          />,
-        ]
-      : []),
+    <Route
+      key="/manage/integrations/stake"
+      path="/manage/integrations/stake"
+      element={withLayout(CommunityStakeIntegration, {
+        scoped: true,
+      })}
+    />,
     <Route
       key="/manage/topics"
       path="/manage/topics"

--- a/packages/commonwealth/client/scripts/navigation/Router.tsx
+++ b/packages/commonwealth/client/scripts/navigation/Router.tsx
@@ -14,7 +14,6 @@ import GeneralRoutes from './GeneralRoutes';
 export type RouteFeatureFlags = {
   proposalTemplatesEnabled: boolean;
   communityHomepageEnabled: boolean;
-  existingCommunityStakeIntegrationEnabled: boolean;
   contestEnabled: boolean;
 };
 
@@ -28,16 +27,11 @@ const Router = (customDomain: string) => {
     'communityHomepage',
     false,
   );
-  const existingCommunityStakeIntegrationEnabled = client.getBooleanValue(
-    'existingCommunityStakeIntegrationEnabled',
-    false,
-  );
   const contestEnabled = client.getBooleanValue('contest', false);
   const flags = {
     proposalTemplatesEnabled,
     communityHomepageEnabled,
     contestEnabled,
-    existingCommunityStakeIntegrationEnabled,
   };
 
   return createBrowserRouter(

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
@@ -1,4 +1,3 @@
-import { useFlag } from 'hooks/useFlag';
 import React from 'react';
 import CommunityManagementLayout from '../common/CommunityManagementLayout';
 import CustomTOS from './CustomTOS';
@@ -11,10 +10,6 @@ import Stake from './Stake';
 import Webhooks from './Webhooks';
 
 const Integrations = () => {
-  const existingCommunityStakeIntegrationEnabled = useFlag(
-    'existingCommunityStakeIntegrationEnabled',
-  );
-
   return (
     <CommunityManagementLayout
       title="Integrations"
@@ -29,7 +24,7 @@ const Integrations = () => {
     >
       <section className="Integrations">
         <Directory />
-        {existingCommunityStakeIntegrationEnabled && <Stake />}
+        <Stake />
         <Snapshots />
         <Discord />
         <Webhooks />

--- a/packages/commonwealth/webpack/webpack.base.config.mjs
+++ b/packages/commonwealth/webpack/webpack.base.config.mjs
@@ -90,12 +90,6 @@ const baseConfig = {
       ),
     }),
     new webpack.DefinePlugin({
-      'process.env.FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED':
-        JSON.stringify(
-          process.env.FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED,
-        ),
-    }),
-    new webpack.DefinePlugin({
       'process.env.FLAG_USER_ONBOARDING_ENABLED': JSON.stringify(
         process.env.FLAG_USER_ONBOARDING_ENABLED,
       ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7477

## Description of Changes
- Removed the `FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED` feature flag

## "How We Fixed It"
N/A

## Test Plan
- For communities that didn't enable stake during the community creation process, verify stake enablement works from admin management pages of that community.

## Deployment Plan
N/A

## Other Considerations
We may also want to remove the flag from unleash dashboard.