### PR TITLE
Show welcome modal to new signups only

### DIFF
--- a/libs/model/src/models/user.ts
+++ b/libs/model/src/models/user.ts
@@ -69,7 +69,7 @@ export default (sequelize: Sequelize.Sequelize): UserModelStatic => {
         allowNull: false,
       },
       promotional_emails_enabled: { type: Sequelize.BOOLEAN, allowNull: true },
-      isWelcomeOnboardFlowComplete: {
+      is_welcome_onboard_flow_complete: {
         type: Sequelize.BOOLEAN,
         defaultValue: false,
         allowNull: false,

--- a/libs/model/src/models/user.ts
+++ b/libs/model/src/models/user.ts
@@ -69,6 +69,11 @@ export default (sequelize: Sequelize.Sequelize): UserModelStatic => {
         allowNull: false,
       },
       promotional_emails_enabled: { type: Sequelize.BOOLEAN, allowNull: true },
+      isWelcomeOnboardFlowComplete: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
       isAdmin: { type: Sequelize.BOOLEAN, defaultValue: false },
       disableRichText: {
         type: Sequelize.BOOLEAN,

--- a/libs/model/src/tester/seedDb.ts
+++ b/libs/model/src/tester/seedDb.ts
@@ -26,13 +26,13 @@ export const seedDb = async () => {
         email: 'drewstone329@gmail.com',
         emailVerified: true,
         isAdmin: true,
-        isWelcomeOnboardFlowComplete: true,
+        is_welcome_onboard_flow_complete: true,
       },
       {
         email: 'temp@gmail.com',
         emailVerified: true,
         isAdmin: true,
-        isWelcomeOnboardFlowComplete: true,
+        is_welcome_onboard_flow_complete: true,
       },
     ]);
 

--- a/libs/model/src/tester/seedDb.ts
+++ b/libs/model/src/tester/seedDb.ts
@@ -26,11 +26,13 @@ export const seedDb = async () => {
         email: 'drewstone329@gmail.com',
         emailVerified: true,
         isAdmin: true,
+        isWelcomeOnboardFlowComplete: true,
       },
       {
         email: 'temp@gmail.com',
         emailVerified: true,
         isAdmin: true,
+        isWelcomeOnboardFlowComplete: true,
       },
     ]);
 

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -13,6 +13,7 @@ export const User = z.object({
     .default('never')
     .optional(),
   promotional_emails_enabled: z.boolean().optional(),
+  isWelcomeOnboardFlowComplete: z.boolean().default(false),
   created_at: z.any().optional(),
   updated_at: z.any().optional(),
 });

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -13,7 +13,7 @@ export const User = z.object({
     .default('never')
     .optional(),
   promotional_emails_enabled: z.boolean().optional(),
-  isWelcomeOnboardFlowComplete: z.boolean().default(false).optional(),
+  is_welcome_onboard_flow_complete: z.boolean().default(false).optional(),
   created_at: z.any().optional(),
   updated_at: z.any().optional(),
 });

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -13,7 +13,7 @@ export const User = z.object({
     .default('never')
     .optional(),
   promotional_emails_enabled: z.boolean().optional(),
-  isWelcomeOnboardFlowComplete: z.boolean().default(false),
+  isWelcomeOnboardFlowComplete: z.boolean().default(false).optional(),
   created_at: z.any().optional(),
   updated_at: z.any().optional(),
 });

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -10,11 +10,9 @@ import { initAppState } from 'state';
 
 import { OpenFeature } from '@openfeature/web-sdk';
 import axios from 'axios';
-import { getUniqueUserAddresses } from 'client/scripts/helpers/user';
 import { fetchProfilesByAddress } from 'client/scripts/state/api/profiles/fetchProfilesByAddress';
 import { authModal } from 'client/scripts/state/ui/modals/authModal';
 import { welcomeOnboardModal } from 'client/scripts/state/ui/modals/welcomeOnboardModal';
-import moment from 'moment';
 import app from 'state';
 import Account from '../../models/Account';
 import AddressInfo from '../../models/AddressInfo';
