### PR TITLE
Fixed thread version date

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -188,8 +188,8 @@ export const CWContentPage = ({
         {...(thread?.lockedAt && {
           lockedAt: thread.lockedAt.toISOString(),
         })}
-        {...(thread?.updatedAt && {
-          lastUpdated: thread.updatedAt.toISOString(),
+        {...(thread?.lastEdited && {
+          lastUpdated: thread.lastEdited.toISOString(),
         })}
         // @ts-expect-error <StrictNullChecks/>
         authorAddress={author?.address}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -204,7 +204,7 @@ export const AuthorAndPublishInfo = ({
             <div className="version-history">
               <CWSelectList
                 options={versionHistoryOptions}
-                placeholder={`Edited ${publishDate
+                placeholder={`Edited ${moment(versionHistory?.[0]?.timestamp)
                   ?.utc?.()
                   ?.local?.()
                   ?.format('DD/MM/YYYY')}`}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/utils.ts
@@ -7,7 +7,10 @@ export const formatVersionText = (
   profile: UserProfile,
   collabInfo: Record<string, string>,
 ) => {
-  const formattedTime = timestamp.format('Do MMMM, YYYY • h:mm A');
+  const formattedTime = timestamp
+    ?.utc?.()
+    ?.local?.()
+    ?.format?.('Do MMMM, YYYY • h:mm A');
   // Some old posts don't have address, so account for them by omitting address
   if (!address) {
     return formattedTime;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -160,7 +160,7 @@ export const ThreadCard = ({
                 lockedAt: thread.lockedAt.toISOString(),
               })}
               {...(thread.updatedAt && {
-                lastUpdated: thread.updatedAt.toISOString(),
+                lastUpdated: thread.lastEdited.toISOString(),
               })}
               discord_meta={thread.discord_meta}
               // @ts-expect-error <StrictNullChecks/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8133

## Description of Changes
Fixed thread version date on view threads page

## "How We Fixed It"
We were showing the `lastEdited` thread date in the version dropdown which can sometimes be different from the latest thread version history date, simply because the `lastEdited` date can be updated even when thread body remains the same. An instance like this happened with [this thread](https://commonwealth.im/layerzero/discussion/22675-sybil-report) on prod which caused the original issue. 

## Test Plan
- Create a thread
- Update that thread 2-3 times, and do each of the updates **after 2-3 minutes** to easily spot issues during tests
- Now after 2-3 more minutes update thread title or any other update that doesn't change thread body
- Verify that the version history dropdown correctly shows the date of the lastest/selected thread version

## Deployment Plan
N/A

## Other Considerations
N/A