### PR TITLE
Fixed bug where unauthenticated users would get subscription errors in the console.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -1,135 +1,117 @@
 import { CommunityAlert } from '@hicommonwealth/schemas';
-import { getUniqueCommunities } from 'helpers/addresses';
-import { useFlag } from 'hooks/useFlag';
-import useUserLoggedIn from 'hooks/useUserLoggedIn';
-import React, { useState } from 'react';
-import { useCommunityAlertsQuery } from 'state/api/trpc/subscription/useCommunityAlertsQuery';
-import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
-import {
-  CWTab,
-  CWTabsRow,
-} from 'views/components/component_kit/new_designs/CWTabs';
-import { PageNotFound } from 'views/pages/404';
-import { CommentSubscriptions } from 'views/pages/NotificationSettings/CommentSubscriptions';
-import { CommunityEntry } from 'views/pages/NotificationSettings/CommunityEntry';
-import { PushNotificationsToggle } from 'views/pages/NotificationSettings/PushNotificationsToggle';
-import { ThreadSubscriptions } from 'views/pages/NotificationSettings/ThreadSubscriptions';
-import { useSupportsPushNotifications } from 'views/pages/NotificationSettings/useSupportsPushNotifications';
-import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
 import { z } from 'zod';
-import { CWText } from '../../components/component_kit/cw_text';
-import { PageLoading } from '../loading';
 import './index.scss';
 
 type NotificationSection = 'community-alerts' | 'threads' | 'comments';
 
 const NotificationSettings = () => {
-  const supportsPushNotifications = useSupportsPushNotifications();
-  const threadSubscriptions = useThreadSubscriptions();
-  const communityAlerts = useCommunityAlertsQuery();
-  const enableKnockPushNotifications = useFlag('knockPushNotifications');
-  const { isLoggedIn } = useUserLoggedIn();
-
-  const communityAlertsIndex = createIndexForCommunityAlerts(
-    (communityAlerts.data as unknown as ReadonlyArray<
-      z.infer<typeof CommunityAlert>
-    >) || [],
-  );
-
-  const [section, setSection] =
-    useState<NotificationSection>('community-alerts');
-
-  if (threadSubscriptions.isLoading) {
-    return <PageLoading />;
-  } else if (!isLoggedIn) {
-    return <PageNotFound />;
-  }
-
-  return (
-    <CWPageLayout>
-      <div className="NotificationSettingsPage NotificationSettings">
-        <CWText type="h3" fontWeight="semiBold" className="page-header-text">
-          Notification settings
-        </CWText>
-
-        <CWText className="page-subheader-text">
-          Manage the emails and alerts you receive about your activity
-        </CWText>
-
-        {enableKnockPushNotifications && supportsPushNotifications && (
-          <div>
-            <CWText type="h5">Push Notifications</CWText>
-
-            <div className="setting-container">
-              <div className="setting-container-left">
-                <CWText className="text-muted">
-                  Turn on notifications to receive alerts on your device.
-                </CWText>
-              </div>
-
-              <div className="setting-container-right">
-                <PushNotificationsToggle />
-              </div>
-            </div>
-          </div>
-        )}
-
-        <CWTabsRow>
-          <CWTab
-            label="Community"
-            isSelected={section === 'community-alerts'}
-            onClick={() => setSection('community-alerts')}
-          />
-          <CWTab
-            label="Threads"
-            isSelected={section === 'threads'}
-            onClick={() => setSection('threads')}
-          />
-
-          <CWTab
-            label="Comments"
-            isSelected={section === 'comments'}
-            onClick={() => setSection('comments')}
-          />
-        </CWTabsRow>
-
-        {!communityAlerts.isLoading && section === 'community-alerts' && (
-          <>
-            <CWText type="h4" fontWeight="semiBold" className="section-header">
-              Community Alerts
-            </CWText>
-
-            <CWText className="page-subheader-text">
-              Get updates on onchain activity and proposals in these
-              communities.
-            </CWText>
-
-            {getUniqueCommunities().map((community) => {
-              return (
-                <CommunityEntry
-                  key={community.id}
-                  communityInfo={community}
-                  communityAlert={communityAlertsIndex[community.id]}
-                />
-              );
-            })}
-          </>
-        )}
-
-        {section === 'threads' && (
-          <>
-            <ThreadSubscriptions />
-          </>
-        )}
-
-        {section === 'comments' && (
-          <>
-            <CommentSubscriptions />
-          </>
-        )}
-      </div>
-    </CWPageLayout>
-  );
+  // const supportsPushNotifications = useSupportsPushNotifications();
+  // const threadSubscriptions = useThreadSubscriptions();
+  // const communityAlerts = useCommunityAlertsQuery();
+  // const enableKnockPushNotifications = useFlag('knockPushNotifications');
+  // const { isLoggedIn } = useUserLoggedIn();
+  //
+  // const communityAlertsIndex = createIndexForCommunityAlerts(
+  //   (communityAlerts.data as unknown as ReadonlyArray<
+  //     z.infer<typeof CommunityAlert>
+  //   >) || [],
+  // );
+  //
+  // const [section, setSection] =
+  //   useState<NotificationSection>('community-alerts');
+  //
+  // if (threadSubscriptions.isLoading) {
+  //   return <PageLoading />;
+  // } else if (!isLoggedIn) {
+  //   return <PageNotFound />;
+  // }
+  //
+  // return (
+  //   <CWPageLayout>
+  //     <div className="NotificationSettingsPage NotificationSettings">
+  //       <CWText type="h3" fontWeight="semiBold" className="page-header-text">
+  //         Notification settings
+  //       </CWText>
+  //
+  //       <CWText className="page-subheader-text">
+  //         Manage the emails and alerts you receive about your activity
+  //       </CWText>
+  //
+  //       {enableKnockPushNotifications && supportsPushNotifications && (
+  //         <div>
+  //           <CWText type="h5">Push Notifications</CWText>
+  //
+  //           <div className="setting-container">
+  //             <div className="setting-container-left">
+  //               <CWText className="text-muted">
+  //                 Turn on notifications to receive alerts on your device.
+  //               </CWText>
+  //             </div>
+  //
+  //             <div className="setting-container-right">
+  //               <PushNotificationsToggle />
+  //             </div>
+  //           </div>
+  //         </div>
+  //       )}
+  //
+  //       <CWTabsRow>
+  //         <CWTab
+  //           label="Community"
+  //           isSelected={section === 'community-alerts'}
+  //           onClick={() => setSection('community-alerts')}
+  //         />
+  //         <CWTab
+  //           label="Threads"
+  //           isSelected={section === 'threads'}
+  //           onClick={() => setSection('threads')}
+  //         />
+  //
+  //         <CWTab
+  //           label="Comments"
+  //           isSelected={section === 'comments'}
+  //           onClick={() => setSection('comments')}
+  //         />
+  //       </CWTabsRow>
+  //
+  //       {!communityAlerts.isLoading && section === 'community-alerts' && (
+  //         <>
+  //           <CWText type="h4" fontWeight="semiBold" className="section-header">
+  //             Community Alerts
+  //           </CWText>
+  //
+  //           <CWText className="page-subheader-text">
+  //             Get updates on onchain activity and proposals in these
+  //             communities.
+  //           </CWText>
+  //
+  //           {getUniqueCommunities().map((community) => {
+  //             return (
+  //               <CommunityEntry
+  //                 key={community.id}
+  //                 communityInfo={community}
+  //                 communityAlert={communityAlertsIndex[community.id]}
+  //               />
+  //             );
+  //           })}
+  //         </>
+  //       )}
+  //
+  //       {section === 'threads' && (
+  //         <>
+  //           <ThreadSubscriptions />
+  //         </>
+  //       )}
+  //
+  //       {section === 'comments' && (
+  //         <>
+  //           <CommentSubscriptions />
+  //         </>
+  //       )}
+  //     </div>
+  //   </CWPageLayout>
+  // );
+  return null;
 };
 
 function createIndexForCommunityAlerts(

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/index.tsx
@@ -1,117 +1,135 @@
 import { CommunityAlert } from '@hicommonwealth/schemas';
+import { getUniqueCommunities } from 'helpers/addresses';
+import { useFlag } from 'hooks/useFlag';
+import useUserLoggedIn from 'hooks/useUserLoggedIn';
+import React, { useState } from 'react';
+import { useCommunityAlertsQuery } from 'state/api/trpc/subscription/useCommunityAlertsQuery';
+import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
+import {
+  CWTab,
+  CWTabsRow,
+} from 'views/components/component_kit/new_designs/CWTabs';
+import { PageNotFound } from 'views/pages/404';
+import { CommentSubscriptions } from 'views/pages/NotificationSettings/CommentSubscriptions';
+import { CommunityEntry } from 'views/pages/NotificationSettings/CommunityEntry';
+import { PushNotificationsToggle } from 'views/pages/NotificationSettings/PushNotificationsToggle';
+import { ThreadSubscriptions } from 'views/pages/NotificationSettings/ThreadSubscriptions';
+import { useSupportsPushNotifications } from 'views/pages/NotificationSettings/useSupportsPushNotifications';
+import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
 import { z } from 'zod';
+import { CWText } from '../../components/component_kit/cw_text';
+import { PageLoading } from '../loading';
 import './index.scss';
 
 type NotificationSection = 'community-alerts' | 'threads' | 'comments';
 
 const NotificationSettings = () => {
-  // const supportsPushNotifications = useSupportsPushNotifications();
-  // const threadSubscriptions = useThreadSubscriptions();
-  // const communityAlerts = useCommunityAlertsQuery();
-  // const enableKnockPushNotifications = useFlag('knockPushNotifications');
-  // const { isLoggedIn } = useUserLoggedIn();
-  //
-  // const communityAlertsIndex = createIndexForCommunityAlerts(
-  //   (communityAlerts.data as unknown as ReadonlyArray<
-  //     z.infer<typeof CommunityAlert>
-  //   >) || [],
-  // );
-  //
-  // const [section, setSection] =
-  //   useState<NotificationSection>('community-alerts');
-  //
-  // if (threadSubscriptions.isLoading) {
-  //   return <PageLoading />;
-  // } else if (!isLoggedIn) {
-  //   return <PageNotFound />;
-  // }
-  //
-  // return (
-  //   <CWPageLayout>
-  //     <div className="NotificationSettingsPage NotificationSettings">
-  //       <CWText type="h3" fontWeight="semiBold" className="page-header-text">
-  //         Notification settings
-  //       </CWText>
-  //
-  //       <CWText className="page-subheader-text">
-  //         Manage the emails and alerts you receive about your activity
-  //       </CWText>
-  //
-  //       {enableKnockPushNotifications && supportsPushNotifications && (
-  //         <div>
-  //           <CWText type="h5">Push Notifications</CWText>
-  //
-  //           <div className="setting-container">
-  //             <div className="setting-container-left">
-  //               <CWText className="text-muted">
-  //                 Turn on notifications to receive alerts on your device.
-  //               </CWText>
-  //             </div>
-  //
-  //             <div className="setting-container-right">
-  //               <PushNotificationsToggle />
-  //             </div>
-  //           </div>
-  //         </div>
-  //       )}
-  //
-  //       <CWTabsRow>
-  //         <CWTab
-  //           label="Community"
-  //           isSelected={section === 'community-alerts'}
-  //           onClick={() => setSection('community-alerts')}
-  //         />
-  //         <CWTab
-  //           label="Threads"
-  //           isSelected={section === 'threads'}
-  //           onClick={() => setSection('threads')}
-  //         />
-  //
-  //         <CWTab
-  //           label="Comments"
-  //           isSelected={section === 'comments'}
-  //           onClick={() => setSection('comments')}
-  //         />
-  //       </CWTabsRow>
-  //
-  //       {!communityAlerts.isLoading && section === 'community-alerts' && (
-  //         <>
-  //           <CWText type="h4" fontWeight="semiBold" className="section-header">
-  //             Community Alerts
-  //           </CWText>
-  //
-  //           <CWText className="page-subheader-text">
-  //             Get updates on onchain activity and proposals in these
-  //             communities.
-  //           </CWText>
-  //
-  //           {getUniqueCommunities().map((community) => {
-  //             return (
-  //               <CommunityEntry
-  //                 key={community.id}
-  //                 communityInfo={community}
-  //                 communityAlert={communityAlertsIndex[community.id]}
-  //               />
-  //             );
-  //           })}
-  //         </>
-  //       )}
-  //
-  //       {section === 'threads' && (
-  //         <>
-  //           <ThreadSubscriptions />
-  //         </>
-  //       )}
-  //
-  //       {section === 'comments' && (
-  //         <>
-  //           <CommentSubscriptions />
-  //         </>
-  //       )}
-  //     </div>
-  //   </CWPageLayout>
-  // );
-  return null;
+  const supportsPushNotifications = useSupportsPushNotifications();
+  const threadSubscriptions = useThreadSubscriptions();
+  const communityAlerts = useCommunityAlertsQuery();
+  const enableKnockPushNotifications = useFlag('knockPushNotifications');
+  const { isLoggedIn } = useUserLoggedIn();
+
+  const communityAlertsIndex = createIndexForCommunityAlerts(
+    (communityAlerts.data as unknown as ReadonlyArray<
+      z.infer<typeof CommunityAlert>
+    >) || [],
+  );
+
+  const [section, setSection] =
+    useState<NotificationSection>('community-alerts');
+
+  if (threadSubscriptions.isLoading) {
+    return <PageLoading />;
+  } else if (!isLoggedIn) {
+    return <PageNotFound />;
+  }
+
+  return (
+    <CWPageLayout>
+      <div className="NotificationSettingsPage NotificationSettings">
+        <CWText type="h3" fontWeight="semiBold" className="page-header-text">
+          Notification settings
+        </CWText>
+
+        <CWText className="page-subheader-text">
+          Manage the emails and alerts you receive about your activity
+        </CWText>
+
+        {enableKnockPushNotifications && supportsPushNotifications && (
+          <div>
+            <CWText type="h5">Push Notifications</CWText>
+
+            <div className="setting-container">
+              <div className="setting-container-left">
+                <CWText className="text-muted">
+                  Turn on notifications to receive alerts on your device.
+                </CWText>
+              </div>
+
+              <div className="setting-container-right">
+                <PushNotificationsToggle />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <CWTabsRow>
+          <CWTab
+            label="Community"
+            isSelected={section === 'community-alerts'}
+            onClick={() => setSection('community-alerts')}
+          />
+          <CWTab
+            label="Threads"
+            isSelected={section === 'threads'}
+            onClick={() => setSection('threads')}
+          />
+
+          <CWTab
+            label="Comments"
+            isSelected={section === 'comments'}
+            onClick={() => setSection('comments')}
+          />
+        </CWTabsRow>
+
+        {!communityAlerts.isLoading && section === 'community-alerts' && (
+          <>
+            <CWText type="h4" fontWeight="semiBold" className="section-header">
+              Community Alerts
+            </CWText>
+
+            <CWText className="page-subheader-text">
+              Get updates on onchain activity and proposals in these
+              communities.
+            </CWText>
+
+            {getUniqueCommunities().map((community) => {
+              return (
+                <CommunityEntry
+                  key={community.id}
+                  communityInfo={community}
+                  communityAlert={communityAlertsIndex[community.id]}
+                />
+              );
+            })}
+          </>
+        )}
+
+        {section === 'threads' && (
+          <>
+            <ThreadSubscriptions />
+          </>
+        )}
+
+        {section === 'comments' && (
+          <>
+            <CommentSubscriptions />
+          </>
+        )}
+      </div>
+    </CWPageLayout>
+  );
 };
 
 function createIndexForCommunityAlerts(

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -14,6 +14,7 @@ import {
   ViewUpvotesDrawerTrigger,
 } from 'client/scripts/views/components/UpvoteDrawer';
 import clsx from 'clsx';
+import { useFlag } from 'hooks/useFlag';
 import type Comment from 'models/Comment';
 import { useFetchConfigurationQuery } from 'state/api/configuration';
 import useUserStore from 'state/ui/user';
@@ -100,6 +101,8 @@ export const CommentCard = ({
   shareURL,
 }: CommentCardProps) => {
   const user = useUserStore();
+  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
+
   const userOwnsComment = comment.profile.userId === user.id;
 
   const [commentText, setCommentText] = useState(comment.text);
@@ -256,7 +259,7 @@ export const CommentCard = ({
                 />
               )}
 
-              {user.id > 0 && (
+              {enableKnockInAppNotifications && user.id > 0 && (
                 <ToggleCommentSubscribe
                   comment={comment}
                   userOwnsComment={userOwnsComment}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -1,5 +1,5 @@
 import type { DeltaStatic } from 'quill';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import app from 'state';
 
 import {
@@ -14,11 +14,8 @@ import {
   ViewUpvotesDrawerTrigger,
 } from 'client/scripts/views/components/UpvoteDrawer';
 import clsx from 'clsx';
-import { useFlag } from 'hooks/useFlag';
 import type Comment from 'models/Comment';
 import { useFetchConfigurationQuery } from 'state/api/configuration';
-import { useCreateCommentSubscriptionMutation } from 'state/api/trpc/subscription/useCreateCommentSubscriptionMutation';
-import { useDeleteCommentSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteCommentSubscriptionMutation';
 import useUserStore from 'state/ui/user';
 import { CommentReactionButton } from 'views/components/ReactionButton/CommentReactionButton';
 import { PopoverMenu } from 'views/components/component_kit/CWPopoverMenu';
@@ -31,7 +28,7 @@ import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_th
 import { ReactQuillEditor } from 'views/components/react_quill_editor';
 import { QuillRenderer } from 'views/components/react_quill_editor/quill_renderer';
 import { deserializeDelta } from 'views/components/react_quill_editor/utils';
-import { useCommentSubscriptions } from 'views/pages/NotificationSettings/useCommentSubscriptions';
+import { ToggleCommentSubscribe } from 'views/pages/discussions/CommentCard/ToggleCommentSubscribe';
 import { AuthorAndPublishInfo } from '../ThreadCard/AuthorAndPublishInfo';
 import './CommentCard.scss';
 
@@ -120,24 +117,6 @@ export const CommentCard = ({
   const [, setOnReaction] = useState<boolean>(false);
   const [isUpvoteDrawerOpen, setIsUpvoteDrawerOpen] = useState<boolean>(false);
 
-  // this is in an inner loop but trpc will batch this so it's only called once.
-  const commentSubscriptions = useCommentSubscriptions();
-
-  const hasCommentSubscriptionDefault = useMemo(() => {
-    const matching = (commentSubscriptions.data || []).filter(
-      (current) => current.comment_id === comment.id,
-    );
-    return matching.length > 0;
-  }, [comment.id, commentSubscriptions.data]);
-
-  const [hasCommentSubscriptionState, setHasCommentSubscriptionState] =
-    useState<boolean | undefined>(undefined);
-
-  const hasCommentSubscription =
-    hasCommentSubscriptionState !== undefined
-      ? hasCommentSubscriptionState
-      : hasCommentSubscriptionDefault;
-
   const { data: config } = useFetchConfigurationQuery();
 
   const doVerify = useCallback(async () => {
@@ -151,45 +130,6 @@ export const CommentCard = ({
       // ignore invalid signed comments
     }
   }, [comment.canvasSignedData]);
-
-  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
-
-  const createCommentSubscriptionMutation =
-    useCreateCommentSubscriptionMutation();
-  const deleteCommentSubscriptionMutation =
-    useDeleteCommentSubscriptionMutation();
-
-  const doToggleSubscribe = useCallback(async () => {
-    if (hasCommentSubscription) {
-      await deleteCommentSubscriptionMutation.mutateAsync({
-        id: comment.id,
-        comment_ids: [comment.id],
-      });
-    } else {
-      await createCommentSubscriptionMutation.mutateAsync({
-        id: comment.id,
-        comment_id: comment.id,
-      });
-    }
-
-    setHasCommentSubscriptionState(!hasCommentSubscription);
-  }, [
-    hasCommentSubscription,
-    deleteCommentSubscriptionMutation,
-    comment.id,
-    createCommentSubscriptionMutation,
-  ]);
-
-  const handleToggleSubscribe = useCallback(
-    (e: React.MouseEvent) => {
-      // prevent clicks from propagating to discussion row
-      e.preventDefault();
-      e.stopPropagation();
-
-      doToggleSubscribe().catch(console.error);
-    },
-    [doToggleSubscribe],
-  );
 
   useEffect(() => {
     if (!config?.enforceSessionKeys) return;
@@ -316,12 +256,10 @@ export const CommentCard = ({
                 />
               )}
 
-              {enableKnockInAppNotifications && userOwnsComment && (
-                <CWThreadAction
-                  action="subscribe"
-                  label="Subscribe"
-                  selected={!hasCommentSubscription}
-                  onClick={handleToggleSubscribe}
+              {user.id > 0 && (
+                <ToggleCommentSubscribe
+                  comment={comment}
+                  userOwnsComment={userOwnsComment}
                 />
               )}
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
@@ -1,4 +1,3 @@
-import { useFlag } from 'hooks/useFlag';
 import type Comment from 'models/Comment';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useCreateCommentSubscriptionMutation } from 'state/api/trpc/subscription/useCreateCommentSubscriptionMutation';
@@ -14,8 +13,6 @@ type ToggleCommentSubscribeProps = Readonly<{
 
 export const ToggleCommentSubscribe = (props: ToggleCommentSubscribeProps) => {
   const { userOwnsComment, comment } = props;
-
-  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
 
   // this is in an inner loop but trpc will batch this, so it's only called once.
   const commentSubscriptions = useCommentSubscriptions();
@@ -74,7 +71,7 @@ export const ToggleCommentSubscribe = (props: ToggleCommentSubscribeProps) => {
 
   return (
     <>
-      {enableKnockInAppNotifications && userOwnsComment && (
+      {userOwnsComment && (
         <CWThreadAction
           action="subscribe"
           label="Subscribe"

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
@@ -7,6 +7,7 @@ import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_th
 import { useCommentSubscriptions } from 'views/pages/NotificationSettings/useCommentSubscriptions';
 
 type ToggleCommentSubscribeProps = Readonly<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   comment: Comment<any>;
   userOwnsComment: boolean;
 }>;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
@@ -1,0 +1,86 @@
+import { useFlag } from 'hooks/useFlag';
+import type Comment from 'models/Comment';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useCreateCommentSubscriptionMutation } from 'state/api/trpc/subscription/useCreateCommentSubscriptionMutation';
+import { useDeleteCommentSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteCommentSubscriptionMutation';
+import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
+import { useCommentSubscriptions } from 'views/pages/NotificationSettings/useCommentSubscriptions';
+
+type ToggleCommentSubscribeProps = Readonly<{
+  comment: Comment<any>;
+  userOwnsComment: boolean;
+}>;
+
+export const ToggleCommentSubscribe = (props: ToggleCommentSubscribeProps) => {
+  const { userOwnsComment, comment } = props;
+
+  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
+
+  // this is in an inner loop but trpc will batch this so it's only called once.
+  const commentSubscriptions = useCommentSubscriptions();
+
+  const hasCommentSubscriptionDefault = useMemo(() => {
+    const matching = (commentSubscriptions.data || []).filter(
+      (current) => current.comment_id === comment.id,
+    );
+    return matching.length > 0;
+  }, [comment.id, commentSubscriptions.data]);
+
+  const [hasCommentSubscriptionState, setHasCommentSubscriptionState] =
+    useState<boolean | undefined>(undefined);
+
+  const hasCommentSubscription =
+    hasCommentSubscriptionState !== undefined
+      ? hasCommentSubscriptionState
+      : hasCommentSubscriptionDefault;
+
+  const createCommentSubscriptionMutation =
+    useCreateCommentSubscriptionMutation();
+  const deleteCommentSubscriptionMutation =
+    useDeleteCommentSubscriptionMutation();
+
+  const doToggleSubscribe = useCallback(async () => {
+    if (hasCommentSubscription) {
+      await deleteCommentSubscriptionMutation.mutateAsync({
+        id: comment.id,
+        comment_ids: [comment.id],
+      });
+    } else {
+      await createCommentSubscriptionMutation.mutateAsync({
+        id: comment.id,
+        comment_id: comment.id,
+      });
+    }
+
+    setHasCommentSubscriptionState(!hasCommentSubscription);
+  }, [
+    hasCommentSubscription,
+    deleteCommentSubscriptionMutation,
+    comment.id,
+    createCommentSubscriptionMutation,
+  ]);
+
+  const handleToggleSubscribe = useCallback(
+    (e: React.MouseEvent) => {
+      // prevent clicks from propagating to discussion row
+      e.preventDefault();
+      e.stopPropagation();
+
+      doToggleSubscribe().catch(console.error);
+    },
+    [doToggleSubscribe],
+  );
+
+  return (
+    <>
+      {enableKnockInAppNotifications && userOwnsComment && (
+        <CWThreadAction
+          action="subscribe"
+          label="Subscribe"
+          selected={!hasCommentSubscription}
+          onClick={handleToggleSubscribe}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/ToggleCommentSubscribe.tsx
@@ -17,7 +17,7 @@ export const ToggleCommentSubscribe = (props: ToggleCommentSubscribeProps) => {
 
   const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
 
-  // this is in an inner loop but trpc will batch this so it's only called once.
+  // this is in an inner loop but trpc will batch this, so it's only called once.
   const commentSubscriptions = useCommentSubscriptions();
 
   const hasCommentSubscriptionDefault = useMemo(() => {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -1,27 +1,14 @@
 import { pluralize } from 'helpers';
 import { GetThreadActionTooltipTextResponse } from 'helpers/threads';
-import { useFlag } from 'hooks/useFlag';
 import Thread from 'models/Thread';
-import React, {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react';
-import { useCreateThreadSubscriptionMutation } from 'state/api/trpc/subscription/useCreateThreadSubscriptionMutation';
-import { useDeleteThreadSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteThreadSubscriptionMutation';
+import React, { Dispatch, SetStateAction } from 'react';
+import useUserStore from 'state/ui/user';
 import Permissions from 'utils/Permissions';
 import { downloadDataAsFile } from 'utils/downloadDataAsFile';
 import { SharePopover } from 'views/components/SharePopover';
 import { ViewUpvotesDrawerTrigger } from 'views/components/UpvoteDrawer';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
-import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
-import {
-  getCommentSubscription,
-  getReactionSubscription,
-  handleToggleSubscription,
-} from '../../helpers';
+import { ToggleThreadSubscribe } from 'views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe';
 import { AdminActions, AdminActionsProps } from './AdminActions';
 import { ReactionButton } from './ReactionButton';
 import './ThreadOptions.scss';
@@ -70,96 +57,13 @@ export const ThreadOptions = ({
   setIsUpvoteDrawerOpen,
   editingDisabled,
 }: OptionsProps) => {
-  const [isSubscribed, setIsSubscribed] = useState(
-    thread &&
-      getCommentSubscription(thread)?.isActive &&
-      getReactionSubscription(thread)?.isActive,
-  );
-
   const isCommunityMember = Permissions.isCommunityMember(thread.communityId);
-
-  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
-
-  const doToggleSubscribeOld = useCallback(async () => {
-    if (!thread) {
-      return;
-    }
-
-    await handleToggleSubscription(
-      thread,
-      getCommentSubscription(thread),
-      getReactionSubscription(thread),
-      isSubscribed,
-      setIsSubscribed,
-    );
-  }, [isSubscribed, thread]);
 
   const handleDownloadMarkdown = () => {
     downloadDataAsFile(thread.plaintext, 'text/markdown', thread.title + '.md');
   };
 
-  const createThreadSubscriptionMutation =
-    useCreateThreadSubscriptionMutation();
-  const deleteThreadSubscriptionMutation =
-    useDeleteThreadSubscriptionMutation();
-
-  const threadSubscriptions = useThreadSubscriptions();
-
-  const hasThreadSubscriptionDefault = useMemo(() => {
-    const matching = (threadSubscriptions.data || []).filter(
-      (current) => current.thread_id === thread.id,
-    );
-
-    return matching.length > 0;
-  }, [thread.id, threadSubscriptions.data]);
-
-  const [hasThreadSubscriptionState, setHasThreadSubscriptionState] = useState<
-    boolean | undefined
-  >(undefined);
-
-  const hasThreadSubscription =
-    hasThreadSubscriptionState !== undefined
-      ? hasThreadSubscriptionState
-      : hasThreadSubscriptionDefault;
-
-  const doToggleSubscribe = useCallback(async () => {
-    if (hasThreadSubscription) {
-      await deleteThreadSubscriptionMutation.mutateAsync({
-        id: thread.id,
-        thread_ids: [thread.id],
-      });
-    } else {
-      await createThreadSubscriptionMutation.mutateAsync({
-        id: thread.id,
-        thread_id: thread.id,
-      });
-    }
-    setHasThreadSubscriptionState(!hasThreadSubscription);
-  }, [
-    createThreadSubscriptionMutation,
-    deleteThreadSubscriptionMutation,
-    hasThreadSubscription,
-    thread.id,
-  ]);
-
-  const handleToggleSubscribe = useCallback(
-    (e: React.MouseEvent) => {
-      async function doAsync() {
-        if (enableKnockInAppNotifications) {
-          await doToggleSubscribe();
-        } else {
-          await doToggleSubscribeOld();
-        }
-      }
-
-      // prevent clicks from propagating to discussion row
-      e.preventDefault();
-      e.stopPropagation();
-
-      doAsync().catch(console.error);
-    },
-    [doToggleSubscribe, doToggleSubscribeOld, enableKnockInAppNotifications],
-  );
+  const userStore = useUserStore();
 
   return (
     <>
@@ -211,23 +115,10 @@ export const ThreadOptions = ({
           {/* @ts-expect-error StrictNullChecks*/}
           <SharePopover linkToShare={shareEndpoint} buttonLabel="Share" />
 
-          {!enableKnockInAppNotifications && (
-            <CWThreadAction
-              action="subscribe"
-              label="Subscribe"
-              onClick={handleToggleSubscribe}
-              selected={!isSubscribed}
-              disabled={!isCommunityMember}
-            />
-          )}
-
-          {enableKnockInAppNotifications && (
-            <CWThreadAction
-              action="subscribe"
-              label="Subscribe"
-              onClick={handleToggleSubscribe}
-              selected={!hasThreadSubscription}
-              disabled={!isCommunityMember}
+          {userStore.id > 0 && (
+            <ToggleThreadSubscribe
+              thread={thread}
+              isCommunityMember={isCommunityMember}
             />
           )}
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -1,5 +1,6 @@
 import { pluralize } from 'helpers';
 import { GetThreadActionTooltipTextResponse } from 'helpers/threads';
+import { useFlag } from 'hooks/useFlag';
 import Thread from 'models/Thread';
 import React, { Dispatch, SetStateAction } from 'react';
 import useUserStore from 'state/ui/user';
@@ -9,6 +10,7 @@ import { SharePopover } from 'views/components/SharePopover';
 import { ViewUpvotesDrawerTrigger } from 'views/components/UpvoteDrawer';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { ToggleThreadSubscribe } from 'views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe';
+import { ToggleThreadSubscribeOld } from 'views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld';
 import { AdminActions, AdminActionsProps } from './AdminActions';
 import { ReactionButton } from './ReactionButton';
 import './ThreadOptions.scss';
@@ -58,12 +60,12 @@ export const ThreadOptions = ({
   editingDisabled,
 }: OptionsProps) => {
   const isCommunityMember = Permissions.isCommunityMember(thread.communityId);
+  const userStore = useUserStore();
+  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
 
   const handleDownloadMarkdown = () => {
     downloadDataAsFile(thread.plaintext, 'text/markdown', thread.title + '.md');
   };
-
-  const userStore = useUserStore();
 
   return (
     <>
@@ -116,10 +118,21 @@ export const ThreadOptions = ({
           <SharePopover linkToShare={shareEndpoint} buttonLabel="Share" />
 
           {userStore.id > 0 && (
-            <ToggleThreadSubscribe
-              thread={thread}
-              isCommunityMember={isCommunityMember}
-            />
+            <>
+              {enableKnockInAppNotifications && (
+                <ToggleThreadSubscribe
+                  thread={thread}
+                  isCommunityMember={isCommunityMember}
+                />
+              )}
+
+              {!enableKnockInAppNotifications && (
+                <ToggleThreadSubscribeOld
+                  thread={thread}
+                  isCommunityMember={isCommunityMember}
+                />
+              )}
+            </>
           )}
 
           {thread && (

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
@@ -1,0 +1,116 @@
+import { useFlag } from 'hooks/useFlag';
+import Thread from 'models/Thread';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useCreateThreadSubscriptionMutation } from 'state/api/trpc/subscription/useCreateThreadSubscriptionMutation';
+import { useDeleteThreadSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteThreadSubscriptionMutation';
+import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
+import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
+import {
+  getCommentSubscription,
+  getReactionSubscription,
+  handleToggleSubscription,
+} from 'views/pages/discussions/helpers';
+
+type ToggleThreadSubscribeProps = Readonly<{
+  readonly thread: Thread;
+  readonly isCommunityMember: boolean;
+}>;
+
+export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
+  const { thread } = props;
+
+  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
+
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(
+    thread &&
+      getCommentSubscription(thread)?.isActive &&
+      getReactionSubscription(thread)?.isActive,
+  );
+
+  const doToggleSubscribeOld = useCallback(async () => {
+    if (!thread) {
+      return;
+    }
+
+    await handleToggleSubscription(
+      thread,
+      getCommentSubscription(thread),
+      getReactionSubscription(thread),
+      isSubscribed,
+      setIsSubscribed,
+    );
+  }, [isSubscribed, thread]);
+
+  const createThreadSubscriptionMutation =
+    useCreateThreadSubscriptionMutation();
+  const deleteThreadSubscriptionMutation =
+    useDeleteThreadSubscriptionMutation();
+
+  const threadSubscriptions = useThreadSubscriptions();
+
+  const hasThreadSubscriptionDefault = useMemo(() => {
+    const matching = (threadSubscriptions.data || []).filter(
+      (current) => current.thread_id === thread.id,
+    );
+
+    return matching.length > 0;
+  }, [thread.id, threadSubscriptions.data]);
+
+  const [hasThreadSubscriptionState, setHasThreadSubscriptionState] = useState<
+    boolean | undefined
+  >(undefined);
+
+  const hasThreadSubscription =
+    hasThreadSubscriptionState !== undefined
+      ? hasThreadSubscriptionState
+      : hasThreadSubscriptionDefault;
+
+  const doToggleSubscribe = useCallback(async () => {
+    if (hasThreadSubscription) {
+      await deleteThreadSubscriptionMutation.mutateAsync({
+        id: thread.id,
+        thread_ids: [thread.id],
+      });
+    } else {
+      await createThreadSubscriptionMutation.mutateAsync({
+        id: thread.id,
+        thread_id: thread.id,
+      });
+    }
+    setHasThreadSubscriptionState(!hasThreadSubscription);
+  }, [
+    createThreadSubscriptionMutation,
+    deleteThreadSubscriptionMutation,
+    hasThreadSubscription,
+    thread.id,
+  ]);
+
+  const handleToggleSubscribe = useCallback(
+    (e: React.MouseEvent) => {
+      async function doAsync() {
+        if (enableKnockInAppNotifications) {
+          await doToggleSubscribe();
+        } else {
+          await doToggleSubscribeOld();
+        }
+      }
+
+      // prevent clicks from propagating to discussion row
+      e.preventDefault();
+      e.stopPropagation();
+
+      doAsync().catch(console.error);
+    },
+    [doToggleSubscribe, doToggleSubscribeOld, enableKnockInAppNotifications],
+  );
+
+  return (
+    <CWThreadAction
+      action="subscribe"
+      label="Subscribe"
+      onClick={handleToggleSubscribe}
+      selected={!hasThreadSubscription}
+      disabled={!props.isCommunityMember}
+    />
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
@@ -17,7 +17,7 @@ type ToggleThreadSubscribeProps = Readonly<{
 }>;
 
 export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
-  const { thread } = props;
+  const { thread, isCommunityMember } = props;
 
   const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
 
@@ -110,7 +110,7 @@ export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
       label="Subscribe"
       onClick={handleToggleSubscribe}
       selected={!hasThreadSubscription}
-      disabled={!props.isCommunityMember}
+      disabled={!isCommunityMember}
     />
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
@@ -1,15 +1,9 @@
-import { useFlag } from 'hooks/useFlag';
 import Thread from 'models/Thread';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useCreateThreadSubscriptionMutation } from 'state/api/trpc/subscription/useCreateThreadSubscriptionMutation';
 import { useDeleteThreadSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteThreadSubscriptionMutation';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { useThreadSubscriptions } from 'views/pages/NotificationSettings/useThreadSubscriptions';
-import {
-  getCommentSubscription,
-  getReactionSubscription,
-  handleToggleSubscription,
-} from 'views/pages/discussions/helpers';
 
 type ToggleThreadSubscribeProps = Readonly<{
   readonly thread: Thread;
@@ -18,28 +12,6 @@ type ToggleThreadSubscribeProps = Readonly<{
 
 export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
   const { thread, isCommunityMember } = props;
-
-  const enableKnockInAppNotifications = useFlag('knockInAppNotifications');
-
-  const [isSubscribed, setIsSubscribed] = useState<boolean>(
-    thread &&
-      getCommentSubscription(thread)?.isActive &&
-      getReactionSubscription(thread)?.isActive,
-  );
-
-  const doToggleSubscribeOld = useCallback(async () => {
-    if (!thread) {
-      return;
-    }
-
-    await handleToggleSubscription(
-      thread,
-      getCommentSubscription(thread),
-      getReactionSubscription(thread),
-      isSubscribed,
-      setIsSubscribed,
-    );
-  }, [isSubscribed, thread]);
 
   const createThreadSubscriptionMutation =
     useCreateThreadSubscriptionMutation();
@@ -88,11 +60,7 @@ export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
   const handleToggleSubscribe = useCallback(
     (e: React.MouseEvent) => {
       async function doAsync() {
-        if (enableKnockInAppNotifications) {
-          await doToggleSubscribe();
-        } else {
-          await doToggleSubscribeOld();
-        }
+        await doToggleSubscribe();
       }
 
       // prevent clicks from propagating to discussion row
@@ -101,7 +69,7 @@ export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
 
       doAsync().catch(console.error);
     },
-    [doToggleSubscribe, doToggleSubscribeOld, enableKnockInAppNotifications],
+    [doToggleSubscribe],
   );
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
@@ -44,6 +44,7 @@ export const ToggleThreadSubscribeOld = (props: ToggleThreadSubscribeProps) => {
     <CWThreadAction
       action="subscribe"
       label="Subscribe"
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onClick={handleToggleSubscribe}
       selected={!isSubscribed}
       disabled={!isCommunityMember}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
@@ -1,0 +1,51 @@
+import Thread from 'models/Thread';
+import React, { useState } from 'react';
+import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
+import {
+  getCommentSubscription,
+  getReactionSubscription,
+  handleToggleSubscription,
+} from 'views/pages/discussions/helpers';
+
+type ToggleThreadSubscribeProps = Readonly<{
+  readonly thread: Thread;
+  readonly isCommunityMember: boolean;
+}>;
+
+export const ToggleThreadSubscribeOld = (props: ToggleThreadSubscribeProps) => {
+  const { thread, isCommunityMember } = props;
+
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(
+    thread &&
+      getCommentSubscription(thread)?.isActive &&
+      getReactionSubscription(thread)?.isActive,
+  );
+
+  const handleToggleSubscribe = async (e) => {
+    // prevent clicks from propagating to discussion row
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!thread) {
+      return;
+    }
+
+    await handleToggleSubscription(
+      thread,
+      getCommentSubscription(thread),
+      getReactionSubscription(thread),
+      isSubscribed,
+      setIsSubscribed,
+    );
+  };
+
+  return (
+    <CWThreadAction
+      action="subscribe"
+      label="Subscribe"
+      onClick={handleToggleSubscribe}
+      selected={!isSubscribed}
+      disabled={!isCommunityMember}
+    />
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribeOld.tsx
@@ -21,6 +21,7 @@ export const ToggleThreadSubscribeOld = (props: ToggleThreadSubscribeProps) => {
       getReactionSubscription(thread)?.isActive,
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const handleToggleSubscribe = async (e) => {
     // prevent clicks from propagating to discussion row
     e.preventDefault();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: 

- https://github.com/hicommonwealth/commonwealth/issues/8822
- https://github.com/hicommonwealth/commonwealth/issues/8821

## Description of Changes

- Moves the subscription toggle and all the associated logic of it to a dedicated class

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Load a thread when the user is not logged in. 
- Make sure there is at least one comment.  
- Then check logs and make sure theres no error.
- Make sure toggling of subscriptions works properly when on the thread page (and it has comments)

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 