### PR TITLE
Fixed upgrade roles form to display all addresses

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.scss
@@ -18,8 +18,12 @@
       display: flex;
       flex-direction: row;
       height: 24px;
-      justify-content: space-between;
+      justify-content: flex-start;
       width: auto;
+      > *:last-child {
+        margin-left: auto; /* Pushes the last item to the end */
+        margin-right: 0; /* Ensure no extra margin on the right */
+      }
 
       svg {
         cursor: pointer;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/ManageRoles/ManageRoles.tsx
@@ -7,8 +7,10 @@ import app from 'state';
 import useUserStore from 'state/ui/user';
 import { User } from 'views/components/user/user';
 import { openConfirmation } from 'views/modals/confirmation_modal';
+import { formatAddressShort } from '../../../../../helpers/index';
 import { CWIcon } from '../../../../components/component_kit/cw_icons/cw_icon';
 import { CWLabel } from '../../../../components/component_kit/cw_label';
+import { CWText } from '../../../../components/component_kit/cw_text';
 import './ManageRoles.scss';
 
 type ManageRoleRowProps = {
@@ -121,7 +123,6 @@ export const ManageRoles = ({
       <div className="roles-container">
         {roledata?.map((r) => {
           const { role, address } = r;
-
           return (
             <div className="role-row" key={address}>
               <User
@@ -131,6 +132,7 @@ export const ManageRoles = ({
                 shouldLinkProfile
                 shouldHideAvatar
               />
+              <CWText>&nbsp;- {formatAddressShort(address)}</CWText>
               <CWIcon
                 iconName="close"
                 iconSize="small"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/UpgradeRolesForm/UpgradeRolesForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/UpgradeRolesForm/UpgradeRolesForm.tsx
@@ -1,4 +1,4 @@
-import { AddressRole, Role } from '@hicommonwealth/shared';
+import { AddressRole, DEFAULT_NAME, Role } from '@hicommonwealth/shared';
 import axios from 'axios';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { formatAddressShort } from 'helpers';
@@ -65,7 +65,7 @@ export const UpgradeRolesForm = ({
   const options = useMemo(() => {
     return rows.map((r) => {
       const roleText = r.role !== 'member' ? `(${r.role})` : '';
-      const text = `${r?.profile_name || 'anonymous'} - ${formatAddressShort(
+      const text = `${r?.profile_name || DEFAULT_NAME} - ${formatAddressShort(
         r.address,
       )} ${roleText}`;
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/UpgradeRolesForm/UpgradeRolesForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/UpgradeRolesForm/UpgradeRolesForm.tsx
@@ -20,12 +20,11 @@ type UpgradeRolesFormProps = {
 };
 
 type UserDisplayRow = {
+  profile_name: string | null | undefined;
   user_id: number;
+  avatar_url: string | null | undefined;
+  role: string;
   address_id: number;
-  community_id: string;
-  profile_name: string;
-  role: Role;
-  avatar_url: string;
   address: string;
 };
 
@@ -107,12 +106,12 @@ export const UpgradeRolesForm = ({
         notifySuccess('Member upgraded');
         onRoleUpdate(
           {
-            address: selectedAddress,
-            role: selectedRole,
+            address: selectedAddress as string,
+            role: selectedRole as Role,
           },
           {
-            address: response.data.result.address,
-            role: response.data.result.role,
+            address: response.data.result.address as string,
+            role: response.data.result.role as Role,
           },
         );
         zeroOutRadioButtons();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8524

## Description of Changes
- Makes upgrade roles form display all addresses and associated user instead of only one of their addresses.

## Test Plan
- As a community admin of a community with at least one user having multiple addresses in that community, go to the upgrade roles form page (/manage/moderators). You should see some users with multiple addresses. From there you should be able to choose which ones you want to upgrade:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/2e0fd2ab-59df-4e7b-bff7-e6e9cd5037cf">
