### PR TITLE
Digest email route

### DIFF
--- a/libs/core/src/integration/email.schemas.ts
+++ b/libs/core/src/integration/email.schemas.ts
@@ -52,3 +52,8 @@ export const GetRecapEmailData = {
     ),
   }),
 };
+
+export const GetDigestEmailData = {
+  input: z.object({}),
+  output: z.object({}),
+};

--- a/libs/core/src/integration/email.schemas.ts
+++ b/libs/core/src/integration/email.schemas.ts
@@ -1,3 +1,4 @@
+import { Thread } from '@hicommonwealth/schemas';
 import { z } from 'zod';
 import {
   ChainProposalsNotification,
@@ -53,7 +54,16 @@ export const GetRecapEmailData = {
   }),
 };
 
+export const EnrichedThread = Thread.extend({
+  name: z
+    .string()
+    .describe('The name of the community that the thread belongs to'),
+  icon_url: z
+    .string()
+    .describe('The icon url of the community that the thread belongs to'),
+});
+
 export const GetDigestEmailData = {
   input: z.object({}),
-  output: z.object({}),
+  output: z.record(z.string(), z.array(EnrichedThread)),
 };

--- a/libs/model/src/emails/GetDigestEmailData.query.ts
+++ b/libs/model/src/emails/GetDigestEmailData.query.ts
@@ -1,0 +1,17 @@
+import {
+  ExternalServiceUserIds,
+  GetDigestEmailData,
+  Query,
+} from '@hicommonwealth/core';
+
+export function GetDigestEmailDataQuery(): Query<typeof GetDigestEmailData> {
+  return {
+    ...GetDigestEmailData,
+    auth: [],
+    secure: true,
+    authStrategy: { name: 'authtoken', userId: ExternalServiceUserIds.Knock },
+    body: async ({ payload }) => {
+      return {};
+    },
+  };
+}

