### PR TITLE
Contest tags

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -36,6 +36,7 @@ function processAssociatedContests(
       content_id: action.content_id,
       start_time: action.Contest.start_time,
       end_time: action.Contest.end_time,
+      contest_interval: action.Contest.ContestManager.interval,
     }));
   }
 
@@ -138,6 +139,7 @@ type Score = {
 type ContestManager = {
   name: string;
   cancelled: boolean;
+  interval: number;
 };
 
 type Contest = {
@@ -193,6 +195,7 @@ export type AssociatedContest = {
   content_id: number;
   start_time: string;
   end_time: string;
+  contest_interval: number;
 };
 
 type RecentComment = {

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -126,8 +126,17 @@ export type AssociatedReaction = {
   last_active?: string;
 };
 
-type AssociatedContest = {
-  id: number;
+export type AssociatedContest = {
+  contest_id: number;
+  contest_name: string;
+  contest_address: string;
+  score: {
+    prize: string;
+    votes: number;
+    content_id: string;
+    creator_address: string;
+  }[];
+  contest_cancelled: boolean;
   thread_id: number;
   content_id: number;
   start_time: string;

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTag.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTag.tsx
@@ -11,7 +11,7 @@ import './ThreadContestTag.scss';
 
 interface ThreadContestTagProps {
   date: string;
-  round?: number;
+  round: number | null;
   title: string;
   prize: number;
 }

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTag.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTag.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React from 'react';
 
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -10,34 +11,36 @@ import './ThreadContestTag.scss';
 
 interface ThreadContestTagProps {
   date: string;
-  isRecurring: boolean;
   round?: number;
+  title: string;
+  prize: number;
 }
 
 const ThreadContestTag = ({
   date,
-  isRecurring,
   round,
+  title,
+  prize,
 }: ThreadContestTagProps) => {
   const popoverProps = usePopover();
 
   return (
     <div className="ThreadContestTag">
       <CWTag
-        label="1st"
+        label={moment.localeData().ordinal(prize)}
         type="contest"
-        classNames="prize-1"
+        classNames={`prize-${prize}`}
         // @ts-expect-error <StrictNullChecks/>
         onMouseEnter={popoverProps.handleInteraction}
         onMouseLeave={popoverProps.handleInteraction}
       />
       <CWPopover
         className="contest-popover"
-        title="Contest Title"
+        title={title}
         body={
           <div>
             <CWText>{date}</CWText>
-            {isRecurring && <CWText>Round {round}</CWText>}
+            {round && <CWText>Round {round}</CWText>}
           </div>
         }
         {...popoverProps}

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { useFlag } from 'hooks/useFlag';
+import { AssociatedContest } from 'models/Thread';
+
+import ThreadContestTag from './ThreadContestTag';
+import { getWinnersFromAssociatedContests } from './utils';
+
+interface ThreadContestTagContainerProps {
+  associatedContests?: AssociatedContest[];
+}
+
+const ThreadContestTagContainer = ({
+  associatedContests,
+}: ThreadContestTagContainerProps) => {
+  const contestsEnabled = useFlag('contest');
+
+  const contestWinners = getWinnersFromAssociatedContests(associatedContests);
+
+  const showContestWinnerTag = contestsEnabled && contestWinners.length > 0;
+
+  return (
+    <>
+      {showContestWinnerTag &&
+        contestWinners.map((winner, index) => {
+          if (!winner) {
+            return null;
+          }
+
+          return (
+            <ThreadContestTag
+              date={winner.date}
+              round={winner.round}
+              title={winner.title}
+              prize={winner.prize}
+              key={index}
+            />
+          );
+        })}
+    </>
+  );
+};
+
+export default ThreadContestTagContainer;

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/index.ts
@@ -1,3 +1,5 @@
 import ThreadContestTag from './ThreadContestTag';
+import ThreadContestTagContainer from './ThreadContestTagContainer';
 
+export { ThreadContestTagContainer };
 export default ThreadContestTag;

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
@@ -20,11 +20,11 @@ export const getWinnersFromAssociatedContests = (
       return {
         date: moment(contest.end_time).format('DD/MM/YYYY'),
         prize:
-          contest.score.findIndex(
+          contest.score?.findIndex(
             (s) => s.content_id === String(contest.content_id),
           ) + 1,
-        // TODO
-        round: undefined,
+        // todo show only for recurring
+        round: contest.contest_id + 1,
         title: contest.contest_name,
       };
     })

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
@@ -1,0 +1,32 @@
+import { AssociatedContest } from 'models/Thread';
+import moment from 'moment/moment';
+
+export const getWinnersFromAssociatedContests = (
+  associatedContests?: AssociatedContest[],
+) => {
+  if (!associatedContests) {
+    return [];
+  }
+
+  return associatedContests
+    .map((contest) => {
+      const hasEnded = moment(contest.end_time) < moment();
+      const isActive = contest.contest_cancelled ? false : !hasEnded;
+
+      if (isActive) {
+        return null;
+      }
+
+      return {
+        date: moment(contest.end_time).format('DD/MM/YYYY'),
+        prize:
+          contest.score.findIndex(
+            (s) => s.content_id === String(contest.content_id),
+          ) + 1,
+        // TODO
+        round: undefined,
+        title: contest.contest_name,
+      };
+    })
+    .filter((el) => el !== null);
+};

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
@@ -23,8 +23,8 @@ export const getWinnersFromAssociatedContests = (
           contest.score?.findIndex(
             (s) => s.content_id === String(contest.content_id),
           ) + 1,
-        // todo show only for recurring
-        round: contest.contest_id + 1,
+        // show only for recurring
+        round: contest.contest_interval > 0 ? contest.contest_id + 1 : null,
         title: contest.contest_name,
       };
     })

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -1,6 +1,5 @@
 import { getThreadActionTooltipText } from 'helpers/threads';
 import { truncate } from 'helpers/truncate';
-import { useFlag } from 'hooks/useFlag';
 import useUserActiveAccount from 'hooks/useUserActiveAccount';
 import { IThreadCollaborator } from 'models/Thread';
 import moment from 'moment';
@@ -10,8 +9,7 @@ import { useSearchParams } from 'react-router-dom';
 import app from 'state';
 import { useRefreshMembershipQuery } from 'state/api/groups';
 import Permissions from 'utils/Permissions';
-import ThreadContestTag from 'views/components/ThreadContestTag';
-import { getWinnersFromAssociatedContests } from 'views/components/ThreadContestTag/utils';
+import { ThreadContestTagContainer } from 'views/components/ThreadContestTag';
 import { isHot } from 'views/pages/discussions/helpers';
 import Account from '../../../../models/Account';
 import AddressInfo from '../../../../models/AddressInfo';
@@ -125,7 +123,6 @@ export const CWContentPage = ({
   const [urlQueryParams] = useSearchParams();
   const { activeAccount: hasJoinedCommunity } = useUserActiveAccount();
   const [isUpvoteDrawerOpen, setIsUpvoteDrawerOpen] = useState<boolean>(false);
-  const contestsEnabled = useFlag('contest');
 
   const { data: memberships = [] } = useRefreshMembershipQuery({
     communityId: app.activeChainId(),
@@ -225,32 +222,14 @@ export const CWContentPage = ({
     isThreadTopicGated: isRestrictedMembership,
   });
 
-  const contestWinners = getWinnersFromAssociatedContests(
-    thread?.associatedContests,
-  );
-  const showContestWinnerTag = contestsEnabled && contestWinners.length > 0;
-
   const mainBody = (
     <div className="main-body-container">
       <div className="header">
         {typeof title === 'string' ? (
           <h1 className="title">
-            {showContestWinnerTag &&
-              contestWinners.map((winner, index) => {
-                if (!winner) {
-                  return null;
-                }
-
-                return (
-                  <ThreadContestTag
-                    date={winner.date}
-                    round={winner.round}
-                    title={winner.title}
-                    prize={winner.prize}
-                    key={index}
-                  />
-                );
-              })}
+            <ThreadContestTagContainer
+              associatedContests={thread?.associatedContests}
+            />
             {truncate(title)}
           </h1>
         ) : (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/EmptyContestsList/EmptyContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/EmptyContestsList/EmptyContestsList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import shape1Url from 'assets/img/shapes/shape1.svg';
+import shape2Url from 'assets/img/shapes/shape2.svg';
 import { useCommonNavigate } from 'navigation/helpers';
 
 import EmptyCard from './EmptyCard';
@@ -21,7 +23,7 @@ const EmptyContestsList = ({
     <div className="EmptyContestsList">
       {!isStakeEnabled ? (
         <EmptyCard
-          img="assets/img/shapes/shape2.svg"
+          img={shape2Url}
           title="You must enable Community Stake"
           subtitle="Contests require Community Stake..."
           button={{
@@ -31,7 +33,7 @@ const EmptyContestsList = ({
         />
       ) : !isContestAvailable ? (
         <EmptyCard
-          img="assets/img/shapes/shape1.svg"
+          img={shape1Url}
           title="You haven’t launched any contests yet"
           subtitle="Setting up a contest just takes a few minutes and can be a huge boost to your community."
           button={{

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -8,13 +8,11 @@ import {
   GetThreadActionTooltipTextResponse,
   filterLinks,
 } from 'helpers/threads';
-import { useFlag } from 'hooks/useFlag';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { LinkSource } from 'models/Thread';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import ThreadContestTag from 'views/components/ThreadContestTag';
-import { getWinnersFromAssociatedContests } from 'views/components/ThreadContestTag/utils';
+import { ThreadContestTagContainer } from 'views/components/ThreadContestTag';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { getClasses } from 'views/components/component_kit/helpers';
@@ -84,7 +82,6 @@ export const ThreadCard = ({
   const { isLoggedIn } = useUserLoggedIn();
   const { isWindowSmallInclusive } = useBrowserWindow({});
   const [isUpvoteDrawerOpen, setIsUpvoteDrawerOpen] = useState<boolean>(false);
-  const contestsEnabled = useFlag('contest');
 
   useEffect(() => {
     if (localStorage.getItem('dark-mode-state') === 'on') {
@@ -113,12 +110,6 @@ export const ThreadCard = ({
   const isTagsRowVisible =
     (thread.stage && !isStageDefault) || linkedProposals?.length > 0;
   const stageLabel = threadStageToLabel(thread.stage);
-
-  const contestWinners = getWinnersFromAssociatedContests(
-    thread.associatedContests,
-  );
-
-  const showContestWinnerTag = contestsEnabled && contestWinners.length > 0;
 
   return (
     <>
@@ -177,23 +168,9 @@ export const ThreadCard = ({
             {thread.markedAsSpamAt && <CWTag label="SPAM" type="disabled" />}
             <div className="content-title">
               <CWText type="h5" fontWeight="semiBold">
-                {showContestWinnerTag &&
-                  contestWinners.map((winner, index) => {
-                    if (!winner) {
-                      return null;
-                    }
-
-                    return (
-                      <ThreadContestTag
-                        date={winner.date}
-                        round={winner.round}
-                        title={winner.title}
-                        prize={winner.prize}
-                        key={index}
-                      />
-                    );
-                  })}
-
+                <ThreadContestTagContainer
+                  associatedContests={thread.associatedContests}
+                />
                 {thread.title}
               </CWText>
             </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -258,7 +258,6 @@ export const ThreadCard = ({
                 ))}
             </div>
           )}
-          <pre>{JSON.stringify(thread.associatedContests, null, 2)}</pre>
           <div
             className="content-footer"
             onClick={(e) => {

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -222,7 +222,7 @@ export async function __getBulkThreads(
         FROM "Contests" CON
         JOIN "ContestManagers" CM ON CM.contest_address = CON.contest_address
         JOIN "ContestActions" CA ON CON.contest_id = CA.contest_id
-        AND CON.contest_address = CA.contest_address AND CA.action = 'added'
+        AND CON.contest_address = CA.contest_address AND CA.action = 'upvoted'
         JOIN top_threads TT ON TT.id = CA.thread_id
         GROUP BY TT.id
     )${

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -205,20 +205,25 @@ export async function __getBulkThreads(
         GROUP BY TT.id
     ), contest_data AS (
       -- get the contest data associated with the thread
-          SELECT
-              TT.id as thread_id,
-              json_agg(json_strip_nulls(json_build_object(
-              'contest_id', CON.contest_id,
-              'contest_address', CON.contest_address,
-              'thread_id', TT.id,
-              'content_id', CA.content_id,
-              'start_time', CON.start_time,
-              'end_time', CON.end_time
-          ))) as "associatedContests"
-          FROM "Contests" CON
-          JOIN "ContestActions" CA ON CON.contest_id = CA.contest_id AND CON.contest_address = CA.contest_address
-          JOIN top_threads TT ON TT.id = CA.thread_id
-          GROUP BY TT.id
+        SELECT
+            TT.id as thread_id,
+            json_agg(json_strip_nulls(json_build_object(
+            'contest_id', CON.contest_id,
+            'contest_name', CM.name,
+            'contest_cancelled', CM.cancelled,
+            'contest_address', CON.contest_address,
+            'score', CON.score,
+            'thread_id', TT.id,
+            'content_id', CA.content_id,
+            'start_time', CON.start_time,
+            'end_time', CON.end_time
+        ))) as "associatedContests"
+        FROM "Contests" CON
+        JOIN "ContestManagers" CM ON CM.contest_address = CON.contest_address
+        JOIN "ContestActions" CA ON CON.contest_id = CA.contest_id 
+        AND CON.contest_address = CA.contest_address AND CA.action = 'upvoted'
+        JOIN top_threads TT ON TT.id = CA.thread_id
+        GROUP BY TT.id
     )${
       withXRecentComments
         ? `, recent_comments AS (

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -211,6 +211,7 @@ export async function __getBulkThreads(
             'contest_id', CON.contest_id,
             'contest_name', CM.name,
             'contest_cancelled', CM.cancelled,
+            'contest_interval', CM.interval,
             'contest_address', CON.contest_address,
             'score', CON.score,
             'thread_id', TT.id,

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_bulk_threads.ts
@@ -221,8 +221,8 @@ export async function __getBulkThreads(
         ))) as "associatedContests"
         FROM "Contests" CON
         JOIN "ContestManagers" CM ON CM.contest_address = CON.contest_address
-        JOIN "ContestActions" CA ON CON.contest_id = CA.contest_id 
-        AND CON.contest_address = CA.contest_address AND CA.action = 'upvoted'
+        JOIN "ContestActions" CA ON CON.contest_id = CA.contest_id
+        AND CON.contest_address = CA.contest_address AND CA.action = 'added'
         JOIN top_threads TT ON TT.id = CA.thread_id
         GROUP BY TT.id
     )${

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -12,6 +12,7 @@ export async function __getThreadsById(
   this: ServerThreadsController,
   { threadIds }: GetThreadsByIdOptions,
 ): Promise<GetThreadsByIdResult> {
+  const sequelize = this.models.Sequelize;
   const threads = await this.models.Thread.findAll({
     where: {
       id: { [Op.in]: threadIds },
@@ -102,10 +103,17 @@ export async function __getThreadsById(
         include: [
           {
             model: this.models.Contest,
-            where: {
-              content_id: {
-                [Op.eq]: this.models.sequelize.col('ContestActions.contest_id'),
-              },
+            on: {
+              contest_id: sequelize.where(
+                sequelize.col('"ContestActions".contest_id'),
+                '=',
+                sequelize.col('"ContestActions->Contest".contest_id'),
+              ),
+              contest_address: sequelize.where(
+                sequelize.col('"ContestActions".contest_address'),
+                '=',
+                sequelize.col('"ContestActions->Contest".contest_address'),
+              ),
             },
             attributes: [
               'contest_id',

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -112,7 +112,7 @@ export async function __getThreadsById(
             include: [
               {
                 model: this.models.ContestManager,
-                attributes: ['name', 'cancelled'],
+                attributes: ['name', 'cancelled', 'interval'],
               },
             ],
           },

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -102,6 +102,11 @@ export async function __getThreadsById(
         include: [
           {
             model: this.models.Contest,
+            where: {
+              content_id: {
+                [Op.eq]: this.models.sequelize.col('ContestActions.contest_id'),
+              },
+            },
             attributes: [
               'contest_id',
               'contest_address',

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -132,7 +132,6 @@ export async function __getThreadsById(
         ],
       },
     ],
-    logging: true,
   });
 
   const result = threads.map((thread) => {

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -96,7 +96,7 @@ export async function __getThreadsById(
       {
         model: this.models.ContestAction,
         where: {
-          action: 'added',
+          action: 'upvoted',
         },
         required: false,
         attributes: ['content_id', 'thread_id'],

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -98,7 +98,7 @@ export async function __getThreadsById(
           action: 'upvoted',
         },
         required: false,
-        attributes: ['content_id'],
+        attributes: ['content_id', 'thread_id'],
         include: [
           {
             model: this.models.Contest,

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -97,6 +97,7 @@ export async function __getThreadsById(
         where: {
           action: 'upvoted',
         },
+        required: false,
         attributes: ['content_id'],
         include: [
           {

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -92,6 +92,31 @@ export async function __getThreadsById(
           },
         ],
       },
+      {
+        model: this.models.ContestAction,
+        where: {
+          action: 'upvoted',
+        },
+        attributes: ['content_id'],
+        include: [
+          {
+            model: this.models.Contest,
+            attributes: [
+              'contest_id',
+              'contest_address',
+              'score',
+              'start_time',
+              'end_time',
+            ],
+            include: [
+              {
+                model: this.models.ContestManager,
+                attributes: ['name', 'cancelled'],
+              },
+            ],
+          },
+        ],
+      },
     ],
   });
 

--- a/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/get_threads_by_id.ts
@@ -96,7 +96,7 @@ export async function __getThreadsById(
       {
         model: this.models.ContestAction,
         where: {
-          action: 'upvoted',
+          action: 'added',
         },
         required: false,
         attributes: ['content_id', 'thread_id'],
@@ -132,6 +132,7 @@ export async function __getThreadsById(
         ],
       },
     ],
+    logging: true,
   });
 
   const result = threads.map((thread) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7940 

## Description of Changes
- with @kurtisassad we adjusted queries in `get_bulk_threads.ts` and `get_threads_by_id.ts` to provide FE with contest/score data
- hooked up data into existing ThreadContestTag component (with some small refactoring)

![image](https://github.com/hicommonwealth/commonwealth/assets/14819225/f65c2a07-7b30-434e-af49-236f011b3770)

![image](https://github.com/hicommonwealth/commonwealth/assets/14819225/4634e23f-f5c5-45b8-9c86-71255f573816)

## Test Plan
- create contest (oneoff or recurring)
- fund it (direct deposit vs buying stake)
- create thread
- upvote it
- wait till the end of the contest
- when contest is finished, next to thread title you should see the tag with the proper place in the contest (1st, 2nd, 3rd etc)
