### PR TITLE
Remove xk6

### DIFF
--- a/packages/load-testing/package.json
+++ b/packages/load-testing/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/k6": "^0.51.0"
+    "@types/k6": "^0.52.0"
   },
   "dependencies": {
     "moment": "^2.23.0"

--- a/packages/load-testing/package.json
+++ b/packages/load-testing/package.json
@@ -7,6 +7,7 @@
     "clean": "sudo rm -rf docker/db && rm -rf docker/grafana && rm -rf k6",
     "check-types": "tsc --noEmit",
     "test-load": "chmod u+x scripts/k6.sh && ./scripts/k6.sh",
+    "test-load-native": "chmod u+x scripts/k6.sh && NATIVE_K6=true ./scripts/k6.sh",
     "start": "chmod u+x scripts/start.sh && ./scripts/start.sh",
     "stop": "docker compose -p load-testing down"
   },

--- a/packages/load-testing/readme.md
+++ b/packages/load-testing/readme.md
@@ -34,10 +34,21 @@ remote database is not specified, a Postgres container will be created.
 
 ### test-load
 
-Definition: `chmod u+x scripts/k6.sh && ./scripts/k6.sh <path-to-test-file>`
+Definition: `chmod u+x scripts/k6.sh && ./scripts/k6.sh <path-to-test-file> <environment>`
 
