### PR TITLE
Add nonce mutex for protocol helpers

### DIFF
--- a/libs/model/package.json
+++ b/libs/model/package.json
@@ -32,6 +32,7 @@
     "@hicommonwealth/shared": "workspace:*",
     "@solana/spl-token": "^0.4.6",
     "@solana/web3.js": "^1.91.6",
+    "async-mutex": "^0.5.0",
     "ethers": "5.7.2",
     "lodash": "^4.17.21",
     "moment": "^2.23.0",

--- a/libs/model/src/policies/ContestWorker.policy.ts
+++ b/libs/model/src/policies/ContestWorker.policy.ts
@@ -82,14 +82,12 @@ export function ContestWorker(): Policy<typeof inputs> {
           (c) => c.contest_address,
         );
 
-        const promises = await contestHelper.addContentBatch(
+        const results = await contestHelper.addContentBatch(
           chainNodeUrl!,
           addressesToProcess,
           userAddress,
           contentUrl,
         );
-
-        const results = await Promise.allSettled(promises);
 
         const errors = results
           .filter(({ status }) => status === 'rejected')
@@ -176,14 +174,12 @@ export function ContestWorker(): Policy<typeof inputs> {
           `ThreadUpvoted addressesToProcess: ${addressesToProcess.join(', ')}`,
         );
 
-        const promises = await contestHelper.voteContentBatch(
+        const results = await contestHelper.voteContentBatch(
           chainNodeUrl!,
           addressesToProcess,
           userAddress,
           activeContestsWithoutVote[0].content_id.toString(),
         );
-
-        const results = await Promise.allSettled(promises);
 
         const errors = results
           .filter(({ status }) => status === 'rejected')

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -302,7 +302,7 @@ export const addContentBatch = async (
   contest: string[],
   creator: string,
   url: string,
-): Promise<Promise<AddContentResponse>[]> => {
+): Promise<PromiseSettledResult<AddContentResponse>[]> => {
   return nonceMutex.runExclusive(async () => {
     const web3 = await createWeb3Provider(rpcNodeUrl);
     let currNonce = Number(
@@ -316,7 +316,7 @@ export const addContentBatch = async (
       currNonce++;
     });
 
-    return promises;
+    return Promise.allSettled(promises);
   });
 };
 
@@ -325,7 +325,7 @@ export const voteContentBatch = async (
   contest: string[],
   voter: string,
   contentId: string,
-): Promise<Promise<any>[]> => {
+): Promise<PromiseSettledResult<any>[]> => {
   return nonceMutex.runExclusive(async () => {
     const web3 = await createWeb3Provider(rpcNodeUrl);
     let currNonce = Number(
@@ -341,6 +341,6 @@ export const voteContentBatch = async (
       currNonce++;
     });
 
-    return promises;
+    return Promise.allSettled(promises);
   });
 };

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -6,7 +6,7 @@ import { config } from '../../config';
 import { contestABI } from './abi/contestAbi';
 import { feeManagerABI } from './abi/feeManagerAbi';
 
-let nonceMutex = new Mutex();
+const nonceMutex = new Mutex();
 
 export type AddContentResponse = {
   txReceipt: any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,6 +735,9 @@ importers:
       '@solana/web3.js':
         specifier: ^1.91.6
         version: 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
       ethers:
         specifier: 5.7.2
         version: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -9679,6 +9682,12 @@ packages:
         integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
       }
     engines: { node: '>=8' }
+
+  async-mutex@0.5.0:
+    resolution:
+      {
+        integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==,
+      }
 
   async-rwlock@1.1.1:
     resolution:
@@ -30399,6 +30408,10 @@ snapshots:
   assertion-error@1.1.0: {}
 
   astral-regex@2.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.6.2
 
   async-rwlock@1.1.1: {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8040

## Description of Changes
- Prevents nonce race condition by wrapping the protocol txn calls in a mutex to guarantee no concurrency when nonce is incremented (within a single instance of the app)
- This also may fix the prize/score bug

## Test Plan
- Create a few contests, then create a thread and immediately upvote it
  - Ensure that the consumer throws no errors

## Deployment Plan
N/A

## Other Considerations
- The original solution was to set RMQ to the requeue retry policy, but having the synchronization mechanism in the protocol helper itself provides a stronger guarantee of no concurrency when reading/incrementing the nonce + the requeue policy might get out of control with endless retries.
- It's assumed that the consumer will not scale horizontally, otherwise Redis should be used for distributed access to the lock