### PR TITLE
Prevent edit profile form from submitting when image is processing

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/edit_profile.tsx
@@ -60,6 +60,8 @@ const EditProfileComponent = () => {
   const [addresses, setAddresses] = useState<AddressInfo[]>();
   const [displayNameValid, setDisplayNameValid] = useState(true);
   const [account, setAccount] = useState<Account>();
+  const [isUploadingProfileImage, setIsUploadingProfileImage] = useState(false);
+  const [isUploadingCoverImage, setIsUploadingCoverImage] = useState(false);
   const backgroundImageRef = useRef<Image>();
 
   const { mutateAsync: updateProfile } = useUpdateProfileByAddressMutation({
@@ -271,6 +273,7 @@ const EditProfileComponent = () => {
                     label="Save"
                     onClick={() => handleSaveProfile()}
                     className="save-button"
+                    disabled={isUploadingProfileImage || isUploadingCoverImage}
                     buttonType="primary"
                   />
                 </div>
@@ -292,7 +295,11 @@ const EditProfileComponent = () => {
                   <AvatarUpload
                     scope="user"
                     account={account}
+                    uploadStartedCallback={() =>
+                      setIsUploadingProfileImage(true)
+                    }
                     uploadCompleteCallback={(files) => {
+                      setIsUploadingProfileImage(false);
                       files.forEach((f) => {
                         if (!f.uploadURL) return;
                         const url = f.uploadURL.replace(/\?.*/, '').trim();
@@ -399,6 +406,7 @@ const EditProfileComponent = () => {
                 enableGenerativeAI
                 defaultImageUrl={backgroundImageRef.current?.url}
                 defaultImageBehavior={backgroundImageRef.current?.imageBehavior}
+                onImageProcessStatusChange={setIsUploadingCoverImage}
               />
             </CWFormSection>
             <CWFormSection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7933

## Description of Changes
Prevent edit profile form from submitting when image is processing

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
N/A

## Test Plan
1. Login
2. Go to edit profile
3. Upload or generate a cover or profile image
4. Verify that the `Save`/submit form button is disabled until the image is uploaded.


## Deployment Plan
N/A

## Other Considerations
N/A