### PR TITLE
Fix UI contest eth check value

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -41,7 +41,7 @@ import ContestTopicBanner from './ContestTopicBanner';
 import './NewThreadForm.scss';
 import { checkNewThreadErrors, useNewThreadForm } from './helpers';
 
-const MIN_ETH_FOR_CONTEST_THREAD = 0.005;
+const MIN_ETH_FOR_CONTEST_THREAD = 0.0005;
 
 export const NewThreadForm = () => {
   const navigate = useCommonNavigate();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8591

## Description of Changes
- Sets min contest eth value to `0.0005`

## Test Plan
- When creating a thread on an active contest, check that the min ETH value is `0.0005`, shown in the UI and properly enforced

## Deployment Plan
N/A

## Other Considerations
N/A