### PR TITLE
Fix sorting by upvotes

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/helpers.ts
@@ -153,9 +153,7 @@ export const sortByFeaturedFilter = (t: Thread[], featuredFilter) => {
   }
 
   if (featuredFilter === ThreadFeaturedFilterTypes.MostLikes) {
-    return [...t].sort(
-      (a, b) => b.associatedReactions.length - a.associatedReactions.length,
-    );
+    return [...t].sort((a, b) => b.reactionWeightsSum - a.reactionWeightsSum);
   }
 
   if (featuredFilter === ThreadFeaturedFilterTypes.LatestActivity) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8739 

## Description of Changes
- So far we sorted by upvotes but we didn't count calculated staked reactions, just the number of votes. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- I tested it by downloading prod dump and using Common community as there was the bug discovered
- To test it you would need to have multiple accounts with and without stake
- Then you need to have multiple threads 
- Vote the threads so each have some upvotes with and without stake

![image](https://github.com/user-attachments/assets/fc2e4cd9-b77b-4021-a4d4-071a0dbf0495)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a