### PR TITLE
Add url links to contest docs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/ContestThreadBanner/ContestThreadBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/ContestThreadBanner/ContestThreadBanner.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
 import { CWText } from 'views/components/component_kit/cw_text';
 import CWBanner from 'views/components/component_kit/new_designs/CWBanner';
+import { CONTEST_FAQ_URL } from 'views/pages/CommunityManagement/Contests/utils';
 
 import './ContestThreadBanner.scss';
 
@@ -32,11 +33,7 @@ const ContestThreadBanner = ({
         </div>
       }
       footer={
-        <a
-          href="https://blog.commonwealth.im"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={CONTEST_FAQ_URL} target="_blank" rel="noopener noreferrer">
           Learn more about contests
         </a>
       }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/EmptyContestsList/EmptyCard/EmptyCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/EmptyContestsList/EmptyCard/EmptyCard.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 
+import { CONTEST_FAQ_URL } from '../../utils';
+
 import './EmptyCard.scss';
 
 interface EmptyCardProps {
@@ -17,7 +19,7 @@ interface EmptyCardProps {
 
 const EmptyCard = ({ img, title, subtitle, button }: EmptyCardProps) => {
   const handleOpenLink = () => {
-    window.open('https://commonwealth.im/', '_blank');
+    window.open(CONTEST_FAQ_URL, '_blank');
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/DetailsFormStep.tsx
@@ -19,6 +19,7 @@ import { CWToggle } from 'views/components/component_kit/new_designs/cw_toggle';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import CommunityManagementLayout from 'views/pages/CommunityManagement/common/CommunityManagementLayout';
 
+import { CONTEST_FAQ_URL } from '../../../utils';
 import {
   ContestFeeType,
   ContestFormData,
@@ -184,7 +185,13 @@ const DetailsFormStep = ({
               create engagement incentives.{' '}
               <CWText fontWeight="medium">Contests last 7 days</CWText> in
               blockchain time.{' '}
-              <a href="https://blog.commonwealth.im">Learn more</a>
+              <a
+                href={CONTEST_FAQ_URL}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Learn more
+              </a>
             </CWText>
           </>
         )

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/utils.ts
@@ -8,3 +8,6 @@ export const isContestActive = ({ contest }: { contest: Contest }) => {
   const hasEnded = moment(end_time) < moment();
   return contest?.cancelled ? false : !hasEnded;
 };
+
+export const CONTEST_FAQ_URL =
+  'https://docs.common.xyz/commonwealth/for-admins-and-mods/enabling-and-running-contests';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8452

## Description of Changes
- added link to the 

## Test Plan
- go to empty contest list or
- go to contest launch page
- or go to create thread page and select topic that is included in the contest
- every "learn more" link should lead to [this page](https://docs.common.xyz/commonwealth/for-admins-and-mods/enabling-and-running-contests)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a
