### PR TITLE
Show proper error messages when user is trying to auth with uninitiated wallet

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_like_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/keplr_like_web_wallet.ts
@@ -87,7 +87,7 @@ class KeplrLikeWebWalletController implements IWebWallet<AccountData> {
 
   public getSessionSigner() {
     return new CosmosSignerCW({
-      bech32Prefix: app.chain?.meta.bech32Prefix || 'osmo',
+      bech32Prefix: app.chain?.meta?.bech32Prefix || 'osmo',
       signer: {
         type: 'amino',
         signAmino: window.wallet.signAmino,
@@ -128,14 +128,14 @@ class KeplrLikeWebWalletController implements IWebWallet<AccountData> {
           `Failed to enable chain: ${err.message}. Trying experimentalSuggestChain...`,
         );
 
-        const bech32Prefix = app.chain.meta.bech32Prefix?.toLowerCase();
+        const bech32Prefix = app.chain?.meta?.bech32Prefix?.toLowerCase();
         const info: ChainInfo = {
           chainId: this._chainId,
-          chainName: app.chain.meta.name,
+          chainName: app.chain?.meta?.name,
           rpc: url,
           // Note that altWalletUrl on Cosmos chains should be the REST endpoint -- if not available, we
           // use the RPC url as hack, which will break some querying functionality but not signing.
-          rest: app.chain.meta.node.altWalletUrl || url,
+          rest: app.chain?.meta?.node?.altWalletUrl || url,
           bip44: {
             coinType: 118,
           },
@@ -149,23 +149,23 @@ class KeplrLikeWebWalletController implements IWebWallet<AccountData> {
           },
           currencies: [
             {
-              coinDenom: app.chain.meta.default_symbol,
-              coinMinimalDenom: `u${app.chain.meta.default_symbol.toLowerCase()}`,
-              coinDecimals: app.chain.meta.decimals || 6,
+              coinDenom: app.chain?.meta?.default_symbol,
+              coinMinimalDenom: `u${app.chain?.meta?.default_symbol?.toLowerCase()}`,
+              coinDecimals: app.chain?.meta?.decimals || 6,
             },
           ],
           feeCurrencies: [
             {
-              coinDenom: app.chain.meta.default_symbol,
-              coinMinimalDenom: `u${app.chain.meta.default_symbol.toLowerCase()}`,
-              coinDecimals: app.chain.meta.decimals || 6,
+              coinDenom: app.chain?.meta?.default_symbol,
+              coinMinimalDenom: `u${app.chain?.meta?.default_symbol?.toLowerCase()}`,
+              coinDecimals: app.chain?.meta?.decimals || 6,
               gasPriceStep: { low: 0, average: 0.025, high: 0.03 },
             },
           ],
           stakeCurrency: {
-            coinDenom: app.chain.meta.default_symbol,
-            coinMinimalDenom: `u${app.chain.meta.default_symbol.toLowerCase()}`,
-            coinDecimals: app.chain.meta.decimals || 6,
+            coinDenom: app.chain?.meta?.default_symbol,
+            coinMinimalDenom: `u${app.chain?.meta?.default_symbol?.toLowerCase()}`,
+            coinDecimals: app.chain?.meta?.decimals || 6,
           },
           features: [],
         };

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/phantom_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/phantom_web_wallet.ts
@@ -68,6 +68,11 @@ class PhantomWebWalletController implements IWebWallet<string> {
       this._enabled = true;
     } catch (err) {
       this._enabling = false;
+      if (!window.solana.isConnected) {
+        throw new Error(
+          'No Phantom accounts found! Please setup your Phantom wallet and try again.',
+        );
+      }
       throw new Error('Could not connect to Phantom wallet!');
     }
   }

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -402,10 +402,21 @@ const useAuthentication = (props: UseAuthenticationProps) => {
   };
 
   const onWalletSelect = async (wallet: Wallet) => {
-    await wallet.enable();
+    try {
+      await wallet.enable();
+    } catch (error) {
+      notifyError(error?.message || error);
+      return;
+    }
     setSelectedWallet(wallet);
 
     const selectedAddress = getAddressFromWallet(wallet);
+    if (!selectedAddress) {
+      notifyError(
+        `We couldn't fetch an address from your wallet! Please make sure your wallet account is setup and try again`,
+      );
+      return;
+    }
 
     if (userOnboardingEnabled) {
       // check if address exists


### PR DESCRIPTION
## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8239

## Description of Changes
Show proper error messages when user is trying to auth with uninitiated wallet

## "How We Fixed It"
N/A

## Test Plan
It would require freshly installing all supported wallets and intentionally **not setting up a wallet account**. I recommend creating a new browser profile and installing fresh wallets there. 

The wallets to install are `Metamask`, `Coinbase`, `Keplr`, `Leap`, `Phantom`, `Polkadot` and `Station` wallet. Once installed perform these steps

1. Visit the global dashboard page
2. Open auth modal
3. Click on each wallet auth option and verify you see toast errors that the wallet is not initialized
4. Now visit specific community pages for different chains ex: `/dydx` for Ethereum, `/agoric` for cosmos, `/solana` for phantom, `/stafi` for polkadot, `/terra` for station wallet.
5. Repeat step 3 when visiting each of the communities listed in step 4.


## Deployment Plan
N/A

## Other Considerations
N/A