### PR TITLE
Update community thread counts when new threads are added/removed from community

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -16,7 +16,7 @@ class ChainInfo {
   public readonly CommunityStakes: StakeInfo[];
   public CommunityTags: Tag[];
   public readonly tokenName: string;
-  public readonly threadCount: number;
+  public threadCount: number;
   public readonly addressCount: number;
   public readonly default_symbol: string;
   public name: string;

--- a/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createThread.ts
@@ -12,6 +12,7 @@ import useUserOnboardingSliderMutationStore from 'state/ui/userTrainingCards';
 import { UserTrainingCardTypes } from 'views/components/UserTrainingSlider/types';
 import { EXCEPTION_CASE_threadCountersStore } from '../../ui/thread';
 import { addThreadInAllCaches } from './helpers/cache';
+import { updateCommunityThreadCount } from './helpers/counts';
 
 interface CreateThreadProps {
   address: string;
@@ -79,6 +80,7 @@ const useCreateThreadMutation = ({
     onSuccess: async (newThread) => {
       // @ts-expect-error StrictNullChecks
       addThreadInAllCaches(communityId, newThread);
+
       // Update community level thread counters variables
       EXCEPTION_CASE_threadCountersStore.setState(
         ({ totalThreadsInCommunity, totalThreadsInCommunityForVoting }) => ({
@@ -89,6 +91,9 @@ const useCreateThreadMutation = ({
               : totalThreadsInCommunityForVoting,
         }),
       );
+
+      // increment communities thread count
+      if (communityId) updateCommunityThreadCount(communityId, 'increment');
 
       if (userOnboardingEnabled) {
         const profileId = app?.user?.addresses?.[0]?.profile?.id;

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteThread.ts
@@ -6,6 +6,7 @@ import { toCanvasSignedDataApiArgs } from 'shared/canvas/types';
 import app from 'state';
 import { EXCEPTION_CASE_threadCountersStore } from '../../ui/thread';
 import { removeThreadFromAllCaches } from './helpers/cache';
+import { updateCommunityThreadCount } from './helpers/counts';
 
 interface DeleteThreadProps {
   communityId: string;
@@ -47,6 +48,8 @@ const useDeleteThreadMutation = ({
   return useMutation({
     mutationFn: deleteThread,
     onSuccess: async (response) => {
+      removeThreadFromAllCaches(communityId, threadId);
+
       // Update community level thread counters variables
       EXCEPTION_CASE_threadCountersStore.setState(
         ({ totalThreadsInCommunity, totalThreadsInCommunityForVoting }) => ({
@@ -57,7 +60,10 @@ const useDeleteThreadMutation = ({
               : totalThreadsInCommunityForVoting,
         }),
       );
-      removeThreadFromAllCaches(communityId, threadId);
+
+      // decrement communities thread count
+      if (communityId) updateCommunityThreadCount(communityId, 'decrement');
+
       return response.data;
     },
   });

--- a/packages/commonwealth/client/scripts/state/api/threads/helpers/counts.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/helpers/counts.ts
@@ -1,14 +1,31 @@
 import { ThreadStage } from 'models/types';
 import { EXCEPTION_CASE_threadCountersStore } from '../../../ui/thread';
+import { ApiEndpoints, queryClient } from '../../config';
 
 export const updateThreadCountsByStageChange = (currentStage, updatedStage) => {
-    let incBy = 0;
-    if (currentStage === ThreadStage.Voting) incBy--;
-    if (updatedStage === ThreadStage.Voting) incBy++;
-    EXCEPTION_CASE_threadCountersStore.setState(
-        ({ totalThreadsInCommunityForVoting }) => ({
-            totalThreadsInCommunityForVoting:
-                totalThreadsInCommunityForVoting + incBy,
-        })
-    );
-}
+  let incBy = 0;
+  if (currentStage === ThreadStage.Voting) incBy--;
+  if (updatedStage === ThreadStage.Voting) incBy++;
+  EXCEPTION_CASE_threadCountersStore.setState(
+    ({ totalThreadsInCommunityForVoting }) => ({
+      totalThreadsInCommunityForVoting:
+        totalThreadsInCommunityForVoting + incBy,
+    }),
+  );
+};
+
+export const updateCommunityThreadCount = (
+  communityId: string,
+  type: 'increment' | 'decrement',
+) => {
+  const key = [ApiEndpoints.FETCH_ACTIVE_COMMUNITIES];
+  const existingCommunities: { communities } | undefined =
+    queryClient.getQueryData(key);
+  const foundCommunity = (existingCommunities?.communities || []).find(
+    (x) => x.id === communityId,
+  );
+  if (foundCommunity && foundCommunity?.thread_count >= 0) {
+    foundCommunity.thread_count += type === 'increment' ? 1 : -1;
+    queryClient.setQueryData(key, { ...existingCommunities });
+  }
+};

--- a/packages/commonwealth/client/scripts/state/api/threads/helpers/dates.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/helpers/dates.ts
@@ -1,36 +1,44 @@
-import { ThreadTimelineFilterTypes } from "models/types";
+import { ThreadTimelineFilterTypes } from 'models/types';
 import moment from 'moment';
 
-export const getToAndFromDatesRangesForThreadsTimelines = (timeline: ThreadTimelineFilterTypes) => {
-    const today = moment();
+export const getToAndFromDatesRangesForThreadsTimelines = (
+  timeline: ThreadTimelineFilterTypes,
+) => {
+  const today = moment();
 
-    const fromDate = (() => {
-        if (!timeline) return null
-        if (timeline.toLowerCase() === ThreadTimelineFilterTypes.AllTime) {
-            return new Date(0).toISOString();
-        }
-        if (
-            [ThreadTimelineFilterTypes.ThisMonth, ThreadTimelineFilterTypes.ThisWeek].includes(timeline)
-        ) {
-            return today
-                .startOf(timeline.toLowerCase().replace('this', '') as any)
-                .toISOString();
-        }
-    })();
+  const fromDate = (() => {
+    if (!timeline) return null;
+    if (timeline.toLowerCase() === ThreadTimelineFilterTypes.AllTime) {
+      return new Date(0).toISOString();
+    }
+    if (
+      [
+        ThreadTimelineFilterTypes.ThisMonth,
+        ThreadTimelineFilterTypes.ThisWeek,
+      ].includes(timeline)
+    ) {
+      return today
+        .startOf(timeline.toLowerCase().replace('this', '') as any)
+        .toISOString();
+    }
+  })();
 
-    const toDate = (() => {
-        if (!timeline) return moment().toISOString();
-        if (timeline.toLowerCase() === ThreadTimelineFilterTypes.AllTime) {
-            return moment().toISOString();
-        }
-        if (
-            [ThreadTimelineFilterTypes.ThisMonth, ThreadTimelineFilterTypes.ThisWeek].includes(timeline)
-        ) {
-            return today
-                .endOf(timeline.toLowerCase().replace('this', '') as any)
-                .toISOString();
-        }
-    })();
+  const toDate = (() => {
+    if (!timeline) return moment().toISOString();
+    if (timeline.toLowerCase() === ThreadTimelineFilterTypes.AllTime) {
+      return moment().toISOString();
+    }
+    if (
+      [
+        ThreadTimelineFilterTypes.ThisMonth,
+        ThreadTimelineFilterTypes.ThisWeek,
+      ].includes(timeline)
+    ) {
+      return today
+        .endOf(timeline.toLowerCase().replace('this', '') as any)
+        .toISOString();
+    }
+  })();
 
-    return { toDate, fromDate }
-}
+  return { toDate, fromDate };
+};

--- a/packages/commonwealth/client/scripts/state/api/threads/helpers/dates.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/helpers/dates.ts
@@ -18,7 +18,11 @@ export const getToAndFromDatesRangesForThreadsTimelines = (
       ].includes(timeline)
     ) {
       return today
-        .startOf(timeline.toLowerCase().replace('this', '') as any)
+        .startOf(
+          timeline
+            .toLowerCase()
+            .replace('this', '') as moment.unitOfTime.StartOf,
+        )
         .toISOString();
     }
   })();
@@ -35,7 +39,11 @@ export const getToAndFromDatesRangesForThreadsTimelines = (
       ].includes(timeline)
     ) {
       return today
-        .endOf(timeline.toLowerCase().replace('this', '') as any)
+        .endOf(
+          timeline
+            .toLowerCase()
+            .replace('this', '') as moment.unitOfTime.StartOf,
+        )
         .toISOString();
     }
   })();


### PR DESCRIPTION
…m a community

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7172

## Description of Changes
Update community thread counts when new threads are added/removed from the community

## "How We Fixed It"
N/A

## Test Plan
Pre-req: on any type of navigation, don't hard reload the page, navigate with browser back/forward buttons

1. Visit `/communities` page
2. Note the thread count of the first community that appears
3. Click on the community card
4. Create a thread in that community
5. Now go back to the `/communities` page with browser back button
6. Verify the new thread count on the community count is incremented by `1`
7. Repeat step 3
8. Now delete any thread you authored in the community
9. Repeat step 5
10. Verify the new thread count on the community count is decremented by `1`

---

Now direct visit the community 

1. Create a thread
2. Delete a thread
3. Verify both `1` and `2` work without any issues or page crashes

## Deployment Plan
N/A

## Other Considerations
N/A