### PR TITLE
user now able to drag and drop image in comment

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -54,10 +54,6 @@ export const useImageDropAndPaste = ({
           }
           return true;
         });
-        setContentDelta({
-          ops: opsWithoutBase64Images,
-          ___isMarkdown: true,
-        } as SerializableDeltaStatic);
 
         const file = base64ToFile(imageDataUrl, imageType);
 
@@ -73,6 +69,7 @@ export const useImageDropAndPaste = ({
         editor.insertText(selectedIndex, `![image](${uploadedFileUrl})`);
 
         setContentDelta({
+          ops: opsWithoutBase64Images,
           ...editor.getContents(),
           ___isMarkdown: true,
         } as SerializableDeltaStatic); // sync state with editor content


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8408 

## Description of Changes
User is now able to drag and drop an image in a comment

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-consolidated code inside `setContentDelta` and deleted redundant code.

## Test Plan
- go to a comment on any thread
- drag and drop an image
- confirm that you are able to click submit and see the image as a comment


https://github.com/hicommonwealth/commonwealth/assets/69872984/b12f27fe-7455-486b-8963-f52ab3d98b2a

