### PR TITLE
Added community page not found component

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -103,6 +103,9 @@ const AdminPanelPage = lazy(() => import('views/pages/AdminPanel'));
 const NewProfilePage = lazy(() => import('views/pages/new_profile'));
 const EditNewProfilePage = lazy(() => import('views/pages/edit_new_profile'));
 const ProfilePageRedirect = lazy(() => import('views/pages/profile_redirect'));
+const CommunityNotFoundPage = lazy(
+  () => import('views/pages/CommunityNotFoundPage'),
+);
 
 const CommonDomainRoutes = ({
   contestEnabled,
@@ -573,6 +576,15 @@ const CommonDomainRoutes = ({
     element={<Navigate to={(parameters) => `/${parameters.scope}/`} />}
   />,
   // LEGACY REDIRECTS END
+
+  // Community not found page - This should be at the end
+  <Route
+    key="/:scope/*"
+    path="/:scope/*"
+    element={withLayout(CommunityNotFoundPage, {
+      scoped: true,
+    })}
+  />,
 ];
 
 export default CommonDomainRoutes;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityNotFoundPage/CommunityNotFoundPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityNotFoundPage/CommunityNotFoundPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
+import { PageNotFound } from '../404';
+
+const CommunityNotFoundPage = () => {
+  return (
+    <CWPageLayout>
+      <PageNotFound />
+    </CWPageLayout>
+  );
+};
+
+export default CommunityNotFoundPage;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityNotFoundPage/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityNotFoundPage/index.tsx
@@ -1,0 +1,3 @@
+import CommunityNotFoundPage from './CommunityNotFoundPage';
+
+export default CommunityNotFoundPage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8733

## Description of Changes
When visiting an invalid link inside a valid community, we now show a `Not found page`

## "How We Fixed It"
N/A

## Test Plan
- Visit any invalid URL inside a valid community ex: `http://localhost:8080/dydx/overview/invalid-endpoint`
- Verify you see the not found page and the community sidebar loads properly.

## Deployment Plan
N/A

## Other Considerations
N/A