### PR TITLE
Fix for linking issue b/w threads

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
+++ b/packages/commonwealth/client/scripts/views/components/thread_selector/thread_selector.tsx
@@ -53,7 +53,7 @@ export const ThreadSelector = ({
           Address: new AddressInfo({
             id: t.address_id,
             address: t.address,
-            communityId: t.address_chain,
+            communityId: t.address_community_id,
           }),
         } as ConstructorParameters<typeof Thread>[0]),
     );
@@ -94,10 +94,6 @@ export const ThreadSelector = ({
     [linkedThreadsToSet, onSelect],
   );
 
-  const EmptyComponent = () => (
-    <div className="empty-component">{getEmptyContentMessage()}</div>
-  );
-
   return (
     <div className="ThreadSelector">
       <CWTextInput
@@ -111,7 +107,12 @@ export const ThreadSelector = ({
       <QueryList
         loading={queryEnabled ? isLoading : false}
         options={options}
-        components={{ EmptyPlaceholder: EmptyComponent }}
+        components={{
+          // eslint-disable-next-line react/no-multi-comp
+          EmptyPlaceholder: () => (
+            <div className="empty-component">{getEmptyContentMessage()}</div>
+          ),
+        }}
         renderItem={renderItem}
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
@@ -22,7 +22,7 @@ export type ThreadResult = {
   body: string;
   address_id: number;
   address: string;
-  address_chain: string;
+  address_community_id: string;
   created_at: string;
 };
 type ThreadResultRowProps = {
@@ -64,8 +64,10 @@ const ThreadResultRow = ({
         <div className="search-results-thread-subtitle">
           <User
             userAddress={thread?.address}
-            userCommunityId={thread?.address_chain}
-            shouldShowAsDeleted={!thread?.address && !thread?.address_chain}
+            userCommunityId={thread?.address_community_id}
+            shouldShowAsDeleted={
+              !thread?.address && !thread?.address_community_id
+            }
           />
           <CWText className="created-at">
             {moment(thread.created_at).fromNow()}
@@ -101,6 +103,7 @@ type ReplyResultRowProps = {
   searchTerm: string;
   setRoute: any;
 };
+// eslint-disable-next-line react/no-multi-comp
 const ReplyResultRow = ({
   comment,
   searchTerm,
@@ -181,6 +184,7 @@ type CommunityResultRowProps = {
   searchTerm: string;
   setRoute: any;
 };
+// eslint-disable-next-line react/no-multi-comp
 const CommunityResultRow = ({
   community,
   setRoute,
@@ -221,6 +225,7 @@ type MemberResultRowProps = {
   addr: MemberResult;
   setRoute: any;
 };
+// eslint-disable-next-line react/no-multi-comp
 const MemberResultRow = ({ addr, setRoute }: MemberResultRowProps) => {
   const { community_id, address } = addr.addresses[0];
   const { data: users } = useFetchProfilesByAddressesQuery({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/7755

## Description of Changes
Fixed linking issue b/w threads

## "How We Fixed It"
There was an undefined `address_chain` key that was referenced when search results were returned for "thread to link". This key was earlier renamed in the backend to `address_community_id`. The fix was to reference the proper key.

## Test Plan
1. Go to any community
2. Create a thread
3. Link a related thread
4. Verify it works

## Deployment Plan
N/A

## Other Considerations
N/A