### PR TITLE
Fix alchemy urls + db scripts + EVM proposal loading

### DIFF
--- a/packages/commonwealth/scripts/load-db.sh
+++ b/packages/commonwealth/scripts/load-db.sh
@@ -5,7 +5,7 @@
 # from which the script exists i.e. commonwealth/scripts/
 . ../../scripts/load-env-var.sh --source-only
 
-load-env-var '.env';
+load-env-var '../../.env';
 
 if [[ -z "${PGPASSWORD}" ]]; then
   PGPASSWORD="edgeware"

--- a/packages/commonwealth/scripts/reset-db.sh
+++ b/packages/commonwealth/scripts/reset-db.sh
@@ -4,7 +4,7 @@
 # from which the script exists i.e. commonwealth/scripts/
 . ../../scripts/load-env-var.sh --source-only
 
-load-env-var '.env';
+load-env-var '../../.env';
 
 if [[ -z "${PGPASSWORD}" ]]; then
   PGPASSWORD="edgeware"

--- a/packages/commonwealth/server/controllers/server_proposal_methods/aave/proposals.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/aave/proposals.ts
@@ -55,7 +55,7 @@ export function formatAaveProposal(
 
 export async function getEthereumAaveProposals(
   aaveGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
 ): Promise<AaveContractProposalsType> {
   // GovernanceV2Helper contract address on Ethereum
   const aaveGovHelperAddress = '0x16ff7583ea21055Bf5F929Ec4b896D997Ff35847';

--- a/packages/commonwealth/server/controllers/server_proposal_methods/aave/votes.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/aave/votes.ts
@@ -25,7 +25,7 @@ export function formatAaveProposalVote(
 
 export async function getAaveProposalVotes(
   aaveGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
   proposalId: number,
 ): Promise<VoteEventArgsObject[]> {
   const govContract = IAaveGovernanceV2__factory.connect(

--- a/packages/commonwealth/server/controllers/server_proposal_methods/compound/compoundVersion.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/compound/compoundVersion.ts
@@ -29,7 +29,7 @@ type ContractAndVersion = {
  */
 async function deriveCompoundGovContractAndVersion(
   compoundGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
 ): Promise<ContractAndVersion> {
   try {
     const contract = GovernorAlpha__factory.connect(
@@ -77,7 +77,7 @@ async function deriveCompoundGovContractAndVersion(
 function getCompoundGovContract(
   govVersion: GovVersion,
   compoundGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
 ) {
   switch (govVersion) {
     case GovVersion.Alpha:
@@ -104,7 +104,7 @@ function getCompoundGovContract(
 
 export async function getCompoundGovContractAndVersion(
   compoundGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
 ): Promise<ContractAndVersion> {
   const govVersion = (await cache().getKey(
     CacheNamespaces.Compound_Gov_Version,

--- a/packages/commonwealth/server/controllers/server_proposal_methods/compound/proposals.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/compound/proposals.ts
@@ -50,7 +50,7 @@ export function formatCompoundBravoProposal(
 
 export async function getCompoundProposals(
   compoundGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
 ): Promise<ProposalDataType[]> {
   const { contract, version: govVersion } =
     await getCompoundGovContractAndVersion(compoundGovAddress, provider);

--- a/packages/commonwealth/server/controllers/server_proposal_methods/compound/votes.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/compound/votes.ts
@@ -23,7 +23,7 @@ export function formatCompoundProposalVote(
 
 export async function getCompoundProposalVotes(
   compoundGovAddress: string,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
   proposalId: string,
 ): Promise<CompoundVoteEvents[]> {
   const { contract, version: govVersion } =

--- a/packages/commonwealth/server/controllers/server_proposal_methods/get_proposal_votes.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/get_proposal_votes.ts
@@ -25,7 +25,7 @@ export type GetProposalVotesResult =
 export async function __getProposalVotes(
   this: ServerProposalsController,
   { communityId, proposalId }: GetProposalVotesOptions,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
   contractInfo: ContractInfo,
 ): Promise<GetProposalVotesResult> {
   let votes: IAaveVoteResponse[] | ICompoundVoteResponse[] = [];

--- a/packages/commonwealth/server/controllers/server_proposal_methods/get_proposals.ts
+++ b/packages/commonwealth/server/controllers/server_proposal_methods/get_proposals.ts
@@ -24,7 +24,7 @@ export type GetProposalsResult =
 export async function __getProposals(
   this: ServerProposalsController,
   { communityId }: GetProposalsOptions,
-  provider: providers.Web3Provider,
+  provider: providers.JsonRpcProvider,
   contractInfo: ContractInfo,
 ): Promise<GetProposalsResult> {
   let formattedProposals: GetProposalsResult = [];

--- a/packages/commonwealth/server/controllers/server_proposals_controller.ts
+++ b/packages/commonwealth/server/controllers/server_proposals_controller.ts
@@ -1,7 +1,7 @@
 import { AppError, ServerError } from '@hicommonwealth/core';
 import { DB } from '@hicommonwealth/model';
 import { ChainNetwork } from '@hicommonwealth/shared';
-import { providers } from 'ethers';
+import { ethers, providers } from 'ethers';
 import {
   GetProposalVotesOptions,
   GetProposalVotesResult,
@@ -92,7 +92,7 @@ export class ServerProposalsController {
 
   private async createEvmProvider(
     communityId: string,
-  ): Promise<providers.Web3Provider> {
+  ): Promise<providers.JsonRpcProvider> {
     const ethNetworkUrl = await this.getRPCUrl(communityId);
 
     if (ethNetworkUrl.slice(0, 4) != 'http')
@@ -101,11 +101,7 @@ export class ServerProposalsController {
       );
 
     try {
-      const Web3 = (await import('web3')).default;
-      const web3Provider = new Web3(ethNetworkUrl);
-      return new providers.Web3Provider(
-        web3Provider.givenProvider as providers.ExternalProvider,
-      );
+      return new ethers.providers.JsonRpcProvider(ethNetworkUrl);
     } catch (e) {
       throw new ServerError(
         `Failed to create EVM provider for ${communityId}. ${e}`,

--- a/packages/commonwealth/server/migrations/20240620220459-update-alchemy-chain-nodes.js
+++ b/packages/commonwealth/server/migrations/20240620220459-update-alchemy-chain-nodes.js
@@ -17,9 +17,9 @@ module.exports = {
 
     await queryInterface.sequelize.query(`
       UPDATE "ChainNodes"
-      SET url = regexp_replace(url, '\\/([^\\/]*)$', '${publicKey}'),
-          alt_wallet_url = regexp_replace(url, '\\/([^\\/]*)$', '${publicKey}'),
-          private_url = regexp_replace(url, '\\/([^\\/]*)$', '${privateKey}')
+      SET url = regexp_replace(url, '\\/([^\\/]*)$', '/${publicKey}'),
+          alt_wallet_url = regexp_replace(url, '\\/([^\\/]*)$', '/${publicKey}'),
+          private_url = regexp_replace(url, '\\/([^\\/]*)$', '/${privateKey}')
       WHERE url LIKE '%.g.alchemy%' OR private_url LIKE '%.g.alchemy%';
     `);
   },


### PR DESCRIPTION
## Link to Issue
Closes: #8213 

## Description of Changes
- Fixes the path to the `.env` file in all db scripts
- Fixes provider creation in proposal routes to fix proposal loading
- Updates Alchemy URL migration to add missing forward-slash

## Test Plan
- Set `ETH_ALCHEMY_API_KEY` in `packages/commonwealth/.env` (unable to use root .env) -> this env var may be found in your root .env (if not dm me).
- Run migrations
- View http://localhost:8080/dydx/proposals
- Proposals should load. The client will throw a Web3 provider error but this error does not block proposal loading and will be handled in a separate ticket: https://github.com/hicommonwealth/commonwealth/issues/8216

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 