### PR TITLE
Solana ChainNodes migration

### DIFF
--- a/packages/commonwealth/scripts/load-db.sh
+++ b/packages/commonwealth/scripts/load-db.sh
@@ -22,8 +22,11 @@ psql -h localhost -d commonwealth -U commonwealth -f "$DUMP_NAME";
 
 if [ "$ETH_ALCHEMY_API_KEY" ]
 then
-  ETH_ALCHEMY_URL="https://eth-mainnet.g.alchemy.com/v2"
-  psql -h localhost -d commonwealth -U commonwealth -c "UPDATE \"ChainNodes\" SET url = '$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY', alt_wallet_url = '$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY', private_url = '$ETH_ALCHEMY_URL/$ETH_ALCHEMY_API_KEY' WHERE url LIKE '%alchemy%';"
+  psql -h localhost -d commonwealth -U commonwealth -c "UPDATE \"ChainNodes\"
+                                                                SET url = regexp_replace(url, '\\/([^\\/]*)$', '/$ETH_ALCHEMY_API_KEY'),
+                                                                    alt_wallet_url = regexp_replace(url, '\\/([^\\/]*)$', '/$ETH_ALCHEMY_API_KEY'),
+                                                                    private_url = regexp_replace(url, '\\/([^\\/]*)$', '/$ETH_ALCHEMY_API_KEY')
+                                                                WHERE url LIKE '%.g.alchemy%' OR private_url LIKE '%.g.alchemy%';"
 else
   echo "You don't have the correct env var set so the Alchemy API urls were not updated"
 fi

--- a/packages/commonwealth/server/migrations/20240624173725-remove-faulty-solana-nodes.js
+++ b/packages/commonwealth/server/migrations/20240624173725-remove-faulty-solana-nodes.js
@@ -17,52 +17,92 @@ module.exports = {
 
     // deletes fake + unused Solana ChainNodes
     await queryInterface.sequelize.transaction(async (transaction) => {
+      const solanaMainnet = await queryInterface.sequelize.query(
+        `
+        SELECT id FROM "ChainNodes" WHERE url LIKE 'https://solana-mainnet.g.alchemy.com/%' AND name = 'Solana (Mainnet Beta)'
+      `,
+        { transaction, type: 'SELECT', raw: true },
+      );
+
+      const fakeSolanaMainnet = await queryInterface.sequelize.query(
+        `
+        SELECT id FROM "ChainNodes" WHERE url LIKE '' AND name = 'Solana (Mainnet Beta)'
+      `,
+        { transaction, type: 'SELECT', raw: true },
+      );
+
+      const fakeSolanaDevnet = await queryInterface.sequelize.query(
+        `
+        SELECT id FROM "ChainNodes" WHERE url LIKE 'testnet' AND name = 'Solana (Testnet)'
+      `,
+        { transaction, type: 'SELECT', raw: true },
+      );
+
+      const incompleteSolanaDevnet = await queryInterface.sequelize.query(
+        `
+        SELECT id FROM "ChainNodes" WHERE url LIKE 'devnet' AND name = 'Solana (Devnet)'
+      `,
+        { transaction, type: 'SELECT', raw: true },
+      );
+
       // switch all communities away from fake ChainNodes to the real ChainNode
-      await queryInterface.bulkUpdate(
-        'Communities',
-        {
-          chain_node_id: 1404,
-        },
-        {
-          chain_node_id: [29, 30],
-        },
-        { transaction },
-      );
+      if (
+        solanaMainnet.length === 1 &&
+        fakeSolanaMainnet.length === 1 &&
+        fakeSolanaDevnet.length === 1
+      ) {
+        await queryInterface.bulkUpdate(
+          'Communities',
+          {
+            chain_node_id: solanaMainnet[0].id,
+          },
+          {
+            chain_node_id: [29, 30],
+          },
+          { transaction },
+        );
+      }
 
-      // update the fake Solana (Devnet) node to be a real node
-      await queryInterface.bulkUpdate(
-        'ChainNodes',
-        {
-          url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
-          alt_wallet_url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
-          private_url: `https://solana-devnet.g.alchemy.com/v2/${privateKey}`,
-        },
-        {
-          id: 1,
-        },
-        { transaction },
-      );
+      if (incompleteSolanaDevnet.length === 1) {
+        // update the fake Solana (Devnet) node to be a real node
+        await queryInterface.bulkUpdate(
+          'ChainNodes',
+          {
+            url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
+            alt_wallet_url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
+            private_url: `https://solana-devnet.g.alchemy.com/v2/${privateKey}`,
+          },
+          {
+            id: incompleteSolanaDevnet[0].id,
+          },
+          { transaction },
+        );
+      }
 
-      // update the contracts linked to the fake ChainNode
-      await queryInterface.bulkUpdate(
-        'Contracts',
-        {
-          chain_node_id: 1404,
-        },
-        {
-          chain_node_id: 29,
-        },
-        { transaction },
-      );
+      if (solanaMainnet.length === 1 && fakeSolanaMainnet.length === 1) {
+        // update the contracts linked to the fake ChainNode
+        await queryInterface.bulkUpdate(
+          'Contracts',
+          {
+            chain_node_id: solanaMainnet[0].id,
+          },
+          {
+            chain_node_id: fakeSolanaMainnet[0].id,
+          },
+          { transaction },
+        );
+      }
 
-      // delete the fake chain nodes
-      await queryInterface.bulkDelete(
-        'ChainNodes',
-        {
-          id: [30, 29],
-        },
-        { transaction },
-      );
+      if (fakeSolanaMainnet.length === 1 && fakeSolanaDevnet.length === 1) {
+        // delete the fake chain nodes
+        await queryInterface.bulkDelete(
+          'ChainNodes',
+          {
+            id: [fakeSolanaMainnet[0].id, fakeSolanaDevnet[0].id],
+          },
+          { transaction },
+        );
+      }
     });
   },
 

