### PR TITLE
Added followup changes to thread previews

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -36,9 +36,6 @@ export const CreateComment = ({
       : `new-comment-reply-${parentCommentId}`,
   );
 
-  const urlParams = new URLSearchParams(location.search);
-  const focusEditorParam = urlParams.get('focusEditor') === 'true';
-
   // get restored draft on init
   const restoredDraft = useMemo(() => {
     return restoreDraft() || createDeltaFromText('');
@@ -170,7 +167,6 @@ export const CreateComment = ({
             onCancel={handleCancel}
             author={author}
             editorValue={editorValue}
-            shouldFocus={canComment && focusEditorParam}
             tooltipText={tooltipText}
           />
           {RevalidationModal}

--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -126,7 +126,7 @@ const FeedThread = ({ thread }: { thread: Thread }) => {
         );
       }}
       threadHref={discussionLink}
-      onCommentBtnClick={() => navigate(`${discussionLink}?focusEditor=true`)}
+      onCommentBtnClick={() => navigate(`${discussionLink}?focusComments=true`)}
       disabledActionsTooltipText={disabledActionsTooltipText}
       customStages={chain.customStages}
       hideReactionButton

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.scss
@@ -3,4 +3,9 @@
 .CommentsTree {
   display: flex;
   flex-direction: column;
+  // breadcrumbs don't have an underlying elemnet that would fill in the space it overlays
+  // this causes an issue (first commnet is cutoff by the breadcrumbs overlay) when scrolling
+  // comments tree into view
+  // TODO: fix breadcrumbs and remove this
+  scroll-margin-block-start: 40px;
 }

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -64,6 +64,21 @@ export const CommentTree = ({
   commentSortType,
   disabledActionsTooltipText,
 }: CommentsTreeAttrs) => {
+  const urlParams = new URLSearchParams(location.search);
+  const focusCommentsParam = urlParams.get('focusComments') === 'true';
+
+  useEffect(() => {
+    if (focusCommentsParam) {
+      const ele = document.getElementsByClassName('CommentsTree')[0];
+      ele.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }
+    // we only want to run this on first mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const [highlightedComment, setHighlightedComment] = useState(false);
 
   const { data: allComments = [] } = useFetchCommentsQuery({

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -68,13 +68,21 @@ export const CommentTree = ({
   const focusCommentsParam = urlParams.get('focusComments') === 'true';
 
   useEffect(() => {
+    let timeout;
+
     if (focusCommentsParam) {
-      const ele = document.getElementsByClassName('CommentsTree')[0];
-      ele.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
+      timeout = setTimeout(() => {
+        const ele = document.getElementsByClassName('CommentsTree')[0];
+        ele.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 100);
     }
+
+    return () => {
+      timeout !== undefined && clearTimeout(timeout);
+    };
     // we only want to run this on first mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -180,7 +180,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                   scrollEle.scrollTop;
               }}
               onCommentBtnClick={() =>
-                navigate(`${discussionLink}?focusEditor=true`)
+                navigate(`${discussionLink}?focusComments=true`)
               }
               disabledActionsTooltipText={disabledActionsTooltipText}
               hideRecentComments

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -105,7 +105,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       contestAddress,
       // @ts-expect-error <StrictNullChecks/>
       contestStatus,
-      withXRecentComments: 3,
     });
 
   const threads = sortPinned(sortByFeaturedFilter(data || [], featuredFilter));
@@ -184,6 +183,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                 navigate(`${discussionLink}?focusEditor=true`)
               }
               disabledActionsTooltipText={disabledActionsTooltipText}
+              hideRecentComments
             />
           );
         }}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -224,7 +224,7 @@ export const AuthorAndPublishInfo = ({
               placement="top"
               content={
                 <div style={{ display: 'flex', gap: '8px' }}>
-                  {publishDate?.utc?.()?.local?.()?.format('MMMM Do, YYYY')}{' '}
+                  {publishDate?.utc?.()?.local?.()?.format('Do MMMM, YYYY')}{' '}
                   {dotIndicator}{' '}
                   {publishDate?.utc?.()?.local?.()?.format('h:mm A')}
                 </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
@@ -7,7 +7,7 @@ export const formatVersionText = (
   profile: UserProfile,
   collabInfo: Record<string, string>,
 ) => {
-  const formattedTime = timestamp.format('MMMM Do, YYYY • h:mm A');
+  const formattedTime = timestamp.format('Do MMMM, YYYY • h:mm A');
   // Some old posts don't have address, so account for them by omitting address
   if (!address) {
     return formattedTime;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
@@ -92,10 +92,15 @@
         .MarkdownFormattedText {
           @include caption;
           overflow: hidden;
+          --line-height: 20px;
+
+          & > div {
+            overflow: hidden;
+          }
 
           @include extraSmall {
             p {
-              line-height: 18px !important;
+              line-height: calc(var(--line-height) - 2) !important;
             }
           }
 
@@ -109,11 +114,26 @@
           span,
           div {
             font-size: 16px !important;
+            line-height: var(--line-height) !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            color: black !important;
+          }
+
+          strong {
+            font-weight: 500;
           }
 
           &.collapsed {
             div :last-child {
-              color: $neutral-300;
+              color: transparent !important;
+              background: linear-gradient(
+                180deg,
+                rgba(2, 0, 36, 1) 0%,
+                rgba(40, 39, 39, 1) 10%,
+                rgb(179, 174, 180) 100%
+              );
+              background-clip: text;
             }
           }
         }

--- a/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/overview/TopicSummaryRow.tsx
@@ -122,7 +122,7 @@ export const TopicSummaryRow = ({
               }}
               threadHref={discussionLink}
               onCommentBtnClick={() =>
-                navigate(`${discussionLinkWithoutChain}?focusEditor=true`)
+                navigate(`${discussionLinkWithoutChain}?focusComments=true`)
               }
               disabledActionsTooltipText={disabledActionsTooltipText}
               hideReactionButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8069

## Description of Changes
- The "comments" button on any thread card now takes user to the first comment on the thread details page
- Recent comments are no longer shown with thread cards on the community discussion page
- Thread content preview on thread card now correctly applies gradient on the last line of the truncated content (the content with "show more" button)

## "How We Fixed It"
N/A

## Test Plan
- Click on "comments" button on any thread card (you can find thread cards in the community overview, discussions or homepage for-you/global sections), verify it takes you to thread details page and scrolls you to first comment
- Verify that the truncated text (any text with "show more" button) is faded with a slight gray color in thread card
- Recent comments are now removed from the thread card display on community discussions page

## Deployment Plan
N/A

## Other Considerations
N/A