### PR TITLE
Protocol/Chain testing sdk additions

### DIFF
--- a/libs/evm-testing/src/config.ts
+++ b/libs/evm-testing/src/config.ts
@@ -32,6 +32,7 @@ export const config = configure(
       PROVIDER_URL: z.string(),
       ETH_ALCHEMY_API_KEY: z.string().optional(),
       ETHERSCAN_JS_API_KEY: z.string().optional(),
+      BASESEP_ALCHEMY_API_KEY: z.string().optional(),
     }),
     COSMOS: z.object({
       COSMOS_GOV_V1_CHAIN_IDS: z.array(z.string()),

--- a/libs/evm-testing/src/sdk/communityStake.ts
+++ b/libs/evm-testing/src/sdk/communityStake.ts
@@ -1,0 +1,69 @@
+import { factoryContracts } from 'shared/src/commonProtocol';
+import { AbiFragment, Contract } from 'web3';
+import { community_stake } from '../utils/contracts';
+import { NamespaceFactory } from './namespaceFactory';
+import { SdkBase } from './sdkBase';
+
+export class CommunityStake extends SdkBase {
+  public address: string = factoryContracts[84532].communityStake;
+  public contract: Contract<AbiFragment[]> = community_stake(
+    this.address,
+    this.web3,
+  );
+  public namespaceFactory: NamespaceFactory = new NamespaceFactory();
+
+  /**
+   * Buy Community Stake, recalculates total buy as CS does not allow slippage
+   * @param name namespace name
+   * @param id id of community stake
+   * @param amount amount to buy
+   * @param accountIndex
+   * @returns Block
+   */
+  async buyStake(
+    name: string,
+    id: number,
+    amount: number,
+    accountIndex?: number,
+  ): Promise<{ block: number }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const namespaceAddress = await this.namespaceFactory.getNamespaceAddress(
+      name,
+    );
+    const totalPrice: string = await this.contract.methods
+      .getBuyPriceAfterFee(namespaceAddress, id.toString(), amount.toString())
+      .call();
+    const txReceipt = await this.contract.methods
+      .buyStake(namespaceAddress, id, amount)
+      .send({
+        value: totalPrice,
+        from: account,
+      });
+    return { block: Number(txReceipt['blockNumber']) };
+  }
+
+  /**
+   * Sell Community Stake
+   * @param name namespace name
+   * @param id id of community stake
+   * @param amount amount to sell
+   * @param accountIndex
+   */
+  async sellStake(
+    name: string,
+    id: number,
+    amount: number,
+    accountIndex?: number,
+  ): Promise<{ block: number }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const namespaceAddress = await this.namespaceFactory.getNamespaceAddress(
+      name,
+    );
+    const txReceipt = await this.contract.methods
+      .sellStake(namespaceAddress, id.toString(), amount.toString())
+      .send({
+        from: account,
+      });
+    return { block: Number(txReceipt['blockNumber']) };
+  }
+}