-Description: Creates a k6 binary (`load-test/k6`) containing the `xk6-sql` and `xk6-ts` extensions if it does not exist 
-and then executes the k6 binary with the provided test file.
+Description: Executes the specified Typescript k6 load test using Docker against the specified environment. The
+environment argument is optional (defaults to local) but can be set to frick, frack, or beta.
+
+Considerations: Executing load tests with Docker is less performant than executing them with a native k6 installation
+(see [test-load-native](#test-load-native)). Requires Grafana, Prometheus, Postgres, and the Commonwealth app to be running. 
+See [start](#start).
+
+### test-load-native
+
+Definition: `chmod u+x scripts/k6.sh && NATIVE_K6=true ./scripts/k6.sh <path-to-test-file> <environment>`
+
+Description: Executes the specified Typescript k6 load test using a native/local k6 installation against the specified 
+environment. The environment argument is optional (defaults to local) but can be set to frick, frack, or beta.
 
 Considerations: Requires Grafana, Prometheus, Postgres, and the Commonwealth app to be running. See [start](#start).
 

--- a/packages/load-testing/scripts/k6.sh
+++ b/packages/load-testing/scripts/k6.sh
@@ -15,34 +15,23 @@ run_docker_command() {
     fi
 }
 
-# Determine the OS
-OS=$(uname -s)
-
-K6_BINARY="./k6"
-
-build_k6_binary() {
-    # Execute the appropriate command based on the OS
-    if [ "$OS" == "Linux" ]; then
-        # -u should normally be set to "$(id -u):$(id -g)" but this produces a permission error in some systems
-        run_docker_command run --rm -u root -v "${PWD}:/xk6" grafana/xk6 build --with github.com/grafana/xk6-sql --with github.com/grafana/xk6-ts
-    elif [ "$OS" == "Darwin" ]; then
-        # -u should normally be set to "$(id -u):$(id -g)" but this produces a permission error in some systems
-        run_docker_command run --rm -e GOOS=darwin -u root -v "${PWD}:/xk6" grafana/xk6 build --with github.com/grafana/xk6-sql --with github.com/grafana/xk6-ts
-    else
-        echo "Unsupported OS: $OS"
-        exit 1
-    fi
-}
-
-if [ ! -f "$K6_BINARY" ]; then
-    # Build k6 binary with Docker if it does not exist
-    build_k6_binary
-fi
-
-# If k6 binary exists, require a filepath to a .ts file
 if [ -z "$1" ]; then
-    echo "Usage: pnpm test test/<path_to_file>.spec.ts"
+    echo "Usage: pnpm test-load test/<path_to_file>.spec.ts"
     exit 1
 fi
 
-$K6_BINARY run "$1"
+
+ENVIRONMENT=${2:-local}
+
+if [[ "$ENVIRONMENT" != "local" && "$ENVIRONMENT" != "frick" && "$ENVIRONMENT" != "frack" && "$ENVIRONMENT" != "beta" ]]; then
+    echo "Error: Invalid argument. Accepted values are: local, frick, frack, or beta."
+    exit 1
+fi
+
+if [ "$ENVIRONMENT" == "local" ]; then
+    SERVER_URL='http://host.docker.internal:8080'
+else
+    SERVER_URL=$(heroku config:get SERVER_URL -a commonwealth-"$ENVIRONMENT")
+fi
+
+docker run --rm -v "${PWD}"/test:/test -i grafana/k6:0.52.0-with-browser run -e SERVER_URL="$SERVER_URL" --compatibility-mode=experimental_enhanced "$1"

--- a/packages/load-testing/test/api/new.example.spec.ts
+++ b/packages/load-testing/test/api/new.example.spec.ts
@@ -1,7 +1,7 @@
 import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
 import { check } from 'k6';
 import http from 'k6/http';
-import { TRPC_API_URL } from '../../src/config';
+import { TRPC_API_URL } from '../util/config.ts';
 
 const JWT_token = '';
 

--- a/packages/load-testing/test/api/public.example.spec.ts
+++ b/packages/load-testing/test/api/public.example.spec.ts
@@ -1,7 +1,7 @@
 import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
 import { check } from 'k6';
 import http from 'k6/http';
-import { LEGACY_API_URL } from '../../src/config';
+import { LEGACY_API_URL } from '../util/config.ts';
 
 const JWT_token = '';
 

--- a/packages/load-testing/test/browser/browser.example.spec.ts
+++ b/packages/load-testing/test/browser/browser.example.spec.ts
@@ -1,6 +1,6 @@
 import { check } from 'k6';
-import { browser } from 'k6/experimental/browser';
-import { SERVER_URL } from '../../src/config';
+import { browser } from 'k6/browser';
+import { SERVER_URL } from '../util/config.ts';
 
 export const options = {
   scenarios: {
@@ -41,55 +41,58 @@ export const options = {
 };
 
 export async function dashboard() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     await page.goto(SERVER_URL);
-    page.waitForLoadState('load');
+    await page.waitForLoadState('load');
 
-    check(page, {
-      'Page title': (page) => page.title() == 'Common',
+    const pageTitle = await page.title();
+    check(pageTitle, {
+      'Page title': (pageTitle) => pageTitle == 'Common',
     });
   } finally {
-    page.close();
+    await page.close();
   }
 }
 
 export async function layer_zero() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     await page.goto(`${SERVER_URL}/layerzero/discussion`);
-    page.waitForLoadState('load');
+    await page.waitForLoadState('load');
 
-    check(page, {
-      'Page title': (page) => page.title() == 'Common',
+    const pageTitle = await page.title();
+    check(pageTitle, {
+      'Page title': (pageTitle) => pageTitle == 'Common',
     });
   } finally {
-    page.close();
+    await page.close();
   }
 }
 
 export async function search() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     await page.goto(`${SERVER_URL}/dashboard/global`);
-    page.waitForLoadState('load');
+    await page.waitForLoadState('load');
     const searchParm = ['Proto', 'Common', 'Layer0', 'Discussion', 'Dashboard'];
     const randomParm =
       searchParm[Math.floor(Math.random() * searchParm.length)];
 
     // Random search
     const searchBox = page.locator('input[placeholder="Search Common"]');
-    searchBox.type(randomParm);
-    searchBox.press('Enter');
-    page.waitForLoadState('load');
+    await searchBox.type(randomParm);
+    await searchBox.press('Enter');
+    await page.waitForLoadState('load');
     console.log(page.url());
-    check(page, {
-      'Page title': (page) => page.title() == 'Common',
+    const pageTitle = await page.title();
+    check(pageTitle, {
+      'Page title': (pageTitle) => pageTitle == 'Common',
     });
   } finally {
-    page.close();
+    await page.close();
   }
 }

--- a/packages/load-testing/test/util/config.ts
+++ b/packages/load-testing/test/util/config.ts
@@ -1,4 +1,5 @@
-export const SERVER_URL = __ENV.SERVER_URL ?? 'http://localhost:8080';
+export const SERVER_URL =
+  __ENV.SERVER_URL ?? 'http://host.docker.internal:8080';
 
 export const TRPC_API_URL = __ENV.TRPC_API_URL ?? `${SERVER_URL}/api/v1/rest`;
 

--- a/packages/load-testing/tsconfig.json
+++ b/packages/load-testing/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "typeRoots": ["test/types.d.ts"]
+    "typeRoots": ["test/types.d.ts"],
+    "allowImportingTsExtensions": true
   },
   "include": ["test", "src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1410,8 +1410,8 @@ importers:
         version: 2.30.1
     devDependencies:
       '@types/k6':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.52.0
+        version: 0.52.0
 
   packages/scripts:
     dependencies:
@@ -6714,10 +6714,10 @@ packages:
         integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==,
       }
 
-  '@types/k6@0.51.0':
+  '@types/k6@0.52.0':
     resolution:
       {
-        integrity: sha512-xelcvFGPI4VYrV5ozADmRuFQBKmDqDRzxfHVuCDD1/firZiSQvTP0pntxHuYUSkRyL8I83kvABXUlnLYNT2VuA==,
+        integrity: sha512-yaw2wg61nKQtToDML+nngzgXVjZ6wNA4R0Q3jKDTeadG5EqfZgis5a1Q2hwY7kjuGuXmu8eM6gHg3tgnOj4vNw==,
       }
 
   '@types/lodash@4.17.1':
@@ -7675,10 +7675,25 @@ packages:
       }
     engines: { node: '>=0.4.0' }
 
+  acorn-walk@8.3.3:
+    resolution:
+      {
+        integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==,
+      }
+    engines: { node: '>=0.4.0' }
+
   acorn@8.11.3:
     resolution:
       {
         integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==,
+      }
+    engines: { node: '>=0.4.0' }
+    hasBin: true
+
+  acorn@8.12.1:
+    resolution:
+      {
+        integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==,
       }
     engines: { node: '>=0.4.0' }
     hasBin: true
@@ -9476,6 +9491,18 @@ packages:
     resolution:
       {
         integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==,
+      }
+    engines: { node: '>=6.0' }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.5:
+    resolution:
+      {
+        integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==,
       }
     engines: { node: '>=6.0' }
     peerDependencies:
@@ -11844,10 +11871,10 @@ packages:
       }
     engines: { node: '>= 6' }
 
-  https-proxy-agent@7.0.4:
+  https-proxy-agent@7.0.5:
     resolution:
       {
-        integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==,
+        integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==,
       }
     engines: { node: '>= 14' }
 
@@ -19147,6 +19174,21 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.0:
+    resolution:
+      {
+        integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==,
+      }
+    engines: { node: '>=10.0.0' }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.5.0:
     resolution:
       {
@@ -23829,7 +23871,7 @@ snapshots:
     dependencies:
       '@types/node': 20.12.10
 
-  '@types/k6@0.51.0': {}
+  '@types/k6@0.52.0': {}
 
   '@types/lodash@4.17.1': {}
 
@@ -24741,7 +24783,13 @@ snapshots:
 
   acorn-walk@8.3.2: {}
 
+  acorn-walk@8.3.3:
+    dependencies:
+      acorn: 8.12.1
+
   acorn@8.11.3: {}
+
+  acorn@8.12.1: {}
 
   adm-zip@0.4.16: {}
 
@@ -24759,7 +24807,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -25867,6 +25915,10 @@ snapshots:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.3.5:
+    dependencies:
+      ms: 2.1.2
 
   decache@3.1.0:
     dependencies:
@@ -27639,7 +27691,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -27679,10 +27731,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.4:
+  https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -28231,35 +28283,6 @@ snapshots:
     dependencies:
       jsdom: 24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  jsdom@24.0.0:
-    dependencies:
-      cssstyle: 4.0.1
-      data-urls: 5.0.0
-      decimal.js: 10.4.3
-      form-data: 4.0.0
-      html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.4
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.10
-      parse5: 7.1.2
-      rrweb-cssom: 0.6.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.4
-      w3c-xmlserializer: 5.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 3.1.1
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 14.0.0
-      ws: 8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       cssstyle: 4.0.1
@@ -28268,7 +28291,7 @@ snapshots:
       form-data: 4.0.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.4
+      https-proxy-agent: 7.0.5
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.10
       parse5: 7.1.2
@@ -28281,7 +28304,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-      ws: 8.17.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -31512,8 +31535,8 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.12.10
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -32044,7 +32067,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.12.10
-      jsdom: 24.0.0
+      jsdom: 24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -32686,6 +32709,11 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 6.0.3
+
+  ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
 
   ws@8.5.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     optionalDependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8375 

## Description of Changes
- Removes xk6 binary building to facilitate k6 cloud execution in #8064
- Adds the ability to execute k6 tests using a native/local k6 installation or Docker.
- Modifies k6 script to automatically fetch Heroku env `SERVER_URL` if a Heroku env is specified

## Test Plan
- Follow quick start instructions in the readme

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 