### PR TITLE
Moved alchemy endpoint to env

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -94,7 +94,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
       import('../../../helpers/mockMetaMaskUtil')
         .then((f) => {
           window['ethereum'] = new f.MockMetaMaskProvider(
-            'https://eth-mainnet.g.alchemy.com/v2/pZsX6R3wGdnwhUJHlVmKg4QqsiS32Qm4',
+            `https://eth-mainnet.g.alchemy.com/v2/${process.env.ETH_ALCHEMY_API_KEY}`,
             '0x09187906d2ff8848c20050df632152b5b27d816ec62acd41d4498feb522ac5c3',
           );
         })

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -123,7 +123,8 @@ export default defineConfig(({ mode }) => {
       ),
       'process.env.FLAG_CONTEST_DEV': JSON.stringify(env.FLAG_CONTEST_DEV),
       'process.env.ETH_ALCHEMY_API_KEY':
-        JSON.stringify(env.ETH_RPC).trim() === '"e2e-test"'
+        (env.ETH_RPC || '').trim() === 'e2e-test' &&
+        (env.NODE_ENV || '').trim() === 'test'
           ? JSON.stringify(env.ETH_ALCHEMY_API_KEY)
           : undefined,
     },

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -122,6 +122,10 @@ export default defineConfig(({ mode }) => {
         env.FLAG_KNOCK_PUSH_NOTIFICATIONS_ENABLED,
       ),
       'process.env.FLAG_CONTEST_DEV': JSON.stringify(env.FLAG_CONTEST_DEV),
+      'process.env.ETH_ALCHEMY_API_KEY':
+        JSON.stringify(env.ETH_RPC).trim() === '"e2e-test"'
+          ? JSON.stringify(env.ETH_ALCHEMY_API_KEY)
+          : undefined,
     },
   };
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8337

## Description of Changes
Now using `ETH_ALCHEMY_API_KEY` in alchemy URL, in the `useAuthentication` hook

## "How We Fixed It"
N/A

## Test Plan
Make sure e2e tests work.

## Deployment Plan
N/A

## Other Considerations
N/A