### PR TITLE
made padding changes to the For You page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -5,12 +5,12 @@ import useStickyHeader from 'hooks/useStickyHeader';
 import useUserLoggedIn from 'hooks/useUserLoggedIn';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/user_dashboard/index.scss';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import app, { LoginState } from 'state';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import {
-  MixpanelPageViewEvent,
   MixpanelPWAEvent,
+  MixpanelPageViewEvent,
 } from '../../../../../shared/analytics/types';
 import useAppStatus from '../../../hooks/useAppStatus';
 import { CWText } from '../../components/component_kit/cw_text';
@@ -61,6 +61,8 @@ const UserDashboard = (props: UserDashboardProps) => {
 
   const loggedIn = app.loginState === LoginState.LoggedIn;
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useBrowserAnalyticsTrack({
     payload: {
       event: isAddedToHomeScreen
@@ -89,7 +91,7 @@ const UserDashboard = (props: UserDashboardProps) => {
   }, [activePage, subpage]);
 
   return (
-    <CWPageLayout>
+    <CWPageLayout ref={containerRef} className="UserDashboard">
       <div className="UserDashboard" key={`${isLoggedIn}`}>
         <CWText type="h2" fontWeight="medium" className="page-header">
           Home

--- a/packages/commonwealth/client/styles/pages/user_dashboard/index.scss
+++ b/packages/commonwealth/client/styles/pages/user_dashboard/index.scss
@@ -1,6 +1,8 @@
 @import '../../shared';
 
 .UserDashboard {
+  padding-top: 24px;
+
   .page-header {
     padding-bottom: 24px;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8492 

## Description of Changes
- changed the padding between Welcome to Common slider and Home

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-refactored the css to somewhat follow how other components are styled. I used `/discussions` as the styling I was trying to emulate. 
## Test Plan
-if you aren't seeing the Welcome to Common slider on the For You page, run `localStorage.clear()` in the dev tools and refresh your page
-confirm that the spacing of Home and the bottom of the Welcome to Common slider is now smaller. 
-dismiss the slider and check the spacing of Home and the breadcrumbs
