### PR TITLE
Contests - Displaying contests (mocked data)

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -182,6 +182,7 @@ export class Thread implements IUniqueId {
   public readonly hasPoll: boolean;
   public numberOfComments: number;
   public associatedReactions: AssociatedReaction[];
+  public associatedContests: any[];
   public reactionWeightsSum: number;
   public links: Link[];
   public readonly discord_meta: any;
@@ -237,6 +238,7 @@ export class Thread implements IUniqueId {
     avatar_url,
     address_last_active,
     associatedReactions,
+    associatedContests,
   }: {
     marked_as_spam_at: string;
     title: string;
@@ -281,6 +283,7 @@ export class Thread implements IUniqueId {
     avatar_url: string;
     address_last_active: string;
     associatedReactions?: AssociatedReaction[];
+    associatedContests?: any[];
   }) {
     this.author = Address?.address;
     this.title = getDecodedString(title);
@@ -330,6 +333,7 @@ export class Thread implements IUniqueId {
         reactedProfileAvatarUrl,
         reactedAddressLastActive,
       );
+    this.associatedContests = associatedContests;
     this.latestActivity = last_commented_on
       ? moment(last_commented_on)
       : moment(created_at);

--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -39,6 +39,8 @@ interface FetchBulkThreadsProps extends CommonProps {
   stage?: string;
   includePinnedThreads?: boolean;
   isOnArchivePage?: boolean;
+  contestAddress?: string;
+  contestStatus?: string;
   orderBy?:
     | 'newest'
     | 'oldest'
@@ -107,6 +109,8 @@ const getFetchThreadsQueryKey = (props) => {
       props.fromDate,
       props.limit,
       props.orderBy,
+      props.contestAddress,
+      props.contestStatus,
     ];
 
     // remove milliseconds from cache key
@@ -159,6 +163,12 @@ const fetchBulkThreads = (props) => {
           to_date: props.toDate,
           orderBy: props.orderBy || 'newest',
           ...(props.isOnArchivePage && { archived: true }),
+          ...(props.contestAddress && {
+            contestAddress: props.contestAddress,
+          }),
+          ...(props.contestStatus && {
+            status: props.contestStatus,
+          }),
         },
       },
     );

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -12,6 +12,7 @@ import {
 } from 'views/components/CommunityStake';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
+import { getUniqueTopicIdsIncludedInContest } from 'views/components/sidebar/helpers';
 import { SubscriptionButton } from 'views/components/subscription_button';
 import ManageCommunityStakeModal from 'views/modals/ManageCommunityStakeModal/ManageCommunityStakeModal';
 import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCommunityContests';
@@ -58,7 +59,11 @@ export const CommunitySection = ({ showSkeleton }: CommunitySectionProps) => {
     ...(selectedAddress &&
       !app?.user?.activeAccount && { walletAddress: selectedAddress }),
   });
-  const { isContestAvailable, isContestDataLoading } = useCommunityContests();
+  const { isContestAvailable, isContestDataLoading, contestsData } =
+    useCommunityContests();
+
+  const topicIdsIncludedInContest =
+    getUniqueTopicIdsIncludedInContest(contestsData);
 
   if (showSkeleton || isLoading || isContestDataLoading)
     return <CommunitySectionSkeleton />;
