### PR TITLE
Fix dates localization for thread/comment

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -196,7 +196,10 @@ export const AuthorAndPublishInfo = ({
             <div className="version-history">
               <CWSelectList
                 options={versionHistoryOptions}
-                placeholder={`Edited ${publishDate?.format('DD/MM/YYYY')}`}
+                placeholder={`Edited ${publishDate
+                  ?.utc?.()
+                  ?.local?.()
+                  ?.format('DD/MM/YYYY')}`}
                 onChange={({ value }) => {
                   changeContentText(value);
                 }}
@@ -211,8 +214,9 @@ export const AuthorAndPublishInfo = ({
               placement="top"
               content={
                 <div style={{ display: 'flex', gap: '8px' }}>
-                  {publishDate.format('MMMM Do, YYYY')} {dotIndicator}{' '}
-                  {publishDate.format('h:mm A')}
+                  {publishDate?.utc?.()?.local?.()?.format('MMMM Do, YYYY')}{' '}
+                  {dotIndicator}{' '}
+                  {publishDate?.utc?.()?.local?.()?.format('h:mm A')}
                 </div>
               }
               renderTrigger={(handleInteraction) => (
@@ -225,7 +229,7 @@ export const AuthorAndPublishInfo = ({
                 >
                   {showPublishLabelWithDate ? 'Published ' : ''}
                   {showEditedLabelWithDate ? 'Edited ' : ''}
-                  {publishDate?.format('DD/MM/YYYY')}
+                  {publishDate?.utc?.()?.local?.()?.format('DD/MM/YYYY')}
                 </CWText>
               )}
             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8036

## Description of Changes
Updated thread/comment publish date view to localize utc

## "How We Fixed It"
N/A

## Test Plan
- Create a thread
- Add comments to that thread
- Hover over thread/comment dates and verify dates are correctly represented in local time, in the tooltips

## Deployment Plan
N/A

## Other Considerations
N/A