### PR TITLE
Copy fix for minimum eth value

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadForm/NewThreadForm.tsx
@@ -334,7 +334,8 @@ export const NewThreadForm = () => {
 
               <MessageRow
                 hasFeedback={walletBalanceError}
-                statusMessage="Ensure that your connected wallet has at least 0.005 ETH to participate."
+                statusMessage={`Ensure that your connected wallet has at least 
+                ${MIN_ETH_FOR_CONTEST_THREAD} ETH to participate.`}
                 validationStatus="failure"
               />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8602 

## Description of Changes
- used MIN_ETH_FOR_CONTEST_THREAD const for value and copy  

## Test Plan
- try to add thread to contest with less than 0.0005 ETH in your wallet

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

