### PR TITLE
Convert ChainNetwork type to string.

### DIFF
--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -20,7 +20,7 @@ export const Community = z.object({
   name: z.string(),
   chain_node_id: PG_INT,
   default_symbol: z.string().default(''),
-  network: z.nativeEnum(ChainNetwork).default(ChainNetwork.Ethereum),
+  network: z.string().default(ChainNetwork.Ethereum),
   base: z.nativeEnum(ChainBase),
   icon_url: z.string().nullish(),
   active: z.boolean(),

--- a/libs/shared/src/types/protocol.ts
+++ b/libs/shared/src/types/protocol.ts
@@ -127,51 +127,26 @@ export enum CommunityCategoryType {
   DAO = 'DAO',
 }
 
-// TODO: remove many of these chain networks, esp substrate (make them all "Substrate"),
-// and just use id to identify specific chains for conditionals
+// This enum represents known values for the "network" field on Community, which can be used for
+// switched functionality against specific groups of communities (so we could e.g. group together all
+// communities on a specific testnet, or all ERC20s). In practice this field is deprecated, and should be
+// removed, but these following values remain as either defaults or for custom integration support.
 export enum ChainNetwork {
-  Edgeware = 'edgeware',
-  EdgewareTestnet = 'edgeware-testnet',
-  Kusama = 'kusama',
-  Kulupu = 'kulupu',
-  Polkadot = 'polkadot',
-  Plasm = 'plasm',
-  Stafi = 'stafi',
-  Darwinia = 'darwinia',
-  Phala = 'phala',
-  Centrifuge = 'centrifuge',
-  Straightedge = 'straightedge',
-  Osmosis = 'osmosis',
-  Injective = 'injective',
-  InjectiveTestnet = 'injective-testnet',
-  Terra = 'terra',
   Ethereum = 'ethereum',
-  NEAR = 'near',
-  NEARTestnet = 'near-testnet',
-  Compound = 'compound',
-  Aave = 'aave',
-  AaveLocal = 'aave-local',
-  dYdX = 'dydx',
-  Metacartel = 'metacartel',
-  ALEX = 'alex',
   ERC20 = 'erc20',
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',
-  CW20 = 'cw20',
-  CW721 = 'cw721',
-  Clover = 'clover',
-  HydraDX = 'hydradx',
-  Crust = 'crust',
-  Sputnik = 'sputnik',
-  SolanaDevnet = 'solana-devnet',
-  SolanaTestnet = 'solana-testnet',
+  Edgeware = 'edgeware',
+  Osmosis = 'osmosis',
+  Injective = 'injective',
   Solana = 'solana',
-  SPL = 'spl', // solana token
+  Terra = 'terra',
+  NEAR = 'near',
+  Stargaze = 'stargaze',
+  Compound = 'compound',
   Evmos = 'evmos',
   Kava = 'kava',
   Kyve = 'kyve',
-  Stargaze = 'stargaze',
-  Cosmos = 'cosmos',
 }
 
 /**

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -1,9 +1,5 @@
 import { ExtendedCommunity } from '@hicommonwealth/schemas';
-import type {
-  AddressRole,
-  ChainNetwork,
-  DefaultPage,
-} from '@hicommonwealth/shared';
+import type { AddressRole, DefaultPage } from '@hicommonwealth/shared';
 import { ChainBase } from '@hicommonwealth/shared';
 import type { RegisteredTypes } from '@polkadot/types/types';
 import { z } from 'zod';
@@ -23,7 +19,7 @@ class ChainInfo {
   public readonly profileCount: number;
   public readonly default_symbol: string;
   public name: string;
-  public readonly network: ChainNetwork;
+  public readonly network: string;
   public readonly base: ChainBase;
   public iconUrl: string;
   public description: string;

--- a/packages/commonwealth/client/scripts/views/pages/communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/communities.tsx
@@ -103,7 +103,7 @@ const CommunitiesPage = () => {
     return list.filter((data) => {
       const communityNetwork =
         Object.keys(ChainNetwork)[
-          Object.values(ChainNetwork).indexOf(data.network)
+          Object.values(ChainNetwork).indexOf(data.network as ChainNetwork)
         ]; // Converts chain.base into a ChainBase key to match our filterMap keys
 
       if (communityNetworks.includes(communityNetwork)) {

--- a/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/create_community.ts
@@ -11,7 +11,6 @@ import { CreateCommunity } from '@hicommonwealth/schemas';
 import {
   BalanceType,
   ChainBase,
-  ChainNetwork,
   ChainType,
   DefaultPage,
   NotificationCategories,
@@ -370,7 +369,7 @@ export async function __createCommunity(
     default_symbol,
     icon_url,
     description,
-    network: network as ChainNetwork,
+    network,
     type,
     // @ts-expect-error StrictNullChecks
     social_links: uniqueLinksArray,

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community_id.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community_id.ts
@@ -4,7 +4,6 @@ import {
   CommunityInstance,
   ModelInstance,
 } from '@hicommonwealth/model';
-import { ChainNetwork } from '@hicommonwealth/shared';
 import { type ModelStatic } from 'sequelize';
 import { z } from 'zod';
 import { ServerCommunitiesController } from '../server_communities_controller';
@@ -61,9 +60,10 @@ export async function __updateCommunityId(
         id: new_community_id,
         ...communityData,
         redirect: community_id,
-        network: (communityData.network === id
-          ? new_community_id
-          : communityData.network) as ChainNetwork,
+        network:
+          communityData.network === id
+            ? new_community_id
+            : communityData.network,
       },
       { transaction },
     );


### PR DESCRIPTION
## Link to Issue
Affects but does not close #8762 

## Description of Changes
- Patch for #8779 to eliminate ChainNetwork field.

## "How We Fixed It"
Converted type to string rather than using an enum type, as arbitrary values are possible and not necessary to account for due to lack of specific logic in most cases.

## Test Plan
- Ensure regen loads as expected and no TRPC errors in server console.
- Ensure communities page functions as expected.
