### PR TITLE
Fix EVM_CE_POLL_INTERVAL default value parsing

### DIFF
--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -116,7 +116,7 @@ export const config = configure(
         10,
       ),
       MESSAGE_RELAYER_PREFETCH: parseInt(MESSAGE_RELAYER_PREFETCH ?? '50', 10),
-      EVM_CE_POLL_INTERVAL_MS: parseInt(EVM_CE_POLL_INTERVAL ?? '120_000', 10),
+      EVM_CE_POLL_INTERVAL_MS: parseInt(EVM_CE_POLL_INTERVAL ?? '120000', 10),
     },
   },
   z.object({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8439

## Description of Changes
- Title
- Checked all other instances of env var parsing with `parseInt`

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 