### PR TITLE
Update contest manager query join

### DIFF
--- a/libs/model/src/policies/ContestWorker.policy.ts
+++ b/libs/model/src/policies/ContestWorker.policy.ts
@@ -132,8 +132,12 @@ export function ContestWorker(): Policy<typeof inputs> {
             JOIN "ContestManagers" cm ON cm.community_id = c.id
             JOIN "ContestTopics" ct ON cm.contest_address = ct.contest_address
             JOIN "Contests" co ON cm.contest_address = co.contest_address
+              AND co.contest_id = (
+                SELECT MAX(contest_id) AS max_id
+                FROM "Contests" c1
+                WHERE c1.contest_address = cm.contest_address
+              )
             JOIN "ContestActions" added on co.contest_address = added.contest_address
-              AND co.contest_id = added.contest_id
               AND added.thread_id = :thread_id
               AND added.action = 'added'
             WHERE ct.topic_id = :topic_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8279 

## Description of Changes
- Removes join on added content by contest_id, since it will always be zero for content where action='added'

## Test Plan
- Create contest, with multiple threads and upvote them
- Wait 5 mins until next round begins
- Create more threads and upvote them
- Ensure there are no errors in the consumer

## Deployment Plan
N/A

## Other Considerations
N/A