### PR TITLE
Hide image in thread card preview

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
@@ -111,6 +111,10 @@
             font-size: 16px !important;
           }
 
+          img {
+            display: none;
+          }
+
           &.collapsed {
             div :last-child {
               color: $neutral-300;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/6857

## Description of Changes
Images in thread card preview are now hidden

## "How We Fixed It"
N/A

## Test Plan
- Create a thread with images
- View the `/discussions` page of that community
- Verify you don't see images in thread card preview

## Deployment Plan
N/A

## Other Considerations
N/A