### PR TITLE
Create contest UI fixes

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
@@ -275,13 +275,14 @@ const DetailsFormStep = ({
                   <>
                     <CWText className="funding-token-address-description">
                       Enter the address of the token you would like to use to
-                      fund your contest
+                      fund your contest (eg: USDT, $degen etc). Leave blank if
+                      using a native token
                     </CWText>
                     <CWTextInput
                       containerClassName="funding-token-address-input"
                       name="fundingTokenAddress"
                       hookToForm
-                      placeholder="Enter funding token address e.g. 0x0000000000000000000000000000000000000000"
+                      placeholder="Enter funding token address"
                       fullWidth
                       label="Token Address"
                       disabled={editMode}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
@@ -293,74 +293,80 @@ const DetailsFormStep = ({
 
               <CWDivider />
 
-              <div className="contest-section contest-section-recurring">
-                <CWText type="h4">Make contest recurring?</CWText>
-                <CWText type="b1">
-                  The remaining prize pool will roll over week to week until you
-                  end the contest.
-                  <br />
-                  {watch('contestRecurring') === ContestRecurringType.Yes ? (
-                    <>
-                      Contests run using Community Stake funds must be
-                      recurring.
-                    </>
-                  ) : (
-                    <>
-                      Contests run using Direct deposit funds can not be
-                      recurring.
-                    </>
-                  )}
-                </CWText>
-                <div className="radio-row">
-                  <CWRadioButton
-                    label="Yes"
-                    value={ContestRecurringType.Yes}
-                    name="contestRecurring"
-                    hookToForm
-                    disabled={
-                      editMode ||
-                      watch('feeType') === ContestFeeType.DirectDeposit
-                    }
-                  />
-                  <CWRadioButton
-                    label="No"
-                    value={ContestRecurringType.No}
-                    name="contestRecurring"
-                    hookToForm
-                    disabled={
-                      editMode ||
-                      watch('feeType') === ContestFeeType.CommunityStake
-                    }
-                  />
-                </div>
-                {watch('contestRecurring') === ContestRecurringType.Yes && (
-                  <div className="prize-subsection">
-                    <CWText type="h5">
-                      How much of the funds would you like to use weekly?
-                    </CWText>
+              {watch('feeType') === ContestFeeType.CommunityStake && (
+                <>
+                  <div className="contest-section contest-section-recurring">
+                    <CWText type="h4">Make contest recurring?</CWText>
                     <CWText type="b1">
-                      Tip: smaller prizes makes the contest run longer
+                      The remaining prize pool will roll over week to week until
+                      you end the contest.
+                      <br />
+                      {watch('contestRecurring') ===
+                      ContestRecurringType.Yes ? (
+                        <>
+                          Contests run using Community Stake funds must be
+                          recurring.
+                        </>
+                      ) : (
+                        <>
+                          Contests run using Direct deposit funds can not be
+                          recurring.
+                        </>
+                      )}
                     </CWText>
-                    <div className="percentage-buttons">
-                      {prizePercentageOptions.map(({ value, label }) => (
-                        <CWButton
-                          disabled={editMode}
-                          type="button"
-                          key={value}
-                          label={label}
-                          buttonHeight="sm"
-                          onClick={() => setPrizePercentage(value)}
-                          buttonType={
-                            prizePercentage === value ? 'primary' : 'secondary'
-                          }
-                        />
-                      ))}
+                    <div className="radio-row">
+                      <CWRadioButton
+                        label="Yes"
+                        value={ContestRecurringType.Yes}
+                        name="contestRecurring"
+                        hookToForm
+                        disabled={
+                          editMode ||
+                          watch('feeType') === ContestFeeType.DirectDeposit
+                        }
+                      />
+                      <CWRadioButton
+                        label="No"
+                        value={ContestRecurringType.No}
+                        name="contestRecurring"
+                        hookToForm
+                        disabled={
+                          editMode ||
+                          watch('feeType') === ContestFeeType.CommunityStake
+                        }
+                      />
                     </div>
+                    {watch('contestRecurring') === ContestRecurringType.Yes && (
+                      <div className="prize-subsection">
+                        <CWText type="h5">
+                          How much of the funds would you like to use weekly?
+                        </CWText>
+                        <CWText type="b1">
+                          Tip: smaller prizes makes the contest run longer
+                        </CWText>
+                        <div className="percentage-buttons">
+                          {prizePercentageOptions.map(({ value, label }) => (
+                            <CWButton
+                              disabled={editMode}
+                              type="button"
+                              key={value}
+                              label={label}
+                              buttonHeight="sm"
+                              onClick={() => setPrizePercentage(value)}
+                              buttonType={
+                                prizePercentage === value
+                                  ? 'primary'
+                                  : 'secondary'
+                              }
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-
-              <CWDivider />
+                  <CWDivider />
+                </>
+              )}
 
               <div className="contest-section contest-section-payout">
                 <CWText type="h4">Winners & payouts</CWText>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/validation.ts
@@ -1,28 +1,13 @@
 import { VALIDATION_MESSAGES } from 'helpers/formValidationMessages';
 import z from 'zod';
 
-import { ContestFeeType } from '../../types';
-
-export const detailsFormValidationSchema = z
-  .object({
-    contestName: z
-      .string()
-      .min(1, { message: 'You must name your contest' })
-      .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
-    contestImage: z.string().optional(),
-    feeType: z.string(),
-    contestRecurring: z.string(),
-    fundingTokenAddress: z.string().optional().nullable(),
-  })
-  .refine(
-    (data) => {
-      return (
-        data.feeType === ContestFeeType.CommunityStake ||
-        data.fundingTokenAddress
-      );
-    },
-    {
-      message: 'You must enter a token address',
-      path: ['fundingTokenAddress'],
-    },
-  );
+export const detailsFormValidationSchema = z.object({
+  contestName: z
+    .string()
+    .min(1, { message: 'You must name your contest' })
+    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
+  contestImage: z.string().optional(),
+  feeType: z.string(),
+  contestRecurring: z.string(),
+  fundingTokenAddress: z.string().optional().nullable(),
+});

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -36,6 +36,7 @@ interface SignTransactionsStepProps {
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
 const FIVE_MINS_IN_SECONDS = 60 * 5;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const SignTransactionsStep = ({
   onSetLaunchContestStep,
@@ -78,7 +79,7 @@ const SignTransactionsStep = ({
     const prizeShare = contestFormData?.prizePercentage;
     const walletAddress = app.user.activeAccount?.address;
     const exchangeToken = isDirectDepositSelected
-      ? contestFormData?.fundingTokenAddress
+      ? contestFormData?.fundingTokenAddress || ZERO_ADDRESS
       : stakeData?.stake_token;
     const winnerShares = contestFormData?.payoutStructure;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8121 #8123 

## Description of Changes
- made funding address optional when direct deposit is selected
- added zero address as default
- changed input title
- hide recurring section when direct deposit is selected

## Test Plan
- open launch contest form
- select direct deposit option
- verify if recurring section is not visible
- verify if you can create a oneoff contest without providing funding token address


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