--- a/libs/evm-testing/src/sdk/namespaceFactory.ts
+++ b/libs/evm-testing/src/sdk/namespaceFactory.ts
@@ -1,0 +1,140 @@
+import { factoryContracts } from 'shared/src/commonProtocol';
+import { AbiFragment, Contract } from 'web3';
+import { namespace_factory } from '../utils/contracts';
+import { SdkBase } from './sdkBase';
+
+const TOPIC_LOG =
+  '0x990f533044dbc89b838acde9cd2c72c400999871cf8f792d731edcae15ead693';
+
+export class NamespaceFactory extends SdkBase {
+  public address: string = factoryContracts[84532].factory;
+  public contract: Contract<AbiFragment[]> = namespace_factory(
+    this.address,
+    this.web3,
+  );
+
+  /**
+   * Deploys a new namespace. Note current wallet will be admin of namespace
+   * @param name New Namespace name
+   * @param accountIndex account index to create approve tx from
+   */
+  async deployNamespace(
+    name: string,
+    accountIndex?: number,
+  ): Promise<{ block: number }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const txReceipt = await this.contract.methods
+      .deployNamespace(name, 'url.com', account, [])
+      .send({
+        from: account,
+      });
+    return { block: Number(txReceipt['blockNumber']) };
+  }
+
+  /**
+   * Configures a community stakes id on the given namespace
+   * Note: current wallet address must be an admin on the namespace specified
+   * @param name Namespace name
+   * @param stakesId the id on the namespace to use for stake
+   * @param accountIndex account to send transaction from, must be admin
+   */
+  async configureCommunityStakes(
+    name: string,
+    stakesId: number,
+    accountIndex?: number,
+  ): Promise<{ block: number }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const txReceipt = await this.contract.methods
+      .configureCommunityStakeId(
+        name,
+        name + ' Community Stake',
+        stakesId,
+        '0x0000000000000000000000000000000000000000',
+        2000000,
+        0,
+      )
+      .send({ from: account });
+    return { block: Number(txReceipt['blockNumber']) };
+  }
+
+  async newRecurringContest(
+    namespaceName: string,
+    contestInterval: number,
+    winnerShares: number[],
+    stakeId: number = 2,
+    prizeShare: number,
+    voterShare: number = 20,
+    feeShare: number = 100,
+    weight: number = 1,
+    accountIndex?: number,
+  ): Promise<{ block: number; contest: string }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const txReceipt = await this.contract.methods
+      .newContest(
+        namespaceName,
+        contestInterval,
+        winnerShares,
+        stakeId,
+        prizeShare,
+        voterShare,
+        feeShare,
+        weight,
+      )
+      .send({ from: account });
+    const eventLog = txReceipt.logs.find((log) => log.topics![0] == TOPIC_LOG);
+    const newContestAddress = this.web3.eth.abi.decodeParameters(
+      ['address', 'address', 'uint256', 'bool'],
+      eventLog!.data!.toString(),
+    )['0'] as string;
+    return {
+      block: Number(txReceipt['blockNumber']),
+      contest: newContestAddress,
+    };
+  }
+
+  async newSingleContest(
+    namespaceName: string,
+    contestLength: number,
+    winnerShares: number[],
+    exchangeToken: string,
+    stakeId: number = 2,
+    voterShare: number = 20,
+    weight: number = 1,
+    accountIndex?: number,
+  ): Promise<{ block: number; contest: string }> {
+    const account = (await this.getAccounts())[accountIndex ?? 0];
+    const txReceipt = await this.contract.methods
+      .newSingleContest(
+        namespaceName,
+        contestLength,
+        winnerShares,
+        stakeId,
+        voterShare,
+        weight,
+        exchangeToken,
+      )
+      .send({ from: account });
+    const eventLog = txReceipt.logs.find((log) => log.topics![0] == TOPIC_LOG);
+    const newContestAddress = this.web3.eth.abi.decodeParameters(
+      ['address', 'address', 'uint256', 'bool'],
+      eventLog!.data!.toString(),
+    )['0'] as string;
+    return {
+      block: Number(txReceipt['blockNumber']),
+      contest: newContestAddress,
+    };
+  }
+
+  /**
+   * Gets the contract address for a namespace with the given name
+   * @param name Namespace name
+   * @returns contract address 0x...
+   */
+  async getNamespaceAddress(name: string): Promise<string> {
+    const hexString = this.web3.utils.utf8ToHex(name);
+    const activeNamespace: string = await this.contract.methods
+      .getNamespace(hexString.padEnd(66, '0'))
+      .call();
+    return activeNamespace;
+  }
+}

--- a/libs/evm-testing/src/utils/abi/CommunityStakesAbi.ts
+++ b/libs/evm-testing/src/utils/abi/CommunityStakesAbi.ts
@@ -1,0 +1,162 @@
+export const communityStakesAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'getBuyPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'getBuyPriceAfterFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'getSellPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'getSellPriceAfterFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+    name: 'buyStake',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sharesSubject',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+    name: 'sellStake',
+  },
+];

