### PR TITLE
gave checkbox text some space

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.scss
@@ -54,6 +54,8 @@
     display: flex;
     flex-direction: column;
     align-items: end;
+    padding-right: 4px;
+    padding-bottom: 4px;
   }
 
   @include smallInclusive {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8028 

## Description of Changes
-gave the checkbox text on All Discussions some padding on the right and bottom

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
 -padding-right: 4px;
-padding-bottom: 4px;

## Test Plan
-go to a community and their All Discussions page
-confirm you can fully read the text that goes with the checkboxes. 

<img width="569" alt="Screenshot 2024-06-03 at 1 18 25 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/3e257214-73e3-40c1-ada6-b3bbf61bc5d8">
