### PR TITLE
Removed duplicates in GetMembersQuery

### DIFF
--- a/libs/model/src/community/GetMembers.query.ts
+++ b/libs/model/src/community/GetMembers.query.ts
@@ -104,7 +104,7 @@ export function GetMembers(): Query<typeof schemas.GetCommunityMembers> {
       ${membershipsWhere}
       GROUP BY "Profiles".id
 
-      UNION ALL
+      UNION
 
       SELECT
       "Profiles".id,


### PR DESCRIPTION
Screwed up in this PR:
https://github.com/hicommonwealth/commonwealth/pull/8229

Accidentally duplicated profiles, this PR fixes that.

old query plan:
https://explain.dalibo.com/plan/a4b2dbaa9f1db481

new query plan:
https://explain.dalibo.com/plan/dd28f7b567c4919f


## Link to Issue
Closes: #8228

## Description of Changes
- Removes UNION ALL so it removes duplicates

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Navigate to http://localhost:8080/dydx/members, ensure there are no duplicate profiles.