### PR TITLE
Fix contest action thread ID

### DIFF
--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -289,7 +289,6 @@ export function Contests(): Projection<typeof inputs> {
         const add_action = await models.ContestAction.findOne({
           where: {
             contest_address: payload.contest_address,
-            contest_id,
             content_id: payload.content_id,
             action: 'added',
           },
@@ -301,7 +300,7 @@ export function Contests(): Projection<typeof inputs> {
           contest_id,
           actor_address: payload.voter_address,
           action: 'upvoted',
-          thread_id: add_action?.thread_id,
+          thread_id: add_action!.thread_id,
           created_at: new Date(),
         });
         setImmediate(() => updateScore(payload.contest_address, contest_id));

--- a/libs/model/src/policies/ContestWorker.policy.ts
+++ b/libs/model/src/policies/ContestWorker.policy.ts
@@ -136,11 +136,6 @@ export function ContestWorker(): Policy<typeof inputs> {
               AND co.contest_id = added.contest_id
               AND added.thread_id = :thread_id
               AND added.action = 'added'
-            LEFT JOIN "ContestActions" ca ON co.contest_address = ca.contest_address
-              AND co.contest_id = ca.contest_id
-              AND ca.thread_id = :thread_id
-              AND ca.actor_address = :actor_address
-              AND ca.action = 'upvoted'
             WHERE ct.topic_id = :topic_id
             AND cm.community_id = :community_id
             AND cm.cancelled = false
@@ -149,7 +144,22 @@ export function ContestWorker(): Policy<typeof inputs> {
               OR
               cm.interval > 0
             )
-            AND ca.action IS NULL;
+          -- content cannot be a winner in a previous contests
+          AND NOT EXISTS (
+            WITH max_contest AS (
+              SELECT MAX(contest_id) AS max_id
+              FROM "Contests" c1
+              WHERE c1.contest_address = cm.contest_address
+            )
+            SELECT c2.score
+            FROM "Contests" c2,
+                jsonb_array_elements(c2.score) AS score_result
+            WHERE
+                c2.contest_address = cm.contest_address AND
+                (score_result->>'content_id')::int = added.content_id::int AND
+                (score_result->>'prize')::float > 0 AND
+                c2.contest_id != (SELECT max_id FROM max_contest)
+          )
         `,
           {
             type: QueryTypes.SELECT,

--- a/libs/model/src/policies/ContestWorker.policy.ts
+++ b/libs/model/src/policies/ContestWorker.policy.ts
@@ -144,7 +144,7 @@ export function ContestWorker(): Policy<typeof inputs> {
               OR
               cm.interval > 0
             )
-          -- content cannot be a winner in a previous contests
+          -- content cannot be a winner in a previous contest
           AND NOT EXISTS (
             WITH max_contest AS (
               SELECT MAX(contest_id) AS max_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8231

## Description of Changes
- Updates contest worker upvote handler to skip if upvote is applied to content that was a winner in a previous contest
- Updates contest projection to find content regardless of the contest ID it was added on, in order to get thread ID

## Test Plan
- Create a recurring contest, buy stake, create thread and upvote it
- Wait for contest to end and next to begin
- Create a new thread and upvote it
- Ensure that in the `ContestActions` table, all rows have a non-null `thread_id` value

## Deployment Plan
N/A

## Other Considerations
N/A