--- a/libs/model/src/emails/GetDigestEmailData.query.ts
+++ b/libs/model/src/emails/GetDigestEmailData.query.ts
@@ -30,7 +30,7 @@ export function GetDigestEmailDataQuery(): Query<typeof GetDigestEmailData> {
               FROM "Threads" T
               WHERE T.community_id = communities.id
                 AND created_at > NOW() - INTERVAL '10 months'
-              ORDER BY T.view_count
+              ORDER BY T.view_count DESC
               LIMIT 2
               ) top_threads ON true;
       `,

--- a/libs/model/src/emails/GetDigestEmailData.query.ts
+++ b/libs/model/src/emails/GetDigestEmailData.query.ts
@@ -1,8 +1,12 @@
 import {
+  EnrichedThread,
   ExternalServiceUserIds,
   GetDigestEmailData,
   Query,
 } from '@hicommonwealth/core';
+import { models } from '@hicommonwealth/model';
+import { QueryTypes } from 'sequelize';
+import { z } from 'zod';
 
 export function GetDigestEmailDataQuery(): Query<typeof GetDigestEmailData> {
   return {
@@ -10,8 +14,44 @@ export function GetDigestEmailDataQuery(): Query<typeof GetDigestEmailData> {
     auth: [],
     secure: true,
     authStrategy: { name: 'authtoken', userId: ExternalServiceUserIds.Knock },
-    body: async ({ payload }) => {
-      return {};
+    body: async () => {
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(new Date().getDate() - 7);
+      const threads = await models.sequelize.query<
+        z.infer<typeof EnrichedThread>
+      >(
+        `
+          SELECT communities.name, communities.icon_url, top_threads.*
+          FROM (SELECT C.id, name, icon_url
+                FROM "Communities" C
+                WHERE C.include_in_digest_email = true) communities
+                   JOIN LATERAL (
+              SELECT *
+              FROM "Threads" T
+              WHERE T.community_id = communities.id
+                AND created_at > NOW() - INTERVAL '10 months'
+              ORDER BY T.view_count
+              LIMIT 2
+              ) top_threads ON true;
+      `,
+        {
+          type: QueryTypes.SELECT,
+          raw: true,
+        },
+      );
+
+      if (!threads.length) return {};
+
+      const result: z.infer<typeof GetDigestEmailData['output']> = {};
+      for (const thread of threads) {
+        if (!result[thread.community_id]) {
+          result[thread.community_id] = [thread];
+        } else {
+          result[thread.community_id].push(thread);
+        }
+      }
+
+      return result;
     },
   };
 }

--- a/libs/model/src/emails/index.ts
+++ b/libs/model/src/emails/index.ts
@@ -1,1 +1,2 @@
+export * from './GetDigestEmailData.query';
 export * from './GetRecapEmailData.query';

--- a/libs/model/src/models/community.ts
+++ b/libs/model/src/models/community.ts
@@ -146,6 +146,10 @@ export default (
         allowNull: false,
         defaultValue: [],
       },
+      include_in_digest_email: {
+        type: Sequelize.BOOLEAN,
+        allowNull: true,
+      },
     },
     {
       tableName: 'Communities',
@@ -153,5 +157,6 @@ export default (
       createdAt: 'created_at',
       updatedAt: 'updated_at',
       underscored: false,
+      indexes: [{ fields: ['include_in_digest_email'] }],
     },
   );

--- a/libs/model/test/email/digest-email-lifecycle.spec.ts
+++ b/libs/model/test/email/digest-email-lifecycle.spec.ts
@@ -1,0 +1,173 @@
+import { ExternalServiceUserIds, dispose, query } from '@hicommonwealth/core';
+import { models } from '@hicommonwealth/model';
+import { Community } from '@hicommonwealth/schemas';
+import { expect } from 'chai';
+import { z } from 'zod';
+import { GetDigestEmailDataQuery } from '../../src/emails';
+import { seed } from '../../src/tester';
+import { generateThreads } from './util';
+
+describe.only('Digest email lifecycle', () => {
+  let communityOne: z.infer<typeof Community> | undefined;
+  let communityTwo: z.infer<typeof Community> | undefined;
+  let communityThree: z.infer<typeof Community> | undefined;
+
+  before(async () => {
+    const [authorUser] = await seed('User', {
+      isAdmin: false,
+      selected_community_id: null,
+    });
+    const [authorProfile] = await seed('Profile', {
+      user_id: authorUser!.id,
+    });
+
+    [communityOne] = await seed('Community', {
+      chain_node_id: undefined,
+      Addresses: [
+        {
+          role: 'member',
+          user_id: authorUser!.id,
+          profile_id: authorProfile!.id,
+        },
+      ],
+    });
+    [communityTwo] = await seed('Community', {
+      chain_node_id: undefined,
+      Addresses: [
+        {
+          role: 'member',
+          user_id: authorUser!.id,
+          profile_id: authorProfile!.id,
+        },
+      ],
+    });
+    // create an additional community to ensure only specific threads are selected
+    [communityThree] = await seed('Community', {
+      chain_node_id: undefined,
+      Addresses: [
+        {
+          role: 'member',
+          user_id: authorUser!.id,
+          profile_id: authorProfile!.id,
+        },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await models.Community.update(
+      {
+        include_in_digest_email: false,
+      },
+      {
+        where: {
+          id: [communityOne!.id!, communityTwo!.id!],
+        },
+      },
+    );
+    await models.sequelize.query(`DELETE FROM "Threads";`);
+  });
+
+  after(async () => {
+    await dispose()();
+  });
+
+  it('should return an empty object if there are no relevant communities', async () => {
+    await generateThreads(communityOne!, communityTwo!, communityThree!);
+    const res = await query(GetDigestEmailDataQuery(), {
+      actor: {
+        user: {
+          id: ExternalServiceUserIds.Knock,
+          email: 'hello@knock.app',
+        },
+      },
+      payload: {},
+    });
+    expect(res).to.deep.equal({});
+    await models.Community.update(
+      {
+        include_in_digest_email: false,
+      },
+      {
+        where: {
+          id: [communityOne!.id!, communityTwo!.id!],
+        },
+      },
+    );
+  });
+
+  it('should return an empty object if there are no relevant threads', async () => {
+    await models.Community.update(
+      {
+        include_in_digest_email: true,
+      },
+      {
+        where: {
+          id: [communityOne!.id!, communityTwo!.id!],
+        },
+      },
+    );
+
+    const res = await query(GetDigestEmailDataQuery(), {
+      actor: {
+        user: {
+          id: ExternalServiceUserIds.Knock,
+          email: 'hello@knock.app',
+        },
+      },
+      payload: {},
+    });
+    expect(res).to.deep.equal({});
+  });
+
+  it('should return enriched threads for each community', async () => {
+    const { threadOne, threadTwo, threadFour } = await generateThreads(
+      communityOne!,
+      communityTwo!,
+      communityThree!,
+    );
+    await models.Community.update(
+      {
+        include_in_digest_email: true,
+      },
+      {
+        where: {
+          id: [communityOne!.id!, communityTwo!.id!],
+        },
+      },
+    );
+
+    const res = await query(GetDigestEmailDataQuery(), {
+      actor: {
+        user: {
+          id: ExternalServiceUserIds.Knock,
+          email: 'hello@knock.app',
+        },
+      },
+      payload: {},
+    });
+
+    expect(res![communityOne!.id!]!.length).to.equal(2);
+    expect(res![communityTwo!.id!]!.length).to.equal(1);
+
+    delete threadOne?.Address;
+    delete threadTwo?.Address;
+    delete threadFour?.Address;
+
+    expect(res![communityOne!.id!]![0]!).to.deep.equal({
+      name: communityOne!.name,
+      icon_url: communityOne!.icon_url,
+      ...threadOne,
+    });
+    expect(res![communityOne!.id!]![1]!).to.deep.equal({
+      name: communityOne!.name,
+      icon_url: communityOne!.icon_url,
+      ...threadTwo,
+    });
+    expect(res![communityTwo!.id!]![0]!).to.deep.equal({
+      name: communityTwo!.name,
+      icon_url: communityTwo!.icon_url,
+      ...threadFour,
+    });
+  });
+});

--- a/libs/model/test/email/util.ts
+++ b/libs/model/test/email/util.ts
@@ -22,6 +22,7 @@ import {
   User,
 } from '@hicommonwealth/schemas';
 import { z } from 'zod';
+import { seed } from '../../src/tester';
 
 type ArrayItemType<T> = T extends Array<infer U> ? U : never;
 
@@ -301,5 +302,67 @@ export function generateProtocolData(
     notifications,
     enrichedNotifications,
     messages,
+  };
+}
+
+export async function generateThreads(
+  communityOne: z.infer<typeof Community>,
+  communityTwo: z.infer<typeof Community>,
+  communityThree: z.infer<typeof Community>,
+) {
+  await seed('Thread', {
+    address_id: communityThree?.Addresses?.at(0)?.id,
+    community_id: communityThree?.id,
+    topic_id: communityThree?.topics?.at(0)?.id,
+    pinned: false,
+    read_only: false,
+    version_history: [],
+  });
+
+  // 3 threads for communityOne and 1 thread for communityTwo
+  const [threadOne] = await seed('Thread', {
+    address_id: communityOne?.Addresses?.at(0)?.id,
+    community_id: communityOne?.id,
+    topic_id: communityOne?.topics?.at(0)?.id,
+    pinned: false,
+    read_only: false,
+    version_history: [],
+    view_count: 10,
+  });
+  const [threadTwo] = await seed('Thread', {
+    address_id: communityOne?.Addresses?.at(0)?.id,
+    community_id: communityOne?.id,
+    topic_id: communityOne?.topics?.at(0)?.id,
+    pinned: false,
+    read_only: false,
+    version_history: [],
+    view_count: 5,
+  });
+
+  const [threadThree] = await seed('Thread', {
+    address_id: communityOne?.Addresses?.at(0)?.id,
+    community_id: communityOne?.id,
+    topic_id: communityTwo?.topics?.at(0)?.id,
+    pinned: false,
+    read_only: false,
+    version_history: [],
+    view_count: 1,
+  });
+
+  const [threadFour] = await seed('Thread', {
+    address_id: communityTwo?.Addresses?.at(0)?.id,
+    community_id: communityTwo?.id,
+    topic_id: communityTwo?.topics?.at(0)?.id,
+    pinned: false,
+    read_only: false,
+    version_history: [],
+    view_count: 10,
+  });
+
+  return {
+    threadOne,
+    threadTwo,
+    threadThree,
+    threadFour,
   };
 }

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -59,4 +59,5 @@ export const Community = z.object({
   groups: z.array(Group).optional(),
   contest_managers: z.array(ContestManager).optional(),
   snapshot_spaces: z.array(z.string().max(255)).default([]).optional(),
+  include_in_digest_email: z.boolean().nullish(),
 });

--- a/packages/commonwealth/server/api/emails.ts
+++ b/packages/commonwealth/server/api/emails.ts
@@ -3,4 +3,5 @@ import { Email } from '@hicommonwealth/model';
 
 export const trpcRouter = trpc.router({
   getRecapEmailData: trpc.query(Email.GetRecapEmailDataQuery),
+  getDigestEmailData: trpc.query(Email.GetDigestEmailDataQuery),
 });

--- a/packages/commonwealth/server/migrations/20240522140649-add-digest-column-to-communities.js
+++ b/packages/commonwealth/server/migrations/20240522140649-add-digest-column-to-communities.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'Communities',
+        'include_in_digest_email',
+        {
+          type: Sequelize.BOOLEAN,
+          allowNull: true,
+        },
+        { transaction },
+      );
+      await queryInterface.addIndex(
+        'Communities',
+        ['include_in_digest_email'],
+        {
+          name: 'communities_include_in_digest_email',
+          transaction,
+        },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Communities', 'include_in_digest_email');
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #[7689](https://github.com/hicommonwealth/commonwealth/issues/7689)

## Description of Changes
- Adds a tRPC route for fetching digest email data
- Adds an `Communities.include_in_digest_email` column

## Test Plan
- Can't test through Knock yet so just ensure model tests should pass

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 