### PR TITLE
Ability to download markdown for Kyve

### DIFF
--- a/packages/commonwealth/client/scripts/utils/downloadDataAsFile.ts
+++ b/packages/commonwealth/client/scripts/utils/downloadDataAsFile.ts
@@ -2,8 +2,12 @@
  * Save the content locally and use the `filename` as the suggested name for the
  * file.
  */
-export function downloadDataAsFile(content: string, filename: string) {
-  const blob = new Blob([content], { type: 'text/markdown' });
+export function downloadDataAsFile(
+  content: string,
+  type: string,
+  filename: string,
+) {
+  const blob = new Blob([content], { type });
 
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);

--- a/packages/commonwealth/client/scripts/utils/downloadDataAsFile.ts
+++ b/packages/commonwealth/client/scripts/utils/downloadDataAsFile.ts
@@ -1,0 +1,19 @@
+/**
+ * Save the content locally and use the `filename` as the suggested name for the
+ * file.
+ */
+export function downloadDataAsFile(content: string, filename: string) {
+  const blob = new Blob([content], { type: 'text/markdown' });
+
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+
+  document.body.appendChild(link);
+
+  link.click();
+
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(link.href);
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
@@ -30,6 +30,7 @@ import {
   Compass,
   Copy,
   DotsThreeVertical,
+  Download,
   Export,
   Eye,
   Flag,
@@ -240,6 +241,7 @@ export const iconLookup = {
   website: Icons.CWWebsite,
   write: Icons.CWWrite,
   members: Icons.CWMembers,
+  download: withPhosphorIcon(Download),
 };
 
 export const customIconLookup = {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -26,6 +26,7 @@ import './AdminActions.scss';
 
 export type AdminActionsProps = {
   thread: Thread;
+  canUpdateThread: boolean;
   onDelete?: () => any;
   onSpamToggle?: (thread: Thread) => any;
   onLockToggle?: (isLocked: boolean) => any;
@@ -56,6 +57,7 @@ export const AdminActions = ({
   hasPendingEdits,
   editingDisabled,
   onDownloadMarkdown,
+  canUpdateThread,
 }: AdminActionsProps) => {
   const navigate = useCommonNavigate();
   const [isEditCollaboratorsModalOpen, setIsEditCollaboratorsModalOpen] =
@@ -298,7 +300,8 @@ export const AdminActions = ({
         <PopoverMenu
           className="AdminActions compact"
           menuItems={[
-            ...(thread.archivedAt === null &&
+            ...(canUpdateThread &&
+            thread.archivedAt === null &&
             (hasAdminPermissions ||
               isThreadAuthor ||
               (isThreadCollaborator && !thread.readOnly))
@@ -321,7 +324,7 @@ export const AdminActions = ({
                   },
                 ]
               : []),
-            ...(hasAdminPermissions
+            ...(canUpdateThread && hasAdminPermissions
               ? [
                   ...(thread.archivedAt === null
                     ? [
@@ -367,7 +370,7 @@ export const AdminActions = ({
                 iconLeftWeight: 'bold' as const,
               },
             ],
-            ...(isThreadAuthor || hasAdminPermissions
+            ...(canUpdateThread && (isThreadAuthor || hasAdminPermissions)
               ? [
                   ...(app.chain?.meta.snapshot.length
                     ? [

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -357,6 +357,14 @@ export const AdminActions = ({
                   },
                 ]
               : []),
+            ...[
+              {
+                onClick: handleDeleteThread,
+                label: 'Download as Markdown',
+                iconLeft: 'trash' as const,
+                iconLeftWeight: 'bold' as const,
+              },
+            ],
             ...(isThreadAuthor || hasAdminPermissions
               ? [
                   ...(app.chain?.meta.snapshot.length

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -26,7 +26,7 @@ import './AdminActions.scss';
 
 export type AdminActionsProps = {
   thread: Thread;
-  canUpdateThread: boolean;
+  canUpdateThread?: boolean;
   onDelete?: () => any;
   onSpamToggle?: (thread: Thread) => any;
   onLockToggle?: (isLocked: boolean) => any;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/AdminActions/AdminActions.tsx
@@ -36,6 +36,7 @@ export type AdminActionsProps = {
   onEditStart?: () => any;
   onEditConfirm?: () => any;
   onEditCancel?: () => any;
+  onDownloadMarkdown?: () => void;
   hasPendingEdits?: boolean;
   editingDisabled?: boolean;
 };
@@ -54,6 +55,7 @@ export const AdminActions = ({
   onEditConfirm,
   hasPendingEdits,
   editingDisabled,
+  onDownloadMarkdown,
 }: AdminActionsProps) => {
   const navigate = useCommonNavigate();
   const [isEditCollaboratorsModalOpen, setIsEditCollaboratorsModalOpen] =
@@ -359,9 +361,9 @@ export const AdminActions = ({
               : []),
             ...[
               {
-                onClick: handleDeleteThread,
+                onClick: () => onDownloadMarkdown?.(),
                 label: 'Download as Markdown',
-                iconLeft: 'trash' as const,
+                iconLeft: 'download' as const,
                 iconLeftWeight: 'bold' as const,
               },
             ],

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -12,6 +12,7 @@ import React, {
 import { useCreateThreadSubscriptionMutation } from 'state/api/trpc/subscription/useCreateThreadSubscriptionMutation';
 import { useDeleteThreadSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteThreadSubscriptionMutation';
 import Permissions from 'utils/Permissions';
+import { downloadDataAsFile } from 'utils/downloadDataAsFile';
 import { SharePopover } from 'views/components/SharePopover';
 import { ViewUpvotesDrawerTrigger } from 'views/components/UpvoteDrawer';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
@@ -92,6 +93,10 @@ export const ThreadOptions = ({
       setIsSubscribed,
     );
   }, [isSubscribed, thread]);
+
+  const handleDownloadMarkdown = () => {
+    downloadDataAsFile(thread.plaintext, thread.title + '.md');
+  };
 
   const createThreadSubscriptionMutation =
     useCreateThreadSubscriptionMutation();
@@ -226,7 +231,7 @@ export const ThreadOptions = ({
             />
           )}
 
-          {canUpdateThread && thread && (
+          {thread && (
             <AdminActions
               thread={thread}
               onLockToggle={onLockToggle}
@@ -239,6 +244,7 @@ export const ThreadOptions = ({
               onProposalStageChange={onProposalStageChange}
               onSnapshotProposalFromThread={onSnapshotProposalFromThread}
               onSpamToggle={onSpamToggle}
+              onDownloadMarkdown={handleDownloadMarkdown}
               hasPendingEdits={hasPendingEdits}
               editingDisabled={editingDisabled}
             />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -95,7 +95,7 @@ export const ThreadOptions = ({
   }, [isSubscribed, thread]);
 
   const handleDownloadMarkdown = () => {
-    downloadDataAsFile(thread.plaintext, thread.title + '.md');
+    downloadDataAsFile(thread.plaintext, 'text/markdown', thread.title + '.md');
   };
 
   const createThreadSubscriptionMutation =

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -233,6 +233,7 @@ export const ThreadOptions = ({
 
           {thread && (
             <AdminActions
+              canUpdateThread={canUpdateThread}
               thread={thread}
               onLockToggle={onLockToggle}
               onCollaboratorsEdit={onCollaboratorsEdit}

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
@@ -3,7 +3,6 @@ import 'components/proposals/json_display.scss';
 import { CoinObject } from 'controllers/chain/cosmos/types';
 import React from 'react';
 import app from 'state';
-import { downloadDataAsFile } from 'utils/downloadDataAsFile';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWButton } from '../../components/component_kit/new_designs/CWButton';
@@ -26,10 +25,21 @@ export const JSONDisplay = ({ data, title }: JSONDisplayProps) => {
   const isKYVE = app.chain.network === ChainNetwork.Kyve;
   const handleExport = () => {
     const dataTitle = data.title || 'Proposal';
-    const filename = `${dataTitle}.md`;
     const proposalDetails = data.details || '';
 
-    downloadDataAsFile(proposalDetails, filename);
+    const blob = new Blob([proposalDetails], { type: 'text/markdown' });
+
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `${dataTitle}.md`;
+
+    document.body.appendChild(link);
+
+    link.click();
+
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(link.href);
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
@@ -3,6 +3,7 @@ import 'components/proposals/json_display.scss';
 import { CoinObject } from 'controllers/chain/cosmos/types';
 import React from 'react';
 import app from 'state';
+import { downloadDataAsFile } from 'utils/downloadDataAsFile';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWButton } from '../../components/component_kit/new_designs/CWButton';
@@ -25,21 +26,10 @@ export const JSONDisplay = ({ data, title }: JSONDisplayProps) => {
   const isKYVE = app.chain.network === ChainNetwork.Kyve;
   const handleExport = () => {
     const dataTitle = data.title || 'Proposal';
+    const filename = `${dataTitle}.md`;
     const proposalDetails = data.details || '';
 
-    const blob = new Blob([proposalDetails], { type: 'text/markdown' });
-
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${dataTitle}.md`;
-
-    document.body.appendChild(link);
-
-    link.click();
-
-    document.body.removeChild(link);
-
-    URL.revokeObjectURL(link.href);
+    downloadDataAsFile(proposalDetails, filename);
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/JSONDisplay.tsx
@@ -3,6 +3,7 @@ import 'components/proposals/json_display.scss';
 import { CoinObject } from 'controllers/chain/cosmos/types';
 import React from 'react';
 import app from 'state';
+import { downloadDataAsFile } from 'utils/downloadDataAsFile';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWButton } from '../../components/component_kit/new_designs/CWButton';
@@ -26,20 +27,7 @@ export const JSONDisplay = ({ data, title }: JSONDisplayProps) => {
   const handleExport = () => {
     const dataTitle = data.title || 'Proposal';
     const proposalDetails = data.details || '';
-
-    const blob = new Blob([proposalDetails], { type: 'text/markdown' });
-
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${dataTitle}.md`;
-
-    document.body.appendChild(link);
-
-    link.click();
-
-    document.body.removeChild(link);
-
-    URL.revokeObjectURL(link.href);
+    downloadDataAsFile(proposalDetails, 'text/markdown', `${dataTitle}.md`);
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8512

## Description of Changes
- There will always be an overflow button on "thread options" (the bar after thread content)
- It will now have a "Download as Markdown" button
- This triggers a download with the current title as the filename with a .md extension.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Load up a thread , go to the context menu, download the content.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 