### PR TITLE
Added secure: false to routes after change makes it required

### DIFF
--- a/libs/model/src/community/GetCommunityStake.query.ts
+++ b/libs/model/src/community/GetCommunityStake.query.ts
@@ -6,6 +6,7 @@ export function GetCommunityStake(): Query<typeof schemas.GetCommunityStake> {
   return {
     ...schemas.GetCommunityStake,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       return (
         await models.CommunityStake.findOne({

--- a/libs/model/src/community/GetMembers.query.ts
+++ b/libs/model/src/community/GetMembers.query.ts
@@ -116,7 +116,7 @@ export function GetMembers(): Query<typeof schemas.GetCommunityMembers> {
       array_agg("Addresses".community_id) as community_ids,
       array_agg("Addresses".address) as addresses,
       MAX("Addresses".last_active) as last_active
-      FROM "Profiles" p
+      FROM "Profiles"
       JOIN "Addresses" ON "Profiles".user_id = "Addresses".user_id
       WHERE ${communityWhere} 
       ("Addresses".address ILIKE '%' || :searchTerm || '%')

--- a/libs/model/src/community/GetMembers.query.ts
+++ b/libs/model/src/community/GetMembers.query.ts
@@ -19,6 +19,7 @@ export function GetMembers(): Query<typeof schemas.GetCommunityMembers> {
   return {
     ...schemas.GetCommunityMembers,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       const community = await models.Community.findByPk(payload.community_id);
       if (!community) {

--- a/libs/model/src/community/GetStakeHistoricalPrice.query.ts
+++ b/libs/model/src/community/GetStakeHistoricalPrice.query.ts
@@ -9,6 +9,7 @@ export function GetStakeHistoricalPrice(): Query<
   return {
     ...schemas.GetStakeHistoricalPrice,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       const { past_date_epoch, community_id, stake_id } = payload;
 

--- a/libs/model/src/community/GetStakeTransaction.query.ts
+++ b/libs/model/src/community/GetStakeTransaction.query.ts
@@ -9,6 +9,7 @@ export function GetStakeTransaction(): Query<
   return {
     ...schemas.GetStakeTransaction,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       const { addresses } = payload;
 

--- a/libs/model/src/contest/GetContestLog.query.ts
+++ b/libs/model/src/contest/GetContestLog.query.ts
@@ -8,6 +8,7 @@ export function GetContestLog(): Query<typeof schemas.GetContestLog> {
   return {
     ...schemas.GetContestLog,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       const results = await models.sequelize.query<
         z.infer<typeof schemas.ContestLogEntry>

--- a/libs/model/src/feed/GetChainActivity.query.ts
+++ b/libs/model/src/feed/GetChainActivity.query.ts
@@ -7,6 +7,7 @@ export function GetChainActivity(): Query<typeof schemas.ChainFeed> {
   return {
     ...schemas.ChainFeed,
     auth: [],
+    secure: false,
     body: async () => {
       const ceNotifs = await models.Notification.findAll({
         where: {

--- a/libs/model/src/feed/GetGlobalActivity.query.ts
+++ b/libs/model/src/feed/GetGlobalActivity.query.ts
@@ -7,6 +7,7 @@ export function GetGlobalActivity(): Query<typeof schemas.ThreadFeed> {
   return {
     ...schemas.ThreadFeed,
     auth: [],
+    secure: false,
     body: async () => {
       return await GlobalActivityCache.getInstance(models).getGlobalActivity();
     },

--- a/libs/model/src/thread/GetBulkThread.query.ts
+++ b/libs/model/src/thread/GetBulkThread.query.ts
@@ -23,6 +23,7 @@ export function GetBulkThreads(): Query<typeof schemas.GetBulkThreads> {
   return {
     ...schemas.GetBulkThreads,
     auth: [],
+    secure: false,
     body: async ({ payload }) => {
       const {
         community_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8344

## Description of Changes
- Change in framework to make trpc routes secure by default did not change the individual routes that used the default as being unsecure. As a result previously unsecured that did not require authentication, now required authentication.

## Test Plan
- Go to http://localhost:8080/dydx/members?tab=all-members and make sure the members is > 0.