### PR TITLE
"Finish setting up your community" text now has more spacing on top

### DIFF
--- a/packages/commonwealth/client/styles/pages/discussions/index.scss
+++ b/packages/commonwealth/client/styles/pages/discussions/index.scss
@@ -22,7 +22,7 @@ $size: 48px;
   .UserTrainingSliderPageLayout,
   .AdminOnboardingSliderPageLayout {
     padding-inline: 0;
-    margin-top: -36px;
+    margin-top: -30px;
 
     @include smallInclusive {
       margin-top: -12px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8830 

## Description of Changes
-"Finish setting up your community" now has more padding on the top so that it sits below the breadcrumbs rather than behind

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
changed ` margin-top: -36px;` to ` margin-top: -30px;`
## Test Plan
- Go to a community that has not finished setting up
- click around and make sure no pages show the text behind the breadcrumbs

<img width="1418" alt="Screenshot 2024-08-12 at 5 59 35 PM" src="https://github.com/user-attachments/assets/84fbbf3c-6424-42da-80c4-f71d75bf22a0">
