### PR TITLE
Get fee manager balance

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -254,7 +254,7 @@ class NamespaceFactory extends ContractBase {
       const balance: number = Number(
         this.web3.eth.abi.decodeParameter('uint256', result),
       );
-      return String((balance / 10) ^ (decimals ?? 18));
+      return String(balance / (10 ^ (decimals ?? 18)));
     }
   }
 }

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -251,8 +251,10 @@ class NamespaceFactory extends ContractBase {
         to: token,
         data: calldata,
       });
-      const balance = this.web3.eth.abi.decodeParameter('uint256', result);
-      return this.web3.utils.fromWei(String(balance), decimals!);
+      const balance: number = Number(
+        this.web3.eth.abi.decodeParameter('uint256', result),
+      );
+      return String((balance / 10) ^ (decimals ?? 18));
     }
   }
 }

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -211,6 +211,50 @@ class NamespaceFactory extends ContractBase {
     }
     return txReceipt;
   }
+
+  async getFeeManagerBalance(
+    namespace: string,
+    token?: string,
+    decimals?: number,
+  ): Promise<string> {
+    const namespaceAddr = await this.getNamespaceAddress(namespace);
+    const namespaceContract = new this.web3.eth.Contract(
+      [
+        {
+          inputs: [],
+          stateMutability: 'view',
+          type: 'function',
+          name: 'feeManager',
+          outputs: [
+            {
+              internalType: 'address',
+              name: '',
+              type: 'address',
+            },
+          ],
+        },
+      ],
+      namespaceAddr,
+    );
+    const feeManager = await namespaceContract.methods.feeManager().call();
+
+    if (!token) {
+      const balance = await this.web3.eth.getBalance(String(feeManager));
+      return this.web3.utils.fromWei(balance, 'ether');
+    } else {
+      const calldata =
+        '0x70a08231' +
+        this.web3.eth.abi
+          .encodeParameters(['address'], [feeManager])
+          .substring(2);
+      const result = await this.web3.eth.call({
+        to: token,
+        data: calldata,
+      });
+      const balance = this.web3.eth.abi.decodeParameter('uint256', result);
+      return this.web3.utils.fromWei(String(balance), decimals ?? 'ether');
+    }
+  }
 }
 
 export default NamespaceFactory;

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -252,7 +252,7 @@ class NamespaceFactory extends ContractBase {
         data: calldata,
       });
       const balance = this.web3.eth.abi.decodeParameter('uint256', result);
-      return this.web3.utils.fromWei(String(balance), decimals ?? 'ether');
+      return this.web3.utils.fromWei(String(balance), decimals);
     }
   }
 }

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -252,7 +252,7 @@ class NamespaceFactory extends ContractBase {
         data: calldata,
       });
       const balance = this.web3.eth.abi.decodeParameter('uint256', result);
-      return this.web3.utils.fromWei(String(balance), decimals);
+      return this.web3.utils.fromWei(String(balance), decimals!);
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8246 

## Description of Changes
- Adds a client helper to get feemanager balance

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- As mentioned in discussions, we only support eth stake at the moment so passing token or decimal is optional and can be sent as null 