### PR TITLE
Fixed sidebar collapse button visibility

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CollapsableSidebarButton/CollapsableSidebarButton.scss
@@ -49,14 +49,9 @@
       top: 68px;
       transform: rotate(-180deg);
       transition: 0.2s linear;
-      opacity: 0;
       position: absolute;
       z-index: 5;
       pointer-events: auto;
-    }
-
-    &:hover .collapse-unscoped {
-      opacity: 1;
     }
 
     .expand-unscoped {
@@ -76,12 +71,7 @@
       left: 10px;
       top: 68px;
       z-index: 5;
-      opacity: 0;
       pointer-events: auto;
-    }
-
-    &:hover .collapse-scoped {
-      opacity: 1;
     }
 
     .expand-scoped {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8640

## Description of Changes
Fixed sidebar collapse button visibility

## "How We Fixed It"
N/A

## Test Plan
- Visit community and non-community pages
- Close the app sidebar and verify the collapse button is still visible (without hovering over it)

## Deployment Plan
N/A

## Other Considerations
N/A