### PR TITLE
Create new contest protocol helper

### DIFF
--- a/libs/model/src/services/commonProtocol/abi/contestAbi.ts
+++ b/libs/model/src/services/commonProtocol/abi/contestAbi.ts
@@ -227,4 +227,18 @@ export const contestABI = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'newContest',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'endContest',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
 ];

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -345,6 +345,16 @@ export const voteContentBatch = async (
   });
 };
 
+/**
+ * attempts to rollover and payout a provided contest. Returns false and does not attempt
+ * transaction if contest is still active
+ * @param rpcNodeUrl the chain node to use
+ * @param contest the address of the contest
+ * @param oneOff indicate if the contest is oneOff
+ * @returns boolean indicating if contest was rolled over
+ * NOTE: A false return does not indicate an error, rather that the contest was still ongoing
+ * errors will still be throw for other issues
+ */
 export const rollOverContest = async (
   rpcNodeUrl: string,
   contest: string,

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -344,3 +344,34 @@ export const voteContentBatch = async (
     return Promise.allSettled(promises);
   });
 };
+
+export const rollOverContest = async (
+  rpcNodeUrl: string,
+  contest: string,
+  oneOff: boolean,
+): Promise<boolean> => {
+  const web3 = await createWeb3Provider(rpcNodeUrl);
+  const contestInstance = new web3.eth.Contract(
+    contestABI as AbiItem[],
+    contest,
+  );
+
+  const contractCall = oneOff
+    ? contestInstance.methods.endContest()
+    : contestInstance.methods.newContest();
+
+  let gasResult;
+  try {
+    gasResult = await contractCall.estimateGas({
+      from: web3.eth.defaultAccount,
+    });
+  } catch {
+    return false;
+  }
+
+  await contractCall.send({
+    from: web3.eth.defaultAccount,
+    gas: gasResult.toString(),
+  });
+  return true;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8141 

## Description of Changes
-  Adds a protocol helper to call the end/newContest function on contests
- fails silently if contest is still active 
