### PR TITLE
console logs no longer props

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -59,6 +59,7 @@ export const CWCoverImageUploader = ({
   subheaderText,
   enableGenerativeAI,
   generatedImageCallback,
+  uploadCompleteCallback,
   defaultImageUrl,
   defaultImageBehavior,
   canSelectImageBehaviour = true,
@@ -184,6 +185,7 @@ export const CWCoverImageUploader = ({
         }
 
         generatedImageCallback?.(generatedImageURL, currentImageBehavior);
+        uploadCompleteCallback?.(generatedImageURL, currentImageBehavior);
       }
 
       setIsUploading(false);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -234,6 +234,7 @@ export const CWCoverImageUploader = ({
       if (defaultImageBehaviour !== ImageBehavior.Circle) {
         attachButton.current.style.display = 'none';
       }
+      uploadCompleteCallback?.(_imageURL, currentImageBehavior);
     }
   };
 
@@ -481,6 +482,7 @@ export const CWCoverImageUploader = ({
             name="image-behaviour"
             onChange={(e) => {
               setImageBehavior(e.target.value);
+              uploadCompleteCallback?.(imageURL, e.target.value);
             }}
             toggledOption={imageBehavior}
             options={[

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_cover_image_uploader.tsx
@@ -33,7 +33,7 @@ type CoverImageUploaderProps = CoverImageUploaderFormValidationProps & {
   generatedImageCallback?: CallableFunction;
   defaultImageUrl?: string;
   defaultImageBehavior?: string;
-  uploadCompleteCallback: CallableFunction;
+  uploadCompleteCallback?: CallableFunction;
   canSelectImageBehaviour?: boolean;
   defaultImageBehaviour?: ImageBehavior;
   showUploadAndGenerateText?: boolean;
@@ -61,7 +61,6 @@ export const CWCoverImageUploader = ({
   generatedImageCallback,
   defaultImageUrl,
   defaultImageBehavior,
-  uploadCompleteCallback,
   canSelectImageBehaviour = true,
   showUploadAndGenerateText,
   defaultImageBehaviour,
@@ -185,7 +184,6 @@ export const CWCoverImageUploader = ({
         }
 
         generatedImageCallback?.(generatedImageURL, currentImageBehavior);
-        uploadCompleteCallback(generatedImageURL, currentImageBehavior);
       }
 
       setIsUploading(false);
@@ -234,7 +232,6 @@ export const CWCoverImageUploader = ({
       if (defaultImageBehaviour !== ImageBehavior.Circle) {
         attachButton.current.style.display = 'none';
       }
-      uploadCompleteCallback(_imageURL, currentImageBehavior);
     }
   };
 
@@ -482,7 +479,6 @@ export const CWCoverImageUploader = ({
             name="image-behaviour"
             onChange={(e) => {
               setImageBehavior(e.target.value);
-              uploadCompleteCallback(imageURL, e.target.value);
             }}
             toggledOption={imageBehavior}
             options={[

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -345,7 +345,6 @@ const CommunityProfileForm = () => {
               showUploadAndGenerateText
               name="communityProfileImageURL"
               canSelectImageBehaviour={false}
-              uploadCompleteCallback={console.log}
               defaultImageBehaviour={ImageBehavior.Circle}
               onImageProcessStatusChange={setIsProcessingProfileImage}
               subheaderText="Community Profile Image (Accepts JPG and PNG files)"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
@@ -229,7 +229,6 @@ const DetailsFormStep = ({
                   png)
                 </CWText>
                 <CWCoverImageUploader
-                  uploadCompleteCallback={console.log}
                   canSelectImageBehaviour={false}
                   showUploadAndGenerateText
                   onImageProcessStatusChange={setIsProcessingProfileImage}

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -251,7 +251,6 @@ const BasicInformationForm = ({
 
       <CWCoverImageUploader
         subheaderText="Community Profile Image (Accepts JPG and PNG files)"
-        uploadCompleteCallback={console.log}
         canSelectImageBehaviour={false}
         showUploadAndGenerateText
         onImageProcessStatusChange={setIsProcessingProfileImage}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7953 

## Description of Changes
-console.logs are no longer passed as props

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-made `uploadCompleteCallback` optional
-removed `uploadCompleteCallback={console.log}` from `CommunityProfileForm.tsx` , `DetailsFormStep.tsx` , and `BasicInformationForm.tsx`
-deleted any instance of `uploadCompleteCallback` being called in `cw_cover_image_uploader.tsx`

## Test Plan
-This was all codebase cleanup
