### PR TITLE
Updated dates format for threads to `DD/MM/YYYY` international

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ArchiveTrayWithTooltip/ArchiveTrayWithTooltip.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ArchiveTrayWithTooltip/ArchiveTrayWithTooltip.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 import moment from 'moment';
+import React from 'react';
 import { CWIcon } from '../component_kit/cw_icons/cw_icon';
+import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 
 type ArchiveTrayWithTooltipProps = {
   archivedAt: moment.Moment;
@@ -13,7 +13,7 @@ export const ArchiveTrayWithTooltip = ({
   return (
     <CWTooltip
       placement="right"
-      content={`Archived on ${archivedAt.format('MM/DD/YYYY')}`}
+      content={`Archived on ${archivedAt.format('DD/MM/YYYY')}`}
       renderTrigger={(handleInteraction) => (
         <CWIcon
           iconName="archiveTrayFilled"

--- a/packages/commonwealth/client/scripts/views/components/Comments/ArchiveMsg/ArchiveMsg.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/ArchiveMsg/ArchiveMsg.tsx
@@ -1,6 +1,6 @@
+import moment from 'moment';
 import React from 'react';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
-import moment from 'moment';
 import './ArchiveMsg.scss';
 
 type ArchiveMsgProps = {
@@ -13,7 +13,7 @@ export const ArchiveMsg = ({ archivedAt }: ArchiveMsgProps) => {
       <div className="archive-msg-container">
         <CWIcon iconName="archiveTrayFilled" iconSize="small" />
         {`This thread was archived on ${moment(archivedAt).format(
-          'MM/DD/YYYY'
+          'DD/MM/YYYY',
         )},
       meaning it can no longer be edited or commented on.`}
       </div>

--- a/packages/commonwealth/client/scripts/views/components/LockWithTooltip.tsx
+++ b/packages/commonwealth/client/scripts/views/components/LockWithTooltip.tsx
@@ -14,8 +14,8 @@ export const LockWithTooltip = ({ lockedAt, updatedAt }: LockWithTooltip) => {
     <CWTooltip
       content={
         lockedAt
-          ? `Locked on ${lockedAt.format('MM/DD/YYYY')}`
-          : `Locked prior to ${updatedAt?.format('MM/DD/YYYY') || 'N/A'}`
+          ? `Locked on ${lockedAt.format('DD/MM/YYYY')}`
+          : `Locked prior to ${updatedAt?.format('DD/MM/YYYY') || 'N/A'}`
       }
       placement="top"
       renderTrigger={(handleInteraction) => (

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -87,7 +87,7 @@ const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
         <div className="dot">.</div>
         <div className="date">
           <CWText type="caption" fontWeight="medium">
-            {moment(createdAt).format('MM/DD/YYYY')}
+            {moment(createdAt).format('DD/MM/YYYY')}
           </CWText>
         </div>
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/contracts/contract_template_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/contracts/contract_template_card.tsx
@@ -103,7 +103,7 @@ export const ContractTemplateCard = ({
   const enabler = templateInfo?.enabledBy
     ? app.chain.accounts.get(templateInfo?.enabledBy)
     : null;
-  const enabledOn = moment(templateInfo.enabledAt).format('MM/DD/YY');
+  const enabledOn = moment(templateInfo.enabledAt).format('DD/MM/YYYY');
 
   return (
     <CWCard fullWidth className="ContractTemplateCard">

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -1,7 +1,6 @@
 import { PopperPlacementType } from '@mui/base/Popper';
 import CommunityInfo from 'client/scripts/views/components/component_kit/CommunityInfo';
 import { threadStageToLabel } from 'helpers';
-import { getRelativeTimestamp } from 'helpers/dates';
 import moment from 'moment';
 import React, { useRef } from 'react';
 import app from 'state';
@@ -197,9 +196,7 @@ export const AuthorAndPublishInfo = ({
             <div className="version-history">
               <CWSelectList
                 options={versionHistoryOptions}
-                placeholder={`Edited ${getRelativeTimestamp(
-                  publishDate?.toISOString(),
-                )}`}
+                placeholder={`Edited ${publishDate?.format('DD/MM/YYYY')}`}
                 onChange={({ value }) => {
                   changeContentText(value);
                 }}
@@ -214,7 +211,7 @@ export const AuthorAndPublishInfo = ({
               placement="top"
               content={
                 <div style={{ display: 'flex', gap: '8px' }}>
-                  {publishDate.format('MMMM Do YYYY')} {dotIndicator}{' '}
+                  {publishDate.format('MMMM Do, YYYY')} {dotIndicator}{' '}
                   {publishDate.format('h:mm A')}
                 </div>
               }
@@ -228,7 +225,7 @@ export const AuthorAndPublishInfo = ({
                 >
                   {showPublishLabelWithDate ? 'Published ' : ''}
                   {showEditedLabelWithDate ? 'Edited ' : ''}
-                  {getRelativeTimestamp(publishDate?.toISOString())}
+                  {publishDate?.format('DD/MM/YYYY')}
                 </CWText>
               )}
             />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
@@ -7,7 +7,7 @@ export const formatVersionText = (
   profile: UserProfile,
   collabInfo: Record<string, string>,
 ) => {
-  const formattedTime = timestamp.format('MMMM D, YYYY h:mmA');
+  const formattedTime = timestamp.format('MMMM Do, YYYY • h:mm A');
   // Some old posts don't have address, so account for them by omitting address
   if (!address) {
     return formattedTime;

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/user_dashboard_row_top.tsx
@@ -91,7 +91,7 @@ export const UserDashboardRowTop = (props: UserDashboardRowTopProps) => {
         </CWText>
         <div className="dot">.</div>
         <CWText type="caption" fontWeight="medium" className="gray-text">
-          {moment(created_at).format('MM/DD/YY')}
+          {moment(created_at).format('DD/MM/YYYY')}
         </CWText>
       </div>
       <div className="comment-thread-info">

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/lock_message.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/lock_message.tsx
@@ -1,12 +1,12 @@
+import moment from 'moment';
 import React from 'react';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
-import moment from 'moment';
 
 const buildLockMessage = (
   fromDiscordBot: boolean,
   lockedAt?: moment.Moment,
-  updatedAt?: moment.Moment
+  updatedAt?: moment.Moment,
 ) => {
   if (fromDiscordBot) {
     return `This thread was started on Discord and cannot be edited or commented on in Common. 
@@ -14,11 +14,11 @@ const buildLockMessage = (
   }
   if (lockedAt) {
     return `This thread was locked on ${lockedAt.format(
-      'MM/DD/YYYY'
+      'DD/MM/YYYY',
     )}, meaning it can no longer be edited or commented on.`;
   }
   return `This thread has been locked, meaning it can no longer be edited or commented on. Thread was locked prior to ${updatedAt.format(
-    'MM/DD/YYYY'
+    'DD/MM/YYYY',
   )}.`;
 };
 

--- a/packages/commonwealth/server/scripts/emailDigest.ts
+++ b/packages/commonwealth/server/scripts/emailDigest.ts
@@ -114,7 +114,7 @@ export const getTopThreads = async (
         author_name: profile ? profile.profile_name : 'Anonymous',
         author_profile_img_url: profile ? profile.avatar_url : '',
         thread_id: row.thread_id,
-        publish_date_string: moment(row.created_at).format('MM/DD/YY'),
+        publish_date_string: moment(row.created_at).format('DD/MM/YYYY'),
         thread_url: `https://www.commonwealth.im/${communityId}/discussion/${row.thread_id}`,
       };
       threadData.push(data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8036

## Description of Changes
Updated date format to be use `DD/MM/YYYY` for display and `MMMM Do, YYYY • h:mm A` for tooltips and removed the "time-ago" format from dates

## "How We Fixed It"
N/A

## Test Plan
1. Verify that dates are now shown as `DD/MM/YYYY` on all threads/comments/replies and other areas of the app where we show dates
2. Verify that date tooltips show date in the format `MMMM Do, YYYY • h:mm A` in all areas of the app.

## Deployment Plan
N/A

## Other Considerations
N/A