### PR TITLE
Fixed lock thread issue

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -203,9 +203,12 @@ export const AdminActions = ({
     })
       .then(() => {
         notifySuccess(thread?.readOnly ? 'Unlocked!' : 'Locked!');
-        onLockToggle(!thread?.readOnly);
+        if (onLockToggle) {
+          onLockToggle(!thread?.readOnly);
+        }
       })
-      .catch(() => {
+      .catch((e) => {
+        console.log(e);
         notifyError('Could not update thread read_only');
       });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7936

## Description of Changes
- Fixes error from locking thread from discussions page

## Test Plan
- Go to the discussions page as an admin, try locking a thread. It should lock correctly with no error.