### PR TITLE
Show "Thread not found" message when visiting a deleted thread page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -292,7 +292,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     // @ts-expect-error <StrictNullChecks/>
     thread.communityId !== app.activeChainId()
   ) {
-    return <PageNotFound />;
+    return <PageNotFound message="Thread not found" />;
   }
 
   // Original posters have full editorial control, while added collaborators


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8109

## Description of Changes
Show "Thread not found" message when visiting a deleted thread page

## "How We Fixed It"
N/A

## Test Plan
1. Visit any non-existant thread URL ex: `http://localhost:8080/dydx/discussion/12477-a-non-existant-thread`
2. Verify you see the "Thread not found" message

## Deployment Plan
N/A

## Other Considerations
N/A