### PR TITLE
Topics now shows correct character count

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/CreateTopicsSection/CreateTopicSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/CreateTopicsSection/CreateTopicSection.tsx
@@ -131,7 +131,9 @@ export const CreateTopicSection = () => {
             setContentDelta={setDescriptionDelta}
           />
           <div className="description-char-count">
-            <CWText type="caption">Character count: {characterCount}</CWText>
+            <CWText type="caption">
+              Character count: {characterCount}/250
+            </CWText>
           </div>
           <CWText type="caption">
             Choose whether topic is featured in sidebar.

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/CreateTopicsSection/CreateTopicSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/CreateTopicsSection/CreateTopicSection.tsx
@@ -17,7 +17,7 @@ import {
   getTextFromDelta,
 } from 'client/scripts/views/components/react_quill_editor';
 import { DeltaStatic } from 'quill';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
 import useAppStatus from '../../../../../hooks/useAppStatus';
 import './CreateTopicSection.scss';
@@ -39,6 +39,7 @@ export const CreateTopicSection = () => {
   const [descriptionDelta, setDescriptionDelta] = useState<DeltaStatic>(
     createDeltaFromText(''),
   );
+  const [characterCount, setCharacterCount] = useState(0);
 
   const { isWindowExtraSmall } = useBrowserWindow({});
 
@@ -60,6 +61,24 @@ export const CreateTopicSection = () => {
       setIsSaving(false);
     }
   };
+
+  const getCharacterCount = (delta) => {
+    if (!delta || !delta.ops) {
+      return 0;
+    }
+    return delta.ops.reduce((count, op) => {
+      if (typeof op.insert === 'string') {
+        const cleanedText = op.insert.replace(/\n$/, '');
+        return count + cleanedText.length;
+      }
+      return count;
+    }, 0);
+  };
+
+  useEffect(() => {
+    const count = getCharacterCount(descriptionDelta);
+    setCharacterCount(count);
+  }, [descriptionDelta]);
 
   const handleInputValidation = (text: string): [ValidationStatus, string] => {
     // @ts-expect-error <StrictNullChecks/>
@@ -112,9 +131,7 @@ export const CreateTopicSection = () => {
             setContentDelta={setDescriptionDelta}
           />
           <div className="description-char-count">
-            <CWText type="caption">
-              {descriptionDelta?.ops?.[0].insert.length / 250 || 0}
-            </CWText>
+            <CWText type="caption">Character count: {characterCount}</CWText>
           </div>
           <CWText type="caption">
             Choose whether topic is featured in sidebar.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8372 

## Description of Changes
-User now sees correct character count when creating a new topic

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added the label "Character count:" 
-created a function `getCharacterCount` to get the correct character count, as insert within Quill adds a trailing "/n", and would make the count +1 more than it actually was
## Test Plan
- Be an Admin and go into Topics
- create a new topic and give it a description
- -confirm that the character count actively changes and correctly corresponds with the amount of characters you have entered.
