### PR TITLE
Fixed getStakeTransaction

### DIFF
--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -56,10 +56,10 @@ export const GetStakeTransaction = {
       stake_direction: z.string(),
       community: z.object({
         id: z.string(),
-        default_symbol: z.string().nullable(),
-        icon_url: z.string().nullable(),
+        default_symbol: z.string().nullish(),
+        icon_url: z.string().nullish(),
         name: z.string(),
-        chain_node_id: PG_INT.nullable(),
+        chain_node_id: PG_INT.nullish(),
       }),
     })
     .array(),
@@ -74,7 +74,7 @@ export const GetStakeHistoricalPrice = {
   output: z
     .object({
       community_id: z.string(),
-      old_price: z.string().nullable(),
+      old_price: z.string().nullish(),
     })
     .array(),
 };

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -56,8 +56,8 @@ export const GetStakeTransaction = {
       stake_direction: z.string(),
       community: z.object({
         id: z.string(),
-        default_symbol: z.string(),
-        icon_url: z.string(),
+        default_symbol: z.string().nullable(),
+        icon_url: z.string().nullable(),
         name: z.string(),
         chain_node_id: PG_INT.nullable(),
       }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8382

## Description of Changes
- Changes output schema of GetStakeTransactions to match the underlying DB models (name and icon_url can be null)

## Test Plan
- Create a community with no icon_url, try to buy stake then go to the myCommunityStake page. You should see no error.