### PR TITLE
Fixes vitest VS code extension loading

### DIFF
--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -17,7 +17,7 @@ function createScriptsResolver(folder: string): Alias {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  const envPath = path.dirname(path.dirname(process.cwd())); // root project .env
+  const envPath = path.dirname(path.dirname(projectRootDir)); // root project .env
   const env = loadEnv(mode, envPath, '');
 
   const unleashConfig = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
-  Use the vitest config path to find root .env instead of the current working directory. VS code extensions are starting from a different path.