### PR TITLE
Recap Email Route Updates

### DIFF
--- a/libs/core/src/integration/email.schemas.ts
+++ b/libs/core/src/integration/email.schemas.ts
@@ -8,8 +8,17 @@ import {
   UserMentionedNotification,
 } from './notifications.schemas';
 
+export const EnrichedNotificationNames = {
+  CommentCreated: 'CommentCreated',
+  UserMentioned: 'UserMentioned',
+  CommunityStakeTrade: 'CommunityStakeTrade',
+  ChainProposal: 'ChainProposal',
+  SnapshotProposalCreated: 'SnapshotProposalCreated',
+} as const;
+
 export const EnrichedCommentCreatedNotification =
   CommentCreatedNotification.extend({
+    event_name: z.literal(EnrichedNotificationNames.CommentCreated),
     author_avatar_url: z.string(),
     inserted_at: z
       .string()
@@ -20,7 +29,8 @@ export const EnrichedCommentCreatedNotification =
 
 export const EnrichedUserMentionedNotification =
   UserMentionedNotification.extend({
-    author_avatar_url: z.string(),
+    event_name: z.literal(EnrichedNotificationNames.UserMentioned),
+    author_avatar_url: z.string().nullish(),
     inserted_at: z
       .string()
       .describe(
@@ -30,6 +40,7 @@ export const EnrichedUserMentionedNotification =
 
 export const EnrichedCommunityStakeNotification =
   CommunityStakeNotification.extend({
+    event_name: z.literal(EnrichedNotificationNames.CommunityStakeTrade),
     community_icon_url: z.string().nullish(),
     inserted_at: z
       .string()
@@ -40,6 +51,7 @@ export const EnrichedCommunityStakeNotification =
 
 export const EnrichedChainProposalsNotification =
   ChainProposalsNotification.extend({
+    event_name: z.literal(EnrichedNotificationNames.ChainProposal),
     community_icon_url: z.string().nullish(),
     inserted_at: z
       .string()
@@ -50,6 +62,7 @@ export const EnrichedChainProposalsNotification =
 
 export const EnrichedSnapshotProposalCreatedNotification =
   SnapshotProposalCreatedNotification.extend({
+    event_name: z.literal(EnrichedNotificationNames.SnapshotProposalCreated),
     community_icon_url: z.string().nullish(),
     inserted_at: z
       .string()

--- a/libs/core/src/integration/email.schemas.ts
+++ b/libs/core/src/integration/email.schemas.ts
@@ -11,26 +11,51 @@ import {
 export const EnrichedCommentCreatedNotification =
   CommentCreatedNotification.extend({
     author_avatar_url: z.string(),
+    inserted_at: z
+      .string()
+      .describe(
+        'The string date at which a notification was registered with a notification provider',
+      ),
   });
 
 export const EnrichedUserMentionedNotification =
   UserMentionedNotification.extend({
     author_avatar_url: z.string(),
+    inserted_at: z
+      .string()
+      .describe(
+        'The string date at which a notification was registered with a notification provider',
+      ),
   });
 
 export const EnrichedCommunityStakeNotification =
   CommunityStakeNotification.extend({
     community_icon_url: z.string().nullish(),
+    inserted_at: z
+      .string()
+      .describe(
+        'The string date at which a notification was registered with a notification provider',
+      ),
   });
 
 export const EnrichedChainProposalsNotification =
   ChainProposalsNotification.extend({
     community_icon_url: z.string().nullish(),
+    inserted_at: z
+      .string()
+      .describe(
+        'The string date at which a notification was registered with a notification provider',
+      ),
   });
 
 export const EnrichedSnapshotProposalCreatedNotification =
   SnapshotProposalCreatedNotification.extend({
     community_icon_url: z.string().nullish(),
+    inserted_at: z
+      .string()
+      .describe(
+        'The string date at which a notification was registered with a notification provider',
+      ),
   });
 
 export const GetRecapEmailData = {

--- a/libs/core/src/integration/email.schemas.ts
+++ b/libs/core/src/integration/email.schemas.ts
@@ -51,6 +51,8 @@ export const GetRecapEmailData = {
         EnrichedSnapshotProposalCreatedNotification,
       ]),
     ),
+    num_notifications: z.number(),
+    notifications_link: z.string(),
   }),
 };
 

--- a/libs/model/src/emails/GetRecapEmailData.query.ts
+++ b/libs/model/src/emails/GetRecapEmailData.query.ts
@@ -15,7 +15,7 @@ import {
 import { QueryTypes } from 'sequelize';
 import { fileURLToPath } from 'url';
 import z from 'zod';
-import { models } from '..';
+import { config, models } from '..';
 
 const __filename = fileURLToPath(import.meta.url);
 const log = logger(__filename);
@@ -235,6 +235,11 @@ export function GetRecapEmailDataQuery(): Query<typeof GetRecapEmailData> {
       return {
         discussion: enrichedDiscussion,
         ...enrichedGovernanceAndProtocol,
+        num_notifications:
+          enrichedDiscussion.length +
+          enrichedGovernanceAndProtocol.governance.length +
+          enrichedGovernanceAndProtocol.protocol.length,
+        notifications_link: config.SERVER_URL,
       };
     },
   };

--- a/libs/model/test/email/util.ts
+++ b/libs/model/test/email/util.ts
@@ -5,6 +5,7 @@ import {
   EnrichedChainProposalsNotification,
   EnrichedCommentCreatedNotification,
   EnrichedCommunityStakeNotification,
+  EnrichedNotificationNames,
   EnrichedSnapshotProposalCreatedNotification,
   EnrichedUserMentionedNotification,
   KnockChannelIds,
@@ -48,6 +49,8 @@ export function generateDiscussionData(
     ArrayItemType<NotificationsProviderGetMessagesReturn>,
   ];
 } {
+  const date = new Date();
+
   const userMentionedNotification: z.infer<typeof UserMentionedNotification> = {
     author: authorProfile.profile_name!,
     author_address: authorAddress.address,
@@ -73,17 +76,19 @@ export function generateDiscussionData(
     typeof EnrichedUserMentionedNotification
   > = {
     ...userMentionedNotification,
+    event_name: EnrichedNotificationNames.UserMentioned,
     author_avatar_url: authorUser.profile.avatar_url!,
+    inserted_at: date.toISOString(),
   };
 
   const enrichedCommentCreatedNotification: z.infer<
     typeof EnrichedCommentCreatedNotification
   > = {
     ...commentCreatedNotification,
+    event_name: EnrichedNotificationNames.CommentCreated,
     author_avatar_url: authorUser.profile.avatar_url!,
+    inserted_at: date.toISOString(),
   };
-
-  const date = new Date();
 
   const userMentionedMessage: ArrayItemType<NotificationsProviderGetMessagesReturn> =
     {
@@ -156,6 +161,8 @@ export function generateGovernanceData(
     ArrayItemType<NotificationsProviderGetMessagesReturn>,
   ];
 } {
+  const date = new Date();
+
   const snapshotProposalCreatedNotification: z.infer<
     typeof SnapshotProposalCreatedNotification
   > = {
@@ -177,17 +184,19 @@ export function generateGovernanceData(
     typeof EnrichedSnapshotProposalCreatedNotification
   > = {
     ...snapshotProposalCreatedNotification,
+    event_name: EnrichedNotificationNames.SnapshotProposalCreated,
     community_icon_url: community.icon_url,
+    inserted_at: date.toISOString(),
   };
 
   const enrichedChainProposalsNotification: z.infer<
     typeof EnrichedChainProposalsNotification
   > = {
     ...chainProposalsNotification,
+    event_name: EnrichedNotificationNames.ChainProposal,
     community_icon_url: community.icon_url,
+    inserted_at: date.toISOString(),
   };
-
-  const date = new Date();
 
   const snapshotProposalCreatedMessage: ArrayItemType<NotificationsProviderGetMessagesReturn> =
     {
@@ -273,7 +282,9 @@ export function generateProtocolData(
 
     enrichedNotifications.push({
       ...notification,
+      event_name: EnrichedNotificationNames.CommunityStakeTrade,
       community_icon_url: community.icon_url,
+      inserted_at: notificationDate.toISOString(),
     });
     notifications.push(notification);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8460 

## Description of Changes
- Adds `num_notifications`, `inserted_at`, `event_name` and `notifications_link` to the recap email route response

## Test Plan
- Start the server and execute (replace user_id with your user id or use `121279`):
```
curl -X 'GET'   'http://localhost:3000/api/v1/rest/query/GetRecapEmailDataQuery?user_id=[user_id]'   -H 'accept: application/json' -H 'authorization: my_secret'
```

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 