### PR TITLE
Fixed community banner link color

### DIFF
--- a/packages/commonwealth/client/styles/pages/terms_banner.scss
+++ b/packages/commonwealth/client/styles/pages/terms_banner.scss
@@ -7,6 +7,7 @@
   .terms-text.Text {
     a {
       margin-left: 4px;
+      color: $primary-500;
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8637

## Description of Changes
Fixed community banner link color

## "How We Fixed It"
N/A

## Test Plan
- Visit `/dydx`
- Make sure the community terms banner has correct link color

## Deployment Plan
N/A

## Other Considerations
N/A