### PR TITLE
stripped out code to fix otuside link bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,6 +1,6 @@
 import { getProposalUrlPath } from 'identifiers';
 import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import useFetchThreadsQuery, {
@@ -85,30 +85,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const { dateCursor } = useDateCursor({
     dateRange: searchParams.get('dateRange') as ThreadTimelineFilterTypes,
   });
-
-  const splitURLPath = useMemo(() => location.pathname.split('/'), []);
-  const decodedString = useMemo(
-    () => decodeURIComponent(splitURLPath[3]),
-    [splitURLPath],
-  );
-  const memoizedTopics = useMemo(() => topics, [topics]);
-
-  //redirects users to All Discussions if they try to access a topic in the url that doesn't exist
-  useEffect(() => {
-    if (
-      decodedString &&
-      splitURLPath[2] === 'discussions' &&
-      splitURLPath.length === 4
-    ) {
-      const validTopics = memoizedTopics?.some(
-        (topic) => topic?.name === decodedString,
-      );
-      if (!validTopics) {
-        navigate('/discussions');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [memoizedTopics, decodedString, splitURLPath]);
 
   const isOnArchivePage =
     location.pathname ===


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8682 

## Description of Changes
- stripped out code that checked for topics to prevent a user being redirected to All Discussions when they try to access a specific topic through a link on an outside platform. 
**- NOTE: This is just a quick fix to make sure any links Growth has put out into the world won't be affected. A more comprehensive fix that accounts for the edge case of an outside link will be done in this ticket:** https://github.com/hicommonwealth/commonwealth/issues/8676

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-removed code that checked for a specific topic 

## Test Plan
-create a new topic and copy the link. It should look something like this https://commonwealth.im/common/discussions/Meme%20Contest
-email the link to yourself and click that link from there, just to make sure, close all tabs that may have Common or localhost open. 
-confirm that you now go to that discussion topic and not All Discussions. 

