### PR TITLE
added mixpanel calls to contests

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -10,8 +10,8 @@ import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import { PageNotFound } from 'views/pages/404';
 
-import useAppStatus from 'client/scripts/hooks/useAppStatus';
 import { useBrowserAnalyticsTrack } from 'client/scripts/hooks/useBrowserAnalyticsTrack';
+import useAppStatus from 'hooks/useAppStatus';
 import {
   BaseMixpanelPayload,
   MixpanelContestEvents,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -10,20 +10,31 @@ import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import { PageNotFound } from 'views/pages/404';
 
+import useAppStatus from 'client/scripts/hooks/useAppStatus';
+import { useBrowserAnalyticsTrack } from 'client/scripts/hooks/useBrowserAnalyticsTrack';
+import {
+  BaseMixpanelPayload,
+  MixpanelContestEvents,
+} from 'shared/analytics/types';
 import ContestsList from '../ContestsList';
 import useCommunityContests from '../useCommunityContests';
-import FeeManagerBanner from './FeeManagerBanner';
-
 import './AdminContestsPage.scss';
+import FeeManagerBanner from './FeeManagerBanner';
 
 const AdminContestsPage = () => {
   const navigate = useCommonNavigate();
+
+  const { isAddedToHomeScreen } = useAppStatus();
 
   const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
 
   const ethChainId = app?.chain?.meta?.ChainNode?.ethChainId;
   const { stakeData } = useCommunityStake();
   const namespace = stakeData?.Community?.namespace;
+
+  const { trackAnalytics } = useBrowserAnalyticsTrack<BaseMixpanelPayload>({
+    onAction: true,
+  });
 
   const {
     stakeEnabled,
@@ -38,6 +49,14 @@ const AdminContestsPage = () => {
       namespace,
       apiEnabled: !!ethChainId && !!namespace && stakeEnabled,
     });
+
+  const handleCreateContestClicked = () => {
+    trackAnalytics({
+      event: MixpanelContestEvents.CREATE_CONTEST_BUTTON_PRESSED,
+      isPWA: isAddedToHomeScreen,
+    });
+    navigate('/manage/contests/launch');
+  };
 
   if (!app.isLoggedIn() || !isAdmin) {
     return <PageNotFound />;
@@ -56,7 +75,7 @@ const AdminContestsPage = () => {
             <CWButton
               iconLeft="plusPhosphor"
               label="Create contest"
-              onClick={() => navigate('/manage/contests/launch')}
+              onClick={handleCreateContestClicked}
             />
           )}
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -25,7 +25,13 @@ import {
   LaunchContestStep,
 } from '../../types';
 
+import useAppStatus from 'client/scripts/hooks/useAppStatus';
+import { useBrowserAnalyticsTrack } from 'client/scripts/hooks/useBrowserAnalyticsTrack';
 import { useFlag } from 'hooks/useFlag';
+import {
+  BaseMixpanelPayload,
+  MixpanelContestEvents,
+} from 'shared/analytics/types';
 import useUserStore from 'state/ui/user';
 import './SignTransactionsStep.scss';
 
@@ -55,6 +61,12 @@ const SignTransactionsStep = ({
     useDeployRecurringContestOnchainMutation();
   const { mutateAsync: createContestMutation } = useCreateContestMutation();
   const user = useUserStore();
+
+  const { isAddedToHomeScreen } = useAppStatus();
+
+  const { trackAnalytics } = useBrowserAnalyticsTrack<BaseMixpanelPayload>({
+    onAction: true,
+  });
 
   const isContestRecurring =
     contestFormData.contestRecurring === ContestRecurringType.Yes;
@@ -145,6 +157,10 @@ const SignTransactionsStep = ({
 
       onSetLaunchContestStep('ContestLive');
       onSetCreatedContestAddress(contestAddress);
+      trackAnalytics({
+        event: MixpanelContestEvents.CONTEST_CREATED,
+        isPWA: isAddedToHomeScreen,
+      });
     } catch (error) {
       console.log('error', error);
       setLaunchContestData((prevState) => ({

--- a/packages/commonwealth/shared/analytics/types.ts
+++ b/packages/commonwealth/shared/analytics/types.ts
@@ -83,6 +83,11 @@ export const enum MixpanelGovernanceEvents {
   COSMOS_VOTE_OCCURRED = 'Cosmos Vote Occurred',
 }
 
+export const enum MixpanelContestEvents {
+  CREATE_CONTEST_BUTTON_PRESSED = 'Create Contest Button Pressed',
+  CONTEST_CREATED = 'Contest Created',
+}
+
 export const enum MixpanelPWAEvent {
   PWA_USED = 'PWA in use',
   PWA_NOT_USED = 'PWA NOT in use',
@@ -99,6 +104,7 @@ export type MixpanelEvents =
   | MixpanelErrorCaptureEvent
   | MixpanelClickthroughEvent
   | MixpanelGovernanceEvents
+  | MixpanelContestEvents
   | MixpanelPWAEvent;
 
 export type AnalyticsEvent = MixpanelEvents; // add other providers events here


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8540 

## Description of Changes
- Added mixpanel calls to Contest flow

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Added mixpanel calls for when "Create contest" button is pressed and after contest is created.
NOTE:This is simply a cursory instantiation of mixpanel calls for Contests. More calls could be added either on this PR or a new one. If one of the reviewers thinks I should put in a call at a specific place let me know. 
## Test Plan
- go to a community where you can create a contest
- click "Create contest" button
- go to mixpanel dev dashboard and confirm that you see "Create Contest Button Pressed"
- continue with the flow and click "Sign"
- go to mixpanel dev dashboard and confirm that you see "Contest Created"

