### PR TITLE
Fix jitter when clicking into quill editor

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -109,6 +109,7 @@
     .QuillEditorWrapper {
       min-height: 255px;
       position: relative;
+      border: 1px solid transparent;
 
       &.isFocused {
         border: 1px solid $primary-500;


### PR DESCRIPTION
## Link to Issue

Closes #8633.

## Description of Changes

- Adds transparent border when editor is unfocused.

## Test Plan

Optional: click into comment editor.

## Deployment Plan

## Other Considerations

None really.