### PR TITLE
user now sees full background image on profile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -108,31 +108,32 @@ const Profile = ({ profileId }: ProfileProps) => {
     }
 
     return (
-      <CWPageLayout>
-        <div
-          className="Profile"
-          style={
-            profile.backgroundImage
-              ? {
-                  backgroundImage: `url(${backgroundUrl})`,
-                  backgroundRepeat: `${
-                    backgroundImageBehavior === ImageBehavior.Fill
-                      ? 'no-repeat'
-                      : 'repeat'
-                  }`,
-                  backgroundSize:
-                    backgroundImageBehavior === ImageBehavior.Fill
-                      ? 'cover'
-                      : '100px',
-                  backgroundPosition:
-                    backgroundImageBehavior === ImageBehavior.Fill
-                      ? 'center'
-                      : '56px 56px',
-                  backgroundAttachment: 'fixed',
-                }
-              : {}
-          }
-        >
+      <div
+        className="Profile"
+        style={
+          profile.backgroundImage
+            ? {
+                backgroundImage: `url(${backgroundUrl})`,
+                backgroundRepeat: `${
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'no-repeat'
+                    : 'repeat'
+                }`,
+                backgroundSize:
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'cover'
+                    : '100px',
+                backgroundPosition:
+                  backgroundImageBehavior === ImageBehavior.Fill
+                    ? 'center'
+                    : '56px 56px',
+                backgroundAttachment: 'fixed',
+              }
+            : {}
+        }
+      >
+        <div className="fixed-slug-header"></div>
+        <CWPageLayout>
           <div className="header">
             <CWText type="h2" fontWeight="medium">
               {profile.name
@@ -156,8 +157,8 @@ const Profile = ({ profileId }: ProfileProps) => {
               addresses={addresses}
             />
           </div>
-        </div>
-      </CWPageLayout>
+        </CWPageLayout>
+      </div>
     );
   } else {
     return (

--- a/packages/commonwealth/client/styles/components/Profile/Profile.scss
+++ b/packages/commonwealth/client/styles/components/Profile/Profile.scss
@@ -9,6 +9,16 @@
   .breadcrumbs {
     padding-left: 32px;
   }
+  .fixed-slug-header {
+    height: 52px;
+    width: 100%;
+    background-color: white;
+    position: fixed;
+
+    @include extraSmall {
+      display: none;
+    }
+  }
 
   .header {
     margin-bottom: 24px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8178 
## Description of Changes
-User now sees their image full width of background on Profile page

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-removed the className logic to be outside of the `CWPageLayout` component
-added a slug at the top to account for breadcrumbs 
## Test Plan
-if you don't have an image set for your profile  go to Edit Profile and add one
-now go to View Profile and confirm that your see the image spanning the full width of the background

<img width="1429" alt="Screenshot 2024-07-01 at 10 07 09 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/25e8e977-ae9c-44d8-97da-256965c0973f">
<img width="287" alt="Screenshot 2024-07-01 at 10 07 44 PM" src="https://github.com/hicommonwealth/commonwealth/assets/69872984/d6feb431-425e-4f04-bd0b-c74d66251850">
