### PR TITLE
Decouple discordbot from profiles

### DIFF
--- a/libs/model/src/services/tokenBalanceCache/providers/getCosmosBalances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/getCosmosBalances.ts
@@ -1,6 +1,6 @@
 import { fromBech32, toBech32 } from '@cosmjs/encoding';
 import { logger } from '@hicommonwealth/core';
-import { BalanceSourceType } from '@hicommonwealth/shared';
+import { BalanceSourceType, DISCORD_BOT_ADDRESS } from '@hicommonwealth/shared';
 import { fileURLToPath } from 'url';
 import { models } from '../../../database';
 import { Balances, GetCosmosBalancesOptions } from '../types';
@@ -39,7 +39,7 @@ export async function getCosmosBalances(
       const encodedAddress = toBech32(chainNode.bech32!, data);
       addressMap[encodedAddress] = address;
     } catch (e) {
-      if (address != '0xdiscordbot') {
+      if (address != DISCORD_BOT_ADDRESS) {
         log.error(
           `Failed to decode Cosmos address`,
           e instanceof Error ? e : undefined,

--- a/libs/shared/src/constants.ts
+++ b/libs/shared/src/constants.ts
@@ -8,3 +8,7 @@ export const MIN_SCHEMA_BIGINT = BigInt(0);
 export const MAX_SCHEMA_BIGINT = BigInt('9223372036854775807');
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export const DISCORD_BOT_NAME = 'Discord Bot';
+export const DISCORD_BOT_EMAIL = 'discord@common.xzy';
+export const DISCORD_BOT_ADDRESS = '0xdiscordbot';

--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
@@ -44,6 +44,7 @@ class EthereumAccounts implements IAccountsModule<EthereumAccount> {
         if (address.length !== 40) {
           console.error(`Invalid address length! ${address}`);
         }
+        /* eslint-disable no-param-reassign */
         address = `0x${address}`;
       }
     }

--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
@@ -1,3 +1,4 @@
+import { DISCORD_BOT_ADDRESS } from '@hicommonwealth/shared';
 import type { IApp } from 'state';
 import { AccountsStore } from 'stores';
 import type { IAccountsModule } from '../../../models/interfaces';
@@ -34,15 +35,17 @@ class EthereumAccounts implements IAccountsModule<EthereumAccount> {
   }
 
   public fromAddress(address: string, ignoreProfiles = true): EthereumAccount {
-    if (address.indexOf('0x') !== -1) {
-      if (address.length !== 42) {
-        console.error(`Invalid address length! ${address}`);
+    if (address !== DISCORD_BOT_ADDRESS) {
+      if (address.indexOf('0x') !== -1) {
+        if (address.length !== 42) {
+          console.error(`Invalid address length! ${address}`);
+        }
+      } else {
+        if (address.length !== 40) {
+          console.error(`Invalid address length! ${address}`);
+        }
+        address = `0x${address}`;
       }
-    } else {
-      if (address.length !== 40) {
-        console.error(`Invalid address length! ${address}`);
-      }
-      address = `0x${address}`;
     }
     try {
       return this._store.getByAddress(address);

--- a/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
+++ b/packages/commonwealth/client/scripts/controllers/chain/ethereum/accounts.ts
@@ -44,7 +44,7 @@ class EthereumAccounts implements IAccountsModule<EthereumAccount> {
         if (address.length !== 40) {
           console.error(`Invalid address length! ${address}`);
         }
-        /* eslint-disable no-param-reassign */
+        // eslint-disable-next-line no-param-reassign
         address = `0x${address}`;
       }
     }

--- a/packages/commonwealth/server/middleware/databaseValidationService.ts
+++ b/packages/commonwealth/server/middleware/databaseValidationService.ts
@@ -57,11 +57,9 @@ export default class DatabaseValidationService {
     if (req.body.auth !== config.CW_BOT_KEY) {
       return next(new AppError('Approved Bot Only Endpoint'));
     }
-    req.user = (
-      await this.models.User.findOne({
-        where: { email: DISCORD_BOT_EMAIL },
-      })
-    )?.toJSON();
+    req.user = (await this.models.User.findOne({
+      where: { email: DISCORD_BOT_EMAIL },
+    }))!;
     next();
   };
 

--- a/packages/commonwealth/server/middleware/databaseValidationService.ts
+++ b/packages/commonwealth/server/middleware/databaseValidationService.ts
@@ -1,6 +1,7 @@
 import { AppError } from '@hicommonwealth/core';
 import type { DB } from '@hicommonwealth/model';
 import { CommunityInstance } from '@hicommonwealth/model';
+import { DISCORD_BOT_EMAIL } from '@hicommonwealth/shared';
 import type { NextFunction, Request, Response } from 'express';
 import { config } from '../config';
 import lookupAddressIsOwnedByUser from './lookupAddressIsOwnedByUser';
@@ -53,18 +54,14 @@ export default class DatabaseValidationService {
     res: Response,
     next: NextFunction,
   ) => {
-    //1. Check for bot token
     if (req.body.auth !== config.CW_BOT_KEY) {
       return next(new AppError('Approved Bot Only Endpoint'));
     }
-    //2. Get Bot User and inject
-    const profile = await this.models.Profile.findOne({
-      where: {
-        profile_name: 'Discord Bot',
-      },
-    });
-    // @ts-expect-error StrictNullChecks
-    req.user = await profile.getUser();
+    req.user = (
+      await this.models.User.findOne({
+        where: { email: DISCORD_BOT_EMAIL },
+      })
+    )?.toJSON();
     next();
   };
 

--- a/packages/commonwealth/server/routes/discord/setDiscordBotConfig.ts
+++ b/packages/commonwealth/server/routes/discord/setDiscordBotConfig.ts
@@ -1,5 +1,6 @@
 import { AppError, logger } from '@hicommonwealth/core';
 import type { DB } from '@hicommonwealth/model';
+import { DISCORD_BOT_ADDRESS } from '@hicommonwealth/shared';
 import { fileURLToPath } from 'url';
 import { validateCommunity } from '../../middleware/validateCommunity';
 import type { TypedRequestBody, TypedResponse } from '../../types';
@@ -120,20 +121,9 @@ const setDiscordBotConfig = async (
   }
 
   await models.sequelize.transaction(async (transaction) => {
-    const profile = await models.Profile.findOne({
-      where: {
-        profile_name: 'Discord Bot',
-      },
-      transaction,
-    });
-
     const [address, created] = await models.Address.findOrCreate({
       where: {
-        // @ts-expect-error StrictNullChecks
-        user_id: profile.user_id,
-        // @ts-expect-error StrictNullChecks
-        profile_id: profile.id,
-        address: '0xdiscordbot',
+        address: DISCORD_BOT_ADDRESS,
         community_id,
       },
       // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/server/routes/discord/setDiscordBotConfig.ts
+++ b/packages/commonwealth/server/routes/discord/setDiscordBotConfig.ts
@@ -1,6 +1,6 @@
 import { AppError, logger } from '@hicommonwealth/core';
 import type { DB } from '@hicommonwealth/model';
-import { DISCORD_BOT_ADDRESS } from '@hicommonwealth/shared';
+import { DISCORD_BOT_ADDRESS, DISCORD_BOT_EMAIL } from '@hicommonwealth/shared';
 import { fileURLToPath } from 'url';
 import { validateCommunity } from '../../middleware/validateCommunity';
 import type { TypedRequestBody, TypedResponse } from '../../types';
@@ -121,8 +121,12 @@ const setDiscordBotConfig = async (
   }
 
   await models.sequelize.transaction(async (transaction) => {
+    const user = await models.User.findOne({
+      where: { email: DISCORD_BOT_EMAIL },
+    });
     const [address, created] = await models.Address.findOrCreate({
       where: {
+        user_id: user?.id,
         address: DISCORD_BOT_ADDRESS,
         community_id,
       },

--- a/packages/commonwealth/server/util/webhooks/destinations/discord.ts
+++ b/packages/commonwealth/server/util/webhooks/destinations/discord.ts
@@ -1,5 +1,8 @@
 import { CommunityInstance } from '@hicommonwealth/model';
-import { NotificationCategories } from '@hicommonwealth/shared';
+import {
+  DISCORD_BOT_NAME,
+  NotificationCategories,
+} from '@hicommonwealth/shared';
 import request from 'superagent';
 import { config } from '../../../config';
 import {
@@ -87,7 +90,7 @@ export async function sendDiscordWebhook(
   data: ForumWebhookData | ChainEventWebhookData,
   chain?: CommunityInstance,
 ) {
-  if ('profileName' in data && data.profileName === 'Discord Bot') {
+  if ('profileName' in data && data.profileName === DISCORD_BOT_NAME) {
     if (!chain) return;
     else if (chain && !chain.discord_bot_webhooks_enabled) return;
   }

--- a/packages/commonwealth/test/devnet/cosmos/tokenBalanceFetching.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/tokenBalanceFetching.spec.ts
@@ -19,6 +19,7 @@ import {
   ChainNetwork,
   ChainType,
   CosmosGovernanceVersion,
+  DISCORD_BOT_ADDRESS,
   delay,
 } from '@hicommonwealth/shared';
 import BN from 'bn.js';
@@ -51,7 +52,7 @@ describe('Token Balance Cache Cosmos Tests', { timeout: 30_000 }, function () {
   const cosmosChainId = 'csdkv1local';
   const addressOne = 'cosmos1zf45elxg5alxxeewvumpprfqtxmy2ufhzvetgx';
   const addressTwo = 'cosmos1f85wzgz83gkq09g9gj79c6w9gydu87a7e6hax7';
-  const discobotAddress = '0xdiscordbot';
+  const discobotAddress = DISCORD_BOT_ADDRESS;
   const addressOneBalance = '50000000000';
   const addressTwoBalance = '30000000000';
 

--- a/packages/commonwealth/test/devnet/cosmos/tokenBalanceFetching.spec.ts
+++ b/packages/commonwealth/test/devnet/cosmos/tokenBalanceFetching.spec.ts
@@ -19,7 +19,6 @@ import {
   ChainNetwork,
   ChainType,
   CosmosGovernanceVersion,
-  DISCORD_BOT_ADDRESS,
   delay,
 } from '@hicommonwealth/shared';
 import BN from 'bn.js';
@@ -52,7 +51,7 @@ describe('Token Balance Cache Cosmos Tests', { timeout: 30_000 }, function () {
   const cosmosChainId = 'csdkv1local';
   const addressOne = 'cosmos1zf45elxg5alxxeewvumpprfqtxmy2ufhzvetgx';
   const addressTwo = 'cosmos1f85wzgz83gkq09g9gj79c6w9gydu87a7e6hax7';
-  const discobotAddress = DISCORD_BOT_ADDRESS;
+  const discobotAddress = '0xdiscordbot';
   const addressOneBalance = '50000000000';
   const addressTwoBalance = '30000000000';
 

--- a/packages/commonwealth/test/devnet/evm/tokenBalanceFetching.spec.ts
+++ b/packages/commonwealth/test/devnet/evm/tokenBalanceFetching.spec.ts
@@ -12,7 +12,12 @@ import {
   type Balances,
   type DB,
 } from '@hicommonwealth/model';
-import { BalanceSourceType, BalanceType, delay } from '@hicommonwealth/shared';
+import {
+  BalanceSourceType,
+  BalanceType,
+  DISCORD_BOT_ADDRESS,
+  delay,
+} from '@hicommonwealth/shared';
 import { Anvil } from '@viem/anvil';
 import BN from 'bn.js';
 import { expect } from 'chai';
@@ -48,7 +53,6 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
 
   const addressOne = '0xCEB3C3D4B78d5d10bd18930DC0757ddB588A862a';
   const addressTwo = '0xD54f2E2173D0a5eA8e0862Aed18b270aFF08389e';
-  const discobotAddress = '0xdiscordbot';
 
   const bulkAddresses = generateEVMAddresses(20);
   bulkAddresses.splice(4, 0, addressOne);
@@ -140,7 +144,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not fail if a single invalid address is given', async () => {
         const balance = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC20,
-          addresses: [discobotAddress],
+          addresses: [DISCORD_BOT_ADDRESS],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: chainLinkAddress,
@@ -187,7 +191,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC20,
-          addresses: [addressOne, discobotAddress, addressTwo],
+          addresses: [addressOne, DISCORD_BOT_ADDRESS, addressTwo],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: chainLinkAddress,
@@ -254,7 +258,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC20,
-          addresses: [addressOne, discobotAddress, addressTwo],
+          addresses: [addressOne, DISCORD_BOT_ADDRESS, addressTwo],
           sourceOptions: {
             evmChainId: newEthChainId,
             contractAddress: chainLinkAddress,
@@ -330,7 +334,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not fail if a single invalid address is given', async () => {
         const balance = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ETHNative,
-          addresses: [discobotAddress],
+          addresses: [DISCORD_BOT_ADDRESS],
           sourceOptions: {
             evmChainId: ethChainId,
           },
@@ -374,7 +378,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ETHNative,
-          addresses: [addressOne, discobotAddress, addressTwo],
+          addresses: [addressOne, DISCORD_BOT_ADDRESS, addressTwo],
           sourceOptions: {
             evmChainId: ethChainId,
           },
@@ -438,7 +442,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ETHNative,
-          addresses: [addressOne, discobotAddress, addressTwo],
+          addresses: [addressOne, DISCORD_BOT_ADDRESS, addressTwo],
           sourceOptions: {
             evmChainId: newEthChainId,
           },
@@ -501,7 +505,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not fail if a single invalid address is given', async () => {
         const balance = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC721,
-          addresses: [discobotAddress],
+          addresses: [DISCORD_BOT_ADDRESS],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: nft.address,
@@ -548,7 +552,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC721,
-          addresses: [addressOne721, discobotAddress, addressTwo721],
+          addresses: [addressOne721, DISCORD_BOT_ADDRESS, addressTwo721],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: nft.address,
@@ -615,7 +619,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not fail if a single invalid address is given', async () => {
         const balance = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC1155,
-          addresses: [discobotAddress],
+          addresses: [DISCORD_BOT_ADDRESS],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: erc1155.address,
@@ -679,7 +683,7 @@ describe('Token Balance Cache EVM Tests', { timeout: 160_000 }, function () {
       test('should not throw if a single address fails', async () => {
         const balances = await tokenBalanceCache.getBalances({
           balanceSourceType: BalanceSourceType.ERC1155,
-          addresses: [addressOne, discobotAddress, addressTwo],
+          addresses: [addressOne, DISCORD_BOT_ADDRESS, addressTwo],
           sourceOptions: {
             evmChainId: ethChainId,
             contractAddress: erc1155.address,

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -22,6 +22,7 @@
     "@hicommonwealth/adapters": "workspace:*",
     "@hicommonwealth/core": "workspace:*",
     "@hicommonwealth/model": "workspace:*",
+    "@hicommonwealth/shared": "workspace:*",
     "axios": "^1.3.4",
     "discord.js": "^14.11.0",
     "moment": "^2.23.0",

--- a/packages/discord-bot/src/config.ts
+++ b/packages/discord-bot/src/config.ts
@@ -11,14 +11,12 @@ export const config = configure(
     DISCORD: {
       CW_BOT_KEY,
       DISCORD_TOKEN,
-      DISCOBOT_ADDRESS: '0xdiscordbot',
     },
   },
   z.object({
     DISCORD: z.object({
       CW_BOT_KEY: z.string().optional(),
       DISCORD_TOKEN: z.string().optional(),
-      DISCOBOT_ADDRESS: z.string(),
     }),
   }),
 );

--- a/packages/discord-bot/src/discord-consumer/discordConsumer.ts
+++ b/packages/discord-bot/src/discord-consumer/discordConsumer.ts
@@ -21,6 +21,7 @@ import {
   IDiscordMessage,
   ThreadDiscordActions,
 } from '@hicommonwealth/model';
+import { DISCORD_BOT_ADDRESS } from '@hicommonwealth/shared';
 import { fileURLToPath } from 'url';
 import v8 from 'v8';
 import { ZodUndefined } from 'zod';
@@ -69,7 +70,7 @@ const processDiscordMessageCreated: EventHandler<
         user: parsedMessage.user,
       },
       author_chain: topic.community_id,
-      address: config.DISCORD.DISCOBOT_ADDRESS,
+      address: DISCORD_BOT_ADDRESS,
       chain: topic.community_id,
     };
 

--- a/packages/discord-bot/tsconfig.build.json
+++ b/packages/discord-bot/tsconfig.build.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../../libs/adapters/tsconfig.build.json" },
     { "path": "../../libs/core/tsconfig.build.json" },
-    { "path": "../../libs/model/tsconfig.build.json" }
+    { "path": "../../libs/model/tsconfig.build.json" },
+    { "path": "../../libs/shared/tsconfig.build.json" }
   ]
 }

--- a/packages/discord-bot/tsconfig.json
+++ b/packages/discord-bot/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "../../libs/adapters/tsconfig.build.json" },
     { "path": "../../libs/core/tsconfig.build.json" },
-    { "path": "../../libs/model/tsconfig.build.json" }
+    { "path": "../../libs/model/tsconfig.build.json" },
+    { "path": "../../libs/shared/tsconfig.build.json" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1414,6 +1414,9 @@ importers:
       '@hicommonwealth/model':
         specifier: workspace:*
         version: link:../../libs/model
+      '@hicommonwealth/shared':
+        specifier: workspace:*
+        version: link:../../libs/shared
       axios:
         specifier: ^1.3.4
         version: 1.6.8
@@ -21553,7 +21556,7 @@ snapshots:
     dependencies:
       '@libp2p/interface': 1.4.0
       '@multiformats/multiaddr': 12.2.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       interface-datastore: 8.2.11
       multiformats: 13.1.0
     transitivePeerDependencies:
@@ -25070,20 +25073,20 @@ snapshots:
 
   axios@0.21.4:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
   axios@0.27.2:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
 
   axios@1.6.8:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -25658,7 +25661,7 @@ snapshots:
 
   connect-session-sequelize@7.1.7(sequelize@6.37.3(pg@8.11.5)):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       sequelize: 6.37.3(pg@8.11.5)
     transitivePeerDependencies:
       - supports-color
@@ -25916,10 +25919,6 @@ snapshots:
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
-
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
 
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
@@ -27197,8 +27196,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  follow-redirects@1.15.6: {}
-
   follow-redirects@1.15.6(debug@4.3.4):
     optionalDependencies:
       debug: 4.3.4(supports-color@8.1.1)
@@ -27711,7 +27708,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.4)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -30679,7 +30676,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.11.9
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       dottie: 2.0.6
       inflection: 1.13.4
       lodash: 4.17.21
@@ -31193,7 +31190,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fast-safe-stringify: 2.1.1
       form-data: 3.0.1
       formidable: 1.2.6


### PR DESCRIPTION
See ticket

## Link to Issue
Closes: #8558

## Description of Changes
- Creates DISCORD constants to avoid magic strings
- Query users instead of Profiles
 
## Test Plan
- Run app, discobot listener and discobot consumer in local env using 
  - DISCORD_TOKEN={token in discobot staging}
  - CW_BOT_KEY=local
- Connect community topic to discord channel 
- Start posting on discord
- Posts should show as threads and comments