### PR TITLE
Fix infinite bug in members page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -156,7 +156,13 @@ const CommunityMembersPage = () => {
     },
     {
       initialCursor: 1,
-      getNextPageParam: (lastPage) => lastPage.page + 1,
+      getNextPageParam: (lastPage) => {
+        const nextPageNum = lastPage.page + 1;
+        if (nextPageNum <= lastPage.totalPages) {
+          return nextPageNum;
+        }
+        return undefined;
+      },
       enabled: user.activeAccount?.address ? !!memberships : true,
     },
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8441

## Description of Changes
- added additional check before firing refetch for next page
- credits to @mzparacha for spending time on this and providing solution 🙏 


## Test Plan
- go to members page in some community like dydx
- type eg `0x`
- you should not see infinite loop in network tab

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- during debugging this issue, found some bad UX pattern. I asked [on Slack](https://commonxyz.slack.com/archives/C050AE0URFH/p1721047019902759) what is expected behaviour. Will create a ticket if I know more details