--- a/libs/evm-testing/src/utils/abi/ContestAbi.ts
+++ b/libs/evm-testing/src/utils/abi/ContestAbi.ts
@@ -1,0 +1,96 @@
+export const ContestAbi = [
+  {
+    inputs: [],
+    name: 'contestToken',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'deposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'winnerIds',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'length',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'winnerShares',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'voterShare',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'weight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'exhangeToken',
+        type: 'address',
+      },
+    ],
+    name: 'newSingleContest',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/libs/evm-testing/src/utils/abi/NamespaceFactoryAbi.ts
+++ b/libs/evm-testing/src/utils/abi/NamespaceFactoryAbi.ts
@@ -1,0 +1,202 @@
+export const namespaceFactoryAbi = [
+  {
+    inputs: [],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'reservationHook',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: '_uri',
+        type: 'string',
+      },
+      {
+        internalType: 'address',
+        name: '_feeManager',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: '_signature',
+        type: 'bytes',
+      },
+    ],
+    name: 'deployNamespace',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'tokenName',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'exchangeToken',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'scalar',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'curve',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+    name: 'configureCommunityStakeId',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'getNamespace',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'interval',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'winnerShares',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'prizeShare',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'voterShare',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'feeShare',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'weight',
+        type: 'uint256',
+      },
+    ],
+    name: 'newContest',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'length',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'winnerShares',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'voterShare',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'weight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'exhangeToken',
+        type: 'address',
+      },
+    ],
+    name: 'newSingleContest',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/libs/evm-testing/src/utils/chainUtil.ts
+++ b/libs/evm-testing/src/utils/chainUtil.ts
@@ -51,9 +51,12 @@ export async function mineBlocks(blocks: number) {
 
 export async function getAnvil(
   options: CreateAnvilOptions = {},
+  protocolFork?: boolean,
 ): Promise<Anvil> {
   const anvil = createAnvil({
-    forkUrl: `https://eth-mainnet.g.alchemy.com/v2/${config.EVM.ETH_ALCHEMY_API_KEY}`,
+    forkUrl: protocolFork
+      ? `https://base-sepolia.g.alchemy.com/v2/${config.EVM.BASESEP_ALCHEMY_API_KEY}`
+      : `https://eth-mainnet.g.alchemy.com/v2/${config.EVM.ETH_ALCHEMY_API_KEY}`,
     silent: false,
     port: 8545,
     autoImpersonate: true,

--- a/libs/evm-testing/src/utils/contracts.ts
+++ b/libs/evm-testing/src/utils/contracts.ts
@@ -1,5 +1,7 @@
 import Web3 from 'web3';
 import { AbiItem } from 'web3-utils';
+import { communityStakesAbi } from './abi/CommunityStakesAbi';
+import { namespaceFactoryAbi } from './abi/NamespaceFactoryAbi';
 import aave_gov_abi from './abi/aaveGov';
 import comp_gov_abi from './abi/compGov';
 import dex_abi from './abi/dex';
@@ -29,4 +31,12 @@ export const erc_721 = (address: string, provider: Web3) => {
 
 export const erc_1155 = (address: string, provider: Web3) => {
   return new provider.eth.Contract(erc_1155_abi as AbiItem[], address);
+};
+
+export const namespace_factory = (address: string, provider: Web3) => {
+  return new provider.eth.Contract(namespaceFactoryAbi as AbiItem[], address);
+};
+
+export const community_stake = (address: string, provider: Web3) => {
+  return new provider.eth.Contract(communityStakesAbi as AbiItem[], address);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8009

## Description of Changes
- Adds an option to fork a testnet with all live protocol contracts
- Includes SDK methods to mimic frontend actions such as
    - deploy namespace
    - configure community stake
    - buy/sell stake
    - launch recurring/single contests

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Please provide any other requested interactions + ideal chainTesting abstractions of these sdk classes