### PR TITLE
Fix custom stages crash on user dashboard.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -126,7 +126,7 @@ const FeedThread = ({ thread }: { thread: Thread }) => {
       threadHref={discussionLink}
       onCommentBtnClick={() => navigate(`${discussionLink}?focusComments=true`)}
       disabledActionsTooltipText={disabledActionsTooltipText}
-      customStages={chain.customStages}
+      customStages={chain?.customStages}
       hideReactionButton
       hideUpvotesDrawer
       layoutType="community-first"


### PR DESCRIPTION
## Link to Issue
Closes: #8433 

## Description of Changes
- Shipped as v1.5.0-1, this PR lands change onto master.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Null check for custom stages.

## Test Plan
- Ensure global feed loads. Error should trigger if a community w/o custom stages gets a thread on the list.
