### PR TITLE
refined the snapshot proposal modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -330,7 +330,7 @@ export const UpdateProposalStatusModal = ({
     setTempCosmosProposals(updatedProposals);
     setVotingStage();
   };
-  console.log('tempSnapshotProposals: ', tempSnapshotProposals);
+
   return (
     <div className="UpdateProposalStatusModal">
       <CWModalHeader

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -29,6 +29,7 @@ import useAppStatus from '../../hooks/useAppStatus';
 import { ThreadStage } from '../../models/types';
 import { CosmosProposalSelector } from '../components/CosmosProposalSelector';
 import { SelectList } from '../components/component_kit/cw_select_list';
+import { CWText } from '../components/component_kit/cw_text';
 import { CWButton } from '../components/component_kit/new_designs/CWButton';
 import {
   CWModalBody,
@@ -329,7 +330,7 @@ export const UpdateProposalStatusModal = ({
     setTempCosmosProposals(updatedProposals);
     setVotingStage();
   };
-
+  console.log('tempSnapshotProposals: ', tempSnapshotProposals);
   return (
     <div className="UpdateProposalStatusModal">
       <CWModalHeader
@@ -337,27 +338,31 @@ export const UpdateProposalStatusModal = ({
         onModalClose={onModalClose}
       />
       <CWModalBody allowOverflow>
-        <SelectList
-          defaultValue={
-            tempStage
-              ? { value: tempStage, label: threadStageToLabel(tempStage) }
-              : null
-          }
-          placeholder="Select a stage"
-          isSearchable={false}
-          options={stages.map((stage) => ({
-            value: stage as unknown as ThreadStage,
-            label: threadStageToLabel(stage),
-          }))}
-          className="StageSelector"
-          // @ts-expect-error <StrictNullChecks/>
-          onChange={(option) => setTempStage(option.value)}
-        />
-        {showSnapshot && (
-          <SnapshotProposalSelector
-            onSelect={handleSelectProposal}
-            snapshotProposalsToSet={tempSnapshotProposals}
-          />
+        {showSnapshot ? (
+          <>
+            <SelectList
+              defaultValue={
+                tempStage
+                  ? { value: tempStage, label: threadStageToLabel(tempStage) }
+                  : null
+              }
+              placeholder="Select a stage"
+              isSearchable={false}
+              options={stages.map((stage) => ({
+                value: stage as unknown as ThreadStage,
+                label: threadStageToLabel(stage),
+              }))}
+              className="StageSelector"
+              // @ts-expect-error <StrictNullChecks/>
+              onChange={(option) => setTempStage(option.value)}
+            />
+            <SnapshotProposalSelector
+              onSelect={handleSelectProposal}
+              snapshotProposalsToSet={tempSnapshotProposals}
+            />
+          </>
+        ) : (
+          <CWText>Please connect your Snapshot space </CWText>
         )}
         {isCosmos && (
           <CosmosProposalSelector
@@ -385,12 +390,14 @@ export const UpdateProposalStatusModal = ({
               buttonHeight="sm"
               onClick={onModalClose}
             />
-            <CWButton
-              buttonType="primary"
-              buttonHeight="sm"
-              label="Save changes"
-              onClick={handleSaveChanges}
-            />
+            {showSnapshot && (
+              <CWButton
+                buttonType="primary"
+                buttonHeight="sm"
+                label="Save changes"
+                onClick={handleSaveChanges}
+              />
+            )}
           </div>
         </div>
       </CWModalFooter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8521 

## Description of Changes
- refined the snapshot proposal modal to better show what is going on when a snapshot space isn't connected. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added conditional statements to show or not show certain information and functionality based on if a snapshot space is connected or not. 

## Test Plan
- make sure you don't have a snapshot space connected in Integrations
- create a thread and try to link a snapshot proposal to that thread
- confirm that you now see the updated message in the modal
- go to Integrations and save a snapshot space. Use `commonspacetester.eth` if you don't have one
- go back to that newly created thread and link a proposal
- confirm that you now see a list of proposals to link to and the corresponding buttons
**- NOTE: As of 7/18/24, if you try to connect a proposal you may see an error. That is being worked on separately and shouldn't hinder the approval of this PR.** 
<img width="774" alt="Screenshot 2024-07-18 at 10 48 28 AM" src="https://github.com/user-attachments/assets/bcf6991a-d89d-4582-b7de-f9fd124bddb6">

