### PR TITLE
FE Contest fixes

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useRerender.ts
+++ b/packages/commonwealth/client/scripts/hooks/useRerender.ts
@@ -1,0 +1,25 @@
+import useForceRerender from 'hooks/useForceRerender';
+import { useEffect } from 'react';
+
+interface UseRerenderProps {
+  isActive?: boolean;
+  interval: number;
+}
+
+const useRerender = ({ isActive, interval }: UseRerenderProps) => {
+  const forceRerender = useForceRerender();
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      forceRerender();
+    }, interval);
+
+    return () => clearInterval(intervalId);
+  }, [forceRerender, interval, isActive]);
+};
+
+export default useRerender;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -5,6 +5,7 @@ import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
 import useCancelContestMutation from 'state/api/contests/cancelContest';
+import { Skeleton } from 'views/components/Skeleton';
 import { CWCard } from 'views/components/component_kit/cw_card';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -110,7 +111,11 @@ const ContestCard = ({
       <div className="contest-body">
         <div className="header-row">
           <CWText type="h3">{name}</CWText>
-          <ContestCountdown finishTime={finishDate} isActive={isActive} />
+          {finishDate ? (
+            <ContestCountdown finishTime={finishDate} isActive={isActive} />
+          ) : (
+            <Skeleton width="70px" />
+          )}
         </div>
         <CWText className="topics">
           Topics: {topics.map(({ name: topicName }) => topicName).join(', ')}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -136,7 +136,10 @@ const ContestCard = ({
                 {moment.localeData().ordinal(index + 1)} Prize
               </CWText>
               <CWText fontWeight="bold">
-                {capDecimals(s.tickerPrize!.toFixed(decimals || 18))} {ticker}
+                {capDecimals(
+                  s.tickerPrize ? s.tickerPrize?.toFixed(decimals || 18) : '',
+                )}
+                {ticker}
               </CWText>
             </div>
           ))}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -11,6 +11,7 @@ import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { SharePopoverOld } from 'views/components/share_popover_old';
+import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 
 import ContestCountdown from '../ContestCountdown';
@@ -30,6 +31,8 @@ interface ContestCardProps {
     prize?: string;
     tickerPrize?: number;
   }[];
+  decimals?: number;
+  ticker?: string;
   isAdmin: boolean;
   isActive: boolean;
   onFund: () => void;
@@ -42,6 +45,8 @@ const ContestCard = ({
   finishDate,
   topics,
   score,
+  decimals,
+  ticker,
   isAdmin,
   isActive,
   onFund,
@@ -119,7 +124,9 @@ const ContestCard = ({
               <CWText className="label">
                 {moment.localeData().ordinal(index + 1)} Prize
               </CWText>
-              <CWText fontWeight="bold">{s.tickerPrize} ETH</CWText>
+              <CWText fontWeight="bold">
+                {capDecimals(s.tickerPrize!.toFixed(decimals))} {ticker}
+              </CWText>
             </div>
           ))}
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import useForceRerender from 'hooks/useForceRerender';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
@@ -35,7 +36,7 @@ interface ContestCardProps {
   decimals?: number;
   ticker?: string;
   isAdmin: boolean;
-  isActive: boolean;
+  isCancelled: boolean;
   onFund: () => void;
 }
 
@@ -49,13 +50,30 @@ const ContestCard = ({
   decimals,
   ticker,
   isAdmin,
-  isActive,
+  isCancelled,
   onFund,
 }: ContestCardProps) => {
+  const forceRerender = useForceRerender();
+
   const navigate = useCommonNavigate();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
   const { mutateAsync: cancelContest } = useCancelContestMutation();
+
+  const hasEnded = moment(finishDate) < moment();
+  const isActive = isCancelled ? false : !hasEnded;
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      forceRerender();
+    }, 6000); // 6s
+
+    return () => clearInterval(interval);
+  }, [forceRerender, isActive]);
 
   const handleCancel = () => {
     cancelContest({

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import useForceRerender from 'hooks/useForceRerender';
+import useRerender from 'hooks/useRerender';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
@@ -36,7 +36,7 @@ interface ContestCardProps {
   decimals?: number;
   ticker?: string;
   isAdmin: boolean;
-  isCancelled: boolean;
+  isCancelled?: boolean;
   onFund: () => void;
 }
 
@@ -53,8 +53,6 @@ const ContestCard = ({
   isCancelled,
   onFund,
 }: ContestCardProps) => {
-  const forceRerender = useForceRerender();
-
   const navigate = useCommonNavigate();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
 
@@ -63,17 +61,7 @@ const ContestCard = ({
   const hasEnded = moment(finishDate) < moment();
   const isActive = isCancelled ? false : !hasEnded;
 
-  useEffect(() => {
-    if (!isActive) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      forceRerender();
-    }, 6000); // 6s
-
-    return () => clearInterval(interval);
-  }, [forceRerender, isActive]);
+  useRerender({ isActive, interval: 6000 });
 
   const handleCancel = () => {
     cancelContest({
@@ -148,7 +136,7 @@ const ContestCard = ({
                 {moment.localeData().ordinal(index + 1)} Prize
               </CWText>
               <CWText fontWeight="bold">
-                {capDecimals(s.tickerPrize!.toFixed(decimals))} {ticker}
+                {capDecimals(s.tickerPrize!.toFixed(decimals || 18))} {ticker}
               </CWText>
             </div>
           ))}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -97,6 +97,8 @@ const ContestsList = ({
                 topics={contest.topics}
                 // @ts-expect-error <StrictNullChecks/>
                 score={score}
+                decimals={contest.decimals}
+                ticker={contest.ticker}
                 finishDate={moment(end_time).toISOString()}
                 isActive={!contest.cancelled && !hasEnded}
                 // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -98,7 +98,7 @@ const ContestsList = ({
                 decimals={contest.decimals}
                 ticker={contest.ticker}
                 finishDate={end_time ? moment(end_time).toISOString() : ''}
-                isCancelled={contest.cancelled!}
+                isCancelled={contest.cancelled}
                 // @ts-expect-error <StrictNullChecks/>
                 onFund={() => setFundDrawerAddress(contest.contest_address)}
               />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -99,7 +99,7 @@ const ContestsList = ({
                 score={score}
                 decimals={contest.decimals}
                 ticker={contest.ticker}
-                finishDate={moment(end_time).toISOString()}
+                finishDate={end_time ? moment(end_time).toISOString() : ''}
                 isActive={!contest.cancelled && !hasEnded}
                 // @ts-expect-error <StrictNullChecks/>
                 onFund={() => setFundDrawerAddress(contest.contest_address)}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -82,8 +82,6 @@ const ContestsList = ({
             const { end_time, score } =
               sortedContests[sortedContests.length - 1] || {};
 
-            const hasEnded = moment(end_time) < moment();
-
             return (
               <ContestCard
                 key={contest.contest_address}
@@ -100,7 +98,7 @@ const ContestsList = ({
                 decimals={contest.decimals}
                 ticker={contest.ticker}
                 finishDate={end_time ? moment(end_time).toISOString() : ''}
-                isActive={!contest.cancelled && !hasEnded}
+                isCancelled={contest.cancelled!}
                 // @ts-expect-error <StrictNullChecks/>
                 onFund={() => setFundDrawerAddress(contest.contest_address)}
               />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8089 #8059

## Description of Changes
- for notation fix: 
  - used `toFixed` method with number provided by the backend (usually it is 18)
- for counter fix:
  - show loaded when the date is not available
  - added interval so the component rerenders every 6s instead of only on refresh



## Test Plan
- notation:
  - in prize section, user should not see scientific notation

- counter:
  - create contest and go to contest list
  - user should see the loader 
  - when the page is visited again, the proper time should be displayed that is dynamic (hours/minutes should change)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
> **:warning: Note**


> there is still gonna be loader visible when the user opens up the list of contests right after creating one but to fix it completely we will need to figure out more robust solution to sync FE data with onchain data
