### PR TITLE
Remove extra upvote weight + prevent stakeless upvotes in staked community

### DIFF
--- a/libs/shared/src/commonProtocol/utils.ts
+++ b/libs/shared/src/commonProtocol/utils.ts
@@ -2,8 +2,7 @@ export const calculateVoteWeight = (
   stakeBalance: string,
   voteWeight: number,
 ) => {
-  // all community members get 1 weight by default
-  return 1 + parseInt(stakeBalance, 10) * voteWeight;
+  return parseInt(stakeBalance, 10) * voteWeight;
 };
 
 export enum Denominations {

--- a/packages/commonwealth/client/scripts/models/Reaction.ts
+++ b/packages/commonwealth/client/scripts/models/Reaction.ts
@@ -44,7 +44,7 @@ class Reaction {
     this.author_chain = author_chain;
     this.canvasSignedData = canvas_signed_data;
     this.canvasHash = canvas_hash;
-    this.calculatedVotingWeight = calculated_voting_weight || 1;
+    this.calculatedVotingWeight = calculated_voting_weight || 0;
     this.updatedAt = updated_at;
 
     this.profile = addressToUserProfile(Address);

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -137,7 +137,7 @@ function processAssociatedReactions(
         type: tempReactionType[i],
         address: tempAddressesReacted[i],
         updated_at: tempReactionTimestamps[i],
-        voting_weight: tempReactionWeights[i] || 1,
+        voting_weight: tempReactionWeights[i] || 0,
         reactedProfileName: emptyStringToNull(reactedProfileName?.[i]),
         reactedProfileAvatarUrl: emptyStringToNull(
           reactedProfileAvatarUrl?.[i],

--- a/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createReaction.ts
@@ -1,6 +1,7 @@
 import { toCanvasSignedDataApiArgs } from '@hicommonwealth/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { notifyError } from 'client/scripts/controllers/app/notifications';
 import { signCommentReaction } from 'controllers/server/sessions';
 import Reaction from 'models/Reaction';
 import app from 'state';
@@ -87,7 +88,14 @@ const useCreateCommentReactionMutation = ({
 
       return reaction;
     },
-    onError: (error) => checkForSessionKeyRevalidationErrors(error),
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.data?.error?.toLowerCase().includes('stake')) {
+          notifyError('Buy stake in community to upvote comments');
+        }
+      }
+      return checkForSessionKeyRevalidationErrors(error);
+    },
   });
 };
 

--- a/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
@@ -141,7 +141,7 @@ export async function __createCommentReaction(
         throw new AppError(Errors.MustHaveStake);
       }
       calculatedVotingWeight = commonProtocol.calculateVoteWeight(
-        stakeBalances[address.address],
+        stakeBalance,
         voteWeight,
       );
     }

--- a/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_comments_methods/create_comment_reaction.ts
@@ -7,6 +7,7 @@ import {
 } from '@hicommonwealth/model';
 import { PermissionEnum } from '@hicommonwealth/schemas';
 import { NotificationCategories, commonProtocol } from '@hicommonwealth/shared';
+import { BigNumber } from 'ethers';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { config } from '../../config';
 import { validateTopicGroupsMembership } from '../../util/requirementsModule/validateTopicGroupsMembership';