@@ -248,6 +246,7 @@ export function updateActiveUser(data) {
     app.user.setEmailVerified(null);
     // @ts-expect-error StrictNullChecks
     app.user.setPromotionalEmailsEnabled(null);
+    app.user.setIsWelcomeOnboardFlowComplete(false);
     // @ts-expect-error StrictNullChecks
     app.user.setKnockJWT(null);
     // @ts-expect-error StrictNullChecks
@@ -267,6 +266,7 @@ export function updateActiveUser(data) {
     app.user.setEmailInterval(data.emailInterval);
     app.user.setEmailVerified(data.emailVerified);
     app.user.setPromotionalEmailsEnabled(data.promotional_emails_enabled);
+    app.user.setIsWelcomeOnboardFlowComplete(data.isWelcomeOnboardFlowComplete);
     app.user.setKnockJWT(data.knockJwtToken);
     app.user.setJWT(data.jwt);
 
@@ -611,11 +611,7 @@ export async function handleSocialLoginCallback({
     }
 
     if (userOnboardingEnabled) {
-      const {
-        created_at: accountCreatedTime,
-        Profiles: profiles,
-        email: ssoEmail,
-      } = response.data.result;
+      const { Profiles: profiles, email: ssoEmail } = response.data.result;
 
       // if email is not set, set the SSO email as the default email
       // only if its a standalone account (no account linking)
@@ -623,21 +619,10 @@ export async function handleSocialLoginCallback({
         await app.user.updateEmail(ssoEmail, false);
       }
 
-      const userUniqueAddresses = getUniqueUserAddresses({});
-
-      // if account is created in last few minutes and has a single
-      // profile and address (no account linking) then open the welcome modal.
+      // if account is newly created and user has not completed onboarding flow
+      // then open the welcome modal.
       const profileId = profiles?.[0]?.id;
-      const isCreatedInLast5Minutes =
-        accountCreatedTime &&
-        moment().diff(moment(accountCreatedTime), 'minutes') < 5;
-      if (
-        isCreatedInLast5Minutes &&
-        profiles?.length === 1 &&
-        userUniqueAddresses.length === 1 &&
-        profileId &&
-        !welcomeOnboardModal?.getState?.()?.onboardedProfiles?.[profileId]
-      ) {
+      if (profileId && !app.user.isWelcomeOnboardFlowComplete) {
         setTimeout(() => {
           welcomeOnboardModal.getState().setIsWelcomeOnboardModalOpen(true);
         }, 1000);

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -266,7 +266,9 @@ export function updateActiveUser(data) {
     app.user.setEmailInterval(data.emailInterval);
     app.user.setEmailVerified(data.emailVerified);
     app.user.setPromotionalEmailsEnabled(data.promotional_emails_enabled);
-    app.user.setIsWelcomeOnboardFlowComplete(data.isWelcomeOnboardFlowComplete);
+    app.user.setIsWelcomeOnboardFlowComplete(
+      data.is_welcome_onboard_flow_complete,
+    );
     app.user.setKnockJWT(data.knockJwtToken);
     app.user.setJWT(data.jwt);
 

--- a/packages/commonwealth/client/scripts/controllers/server/user.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/user.ts
@@ -67,8 +67,17 @@ export class UserController {
     return this._promotionalEmailsEnabled;
   }
 
+  private _isWelcomeOnboardFlowComplete: boolean;
+  public get isWelcomeOnboardFlowComplete(): boolean {
+    return this._isWelcomeOnboardFlowComplete;
+  }
+
   private _setPromotionalEmailsEnabled(enabled: boolean): void {
     this._promotionalEmailsEnabled = enabled;
+  }
+
+  private _setIsWelcomeOnboardFlowComplete(enabled: boolean): void {
+    this._isWelcomeOnboardFlowComplete = enabled;
   }
 
   private _knockJWT: string;
@@ -173,6 +182,10 @@ export class UserController {
 
   public setPromotionalEmailsEnabled(enabled: boolean): void {
     this._setPromotionalEmailsEnabled(enabled);
+  }
+
+  public setIsWelcomeOnboardFlowComplete(enabled: boolean): void {
+    this._setIsWelcomeOnboardFlowComplete(enabled);
   }
 
   public async updateEmail(

--- a/packages/commonwealth/client/scripts/state/api/profiles/updateProfileByAddress.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/updateProfileByAddress.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useFlag } from 'client/scripts/hooks/useFlag';
 import MinimumProfile from 'models/MinimumProfile';
 import app from 'state';
 import { ApiEndpoints, queryClient } from 'state/api/config';
@@ -47,10 +48,10 @@ const updateProfileByAddress = async ({
   const responseProfile = response.data.result.profile;
   const updatedProfile = new MinimumProfile(address, chain);
   updatedProfile.initialize(
-    responseProfile.name,
+    responseProfile.name || responseProfile.profile_name,
     address,
     responseProfile.avatarUrl,
-    profileId,
+    profileId || responseProfile.id,
     chain,
     responseProfile.lastActive,
   );
@@ -69,6 +70,8 @@ interface UseUpdateProfileByAddressMutation {
 const useUpdateProfileByAddressMutation = ({
   addressesWithChainsToUpdate,
 }: UseUpdateProfileByAddressMutation = {}) => {
+  const userOnboardingEnabled = useFlag('userOnboardingEnabled');
+
   return useMutation({
     mutationFn: updateProfileByAddress,
     onSuccess: async (updatedProfile) => {
@@ -83,11 +86,11 @@ const useUpdateProfileByAddressMutation = ({
         }
       });
 
-      // if `profileId` matches auth user's profile id, refetch profile-by-id query for auth user.
       const userProfileId = app?.user?.addresses?.[0]?.profile?.id;
       const doesProfileIdMatch =
         userProfileId && userProfileId === updatedProfile?.id;
       if (doesProfileIdMatch) {
+        // if `profileId` matches auth user's profile id, refetch profile-by-id query for auth user.
         const keys = [
           [ApiEndpoints.FETCH_PROFILES_BY_ID, undefined],
           [ApiEndpoints.FETCH_PROFILES_BY_ID, updatedProfile.id.toString()],
@@ -96,6 +99,17 @@ const useUpdateProfileByAddressMutation = ({
           queryClient.cancelQueries(key).catch(console.error);
           queryClient.refetchQueries(key).catch(console.error);
         });
+
+        // if `profileId` matches auth user's profile id, and user profile has a defined name, then
+        // set welcome onboard step as complete
+        if (
+          userOnboardingEnabled &&
+          updatedProfile.name &&
+          updatedProfile.name !== 'Anonymous' &&
+          !app.user.isWelcomeOnboardFlowComplete
+        ) {
+          app.user.setIsWelcomeOnboardFlowComplete(true);
+        }
       }
 
       return updatedProfile;

--- a/packages/commonwealth/client/scripts/state/ui/modals/welcomeOnboardModal.ts
+++ b/packages/commonwealth/client/scripts/state/ui/modals/welcomeOnboardModal.ts
@@ -1,52 +1,24 @@
 import { createBoundedUseStore } from 'state/ui/utils';
-import { devtools, persist } from 'zustand/middleware';
+import { devtools } from 'zustand/middleware';
 import { createStore } from 'zustand/vanilla';
 
 interface WelcomeOnboardModalProps {
-  onboardedProfiles: {
-    [profileId: string]: boolean;
-  };
-  setProfileAsOnboarded: (profileId: string | number) => void;
   isWelcomeOnboardModalOpen: boolean;
   setIsWelcomeOnboardModalOpen: (isOpen: boolean) => void;
 }
 
 export const welcomeOnboardModal = createStore<WelcomeOnboardModalProps>()(
-  devtools(
-    persist(
-      (set) => ({
-        onboardedProfiles: {},
-        setProfileAsOnboarded: (profileId) => {
-          if (!profileId) return;
-
-          set((state) => {
-            return {
-              ...state,
-              onboardedProfiles: {
-                ...state.onboardedProfiles,
-                [profileId]: true,
-              },
-            };
-          });
-        },
-        isWelcomeOnboardModalOpen: false,
-        setIsWelcomeOnboardModalOpen: (isOpen) => {
-          set((state) => {
-            return {
-              ...state,
-              isWelcomeOnboardModalOpen: isOpen,
-            };
-          });
-        },
-      }),
-      {
-        name: 'onboarded-users', // unique name
-        partialize: (state) => ({
-          onboardedProfiles: state.onboardedProfiles,
-        }), // persist only shouldHionboardedProfilesdeAdminCardsPermanently
-      },
-    ),
-  ),
+  devtools((set) => ({
+    isWelcomeOnboardModalOpen: false,
+    setIsWelcomeOnboardModalOpen: (isOpen) => {
+      set((state) => {
+        return {
+          ...state,
+          isWelcomeOnboardModalOpen: isOpen,
+        };
+      });
+    },
+  })),
 );
 
 const useWelcomeOnboardModal = createBoundedUseStore(welcomeOnboardModal);

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -9,7 +9,6 @@ import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { SublayoutHeader } from 'views/components/SublayoutHeader';
 import { Sidebar } from 'views/components/sidebar';
-import { getUniqueUserAddresses } from '../helpers/user';
 import { useFlag } from '../hooks/useFlag';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
 import useStickyHeader from '../hooks/useStickyHeader';
@@ -62,12 +61,8 @@ const Sublayout = ({
     }
   }, [triggerOpenModalType, setTriggerOpenModalType]);
 
-  const {
-    onboardedProfiles,
-    setProfileAsOnboarded,
-    isWelcomeOnboardModalOpen,
-    setIsWelcomeOnboardModalOpen,
-  } = useWelcomeOnboardModal();
+  const { isWelcomeOnboardModalOpen, setIsWelcomeOnboardModalOpen } =
+    useWelcomeOnboardModal();
 
   useEffect(() => {
     let timeout = null;
@@ -91,28 +86,10 @@ const Sublayout = ({
       isLoggedIn &&
       userOnboardingEnabled &&
       !isWelcomeOnboardModalOpen &&
-      profileId
+      profileId &&
+      !app.user.isWelcomeOnboardFlowComplete
     ) {
-      // if a single user address has a set `username` (not defaulting to `Anonymous`), then user is onboarded
-      const hasUsername = app?.user?.addresses?.find(
-        (addr) => addr?.profile?.name && addr.profile?.name !== 'Anonymous',
-      );
-
-      const userUniqueAddresses = getUniqueUserAddresses({});
-
-      // open welcome modal if user is not onboarded and there is a single connected address
-      if (
-        !hasUsername &&
-        !onboardedProfiles[profileId] &&
-        userUniqueAddresses.length === 1
-      ) {
-        setIsWelcomeOnboardModalOpen(true);
-      }
-
-      // if the user has a set username, mark as onboarded
-      if (hasUsername && !onboardedProfiles[profileId]) {
-        setProfileAsOnboarded(profileId);
-      }
+      setIsWelcomeOnboardModalOpen(true);
     }
 
     if (!isLoggedIn && isWelcomeOnboardModalOpen) {
@@ -120,11 +97,9 @@ const Sublayout = ({
     }
   }, [
     profileId,
-    onboardedProfiles,
     userOnboardingEnabled,
     isWelcomeOnboardModalOpen,
     setIsWelcomeOnboardModalOpen,
-    setProfileAsOnboarded,
     isLoggedIn,
   ]);
 

--- a/packages/commonwealth/client/scripts/views/components/UserTrainingSlider/UserTrainingSlider.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UserTrainingSlider/UserTrainingSlider.tsx
@@ -144,9 +144,9 @@ export const UserTrainingSlider = () => {
   ]);
 
   if (
+    !profileId ||
     !isLoggedIn ||
     isLoadingProfile ||
-    // @ts-expect-error <StrictNullChecks/>
     (trainingActionPermanentlyHidden?.[profileId]?.length === 4 &&
       completedActions.length === 0) ||
     isAdminSliderVisible // if admin slider is visible, we hide user training slider
@@ -277,7 +277,6 @@ export const UserTrainingSlider = () => {
 
                   markTrainingActionAsComplete(
                     UserTrainingCardTypes.ExploreCommunities,
-                    // @ts-expect-error <StrictNullChecks/>
                     profileId,
                   );
                 }}

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -1,7 +1,5 @@
 import clsx from 'clsx';
 import React, { useState } from 'react';
-import app from 'state';
-import { useWelcomeOnboardModal } from 'state/ui/modals';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWModal } from '../../components/component_kit/new_designs/CWModal';
@@ -15,8 +13,6 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
   const [activeStep, setActiveStep] = useState<WelcomeOnboardModalSteps>(
     WelcomeOnboardModalSteps.PersonalInformation,
   );
-
-  const { setProfileAsOnboarded } = useWelcomeOnboardModal();
 
   const handleClose = () => {
     // we require the user's to add their usernames in personal information step
@@ -33,14 +29,9 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
           title: 'Welcome to Common!',
           component: (
             <PersonalInformationStep
-              onComplete={() => {
-                // set profile as onboarded, once this step is complete
-                const profileId = app?.user?.addresses?.[0]?.profile?.id;
-                // @ts-expect-error <StrictNullChecks/>
-                setProfileAsOnboarded(profileId);
-
-                setActiveStep(WelcomeOnboardModalSteps.Preferences);
-              }}
+              onComplete={() =>
+                setActiveStep(WelcomeOnboardModalSteps.Preferences)
+              }
             />
           ),
         };

--- a/packages/commonwealth/client/scripts/views/pages/notification_settings/useNotificationSettings.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notification_settings/useNotificationSettings.tsx
@@ -122,7 +122,7 @@ const useNotificationSettings = () => {
       subIds.push(...(subs || [])),
     );
     // @ts-expect-error StrictNullChecks
-    snapshotsInfo.map(({ snapshotId, subs }: SnapshotInfo) => {
+    snapshotsInfo?.map(({ snapshotId, subs }: SnapshotInfo) => {
       // @ts-expect-error StrictNullChecks
       if (snapshotId) subIds.push(...(subs || []));
     });

--- a/packages/commonwealth/server/migrations/20240612153431-added-isWelcomeOnboardFlowComplete-to-users.js
+++ b/packages/commonwealth/server/migrations/20240612153431-added-isWelcomeOnboardFlowComplete-to-users.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'Users',
+        'isWelcomeOnboardFlowComplete',
+        {
+          type: Sequelize.BOOLEAN,
+          defaultValue: true, // true for all existing users
+          allowNull: false,
+        },
+        { transaction: t },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        'Users',
+        'isWelcomeOnboardFlowComplete',
+        {
+          transaction: t,
+        },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/migrations/20240612153431-added-isWelcomeOnboardFlowComplete-to-users.js
+++ b/packages/commonwealth/server/migrations/20240612153431-added-isWelcomeOnboardFlowComplete-to-users.js
@@ -6,7 +6,7 @@ module.exports = {
     return queryInterface.sequelize.transaction(async (t) => {
       await queryInterface.addColumn(
         'Users',
-        'isWelcomeOnboardFlowComplete',
+        'is_welcome_onboard_flow_complete',
         {
           type: Sequelize.BOOLEAN,
           defaultValue: true, // true for all existing users
@@ -21,7 +21,7 @@ module.exports = {
     return queryInterface.sequelize.transaction(async (t) => {
       await queryInterface.removeColumn(
         'Users',
-        'isWelcomeOnboardFlowComplete',
+        'is_welcome_onboard_flow_complete',
         {
           transaction: t,
         },

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -286,7 +286,7 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
       emailVerified: user.emailVerified,
       emailInterval: user.emailNotificationInterval,
       promotional_emails_enabled: user.promotional_emails_enabled,
-      isWelcomeOnboardFlowComplete: user.isWelcomeOnboardFlowComplete,
+      is_welcome_onboard_flow_complete: user.is_welcome_onboard_flow_complete,
       jwt: '',
       knockJwtToken: '',
       addresses,

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -286,6 +286,7 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
       emailVerified: user.emailVerified,
       emailInterval: user.emailNotificationInterval,
       promotional_emails_enabled: user.promotional_emails_enabled,
+      isWelcomeOnboardFlowComplete: user.isWelcomeOnboardFlowComplete,
       jwt: '',
       knockJwtToken: '',
       addresses,

--- a/packages/commonwealth/server/routes/updateNewProfile.ts
+++ b/packages/commonwealth/server/routes/updateNewProfile.ts
@@ -102,9 +102,9 @@ const updateNewProfile = async (
       name !== DEFAULT_NAME &&
       isProfileNameUnset &&
       req.user &&
-      !req.user.isWelcomeOnboardFlowComplete
+      !req.user.is_welcome_onboard_flow_complete
     ) {
-      req.user.isWelcomeOnboardFlowComplete = true;
+      req.user.is_welcome_onboard_flow_complete = true;
       await req.user.save();
     }
   }

--- a/packages/commonwealth/server/routes/updateNewProfile.ts
+++ b/packages/commonwealth/server/routes/updateNewProfile.ts
@@ -92,6 +92,23 @@ const updateNewProfile = async (
   // @ts-expect-error StrictNullChecks
   await updateTags(tag_ids, models, profile.id, 'profile_id');
 
+  if (process.env.FLAG_USER_ONBOARDING_ENABLED === 'true') {
+    const DEFAULT_NAME = 'Anonymous';
+    const isProfileNameUnset =
+      !profile.profile_name || profile.profile_name === DEFAULT_NAME;
+
+    if (
+      name &&
+      name !== DEFAULT_NAME &&
+      isProfileNameUnset &&
+      req.user &&
+      !req.user.isWelcomeOnboardFlowComplete
+    ) {
+      req.user.isWelcomeOnboardFlowComplete = true;
+      await req.user.save();
+    }
+  }
+
   if (!updateStatus || !rows) {
     return failure(res.status(400), {
       status: 'Failed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8132

## Description of Changes
Updated to only show welcome modal for new user signups.

## "How We Fixed It"
N/A

## Test Plan
- Enable `FLAG_USER_ONBOARDING_ENABLED`
- Verify that you can signup with multiple auth options
- Verify you see the welcome modal, and you keep seeing it after page refresh, until you set username in the welcome modal.

## Deployment Plan
N/A

## Other Considerations
N/A