### PR TITLE
Fix to remove useNotificationSubscriptions

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/addresses.ts
+++ b/packages/commonwealth/client/scripts/helpers/addresses.ts
@@ -1,0 +1,15 @@
+import ChainInfo from 'models/ChainInfo';
+import app from 'state';
+
+/**
+ * Get the unique communities but also sort them.
+ */
+export function getUniqueCommunities() {
+  const dict: { [id: string]: ChainInfo } = {};
+
+  for (const addr of app.user.addresses) {
+    dict[addr.community.id] = addr.community;
+  }
+
+  return Object.values(dict).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -124,7 +124,7 @@ const NotificationSettings = () => {
                   <CommunityEntry
                     key={current.id}
                     communityInfo={current.community}
-                    communityAlert={communityAlertsIndex[current.id]}
+                    communityAlert={communityAlertsIndex[current.community.id]}
                   />
                 </div>
               );

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState } from 'react';
 import app from 'state';
 import { useCommunityAlertsQuery } from 'state/api/trpc/subscription/useCommunityAlertsQuery';
 // eslint-disable-next-line max-len
+import ChainInfo from 'models/ChainInfo';
 import { useRegisterClientRegistrationTokenMutation } from 'state/api/trpc/subscription/useRegisterClientRegistrationTokenMutation';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
@@ -23,6 +24,19 @@ import { SubscriptionEntry } from './SubscriptionEntry';
 import './index.scss';
 
 type NotificationSection = 'community-alerts' | 'subscriptions';
+
+/**
+ * Get the unique communities but also sort them.
+ */
+function getUniqueCommunities() {
+  const dict: { [id: string]: ChainInfo } = {};
+
+  for (const addr of app.user.addresses) {
+    dict[addr.community.id] = addr.community;
+  }
+
+  return Object.values(dict).sort((a, b) => a.name.localeCompare(b.name));
+}
 
 const NotificationSettings = () => {
   const threadSubscriptions = useThreadSubscriptions();
@@ -118,12 +132,12 @@ const NotificationSettings = () => {
               Get updates on new threads and discussions from these communities
             </CWText>
 
-            {app.user.addresses.map((current) => {
+            {getUniqueCommunities().map((community) => {
               return (
                 <CommunityEntry
-                  key={current.id}
-                  communityInfo={current.community}
-                  communityAlert={communityAlertsIndex[current.community.id]}
+                  key={community.id}
+                  communityInfo={community}
+                  communityAlert={communityAlertsIndex[community.id]}
                 />
               );
             })}

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -120,13 +120,11 @@ const NotificationSettings = () => {
 
             {app.user.addresses.map((current) => {
               return (
-                <div>
-                  <CommunityEntry
-                    key={current.id}
-                    communityInfo={current.community}
-                    communityAlert={communityAlertsIndex[current.community.id]}
-                  />
-                </div>
+                <CommunityEntry
+                  key={current.id}
+                  communityInfo={current.community}
+                  communityAlert={communityAlertsIndex[current.community.id]}
+                />
               );
             })}
           </>

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -2,10 +2,9 @@ import { CommunityAlert, ThreadSubscription } from '@hicommonwealth/schemas';
 import { useFlag } from 'hooks/useFlag';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import React, { useCallback, useState } from 'react';
-import app from 'state';
 import { useCommunityAlertsQuery } from 'state/api/trpc/subscription/useCommunityAlertsQuery';
 // eslint-disable-next-line max-len
-import ChainInfo from 'models/ChainInfo';
+import { getUniqueCommunities } from 'helpers/addresses';
 import { useRegisterClientRegistrationTokenMutation } from 'state/api/trpc/subscription/useRegisterClientRegistrationTokenMutation';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
@@ -24,19 +23,6 @@ import { SubscriptionEntry } from './SubscriptionEntry';
 import './index.scss';
 
 type NotificationSection = 'community-alerts' | 'subscriptions';
-
-/**
- * Get the unique communities but also sort them.
- */
-function getUniqueCommunities() {
-  const dict: { [id: string]: ChainInfo } = {};
-
-  for (const addr of app.user.addresses) {
-    dict[addr.community.id] = addr.community;
-  }
-
-  return Object.values(dict).sort((a, b) => a.name.localeCompare(b.name));
-}
 
 const NotificationSettings = () => {
   const threadSubscriptions = useThreadSubscriptions();

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -1,10 +1,10 @@
 import { CommunityAlert, ThreadSubscription } from '@hicommonwealth/schemas';
+import { getUniqueCommunities } from 'helpers/addresses';
 import { useFlag } from 'hooks/useFlag';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import React, { useCallback, useState } from 'react';
 import { useCommunityAlertsQuery } from 'state/api/trpc/subscription/useCommunityAlertsQuery';
 // eslint-disable-next-line max-len
-import { getUniqueCommunities } from 'helpers/addresses';
 import { useRegisterClientRegistrationTokenMutation } from 'state/api/trpc/subscription/useRegisterClientRegistrationTokenMutation';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -16,7 +16,6 @@ import { PageNotFound } from 'views/pages/404';
 import { CommunityEntry } from 'views/pages/NotificationSettings/CommunityEntry';
 import { getFirebaseMessagingToken } from 'views/pages/NotificationSettings/getFirebaseMessagingToken';
 import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
-import useNotificationSettings from 'views/pages/NotificationSettingsOld/useNotificationSettings';
 import { z } from 'zod';
 import { CWText } from '../../components/component_kit/cw_text';
 import { PageLoading } from '../loading';
@@ -38,8 +37,6 @@ const NotificationSettings = () => {
       z.infer<typeof CommunityAlert>
     >) || [],
   );
-
-  const { bundledSubs } = useNotificationSettings();
 
   const [threadsFilter, setThreadsFilter] = useState<readonly number[]>([]);
   const [section, setSection] =
@@ -121,18 +118,17 @@ const NotificationSettings = () => {
               Get updates on new threads and discussions from these communities
             </CWText>
 
-            {Object.entries(bundledSubs)
-              .sort((x, y) => x[0].localeCompare(y[0]))
-              .map(([communityName]) => {
-                const communityInfo = app?.config.chains.getById(communityName);
-                return (
+            {app.user.addresses.map((current) => {
+              return (
+                <div>
                   <CommunityEntry
-                    key={communityInfo.id}
-                    communityInfo={communityInfo}
-                    communityAlert={communityAlertsIndex[communityInfo.id]}
+                    key={current.id}
+                    communityInfo={current.community}
+                    communityAlert={communityAlertsIndex[current.id]}
                   />
-                );
-              })}
+                </div>
+              );
+            })}
           </>
         )}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8259

## Description of Changes

- we don't useNotificationSettings anymore but use the data that's already in memory

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Just load the subscriptions notification page and make sure your subscriptions load and you can toggle them. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 