### PR TITLE
Rotate Alchemy keys

### DIFF
--- a/packages/commonwealth/server/migrations/20240621195630-rotate-alchemy-keys.js
+++ b/packages/commonwealth/server/migrations/20240621195630-rotate-alchemy-keys.js
@@ -1,0 +1,28 @@
+'use strict';
+require('dotenv').config();
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const privateKey =
+      process.env.NEW_ALCHEMY_PRIVATE_KEY || process.env.ETH_ALCHEMY_API_KEY;
+    const publicKey =
+      process.env.NEW_ALCHEMY_PUBLIC_KEY || process.env.ETH_ALCHEMY_API_KEY;
+
+    if (!privateKey || !publicKey) {
+      throw new Error(
+        'Must have ETH_ALCHEMY_API_KEY env var set in packages/commonwealth/.env to migrate!',
+      );
+    }
+
+    await queryInterface.sequelize.query(`
+      UPDATE "ChainNodes"
+      SET url = regexp_replace(url, '\\/([^\\/]*)$', '/${publicKey}'),
+          alt_wallet_url = regexp_replace(url, '\\/([^\\/]*)$', '/${publicKey}'),
+          private_url = regexp_replace(url, '\\/([^\\/]*)$', '/${privateKey}')
+      WHERE url LIKE '%.g.alchemy%' OR private_url LIKE '%.g.alchemy%';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8193 

## Description of Changes
- Adds a migration which rotates all Alchemy keys

## Test Plan
- Set a new `ETH_ALCHEMY_API_KEY` in `packages/commonwealth/.env` (cannot use root `.env`) -> DM me for the key.

## Deployment Plan
<!--- Omit if unneeded -->
1. Set `NEW_ALCHEMY_PRIVATE_KEY` to a new key
2. Set `NEW_ALCHEMY_PUBLIC_KEY` to a new key

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This completes the Alchemy app/key clean-up + update.