### PR TITLE
Link `composable-finance` ChainNode

### DIFF
--- a/packages/commonwealth/server/migrations/20240617181557-fix-composable-finance-cn.js
+++ b/packages/commonwealth/server/migrations/20240617181557-fix-composable-finance-cn.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const res = await queryInterface.sequelize.query(
+        `
+          SELECT id
+          FROM "ChainNodes"
+          WHERE cosmos_chain_id = 'composable';
+      `,
+        { transaction, type: 'SELECT', raw: true },
+      );
+
+      await queryInterface.bulkUpdate(
+        'Communities',
+        {
+          chain_node_id: res[0].id,
+        },
+        {
+          id: 'composable-finance',
+        },
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkUpdate(
+      'Communities',
+      {
+        chain_node_id: null,
+      },
+      {
+        id: 'composable-finance',
+      },
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8162 

## Description of Changes
- Adds a migration with relinks `composable-finance` community to their existing chain node

## Test Plan
- Run `pnpm db-all`
- Go to `localhost:8080/composable-finance`
- Sign in with Keplr

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- I'm not sure how the community was unlinked from the chain node to begin with. In my local dump from a few weeks ago, the community is still linked to the chain node so sign-in works fine. My guess is that this occurred either because the admin-panel 'update chain node' functionality is buggy or someone ran a custom query against the production database.