### PR TITLE
only enable push notification on Safari with the PWA enabled.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -12,7 +12,7 @@ import {
 import { PageNotFound } from 'views/pages/404';
 import { CommunityEntry } from 'views/pages/NotificationSettings/CommunityEntry';
 import { PushNotificationsToggle } from 'views/pages/NotificationSettings/PushNotificationsToggle';
-import { supportsPushNotifications } from 'views/pages/NotificationSettings/supportsPushNotifications';
+import { useSupportsPushNotifications } from 'views/pages/NotificationSettings/useSupportsPushNotifications';
 import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
 import { z } from 'zod';
 import { CWText } from '../../components/component_kit/cw_text';
@@ -23,6 +23,7 @@ import './index.scss';
 type NotificationSection = 'community-alerts' | 'subscriptions';
 
 const NotificationSettings = () => {
+  const supportsPushNotifications = useSupportsPushNotifications();
   const threadSubscriptions = useThreadSubscriptions();
   const communityAlerts = useCommunityAlertsQuery();
   const enableKnockPushNotifications = useFlag('knockPushNotifications');
@@ -62,7 +63,7 @@ const NotificationSettings = () => {
           Manage the emails and alerts you receive about your activity
         </CWText>
 
-        {enableKnockPushNotifications && supportsPushNotifications() && (
+        {enableKnockPushNotifications && supportsPushNotifications && (
           <div>
             <CWText type="h5">Push Notifications</CWText>
 

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/supportsPushNotifications.ts
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/supportsPushNotifications.ts
@@ -1,6 +1,0 @@
-import { getBrowserType } from 'helpers/browser';
-
-export function supportsPushNotifications() {
-  const browserType = getBrowserType();
-  return browserType === 'chrome' || browserType === 'safari';
-}

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/useSupportsPushNotifications.ts
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/useSupportsPushNotifications.ts
@@ -1,0 +1,15 @@
+import { getBrowserType } from 'helpers/browser';
+import useAppStatus from 'hooks/useAppStatus';
+
+export function useSupportsPushNotifications() {
+  const { isAddedToHomeScreen } = useAppStatus();
+
+  const browserType = getBrowserType();
+
+  if (browserType === 'safari' && isAddedToHomeScreen) {
+    // Safari only works if we've added it as a PWA
+    return true;
+  }
+
+  return browserType === 'chrome';
+}

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/useSupportsPushNotifications.ts
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/useSupportsPushNotifications.ts
@@ -1,7 +1,7 @@
 import { getBrowserType } from 'helpers/browser';
 import useAppStatus from 'hooks/useAppStatus';
 
-export function useSupportsPushNotifications() {
+export const useSupportsPushNotifications = () => {
   const { isAddedToHomeScreen } = useAppStatus();
 
   const browserType = getBrowserType();
@@ -12,4 +12,4 @@ export function useSupportsPushNotifications() {
   }
 
   return browserType === 'chrome';
-}
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8576

## Description of Changes
- detects the PWA and only then do we enable the push notifications.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- We have to go through the full debug process of testing push notifications again but on frack.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 