### PR TITLE
Add performance metrics for contests

### DIFF
--- a/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
+++ b/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
@@ -192,6 +192,10 @@ export class RabbitMQAdapter implements Broker {
     topic: BrokerSubscriptions,
     handler: EventsHandlerMetadata<EventSchemas>,
     retryStrategy?: RetryStrategyFn,
+    hooks?: {
+      beforeHandleEvent: (topic: string, event: any, context: any) => void;
+      afterHandleEvent: (topic: string, event: any, context: any) => void;
+    },
   ): Promise<boolean> {
     if (!this.initialized) {
       return false;
@@ -216,6 +220,16 @@ export class RabbitMQAdapter implements Broker {
       subscription.on(
         'message',
         (_message: Message, content: any, ackOrNackFn: AckOrNack) => {
+          const { beforeHandleEvent, afterHandleEvent } = hooks || {};
+          const context: any = {};
+          try {
+            beforeHandleEvent?.(topic, content, context);
+          } catch (err) {
+            this._log.error(
+              `afterHandleEvent failed on topic ${topic}`,
+              err as Error,
+            );
+          }
           handleEvent(handler, content, true)
             .then(() => {
               this._log.debug('Message Acked', {
@@ -235,6 +249,16 @@ export class RabbitMQAdapter implements Broker {
                   ackOrNackFn,
                   this._log,
                 );
+            })
+            .finally(async () => {
+              try {
+                afterHandleEvent?.(topic, content, context);
+              } catch (err) {
+                this._log.error(
+                  `afterHandleEvent failed on topic ${topic}`,
+                  err as Error,
+                );
+              }
             });
         },
       );

--- a/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
+++ b/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
@@ -226,7 +226,7 @@ export class RabbitMQAdapter implements Broker {
             beforeHandleEvent?.(topic, content, context);
           } catch (err) {
             this._log.error(
-              `afterHandleEvent failed on topic ${topic}`,
+              `beforeHandleEvent failed on topic ${topic}`,
               err as Error,
             );
           }

--- a/libs/core/src/ports/interfaces.ts
+++ b/libs/core/src/ports/interfaces.ts
@@ -216,6 +216,10 @@ export interface Broker extends Disposable {
     topic: BrokerSubscriptions,
     handler: EventsHandlerMetadata<Inputs>,
     retryStrategy?: RetryStrategyFn,
+    hooks?: {
+      beforeHandleEvent: (topic: string, content: any, context: any) => void;
+      afterHandleEvent: (topic: string, content: any, context: any) => void;
+    },
   ): Promise<boolean>;
 }
 

--- a/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
+++ b/packages/commonwealth/server/workers/commonwealthConsumer/commonwealthConsumer.ts
@@ -74,6 +74,16 @@ export async function setupCommonwealthConsumer(): Promise<void> {
     BrokerSubscriptions.ContestWorkerPolicy,
     ContestWorker(),
     buildRetryStrategy(undefined, 20_000),
+    {
+      beforeHandleEvent: (topic, event, context) => {
+        context.start = Date.now();
+      },
+      afterHandleEvent: (topic, event, context) => {
+        const duration = Date.now() - context.start;
+        const handler = `${topic}.${event.name}`;
+        stats().histogram(`cw.handlerExecutionTime`, duration, { handler });
+      },
+    },
   );
 
   const contestProjectionsSubRes = await brokerInstance.subscribe(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8254

## Description of Changes
- Updates Broker interface + RMQ adapter to support before/after hooks when handling event subscriptions
- Applies before/after hooks in consumer for contest worker policy to send event handler execution time to DD

## Test Plan
- Will need to test on frack/QA:
  - Create thread
  - In DD dashboard, confirm that under the `cw.handlerExecutionTime` event there's a `ContestWorkerPolicy.ThreadCreated` integer value

## Deployment Plan
N/A

## Other Considerations
N/A