@@ -23,6 +24,7 @@ const Errors = {
   BalanceCheckFailed: 'Could not verify user token balance',
   FailedCreateReaction: 'Failed to create reaction',
   CommunityNotFound: 'Community not found',
+  MustHaveStake: 'Must have stake to upvote',
 };
 
 export type CreateCommentReactionOptions = {
@@ -133,6 +135,11 @@ export async function __createCommentReaction(
           node.eth_chain_id,
           [address.address],
         );
+      const stakeBalance = stakeBalances[address.address];
+      if (BigNumber.from(stakeBalance).lte(0)) {
+        // stake is enabled but user has no stake
+        throw new AppError(Errors.MustHaveStake);
+      }
       calculatedVotingWeight = commonProtocol.calculateVoteWeight(
         stakeBalances[address.address],
         voteWeight,

--- a/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
+++ b/packages/commonwealth/server/controllers/server_threads_methods/create_thread_reaction.ts
@@ -7,6 +7,7 @@ import {
 } from '@hicommonwealth/model';
 import { PermissionEnum } from '@hicommonwealth/schemas';
 import { NotificationCategories, commonProtocol } from '@hicommonwealth/shared';
+import { BigNumber } from 'ethers';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { config } from '../../config';
 import { validateTopicGroupsMembership } from '../../util/requirementsModule/validateTopicGroupsMembership';
@@ -23,6 +24,7 @@ export const Errors = {
   ThreadArchived: 'Thread is archived',
   FailedCreateReaction: 'Failed to create reaction',
   CommunityNotFound: 'Community not found',
+  MustHaveStake: 'Must have stake to upvote',
 };
 
 export type CreateThreadReactionOptions = {
@@ -125,8 +127,13 @@ export async function __createThreadReaction(
           node.eth_chain_id,
           [address.address],
         );
+      const stakeBalance = stakeBalances[address.address];
+      if (BigNumber.from(stakeBalance).lte(0)) {
+        // stake is enabled but user has no stake
+        throw new AppError(Errors.MustHaveStake);
+      }
       calculatedVotingWeight = commonProtocol.calculateVoteWeight(
-        stakeBalances[address.address],
+        stakeBalance,
         voteWeight,
       );
     }

--- a/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
+++ b/packages/commonwealth/test/integration/api/reactionVoteWeight.spec.ts
@@ -122,7 +122,7 @@ describe('Reaction vote weight', () => {
       reaction: 'like',
       threadId: thread.id,
     });
-    const expectedWeight = 1 + 50 * 200;
+    const expectedWeight = 50 * 200;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
     const t = await server.models.Thread.findByPk(thread.id);
     // @ts-expect-error StrictNullChecks
@@ -142,7 +142,7 @@ describe('Reaction vote weight', () => {
       reaction: 'like',
       commentId: comment.id,
     });
-    const expectedWeight = 1 + 50 * 200;
+    const expectedWeight = 50 * 200;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
     const c = await server.models.Comment.findByPk(comment.id);
     // @ts-expect-error StrictNullChecks
@@ -152,7 +152,7 @@ describe('Reaction vote weight', () => {
   test('should set thread reaction vote weight to min 1', async () => {
     Sinon.stub(commonProtocol.contractHelpers, 'getNamespaceBalance').resolves({
       // @ts-expect-error StrictNullChecks
-      [address.address]: '0',
+      [address.address]: '17',
     });
     const thread = await createThread();
     const [reaction] = await threadsController.createThreadReaction({
@@ -161,14 +161,14 @@ describe('Reaction vote weight', () => {
       reaction: 'like',
       threadId: thread.id,
     });
-    const expectedWeight = 1;
+    const expectedWeight = 17 * 200;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
   });
 
   test('should set comment reaction vote weight to min 1', async () => {
     Sinon.stub(commonProtocol.contractHelpers, 'getNamespaceBalance').resolves({
       // @ts-expect-error StrictNullChecks
-      [address.address]: '0',
+      [address.address]: '7',
     });
     const thread = await createThread();
     const comment = await createComment(thread.id);
@@ -178,7 +178,7 @@ describe('Reaction vote weight', () => {
       reaction: 'like',
       commentId: comment.id,
     });
-    const expectedWeight = 1;
+    const expectedWeight = 7 * 200;
     expect(reaction.calculated_voting_weight).to.eq(expectedWeight);
   });
 });

--- a/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_comments_controller.spec.ts
@@ -70,11 +70,7 @@ describe('ServerCommentsController', () => {
           }),
         },
         CommunityStake: {
-          findOne: sandbox.stub().resolves({
-            id: 5,
-            stake_id: 1,
-            vote_weight: 1,
-          }),
+          findOne: sandbox.stub().resolves(null),
         },
         Community: {
           findByPk: async () => ({

--- a/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
+++ b/packages/commonwealth/test/unit/server_controllers/server_threads_controller.spec.ts
@@ -70,11 +70,7 @@ describe('ServerThreadsController', () => {
           }),
         },
         CommunityStake: {
-          findOne: sandbox.stub().resolves({
-            id: 5,
-            stake_id: 1,
-            vote_weight: 1,
-          }),
+          findOne: sandbox.stub().resolves(null),
         },
 
         Community: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8681
Closes: #8752

## Description of Changes
- Removes extra upvote weight from reactions
- Prevents user from casting stakeless votes in a staked community
- Updates UI to show toast message with error if insufficient stake

## Test Plan
- Create a community, don't buy stake
- Create a thread and attempt to upvote it– ensure that the upvote fails with toast
- Create a comment and attempt to upvote it– ensure that the upvote fails with toast
- Buy some stake
- Create a thread, ensure that thread upvote can be cast
- Create a comment, ensure that comment upvote can be cast

## Deployment Plan
N/A

## Other Considerations
N/A