### PR TITLE
made more robust changes to the url redirect bug

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -35,6 +35,8 @@ export const slugify = (str: string): string => {
 /* eslint-disable */
 
 export const splitAndDecodeURL = (locationPathname: string) => {
+  //checks if a url is custom or not and decodes the url after splitting it
+  //this is to check for malformed urls on a topics page in /discussions
   const splitURLPath = locationPathname.split('/');
   if (splitURLPath[2] === 'discussions') {
     return decodeURIComponent(splitURLPath[3]);

--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -34,6 +34,15 @@ export const slugify = (str: string): string => {
 };
 /* eslint-disable */
 
+export const splitAndDecodeURL = (locationPathname: string) => {
+  const splitURLPath = locationPathname.split('/');
+  if (splitURLPath[2] === 'discussions') {
+    return decodeURIComponent(splitURLPath[3]);
+  }
+  splitURLPath[1] === 'discussions';
+  return decodeURIComponent(splitURLPath[2]);
+};
+
 export const getThreadUrl = (
   thread: {
     chain: string;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,6 +1,6 @@
 import { getProposalUrlPath } from 'identifiers';
 import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import useFetchThreadsQuery, {
@@ -58,7 +58,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     'dateRange',
   ) as ThreadTimelineFilterTypes;
 
-  const { data: topics } = useFetchTopicsQuery({
+  const { data: topics, isLoading: isLoadingTopics } = useFetchTopicsQuery({
     communityId,
   });
   const contestAddress = searchParams.get('contest');
@@ -126,6 +126,28 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
 
     return t;
   });
+
+  const splitURLPath = useMemo(() => location.pathname.split('/'), []);
+  const decodedString = useMemo(() => {
+    if (splitURLPath[2] === 'discussions') {
+      return decodeURIComponent(splitURLPath[3]);
+    }
+    splitURLPath[1] === 'discussions';
+    return decodeURIComponent(splitURLPath[2]);
+  }, [splitURLPath]);
+
+  //redirects users to All Discussions if they try to access a topic in the url that doesn't exist
+  useEffect(() => {
+    if (!isLoadingTopics && decodedString) {
+      const validTopics = topics?.some(
+        (topic) => topic?.name === decodedString,
+      );
+      if (!validTopics) {
+        navigate('/discussions');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topics, decodedString, splitURLPath, isLoadingTopics]);
 
   useManageDocumentTitle('Discussions');
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -1,6 +1,6 @@
 import { getProposalUrlPath } from 'identifiers';
 import { getScopePrefix, useCommonNavigate } from 'navigation/helpers';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import useFetchThreadsQuery, {
@@ -18,7 +18,7 @@ import { HeaderWithFilters } from './HeaderWithFilters';
 import { ThreadCard } from './ThreadCard';
 import { sortByFeaturedFilter, sortPinned } from './helpers';
 
-import { slugify } from '@hicommonwealth/shared';
+import { slugify, splitAndDecodeURL } from '@hicommonwealth/shared';
 import { getThreadActionTooltipText } from 'helpers/threads';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import useManageDocumentTitle from 'hooks/useManageDocumentTitle';
@@ -127,16 +127,8 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     return t;
   });
 
-  const splitURLPath = useMemo(() => location.pathname.split('/'), []);
-  const decodedString = useMemo(() => {
-    if (splitURLPath[2] === 'discussions') {
-      return decodeURIComponent(splitURLPath[3]);
-    }
-    splitURLPath[1] === 'discussions';
-    return decodeURIComponent(splitURLPath[2]);
-  }, [splitURLPath]);
+  const decodedString = splitAndDecodeURL(location.pathname);
 
-  //redirects users to All Discussions if they try to access a topic in the url that doesn't exist
   useEffect(() => {
     if (!isLoadingTopics && decodedString) {
       const validTopics = topics?.some(
@@ -147,7 +139,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topics, decodedString, splitURLPath, isLoadingTopics]);
+  }, [topics, decodedString, isLoadingTopics]);
 
   useManageDocumentTitle('Discussions');
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -129,6 +129,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
 
   const decodedString = splitAndDecodeURL(location.pathname);
 
+  //checks for malformed url in topics and redirects if the topic does not exist
   useEffect(() => {
     if (!isLoadingTopics && decodedString) {
       const validTopics = topics?.some(

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -127,20 +127,21 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     return t;
   });
 
-  const decodedString = splitAndDecodeURL(location.pathname);
+  //splitAndDecodeURL checks if a url is custom or not and decodes the url after splitting it
+  const topicNameFromURL = splitAndDecodeURL(location.pathname);
 
   //checks for malformed url in topics and redirects if the topic does not exist
   useEffect(() => {
-    if (!isLoadingTopics && decodedString) {
+    if (!isLoadingTopics && topicNameFromURL) {
       const validTopics = topics?.some(
-        (topic) => topic?.name === decodedString,
+        (topic) => topic?.name === topicNameFromURL,
       );
       if (!validTopics) {
         navigate('/discussions');
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topics, decodedString, isLoadingTopics]);
+  }, [topics, topicNameFromURL, isLoadingTopics]);
 
   useManageDocumentTitle('Discussions');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8924 

## Description of Changes
- Added logic to handle malformed urls, redirecting a user to `/discussions` on regular and custom domains. This fix also accounts for outside links that go to a specific topic. 
- This solves for #8676 for the direct link and for the custom domains mentioned in the comments of #8744 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added logic to look for matching topics, and if it doesn't match then to redirect user to `/discussions`. The direct link to a topic bug was fixed by accounting for loading of the topics query. 
## Test Plan
- go to a community with many topics, such as 1inch
- go to a specific topic, such as http://localhost:8080/1inch/discussions/2.0%201inch%20DAO
- delete some of the characters away from the url, such as http://localhost:8080/1inch/discussions/2.0%201inch%20D
- confirm that you are now redirected to `/discussions`
- email this link to yourself and click it from inside your email, make sure the localhost tab has been closed first http://localhost:8080/1inch/discussions/2.0%201inch%20DAO
- confirm that you are brought to that topic and not `/discussions`