### PR TITLE
Hide react query dev tools on prod

### DIFF
--- a/packages/commonwealth/client/scripts/App.tsx
+++ b/packages/commonwealth/client/scripts/App.tsx
@@ -47,7 +47,7 @@ const App = () => {
               )}
 
               <ToastContainer />
-              <ReactQueryDevtools />
+              {import.meta.env.DEV && <ReactQueryDevtools />}
             </OpenFeatureProvider>
           </trpc.Provider>
         </QueryClientProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8346

## Description of Changes
- Only shows react query dev tools in DEV mode. Will be hidden from prod.

## Test Plan
Run it from production mode:
- Inside packages/commonwealth run pnpm run build && pnpm run bundle
- Then run node --import=extensionless/register --enable-source-maps ./build/server.js
- Go to http://localhost:8080 and ensure that react query dev tools do not show up