### PR TITLE
Add getCommunity route to query single community info.

### DIFF
--- a/libs/model/src/community/GetCommunity.query.ts
+++ b/libs/model/src/community/GetCommunity.query.ts
@@ -15,7 +15,6 @@ export function GetCommunity(): Query<typeof schemas.GetCommunity> {
         include.push({
           model: models.ChainNode,
           required: true,
-          // TODO: attributes
         });
       }
 

--- a/libs/model/src/community/GetCommunity.query.ts
+++ b/libs/model/src/community/GetCommunity.query.ts
@@ -1,0 +1,30 @@
+import { type Query } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { Includeable } from 'sequelize';
+import { models } from '../database';
+
+export function GetCommunity(): Query<typeof schemas.GetCommunity> {
+  return {
+    ...schemas.GetCommunity,
+    auth: [],
+    secure: false,
+    body: async ({ payload }) => {
+      const where = { id: payload.id };
+      const include: Includeable[] = [];
+      if (payload.include_node_info) {
+        include.push({
+          model: models.ChainNode,
+          required: true,
+          // TODO: attributes
+        });
+      }
+
+      return (
+        await models.Community.findOne({
+          where,
+          include,
+        })
+      )?.toJSON();
+    },
+  };
+}

--- a/libs/model/src/community/index.ts
+++ b/libs/model/src/community/index.ts
@@ -1,6 +1,7 @@
 export * from './CreateGroup.command';
 export * from './CreateStakeTransaction.command';
 export * from './GenerateStakeholderGroups.command';
+export * from './GetCommunity.query';
 export * from './GetCommunityStake.query';
 export * from './GetMembers.query';
 export * from './GetStakeHistoricalPrice.query';

--- a/libs/schemas/src/entities/chain.schemas.ts
+++ b/libs/schemas/src/entities/chain.schemas.ts
@@ -5,7 +5,6 @@ import {
 } from '@hicommonwealth/shared';
 import z from 'zod';
 import { PG_INT } from '../utils';
-import { Community } from './community.schemas';
 import { Contract } from './contract.schemas';
 
 export const ChainNode = z.object({
@@ -32,6 +31,3 @@ export const ChainNode = z.object({
   block_explorer: z.string().optional(),
   max_ce_block_range: z.number().gte(-1).nullish(),
 });
-
-// aliases
-export const Chain = Community;

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -6,6 +6,7 @@ import {
 } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import { PG_INT } from '../utils';
+import { ChainNode } from './chain.schemas';
 import { ContestManager } from './contest-manager.schemas';
 import { Group } from './group.schemas';
 import { CommunityStake } from './stake.schemas';
@@ -55,6 +56,7 @@ export const Community = z.object({
   Addresses: z.array(Address).optional(),
   CommunityStakes: z.array(CommunityStake).optional(),
   CommunityTags: z.array(CommunityTag).optional(),
+  ChainNode: ChainNode.optional(),
   topics: z.array(Topic).optional(),
   groups: z.array(Group).optional(),
   contest_managers: z.array(ContestManager).optional(),

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -63,3 +63,6 @@ export const Community = z.object({
   snapshot_spaces: z.array(z.string().max(255)).default([]).optional(),
   include_in_digest_email: z.boolean().nullish(),
 });
+
+// aliases
+export const Chain = Community;

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -1,8 +1,16 @@
 import { MAX_SCHEMA_INT, MIN_SCHEMA_INT } from '@hicommonwealth/shared';
 import { z } from 'zod';
-import { CommunityMember, CommunityStake } from '../entities';
+import { Community, CommunityMember, CommunityStake } from '../entities';
 import { PG_INT } from '../utils';
 import { PaginatedResultSchema, PaginationParamsSchema } from './pagination';
+
+export const GetCommunity = {
+  input: z.object({
+    id: z.string(),
+    include_node_info: z.boolean().optional(),
+  }),
+  output: Community.optional(),
+};
 
 export const GetCommunityStake = {
   input: z.object({

--- a/packages/commonwealth/server/api/community.ts
+++ b/packages/commonwealth/server/api/community.ts
@@ -2,6 +2,7 @@ import { trpc } from '@hicommonwealth/adapters';
 import { Community } from '@hicommonwealth/model';
 
 export const trpcRouter = trpc.router({
+  getCommunity: trpc.query(Community.GetCommunity),
   getStake: trpc.query(Community.GetCommunityStake),
   getStakeTransaction: trpc.query(Community.GetStakeTransaction),
   getStakeHistoricalPrice: trpc.query(Community.GetStakeHistoricalPrice),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8755

## Description of Changes
- Adds GetCommunity TPRC route to get a specific community, as part of the changes required to complete #4976.

## Test Plan
- Will be exercised by a follow-up PR by @mzparacha that will use it to query single community info, rather than querying against the list of all communities in the /communities legacy route.