### PR TITLE
Fixed allowlist incorrect merge

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/members/getMembers.ts
+++ b/packages/commonwealth/client/scripts/state/api/members/getMembers.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 import { GetCommunityMembers } from '@hicommonwealth/schemas';
 import { trpc } from 'utils/trpcClient';
-import app from '../../index';
 
 type UseGetMembersQueryProps = z.infer<typeof GetCommunityMembers.input>;
 
@@ -19,25 +18,20 @@ const useGetMembersQuery = ({
   allowedAddresses,
   include_stake_balances,
 }: UseGetMembersQueryProps) => {
-  return trpc.community.getMembers.useQuery(
-    {
-      limit,
-      order_by,
-      order_direction: order_direction as 'ASC' | 'DESC',
-      search,
-      community_id,
-      include_roles,
-      memberships,
-      include_group_ids,
-      cursor,
-      allowedAddresses,
-      // only include stake balances if community has staking enabled
-      include_stake_balances,
-    },
-    {
-      enabled: app?.user?.activeAccount?.address ? !!memberships : true,
-    },
-  );
+  return trpc.community.getMembers.useQuery({
+    limit,
+    order_by,
+    order_direction: order_direction as 'ASC' | 'DESC',
+    search,
+    community_id,
+    include_roles,
+    memberships,
+    include_group_ids,
+    cursor,
+    allowedAddresses,
+    // only include stake balances if community has staking enabled
+    include_stake_balances,
+  });
 };
 
 export default useGetMembersQuery;

--- a/packages/commonwealth/webpack/webpack.base.config.mjs
+++ b/packages/commonwealth/webpack/webpack.base.config.mjs
@@ -87,9 +87,6 @@ const baseConfig = {
       ),
     }),
     new webpack.DefinePlugin({
-      'process.env.FLAG_ALLOWLIST': JSON.stringify(process.env.FLAG_ALLOWLIST),
-    }),
-    new webpack.DefinePlugin({
       'process.env.FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED':
         JSON.stringify(
           process.env.FLAG_EXISTING_COMMUNITY_STAKE_INTEGRATION_ENABLED,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7901

## Description of Changes
- Removes double FLAG_ALLOWLIST in webpack config
- Removes incorrect enabled for useMemeberData

## Test Plan
- Create group with allowlist
- Edit group with allowlist