--- a/packages/commonwealth/server/migrations/20240624173725-remove-faulty-solana-nodes.js
+++ b/packages/commonwealth/server/migrations/20240624173725-remove-faulty-solana-nodes.js
@@ -1,0 +1,70 @@
+'use strict';
+require('dotenv').config();
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const privateKey =
+      process.env.NEW_ALCHEMY_PRIVATE_KEY || process.env.ETH_ALCHEMY_API_KEY;
+    const publicKey =
+      process.env.NEW_ALCHEMY_PUBLIC_KEY || process.env.ETH_ALCHEMY_API_KEY;
+
+    if (!privateKey || !publicKey) {
+      throw new Error(
+        'Must have ETH_ALCHEMY_API_KEY env var set in packages/commonwealth/.env to migrate!',
+      );
+    }
+
+    // deletes fake + unused Solana ChainNodes
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // switch all communities away from fake ChainNodes to the real ChainNode
+      await queryInterface.bulkUpdate(
+        'Communities',
+        {
+          chain_node_id: 1404,
+        },
+        {
+          chain_node_id: [29, 30],
+        },
+        { transaction },
+      );
+
+      // update the fake Solana (Devnet) node to be a real node
+      await queryInterface.bulkUpdate(
+        'ChainNodes',
+        {
+          url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
+          alt_wallet_url: `https://solana-devnet.g.alchemy.com/v2/${publicKey}`,
+          private_url: `https://solana-devnet.g.alchemy.com/v2/${privateKey}`,
+        },
+        {
+          id: 1,
+        },
+        { transaction },
+      );
+
+      // update the contracts linked to the fake ChainNode
+      await queryInterface.bulkUpdate(
+        'Contracts',
+        {
+          chain_node_id: 1404,
+        },
+        {
+          chain_node_id: 29,
+        },
+        { transaction },
+      );
+
+      // delete the fake chain nodes
+      await queryInterface.bulkDelete(
+        'ChainNodes',
+        {
+          id: [30, 29],
+        },
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8237 

## Description of Changes
- Removes the 'fake' Solana ChainNodes which did not have URLs set
- Updates the Solana Devnet node
- Several communities were linked to the fake Solana Mainnet Beta chain node so these have all been moved to the correct chain node.

Note:
ChainNodes with id 1, 29, and 30 are fake ChainNodes with no URLs. The correct ChainNode has id 1404 (Mainnet). Chain node with id 1 is Solana Devnet and was updated accordingly. 

## Test Plan
- Run migrations
- Make yourself admin of the `solana` community 
- Create a group
  - When selecting the ChainNode there should only be 2 options (Mainnet Beta and Devnet)

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 