### PR TITLE
Updated SSO display logic in AuthModal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -200,6 +200,7 @@ const ModalBase = ({
     // 1. When `showWalletsFor` is either `Ethereum` or `Cosmos`, show all SSO options.
     // 2. On communities based on `Ethereum` and `Cosmos`, show all SSO options.
     // 3. On unscoped pages, show all SSO options.
+    // 4. In all other cases, hide all SSO options.
     const showSSOOptionsForSpecificChains = showWalletsFor || app?.chain?.base;
     if (showSSOOptionsForSpecificChains) {
       switch (showSSOOptionsForSpecificChains) {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -50,6 +50,21 @@ const MODAL_COPY = {
   },
 };
 
+/**
+ * AuthModal base component with customizable options, callbacks, layouts and auth options display strategy.
+ * @param onClose callback triggered when the modal is closed or user is authenticated
+ * @param onSuccess callback triggered on successful user authentication.
+ * @param layoutType specifies the layout type/variant of the modal.
+ * @param hideDescription if `true`, hides the description after modal header.
+ * @param customBody custom content to add before the modal body.
+ * @param showAuthenticationOptionsFor determines authentication options ('wallets', 'sso', or both) to display.
+ *                                     Ignored if internal modal state hides SSO options.
+ * @param showWalletsFor specifies wallets to display for the specified chain.
+ * @param bodyClassName custom class to apply to the modal body.
+ * @param onSignInClick callback triggered when the user clicks on the `Sign in` link in the modal footer.
+ * @param onChangeModalType callback triggered when `layoutType` change is requested from within the modal.
+ * @returns {ReactNode}
+ */
 const ModalBase = ({
   onClose,
   onSuccess,
@@ -71,16 +86,6 @@ const ModalBase = ({
       ? 1
       : 0,
   );
-  useEffect(() => {
-    setActiveTabIndex((prevActiveTab) => {
-      return (showAuthenticationOptionsFor?.includes('sso') &&
-        showAuthenticationOptionsFor.length === 1) ||
-        prevActiveTab === 1
-        ? 1
-        : 0;
-    });
-  }, [showAuthenticationOptionsFor]);
-
   const [isEVMWalletsModalVisible, setIsEVMWalletsModalVisible] =
     useState(false);
   const [isAuthenticatingWithEmail, setIsAuthenticatingWithEmail] =
@@ -149,14 +154,14 @@ const ModalBase = ({
   const getWalletNames = () => {
     // Wallet Display Logic:
     // 1. When `showWalletsFor` is present, show wallets for that specific chain only.
-    // 2. On communities based on 'Ethereum', 'Cosmos', 'Solana', 'Substrate', or 'Near' chains:
+    // 2. On communities based on `Ethereum`, `Cosmos`, `Solana`, `Substrate`, or `Near` chains:
     //    - Display wallets specific to the respective community chain.
-    //    - 'Near' is the only community where 'Near' wallet is shown
-    // 3. On non-community pages, show 'Ethereum', 'Cosmos', 'Solana', and 'Substrate' based wallets
+    //    - `Near` is the only community where `Near` wallet is shown
+    // 3. On non-community pages, show `Ethereum`, `Cosmos`, `Solana`, and `Substrate` based wallets
     // 4. On specific communities, show specific wallets
-    //    a. On 'terra' community, only show 'terrastation' and 'terra-walletconnect' (wallet connect for terra) wallets
-    //    b. On 'evmos' and 'injective' communities, only show 'cosm-metamask' (metamask for cosmos communities) and
-    //       'keplr-ethereum' (keplr for ethereum communities) wallets
+    //    a. On `terra` community, only show `terrastation` and `terra-walletconnect` (wallet connect for terra) wallets
+    //    b. On `evmos` and `injective` communities, only show `cosm-metamask` (metamask for cosmos communities) and
+    //       `keplr-ethereum` (keplr for ethereum communities) wallets
 
     const showWalletsForSpecificChains = showWalletsFor || app?.chain?.base;
     if (showWalletsForSpecificChains) {
@@ -188,6 +193,26 @@ const ModalBase = ({
     return [];
   };
 
+  const shouldShowSSOOptions = (() => {
+    // All auth options lead to either an `Ethereum` or `Cosmos` address once user authenticates.
+    // SSO Display Logic:
+    // 1. When `showWalletsFor` is either `Ethereum` or `Cosmos`, show all SSO options.
+    // 2. On communities based on `Ethereum` and `Cosmos`, show all SSO options.
+    // 3. On unscoped pages, show all SSO options.
+    const showSSOOptionsForSpecificChains = showWalletsFor || app?.chain?.base;
+    if (showSSOOptionsForSpecificChains) {
+      switch (showSSOOptionsForSpecificChains) {
+        case ChainBase.Ethereum:
+        case ChainBase.CosmosSDK:
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    return true;
+  })();
+
   const tabsList: ModalBaseTabs[] = [
     {
       name: 'Wallet',
@@ -198,6 +223,22 @@ const ModalBase = ({
       options: ['google', 'discord', 'x', 'apple', 'github', 'email'],
     },
   ];
+
+  useEffect(() => {
+    setActiveTabIndex((prevActiveTab) => {
+      if (!shouldShowSSOOptions && prevActiveTab === 1) return 0;
+
+      if (
+        (showAuthenticationOptionsFor?.includes('sso') &&
+          showAuthenticationOptionsFor.length === 1) ||
+        prevActiveTab === 1
+      ) {
+        return 1;
+      }
+
+      return 0;
+    });
+  }, [showAuthenticationOptionsFor, shouldShowSSOOptions]);
 
   const onAuthMethodSelect = async (option: AuthTypes) => {
     if (option === 'email') {
@@ -262,20 +303,21 @@ const ModalBase = ({
           {/* @ts-expect-error StrictNullChecks*/}
           {showAuthenticationOptionsFor?.length > 0 && (
             <>
-              {/* @ts-expect-error StrictNullChecks*/}
-              {showAuthenticationOptionsFor?.length > 1 && (
-                <CWTabsRow className="tabs">
-                  {tabsList.map((tab, index) => (
-                    <CWTab
-                      key={tab.name}
-                      label={tab.name}
-                      isDisabled={isMagicLoading}
-                      isSelected={tabsList[activeTabIndex].name === tab.name}
-                      onClick={() => setActiveTabIndex(index)}
-                    />
-                  ))}
-                </CWTabsRow>
-              )}
+              {shouldShowSSOOptions &&
+                // @ts-expect-error StrictNullChecks*
+                showAuthenticationOptionsFor?.length > 1 && (
+                  <CWTabsRow className="tabs">
+                    {tabsList.map((tab, index) => (
+                      <CWTab
+                        key={tab.name}
+                        label={tab.name}
+                        isDisabled={isMagicLoading}
+                        isSelected={tabsList[activeTabIndex].name === tab.name}
+                        onClick={() => setActiveTabIndex(index)}
+                      />
+                    ))}
+                  </CWTabsRow>
+                )}
 
               <section className="auth-options">
                 {/* On the wallets tab, if no wallet is found, show "No wallets Found" */}

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -52,13 +52,14 @@ const MODAL_COPY = {
 
 /**
  * AuthModal base component with customizable options, callbacks, layouts and auth options display strategy.
- * @param onClose callback triggered when the modal is closed or user is authenticated
+ * @param onClose callback triggered when the modal is closed or user is authenticated.
  * @param onSuccess callback triggered on successful user authentication.
  * @param layoutType specifies the layout type/variant of the modal.
  * @param hideDescription if `true`, hides the description after modal header.
  * @param customBody custom content to add before the modal body.
- * @param showAuthenticationOptionsFor determines authentication options ('wallets', 'sso', or both) to display.
- *                                     Ignored if internal modal state hides SSO options.
+ * @param showAuthenticationOptionsFor determines auth options category ('wallets', 'sso', or both) to display.
+ *                                     All options are displayed if prop is not provided.
+ *                                     Prop is ignored if internal modal state hides SSO options.
  * @param showWalletsFor specifies wallets to display for the specified chain.
  * @param bodyClassName custom class to apply to the modal body.
  * @param onSignInClick callback triggered when the user clicks on the `Sign in` link in the modal footer.

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -198,7 +198,7 @@ const ModalBase = ({
     // All auth options lead to either an `Ethereum` or `Cosmos` address once user authenticates.
     // SSO Display Logic:
     // 1. When `showWalletsFor` is either `Ethereum` or `Cosmos`, show all SSO options.
-    // 2. On communities based on `Ethereum` and `Cosmos`, show all SSO options.
+    // 2. On communities based on `Ethereum` or `Cosmos`, show all SSO options.
     // 3. On unscoped pages, show all SSO options.
     // 4. In all other cases, hide all SSO options.
     const showSSOOptionsForSpecificChains = showWalletsFor || app?.chain?.base;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8129

## Description of Changes
Since all auth options lead to either an `Ethereum` or `Cosmos` address once the user authenticates, I updated the SSO display logic in AuthModal to show relevant options, it now works like this

1. When `showWalletsFor` is either `Ethereum` or `Cosmos`, show all SSO options.
2. On communities based on `Ethereum` and `Cosmos`, show all SSO options.
3. On unscoped pages, show all SSO options.

## "How We Fixed It"
N/A

## Test Plan
1. Logout
2. Visit any unscoped page, open auth modal, and verify you see all SSO options along with wallet options
3. Visit any `Ethereum` community ex: `/dydx`, open auth modal and verify you see all SSO options along with wallet options
4. Visit any `Cosmos` community ex: `/osmosis`, open auth modal and verify you see all SSO options along with wallet options
6. Visit the `Evmos` community ex: `/evmos`, open auth modal and verify you see all SSO options along with wallet options
7. Visit the `Injective` community ex: `/injective`, open auth modal, and verify you see all SSO options along with wallet options
8. Visit any `Solana` community ex: `/solana`, open auth modal and verify you only see wallet options and all SSO options are hidden.
9. Visit any `Substrate` community ex: `/stafi`, open auth modal, and verify you only see wallet options and all SSO options are hidden.
10. Visit the `Near` community ex: `/near`, open auth modal, and verify you only see wallet options and all SSO options are hidden.
11. For all of the communities mentioned in steps 3-9, perform steps 12 and 13 as mentioned below
12. Login with the community-supported wallet, and try to connect a new address -- verify that SSO display behavior is the same as it was when you visited that community without auth state.
13. Visit an unscoped page and login with a wallet not supported by the community, then visit the community and click on the `Join community` button  -- verify that SSO display behavior is the same as it was when you visited that community without an auth state.
14. Visit create community page `/createCommunity`
15. Click on the `Cosmos` community card and press `Connect Wallet`. Verify you see all SSO options along with wallet options
16. Click on the `Solana` community card and press `Connect Wallet`. Verify you only see wallet options and all SSO options are hidden.
17. Click on any other community card (all of them are `Ethereum` based) and press `Connect Wallet`. Verify you see all SSO options along with wallet options
18. Enable `FLAG_USER_ONBOARDING_ENABLED`  and visit any community that is not based on `Ethereum` or `Cosmos`. Open the create account modal and verify that pressing the `Create a wallet for me` correctly shows all SSO options even tho the active community doesn't support them.
19. Once you are logged in, click on the `Join community` button and verify you only see wallet options and all SSO options are hidden.

## Deployment Plan
N/A

## Other Considerations
N/A