### PR TITLE
Optimize search

### DIFF
--- a/libs/model/src/thread/GetThread.query.ts
+++ b/libs/model/src/thread/GetThread.query.ts
@@ -7,6 +7,7 @@ export const GetThreadsParamsSchema = z.object({
   active: z.string().optional(),
   search: z.string().optional(),
   count: z.coerce.boolean().optional().default(false),
+  include_count: z.coerce.boolean().default(false),
 });
 
 export const GetBulkThreadsParamsSchema = z.object({

--- a/packages/commonwealth/client/scripts/state/api/comments/searchComments.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/searchComments.ts
@@ -24,6 +24,7 @@ interface SearchCommentsProps {
   limit: number;
   orderBy: APIOrderBy;
   orderDirection: APIOrderDirection;
+  includeCount?: boolean;
   enabled?: boolean;
 }
 
@@ -34,6 +35,7 @@ const searchComments = async ({
   limit,
   orderBy,
   orderDirection,
+  includeCount,
 }: SearchCommentsProps & { pageParam: number }) => {
   const {
     data: { result },
@@ -50,6 +52,7 @@ const searchComments = async ({
         page: pageParam.toString(),
         order_by: orderBy,
         order_direction: orderDirection,
+        include_count: includeCount,
       },
     },
   );
@@ -62,6 +65,7 @@ const useSearchCommentsQuery = ({
   limit,
   orderBy,
   orderDirection,
+  includeCount,
   enabled = true,
 }: SearchCommentsProps) => {
   const key = [
@@ -82,6 +86,7 @@ const useSearchCommentsQuery = ({
         limit,
         orderBy,
         orderDirection,
+        includeCount,
       }),
     {
       getNextPageParam: (lastPage) => {

--- a/packages/commonwealth/client/scripts/state/api/comments/searchComments.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/searchComments.ts
@@ -92,7 +92,7 @@ const useSearchCommentsQuery = ({
         return undefined;
       },
       staleTime: SEARCH_COMMENTS_STALE_TIME,
-      enabled,
+      enabled: enabled && searchTerm.length >= 3,
     },
   );
 };

--- a/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
@@ -2,16 +2,17 @@ import { z } from 'zod';
 
 import { GetAllContests } from '@hicommonwealth/schemas';
 import { trpc } from 'utils/trpcClient';
-import { useFlag } from '../../../hooks/useFlag';
 
-type UseGetContestsQueryProps = z.infer<typeof GetAllContests.input>;
+type UseGetContestsQueryProps = z.infer<typeof GetAllContests.input> & {
+  enabled: boolean;
+};
 
 const useGetContestsQuery = ({
   contest_id,
   community_id,
   running,
+  enabled,
 }: UseGetContestsQueryProps) => {
-  const enabled = useFlag('contest');
   return trpc.contest.getAllContests.useQuery(
     {
       contest_id,

--- a/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { GetAllContests } from '@hicommonwealth/schemas';
 import { trpc } from 'utils/trpcClient';
+import { useFlag } from '../../../hooks/useFlag';
 
 type UseGetContestsQueryProps = z.infer<typeof GetAllContests.input>;
 
@@ -10,15 +11,14 @@ const useGetContestsQuery = ({
   community_id,
   running,
 }: UseGetContestsQueryProps) => {
+  const enabled = useFlag('contest');
   return trpc.contest.getAllContests.useQuery(
     {
       contest_id,
       community_id,
       running,
     },
-    // { enabled: !!community_id },
-    // TODO: When we hook up community, fix this, also make sure its behind a FF.
-    { enabled: false },
+    { enabled: enabled && !!community_id },
   );
 };
 

--- a/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
@@ -16,7 +16,9 @@ const useGetContestsQuery = ({
       community_id,
       running,
     },
-    { enabled: !!community_id },
+    // { enabled: !!community_id },
+    // TODO: When we hook up community, fix this, also make sure its behind a FF.
+    { enabled: false },
   );
 };
 

--- a/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
@@ -27,6 +27,7 @@ interface SearchProfilesProps {
   includeRoles: boolean;
   includeMembershipTypes?: 'in-group' | `in-group:${string}` | 'not-in-group';
   includeGroupIds?: boolean;
+  includeCount?: boolean;
   enabled?: boolean;
 }
 
@@ -38,6 +39,7 @@ const searchProfiles = async ({
   orderBy,
   orderDirection,
   includeRoles,
+  includeCount,
 }: SearchProfilesProps & { pageParam: number }) => {
   const {
     data: { result },
@@ -55,6 +57,7 @@ const searchProfiles = async ({
         order_by: orderBy,
         order_direction: orderDirection,
         include_roles: includeRoles,
+        include_count: includeCount,
       },
     },
   );
@@ -68,6 +71,7 @@ const useSearchProfilesQuery = ({
   orderBy,
   orderDirection,
   includeRoles,
+  includeCount,
   enabled = true,
 }: SearchProfilesProps) => {
   const key = [
@@ -90,6 +94,7 @@ const useSearchProfilesQuery = ({
         orderBy,
         orderDirection,
         includeRoles,
+        includeCount,
       }),
     {
       getNextPageParam: (lastPage) => {

--- a/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/searchProfiles.ts
@@ -100,7 +100,7 @@ const useSearchProfilesQuery = ({
         return undefined;
       },
       staleTime: SEARCH_PROFILES_STALE_TIME,
-      enabled,
+      enabled: enabled && searchTerm.length >= 3,
     },
   );
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
@@ -92,12 +92,8 @@ const useSearchThreadsQuery = ({
         threadTitleOnly,
       }),
     {
-      getNextPageParam: (lastPage) => {
-        const nextPageNum = lastPage.page + 1;
-        if (nextPageNum <= lastPage.totalPages) {
-          return nextPageNum;
-        }
-        return undefined;
+      getNextPageParam: (_) => {
+        console.error('Not implemented');
       },
       staleTime: SEARCH_THREADS_STALE_TIME,
       enabled: enabled && searchTerm.length >= 3,

--- a/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
@@ -100,7 +100,7 @@ const useSearchThreadsQuery = ({
         return undefined;
       },
       staleTime: SEARCH_THREADS_STALE_TIME,
-      enabled,
+      enabled: enabled && searchTerm.length >= 3,
     },
   );
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
@@ -92,8 +92,12 @@ const useSearchThreadsQuery = ({
         threadTitleOnly,
       }),
     {
-      getNextPageParam: (_) => {
-        console.error('Not implemented');
+      getNextPageParam: (lastPage) => {
+        const nextPageNum = lastPage.page + 1;
+        if (nextPageNum <= lastPage.totalPages) {
+          return nextPageNum;
+        }
+        return undefined;
       },
       staleTime: SEARCH_THREADS_STALE_TIME,
       enabled: enabled && searchTerm.length >= 3,

--- a/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/searchThreads.ts
@@ -25,6 +25,7 @@ interface SearchThreadsProps {
   orderBy: APIOrderBy;
   orderDirection: APIOrderDirection;
   threadTitleOnly?: boolean;
+  includeCount?: boolean;
 
   enabled?: boolean;
 }
@@ -37,6 +38,7 @@ const searchThreads = async ({
   orderBy,
   orderDirection,
   threadTitleOnly,
+  includeCount,
 }: SearchThreadsProps & {
   pageParam: number;
 }): Promise<SearchThreadsResponse> => {
@@ -56,6 +58,7 @@ const searchThreads = async ({
         order_by: orderBy,
         order_direction: orderDirection,
         thread_title_only: threadTitleOnly,
+        include_count: includeCount,
       },
     },
   );
@@ -69,6 +72,7 @@ const useSearchThreadsQuery = ({
   orderBy,
   orderDirection,
   threadTitleOnly,
+  includeCount,
   enabled = true,
 }: SearchThreadsProps) => {
   const key = [
@@ -90,6 +94,7 @@ const useSearchThreadsQuery = ({
         orderBy,
         orderDirection,
         threadTitleOnly,
+        includeCount,
       }),
     {
       getNextPageParam: (lastPage) => {

--- a/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
+++ b/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
@@ -99,7 +99,6 @@ const useCommunityStake = (props: UseCommunityStakeProps = {}) => {
     isLoading,
     activeChainId,
     refetchStakeQuery,
-    featureFlagEnabled: communityStakeEnabled,
   };
 };
 

--- a/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
+++ b/packages/commonwealth/client/scripts/views/components/CommunityStake/useCommunityStake.ts
@@ -99,6 +99,7 @@ const useCommunityStake = (props: UseCommunityStakeProps = {}) => {
     isLoading,
     activeChainId,
     refetchStakeQuery,
+    featureFlagEnabled: communityStakeEnabled,
   };
 };
 

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
@@ -84,11 +84,11 @@ export const SearchBarDropdown: FC<SearchBarDropdownProps> = ({
   onSearchItemClick,
 }) => {
   const showResults =
-    searchTerm.length > 0 && Object.values(searchResults).flat(1).length > 0;
+    searchTerm.length >= 3 && Object.values(searchResults).flat(1).length > 0;
 
   return (
     <div className="SearchBarDropdown">
-      {showResults ? (
+      {showResults && (
         <div className="previews-section">
           {Object.entries(searchResults).map(([scope, results]) => (
             <SearchBarPreviewSection
@@ -100,9 +100,14 @@ export const SearchBarDropdown: FC<SearchBarDropdownProps> = ({
             />
           ))}
         </div>
-      ) : (
+      )}
+      {!showResults && searchTerm.length >= 3 ? (
         <div className="no-results">
           <CWText type="b2">No results found</CWText>
+        </div>
+      ) : (
+        <div className="no-results">
+          <CWText type="b2">Search term requires 3 or more characters</CWText>
         </div>
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
@@ -101,11 +101,12 @@ export const SearchBarDropdown: FC<SearchBarDropdownProps> = ({
           ))}
         </div>
       )}
-      {!showResults && searchTerm.length >= 3 ? (
+      {!showResults && searchTerm.length >= 3 && (
         <div className="no-results">
           <CWText type="b2">No results found</CWText>
         </div>
-      ) : (
+      )}
+      {!showResults && searchTerm.length < 3 && (
         <div className="no-results">
           <CWText type="b2">Search term requires 3 or more characters</CWText>
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/useCommunityContests.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/useCommunityContests.ts
@@ -2,12 +2,14 @@ import app from 'state';
 import { useGetContestsQuery } from 'state/api/contests';
 import { useCommunityStake } from 'views/components/CommunityStake';
 import { Contest } from 'views/pages/CommunityManagement/Contests/ContestsList';
+import { useFlag } from '../../../../hooks/useFlag';
 
 const useCommunityContests = () => {
+  const enabled = useFlag('contest');
   const { stakeEnabled } = useCommunityStake();
 
   const { data: contestsData, isLoading: isContestDataLoading } =
-    useGetContestsQuery({ community_id: app.activeChainId() });
+    useGetContestsQuery({ community_id: app.activeChainId(), enabled });
 
   const isContestAvailable = !isContestDataLoading && contestsData?.length > 0;
 
@@ -21,7 +23,7 @@ const useCommunityContests = () => {
     stakeEnabled,
     isContestAvailable,
     contestsData: contestsData as unknown as Contest[],
-    isContestDataLoading,
+    isContestDataLoading: isContestDataLoading && enabled,
     getContestByAddress,
   };
 };

--- a/packages/commonwealth/client/scripts/views/pages/search/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/index.tsx
@@ -116,6 +116,7 @@ const SearchPage = () => {
     limit: 20,
     orderBy,
     orderDirection,
+    includeCount: true,
   };
 
   const {

--- a/packages/commonwealth/server/controllers/server_comments_methods/search_comments.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/search_comments.ts
@@ -12,6 +12,7 @@ export type SearchCommentsOptions = {
   page?: number;
   orderBy?: string;
   orderDirection?: 'ASC' | 'DESC';
+  includeCount?: boolean;
 };
 export type SearchCommentsResult = TypedPaginatedResult<{
   id: number;
@@ -36,6 +37,7 @@ export async function __searchComments(
     page,
     orderBy,
     orderDirection,
+    includeCount,
   }: SearchCommentsOptions,
 ): Promise<SearchCommentsResult> {
   // sort by rank by default
@@ -121,10 +123,12 @@ export async function __searchComments(
       bind,
       type: QueryTypes.SELECT,
     }),
-    this.models.sequelize.query(sqlCountQuery, {
-      bind,
-      type: QueryTypes.SELECT,
-    }),
+    !includeCount
+      ? [{ count: 0 }]
+      : this.models.sequelize.query(sqlCountQuery, {
+          bind,
+          type: QueryTypes.SELECT,
+        }),
   ]);
 
   const totalResults = parseInt(count, 10);

--- a/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
+++ b/packages/commonwealth/server/controllers/server_profiles_methods/search_profiles.ts
@@ -19,6 +19,7 @@ export type SearchProfilesOptions = {
   orderBy?: string;
   orderDirection?: 'ASC' | 'DESC';
   includeGroupIds?: boolean;
+  includeCount?: boolean;
 };
 
 type Profile = {
@@ -46,6 +47,7 @@ export async function __searchProfiles(
     page,
     orderBy,
     orderDirection,
+    includeCount,
   }: SearchProfilesOptions,
 ): Promise<SearchProfilesResult> {
   let sortOptions: PaginationSqlOptions = {
@@ -121,13 +123,15 @@ export async function __searchProfiles(
       bind,
       type: QueryTypes.SELECT,
     }),
-    this.models.sequelize.query(
-      `SELECT COUNT(*) FROM ( ${sqlWithoutPagination} ) as count`,
-      {
-        bind,
-        type: QueryTypes.SELECT,
-      },
-    ),
+    !includeCount
+      ? [{ count: 0 }]
+      : this.models.sequelize.query(
+          `SELECT COUNT(*) FROM ( ${sqlWithoutPagination} ) as count`,
+          {
+            bind,
+            type: QueryTypes.SELECT,
+          },
+        ),
   ]);
 
   const totalResults = parseInt(count, 10);

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -106,10 +106,18 @@ export async function __searchThreads(
     ${paginationSort}
   `;
 
-  const results: any[] = await this.models.sequelize.query(sqlBaseQuery, {
-    bind,
-    type: QueryTypes.SELECT,
-  });
+  const results: ThreadSearchData[] = await this.models.sequelize.query(
+    sqlBaseQuery,
+    {
+      bind,
+      type: QueryTypes.SELECT,
+      raw: true,
+    },
+  );
 
-  return buildPaginatedResponse(results, results.length, bind);
+  return buildPaginatedResponse(
+    results,
+    results.length,
+    bind,
+  ) as unknown as SearchThreadsResult;
 }

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -18,6 +18,7 @@ export type SearchThreadsOptions = {
   page?: number;
   orderBy?: string;
   orderDirection?: 'ASC' | 'DESC';
+  includeCount?: boolean;
 };
 
 type ThreadSearchData = ThreadAttributes;
@@ -36,6 +37,7 @@ export async function __searchThreads(
     page,
     orderBy,
     orderDirection,
+    includeCount,
   }: SearchThreadsOptions,
 ): Promise<SearchThreadsResult> {
   // sort by rank by default
@@ -122,10 +124,12 @@ export async function __searchThreads(
       bind,
       type: QueryTypes.SELECT,
     }),
-    await this.models.sequelize.query(sqlCountQuery, {
-      bind,
-      type: QueryTypes.SELECT,
-    }),
+    !includeCount
+      ? [{ count: 0 }]
+      : await this.models.sequelize.query(sqlCountQuery, {
+          bind,
+          type: QueryTypes.SELECT,
+        }),
   ]);
 
   const totalResults = parseInt(count, 10);

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -106,30 +106,10 @@ export async function __searchThreads(
     ${paginationSort}
   `;
 
-  const sqlCountQuery = `
-    SELECT
-      COUNT (*) as count
-    FROM "Threads"
-    JOIN "Addresses" ON "Threads".address_id = "Addresses".id,
-    websearch_to_tsquery('english', $searchTerm) as query
-    WHERE
-      ${communityWhere}
-      "Threads".deleted_at IS NULL AND
-      ${searchWhere}
-  `;
+  const results: any[] = await this.models.sequelize.query(sqlBaseQuery, {
+    bind,
+    type: QueryTypes.SELECT,
+  });
 
-  const [results, [{ count }]]: [any[], any[]] = await Promise.all([
-    await this.models.sequelize.query(sqlBaseQuery, {
-      bind,
-      type: QueryTypes.SELECT,
-    }),
-    await this.models.sequelize.query(sqlCountQuery, {
-      bind,
-      type: QueryTypes.SELECT,
-    }),
-  ]);
-
-  const totalResults = parseInt(count, 10);
-
-  return buildPaginatedResponse(results, totalResults, bind);
+  return buildPaginatedResponse(results, results.length, bind);
 }

--- a/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/search_threads.ts
@@ -80,8 +80,7 @@ export async function __searchThreads(
 
   let searchWhere = `"Threads".title ILIKE '%' || $searchTerm || '%'`;
   if (!threadTitleOnly) {
-    // for full search, use search column too
-    searchWhere += ` OR query @@ "Threads"._search`;
+    searchWhere = `("Threads".title ILIKE '%' || $searchTerm || '%' OR query @@ "Threads"._search)`;
   }
 
   const sqlBaseQuery = `

--- a/packages/commonwealth/server/migrations/20240529112420-thread-title-index.js
+++ b/packages/commonwealth/server/migrations/20240529112420-thread-title-index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, _) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.sequelize.query(
+        `
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+        CREATE INDEX threads_title_trgm_idx ON "Threads" USING gin (title gin_trgm_ops);
+        `,
+        { transaction: t },
+      );
+    });
+  },
+
+  async down(queryInterface, _) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.sequelize.query(
+        `
+        DROP INDEX IF EXISTS threads_title_trgm_idx;
+        DROP EXTENSION IF EXISTS pg_trgm;
+      `,
+        { transaction: t },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/routes/comments/search_comments_handler.ts
+++ b/packages/commonwealth/server/routes/comments/search_comments_handler.ts
@@ -17,6 +17,7 @@ const Errors = {
 type SearchCommentsRequestQuery = {
   search: string;
   community_id?: string;
+  include_count?: boolean;
 } & PaginationQueryParams;
 
 type SearchCommentsResponse = SearchCommentsResult;
@@ -39,6 +40,7 @@ export const searchCommentsHandler = async (
     page: parseInt(options.page, 10) || 0,
     orderBy: options.order_by,
     orderDirection: options.order_direction as any,
+    includeCount: options.include_count,
   });
 
   return success(res, commentSearchResults);

--- a/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
+++ b/packages/commonwealth/server/routes/profiles/search_profiles_handler.ts
@@ -18,6 +18,7 @@ type SearchProfilesRequestParams = {
   community_id?: string;
   include_roles?: string;
   include_group_ids?: string;
+  include_count?: boolean;
 } & PaginationQueryParams;
 
 type SearchProfilesResponse = SearchProfilesResult;
@@ -42,6 +43,7 @@ export const searchProfilesHandler = async (
     orderBy: options.order_by,
     orderDirection: options.order_direction as any,
     includeGroupIds: options.include_group_ids === 'true',
+    includeCount: options.include_count,
   });
 
   return success(res, profileSearchResults);

--- a/packages/commonwealth/server/routes/threads/get_threads_handler.ts
+++ b/packages/commonwealth/server/routes/threads/get_threads_handler.ts
@@ -72,8 +72,15 @@ export const getThreadsHandler = async (
     throw new AppError(formatErrorPretty(queryValidationResult));
   }
 
-  const { thread_ids, bulk, active, search, count, community_id } =
-    queryValidationResult.data;
+  const {
+    thread_ids,
+    bulk,
+    active,
+    search,
+    count,
+    community_id,
+    include_count,
+  } = queryValidationResult.data;
 
   // get threads by IDs
   if (thread_ids) {
@@ -152,6 +159,7 @@ export const getThreadsHandler = async (
       page: parseInt(page, 10) || 0,
       orderBy: order_by,
       orderDirection: order_direction as any,
+      includeCount: include_count,
     });
     return success(res, searchResults);
   }

--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -505,6 +505,7 @@ describe('ServerCommentsController', () => {
         page: 2,
         orderBy: 'created_at',
         orderDirection: 'DESC',
+        includeCount: true,
       };
       const comments = await serverCommentsController.searchComments(
         searchOptions,


### PR DESCRIPTION
Our worst performing queries are related to thread search. I had added a trigram index to them to improve the performance.

## Link to Issue
Closes: #7970

## Description of Changes
- Adds trigram index to threads.title
- Puts getContest calls behind the feature flag.
- Modifies search so that we will only search if the search term >= 3 characters. This ensures the trigram index will exist for the search term and we don't need to resort to looping.
- Only includes search entity counts on the search page. This prevents us from making unnecessary db calls.
- Fixed bug where thread count would count all the threads in all communities that match the search term, instead of just the threads that matched the search term that belong to the community.

## Test Plan
- Add some search term < 3 characters, see the "Search term requires 3 or more characters"
- Add some search term > 3 characters, make sure it matches some threads
- Make sure that you don't get any getContest queries in the network tab when the FLAG_CONTEST is off.

## Other Considerations
The query plans
old (Not hitting index on the where clause):
https://explain.dalibo.com/plan/7e1794142efd2d17#plan

new (hitting the trigram index):
https://explain.dalibo.com/plan/3b1bf1ece68ghbhc#plan

Note the misc section of the nodes. In the old query plan we do the bitmap heap scan over all the fields except for the community_id check.

In the new query plan, we perform bitmap index scans over each individual where clause.
