### PR TITLE
user now able to add social link without community having an image

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -477,7 +477,7 @@ const CommunityProfileForm = () => {
               }}
             />
             <CWButton
-              label="Save Changes"
+              label="Save changes"
               buttonWidth="narrow"
               buttonType="primary"
               type="submit"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
@@ -9,9 +9,9 @@ export const communityProfileValidationSchema = z.object({
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
-  communityProfileImageURL: z
-    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  communityProfileImageURL: z.string({
+    invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
+  }),
   defaultPage: z.string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT }),
   hasStagesEnabled: z.boolean({
     invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7283 

## Description of Changes
- user now able to add social link without community having an image

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-removed zod validation that made an image required in order to submit the form
-also changed button text "Save Changes" to "Save changes" to reflect other buttons on platform
## Test Plan
- make sure you're an Admin
- go to a community that doesn't have an image, try this one if needed `/my-first-community/manage/profile`
- add a social link
- -confirm that you are now able to click Save changes

https://github.com/user-attachments/assets/15fb1313-13f9-4a3b-8437-941e09b54502

