### PR TITLE
One-off contest fixes

### DIFF
--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -203,7 +203,9 @@ export async function updateScore(contest_address: string, contest_id: number) {
       );
 
     const prizePool =
-      (Number(contestBalance) * Number(details.prize_percentage)) / 100;
+      (Number(contestBalance) *
+        Number(oneOff ? 100 : details.prize_percentage)) /
+      100;
     const score: z.infer<typeof ContestScore> = scores.map((s, i) => ({
       content_id: s.winningContent.toString(),
       creator_address: s.winningAddress,

--- a/libs/model/src/contest/PerformContestRollovers.command.ts
+++ b/libs/model/src/contest/PerformContestRollovers.command.ts
@@ -1,0 +1,98 @@
+import { logger, type Command } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { QueryTypes } from 'sequelize';
+import { fileURLToPath } from 'url';
+import { models } from '../database';
+import { rollOverContest } from '../services/commonProtocol/contestHelper';
+
+const __filename = fileURLToPath(import.meta.url);
+const log = logger(__filename);
+
+export function PerformContestRollovers(): Command<
+  typeof schemas.PerformContestRollovers
+> {
+  return {
+    ...schemas.PerformContestRollovers,
+    auth: [],
+    body: async () => {
+      const contestManagersWithEndedContest = await models.sequelize.query<{
+        contest_address: string;
+        interval: number;
+        ended: boolean;
+        url: string;
+      }>(
+        `
+          SELECT
+            cm.contest_address,
+            cm.interval,
+            cm.ended,
+            co.end_time,
+            COALESCE(cn.private_url, cn.url) as url
+          FROM "ContestManagers" cm
+          JOIN (
+              SELECT *
+              FROM "Contests"
+              WHERE (contest_address, contest_id) IN (
+                  SELECT contest_address, MAX(contest_id) AS contest_id
+                  FROM "Contests"
+                  GROUP BY contest_address
+              )
+          ) co ON co.contest_address = cm.contest_address
+          AND (
+            cm.interval = 0 AND cm.ended IS NOT TRUE
+            OR
+            cm.interval > 0
+          )
+          AND NOW() > co.end_time
+          AND cm.cancelled = false
+          JOIN "Communities" cu ON cm.community_id = cu.id
+          JOIN "ChainNodes" cn ON cu.chain_node_id = cn.id;
+        `,
+        {
+          type: QueryTypes.SELECT,
+          raw: true,
+        },
+      );
+
+      const contestRolloverPromises = contestManagersWithEndedContest.map(
+        async ({ url, contest_address, interval, ended }) => {
+          log.debug(`ROLLOVER: ${contest_address}`);
+
+          if (interval === 0 && !ended) {
+            // preemptively mark as ended so that rollover
+            // is not attempted again after failure
+            await models.ContestManager.update(
+              {
+                ended: true,
+              },
+              {
+                where: {
+                  contest_address,
+                },
+              },
+            );
+          }
+
+          return rollOverContest(url, contest_address, interval === 0);
+        },
+      );
+
+      const promiseResults = await Promise.allSettled(contestRolloverPromises);
+
+      const errors = promiseResults
+        .filter(({ status }) => status === 'rejected')
+        .map(
+          (result) =>
+            (result as PromiseRejectedResult).reason || '<unknown reason>',
+        );
+
+      if (errors.length > 0) {
+        log.warn(
+          `GetAllContests performContestRollovers: failed with errors: ${errors.join(
+            ', ',
+          )}"`,
+        );
+      }
+    },
+  };
+}

--- a/libs/model/src/contest/index.ts
+++ b/libs/model/src/contest/index.ts
@@ -3,4 +3,5 @@ export * from './Contests.projection';
 export * from './CreateContestManagerMetadata.command';
 export * from './GetAllContests.query';
 export * from './GetContestLog.query';
+export * from './PerformContestRollovers.command';
 export * from './UpdateContestManagerMetadata.command';

--- a/libs/model/src/models/contest_manager.ts
+++ b/libs/model/src/models/contest_manager.ts
@@ -39,6 +39,7 @@ export default (
       decimals: { type: Sequelize.INTEGER },
       created_at: { type: Sequelize.DATE, allowNull: false },
       cancelled: { type: Sequelize.BOOLEAN },
+      ended: { type: Sequelize.BOOLEAN },
     },
     {
       tableName: 'ContestManagers',

--- a/libs/schemas/src/commands/contest.schemas.ts
+++ b/libs/schemas/src/commands/contest.schemas.ts
@@ -65,3 +65,8 @@ export const ResumeContestManagerMetadata = {
     contest_managers: z.array(ContestManager),
   }),
 };
+
+export const PerformContestRollovers = {
+  input: z.object({}),
+  output: z.object({}),
+};

--- a/libs/schemas/src/entities/contest-manager.schemas.ts
+++ b/libs/schemas/src/entities/contest-manager.schemas.ts
@@ -39,6 +39,12 @@ export const ContestManager = z
       .boolean()
       .nullish()
       .describe('Flags when contest policy is cancelled by admin'),
+    ended: z
+      .boolean()
+      .nullish()
+      .describe(
+        'Flags when the one-off contest has ended and rollover was completed',
+      ),
     topics: z.array(Topic).optional(),
     contests: z.array(Contest).optional(),
   })

--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/useNewThreadForm.ts
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/useNewThreadForm.ts
@@ -50,7 +50,7 @@ const useNewThreadForm = (communityId: string, topicsForSelector: Topic[]) => {
   const [threadTopic, setThreadTopic] = useState<Topic>(defaultTopic);
   const [threadTitle, setThreadTitle] = useState(restoredDraft?.title || '');
   const [threadContentDelta, setThreadContentDelta] = useState<DeltaStatic>(
-    restoredDraft!.body,
+    restoredDraft?.body,
   );
   const [isSaving, setIsSaving] = useState(false);
 

--- a/packages/commonwealth/server/migrations/20240618180325-add-contest-manager-ended.js
+++ b/packages/commonwealth/server/migrations/20240618180325-add-contest-manager-ended.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('ContestManagers', 'ended', {
+      type: Sequelize.BOOLEAN,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('ContestManagers', 'ended');
+  },
+};

--- a/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
+++ b/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
@@ -8,9 +8,11 @@ import {
   startHealthCheckLoop,
 } from '@hicommonwealth/adapters';
 import {
+  Actor,
   Broker,
   BrokerSubscriptions,
   broker,
+  command,
   logger,
   stats,
 } from '@hicommonwealth/core';
@@ -112,8 +114,17 @@ export async function setupCommonwealthConsumer(): Promise<void> {
 
 function startRolloverLoop() {
   log.info('Starting rollover loop');
+
+  // TODO: move to external service triggered via scheduler?
   setInterval(() => {
-    Contest.performContestRollovers().catch(console.error);
+    command(
+      Contest.PerformContestRollovers(),
+      {
+        actor: {} as Actor,
+        payload: {},
+      },
+      false,
+    ).catch(console.error);
   }, 1_000 * 60);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8167

## Description of Changes
- Prevents onchain actions for ended one-off contests
- Applies rollover for ended one-off contests
- Fixes score calculation for one-off contests
- Moves rollover logic into a command (one step closer to the final scheduler implementation)

## Test Plan
- Make a one-off contest + thread + upvote
- Wait for contest to end
- Create another thread– consumer should show warning message that no matching contest manager was found

## Deployment Plan
N/A

## Other Considerations
N/A