### PR TITLE
Showing topic contest icon only for active contest

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -80,7 +80,11 @@ export const NewThreadForm = () => {
     setCanShowGatingBanner,
   } = useNewThreadForm(communityId, topicsForSelector);
 
-  const isTopicInContest = checkIsTopicInContest(contestsData, threadTopic?.id);
+  const isTopicInContest = checkIsTopicInContest(
+    contestsData,
+    threadTopic?.id,
+    true,
+  );
 
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();

--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/helpers/helpers.ts
@@ -1,5 +1,6 @@
 import { notifyError } from 'controllers/app/notifications';
 import { Contest } from 'views/pages/CommunityManagement/Contests/ContestsList';
+import { isContestActive } from 'views/pages/CommunityManagement/Contests/utils';
 import { ThreadKind } from '../../../../models/types';
 import type { NewThreadFormType } from '../types';
 import { NewThreadErrors } from '../types';
@@ -25,13 +26,21 @@ export const checkNewThreadErrors = (
   }
 };
 
-export const checkIsTopicInContest = (data: Contest[], topicId?: number) => {
+export const checkIsTopicInContest = (
+  data: Contest[],
+  topicId?: number,
+  checkOnlyActiveContest = false,
+) => {
   if (!topicId) {
     return false;
   }
 
-  return (data || []).some(
-    (item) =>
-      item?.topics && item?.topics.some((topic) => topic?.id === topicId),
-  );
+  return (data || [])
+    .filter((item) =>
+      checkOnlyActiveContest ? isContestActive({ contest: item }) : true,
+    )
+    .some(
+      (item) =>
+        item?.topics && item?.topics.some((topic) => topic?.id === topicId),
+    );
 };

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -12,7 +12,7 @@ import {
 } from 'views/components/CommunityStake';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
-import { getUniqueTopicIdsIncludedInContest } from 'views/components/sidebar/helpers';
+import { getUniqueTopicIdsIncludedInActiveContest } from 'views/components/sidebar/helpers';
 import { SubscriptionButton } from 'views/components/subscription_button';
 import ManageCommunityStakeModal from 'views/modals/ManageCommunityStakeModal/ManageCommunityStakeModal';
 import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCommunityContests';
@@ -64,7 +64,7 @@ export const CommunitySection = ({ showSkeleton }: CommunitySectionProps) => {
     useCommunityContests();
 
   const topicIdsIncludedInContest =
-    getUniqueTopicIdsIncludedInContest(contestsData);
+    getUniqueTopicIdsIncludedInActiveContest(contestsData);
 
   if (showSkeleton || isLoading || isContestDataLoading)
     return <CommunitySectionSkeleton />;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/helpers.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 
 import app from 'state';
+import { Contest } from 'views/pages/CommunityManagement/Contests/ContestsList';
+import { isContestActive } from 'views/pages/CommunityManagement/Contests/utils';
 import type { ToggleTree } from './types';
 
 function comparisonCustomizer(value1, value2) {
@@ -20,17 +22,21 @@ export function verifyCachedToggleTree(
   return _.isEqualWith(cachedTree, toggleTree, comparisonCustomizer);
 }
 
-export const getUniqueTopicIdsIncludedInContest = (
-  contestData: {
-    topics?: { id?: number }[];
-  }[],
+export const getUniqueTopicIdsIncludedInActiveContest = (
+  contestData: Contest[],
 ) => {
   if (!contestData) {
     return [];
   }
 
-  const topicIds = contestData.reduce((acc, curr) => {
-    return [...acc, ...(curr.topics || []).map((t) => t.id)];
+  const topicIds = contestData.reduce((acc, contest) => {
+    const isActive = isContestActive({ contest });
+
+    if (!isActive) {
+      return acc;
+    }
+
+    return [...acc, ...(contest?.topics || []).map((t) => t.id)];
   }, []);
 
   return [...new Set(topicIds)];

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -21,6 +21,7 @@ import { SharePopoverOld } from 'views/components/share_popover_old';
 import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 
+import { isContestActive } from '../../utils';
 import ContestAlert from '../ContestAlert';
 import ContestCountdown from '../ContestCountdown';
 
@@ -84,8 +85,12 @@ const ContestCard = ({
 
   const { mutateAsync: cancelContest } = useCancelContestMutation();
 
-  const hasEnded = moment(finishDate) < moment();
-  const isActive = isCancelled ? false : !hasEnded;
+  const isActive = isContestActive({
+    contest: {
+      cancelled: isCancelled,
+      contests: [{ end_time: new Date(finishDate) }],
+    },
+  });
 
   useRerender({ isActive, interval: 6000 });
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
@@ -443,6 +443,7 @@ const DetailsFormStep = ({
                       <div key={topic.id} className="list-row">
                         <CWText>{topic.name}</CWText>
                         <CWToggle
+                          disabled={editMode}
                           checked={
                             toggledTopicList.find((t) => t.id === topic.id)
                               ?.checked
@@ -455,6 +456,7 @@ const DetailsFormStep = ({
                   <div className="list-footer">
                     <CWText>All</CWText>
                     <CWToggle
+                      disabled={editMode}
                       checked={allTopicsToggled}
                       size="small"
                       onChange={handleToggleAllTopics}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/utils.ts
@@ -1,0 +1,10 @@
+import moment from 'moment';
+import { Contest } from './ContestsList';
+
+// checks if contest has ended or if it is cancelled
+export const isContestActive = ({ contest }: { contest: Contest }) => {
+  // first item is the most recent contest
+  const { end_time } = contest?.contests?.[0] || {};
+  const hasEnded = moment(end_time) < moment();
+  return contest?.cancelled ? false : !hasEnded;
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -24,13 +24,13 @@ import { getThreadActionTooltipText } from 'helpers/threads';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import { useFlag } from 'hooks/useFlag';
 import useManageDocumentTitle from 'hooks/useManageDocumentTitle';
-import moment from 'moment';
 import 'pages/discussions/index.scss';
 import { useRefreshMembershipQuery } from 'state/api/groups';
 import Permissions from 'utils/Permissions';
 import { checkIsTopicInContest } from 'views/components/NewThreadForm/helpers';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCommunityContests';
+import { isContestActive } from 'views/pages/CommunityManagement/Contests/utils';
 import { AdminOnboardingSlider } from '../../components/AdminOnboardingSlider';
 import { UserTrainingSlider } from '../../components/UserTrainingSlider';
 import { DiscussionsFeedDiscovery } from './DiscussionsFeedDiscovery';
@@ -159,12 +159,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     const isContestInTopic = (contest.topics || []).find(
       (topic) => topic.id === topicId,
     );
-    // @ts-expect-error <StrictNullChecks/>
-    const { end_time } = contest.contests[0] || {};
-    const hasEnded = moment(end_time) < moment();
-    const isContestActive = contest.cancelled ? false : !hasEnded;
-
-    return isContestInTopic && isContestActive;
+    const isActive = isContestActive({ contest });
+    return isContestInTopic && isActive;
   });
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8412 
Closes: #8421 

## Description of Changes
- hide trophy icon for contests that are not active anymore
- created util that calculates if the contest is active => it is reused in couple places 
- disabled editing topics in running contest 

## Test Plan
- create contest with topic-A
- trophy icon should be visible next to the topic-A menu item
- wait till the contest is finished or cancel it
- trophy icon should NOT be visible next to the topic-A menu item

- go to edit contest view
- topics section should be disabled

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

