### PR TITLE
Delete user script

### DIFF
--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -28,6 +28,7 @@
     "create-migration": "npx sequelize migration:generate --name",
     "db-all": "chmod u+x scripts/db-all.sh && ./scripts/db-all.sh",
     "db-doc": "chmod u+x scripts/gen-mermaid-erd.sh && ./scripts/gen-mermaid-erd.sh > ../../knowledge_base/Database-ERD.md",
+    "delete-user": "chmod u+x scripts/delete-user.sh && ./scripts/delete-user.sh",
     "dump-db": "chmod u+x scripts/dump-db.sh && ./scripts/dump-db.sh",
     "e2e-start-server": "pnpm bootstrap-test-db && NODE_ENV=test ETH_RPC=e2e-test pnpm start",
     "emit-notification": "tsx server/scripts/emitTestNotification.ts",

--- a/packages/commonwealth/scripts/delete-user.sh
+++ b/packages/commonwealth/scripts/delete-user.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-userId=$1
+user=$1
 app=${2:-local}
 
-if [ -z "$userId" ]; then
-  echo "Error: userId argument is required. Usage: pnpm delete-user [userId]"
+if [ -z "$user" ]; then
+  echo "Error: user argument is required. Usage: pnpm delete-user [user id | user email]"
   exit 1
 fi
 
 if [ "$app" == "local" ]; then
-  pnpm ts-exec scripts/delete-user.ts "$userId"
+  pnpm ts-exec scripts/delete-user.ts "$user"
 elif [ "$app" == "frick" ] || [ "$app" == "frack" ] || [ "$app" == "beta" ]; then
   NODE_ENV=production DATABASE_URL=$(heroku config:get DATABASE_URL -a commonwealth-"$app") \
   JWT_SECRET=$(heroku config:get DATABASE_URL -a commonwealth-"$app") \
-  pnpm ts-exec scripts/delete-user.ts "$userId"
+  pnpm ts-exec scripts/delete-user.ts "$user"
 else
   echo "Invalid app argument. Please use 'local', 'frick', 'frack', or 'beta'."
 fi

--- a/packages/commonwealth/scripts/delete-user.sh
+++ b/packages/commonwealth/scripts/delete-user.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+userId=$1
+app=${2:-local}
+
+if [ -z "$userId" ]; then
+  echo "Error: userId argument is required. Usage: pnpm delete-user [userId]"
+  exit 1
+fi
+
+if [ "$app" == "local" ]; then
+  pnpm ts-exec scripts/delete-user.ts "$userId"
+elif [ "$app" == "frick" ] || [ "$app" == "frack" ] || [ "$app" == "beta" ]; then
+  NODE_ENV=production DATABASE_URL=$(heroku config:get DATABASE_URL -a commonwealth-"$app") \
+  JWT_SECRET=$(heroku config:get DATABASE_URL -a commonwealth-"$app") \
+  pnpm ts-exec scripts/delete-user.ts "$userId"
+else
+  echo "Invalid app argument. Please use 'local', 'frick', 'frack', or 'beta'."
+fi

--- a/packages/commonwealth/scripts/delete-user.ts
+++ b/packages/commonwealth/scripts/delete-user.ts
@@ -1,0 +1,141 @@
+import { dispose, logger } from '@hicommonwealth/core';
+import { models } from '@hicommonwealth/model';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const log = logger(__filename);
+
+async function deleteUser(user_id: number) {
+  log.info(`Deleting user ${user_id}`);
+  await models.sequelize.transaction(async (transaction) => {
+    await models.CommentSubscription.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.CommunityAlert.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.NotificationsRead.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.StarredCommunity.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.SubscriptionPreference.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.ThreadSubscription.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.ProfileTags.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+
+    const address_ids = (
+      await models.Address.findAll({
+        where: {
+          user_id,
+        },
+        transaction,
+      })
+    ).map((a) => a.id!);
+
+    // address dependencies
+    await models.Collaboration.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.Comment.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.Membership.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.Reaction.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.Thread.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.SsoToken.destroy({
+      where: {
+        address_id: address_ids,
+      },
+      transaction,
+    });
+    await models.Address.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.Profile.destroy({
+      where: {
+        user_id,
+      },
+      transaction,
+    });
+    await models.User.destroy({
+      where: {
+        id: user_id,
+      },
+      transaction,
+    });
+  });
+  log.info(`User ${user_id} deleted`);
+}
+
+async function main() {
+  if (!process.argv[2]) {
+    throw new Error('Must provide a user id (number) to delete');
+  }
+
+  await deleteUser(parseInt(process.argv[2]));
+}
+
+if (import.meta.url.endsWith(process.argv[1])) {
+  main()
+    .then(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      dispose()('EXIT', true);
+    })
+    .catch((err) => {
+      console.log('Failed to delete user', err);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      dispose()('ERROR', true);
+    });
+}

--- a/packages/commonwealth/scripts/delete-user.ts
+++ b/packages/commonwealth/scripts/delete-user.ts
@@ -1,5 +1,5 @@
 import { dispose, logger } from '@hicommonwealth/core';
-import { models } from '@hicommonwealth/model';
+import { UserInstance, models } from '@hicommonwealth/model';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -126,20 +126,25 @@ async function main() {
     );
   }
 
+  let user: UserInstance | null;
   if (process.argv[2].includes('@')) {
-    const user = await models.User.findOne({
+    user = await models.User.findOne({
       where: {
         email: process.argv[2],
       },
     });
-
-    if (user) {
-      await deleteUser(user.id!);
-    } else {
-      log.warn(`User with email ${process.argv[2]} not found.`);
-    }
   } else {
-    await deleteUser(parseInt(process.argv[2]));
+    user = await models.User.findOne({
+      where: {
+        id: parseInt(process.argv[2]),
+      },
+    });
+  }
+
+  if (user) {
+    await deleteUser(user.id!);
+  } else {
+    log.warn(`User not found.`);
   }
 }
 

--- a/packages/commonwealth/scripts/delete-user.ts
+++ b/packages/commonwealth/scripts/delete-user.ts
@@ -121,10 +121,26 @@ async function deleteUser(user_id: number) {
 
 async function main() {
   if (!process.argv[2]) {
-    throw new Error('Must provide a user id (number) to delete');
+    throw new Error(
+      'Must provide a user id (number) or email (string) to delete',
+    );
   }
 
-  await deleteUser(parseInt(process.argv[2]));
+  if (process.argv[2].includes('@')) {
+    const user = await models.User.findOne({
+      where: {
+        email: process.argv[2],
+      },
+    });
+
+    if (user) {
+      await deleteUser(user.id!);
+    } else {
+      log.warn(`User with email ${process.argv[2]} not found.`);
+    }
+  } else {
+    await deleteUser(parseInt(process.argv[2]));
+  }
 }
 
 if (import.meta.url.endsWith(process.argv[1])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8500

## Description of Changes
- Adds a TS script which deletes a user and all their related content (threads, addresses, profile, etc).
- Adds a bash script which allows executing the TS script above in any Heroku app except production
  - Note: `JWT_SECRET` is required in the bash script because of this issue: https://github.com/hicommonwealth/commonwealth/issues/8499

## Test Plan
- Get your user id: `SELECT user_id FROM "Addresses" WHERE address = '[your address]'`
- Execute `pnpm delete-user [user_id]` to delete the user from your local DB
- If you have Heroku access you can also do `pnpm delete-user [user_id] [frick | frack | beta]` to delete the user from a Heroku app

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 