### PR TITLE
Fixed community switching for auth user

### DIFF
--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -81,7 +81,7 @@ const LayoutComponent = ({
     providedCommunityScope &&
     providedCommunityScope !== app.activeChainId() &&
     providedCommunityScope !== communityToLoad &&
-    community &&
+    !!community &&
     !isVerifyingCommunityExistance;
 
   useNecessaryEffect(() => {
@@ -130,7 +130,10 @@ const LayoutComponent = ({
   // A loading state (i.e. spinner) is shown in the following cases:
   // - a community is still being initialized or deinitialized
   const shouldShowLoadingState =
-    isLoading || shouldSelectChain || shouldDeInitChain;
+    isLoading ||
+    shouldSelectChain ||
+    shouldDeInitChain ||
+    isVerifyingCommunityExistance;
 
   const childToRender = () => {
     if (appError.loadingError) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8913

## Description of Changes
Fixed community switching for auth user

## "How We Fixed It"
There was a missing condition to check for loading state during app init. We added that back to fix it.


## Test Plan
- Login
- Switch to different communities from the app sidebar
- Verify it works correctly.

## Deployment Plan
N/A

## Other Considerations
N/A