### PR TITLE
Add block gas estimation to avoid overpaying

### DIFF
--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -411,7 +411,7 @@ export const rollOverContest = async (
   });
 };
 
-const estimateGas = async (web3: Web3): Promise<BigInt | null> => {
+const estimateGas = async (web3: Web3): Promise<bigint | null> => {
   try {
     const latestBlock = await web3.eth.getBlock('latest');
 

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -69,11 +69,16 @@ const addContent = async (
     contestABI as AbiItem[],
     contest,
   );
+
+  const maxFeePerGasEst = await estimateGas(web3);
   let txReceipt;
   try {
     const txDetails: PayableCallOptions = {
       from: web3.eth.defaultAccount,
       gas: '1000000',
+      type: '0x2',
+      maxFeePerGas: maxFeePerGasEst?.toString(),
+      maxPriorityFeePerGas: web3.utils.toWei('0.001', 'gwei'),
     };
     if (nonce) {
       txDetails.nonce = nonce.toString();
@@ -125,11 +130,15 @@ const voteContent = async (
     contest,
   );
 
+  const maxFeePerGasEst = await estimateGas(web3);
   let txReceipt;
   try {
     const txDetails: PayableCallOptions = {
       from: web3.eth.defaultAccount,
       gas: '1000000',
+      type: '0x2',
+      maxFeePerGas: maxFeePerGasEst?.toString(),
+      maxPriorityFeePerGas: web3.utils.toWei('0.001', 'gwei'),
     };
     if (nonce) {
       txDetails.nonce = nonce.toString();
@@ -390,11 +399,29 @@ export const rollOverContest = async (
     } catch {
       return false;
     }
-
+    const maxFeePerGasEst = await estimateGas(web3);
     await contractCall.send({
       from: web3.eth.defaultAccount,
       gas: gasResult.toString(),
+      type: '0x2',
+      maxFeePerGas: maxFeePerGasEst?.toString(),
+      maxPriorityFeePerGas: web3.utils.toWei('0.001', 'gwei'),
     });
     return true;
   });
+};
+
+const estimateGas = async (web3: Web3): Promise<BigInt | null> => {
+  try {
+    const latestBlock = await web3.eth.getBlock('latest');
+
+    // Calculate maxFeePerGas and maxPriorityFeePerGas
+    const baseFeePerGas = latestBlock.baseFeePerGas;
+    const maxPriorityFeePerGas = web3.utils.toWei('0.001', 'gwei');
+    const maxFeePerGas =
+      baseFeePerGas! * BigInt(2) + BigInt(parseInt(maxPriorityFeePerGas));
+    return maxFeePerGas;
+  } catch {
+    return null;
+  }
 };

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/CommunityStakes.tsx
@@ -127,6 +127,7 @@ class CommunityStakes extends ContractBase {
     const totalPrice = await this.contract.methods
       .getBuyPriceAfterFee(namespaceAddress, id.toString(), amount.toString())
       .call();
+    const maxFeePerGasEst = await this.estimateGas();
     let txReceipt;
     try {
       txReceipt = await this.contract.methods
@@ -134,8 +135,9 @@ class CommunityStakes extends ContractBase {
         .send({
           value: totalPrice,
           from: walletAddress,
-          maxPriorityFeePerGas: null,
-          maxFeePerGas: null,
+          type: '0x2',
+          maxFeePerGas: maxFeePerGasEst?.toString(),
+          maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
         });
       try {
         // @ts-expect-error StrictNullChecks
@@ -176,14 +178,16 @@ class CommunityStakes extends ContractBase {
     }
 
     const namespaceAddress = await this.getNamespaceAddress(name);
+    const maxFeePerGasEst = await this.estimateGas();
     let txReceipt;
     try {
       txReceipt = await this.contract.methods
         .sellStake(namespaceAddress, id.toString(), amount.toString())
         .send({
           from: walletAddress,
-          maxPriorityFeePerGas: null,
-          maxFeePerGas: null,
+          type: '0x2',
+          maxFeePerGas: maxFeePerGasEst?.toString(),
+          maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
         });
     } catch {
       throw new Error('Transaction failed');

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
@@ -67,6 +67,21 @@ abstract class ContractBase {
       this.contractAddress,
     );
   }
+
+  async estimateGas(): Promise<BigInt | null> {
+    try {
+      const latestBlock = await this.web3.eth.getBlock('latest');
+
+      // Calculate maxFeePerGas and maxPriorityFeePerGas
+      const baseFeePerGas = latestBlock.baseFeePerGas;
+      const maxPriorityFeePerGas = this.web3.utils.toWei('0.001', 'gwei');
+      const maxFeePerGas =
+        baseFeePerGas! * BigInt(2) + BigInt(parseInt(maxPriorityFeePerGas));
+      return maxFeePerGas;
+    } catch {
+      return null;
+    }
+  }
 }
 
 export default ContractBase;

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
@@ -68,7 +68,7 @@ abstract class ContractBase {
     );
   }
 
-  async estimateGas(): Promise<BigInt | null> {
+  async estimateGas(): Promise<bigint | null> {
     try {
       const latestBlock = await this.web3.eth.getBlock('latest');
 

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -97,7 +97,7 @@ class NamespaceFactory extends ContractBase {
     if (!namespaceStatus) {
       throw new Error('Namespace already reserved');
     }
-
+    const maxFeePerGasEst = await this.estimateGas();
     let txReceipt;
     try {
       const uri = `${window.location.origin}/api/namespaceMetadata/${name}/{id}`;
@@ -105,8 +105,9 @@ class NamespaceFactory extends ContractBase {
         .deployNamespace(name, uri, feeManager, [])
         .send({
           from: walletAddress,
-          maxPriorityFeePerGas: null,
-          maxFeePerGas: null,
+          type: '0x2',
+          maxFeePerGas: maxFeePerGasEst?.toString(),
+          maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
         });
     } catch (error) {
       throw new Error('Transaction failed: ' + error);
@@ -132,7 +133,7 @@ class NamespaceFactory extends ContractBase {
     if (!this.initialized || !this.walletEnabled) {
       await this.initialize(true, chainId);
     }
-
+    const maxFeePerGasEst = await this.estimateGas();
     let txReceipt;
     try {
       txReceipt = await this.contract.methods
@@ -146,8 +147,9 @@ class NamespaceFactory extends ContractBase {
         )
         .send({
           from: walletAddress,
-          maxPriorityFeePerGas: null,
-          maxFeePerGas: null,
+          type: '0x2',
+          maxFeePerGas: maxFeePerGasEst?.toString(),
+          maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
         });
     } catch {
       throw new Error('Transaction failed');
@@ -170,6 +172,7 @@ class NamespaceFactory extends ContractBase {
     if (!this.initialized || !this.walletEnabled) {
       await this.initialize(true);
     }
+    const maxFeePerGasEst = await this.estimateGas();
     let txReceipt;
     try {
       if (!exchangeToken) {
@@ -186,8 +189,9 @@ class NamespaceFactory extends ContractBase {
           )
           .send({
             from: walletAddress,
-            maxPriorityFeePerGas: null,
-            maxFeePerGas: null,
+            type: '0x2',
+            maxFeePerGas: maxFeePerGasEst?.toString(),
+            maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
           });
       } else {
         txReceipt = await this.contract.methods
@@ -202,8 +206,9 @@ class NamespaceFactory extends ContractBase {
           )
           .send({
             from: walletAddress,
-            maxPriorityFeePerGas: null,
-            maxFeePerGas: null,
+            type: '0x2',
+            maxFeePerGas: maxFeePerGasEst?.toString(),
+            maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
           });
       }
     } catch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8627
## Description of Changes
- Adds block gas estimation to reduce gas paid after ETH upgrades/L2 changes
- Gas reduction examples
- Namespace/Community stake $0.30 - < $0.01
- Contest deployment $26 -> $0.16
- add/VoteContent $0.50 -> < $0.01 (Note this one is most important as it changes our perspective of how much it will cost to sequence content/votes)


## Test Plan
- Attempt frontend actions such as namespace deployment/buy/sell/deploy contest

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Suggest to deploy asap 