### PR TITLE
user can now click image upload

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -280,7 +280,7 @@ export const CWCoverImageUploader = ({
 
     pseudoInput.current.addEventListener('change', pseudoInputHandler);
     attachZone.current.addEventListener('click', (e: any) => {
-      if (e.target.classList.contains('attach-zone')) clickHandler(e);
+      if (e.target.classList.contains('attach-btn')) clickHandler(e);
     });
 
     attachZone.current.addEventListener('dragenter', dragEnterHandler);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -280,7 +280,11 @@ export const CWCoverImageUploader = ({
 
     pseudoInput.current.addEventListener('change', pseudoInputHandler);
     attachZone.current.addEventListener('click', (e: any) => {
-      if (e.target.classList.contains('attach-btn')) clickHandler(e);
+      if (
+        e.target.classList.contains('attach-btn') ||
+        e.target.classList.contains('attach-zone')
+      )
+        clickHandler(e);
     });
 
     attachZone.current.addEventListener('dragenter', dragEnterHandler);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -280,11 +280,8 @@ export const CWCoverImageUploader = ({
 
     pseudoInput.current.addEventListener('change', pseudoInputHandler);
     attachZone.current.addEventListener('click', (e: any) => {
-      if (
-        e.target.classList.contains('attach-btn') ||
-        e.target.classList.contains('attach-zone')
-      )
-        clickHandler(e);
+      if (e.target.classList.contains('attach-btn')) clickHandler(e);
+      if (e.target.classList.contains('attach-zone')) clickHandler(e);
     });
 
     attachZone.current.addEventListener('dragenter', dragEnterHandler);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7967 

## Description of Changes
-User can now click the image uploader to upload an image from their computer without first generating an image or dragging and dropping

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Changed `e.target.classList.contains(‘attach-zone’)` to `e.target.classList.contains(‘attach-btn’)`
-Props to Malik for showing me the fix

## Test Plan
-create a new community
-click in the image uploader and confirm that a file selector modal pops up. 
