### PR TITLE
request the latest clock when signing actions

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -11,6 +11,7 @@ import {
   chainBaseToCanvasChainId,
   getSessionSigners,
 } from '@hicommonwealth/shared';
+import axios from 'axios';
 import app from 'state';
 import { fetchCachedConfiguration } from 'state/api/configuration';
 import Account from '../../models/Account';
@@ -163,9 +164,13 @@ async function sign(
         }
       }
 
+      // get the clock and parents from the backend
+      const response = await axios.get(`${app.serverUrl()}/getCanvasClock`);
+      const { clock, heads: parents } = response.data.result;
+
       const sessionMessage: Message<Session> = {
-        clock: 1,
-        parents: [],
+        clock,
+        parents,
         topic: CANVAS_TOPIC,
         payload: session,
       };
@@ -177,7 +182,7 @@ async function sign(
       ).id;
 
       const actionMessage: Message<Action> = {
-        clock: 2,
+        clock: clock + 1,
         parents: [sessionMessageId],
         topic: CANVAS_TOPIC,
         payload: {

--- a/packages/commonwealth/server/routes/canvas/get_canvas_clock_handler.ts
+++ b/packages/commonwealth/server/routes/canvas/get_canvas_clock_handler.ts
@@ -1,0 +1,18 @@
+import { canvas } from 'server';
+import { ServerControllers } from '../../routing/router';
+import { TypedRequestQuery, TypedResponse, success } from '../../types';
+
+type GetStatsResponse = {
+  clock: number;
+  heads: string[];
+};
+
+export const getCanvasClockHandler = async (
+  controllers: ServerControllers,
+  req: TypedRequestQuery<{}>,
+  res: TypedResponse<GetStatsResponse>,
+) => {
+  const [clock, heads] = await canvas.messageLog.getClock();
+
+  return success(res, { clock, heads });
+};

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -112,6 +112,7 @@ import { getNamespaceMetadata } from 'server/routes/communities/get_namespace_me
 import { updateChainNodeHandler } from 'server/routes/communities/update_chain_node_handler';
 import { config } from '../config';
 import { getStatsHandler } from '../routes/admin/get_stats_handler';
+import { getCanvasClockHandler } from '../routes/canvas/get_canvas_clock_handler';
 import { createCommentReactionHandler } from '../routes/comments/create_comment_reaction_handler';
 import { deleteBotCommentHandler } from '../routes/comments/delete_comment_bot_handler';
 import { deleteCommentHandler } from '../routes/comments/delete_comment_handler';
@@ -1106,6 +1107,13 @@ function setupRouter(
     passport.authenticate('jwt', { session: false }),
     databaseValidationService.validateAuthor,
     deleteGroupHandler.bind(this, serverControllers),
+  );
+
+  registerRoute(
+    router,
+    'get',
+    '/getCanvasClock',
+    getCanvasClockHandler.bind(this, serverControllers),
   );
 
   registerRoute(router, 'get', '/health', healthHandler.bind(this));


### PR DESCRIPTION
Note that this PR is just to merge into https://github.com/hicommonwealth/commonwealth/pull/8537 - I've just put it in a separate PR to make it more convenient to discuss with @raykyri 

## Description of Changes
This PR populates the `clock` and `parents` fields when the session message (`Message<Session>`) and action message (`Message<Action>`) are created. It adds a new endpoint `/getCanvasClock` which returns the current clock and message head ids. This is called from the `sign` function in `/packages/commonwealth/client/scripts/controllers/server/sessions.ts`.

TODO:
- Currently we create a `Message<Session>` object every time a verified action takes place. In theory we should be able to only create one of these, when the user authorises a new session (this happens when the user logs in or when they revalidate a session).

## Test Plan
Tested by logging in and performing actions
