### PR TITLE
Adds custom eslint rules to libs

### DIFF
--- a/libs/.eslintrc.cjs
+++ b/libs/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ['@hicommonwealth'],
+  rules: {
+    '@hicommonwealth/no-self-imports': 'error',
+  },
+};

--- a/libs/eslint-plugin/index.cjs
+++ b/libs/eslint-plugin/index.cjs
@@ -2,6 +2,32 @@ module.exports = {
   name: 'eslint-plugin-common',
   version: '1.0.0',
   rules: {
+    'no-self-imports': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Prevents self importing libraries',
+          recommended: true,
+        },
+      },
+      create(context) {
+        return {
+          ImportDeclaration(node) {
+            const path = context.getFilename();
+            const lib = path.match(/\/libs\/(.*?)\/src\//);
+            if (lib) {
+              const selfimport = `@hicommonwealth/${lib[1]}`;
+              if (selfimport === node.source.value)
+                context.report({
+                  node,
+                  message: `Avoid self importing '${node.source.value}'`,
+                });
+            }
+          },
+        };
+      },
+    },
+
     'no-server-imports': {
       meta: {
         type: 'problem',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint-all": "NODE_OPTIONS=\"--max-old-space-size=4096\" eslint './packages/**/*.{ts,tsx}'",
     "lint-branch": "./scripts/lint-branch.sh",
     "lint-branch-warnings": "FAIL_WARNINGS=1 ./scripts/lint-branch.sh",
+    "lint-libs": "eslint './libs/**/*.ts' --ignore-pattern '**/eth/scripts/**' --quiet",
     "load-db": "pnpm -F commonwealth load-db",
     "migrate-db": "pnpm -F commonwealth migrate-db",
     "prepare": "husky install",


### PR DESCRIPTION
Creates first custom rule to check that libs are not eating their tails - avoid self imports

- Use `pnpm lint-libs` to test
- Feel free to suggest more rules

## Link to Issue
Closes: #TODO

## Description of Changes
- Creates custom eslint rule to avoid self imports in libs
- Adds `lint-libs` script to root package.json
