### PR TITLE
create dev flag for contest interval

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -30,6 +30,7 @@ const featureFlags = {
   knockInAppNotifications: buildFlag(
     process.env.FLAG_KNOCK_INTEGRATION_ENABLED,
   ),
+  contestDev: buildFlag(process.env.FLAG_CONTEST_DEV),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -70,7 +70,9 @@ const SignTransactionsStep = ({
     const voterShare = commonProtocol.CONTEST_VOTER_SHARE;
     const feeShare = commonProtocol.CONTEST_FEE_SHARE;
     const weight = Number(app?.chain?.meta?.CommunityStakes?.[0]?.voteWeight);
-    const contestInterval = SEVEN_DAYS_IN_SECONDS;
+    const contestInterval = devContest
+      ? FIVE_MINS_IN_SECONDS
+      : SEVEN_DAYS_IN_SECONDS;
     const prizeShare = contestFormData?.prizePercentage;
     const walletAddress = app.user.activeAccount?.address;
     const exchangeToken = isDirectDepositSelected

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -24,6 +24,7 @@ import {
   LaunchContestStep,
 } from '../../types';
 
+import { useFlag } from 'client/scripts/hooks/useFlag';
 import './SignTransactionsStep.scss';
 
 interface SignTransactionsStepProps {
@@ -33,6 +34,7 @@ interface SignTransactionsStepProps {
 }
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
+const FIVE_MINS_IN_SECONDS = 60 * 5;
 
 const SignTransactionsStep = ({
   onSetLaunchContestStep,
@@ -55,11 +57,15 @@ const SignTransactionsStep = ({
   const isDirectDepositSelected =
     contestFormData.feeType === ContestFeeType.DirectDeposit;
 
+  const devContest = useFlag('contestDev');
+
   const signTransaction = async () => {
     const ethChainId = app?.chain?.meta?.ChainNode?.ethChainId;
     const chainRpc = app?.chain?.meta?.ChainNode?.url;
     const namespaceName = app?.chain?.meta?.namespace;
-    const contestLength = SEVEN_DAYS_IN_SECONDS;
+    const contestLength = devContest
+      ? FIVE_MINS_IN_SECONDS
+      : SEVEN_DAYS_IN_SECONDS;
     const stakeId = app?.chain?.meta?.CommunityStakes?.[0]?.stakeId;
     const voterShare = commonProtocol.CONTEST_VOTER_SHARE;
     const feeShare = commonProtocol.CONTEST_FEE_SHARE;

--- a/packages/commonwealth/webpack/webpack.base.config.mjs
+++ b/packages/commonwealth/webpack/webpack.base.config.mjs
@@ -117,6 +117,11 @@ const baseConfig = {
         process.env.FLAG_KNOCK_INTEGRATION_ENABLED,
       ),
     }),
+    new webpack.DefinePlugin({
+      'process.env.FLAG_CONTEST_DEV': JSON.stringify(
+        process.env.FLAG_CONTEST_DEV,
+      ),
+    }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../client/index.html'),
       attributes: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7931 

## Description of Changes
- Adds `FLAG_CONTEST_DEV` which adjusts default contest interval to 5mins(300 secs)

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- A breakpoint on contest interval and variable updated  in `SignTransactionStep.tsx` for uncommon dev cases where shorter or longer custom intervals are required.