### PR TITLE
Clean up ancient slug identifiers file.

### DIFF
--- a/packages/commonwealth/client/scripts/identifiers.ts
+++ b/packages/commonwealth/client/scripts/identifiers.ts
@@ -1,8 +1,5 @@
-import { ChainBase, ProposalType, slugify } from '@hicommonwealth/shared';
-import type { ProposalStore } from 'stores';
-import type ChainInfo from './models/ChainInfo';
+import { ProposalType, slugify } from '@hicommonwealth/shared';
 import type NotificationSubscription from './models/NotificationSubscription';
-import type ProposalModule from './models/ProposalModule';
 import app from './state';
 
 // returns a URL path to a proposal based on its type and id, taking into account
@@ -36,60 +33,4 @@ export const getNotificationUrlPath = (
   )}`;
 
   return `/${community}/${type}/${id}`;
-};
-
-export const chainToProposalSlug = (c: ChainInfo): ProposalType => {
-  if (c.base === ChainBase.CosmosSDK) return ProposalType.CosmosProposal;
-  throw new Error(`Cannot determine proposal slug from chain ${c.id}.`);
-};
-
-export const proposalSlugToClass = () => {
-  // @ts-expect-error StrictNullChecks
-  const mmap = new Map<string, ProposalModule<any, any, any>>([
-    [ProposalType.Thread, null],
-  ]);
-  if (!app.chain) {
-    return mmap;
-  }
-  if (app.chain.base === ChainBase.CosmosSDK) {
-    mmap.set(ProposalType.CosmosProposal, (app.chain as any).governance);
-  }
-  return mmap;
-};
-
-/*
- * Slug helpers for routing
- */
-export const proposalSlugToStore = (slug: string): ProposalStore<any> => {
-  // @ts-expect-error StrictNullChecks
-  return proposalSlugToClass().get(slug).store;
-};
-
-export const proposalSlugToFriendlyName = new Map<ProposalType, string>([
-  [ProposalType.Thread, 'Discussion Thread'],
-  [ProposalType.CosmosProposal, 'Proposal'],
-]);
-
-export const idToProposal = (slug: string, id: string | number) => {
-  const store = proposalSlugToStore(slug);
-  const proposal = store.getByIdentifier(id);
-  if (!proposal) {
-    throw new Error(`Proposal missing from store with id ${id}`);
-  } else {
-    return proposal;
-  }
-};
-
-export const chainEntityTypeToProposalSlug = (): ProposalType => {
-  if (app.chain.base === ChainBase.CosmosSDK) {
-    return ProposalType.CosmosProposal;
-  }
-  return '' as ProposalType;
-};
-
-export const chainEntityTypeToProposalName = (): string => {
-  if (app.chain.base === ChainBase.CosmosSDK) {
-    return 'Proposal';
-  }
-  return '';
 };

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -10,7 +10,6 @@ import { setDarkMode } from '../helpers/darkMode';
 import { EXCEPTION_CASE_threadCountersStore } from '../state/ui/thread';
 import Account from './Account';
 import type ChainInfo from './ChainInfo';
-import ProposalModule from './ProposalModule';
 import type { IAccountsModule, IBlockInfo, IChainModule } from './interfaces';
 
 // Extended by a chain's main implementation. Responsible for module
@@ -34,7 +33,6 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
 
   public abstract chain: IChainModule<C, A>;
   public abstract accounts: IAccountsModule<A>;
-  public abstract governance?: ProposalModule<any, any, any>;
 
   protected _serverLoaded: boolean;
   public get serverLoaded() {

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -34,6 +34,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
 
   public abstract chain: IChainModule<C, A>;
   public abstract accounts: IAccountsModule<A>;
+  public abstract governance?: ProposalModule<any, any, any>;
 
   protected _serverLoaded: boolean;
   public get serverLoaded() {
@@ -114,19 +115,6 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
       !localStorage.getItem('user-dark-mode-state')
     ) {
       setDarkMode(false);
-    }
-  }
-
-  public async loadModules(modules: ProposalModule<any, any, any>[]) {
-    if (!this.loaded) {
-      throw new Error('secondary loading cmd called before chain load');
-    }
-    // TODO: does this need debouncing?
-    if (modules.some((mod) => !!mod && !mod.initializing && !mod.ready)) {
-      await Promise.all(
-        modules.map((mod) => mod.init(this.chain, this.accounts)),
-      );
-      this.app.chainModuleReady.emit('ready');
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/components/countdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/countdown.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import moment from 'moment';
+import React from 'react';
 import { useCountdown } from 'usehooks-ts';
 
-import { blocknumToDuration, formatDuration } from 'helpers';
+import { formatDuration } from 'helpers';
 
 type CountdownProps = {
   duration: number;
@@ -11,7 +11,7 @@ type CountdownProps = {
 export const Countdown = (props: CountdownProps) => {
   const { duration } = props;
 
-  const [count, { startCountdown }] = useCountdown({
+  const [, { startCountdown }] = useCountdown({
     countStart: duration,
     intervalMs: 1000,
   });
@@ -24,12 +24,8 @@ export const Countdown = (props: CountdownProps) => {
     <span>
       {formatDuration(
         moment.duration(moment().add(duration, 'ms').diff(moment())),
-        false
+        false,
       )}
     </span>
   );
-};
-
-type CountdownUntilBlockProps = {
-  block: number;
 };

--- a/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/create_content_menu.tsx
@@ -66,9 +66,7 @@ const getCreateContentMenuItems = (navigate): PopoverMenuItem[] => {
               resetSidebarState();
               const snapshotSpaces = app.chain.meta.snapshot;
               if (snapshotSpaces.length > 1) {
-                navigate('/multiple-snapshots', {
-                  action: 'create-proposal',
-                });
+                navigate('/multiple-snapshots');
               } else {
                 navigate(`/new/snapshot/${snapshotSpaces}`);
               }

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -49,6 +49,7 @@ const NewProposalPage = () => {
   // special case for initializing cosmos governance
   const onCosmos = app.chain?.base === ChainBase.CosmosSDK;
   if (onCosmos) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const governance = (app.chain as any)?.governance;
     if (governance && !governance.ready) {
       if (!governance.initializing) {

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -1,4 +1,4 @@
-import { ChainBase, ProposalType } from '@hicommonwealth/shared';
+import { ChainBase } from '@hicommonwealth/shared';
 import useForceRerender from 'hooks/useForceRerender';
 import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
 import 'pages/new_proposal/index.scss';
@@ -10,15 +10,10 @@ import { CWText } from '../../components/component_kit/cw_text';
 import { PageNotFound } from '../404';
 import { CosmosProposalForm } from './cosmos_proposal_form';
 
-type NewProposalPageProps = {
-  type: ProposalType;
-};
-
 /// NOTE: THIS PAGE IS ONLY ACCESSIBLE FOR COSMOS CHAINS, FOLLOWING
 /// DEPRECATION OF OTHER GOVERNANCE FORMS, AND IS CONSIDERED LEGACY.
 
-const NewProposalPage = (props: NewProposalPageProps) => {
-  const { type } = props;
+const NewProposalPage = () => {
   const forceRerender = useForceRerender();
   const [isLoaded, setIsLoaded] = useState(app.chain?.loaded);
   useInitChainIfNeeded(app);

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -49,13 +49,12 @@ const NewProposalPage = () => {
   // special case for initializing cosmos governance
   const onCosmos = app.chain?.base === ChainBase.CosmosSDK;
   if (onCosmos) {
-    if (app.chain?.governance && !app.chain.governance.ready) {
-      if (!app.chain.governance.initializing) {
-        app.chain.governance
-          .init(app.chain.chain, app.chain.accounts)
-          .then(() => {
-            app.chainModuleReady.emit('ready');
-          });
+    const governance = (app.chain as any)?.governance;
+    if (governance && !governance.ready) {
+      if (!governance.initializing) {
+        governance.init(app.chain.chain, app.chain.accounts).then(() => {
+          app.chainModuleReady.emit('ready');
+        });
       }
       return <PageLoading />;
     }

--- a/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_proposal/index.tsx
@@ -1,17 +1,11 @@
-import { ProposalType } from '@hicommonwealth/shared';
+import { ChainBase, ProposalType } from '@hicommonwealth/shared';
 import useForceRerender from 'hooks/useForceRerender';
 import { useInitChainIfNeeded } from 'hooks/useInitChainIfNeeded';
-import {
-  chainToProposalSlug,
-  proposalSlugToClass,
-  proposalSlugToFriendlyName,
-} from 'identifiers';
 import 'pages/new_proposal/index.scss';
 import React, { useEffect, useState } from 'react';
 import app from 'state';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import { PageLoading } from 'views/pages/loading';
-import type ProposalModule from '../../../models/ProposalModule';
 import { CWText } from '../../components/component_kit/cw_text';
 import { PageNotFound } from '../404';
 import { CosmosProposalForm } from './cosmos_proposal_form';
@@ -20,10 +14,12 @@ type NewProposalPageProps = {
   type: ProposalType;
 };
 
+/// NOTE: THIS PAGE IS ONLY ACCESSIBLE FOR COSMOS CHAINS, FOLLOWING
+/// DEPRECATION OF OTHER GOVERNANCE FORMS, AND IS CONSIDERED LEGACY.
+
 const NewProposalPage = (props: NewProposalPageProps) => {
   const { type } = props;
   const forceRerender = useForceRerender();
-  const [internalType, setInternalType] = useState<ProposalType>(type);
   const [isLoaded, setIsLoaded] = useState(app.chain?.loaded);
   useInitChainIfNeeded(app);
 
@@ -55,46 +51,28 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     return <PageLoading />;
   }
 
-  // infer proposal type if possible
-  if (!internalType) {
-    try {
-      setInternalType(chainToProposalSlug(app.chain.meta));
-    } catch (e) {
-      return (
-        <PageNotFound
-          title="Invalid Page"
-          message="Cannot determine proposal type."
-        />
-      );
+  // special case for initializing cosmos governance
+  const onCosmos = app.chain?.base === ChainBase.CosmosSDK;
+  if (onCosmos) {
+    if (app.chain?.governance && !app.chain.governance.ready) {
+      if (!app.chain.governance.initializing) {
+        app.chain.governance
+          .init(app.chain.chain, app.chain.accounts)
+          .then(() => {
+            app.chainModuleReady.emit('ready');
+          });
+      }
+      return <PageLoading />;
     }
+  } else {
+    return <PageNotFound />;
   }
-
-  // check if module is still initializing
-  const c = proposalSlugToClass()?.get(internalType) as ProposalModule<
-    any,
-    any,
-    any
-  >;
-
-  if (!c || !c.ready) {
-    app.chain.loadModules([c]);
-    return <PageLoading />;
-  }
-
-  const getForm = (typeEnum) => {
-    switch (typeEnum) {
-      case ProposalType.CosmosProposal:
-        return <CosmosProposalForm />;
-      default:
-        return <CWText>Invalid proposal type</CWText>;
-    }
-  };
 
   const getBody = () => {
     if (!app.user.activeAccount) {
       return <CWText>Must be signed in</CWText>;
     } else {
-      return getForm(internalType);
+      return <CosmosProposalForm />;
     }
   };
 
@@ -102,7 +80,7 @@ const NewProposalPage = (props: NewProposalPageProps) => {
     <CWPageLayout>
       <div className="NewProposalPage">
         <CWText type="h3" fontWeight="medium">
-          New {proposalSlugToFriendlyName.get(internalType)}
+          New Proposal
         </CWText>
         {getBody()}
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -8,8 +8,7 @@ import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/new_snapshot_proposal.scss';
 import { DeltaStatic } from 'quill';
-import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router';
+import React, { useEffect, useState } from 'react';
 import app from 'state';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { MixpanelSnapshotEvents } from '../../../../../shared/analytics/types';
@@ -54,16 +53,6 @@ export const NewSnapshotProposalForm = ({
   const [errorMessage, setErrorMessage] = useState(false);
 
   const { isAddedToHomeScreen } = useAppStatus();
-
-  const location = useLocation();
-  const pathVars = useMemo(() => {
-    const search = new URLSearchParams(location.search);
-    const params: Record<string, any> = {};
-    for (const [key, value] of search) {
-      params[key] = value;
-    }
-    return params;
-  }, [location]);
 
   const clearLocalStorage = () => {
     localStorage.removeItem(

--- a/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_snapshot_proposal/index.tsx
@@ -2,7 +2,6 @@ import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import type { SnapshotSpace } from 'helpers/snapshot_utils';
 import { getScore } from 'helpers/snapshot_utils';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
-import { idToProposal } from 'identifiers';
 import _ from 'lodash';
 import Thread from 'models/Thread';
 import moment from 'moment';
@@ -126,27 +125,6 @@ export const NewSnapshotProposalForm = ({
         type: 'single-choice',
       };
 
-      if (pathVars.fromProposalType && pathVars.fromProposalId) {
-        const fromProposalId =
-          typeof pathVars.fromProposalId === 'number'
-            ? pathVars.fromProposalId
-            : pathVars.fromProposalId.toString();
-
-        const fromProposalType = pathVars.fromProposalType.toString();
-
-        const fromProposal = idToProposal(fromProposalType, fromProposalId);
-
-        initialForm.name = fromProposal.title;
-
-        if (fromProposal.body) {
-          try {
-            const parsedBody = JSON.parse(fromProposal.body);
-            initialForm.body = parsedBody.ops[0].insert;
-          } catch (e) {
-            console.error(e);
-          }
-        }
-      }
       if (thread && thread.body) {
         const currentPath = window.location.pathname;
         if (currentPath.includes('/discussion/')) {

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/SnapshotSpaceCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/SnapshotSpaceCard.tsx
@@ -3,8 +3,6 @@ import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/snapshot/SnapshotSpaceCard.scss';
 import React from 'react';
 import app from 'state';
-import { REDIRECT_ACTIONS } from '.';
-import type Thread from '../../../models/Thread';
 import { CWCard } from '../../components/component_kit/cw_card';
 import { SnapshotSpaceCardSkeleton } from './SnapshotSpaceCardSkeleton';
 
@@ -13,15 +11,13 @@ function countActiveProposals(proposals: SnapshotProposal[]): number {
 }
 
 type SnapshotSpaceCardProps = {
-  proposal: null | Thread;
   proposals: SnapshotProposal[];
-  redirectAction: string;
   space: SnapshotSpace;
   showSkeleton?: boolean;
 };
 
 export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
-  const { space, proposals, redirectAction, proposal, showSkeleton } = props;
+  const { space, proposals, showSkeleton } = props;
   const navigate = useCommonNavigate();
 
   if (showSkeleton) return <SnapshotSpaceCardSkeleton />;
@@ -29,26 +25,6 @@ export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
   if (!space || !proposals) return;
 
   const numActiveProposals = countActiveProposals(proposals);
-
-  function handleClicks() {
-    if (redirectAction === REDIRECT_ACTIONS.ENTER_SPACE) {
-      app.snapshot.init(space.id).then(() => {
-        navigate(`/snapshot/${space.id}`);
-      });
-    } else if (redirectAction === REDIRECT_ACTIONS.NEW_PROPOSAL) {
-      app.snapshot.init(space.id).then(() => {
-        navigate(`/new/snapshot/${space.id}`);
-      });
-    } else if (redirectAction === REDIRECT_ACTIONS.NEW_FROM_THREAD) {
-      app.snapshot.init(space.id).then(() => {
-        navigate(
-          `/new/snapshot/${app.chain.meta.snapshot}` +
-            // @ts-expect-error <StrictNullChecks/>
-            `?fromProposalType=${proposal.slug}&fromProposalId=${proposal.id}`,
-        );
-      });
-    }
-  }
 
   return (
     <CWCard
@@ -58,7 +34,9 @@ export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
       onClick={(e) => {
         e.stopPropagation();
         e.preventDefault();
-        handleClicks();
+        app.snapshot.init(space.id).then(() => {
+          navigate(`/snapshot/${space.id}`);
+        });
       }}
     >
       <div className="space-card-container">

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/SnapshotSpaceCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/SnapshotSpaceCard.tsx
@@ -34,6 +34,7 @@ export const SnapshotSpaceCard = (props: SnapshotSpaceCardProps) => {
       onClick={(e) => {
         e.stopPropagation();
         e.preventDefault();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         app.snapshot.init(space.id).then(() => {
           navigate(`/snapshot/${space.id}`);
         });

--- a/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_multiple_snapshot_spaces/index.tsx
@@ -4,61 +4,11 @@ import 'pages/snapshot/multiple_snapshots_page.scss';
 import React from 'react';
 import app from 'state';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
-import type Thread from '../../../models/Thread';
 import { Skeleton } from '../../components/Skeleton';
 import { CardsCollection } from '../../components/cards_collection';
-import { CWText } from '../../components/component_kit/cw_text';
 import { SnapshotSpaceCard } from './SnapshotSpaceCard';
 
-enum SPACES_HEADER_MESSAGES {
-  NEW_PROPOSAL = 'Select a Snapshot Space to Create a Proposal:',
-  ENTER_SPACES = 'Community Snapshot Spaces',
-}
-
-export enum REDIRECT_ACTIONS {
-  NEW_PROPOSAL = 'NEW_PROPOSAL',
-  NEW_FROM_THREAD = 'NEW_FROM_THREAD',
-  ENTER_SPACE = 'ENTER_SPACE',
-}
-
-function redirectHandler(
-  action: string,
-  proposal: null | Thread,
-): {
-  headerMessage: string;
-  redirectOption: string;
-  proposal: null | Thread;
-} {
-  // Default to Enter Snapshot Space View
-  let header = SPACES_HEADER_MESSAGES.ENTER_SPACES;
-  let redirect = REDIRECT_ACTIONS.ENTER_SPACE;
-  let fromProposal = null;
-
-  if (action === 'create-proposal') {
-    header = SPACES_HEADER_MESSAGES.NEW_PROPOSAL;
-    redirect = REDIRECT_ACTIONS.NEW_PROPOSAL;
-  } else if (action === 'create-from-thread') {
-    header = SPACES_HEADER_MESSAGES.NEW_PROPOSAL;
-    redirect = REDIRECT_ACTIONS.NEW_FROM_THREAD;
-    // @ts-expect-error <StrictNullChecks/>
-    fromProposal = proposal;
-  }
-
-  return {
-    headerMessage: header,
-    redirectOption: redirect,
-    proposal: fromProposal,
-  };
-}
-
-type MultipleSnapshotsPageProps = {
-  action?: string;
-  proposal?: Thread;
-};
-
-const MultipleSnapshotsPage = (props: MultipleSnapshotsPageProps) => {
-  const { action, proposal } = props;
-
+const MultipleSnapshotsPage = () => {
   const [snapshotSpaces, setSnapshotSpaces] = React.useState<Array<string>>();
   const [spacesMetadata, setSpacesMetadata] = React.useState<
     Array<{
@@ -66,9 +16,6 @@ const MultipleSnapshotsPage = (props: MultipleSnapshotsPageProps) => {
       proposals: SnapshotProposal[];
     }>
   >();
-
-  // @ts-expect-error <StrictNullChecks/>
-  const redirectOptions = redirectHandler(action, proposal);
 
   if (app.chain && !snapshotSpaces) {
     setSnapshotSpaces(
@@ -91,9 +38,7 @@ const MultipleSnapshotsPage = (props: MultipleSnapshotsPageProps) => {
               <SnapshotSpaceCard
                 key={index}
                 showSkeleton={true}
-                proposal={null}
                 proposals={[]}
-                redirectAction=""
                 space={{} as any}
               />
             ))}
@@ -106,7 +51,6 @@ const MultipleSnapshotsPage = (props: MultipleSnapshotsPageProps) => {
   return (
     <CWPageLayout>
       <div className="MultipleSnapshotsPage">
-        <CWText type="h3">{redirectOptions.headerMessage}</CWText>
         {app.chain && spacesMetadata && (
           <CardsCollection
             content={spacesMetadata.map((data, index) => (
@@ -114,8 +58,6 @@ const MultipleSnapshotsPage = (props: MultipleSnapshotsPageProps) => {
                 key={index}
                 space={data.space}
                 proposals={data.proposals}
-                redirectAction={redirectOptions.redirectOption}
-                proposal={redirectOptions.proposal}
               />
             ))}
           />

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -1,11 +1,8 @@
 import { loadMultipleSpacesData } from 'helpers/snapshot_utils';
 import { filterLinks } from 'helpers/threads';
 
-import {
-  chainEntityTypeToProposalName,
-  chainEntityTypeToProposalSlug,
-  getProposalUrlPath,
-} from 'identifiers';
+import { ProposalType } from '@hicommonwealth/shared';
+import { getProposalUrlPath } from 'identifiers';
 import { LinkSource } from 'models/Thread';
 import 'pages/view_thread/linked_proposals_card.scss';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -25,8 +22,8 @@ type ThreadLinkProps = {
 };
 
 const getThreadLink = ({ threadChain, identifier }: ThreadLinkProps) => {
-  const slug = chainEntityTypeToProposalSlug();
-
+  // XXX 7/3/2024: proposal links only supported for cosmos
+  const slug = ProposalType.CosmosProposal;
   const threadLink = `${
     app.isCustomDomain() ? '' : `/${threadChain}`
   }${getProposalUrlPath(slug, identifier, true)}`;
@@ -116,11 +113,7 @@ export const LinkedProposalsCard = ({
                               identifier: l.identifier,
                             })}
                           >
-                            {`${
-                              l.title ??
-                              chainEntityTypeToProposalName() ??
-                              'Proposal'
-                            } #${l.identifier}`}
+                            {`${l.title ?? 'Proposal'} #${l.identifier}`}
                           </ReactRouterLink>
                         );
                       })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Part of #8356 but does not close it.

## Description of Changes
- Removed snapshot redirects (broken since react migration). See #8360 for outstanding issue.
- Removed many ancient slug functions in identifiers.ts.
- Removed loadModules system designed for deprecated substrate governance and replaced with simpler loading scheme.

## Test Plan
- Ensure Cosmos governance still works.
- Ensure no other regressions.