### PR TITLE
X logo now seen in sidebar socials

### DIFF
--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -376,7 +376,10 @@ class ChainInfo {
           categorizedLinks.telegrams.push(link);
         } else if (link.includes('://matrix.to')) {
           categorizedLinks.elements.push(link);
-        } else if (link.includes('://twitter.com')) {
+        } else if (
+          link.includes('://twitter.com') ||
+          link.includes('://x.com')
+        ) {
           categorizedLinks.twitters.push(link);
         } else {
           categorizedLinks.remainingLinks.push(link);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8550 

## Description of Changes
-X logo now seen in sidebar socials

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added a `|| link.includes('://x.com')` check 
## Test Plan
- add a x.com link to the socials link in Community Profile
- -confirm that you now see the X logo in the sidebar
<img width="320" alt="Screenshot 2024-07-22 at 9 17 32 AM" src="https://github.com/user-attachments/assets/6f2fc101-3bbc-40b0-9cee-3f3ef6bdb17e">

