### PR TITLE
I don't like this, but we have to use click handlers for now.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/CommentSubscriptionEntry.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/CommentSubscriptionEntry.tsx
@@ -3,11 +3,9 @@ import { getThreadUrl, safeTruncateBody } from '@hicommonwealth/shared';
 import { notifySuccess } from 'controllers/app/notifications';
 import { pluralize } from 'helpers';
 import { getRelativeTimestamp } from 'helpers/dates';
-import { useCommonNavigate } from 'navigation/helpers';
+import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
 import { useDeleteCommentSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteCommentSubscriptionMutation';
-import { getCommunityUrl } from 'utils';
 import { CWCommunityAvatar } from 'views/components/component_kit/cw_community_avatar';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
@@ -63,6 +61,16 @@ export const CommentSubscriptionEntry = (
     navigate(threadUrl);
   };
 
+  const handleNavigateToCommunity = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    navigateToCommunity({
+      navigate,
+      path: '/',
+      chain: thread.Community.id!,
+    });
+  };
+
   return (
     <div className="SubscriptionEntry">
       <div className="SubscriptionHeader">
@@ -76,9 +84,9 @@ export const CommentSubscriptionEntry = (
           />
         </div>
         <div>
-          <Link to={getCommunityUrl(thread.Community.name)}>
+          <a onClick={handleNavigateToCommunity}>
             <CWText fontWeight="semiBold">{thread.Community.name}</CWText>
-          </Link>
+          </a>
         </div>
 
         <div>•</div>

--- a/packages/commonwealth/client/scripts/views/pages/NotificationSettings/ThreadSubscriptionEntry.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NotificationSettings/ThreadSubscriptionEntry.tsx
@@ -3,11 +3,9 @@ import { getThreadUrl } from '@hicommonwealth/shared';
 import { notifySuccess } from 'controllers/app/notifications';
 import { pluralize } from 'helpers';
 import { getRelativeTimestamp } from 'helpers/dates';
-import { useCommonNavigate } from 'navigation/helpers';
+import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
 import { useDeleteThreadSubscriptionMutation } from 'state/api/trpc/subscription/useDeleteThreadSubscriptionMutation';
-import { getCommunityUrl } from 'utils';
 import { CWCommunityAvatar } from 'views/components/component_kit/cw_community_avatar';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
@@ -60,6 +58,16 @@ export const ThreadSubscriptionEntry = (
       .catch(console.error);
   }, [deleteThreadSubscription, onUnsubscribe, thread_id]);
 
+  const handleNavigateToCommunity = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    navigateToCommunity({
+      navigate,
+      path: '/',
+      chain: thread.Community.id!,
+    });
+  };
+
   return (
     <div className="SubscriptionEntry">
       <div className="SubscriptionHeader">
@@ -73,9 +81,9 @@ export const ThreadSubscriptionEntry = (
           />
         </div>
         <div>
-          <Link to={getCommunityUrl(thread.Community.name)}>
+          <a onClick={handleNavigateToCommunity}>
             <CWText fontWeight="semiBold">{thread.Community.name}</CWText>
-          </Link>
+          </a>
         </div>
 
         <div>•</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8809

## Description of Changes
- changes the links in the comment notifications to use click handlers instead of react-router <Link>s.

I don't like this but it's the only way we can fix things for now due to this (insane link handling behavior)

https://github.com/hicommonwealth/commonwealth/issues/8853

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Login, go to your notifications, try to click on the community name in the title of an event.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 