### PR TITLE
gave contest banner max width

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
@@ -13,7 +13,7 @@
     .contest-image {
       border-radius: 5px 0 0 5px;
       max-height: 240px;
-      max-width: 510px;
+      max-width: 522px;
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
@@ -13,6 +13,7 @@
     .contest-image {
       border-radius: 5px 0 0 5px;
       max-height: 240px;
+      max-width: 510px;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8648 

## Description of Changes
- Added a max width of 510px to `.contest-image` as per designs here:
https://www.figma.com/design/NNqlhNPHvn0O96TCBIi6WU/Contests?node-id=1240-18985&m=dev
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Added a max width of 522px to `.contest-image` as per designs here:
https://www.figma.com/design/NNqlhNPHvn0O96TCBIi6WU/Contests?node-id=1240-18985&m=dev
## Test Plan
- make sure you have a very recent dump file that has the Meme Contest topic in the Common community
- go here `/common/discussions/Meme%20Contest`
- -confirm that the banner has the same dimensions width wise as the designs
