### PR TITLE
Fixed scrolling parent for `<Virtuoso/>` list in community discussions page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -137,6 +137,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
         className="thread-list"
         style={{ height: '100%', width: '100%' }}
         data={isInitialLoading ? [] : filteredThreads}
+        customScrollParent={containerRef.current}
         itemContent={(i, thread) => {
           const discussionLink = getProposalUrlPath(
             thread.slug,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8039

## Description of Changes
Fixed scrolling parent for `<Virtuoso/>` list in the community discussions page

## "How We Fixed It"
N/A

## Test Plan
- Verify that you can scroll out of the `<Virtuoso/>` list element in `> 1600px` screen sizes

## Deployment Plan
N/A

## Other Considerations
N/A