### PR TITLE
Turn on lint-branch warnings.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -210,8 +210,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      #- name: Run linter
-      #  run: pnpm lint-branch-warnings
+      - name: Run linter
+        run: pnpm lint-branch-warnings
 
   # Lint and Typecheck
   commonwealth-code-quality:
@@ -253,8 +253,8 @@ jobs:
       # fun the *old* linter last because I want to try to migrate away from
       # this and JUST to eslint-diff but if this fails we still might be able
       # to salvage the branch
-      #- name: Run linter
-      #  run: pnpm lint-branch
+      - name: Run linter
+        run: pnpm lint-branch
 
   # These tests run quickly, so run them in a separate job
   commonwealth-unit-integration:


### PR DESCRIPTION
With the strictNullChecks branch I turned off the lint-branch warnings CI task but I want to double check the lint-diff setup and then get team approval to kill it.

I'm like 95% certain we don't need it anymore but we should discuss first.

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 

## Description of Changes
- turns back on the lint-branch warnings.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 