### PR TITLE
Refactor profiles in comment created handler

### DIFF
--- a/packages/commonwealth/server/workers/knock/eventHandlers/commentCreated.ts
+++ b/packages/commonwealth/server/workers/knock/eventHandlers/commentCreated.ts
@@ -27,10 +27,8 @@ export const processCommentCreated: EventHandler<
   typeof output
 > = async ({ payload }) => {
   const author = await models.Address.findOne({
-    where: {
-      id: payload.address_id,
-    },
-    include: [{ model: models.Profile, required: true }],
+    where: { id: payload.address_id },
+    include: [{ model: models.User, required: true, attributes: ['profile'] }],
   });
 
   if (!author || !author.user_id) {
@@ -41,9 +39,7 @@ export const processCommentCreated: EventHandler<
   }
 
   const community = await models.Community.findOne({
-    where: {
-      id: payload.community_id,
-    },
+    where: { id: payload.community_id },
   });
 
   if (!community) {
@@ -78,13 +74,12 @@ export const processCommentCreated: EventHandler<
   if (users.length > 0) {
     const provider = notificationsProvider();
 
-    // TODO: error handling -> Ryan's event handling utility?
     return await provider.triggerWorkflow({
       key: WorkflowKeys.CommentCreation,
       users: users.map((u) => ({ id: String(u.user_id) })),
       data: {
         // @ts-expect-error StrictNullChecks
-        author: author.Profile.profile_name || author.address.substring(0, 8),
+        author: author.User.profile.name || author.address.substring(0, 8),
         comment_parent_name: payload.parent_id ? 'comment' : 'thread',
         community_name: community.name,
         comment_body: safeTruncateBody(decodeURIComponent(payload.text), 255),

--- a/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
+++ b/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
@@ -57,7 +57,7 @@ describe('CommentCreated Event Handler', () => {
     [authorProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks
       user_id: author.id,
-      profile_name: author?.profile.name!,
+      profile_name: author?.profile.name ?? '',
     });
     [subscriberProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
+++ b/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
@@ -57,6 +57,7 @@ describe('CommentCreated Event Handler', () => {
     [authorProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks
       user_id: author.id,
+      profile_name: author?.profile.name!,
     });
     [subscriberProfile] = await tester.seed('Profile', {
       // @ts-expect-error StrictNullChecks


### PR DESCRIPTION
Small change that was missed in #8502 

## Link to Issue
Closes: #8530

## Description of Changes
- Replace Profile with User

## Test Plan
- Unit test 
