### PR TITLE
Add contest metadata to events

### DIFF
--- a/libs/core/src/integration/events.schemas.ts
+++ b/libs/core/src/integration/events.schemas.ts
@@ -1,5 +1,6 @@
 import {
   Comment,
+  ContestManager,
   ETHERS_BIG_NUMBER,
   EVM_ADDRESS,
   Reaction,
@@ -9,8 +10,12 @@ import {
 } from '@hicommonwealth/schemas';
 import { z } from 'zod';
 
-export const ThreadCreated = Thread;
-export const ThreadUpvoted = Reaction;
+export const ThreadCreated = Thread.extend({
+  contestManagers: z.array(ContestManager).nullish(),
+});
+export const ThreadUpvoted = Reaction.extend({
+  contestManagers: z.array(ContestManager).nullish(),
+});
 export const CommentCreated = Comment;
 export const GroupCreated = z.object({
   groupId: z.string(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8366

## Description of Changes
- Adds `contestManagers` property to `ThreadCreated` and `ThreadUpvoted` event payload

## Test Plan
- Create contest, thread and add upvote– confirm that the ContentAdded and ContentUpvoted projections are eventually added to outbox

## Deployment Plan
N/A

## Other Considerations
N/A