### PR TITLE
Fixed console error in members page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -161,7 +161,7 @@ const CommunityMembersPage = () => {
     },
   );
 
-  const { data: groups } = useFetchGroupsQuery({
+  const { data: groups, refetch } = useFetchGroupsQuery({
     communityId: app.activeChainId(),
     includeTopics: true,
     enabled: app?.user?.activeAccount?.address ? !!memberships : true,
@@ -283,8 +283,8 @@ const CommunityMembersPage = () => {
   useEffect(() => {
     // Invalidate group memberships cache
     queryClient.cancelQueries([ApiEndpoints.FETCH_GROUPS]);
-    queryClient.refetchQueries([ApiEndpoints.FETCH_GROUPS]);
-  }, []);
+    refetch();
+  }, [refetch]);
 
   useEffect(() => {
     // Set the active tab based on URL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

we were using query client to refetch the members, but were not passing in required params. An easier way is to just get the refetch function from the react query and call it instead.

## Link to Issue
Closes: #8338

## Description of Changes
- replaced query client refetch with specific react query refetch.

## Test Plan
- Go to http://localhost:8080/element-finance/members?tab=all-members and check console logs. Make sure there is no error relating to "the query data cannot be undefined"