### PR TITLE
De-duped winners tags for contests

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -182,6 +182,30 @@ const fetchBulkThreads = (props) => {
       },
     );
 
+    /**
+     * TODO: When we fix the content_id issue for 'added' contests, we should remove this if statement and body
+     **/
+    if (res.data.result) {
+      // Filters out unique contests for each associated contest array.
+      const uniqueContestIds = new Set<string>();
+
+      res.data.result.threads = res.data.result.threads.map((thread) => {
+        const filteredContests = thread.associatedContests?.filter((ac) => {
+          const key = `${ac.contest_id}:${ac.content_id}`;
+          if (!uniqueContestIds.has(key)) {
+            uniqueContestIds.add(key);
+            return true;
+          }
+          return false;
+        });
+
+        return {
+          ...thread,
+          associatedContests: filteredContests,
+        };
+      });
+    }
+
     // transform the response
     const transformedData = {
       ...res.data.result,

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
@@ -23,7 +23,7 @@ const ThreadContestTagContainer = ({
     <>
       {showContestWinnerTag &&
         contestWinners.map((winner, index) => {
-          if (!winner) {
+          if (!winner || winner?.prize === 0) {
             return null;
           }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8402

## Description of Changes
- Dedupe contest winners
- Remove 0th winner from threads that did not win

## Test Plan
- Check the /cappuccino/discussions with the QA env db dump.