### PR TITLE
`KNOCK_INTEGRATION_ENABLED` Flag

### DIFF
--- a/libs/adapters/src/config.ts
+++ b/libs/adapters/src/config.ts
@@ -48,12 +48,70 @@ export const config = configure(
     BROKER: z.object({
       RABBITMQ_URI: z.string(),
     }),
-    NOTIFICATIONS: z.object({
-      KNOCK_AUTH_TOKEN: z.string().optional(),
-      KNOCK_SECRET_KEY: z.string().optional(),
-      KNOCK_SIGNING_KEY: z.string().optional(),
-      KNOCK_INTEGRATION_ENABLED: z.boolean().optional().default(false),
-    }),
+    NOTIFICATIONS: z
+      .object({
+        KNOCK_AUTH_TOKEN: z
+          .string()
+          .optional()
+          .describe(
+            'A secret token used by the Knock fetch step to interact with private routes on Common',
+          ),
+        KNOCK_SECRET_KEY: z
+          .string()
+          .optional()
+          .describe(
+            'The secret API key used to interact with the Knock API from the platform side',
+          ),
+        KNOCK_SIGNING_KEY: z
+          .string()
+          .optional()
+          .describe(
+            'The key used by the platform to generate Knock JWTs. Required when Knock is in Enhanced Security mode',
+          ),
+        KNOCK_PUBLIC_API_KEY: z
+          .string()
+          .optional()
+          .describe(
+            'The public API key used on the client to interact with public Knock API',
+          ),
+        KNOCK_IN_APP_FEED_ID: z
+          .string()
+          .optional()
+          .describe('The channel ID of the in-app integration on Knock'),
+        KNOCK_INTEGRATION_ENABLED: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            'A flag indicating whether the Knock integration is enabled or disabled',
+          ),
+      })
+      .refine(
+        (data) => {
+          if (data.KNOCK_INTEGRATION_ENABLED) {
+            return (
+              data.KNOCK_AUTH_TOKEN &&
+              data.KNOCK_SECRET_KEY &&
+              data.KNOCK_SIGNING_KEY &&
+              data.KNOCK_PUBLIC_API_KEY &&
+              data.KNOCK_IN_APP_FEED_ID
+            );
+          }
+          return true;
+        },
+        {
+          message:
+            'KNOCK_AUTH_TOKEN, KNOCK_SECRET_KEY, KNOCK_PUBLIC_API_KEY, KNOCK_IN_APP_FEED_ID, and KNOCK_SIGNING_KEY ' +
+            'are required when KNOCK_INTEGRATION_ENABLED is true',
+          path: [
+            'KNOCK_AUTH_TOKEN',
+            'KNOCK_SECRET_KEY',
+            'KNOCK_SIGNING_KEY',
+            'KNOCK_PUBLIC_API_KEY',
+            'KNOCK_IN_APP_FEED_ID',
+          ],
+        },
+      ),
     ANALYTICS: z.object({
       MIXPANEL_PROD_TOKEN: z.string().optional(),
       MIXPANEL_DEV_TOKEN: z.string().optional(),

--- a/libs/adapters/src/config.ts
+++ b/libs/adapters/src/config.ts
@@ -11,6 +11,7 @@ const {
   CLOUDAMQP_URL,
   REDIS_URL, // local + staging
   REDIS_TLS_URL, // staging + production
+  KNOCK_INTEGRATION_ENABLED,
 } = process.env;
 
 export const config = configure(
@@ -29,9 +30,10 @@ export const config = configure(
           : CLOUDAMQP_URL,
     },
     NOTIFICATIONS: {
-      KNOCK_AUTH_TOKEN: KNOCK_AUTH_TOKEN || 'my secret',
-      KNOCK_SECRET_KEY: KNOCK_SECRET_KEY || 'my secret',
-      KNOCK_SIGNING_KEY: KNOCK_SIGNING_KEY || 'my secret',
+      KNOCK_AUTH_TOKEN: KNOCK_AUTH_TOKEN,
+      KNOCK_SECRET_KEY: KNOCK_SECRET_KEY,
+      KNOCK_SIGNING_KEY: KNOCK_SIGNING_KEY,
+      KNOCK_INTEGRATION_ENABLED: KNOCK_INTEGRATION_ENABLED === 'true',
     },
     ANALYTICS: {
       MIXPANEL_PROD_TOKEN,
@@ -47,9 +49,10 @@ export const config = configure(
       RABBITMQ_URI: z.string(),
     }),
     NOTIFICATIONS: z.object({
-      KNOCK_AUTH_TOKEN: z.string(),
+      KNOCK_AUTH_TOKEN: z.string().optional(),
       KNOCK_SECRET_KEY: z.string().optional(),
       KNOCK_SIGNING_KEY: z.string().optional(),
+      KNOCK_INTEGRATION_ENABLED: z.boolean().optional().default(false),
     }),
     ANALYTICS: z.object({
       MIXPANEL_PROD_TOKEN: z.string().optional(),

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -27,9 +27,7 @@ const featureFlags = {
   communityHomepage: buildFlag(process.env.FLAG_COMMUNITY_HOMEPAGE),
   communityStake: buildFlag(process.env.FLAG_COMMUNITY_STAKE),
   userOnboardingEnabled: buildFlag(process.env.FLAG_USER_ONBOARDING_ENABLED),
-  knockInAppNotifications: buildFlag(
-    process.env.FLAG_KNOCK_IN_APP_NOTIFICATIONS,
-  ),
+  knockInAppNotifications: buildFlag(process.env.KNOCK_INTEGRATION_ENABLED),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/server.ts
+++ b/packages/commonwealth/server.ts
@@ -27,7 +27,10 @@ const log = logger(__filename);
 stats(HotShotsStats());
 analytics(MixpanelAnalytics());
 config.CACHE.REDIS_URL && cache(new RedisCache(config.CACHE.REDIS_URL));
-notificationsProvider(KnockProvider());
+
+if (config.NOTIFICATIONS.KNOCK_INTEGRATION_ENABLED)
+  notificationsProvider(KnockProvider());
+else notificationsProvider();
 
 let isServiceHealthy = false;
 startHealthCheckLoop({

--- a/packages/commonwealth/server/api/index.ts
+++ b/packages/commonwealth/server/api/index.ts
@@ -1,7 +1,7 @@
 import { express, trpc } from '@hicommonwealth/adapters';
 import { Router } from 'express';
 import swaggerUi from 'swagger-ui-express';
-import { NEW_SUBSCRIPTION_API_FLAG } from '../config';
+import { config } from '../config';
 import * as community from './community';
 import * as contest from './contest';
 import * as email from './emails';
@@ -21,7 +21,7 @@ const artifacts = {
   contest: contest.trpcRouter,
 };
 
-if (NEW_SUBSCRIPTION_API_FLAG) {
+if (config.NOTIFICATIONS.KNOCK_INTEGRATION_ENABLED) {
   artifacts['subscription'] = subscription.trpcRouter;
   artifacts['email'] = email.trpcRouter;
 }

--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -141,6 +141,3 @@ export const MESSAGE_RELAYER_PREFETCH =
 
 export const EVM_CE_POLL_INTERVAL_MS =
   parseInt(process.env.EVM_CE_POLL_INTERVAL || '') || 120_000;
-
-export const NEW_SUBSCRIPTION_API_FLAG =
-  process.env.NEW_SUBSCRIPTION_API_FLAG === 'true' || false;

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -370,13 +370,16 @@ export const status = async (
  * We have to generate a JWT token for use by the frontend Knock SDK.
  */
 async function computeKnockJwtToken(userId: number) {
-  if (config.NOTIFICATIONS.KNOCK_SIGNING_KEY) {
+  if (
+    config.NOTIFICATIONS.KNOCK_INTEGRATION_ENABLED &&
+    config.NOTIFICATIONS.KNOCK_SIGNING_KEY
+  ) {
     return await Knock.signUserToken(`${userId}`, {
       signingKey: config.NOTIFICATIONS.KNOCK_SIGNING_KEY,
       expiresInSeconds: config.AUTH.SESSION_EXPIRY_MILLIS / 1000,
     });
   } else {
-    log.warn('No process.env.KNOCK_SIGNING_KEY defined ');
+    log.warn('No process.env.KNOCK_SIGNING_KEY defined');
     return '';
   }
 }

--- a/packages/commonwealth/server/workers/knock/knockWorker.ts
+++ b/packages/commonwealth/server/workers/knock/knockWorker.ts
@@ -58,7 +58,9 @@ async function startKnockWorker() {
   }
 
   // init Knock as notifications provider - this is necessary since the policies do not define the provider
-  notificationsProvider(KnockProvider());
+  if (config.NOTIFICATIONS.KNOCK_INTEGRATION_ENABLED)
+    notificationsProvider(KnockProvider());
+  else notificationsProvider();
 
   const sub = await brokerInstance.subscribe(
     BrokerSubscriptions.NotificationsProvider,

--- a/packages/commonwealth/webpack/webpack.base.config.mjs
+++ b/packages/commonwealth/webpack/webpack.base.config.mjs
@@ -113,8 +113,8 @@ const baseConfig = {
       ),
     }),
     new webpack.DefinePlugin({
-      'process.env.FLAG_KNOCK_IN_APP_NOTIFICATIONS': JSON.stringify(
-        process.env.FLAG_KNOCK_IN_APP_NOTIFICATIONS,
+      'process.env.KNOCK_INTEGRATION_ENABLED': JSON.stringify(
+        process.env.KNOCK_INTEGRATION_ENABLED,
       ),
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7892 

## Description of Changes
- Adds a `KNOCK_INTEGRATION_ENABLED` env var which enables/disables all Knock (or related) integration functionality including:
  - tRPC subscription and email routes
  - `KnockProvider`
  - In-app Knock notifications feed
- Removes all default values for KNOCK env var
- Adds all Knock related env var to the new config with a refinement step that requires them to be defined if `KNOCK_INTEGRATION_ENABLED` is true.

## Test Plan
- Run the local server without `KNOCK_INTEGRATION_ENABLED` in `.env`
- Should be able to see the regular/old notifications modal in the top right after signing in

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 