### PR TITLE
Update Alchemy API Keys Part 1

### DIFF
--- a/packages/commonwealth/server/migrations/20240620220459-update-alchemy-chain-nodes.js
+++ b/packages/commonwealth/server/migrations/20240620220459-update-alchemy-chain-nodes.js
@@ -1,0 +1,27 @@
+'use strict';
+require('dotenv').config();
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const privateKey =
+      process.env.NEW_ALCHEMY_PRIVATE_KEY || process.env.ETH_ALCHEMY_API_KEY;
+    const publicKey =
+      process.env.NEW_ALCHEMY_PUBLIC_KEY || process.env.ETH_ALCHEMY_API_KEY;
+
+    if (!privateKey || !publicKey) {
+      throw new Error(
+        'Must have ETH_ALCHEMY_API_KEY env var set in packages/commonwealth/.env to migrate!',
+      );
+    }
+
+    await queryInterface.sequelize.query(`
+      UPDATE "ChainNodes"
+      SET url = regexp_replace(url, '\\/([^\\/]*)$', '${publicKey}'),
+          private_url = regexp_replace(url, '\\/([^\\/]*)$', '${privateKey}')
+      WHERE url LIKE '%.g.alchemy%' OR private_url LIKE '%.g.alchemy%';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8193 

## Description of Changes
- Updates all public and private Alchemy API keys

## Test Plan
- Set `ETH_ALCHEMY_API_KEY` in `packages/commonwealth/.env` (setting the `.env` path to root doesn't work for some reason).
- Run migrations

## Deployment Plan
<!--- Omit if unneeded -->
1. Set `NEW_ALCHEMY_PRIVATE_KEY` to the 'Eth Private' Alchemy app API key
2. Set `NEW_ALCHEMY_PUBLIC_KEY` to the 'Base Public' Alchemy app API key

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This is step 1 in a 2 step process of updating our keys. This first part merges all of our existing apps together since Alchemy introduced multi-chain apps. The second part will rotate the keys so an almost identical migration is required. This has to be a 2 step process because we have reached the limit on the number of apps we can create in Alchemy (so we have to reuse an existing app in order to delete the others).