### PR TITLE
Fix Coveralls in Cosmos Devnet Tests CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -459,6 +459,7 @@ jobs:
           (pnpm -F commonwealth wait-server && pnpm -F commonwealth test-devnet:cosmos --allowOnly=false)
 
       - name: Coveralls parallel
+        if: steps.changed-files-specific.outputs.all_changed_files
         uses: coverallsapp/github-action@v2
         with:
           flag-name: cosmos-devnet-test-coverage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8159 

## Description of Changes
- Makes uploading coverage for Cosmos devnet tests optional -> coverage will be carried forward from previous builds if there were no changes to Cosmos related files

## Test Plan
- Ensure CI passes without any changes to Cosmos related files (Cosmos devnet tests don't run).

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 