### PR TITLE
Removes author profile id

### DIFF
--- a/libs/core/src/integration/events.schemas.ts
+++ b/libs/core/src/integration/events.schemas.ts
@@ -20,7 +20,6 @@ export const UserMentioned = z.object({
   authorAddressId: z.number(),
   authorUserId: z.number(),
   authorAddress: z.string(),
-  authorProfileId: z.number(),
   mentionedUserId: z.number(),
   communityId: z.string(),
   thread: Thread.optional(),

--- a/libs/core/src/integration/notifications.schemas.ts
+++ b/libs/core/src/integration/notifications.schemas.ts
@@ -44,9 +44,6 @@ export const UserMentionedNotification = z.object({
   author_address_id: z.number().describe("The id of the author's address"),
   author_user_id: z.number().describe("The id of the author's user record"),
   author_address: z.string().max(255).describe('The address of the author'),
-  author_profile_id: z
-    .number()
-    .describe('The profile id of the author of the mention'),
   community_id: z.string().max(255).describe('The id of the community'),
   community_name: z
     .string()

--- a/libs/model/test/email/util.ts
+++ b/libs/model/test/email/util.ts
@@ -52,7 +52,6 @@ export function generateDiscussionData(
     author: authorProfile.profile_name!,
     author_address: authorAddress.address,
     author_address_id: authorAddress.id!,
-    author_profile_id: authorProfile.id,
     author_user_id: authorUser.id!,
     community_id: community.id!,
     community_name: community.name,

--- a/packages/commonwealth/server/controllers/server_comments_methods/update_comment.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/update_comment.ts
@@ -149,8 +149,6 @@ export async function __updateComment(
       // @ts-expect-error StrictNullChecks
       authorUserId: user.id,
       authorAddress: address.address,
-      // @ts-expect-error StrictNullChecks
-      authorProfileId: address.profile_id,
       mentions: mentionedAddresses,
       comment,
     });

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread.ts
@@ -199,8 +199,6 @@ export async function __createThread(
         // @ts-expect-error StrictNullChecks
         authorUserId: user.id,
         authorAddress: address.address,
-        // @ts-expect-error StrictNullChecks
-        authorProfileId: address.profile_id,
         mentions: mentionedAddresses,
         thread,
       });

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_comment.ts
@@ -217,8 +217,6 @@ export async function __createThreadComment(
         // @ts-expect-error StrictNullChecks
         authorUserId: user.id,
         authorAddress: address.address,
-        // @ts-expect-error StrictNullChecks
-        authorProfileId: address.profile_id,
         mentions: mentionedAddresses,
         comment,
       });

--- a/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/update_thread.ts
@@ -310,8 +310,6 @@ export async function __updateThread(
       // @ts-expect-error StrictNullChecks
       authorUserId: user.id,
       authorAddress: address.address,
-      // @ts-expect-error StrictNullChecks
-      authorProfileId: address.profile_id,
       mentions: mentionedAddresses,
       thread,
     });

--- a/packages/commonwealth/server/util/parseUserMentions.ts
+++ b/packages/commonwealth/server/util/parseUserMentions.ts
@@ -174,7 +174,6 @@ type EmitMentionsData = {
   authorAddressId: number;
   authorUserId: number;
   authorAddress: string;
-  authorProfileId: number;
   mentions: UserMentionQuery;
 } & (
   | {
@@ -200,7 +199,6 @@ export const emitMentions = async (
         authorAddressId: data.authorAddressId,
         authorUserId: data.authorUserId,
         authorAddress: data.authorAddress,
-        authorProfileId: data.authorProfileId,
         mentionedUserId: user_id,
         communityId:
           'comment' in data

--- a/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
+++ b/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
@@ -33,13 +33,13 @@ export const processUserMentioned: EventHandler<
     return false;
   }
 
-  const profile = await models.Profile.findOne({
+  const user = await models.User.findOne({
     where: {
-      id: payload.authorProfileId,
+      id: payload.authorUserId,
     },
   });
 
-  if (!profile) {
+  if (!user) {
     log.error('Author profile not found', undefined, payload);
     return false;
   }
@@ -51,10 +51,9 @@ export const processUserMentioned: EventHandler<
       author_address_id: payload.authorAddressId,
       author_user_id: payload.authorUserId,
       author_address: payload.authorAddress,
-      author_profile_id: payload.authorProfileId,
       community_id: payload.communityId,
       community_name: community.name,
-      author: profile.profile_name || payload.authorAddress.substring(255),
+      author: user.profile.name || payload.authorAddress.substring(255),
       object_body:
         'thread' in payload
           ? // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
+++ b/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
@@ -111,7 +111,6 @@ describe('userMentioned Event Handler', () => {
         authorUserId: author!.id,
         // @ts-expect-error StrictNullChecks
         authorAddress: community!.Addresses[0].address,
-        authorProfileId: authorProfile!.id,
         mentionedUserId: user!.id,
         // @ts-expect-error StrictNullChecks
         communityId: community!.id,
@@ -135,7 +134,6 @@ describe('userMentioned Event Handler', () => {
         author_address_id: community!.Addresses![0].id,
         author_user_id: author!.id,
         author_address: community!.Addresses![0].address,
-        author_profile_id: authorProfile!.id,
         community_id: community!.id,
         community_name: community!.name,
         author: authorProfile!.profile_name,
@@ -159,7 +157,6 @@ describe('userMentioned Event Handler', () => {
           authorUserId: author!.id,
           // @ts-expect-error StrictNullChecks
           authorAddress: community!.Addresses[0].address,
-          authorProfileId: authorProfile!.id,
           mentionedUserId: user!.id,
           // @ts-expect-error StrictNullChecks
           communityId: community!.id,

--- a/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
+++ b/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
@@ -46,7 +46,7 @@ describe('userMentioned Event Handler', () => {
     [authorProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks
       user_id: author.id,
-      profile_name: author?.profile.name!,
+      profile_name: author?.profile.name ?? '',
     });
     [community] = await tester.seed('Community', {
       chain_node_id: chainNode?.id,

--- a/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
+++ b/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
@@ -46,6 +46,7 @@ describe('userMentioned Event Handler', () => {
     [authorProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks
       user_id: author.id,
+      profile_name: author?.profile.name!,
     });
     [community] = await tester.seed('Community', {
       chain_node_id: chainNode?.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8502

## Description of Changes
- Removes refs to author profile id
- Replaced with user_id 

 
## Test Plan
- Unit tests

## Deployment Plan
- @timolegros any deployment plans to consider given we might have old events with author profile id? Probably nothing.