### PR TITLE
7845.israel.android pwa prompt error

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/AddToHomeScreenPrompt/AndroidPrompt/AndroidPrompt.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AddToHomeScreenPrompt/AndroidPrompt/AndroidPrompt.tsx
@@ -32,7 +32,7 @@ export const AndroidPrompt = ({
   });
 
   const handleInstallClick = () => {
-    try {
+    if (installPromptEvent) {
       // @ts-expect-error StrictNullChecks
       installPromptEvent.prompt();
 
@@ -50,7 +50,7 @@ export const AndroidPrompt = ({
           setShowPrompt(false);
         }
       });
-    } catch (e) {
+    } else {
       const manualStepsInstructionsEle =
         document.getElementById('manual-install');
       if (manualStepsInstructionsEle) {

--- a/packages/commonwealth/client/scripts/views/components/AddToHomeScreenPrompt/AndroidPrompt/AndroidPrompt.tsx
+++ b/packages/commonwealth/client/scripts/views/components/AddToHomeScreenPrompt/AndroidPrompt/AndroidPrompt.tsx
@@ -21,6 +21,7 @@ export const AndroidPrompt = ({
   const { animationStyles } = useAnimation({ transitionDuration: '.5s' });
   let installPromptEvent = null;
   const [checkboxChecked, setCheckboxChecked] = useState(false);
+  const [showInstallButton, setShowInstallButton] = useState(true);
 
   window.addEventListener('beforeinstallprompt', (event) => {
     // Prevent Chrome 67 and earlier from automatically showing the prompt
@@ -50,14 +51,14 @@ export const AndroidPrompt = ({
         }
       });
     } catch (e) {
-      console.error(e);
       const manualStepsInstructionsEle =
         document.getElementById('manual-install');
       if (manualStepsInstructionsEle) {
         setTimeout(() => {
           manualStepsInstructionsEle.style.display = 'flex';
-        }, 1000);
+        }, 500);
       }
+      setShowInstallButton(false);
     }
   };
 
@@ -120,12 +121,14 @@ export const AndroidPrompt = ({
             label="Cancel"
             onClick={handleCancelClick}
           />
-          <CWButton
-            buttonType="tertiary"
-            className="prompt-button"
-            label="Install"
-            onClick={handleInstallClick}
-          />
+          {showInstallButton && (
+            <CWButton
+              buttonType="tertiary"
+              className="prompt-button"
+              label="Install"
+              onClick={handleInstallClick}
+            />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7845 

## Description of Changes
-user no longer sees error is console
-install button is hidden when install instructions are shown since the Install button is no longer applicable

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed logic to be inside if/else rather than try/catch
-added logic to hide the Install button after it's been clicked
**NOTE: This ticket is only to get rid of the error message, the logic inside the if statement was confirmed by many other engineers that it doesn't work and a bigger fix needs to be made for this. That is why I changed it to an if/else rather than a try/catch. So when reviewing this PR one should only be looking at if they don't see the error and how the android pwa prompt modal functions.** 

## Test Plan
-look at the app on android mobile
-confirm you see the pwa prompt
-click install
-confirm the install button is hidden and new instructions are shown
-click cancel
-confirm that the modal disappears


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-This was originally a different PR, but because it sat for so long there were irreconcilable merge conflicts, so a new PR was made  