### PR TITLE
Fix duplicate threads

### DIFF
--- a/libs/model/src/globalActivityCache.ts
+++ b/libs/model/src/globalActivityCache.ts
@@ -10,7 +10,7 @@ export async function getActivityFeed(models: DB, id = 0) {
    */
   const query = `
       WITH 
-      user_communities AS (SELECT community_id FROM "Addresses" WHERE user_id = :id),
+      user_communities AS (SELECT DISTINCT community_id FROM "Addresses" WHERE user_id = :id),
       top_threads AS (
           SELECT T.*
           FROM "Threads" T


### PR DESCRIPTION
## Link to Issue
Closes: #8597 

## Description of Changes
- Adds DISTINCT to `Address.community_id` since users can have multiple addresses in a single community.
  - Funnily enough this seems to also improve the performance of the query though I am unsure why that is the case:
    - Before: https://explain.dalibo.com/plan/bg7dab5fb9b4f2dg#plan
    - After: https://explain.dalibo.com/plan/ab46f2e9d3252g08 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Pick an EVM community and join that community with 2 different addresses linked to the same user
- Using a third address not linked to the user above, create a thread in the community you picked
- View the 'for you' activity feed from your initial user (either of the first 2 addresses) -> the thread should show up only once

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 