### PR TITLE
user no longer shows as anonymous when first commenting

### DIFF
--- a/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
+++ b/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
@@ -17,7 +17,7 @@ export function addressToUserProfile(address): UserProfile {
   return {
     id: profile.id,
     avatarUrl: profile?.avatar_url,
-    name: profile?.profile_name,
+    name: profile?.profile_name || profile?.name,
     address: address?.address,
     lastActive: address?.last_active,
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7907 

## Description of Changes
User no longer sees themselves as Anonymous when commenting

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added a conditional to look for ` name: profile?.profile_name || profile?.name,`
## Test Plan
-create a thred
-comment on that thread
-notice that your name is no longer Anonymous when the comment is first shown


https://github.com/hicommonwealth/commonwealth/assets/69872984/7b340e41-8e9b-4cb8-bf27-30c96cc4687e

