### PR TITLE
Replaced app.loadingError with zustand

### DIFF
--- a/packages/commonwealth/client/scripts/state/index.ts
+++ b/packages/commonwealth/client/scripts/state/index.ts
@@ -16,6 +16,7 @@ import StarredCommunity from 'models/StarredCommunity';
 import { queryClient, QueryKeys, SERVER_URL } from 'state/api/config';
 import { Configuration } from 'state/api/configuration';
 import { fetchNodesQuery } from 'state/api/nodes';
+import { errorStore } from 'state/ui/error';
 import { ChainStore } from 'stores';
 import { userStore } from './ui/user';
 
@@ -208,8 +209,11 @@ export async function initAppState(
       }
     }
   } catch (err) {
-    app.loadingError =
-      err.response?.data?.error || 'Error loading application state';
+    errorStore
+      .getState()
+      .setLoadingError(
+        err.response?.data?.error || 'Error loading application state',
+      );
     throw err;
   }
 }

--- a/packages/commonwealth/client/scripts/state/ui/error/error.ts
+++ b/packages/commonwealth/client/scripts/state/ui/error/error.ts
@@ -1,0 +1,19 @@
+import { createBoundedUseStore } from 'state/ui/utils';
+import { devtools } from 'zustand/middleware';
+import { createStore } from 'zustand/vanilla';
+
+interface ErrorStore {
+  loadingError: string;
+  setLoadingError: (loadingError: string) => void;
+}
+
+export const errorStore = createStore<ErrorStore>()(
+  devtools((set) => ({
+    loadingError: '',
+    setLoadingError: (loadingError) => set({ loadingError }),
+  })),
+);
+
+const useErrorStore = createBoundedUseStore(errorStore);
+
+export default useErrorStore;

--- a/packages/commonwealth/client/scripts/state/ui/error/index.ts
+++ b/packages/commonwealth/client/scripts/state/ui/error/index.ts
@@ -1,0 +1,4 @@
+import useErrorStore, { errorStore } from './error';
+
+export { errorStore };
+export default useErrorStore;

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useParams } from 'react-router-dom';
 import app from 'state';
 import { useFetchConfigurationQuery } from 'state/api/configuration';
+import useErrorStore from 'state/ui/error';
 import useUserStore from 'state/ui/user';
 import { PageNotFound } from 'views/pages/404';
 import ErrorPage from 'views/pages/error';
@@ -43,6 +44,7 @@ const LayoutComponent = ({
   const pathScope = routerParams?.scope?.toString() || app.customDomainId();
   const providedCommunityScope = scoped ? pathScope : null;
   const user = useUserStore();
+  const appError = useErrorStore();
 
   const [communityToLoad, setCommunityToLoad] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>();
@@ -131,13 +133,13 @@ const LayoutComponent = ({
     isLoading || shouldSelectChain || shouldDeInitChain;
 
   const childToRender = () => {
-    if (app.loadingError) {
+    if (appError.loadingError) {
       return (
         <CWEmptyState
           iconName="cautionTriangle"
           content={
             <div className="loading-error">
-              <CWText>Application error: {app.loadingError}</CWText>
+              <CWText>Application error: {appError.loadingError}</CWText>
               <CWText>Please try again later</CWText>
             </div>
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8300

## Description of Changes
- had to use zustand to keep the error state. Ideally, error handling should be handled by react error boundary. The problem is that error in this case is thrown from `initAppState` which is non-react function + it is invoked from 7 different places. So to make it work properly, we should get rid of  initAppState by splitting it up into few smaller api calls that would be initiated from react-context environment. 
- The goal for now is to get rid of app object, therefore, we need to stick for zustand solution, because refactor explained above is way to big.

## Test Plan
- hard to test it on qa. The best way to test it locally is to throw the error from the /status or /communities route and then the error page would appear on the screen

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a