### PR TITLE
Image Uploading Fixes

### DIFF
--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -101,7 +101,7 @@ export async function emitEvent(
 }
 
 /**
- * Creates a valid S3 asset url for the client. Only for the public assets.commonwealth.im bucket
+ * Creates a valid S3 asset url from an upload.Location url
  * @param uploadLocation The url returned by the Upload method of @aws-sdk/lib-storage
  * @param bucketName The name of the bucket or the domain (alias) of the bucket. Defaults to assets.commonwealth.im
  */

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -99,3 +99,23 @@ export async function emitEvent(
     await outbox.bulkCreate(values, { transaction });
   }
 }
+
+/**
+ * Creates a valid S3 asset url for the client. Only for the public assets.commonwealth.im bucket
+ * @param uploadLocation The url returned by the Upload method of @aws-sdk/lib-storage
+ * @param bucketName The name of the bucket or the domain (alias) of the bucket. Defaults to assets.commonwealth.im
+ */
+export function formatS3Url(
+  uploadLocation: string,
+  bucketName: string = 'assets.commonwealth.im',
+): string {
+  if (uploadLocation.includes('/assets.commonwealth.im/')) {
+    return (
+      `https://assets.commonwealth.im/` +
+      uploadLocation.split('/assets.commonwealth.im/').pop()
+    );
+  }
+  return (
+    `https://${bucketName}/` + uploadLocation.split('amazonaws.com/').pop()
+  );
+}

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -109,12 +109,6 @@ export function formatS3Url(
   uploadLocation: string,
   bucketName: string = 'assets.commonwealth.im',
 ): string {
-  if (uploadLocation.includes('/assets.commonwealth.im/')) {
-    return (
-      `https://assets.commonwealth.im/` +
-      uploadLocation.split('/assets.commonwealth.im/').pop()
-    );
-  }
   return (
     `https://${bucketName}/` + uploadLocation.split('amazonaws.com/').pop()
   );

--- a/libs/sitemaps/src/createAsyncWriter.ts
+++ b/libs/sitemaps/src/createAsyncWriter.ts
@@ -1,6 +1,8 @@
 import { PutObjectCommandInput, S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
+import { formatS3Url } from '@hicommonwealth/model';
 
+const BUCKET_NAME = 'common-sitemap';
 const s3 = new S3();
 
 export interface Resource {
@@ -27,7 +29,7 @@ export function createAsyncWriterMock() {
 export function createAsyncWriterS3(): AsyncWriter {
   async function write(filename: string, content: string): Promise<Resource> {
     const params: PutObjectCommandInput = {
-      Bucket: 'common-sitemap',
+      Bucket: BUCKET_NAME,
       Key: `${filename}`,
       Body: content,
       ContentType: 'text/xml; charset=utf-8',
@@ -42,7 +44,7 @@ export function createAsyncWriterS3(): AsyncWriter {
       throw new Error('Failed to return upload location');
     }
 
-    return { location: upload.Location };
+    return { location: formatS3Url(upload.Location, BUCKET_NAME) };
   }
 
   return { write };

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/utils.tsx
@@ -98,8 +98,9 @@ export const uploadFileToS3 = async (
 
     // upload the file via the signed URL
     await axios.put(signedUploadUrl, compressedFile, {
-      params: {
+      headers: {
         'Content-Type': file.type,
+        'Content-Length': file.size,
       },
     });
 

--- a/packages/commonwealth/scripts/archive-outbox.ts
+++ b/packages/commonwealth/scripts/archive-outbox.ts
@@ -2,7 +2,7 @@ import { S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { HotShotsStats } from '@hicommonwealth/adapters';
 import { logger, stats } from '@hicommonwealth/core';
-import { config } from '@hicommonwealth/model';
+import { config, formatS3Url } from '@hicommonwealth/model';
 import { execSync } from 'child_process';
 import { createReadStream, createWriteStream } from 'fs';
 import { QueryTypes } from 'sequelize';
@@ -68,7 +68,12 @@ async function uploadToS3(filePath: string): Promise<boolean> {
       client: s3,
       params,
     }).done();
-    log.info(`File uploaded successfully at ${data.Location}`);
+    log.info(
+      `File uploaded successfully at ${formatS3Url(
+        data.Location,
+        S3_BUCKET_NAME,
+      )}`,
+    );
     return true;
   } catch (error) {
     log.error(`S3 upload failed`, error, {

--- a/packages/commonwealth/scripts/resizeImages.ts
+++ b/packages/commonwealth/scripts/resizeImages.ts
@@ -6,7 +6,7 @@
 
 import { PutObjectCommandInput, S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
-import { models, sequelize } from '@hicommonwealth/model';
+import { formatS3Url, models, sequelize } from '@hicommonwealth/model';
 import * as https from 'https';
 import fetch from 'node-fetch';
 import { Op } from 'sequelize';
@@ -198,10 +198,7 @@ async function uploadToS3AndReplace(
 
     // although it gets added to the assets.commonwealth.im bucket, the location of the newImage object points
     // to the bucket directly. We want to swap this out with the cloudflare url.
-    const newLocation = newImage.Location.replace(
-      's3.amazonaws.com/assets.commonwealth.im',
-      'assets.commonwealth.im',
-    );
+    const newLocation = formatS3Url(newImage.Location);
 
     console.log(
       `Successfully resized ${name} ${datum.id} with new url ${newLocation}`,

--- a/packages/commonwealth/server/routes/generateImage.ts
+++ b/packages/commonwealth/server/routes/generateImage.ts
@@ -5,7 +5,7 @@ import { OpenAI } from 'openai';
 import { v4 as uuidv4 } from 'uuid';
 
 import { AppError } from '@hicommonwealth/core';
-import type { DB } from '@hicommonwealth/model';
+import { DB, formatS3Url } from '@hicommonwealth/model';
 import type { TypedRequestBody, TypedResponse } from '../types';
 import { success } from '../types';
 
@@ -72,7 +72,7 @@ const generateImage = async (
       client: s3,
       params,
     }).done();
-    imageUrl = upload.Location;
+    imageUrl = formatS3Url(upload.Location);
   } catch (e) {
     console.log(e);
     throw new AppError('Problem uploading image!');

--- a/packages/commonwealth/server/routes/getUploadSignature.ts
+++ b/packages/commonwealth/server/routes/getUploadSignature.ts
@@ -3,7 +3,7 @@ import { AppError } from '@hicommonwealth/core';
 import { PutObjectCommand, S3 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-import { DB, formatS3Url } from '@hicommonwealth/model';
+import { DB } from '@hicommonwealth/model';
 import type { NextFunction, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -44,10 +44,8 @@ const getUploadSignature = async (
   };
 
   try {
-    const url = await getSignedUrl(s3, new PutObjectCommand(params), {
-      expiresIn: 3600,
-    });
-    res.json({ status: 'Success', result: formatS3Url(url) });
+    const url = await getSignedUrl(s3, new PutObjectCommand(params));
+    res.json({ status: 'Success', result: url });
   } catch (err) {
     res.json({ status: 'Failure', result: err });
   }

--- a/packages/commonwealth/server/routes/getUploadSignature.ts
+++ b/packages/commonwealth/server/routes/getUploadSignature.ts
@@ -3,7 +3,7 @@ import { AppError } from '@hicommonwealth/core';
 import { PutObjectCommand, S3 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-import type { DB } from '@hicommonwealth/model';
+import { DB, formatS3Url } from '@hicommonwealth/model';
 import type { NextFunction, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -47,7 +47,7 @@ const getUploadSignature = async (
     const url = await getSignedUrl(s3, new PutObjectCommand(params), {
       expiresIn: 3600,
     });
-    res.json({ status: 'Success', result: url });
+    res.json({ status: 'Success', result: formatS3Url(url) });
   } catch (err) {
     res.json({ status: 'Failure', result: err });
   }

--- a/packages/commonwealth/server/routes/getUploadSignature.ts
+++ b/packages/commonwealth/server/routes/getUploadSignature.ts
@@ -3,7 +3,7 @@ import { AppError } from '@hicommonwealth/core';
 import { PutObjectCommand, S3 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-import { DB } from '@hicommonwealth/model';
+import type { DB } from '@hicommonwealth/model';
 import type { NextFunction, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/commonwealth/server/routes/getUploadSignature.ts
+++ b/packages/commonwealth/server/routes/getUploadSignature.ts
@@ -44,7 +44,9 @@ const getUploadSignature = async (
   };
 
   try {
-    const url = await getSignedUrl(s3, new PutObjectCommand(params));
+    const url = await getSignedUrl(s3, new PutObjectCommand(params), {
+      expiresIn: 3600,
+    });
     res.json({ status: 'Success', result: url });
   } catch (err) {
     res.json({ status: 'Failure', result: err });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7920

## Description of Changes
- Adds utility function to convert URLs to use CDN
- Updated the put request headers for image uploads in the quill editor

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
The headers/params of the signed url must exactly match the headers/params used to make the request with the signed URL. The most likely explanation for this issue is that the v2 client signed URLs didn't include 'Content-Type' in the generated signature so having the `Content-Type` in the params when using the signed URL didn't cause an error. If this assumption is correct then it means that in v3 `Content-Type` is included so we needed to move the `Content-Type` from params to headers (where it should be).

This error did not occur for avatar uploads because the request already correctly adds the 'Content-Type' in the headers rather than in the params.

## Test Plan
- Create a community and generate/upload an image
- In the community you created create a thread and upload an image into the thread

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 