### PR TITLE
Remove `ETHERSCAN_JS_API_KEY`

### DIFF
--- a/libs/evm-testing/src/config.ts
+++ b/libs/evm-testing/src/config.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 const {
   ETH_ALCHEMY_API_KEY,
   PROVIDER_URL,
-  ETHERSCAN_JS_API_KEY,
   ETH_RPC,
   COSMOS_GOV_V1,
   COSMOS_REGISTRY_API,
@@ -18,7 +17,6 @@ export const config = configure(
       // URL of the local Ganache, Anvil, or Hardhat chain
       PROVIDER_URL: PROVIDER_URL ?? 'http://127.0.0.1:8545',
       ETH_ALCHEMY_API_KEY,
-      ETHERSCAN_JS_API_KEY,
     },
     COSMOS: {
       COSMOS_GOV_V1_CHAIN_IDS: COSMOS_GOV_V1 ? COSMOS_GOV_V1.split(',') : [],
@@ -31,7 +29,6 @@ export const config = configure(
       ETH_RPC: z.string(),
       PROVIDER_URL: z.string(),
       ETH_ALCHEMY_API_KEY: z.string().optional(),
-      ETHERSCAN_JS_API_KEY: z.string().optional(),
       BASESEP_ALCHEMY_API_KEY: z.string().optional(),
     }),
     COSMOS: z.object({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8367 

## Description of Changes
- Removes env var

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. Remove `ETHERSCAN_JS_API_KEY` from all environments

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 