### PR TITLE
Show contest prize affordance

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/contests/createContest.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/createContest.ts
@@ -1,7 +1,13 @@
 import { trpc } from 'utils/trpcClient';
 
 const useCreateContestMutation = () => {
-  return trpc.contest.createContestMetadata.useMutation();
+  const utils = trpc.useUtils();
+
+  return trpc.contest.createContestMetadata.useMutation({
+    onSuccess: async () => {
+      await utils.contest.getAllContests.invalidate();
+    },
+  });
 };
 
 export default useCreateContestMutation;

--- a/packages/commonwealth/client/scripts/state/api/contests/getContestBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/getContestBalance.ts
@@ -25,12 +25,14 @@ interface UseGetContestBalanceQueryProps {
   contestAddress: string;
   chainRpc: string;
   ethChainId: number;
+  apiEnabled?: boolean;
 }
 
 const useGetContestBalanceQuery = ({
   contestAddress,
   chainRpc,
   ethChainId,
+  apiEnabled = true,
 }: UseGetContestBalanceQueryProps) => {
   return useQuery({
     queryKey: [
@@ -41,7 +43,7 @@ const useGetContestBalanceQuery = ({
     ],
     queryFn: () => getContestBalance({ contestAddress, chainRpc, ethChainId }),
     staleTime: GET_CONTEST_BALANCE_STALE_TIME,
-    enabled: !!contestAddress,
+    enabled: !!contestAddress && apiEnabled,
   });
 };
 

--- a/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/getContests.ts
@@ -7,7 +7,7 @@ type UseGetContestsQueryProps = z.infer<typeof GetAllContests.input> & {
   enabled: boolean;
 };
 
-const CONTESTS_STALE_TIME = 60 * 1_000; // 60 s
+const CONTESTS_STALE_TIME = 10 * 1_000; // 10 s
 
 const useGetContestsQuery = ({
   contest_id,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
+import useGetFeeManagerBalanceQuery from 'state/api/communityStake/getFeeManagerBalance';
 import Permissions from 'utils/Permissions';
 import { useCommunityStake } from 'views/components/CommunityStake';
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -31,6 +32,13 @@ const AdminContestsPage = () => {
     isContestDataLoading,
   } = useCommunityContests();
 
+  const { data: feeManagerBalance, isLoading: isFeeManagerBalanceLoading } =
+    useGetFeeManagerBalanceQuery({
+      ethChainId: ethChainId!,
+      namespace,
+      apiEnabled: !!ethChainId && !!namespace && stakeEnabled,
+    });
+
   if (!app.isLoggedIn() || !isAdmin) {
     return <PageNotFound />;
   }
@@ -54,7 +62,10 @@ const AdminContestsPage = () => {
         </div>
 
         {showBanner && (
-          <FeeManagerBanner ethChainId={ethChainId} namespace={namespace} />
+          <FeeManagerBanner
+            feeManagerBalance={feeManagerBalance}
+            isLoading={isFeeManagerBalanceLoading}
+          />
         )}
 
         <ContestsList
@@ -63,6 +74,7 @@ const AdminContestsPage = () => {
           isAdmin={isAdmin}
           isContestAvailable={isContestAvailable}
           stakeEnabled={stakeEnabled}
+          feeManagerBalance={feeManagerBalance}
         />
       </div>
     </CWPageLayout>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/FeeManagerBanner/FeeManagerBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/FeeManagerBanner/FeeManagerBanner.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { isMobile } from 'react-device-detect';
 
-import useGetFeeManagerBalanceQuery from 'state/api/communityStake/getFeeManagerBalance';
 import { useManageCommunityStakeModalStore } from 'state/ui/modals';
 import { Skeleton } from 'views/components/Skeleton';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
@@ -15,20 +14,16 @@ import CWPopover, {
 import './FeeManagerBanner.scss';
 
 interface FeeManagerBannerProps {
-  ethChainId: number;
-  namespace: string;
+  feeManagerBalance?: string;
+  isLoading: boolean;
 }
 
-const FeeManagerBanner = ({ ethChainId, namespace }: FeeManagerBannerProps) => {
+const FeeManagerBanner = ({
+  feeManagerBalance,
+  isLoading,
+}: FeeManagerBannerProps) => {
   const { setModeOfManageCommunityStakeModal } =
     useManageCommunityStakeModalStore();
-
-  const { data: feeManagerBalance, isLoading: isFeeManagerBalanceLoading } =
-    useGetFeeManagerBalanceQuery({
-      ethChainId: ethChainId,
-      namespace,
-      apiEnabled: !!ethChainId,
-    });
 
   const popoverProps = usePopover();
 
@@ -36,7 +31,7 @@ const FeeManagerBanner = ({ ethChainId, namespace }: FeeManagerBannerProps) => {
     setModeOfManageCommunityStakeModal('buy');
   };
 
-  if (isFeeManagerBalanceLoading) {
+  if (isLoading) {
     return <Skeleton className="FeeManagerBannerSkeleton" />;
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/ContestAlert.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/ContestAlert.scss
@@ -1,0 +1,26 @@
+@import '../../../../../../../styles/shared';
+
+.ContestAlert {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border-radius: 6px;
+  background-color: $yellow-100;
+  margin-block: 8px;
+  gap: 16px;
+
+  svg {
+    width: 40px;
+    height: 40px;
+    padding: 4px;
+    background-color: $yellow-400;
+    fill: $yellow-800;
+    border-radius: 6px;
+  }
+
+  .right-side {
+    .Text {
+      color: $yellow-800;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/ContestAlert.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/ContestAlert.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
+import { IconName } from 'views/components/component_kit/cw_icons/cw_icon_lookup';
+import { CWText } from 'views/components/component_kit/cw_text';
+
+import './ContestAlert.scss';
+
+interface ContestAlertProps {
+  title: string;
+  description: string;
+  iconName: IconName;
+}
+
+const ContestAlert = ({ title, description, iconName }: ContestAlertProps) => {
+  return (
+    <div className="ContestAlert">
+      <CWIcon iconName={iconName} iconSize="large" />
+      <div className="right-side">
+        <CWText fontWeight="bold">{title}</CWText>
+        <CWText>{description}</CWText>
+      </div>
+    </div>
+  );
+};
+
+export default ContestAlert;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestAlert/index.ts
@@ -1,0 +1,3 @@
+import ContestAlert from './ContestAlert';
+
+export default ContestAlert;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -44,6 +44,7 @@ interface ContestsListProps {
   isLoading: boolean;
   stakeEnabled: boolean;
   isContestAvailable: boolean;
+  feeManagerBalance?: string;
 }
 const ContestsList = ({
   contests,
@@ -51,6 +52,7 @@ const ContestsList = ({
   isLoading,
   stakeEnabled,
   isContestAvailable,
+  feeManagerBalance,
 }: ContestsListProps) => {
   const [fundDrawerAddress, setFundDrawerAddress] = useState('');
 
@@ -101,6 +103,8 @@ const ContestsList = ({
                 isCancelled={contest.cancelled}
                 // @ts-expect-error <StrictNullChecks/>
                 onFund={() => setFundDrawerAddress(contest.contest_address)}
+                feeManagerBalance={feeManagerBalance}
+                isRecurring={!contest.funding_token_address}
               />
             );
           })

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/useNamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/useNamespaceFactory.ts
@@ -4,7 +4,7 @@ import app from 'state';
 
 const useNamespaceFactory = (ethChainId: number) => {
   const chainFactoryAddress =
-    commonProtocol.factoryContracts[ethChainId].factory;
+    commonProtocol.factoryContracts[ethChainId]?.factory;
   const chainRpc = app.config.nodes
     .getAll()
     .find((node) => node.ethChainId === ethChainId)?.url;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8253 

## Description of Changes
- created generic ContestAlert component that is displayed in different conditions
- adjusted ContestCard component to display prizes properly

## Test Plan
- create contest
- you should see 'There are no funds for this contest' alert
- for one-off, fund contest
- for recursive, buy stake
- the alert should change to 'There are no upvotes on this contest'
- create thread and upvote it
- the alert should be gone and the prize should be visible

https://github.com/hicommonwealth/commonwealth/assets/14819225/27937894-ba7d-4fb9-8644-84673b8324ac



## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

