### PR TITLE
Israel.7440 8125.remove proposal in modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalFooter/CWModalFooter.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWModal/CWModalFooter/CWModalFooter.scss
@@ -3,4 +3,19 @@
   justify-content: flex-end;
   padding: 16px 24px 24px 24px;
   gap: 8px;
+
+  &.proposal-modal {
+    display: flex;
+    justify-content: space-between;
+
+    .left-buttons {
+      display: flex;
+      align-items: start;
+    }
+    .right-buttons {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  }
 }

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector.tsx
@@ -5,8 +5,8 @@ import type { SnapshotProposal } from 'helpers/snapshot_utils';
 import { loadMultipleSpacesData } from 'helpers/snapshot_utils';
 
 import app from 'state';
-import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { QueryList } from 'views/components/component_kit/cw_query_list';
+import { CWTextInput } from 'views/components/component_kit/cw_text_input';
 import { SnapshotProposalSelectorItem } from 'views/components/snapshot_proposal_selector';
 
 type SnapshotProposalSelectorProps = {
@@ -40,7 +40,7 @@ export const SnapshotProposalSelector = ({
       loadMultipleSpacesData(app.chain.meta.snapshot).then((data = []) => {
         const loadedProposals = data.reduce(
           (acc, curr) => [...acc, ...curr.proposals],
-          []
+          [],
         );
 
         setAllProposals(loadedProposals);
@@ -54,15 +54,15 @@ export const SnapshotProposalSelector = ({
       allProposals
         .sort((a, b) => b.created - a.created)
         .filter(({ title }) =>
-          title.toLowerCase().includes(searchTerm.toLowerCase())
+          title.toLowerCase().includes(searchTerm.toLowerCase()),
         ),
-    [allProposals, searchTerm]
+    [allProposals, searchTerm],
   );
 
   const renderItem = useCallback(
     (i: number, snapshot: SnapshotProposal) => {
       const isSelected = !!snapshotProposalsToSet.find(
-        ({ id }) => id === snapshot.id
+        ({ id }) => id === snapshot.id,
       );
 
       return (
@@ -73,7 +73,7 @@ export const SnapshotProposalSelector = ({
         />
       );
     },
-    [onSelect, snapshotProposalsToSet]
+    [onSelect, snapshotProposalsToSet],
   );
 
   if (!app.chain || !app.activeChainId()) {
@@ -98,7 +98,7 @@ export const SnapshotProposalSelector = ({
         placeholder="Search for snapshot proposals"
         iconRightonClick={handleClearButtonClick}
         value={searchTerm}
-        iconRight="close"
+        iconRight={searchTerm ? 'close' : 'magnifyingGlass'}
         onInput={handleInputChange}
       />
 

--- a/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
+++ b/packages/commonwealth/client/scripts/views/components/snapshot_proposal_selector/snapshot_proposal_selector_item.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import type { SnapshotProposal } from 'helpers/snapshot_utils';
+import React from 'react';
+import smartTruncate from 'smart-truncate';
 import { CWCheck } from 'views/components/component_kit/cw_icons/cw_icons';
 import { CWText } from '../component_kit/cw_text';
-import smartTruncate from 'smart-truncate';
 interface SnapshotProposalSelectorItemProps {
   snapshot: SnapshotProposal;
   isSelected: boolean;

--- a/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
@@ -104,7 +104,7 @@ export const ThreadSelector = ({
         placeholder="Search thread titles..."
         iconRightonClick={handleClearButtonClick}
         value={searchTerm}
-        iconRight="close"
+        iconRight={searchTerm ? 'close' : 'magnifyingGlass'}
         onInput={handleInputChange}
       />
 

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -53,12 +53,16 @@ type UpdateProposalStatusModalProps = {
   onChangeHandler?: (stage: string, links?: Link[]) => void;
   onModalClose: () => void;
   thread: Thread;
+  snapshotProposalConnected?: boolean;
+  initialSnapshotLinks?: Link[];
 };
 
 export const UpdateProposalStatusModal = ({
   onChangeHandler,
   onModalClose,
   thread,
+  snapshotProposalConnected,
+  initialSnapshotLinks,
 }: UpdateProposalStatusModalProps) => {
   const { customStages } = app.chain.meta;
   const stages = parseCustomStages(customStages);
@@ -177,7 +181,6 @@ export const UpdateProposalStatusModal = ({
             identifier: String(sn.id),
           })),
         });
-
         links = updatedThread.links;
       }
     } catch (err) {
@@ -231,6 +234,25 @@ export const UpdateProposalStatusModal = ({
     // @ts-expect-error <StrictNullChecks/>
     onChangeHandler?.(tempStage, links);
     onModalClose();
+  };
+
+  const handleRemoveProposal = async () => {
+    try {
+      await deleteThreadLinks({
+        communityId: app.activeChainId(),
+        threadId: thread.id,
+        links: [
+          {
+            source: LinkSource.Snapshot,
+            identifier: initialSnapshotLinks?.[0]?.identifier ?? '',
+          },
+        ],
+      });
+      onModalClose();
+    } catch (error) {
+      console.log(error);
+      throw new Error('Failed to remove linked proposal');
+    }
   };
 
   const setVotingStage = () => {
@@ -303,25 +325,32 @@ export const UpdateProposalStatusModal = ({
           />
         )}
       </CWModalBody>
-      <CWModalFooter>
-        <CWButton
-          label="Remove proposal"
-          buttonType="destructive"
-          buttonHeight="sm"
-          onClick={onModalClose}
-        />
-        <CWButton
-          label="Cancel"
-          buttonType="secondary"
-          buttonHeight="sm"
-          onClick={onModalClose}
-        />
-        <CWButton
-          buttonType="primary"
-          buttonHeight="sm"
-          label="Save changes"
-          onClick={handleSaveChanges}
-        />
+      <CWModalFooter className="proposal-modal">
+        <div className="left-button">
+          {snapshotProposalConnected && (
+            <CWButton
+              label="Remove proposal"
+              buttonType="destructive"
+              buttonHeight="sm"
+              className="test"
+              onClick={handleRemoveProposal}
+            />
+          )}
+        </div>
+        <div className="right-buttons">
+          <CWButton
+            label="Cancel"
+            buttonType="secondary"
+            buttonHeight="sm"
+            onClick={onModalClose}
+          />
+          <CWButton
+            buttonType="primary"
+            buttonHeight="sm"
+            label="Save changes"
+            onClick={handleSaveChanges}
+          />
+        </div>
       </CWModalFooter>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -305,6 +305,12 @@ export const UpdateProposalStatusModal = ({
       </CWModalBody>
       <CWModalFooter>
         <CWButton
+          label="Remove proposal"
+          buttonType="destructive"
+          buttonHeight="sm"
+          onClick={onModalClose}
+        />
+        <CWButton
           label="Cancel"
           buttonType="secondary"
           buttonHeight="sm"

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/linked_proposals_card.tsx
@@ -157,6 +157,8 @@ export const LinkedProposalsCard = ({
           <UpdateProposalStatusModal
             thread={thread}
             onModalClose={() => setIsModalOpen(false)}
+            snapshotProposalConnected={showSnapshot}
+            initialSnapshotLinks={initialSnapshotLinks}
           />
         }
         onClose={() => setIsModalOpen(false)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8125 
Closes: #7440 

## Description of Changes
- User is now able to remove a connected snapshot proposal from thread

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added a new "Remove proposal' button that removes the saved proposal
-added a little more functionality to the `snapshot_proposal_selector.tsx` and added the same to `thread_selector.tsx` so that they would match
## Test Plan
- be an admin and create a thread
- make sure you have a snapshot space connected to that community. You can use commonspacetester.eth if you don't have one
- now link a proposal
- open the modal again and confirm that you now see a button to Remove proposal
- click that button and confirm that the proposal is now removed from the thread
