### PR TITLE
user is now able to create community without error

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -64,8 +64,8 @@ export async function getFileSizeBytes(url: string): Promise<number> {
     // Range header is to prevent it from reading any bytes from the GET request because we only want the headers.
     const response = await fetch(url, { headers: { Range: 'bytes=0-0' } });
     if (!response) return 0;
-    const contentRange = response.headers.get('content-range');
-    return contentRange ? parseInt(contentRange.split('/')[1], 10) : 0;
+    const contentLength = response.headers.get('content-length');
+    return contentLength ? parseInt(contentLength, 10) : 0;
   } catch (err) {
     return 0;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7966 

## Description of Changes
-User is now able to create a community without seeing an error that an icon_url doesn't exist

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the `superRefine` validation to look for the the `content-length` header instead of `content-range`.
-changed the parseInt() to correctly reflect the value returned
-changed variable names to better describe the update in what was being queried. 

## Test Plan
-create a new community
-fill out all the needed info
-click Launch Community
-confirm that the community is now created and no error is shown
