### PR TITLE
Change chainNodeId error into warning log

### DIFF
--- a/packages/commonwealth/server/workers/evmChainEvents/nodeProcessing.ts
+++ b/packages/commonwealth/server/workers/evmChainEvents/nodeProcessing.ts
@@ -161,7 +161,7 @@ export async function processChainNode(
     );
   } catch (e) {
     const msg = `Error occurred while processing chainNodeId ${chainNodeId}`;
-    log.error(msg, e);
+    log.warn(msg, e);
   }
 }
 


### PR DESCRIPTION
Change error log to warning log to reduce rollbar usage.