### PR TITLE
Show latest comment version after comment update

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -479,6 +479,7 @@ export const CommentTree = ({
                 </div>
               )}
               <CommentCard
+                key={`${comment.id}-${comment.text}`}
                 disabledActionsTooltipText={disabledActionsTooltipText}
                 isThreadArchived={!!thread.archivedAt}
                 canReply={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8586

## Description of Changes
Now showing correct latest comment version after comment update

## "How We Fixed It"
N/A

## Test Plan
1. Added a comment to any thread
2. Update it
3. Verify you see the latest comment version text

## Deployment Plan
N/A

## Other Considerations
N/A