### PR TITLE
Fix namespace manager ABI

### DIFF
--- a/libs/model/src/utils/utils.ts
+++ b/libs/model/src/utils/utils.ts
@@ -140,7 +140,7 @@ export async function getThreadContestManagers(
             WHERE ct.topic_id = :topic_id
             AND cm.community_id = :community_id
             AND cm.cancelled = false
-            AND cm.ended = false
+            AND cm.ended IS NULL;
           `,
     {
       type: QueryTypes.SELECT,

--- a/libs/model/src/utils/utils.ts
+++ b/libs/model/src/utils/utils.ts
@@ -140,7 +140,7 @@ export async function getThreadContestManagers(
             WHERE ct.topic_id = :topic_id
             AND cm.community_id = :community_id
             AND cm.cancelled = false
-            AND cm.ended IS NULL;
+            AND (cm.ended IS NULL OR cm.ended = false)
           `,
     {
       type: QueryTypes.SELECT,

--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -34,7 +34,7 @@ export const CreateCommunity = {
     // hidden optional params
     user_address: z.string().optional(), // address for the user
     alt_wallet_url: z.string().url().optional(),
-    eth_chain_id: PG_INT.optional(),
+    eth_chain_id: z.string().optional(),
     cosmos_chain_id: z.string().optional(),
     address: z.string().optional(), // address for the contract of the chain
     decimals: PG_INT.optional(),

--- a/packages/commonwealth/server/migrations/20240815110642-contests-abi-fix.js
+++ b/packages/commonwealth/server/migrations/20240815110642-contests-abi-fix.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Get old namespace factory ABI
+      const [oldResult] = await queryInterface.sequelize.query(
+        `
+          SELECT id FROM "ContractAbis" WHERE nickname = 'NamespaceFactory'
+        `,
+      );
+      const oldContractAbiId = oldResult[0]?.id;
+      if (!oldContractAbiId) {
+        throw new Error('Failed to get old contract ABI ID');
+      }
+
+      // Get new namespace factory ABI
+      const [newResult] = await queryInterface.sequelize.query(
+        `
+          SELECT id FROM "ContractAbis" WHERE nickname = 'NamespaceFactoryForContests'
+        `,
+      );
+      const contractAbiId = newResult[0]?.id;
+      if (!contractAbiId) {
+        throw new Error('Failed to get new contract ABI ID');
+      }
+
+      // Update old EVM event sources to use new namespace factory ABI
+      await queryInterface.sequelize.query(
+        `
+        UPDATE "EvmEventSources"
+        SET abi_id = :contractAbiId
+        WHERE abi_id = :oldContractAbiId
+        `,
+        {
+          replacements: { contractAbiId, oldContractAbiId },
+          transaction,
+        },
+      );
+
+      // Delete old ABI
+      await queryInterface.sequelize.query(
+        `
+        DELETE FROM "ContractAbis" WHERE nickname = 'NamespaceFactory'
+        `,
+        { transaction },
+      );
+
+      // Rename new ABI to old name
+      await queryInterface.sequelize.query(
+        `
+        UPDATE "ContractAbis" SET nickname = 'NamespaceFactory' WHERE nickname = 'NamespaceFactoryForContests'
+        `,
+        { transaction },
+      );
+    });
+  },
+
+  // Migration not reversible
+  async down(queryInterface, Sequelize) {
+    // This migration is not reversible. If you need to reverse it, please handle it manually.
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8844 

## Description of Changes
- Creates migration that
  - Removes old duplicate namespace factory ABI to fix query issue
  - Adds outbox entries to simulate the NewContest event for broken contest managers, to ultimately create the `EvmEventSources`
- Fixes type bug that prevents community from being created 
- Fixes bug where contest manager metadata was not added to the `ThreadCreated`/`ThreadUpvoted` events

## Test Plan
- First, check DB `EvmEventSources` table to see that the `DeployedNamespace` abi_id is different from the `NewContest` abi_id values.
- Run the migration
- Confirm that the abi_id for both events is the same
- For the community fix, confirm that you can create a community

NOTE: the outbox entries will only be created for contest managers that are "broken", e.g. they don't have any associated Contests which implies that the onchain event was never detected.

## Deployment Plan
N/A

## Other Considerations
- The fixed contest managers might display a time that's out of sync initially because the start time is based on when the policy was executed, not block time