### PR TITLE
Changed get_bulk_threads to not return version_history

### DIFF
--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -107,7 +107,7 @@ export async function __getBulkThreads(
   const responseThreadsQuery = this.models.sequelize.query<ThreadsQuery>(
     `
         WITH top_threads AS (
-        SELECT id, title, url, body, version_history, kind, stage, read_only, discord_meta,
+        SELECT id, title, url, body, kind, stage, read_only, discord_meta,
             pinned, community_id, T.created_at, updated_at, locked_at as thread_locked, links,
             has_poll, last_commented_on, plaintext, comment_count as "numberOfComments",
             marked_as_spam_at, archived_at, topic_id, reaction_weights_sum, canvas_action as "canvasAction",


### PR DESCRIPTION
## Link to Issue
Closes: #7960

## Description of Changes
- Removes version history from get_bulk_threads since it is not necessary

## Test Plan
- Go to a discussions page. Make sure you can create a thread and read the threads