@@ -111,6 +116,7 @@ export const CommunitySection = ({ showSkeleton }: CommunitySectionProps) => {
         <CWDivider />
         <DiscussionSection
           isContestAvailable={stakeEnabled && isContestAvailable}
+          topicIdsIncludedInContest={topicIdsIncludedInContest}
         />
         <CWDivider />
         <GovernanceSection />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -46,8 +46,10 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
 
 export const DiscussionSection = ({
   isContestAvailable,
+  topicIdsIncludedInContest,
 }: {
   isContestAvailable: boolean;
+  topicIdsIncludedInContest: number[];
 }) => {
   const navigate = useCommonNavigate();
   const location = useLocation();
@@ -235,7 +237,8 @@ export const DiscussionSection = ({
 
   for (const topic of topics) {
     if (topic.featuredInSidebar) {
-      const topicInvolvedInActiveContest = false;
+      const topicInvolvedInActiveContest =
+        contestsEnabled && topicIdsIncludedInContest.includes(topic.id);
 
       const discussionSectionGroup: SectionGroupAttrs = {
         title: topic.name,

--- a/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
@@ -12,10 +12,26 @@ function comparisonCustomizer(value1, value2) {
 // Check that our current cached tree is structurally correct
 export function verifyCachedToggleTree(
   treeName: string,
-  toggleTree: ToggleTree
+  toggleTree: ToggleTree,
 ) {
   const cachedTree = JSON.parse(
-    localStorage[`${app.activeChainId()}-${treeName}-toggle-tree`]
+    localStorage[`${app.activeChainId()}-${treeName}-toggle-tree`],
   );
   return _.isEqualWith(cachedTree, toggleTree, comparisonCustomizer);
 }
+
+export const getUniqueTopicIdsIncludedInContest = (
+  contestData: {
+    topics?: { id?: number }[];
+  }[],
+) => {
+  if (!contestData) {
+    return [];
+  }
+
+  const topicIds = contestData.reduce((acc, curr) => {
+    return [...acc, ...(curr.topics || []).map((t) => t.id)];
+  }, []);
+
+  return [...new Set(topicIds)];
+};

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -60,6 +60,8 @@ const ContestsList = ({
             const { end_time, winners } =
               contest.contests[contest.contests.length - 1] || {};
 
+            const hasEnded = new Date(end_time) < new Date();
+
             return (
               <ContestCard
                 key={contest.contest_address}
@@ -74,7 +76,7 @@ const ContestsList = ({
                     ? new Date(end_time)?.toISOString()
                     : new Date().toISOString()
                 }
-                isActive={!contest.cancelled}
+                isActive={!contest.cancelled && !hasEnded}
                 onFund={() => setFundDrawerAddress(contest.contest_address)}
               />
             );

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -53,6 +53,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const { data: topics } = useFetchTopicsQuery({
     communityId,
   });
+  const contestAddress = searchParams.get('contest');
+  const contestStatus = searchParams.get('status');
 
   const containerRef = useRef();
 
@@ -93,6 +95,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       toDate: dateCursor.toDate,
       fromDate: dateCursor.fromDate,
       isOnArchivePage: isOnArchivePage,
+      contestAddress,
+      contestStatus,
     });
 
   const threads = sortPinned(sortByFeaturedFilter(data || [], featuredFilter));

--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -129,7 +129,7 @@ export const HeaderWithFilters = ({
 
   const contestNameOptions = (contestsData || []).map((contest) => ({
     label: contest?.name,
-    value: contest?.name,
+    value: contest?.contest_address,
     id: contest?.contest_address,
     type: 'contest',
   }));
@@ -395,12 +395,11 @@ export const HeaderWithFilters = ({
               )}
               {matchesContestFilterRoute ? (
                 <Select
-                  selected={urlParams.status || 'all-statuses'}
+                  selected={urlParams.status || 'all'}
                   onSelect={(item: any) =>
                     onFilterSelect({
                       filterKey: 'status',
-                      filterVal:
-                        item.value === 'all-statuses' ? '' : item.value,
+                      filterVal: item.value === 'all' ? '' : item.value,
                     })
                   }
                   options={[
@@ -412,12 +411,12 @@ export const HeaderWithFilters = ({
                     {
                       id: 1,
                       label: 'Past winners',
-                      value: 'past-winners',
+                      value: 'pastWinners',
                     },
                     {
                       id: 2,
                       label: 'All Statuses',
-                      value: 'all-statuses',
+                      value: 'all',
                     },
                   ]}
                   dropdownPosition={rightFiltersDropdownPosition}

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -59,10 +59,9 @@ export async function __getBulkThreads(
   if (stage && status) {
     throw new AppError('Cannot provide both stage and status');
   }
-  if (!((contestAddress && status) || (!contestAddress && !status))) {
-    throw new AppError(
-      'Must provide both contestAddress and status or neither',
-    );
+
+  if (status && !contestAddress) {
+    throw new AppError('Must provide contestAddress if status is provided');
   }
 
   // query params that bind to sql query
@@ -126,7 +125,7 @@ export async function __getBulkThreads(
             ${
               contestAddress ? ' AND CA.contest_address = :contestAddress ' : ''
             }
-            ${contestAddress ? contestStatus[status] : ''}
+            ${contestAddress ? contestStatus[status] || contestStatus.all : ''}
         ORDER BY pinned DESC, ${orderByQueries[orderBy] ?? 'T.created_at DESC'} 
         LIMIT :limit OFFSET :offset
     ), thread_metadata AS (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7403 

## Description of Changes
- adjusted code in several places to be able to:
  - display list of contests with proper end date, disabled cancel/edit button
  - display trophy icon next to the topic name
  - filter threads by contests and status

## Test Plan
- to test it out there is a need of inserting multiple rows in 3 different tables with proper primary keys etc
- at this point this does not make sense to test it as it is a lot of hassle 
- very soon we will get working environment where the whole flow will be testable

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a
