### PR TITLE
Made openfeature default undefined resolution to false.

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useFlag.ts
+++ b/packages/commonwealth/client/scripts/hooks/useFlag.ts
@@ -1,8 +1,10 @@
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { AvailableFeatureFlag } from '../helpers/feature-flags';
 
-export const useFlag = (name: AvailableFeatureFlag) => {
-  return useBooleanFlagValue(name, false, {
-    updateOnConfigurationChanged: false,
-  });
+export const useFlag = (name: AvailableFeatureFlag): boolean => {
+  return (
+    useBooleanFlagValue(name, false, {
+      updateOnConfigurationChanged: false,
+    }) ?? false
+  );
 };


### PR DESCRIPTION
There are two unfortunate considences here that result in this error:
- the openfeature `useBooleanFlagValue` method, is incorrectly typed as a strict boolean. Instead it can actually return undefined if the feature flag does not exist in the set.
- React query will still perform the query, even if the enabled option is set to undefined (You would think since it is falsy, it would make enabled = false)

As a result our getContest query still ran, even though we had expected it not to, which caused the error.

## Link to Issue
Closes: #7994

## Description of Changes
- null coalesced the useFlag (which uses `useBooleanFlagValue` under the hood to false).
coa

## Test Plan
- Update the .env to use the keys to connect to our feature flag server
- Run any discussions page, this error in the issue linked will not appear in the console logs.