### PR TITLE
Body truncate utility

### DIFF
--- a/libs/model/package.json
+++ b/libs/model/package.json
@@ -17,7 +17,8 @@
     "build": "tsc -b ./tsconfig.build.json",
     "clean": "rm -rf build && rm -rf coverage && find . -type f -name '*.tsbuildinfo' -exec rm {} +",
     "check-types": "tsc --noEmit",
-    "test": "INIT_TEST_DB=true NODE_ENV=test vitest --config ../../vite.config.ts --fileParallelism=false --coverage run test"
+    "test": "INIT_TEST_DB=true NODE_ENV=test vitest --config ../../vite.config.ts --fileParallelism=false --coverage run test",
+    "test-select": "INIT_TEST_DB=true NODE_ENV=test vitest --config ../../vite.config.ts --fileParallelism=false run"
   },
   "dependencies": {
     "@anatine/zod-mock": "^3.13.3",

--- a/libs/model/src/utils.ts
+++ b/libs/model/src/utils.ts
@@ -153,7 +153,7 @@ function getWordAtIndex(
   startIndex: number;
   endIndex: number;
 } | null {
-  if (index < 0 || index >= inputString.length) {
+  if (index < 0 || index >= inputString.length || inputString[index] === ' ') {
     return null;
   }
 

--- a/libs/model/test/util-tests/safeTruncateBody.spec.ts
+++ b/libs/model/test/util-tests/safeTruncateBody.spec.ts
@@ -6,7 +6,7 @@ const spliceUserMentionIndex = 12;
 const spliceUrlIndex = 38;
 const testString = '012345 [@Tim](/profile/id/118532) https://www.google.com';
 
-describe.only('safeTruncateBody', () => {
+describe('safeTruncateBody', () => {
   test('should not splice user mentions', () => {
     const res = safeTruncateBody(testString, spliceUserMentionIndex);
     expect(res).to.equal(testString.substring(0, 7));
@@ -65,10 +65,15 @@ describe.only('safeTruncateBody', () => {
   });
 
   test('should properly truncate a string with multiple matches', () => {
-    let res = safeTruncateBody(
+    const res = safeTruncateBody(
       '[@Tim](/profile/id/1) [@Tim2](/profile/id/2) [@Tim3](/profile/id/3)',
       63,
     );
     expect(res).to.equal('[@Tim](/profile/id/1) [@Tim2](/profile/id/2) ');
+  });
+
+  test('should truncate normally on whitespace', () => {
+    const res = safeTruncateBody('1234 6789', 5);
+    expect(res).to.equal('1234 ');
   });
 });

--- a/libs/model/test/util-tests/safeTruncateBody.spec.ts
+++ b/libs/model/test/util-tests/safeTruncateBody.spec.ts
@@ -48,4 +48,27 @@ describe.only('safeTruncateBody', () => {
     const res = safeTruncateBody('[@Tim](/profile/id/118532)', 5);
     expect(res).to.equal('...');
   });
+
+  // Parsing mentions without whitespaces in between each is expensive so treat these as 'one word'
+  test('should properly truncate a string with multiple profiles without spaces', () => {
+    let res = safeTruncateBody(
+      '[@Tim](/profile/id/118532)[@Tim](/profile/id/118532)',
+      5,
+    );
+    expect(res).to.equal('...');
+
+    res = safeTruncateBody(
+      '[@Tim](/profile/id/118532)[@Tim](/profile/id/118532)[@Tim](/profile/id/118532)',
+      28,
+    );
+    expect(res).to.equal('...');
+  });
+
+  test('should properly truncate a string with multiple matches', () => {
+    let res = safeTruncateBody(
+      '[@Tim](/profile/id/1) [@Tim2](/profile/id/2) [@Tim3](/profile/id/3)',
+      63,
+    );
+    expect(res).to.equal('[@Tim](/profile/id/1) [@Tim2](/profile/id/2) ');
+  });
 });

--- a/libs/model/test/util-tests/safeTruncateBody.spec.ts
+++ b/libs/model/test/util-tests/safeTruncateBody.spec.ts
@@ -1,0 +1,51 @@
+import { safeTruncateBody } from '@hicommonwealth/model';
+import { expect } from 'chai';
+import { describe, test } from 'vitest';
+
+const spliceUserMentionIndex = 12;
+const spliceUrlIndex = 38;
+const testString = '012345 [@Tim](/profile/id/118532) https://www.google.com';
+
+describe.only('safeTruncateBody', () => {
+  test('should not splice user mentions', () => {
+    const res = safeTruncateBody(testString, spliceUserMentionIndex);
+    expect(res).to.equal(testString.substring(0, 7));
+  });
+
+  test('should not splice urls', () => {
+    const resHttps = safeTruncateBody(testString, spliceUrlIndex);
+    expect(resHttps).to.equal(testString.substring(0, 34));
+
+    const resHttp = safeTruncateBody(
+      testString.replace('https', 'http'),
+      spliceUrlIndex,
+    );
+    expect(resHttp).to.equal(testString.substring(0, 34));
+
+    const resWww = safeTruncateBody(
+      testString.replace('https://www.', 'www.'),
+      spliceUrlIndex,
+    );
+    expect(resWww).to.equal(testString.substring(0, 34));
+  });
+
+  test('should not splice a body that is already short enough', () => {
+    const res = safeTruncateBody(testString);
+    expect(res).to.equal(testString);
+  });
+
+  test('should splice a body without urls or mentions', () => {
+    const res = safeTruncateBody('123456789', 5);
+    expect(res).to.equal('12345');
+  });
+
+  test('should return "..." when the body only contains a url that is too long', () => {
+    const res = safeTruncateBody('https://www.google.com', 5);
+    expect(res).to.equal('...');
+  });
+
+  test('should return "..." when the body only contains a user mention that is too long', () => {
+    const res = safeTruncateBody('[@Tim](/profile/id/118532)', 5);
+    expect(res).to.equal('...');
+  });
+});

--- a/packages/commonwealth/server/workers/knock/eventHandlers/commentCreated.ts
+++ b/packages/commonwealth/server/workers/knock/eventHandlers/commentCreated.ts
@@ -4,7 +4,7 @@ import {
   notificationsProvider,
   WorkflowKeys,
 } from '@hicommonwealth/core';
-import { models } from '@hicommonwealth/model';
+import { models, safeTruncateBody } from '@hicommonwealth/model';
 import { Op } from 'sequelize';
 import { fileURLToPath } from 'url';
 import z from 'zod';
@@ -87,7 +87,7 @@ export const processCommentCreated: EventHandler<
         author: author.Profile.profile_name || author.address.substring(0, 8),
         comment_parent_name: payload.parent_id ? 'comment' : 'thread',
         community_name: community.name,
-        comment_body: decodeURIComponent(payload.text).substring(0, 255),
+        comment_body: safeTruncateBody(decodeURIComponent(payload.text), 255),
         comment_url: getCommentUrl(
           payload.community_id,
           payload.thread_id,

--- a/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
+++ b/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
@@ -4,7 +4,7 @@ import {
   notificationsProvider,
   WorkflowKeys,
 } from '@hicommonwealth/core';
-import { models } from '@hicommonwealth/model';
+import { models, safeTruncateBody } from '@hicommonwealth/model';
 import { fileURLToPath } from 'url';
 import z from 'zod';
 import { getCommentUrl, getThreadUrl } from '../util';
@@ -58,9 +58,9 @@ export const processUserMentioned: EventHandler<
       object_body:
         'thread' in payload
           ? // @ts-expect-error StrictNullChecks
-            payload.thread.body.substring(255)
+            safeTruncateBody(payload.thread.body, 255)
           : // @ts-expect-error StrictNullChecks
-            payload.comment.text.substring(255),
+            safeTruncateBody(payload.comment.text, 255),
       object_url:
         'thread' in payload
           ? // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
+++ b/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
@@ -9,7 +9,7 @@ import {
   disposeAdapter,
   notificationsProvider,
 } from '@hicommonwealth/core';
-import { tester } from '@hicommonwealth/model';
+import { safeTruncateBody, tester } from '@hicommonwealth/model';
 import * as schemas from '@hicommonwealth/schemas';
 import { BalanceType } from '@hicommonwealth/shared';
 import chai, { expect } from 'chai';
@@ -132,19 +132,15 @@ describe('userMentioned Event Handler', () => {
       key: WorkflowKeys.UserMentioned,
       users: [{ id: String(user!.id) }],
       data: {
-        // @ts-expect-error StrictNullChecks
-        author_address_id: community!.Addresses[0].id,
+        author_address_id: community!.Addresses![0].id,
         author_user_id: author!.id,
-        // @ts-expect-error StrictNullChecks
-        author_address: community!.Addresses[0].address,
+        author_address: community!.Addresses![0].address,
         author_profile_id: authorProfile!.id,
         community_id: community!.id,
         community_name: community!.name,
         author: authorProfile!.profile_name,
-        // @ts-expect-error StrictNullChecks
-        object_body: thread!.body.substring(255),
-        // @ts-expect-error StrictNullChecks
-        object_url: getThreadUrl(community!.id, thread!.id),
+        object_body: safeTruncateBody(thread!.body!, 255),
+        object_url: getThreadUrl(community!.id!, thread!.id!),
       },
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7793 

## Description of Changes
- Adds the `safeTruncateBody` function which truncates a body at the desired length (or less) without truncating in the middle of a URL or user mention.

## Test Plan
- Ensure CI model tests for `safeTruncateBody.spec` pass

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 