### PR TITLE
Fixed thread card preview rendering issue on iOS mobile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -152,9 +152,9 @@ export const Feed = ({
         customScrollParent={customScrollParent}
         totalCount={queryData?.data?.length || DEFAULT_COUNT}
         style={{ height: '100%' }}
-        itemContent={(i) => {
-          return <FeedThread key={1} thread={queryData.data[i] as Thread} />;
-        }}
+        itemContent={(i) => (
+          <FeedThread key={1} thread={queryData.data[i] as Thread} />
+        )}
       />
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -153,7 +153,7 @@ export const Feed = ({
         totalCount={queryData?.data?.length || DEFAULT_COUNT}
         style={{ height: '100%' }}
         itemContent={(i) => (
-          <FeedThread key={1} thread={queryData.data[i] as Thread} />
+          <FeedThread key={i} thread={queryData.data[i] as Thread} />
         )}
       />
     </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { isDefaultStage, threadStageToLabel } from 'helpers';
+import { getBrowserInfo } from 'helpers/browser';
 import {
   GetThreadActionTooltipTextResponse,
   filterLinks,
@@ -111,6 +112,16 @@ export const ThreadCard = ({
     (thread.stage && !isStageDefault) || linkedProposals?.length > 0;
   const stageLabel = threadStageToLabel(thread.stage);
 
+  // Future Ref: this fixes https://github.com/hicommonwealth/commonwealth/issues/8611 for iOS mobile
+  // where quill renders broken/cut-off/overlapping thread.plaintext in cases when there are multiple
+  // <p/> tags in the quill delta for thread.plaintext or if thread.plaintext has \n characters which
+  // iOS devices don't seem to render correctly.
+  // Not updating it for desktop per a previous issue where markdown wasn't rendered correctly in
+  // preview because of .slice()'d  content.
+  const bodyText = getBrowserInfo().isMobile
+    ? thread.plaintext.replaceAll(/\n/g, '').slice(0, 150)
+    : thread.plaintext;
+
   return (
     <>
       <Link
@@ -191,7 +202,7 @@ export const ThreadCard = ({
             </div>
             <CWText type="b1" className="content-body">
               <QuillRenderer
-                doc={thread.plaintext}
+                doc={bodyText}
                 cutoffLines={4}
                 customShowMoreButton={
                   <CWText type="b1" className="show-more-btn">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8611

## Description of Changes
Fixed thread card preview rendering issue on iOS mobile

## "How We Fixed It"
For iOS mobile, quill renders broken/cut-off/overlapping `thread.plaintext` in cases when there are multiple `<p/>` tags in the quill delta for `thread.plaintext` or if `thread.plaintext` has `\n` characters which iOS devices don't seem to render correctly.

We fixed it by handling `\n` and multiple `<p>` tags cases for iOS mobile only.

## Test Plan
- Open site with local network on a mobile device (Important: as the issue is not reproducible on desktop even with responsive mode)
- Scroll through the home or any community feed and verify you don't see the broken/cut-off/overlapping thread body like this
<img width="857" alt="image" src="https://github.com/user-attachments/assets/56c2d0f0-555b-4c6d-9c1c-bc7e3e49cdb9">


## Deployment Plan
N/A

## Other Considerations
N/A