### PR TITLE
Fix upvote race condition

### DIFF
--- a/libs/model/src/policies/ContestWorker.policy.ts
+++ b/libs/model/src/policies/ContestWorker.policy.ts
@@ -158,10 +158,10 @@ export function ContestWorker(): Policy<typeof inputs> {
         );
 
         if (!activeContestsWithoutVote?.length) {
-          log.warn(
-            'ThreadCreated: no matching active contests without actions',
+          // throw to trigger retry in case the content is pending creation
+          throw new Error(
+            'ThreadUpvoted: no matching active contests without actions',
           );
-          return;
         }
 
         const chainNodeUrl =
@@ -172,8 +172,9 @@ export function ContestWorker(): Policy<typeof inputs> {
           (c) => c.contest_address,
         );
 
-        console.log('addressesToProcess: ', addressesToProcess);
-        // return;
+        log.debug(
+          `ThreadUpvoted addressesToProcess: ${addressesToProcess.join(', ')}`,
+        );
 
         const promises = await contestHelper.voteContentBatch(
           chainNodeUrl!,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7995

## Description of Changes
- Throws an error if the vote event cannot find associated contest content, which triggers the retry policy
  - This allows the vote event to retry until the content (hopefully) exists

## Test Plan
- With all the contest-related services running:
  - Create a thread
  - Immediately create an upvote
  - Confirm outbox shows `ThreadCreated` + `ThreadUpvoted` event with nothing between
  - Wait 30-ish seconds
  - Confirm that the `ContestContentAdded` and `ContestContentUpvoted` events are in the outbox table + `added` and `upvoted` actions in the `ContestActions` table

## Deployment Plan
N/A

## Other Considerations
N/A