### PR TITLE
Added support for fetching trending communities from fetch communities list api

### DIFF
--- a/common_knowledge/Database-ERD.md
+++ b/common_knowledge/Database-ERD.md
@@ -280,7 +280,7 @@ erDiagram
     character-varying(255)[] social_links 
     character-varying(255) namespace 
     text redirect 
-    integer thread_count 
+    integer lifetime_thread_count 
     integer address_count 
     boolean stages_enabled 
     text[] custom_stages 

--- a/libs/api-client/src/api.ts
+++ b/libs/api-client/src/api.ts
@@ -3112,7 +3112,7 @@ export class CommunityApi extends BaseAPI {
  */
 export const GetCommunitiesOrderByEnum = {
   ProfileCount: 'profile_count',
-  ThreadCount: 'thread_count',
+  ThreadCount: 'lifetime_thread_count',
 } as const;
 export type GetCommunitiesOrderByEnum =
   typeof GetCommunitiesOrderByEnum[keyof typeof GetCommunitiesOrderByEnum];

--- a/libs/model/src/community/GetCommunities.query.ts
+++ b/libs/model/src/community/GetCommunities.query.ts
@@ -70,7 +70,7 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
                   "Community"."discord_bot_webhooks_enabled",
                   "Community"."directory_page_enabled",
                   "Community"."directory_page_chain_node_id",
-                  "Community"."thread_count" as "lifetime_thread_count",
+                  "Community"."lifetime_thread_count",
                   "Community"."profile_count",
                   "Community"."namespace",
                   "Community"."namespace_address",
@@ -263,17 +263,7 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
             END DESC,`
               : ''
           }
-          ${
-            // TODO: move into a func
-            (() => {
-              if (order_col == 'lifetime_thread_count')
-                return `"community_CTE"."thread_count" ${direction}`;
-              if (order_col == 'profile_count')
-                return `"community_CTE"."profile_count" ${direction}`;
-              if (order_col == 'last_30_day_thread_count')
-                return `"community_CTE"."last_30_day_thread_count" ${direction}`;
-            })()
-          }
+          "community_CTE"."${order_col}" ${direction}
           LIMIT ${limit} 
           OFFSET ${offset};
           `;

--- a/libs/model/src/community/GetCommunities.query.ts
+++ b/libs/model/src/community/GetCommunities.query.ts
@@ -78,10 +78,10 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
                   "Community"."updated_at",
                   "Community"."redirect",
                   "Community"."snapshot_spaces",
-                  "Community"."include_in_digest_email",
+                  "Community"."include_in_digest_email"
                   ${
                     include_last_30_day_thread_count
-                      ? `(SELECT COUNT("Threads".id)::int FROM "Threads" WHERE "Threads".community_id = "Community".id AND "Threads".created_at > '${date30DaysAgo.toISOString()}' AND "Threads".deleted_at IS NULL) as last_30_day_thread_count`
+                      ? `,(SELECT COUNT("Threads".id)::int FROM "Threads" WHERE "Threads".community_id = "Community".id AND "Threads".created_at > '${date30DaysAgo.toISOString()}' AND "Threads".deleted_at IS NULL) as last_30_day_thread_count`
                       : ''
                   }
           FROM    "Communities" AS "Community"

--- a/libs/model/src/models/community.ts
+++ b/libs/model/src/models/community.ts
@@ -23,7 +23,7 @@ export type CommunityAttributes = z.infer<typeof Community> & {
   Users?: UserAttributes[] | UserAttributes['id'][];
   ChainObjectVersion?: any; // TODO
   Contract?: ContractInstance;
-  thread_count?: number;
+  lifetime_thread_count?: number;
   profile_count?: number;
   count_updated?: boolean;
   communityAlerts?: CommunityAlertAttributes[];
@@ -124,7 +124,7 @@ export default (
         allowNull: true,
         defaultValue: null,
       },
-      thread_count: {
+      lifetime_thread_count: {
         type: Sequelize.INTEGER,
         allowNull: false,
         defaultValue: 0,

--- a/libs/model/src/models/thread.ts
+++ b/libs/model/src/models/thread.ts
@@ -146,7 +146,7 @@ export default (
         ) => {
           const { Community, Outbox } = sequelize.models;
 
-          await Community.increment('thread_count', {
+          await Community.increment('lifetime_thread_count', {
             by: 1,
             where: { id: thread.community_id },
             transaction: options.transaction,
@@ -178,7 +178,7 @@ export default (
           options: Sequelize.InstanceDestroyOptions,
         ) => {
           const { Community } = sequelize.models;
-          await Community.increment('thread_count', {
+          await Community.increment('lifetime_thread_count', {
             by: 1,
             where: { id: thread.community_id },
             transaction: options.transaction,

--- a/libs/model/test/community/group-lifecycle.spec.ts
+++ b/libs/model/test/community/group-lifecycle.spec.ts
@@ -38,7 +38,7 @@ describe('Group lifecycle', () => {
     const [community] = await seed('Community', {
       chain_node_id: node!.id!,
       active: true,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/community/stake-historical-price.spec.ts
+++ b/libs/model/test/community/stake-historical-price.spec.ts
@@ -26,7 +26,7 @@ describe('Stake Historical Price', () => {
     });
     const [community] = await seed('Community', {
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/community/stake-lifecycle.spec.ts
+++ b/libs/model/test/community/stake-lifecycle.spec.ts
@@ -41,7 +41,7 @@ describe('Stake lifecycle', () => {
       active: true,
       chain_node_id: node!.id!,
       namespace: 'test1',
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {
@@ -62,7 +62,7 @@ describe('Stake lifecycle', () => {
       active: true,
       chain_node_id: node!.id!,
       namespace: 'test2',
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {
@@ -74,7 +74,7 @@ describe('Stake lifecycle', () => {
     const [community_without_stake] = await seed('Community', {
       active: true,
       chain_node_id: node!.id!,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/community/stake-transaction.spec.ts
+++ b/libs/model/test/community/stake-transaction.spec.ts
@@ -32,7 +32,7 @@ describe('Stake transactions', () => {
     const [community] = await seed('Community', {
       namespace: 'qaa',
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/community/tags.spec.ts
+++ b/libs/model/test/community/tags.spec.ts
@@ -16,13 +16,13 @@ describe('Tags', () => {
     await seed('Community', {
       chain_node_id: node!.id!,
       active: true,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
     const [community1Tag1Only] = await seed('Community', {
       chain_node_id: node!.id!,
       active: true,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
     await seed('CommunityTags', {
@@ -32,7 +32,7 @@ describe('Tags', () => {
     const [community2Tag1And2] = await seed('Community', {
       chain_node_id: node!.id!,
       active: true,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
     await seed('CommunityTags', {

--- a/libs/model/test/contest-worker/contest-worker-policy.spec.ts
+++ b/libs/model/test/contest-worker/contest-worker-policy.spec.ts
@@ -30,7 +30,7 @@ describe('Contest Worker Policy', () => {
     const [community] = await seed('Community', {
       id: communityId,
       chain_node_id: chainNode!.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/contest/contests-metadata-commands-lifecycle.spec.ts
+++ b/libs/model/test/contest/contests-metadata-commands-lifecycle.spec.ts
@@ -56,7 +56,7 @@ describe('Contests metadata commands lifecycle', () => {
         id: community_id,
         namespace,
         chain_node_id: chain!.id,
-        thread_count: 0,
+        lifetime_thread_count: 0,
         profile_count: 2,
         Addresses: [
           {

--- a/libs/model/test/contest/contests-projection-lifecycle.spec.ts
+++ b/libs/model/test/contest/contests-projection-lifecycle.spec.ts
@@ -108,7 +108,7 @@ describe('Contests projection lifecycle', () => {
           namespace_address: namespace,
           chain_node_id: chain!.id,
           discord_config_id: undefined,
-          thread_count: 0,
+          lifetime_thread_count: 0,
           profile_count: 1,
           Addresses: [
             {

--- a/libs/model/test/email/digest-email-lifecycle.spec.ts
+++ b/libs/model/test/email/digest-email-lifecycle.spec.ts
@@ -22,7 +22,7 @@ describe('Digest email lifecycle', () => {
 
     [communityOne] = await seed('Community', {
       chain_node_id: undefined,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {
@@ -33,7 +33,7 @@ describe('Digest email lifecycle', () => {
     });
     [communityTwo] = await seed('Community', {
       chain_node_id: undefined,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {
@@ -45,7 +45,7 @@ describe('Digest email lifecycle', () => {
     // create an additional community to ensure only specific threads are selected
     [communityThree] = await seed('Community', {
       chain_node_id: undefined,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/email/recap-email-lifecycle.spec.ts
+++ b/libs/model/test/email/recap-email-lifecycle.spec.ts
@@ -52,7 +52,7 @@ describe('Recap email lifecycle', () => {
     });
     [community] = await seed('Community', {
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/reaction/reaction-lifecycle.spec.ts
+++ b/libs/model/test/reaction/reaction-lifecycle.spec.ts
@@ -26,7 +26,7 @@ describe('Reactions lifecycle', () => {
         id: communityId,
         chain_node_id: chain!.id,
         discord_config_id: undefined,
-        thread_count: 0,
+        lifetime_thread_count: 0,
         profile_count: 1,
         Addresses: [
           {

--- a/libs/model/test/seed/seed.spec.ts
+++ b/libs/model/test/seed/seed.spec.ts
@@ -123,7 +123,7 @@ describe('Seed functions', () => {
         base: ChainBase.Ethereum,
         has_chain_events_listener: false,
         chain_node_id: node!.id,
-        thread_count: 1,
+        lifetime_thread_count: 1,
         profile_count: 1,
         Addresses: [
           {
@@ -150,7 +150,7 @@ describe('Seed functions', () => {
         base: ChainBase.Ethereum,
         has_chain_events_listener: false,
         chain_node_id: node!.id,
-        thread_count: 1,
+        lifetime_thread_count: 1,
         profile_count: 1,
         Addresses: [
           {
@@ -198,7 +198,7 @@ describe('Seed functions', () => {
         seed(
           'Community',
           {
-            thread_count: 0,
+            lifetime_thread_count: 0,
             profile_count: 1,
           },
           { mock: false },

--- a/libs/model/test/subscription/comment-subscription-lifecycle.spec.ts
+++ b/libs/model/test/subscription/comment-subscription-lifecycle.spec.ts
@@ -30,7 +30,7 @@ describe('Comment subscription lifecycle', () => {
     });
     const [community] = await seed('Community', {
       chain_node_id: node!.id!,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/subscription/community-alerts-lifecycle.spec.ts
+++ b/libs/model/test/subscription/community-alerts-lifecycle.spec.ts
@@ -31,12 +31,12 @@ describe('Community alerts lifecycle', () => {
     });
     [community] = await seed('Community', {
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
     [communityTwo] = await seed('Community', {
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
     actor = {

--- a/libs/model/test/subscription/thread-subscription-lifecycle.spec.ts
+++ b/libs/model/test/subscription/thread-subscription-lifecycle.spec.ts
@@ -29,7 +29,7 @@ describe('Thread subscription lifecycle', () => {
     });
     const [community] = await seed('Community', {
       chain_node_id: node!.id!,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/libs/model/test/user/new-content-lifecycle.spec.ts
+++ b/libs/model/test/user/new-content-lifecycle.spec.ts
@@ -17,7 +17,7 @@ describe('New Content lifecycle', () => {
     const [user2] = await seed('User');
     const [community] = await seed('Community', {
       chain_node_id: node?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 2,
       Addresses: [
         {

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -55,7 +55,7 @@ export const Community = z.object({
   snapshot_spaces: z.array(z.string().max(255)).default([]),
   include_in_digest_email: z.boolean().nullish(),
   profile_count: PG_INT.nullish(),
-  thread_count: PG_INT.nullish(),
+  lifetime_thread_count: PG_INT.nullish(),
 
   // 2. Timestamps are managed by sequelize, thus optional
   created_at: z.coerce.date().optional(),

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -36,7 +36,6 @@ export const GetCommunities = {
     stake_enabled: z.boolean().optional(),
     has_groups: z.boolean().optional(),
     include_last_30_day_thread_count: z.boolean().optional(),
-    // TODO: add describe
     order_by: z
       .enum([
         'profile_count',

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -35,6 +35,7 @@ export const GetCommunities = {
     include_node_info: z.boolean().optional(),
     stake_enabled: z.boolean().optional(),
     has_groups: z.boolean().optional(),
+    include_last_30_day_thread_count: z.boolean().optional(),
     // TODO: add describe
     order_by: z
       .enum([
@@ -43,7 +44,24 @@ export const GetCommunities = {
         'last_30_day_thread_count',
       ])
       .optional(),
-  }),
+  }).refine(
+    (data) => {
+      // order_by can't be 'last_30_day_thread_count' if 'include_last_30_day_thread_count' is falsy
+      if (
+        !data.include_last_30_day_thread_count &&
+        data.order_by === 'last_30_day_thread_count'
+      ) {
+        return false; // fail validation
+      }
+
+      // pass validation
+      return true;
+    },
+    {
+      message:
+        "'order_by' cannot be 'last_30_day_thread_count' when 'include_last_30_day_thread_count' is not specified",
+    },
+  ),
   output: PaginatedResultSchema.extend({
     results: Community.extend({
       last_30_day_thread_count: PG_INT.optional().nullish(),

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -6,6 +6,7 @@ import {
 } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import {
+  Community,
   CommunityMember,
   CommunityStake,
   ExtendedCommunity,
@@ -34,7 +35,7 @@ export const GetCommunities = {
     include_node_info: z.boolean().optional(),
     stake_enabled: z.boolean().optional(),
     has_groups: z.boolean().optional(),
-    // TODO: rename thread_count
+    // TODO: add describe
     order_by: z
       .enum([
         'profile_count',
@@ -44,7 +45,9 @@ export const GetCommunities = {
       .optional(),
   }),
   output: PaginatedResultSchema.extend({
-    results: z.any().array(), // TODO: fix type
+    results: Community.extend({
+      last_30_day_thread_count: PG_INT.optional().nullish(),
+    }).array(),
   }),
 };
 

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -6,7 +6,6 @@ import {
 } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import {
-  Community,
   CommunityMember,
   CommunityStake,
   ExtendedCommunity,
@@ -16,7 +15,10 @@ import { PaginatedResultSchema, PaginationParamsSchema } from './pagination';
 
 export const GetCommunities = {
   input: PaginationParamsSchema.extend({
-    relevance_by: z.enum(['tag_ids']).optional(),
+    relevance_by: z.enum(['tag_ids', 'membership']).optional().describe(`\n
+      - When 'tag_ids', results would be 'DESC' ordered based on the provided 'tag_ids' param, and wouldn't strictly include matching 'tag_ids'\n
+      - When 'memberships', results would be 'DESC' ordered, the communities with auth-user membership will come before non-membership communities\n
+    `),
     network: z.nativeEnum(ChainNetwork).optional(),
     base: z.nativeEnum(ChainBase).optional(),
     // NOTE 8/7/24: passing arrays in GET requests directly is not supported.
@@ -32,10 +34,17 @@ export const GetCommunities = {
     include_node_info: z.boolean().optional(),
     stake_enabled: z.boolean().optional(),
     has_groups: z.boolean().optional(),
-    order_by: z.enum(['profile_count', 'thread_count']).optional(),
+    // TODO: rename thread_count
+    order_by: z
+      .enum([
+        'profile_count',
+        'lifetime_thread_count',
+        'last_30_day_thread_count',
+      ])
+      .optional(),
   }),
   output: PaginatedResultSchema.extend({
-    results: Community.array(),
+    results: z.any().array(), // TODO: fix type
   }),
 };
 

--- a/libs/sitemaps/test/integration/createSitemapGenerator.spec.ts
+++ b/libs/sitemaps/test/integration/createSitemapGenerator.spec.ts
@@ -26,7 +26,7 @@ describe('createSitemapGenerator', { timeout: 10_000 }, function () {
     const [community] = await tester.seed('Community', {
       name: 'Acme',
       chain_node_id: node.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
     });
 

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -14,7 +14,7 @@ class ChainInfo {
   public readonly CommunityStakes: StakeInfo[];
   public CommunityTags: Tag[];
   public readonly tokenName: string;
-  public threadCount: number;
+  public lifetimeThreadCount: number;
   public readonly profileCount: number;
   public readonly default_symbol: string;
   public name: string;
@@ -89,7 +89,7 @@ class ChainInfo {
     directoryPageChainNodeId,
     namespace,
     redirect,
-    thread_count,
+    lifetime_thread_count,
     profile_count,
     snapshot_spaces,
     communityBanner,
@@ -129,7 +129,7 @@ class ChainInfo {
     this.directoryPageChainNodeId = directoryPageChainNodeId;
     this.namespace = namespace;
     this.redirect = redirect;
-    this.threadCount = thread_count;
+    this.lifetimeThreadCount = lifetime_thread_count;
     this.profileCount = profile_count;
     this.snapshot = snapshot_spaces || [];
   }
@@ -166,7 +166,7 @@ class ChainInfo {
     directory_page_chain_node_id,
     namespace,
     redirect,
-    thread_count,
+    lifetime_thread_count,
     profile_count,
     CommunityStakes,
     CommunityTags,
@@ -226,7 +226,7 @@ class ChainInfo {
       directoryPageChainNodeId: directory_page_chain_node_id,
       namespace,
       redirect,
-      thread_count,
+      lifetime_thread_count,
       profile_count,
       snapshot_spaces,
       adminsAndMods: adminsAndMods || Addresses,
@@ -282,7 +282,7 @@ class ChainInfo {
       snapshot_spaces: community.snapshot_spaces,
       stages_enabled: community.stages_enabled,
       terms: community.terms,
-      thread_count: community.numTotalThreads,
+      lifetime_thread_count: community.numTotalThreads,
       social_links: community.social_links,
       ss58_prefix: community.ss58_prefix,
       type: community.type,

--- a/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
@@ -18,7 +18,7 @@ const useFetchCommunitiesQuery = ({
   tag_ids,
   limit = 50,
   order_direction = 'DESC',
-  order_by = 'thread_count',
+  order_by = 'lifetime_thread_count',
   enabled = true,
 }: UseFetchCommunitiesProps) => {
   return trpc.community.getCommunities.useInfiniteQuery(

--- a/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
@@ -12,6 +12,7 @@ const useFetchCommunitiesQuery = ({
   base,
   has_groups,
   include_node_info,
+  include_last_30_day_thread_count,
   relevance_by,
   network,
   stake_enabled,
@@ -25,6 +26,7 @@ const useFetchCommunitiesQuery = ({
     {
       limit: limit,
       include_node_info,
+      include_last_30_day_thread_count,
       order_by,
       order_direction,
       base,

--- a/packages/commonwealth/client/scripts/state/api/communities/fetchRelatedCommunities.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/fetchRelatedCommunities.ts
@@ -14,7 +14,7 @@ interface FetchRelatedCommunitiesResponse {
   description: string;
   icon_url: string;
   id: string;
-  thread_count: string;
+  lifetime_thread_count: string;
   namespace: string;
   chain_node_id: number;
 }

--- a/packages/commonwealth/client/scripts/state/api/threads/helpers/counts.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/helpers/counts.ts
@@ -24,8 +24,8 @@ export const updateCommunityThreadCount = (
   const foundCommunity = (existingCommunities?.communities || []).find(
     (x) => x.id === communityId,
   );
-  if (foundCommunity && foundCommunity?.thread_count >= 0) {
-    foundCommunity.thread_count += type === 'increment' ? 1 : -1;
+  if (foundCommunity && foundCommunity?.lifetime_thread_count >= 0) {
+    foundCommunity.lifetime_thread_count += type === 'increment' ? 1 : -1;
     queryClient.setQueryData(key, { ...existingCommunities });
   }
 };

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityCard/JoinCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityCard/JoinCommunityCard.tsx
@@ -10,7 +10,7 @@ import './JoinCommunityCard.scss';
 type JoinCommunityCardProps = {
   community: Pick<
     ChainInfo,
-    'name' | 'iconUrl' | 'profileCount' | 'threadCount'
+    'name' | 'iconUrl' | 'profileCount' | 'lifetimeThreadCount'
   >;
   isJoined?: boolean;
   canJoin?: boolean;
@@ -50,9 +50,12 @@ const JoinCommunityCard = ({
 
           <CWText className="dot">•</CWText>
 
-          <CWText type="b2" title={`${community?.threadCount}`}>
-            {community?.threadCount}&nbsp;
-            {pluralizeWithoutNumberPrefix(community?.threadCount, 'Thread')}
+          <CWText type="b2" title={`${community?.lifetimeThreadCount}`}>
+            {community?.lifetimeThreadCount}&nbsp;
+            {pluralizeWithoutNumberPrefix(
+              community?.lifetimeThreadCount,
+              'Thread',
+            )}
           </CWText>
         </div>
       </div>

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
@@ -36,7 +36,7 @@ const JoinCommunityStep = ({ onComplete }: JoinCommunityStepProps) => {
       limit: 4,
       relevance_by: 'tag_ids',
       include_node_info: true,
-      order_by: 'thread_count',
+      order_by: 'lifetime_thread_count',
       order_direction: 'DESC',
       base: userAddress?.community?.base,
       cursor: 1,

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/JoinCommunityStep/JoinCommunityStep.tsx
@@ -80,7 +80,7 @@ const JoinCommunityStep = ({ onComplete }: JoinCommunityStepProps) => {
                   iconUrl: community.icon_url || '',
                   name: community.name || '',
                   profileCount: community.profile_count || 0,
-                  threadCount: community.thread_count || 0,
+                  lifetimeThreadCount: community.lifetime_thread_count || 0,
                 }}
                 onJoinClick={() =>
                   handleCommunityJoin({

--- a/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
@@ -249,7 +249,7 @@ const CommunitiesPage = () => {
                     <CWRelatedCommunityCard
                       community={community}
                       memberCount={community.profile_count || 0}
-                      threadCount={community.thread_count || 0}
+                      threadCount={community.lifetime_thread_count || 0}
                       canBuyStake={canBuyStake}
                       onStakeBtnClick={() =>
                         setSelectedCommunityId(community?.id || '')

--- a/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
@@ -71,7 +71,7 @@ const CommunitiesPage = () => {
   } = useFetchCommunitiesQuery({
     limit: 50,
     include_node_info: true,
-    order_by: 'thread_count',
+    order_by: 'lifetime_thread_count',
     order_direction: 'DESC',
     base: filters.withChainBase ? ChainBase[filters.withChainBase] : undefined,
     network: filters.withNetwork,

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/useDirectoryPageData.tsx
@@ -67,7 +67,7 @@ const useDirectoryPageData = ({
         namespace: c.namespace,
         description: c.description,
         members: c.profile_count,
-        threads: c.thread_count,
+        threads: c.lifetime_thread_count,
         iconUrl: c.icon_url,
         id: c.id,
       })),

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -19,6 +19,7 @@ export const TrendingCommunitiesPreview = () => {
     ...(user.isLoggedIn && {
       relevance_by: 'membership',
     }),
+    include_last_30_day_thread_count: true,
     order_by: 'last_30_day_thread_count',
     order_direction: 'DESC',
   });

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -63,9 +63,9 @@ export const TrendingCommunitiesPreview = () => {
         Trending Communities
       </CWText>
       <div className="community-preview-cards-collection">
-        {trendingCommunities.map((sortedCommunity, index) => (
+        {trendingCommunities.map((sortedCommunity) => (
           <CommunityPreviewCard
-            key={index}
+            key={sortedCommunity.community.id}
             community={{
               name: sortedCommunity.community.name || '',
               icon_url: sortedCommunity.community.icon_url || '',

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -1,6 +1,6 @@
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
-import useFetchActiveCommunitiesQuery from 'state/api/communities/fetchActiveCommunities';
+import { useFetchCommunitiesQuery } from 'state/api/communities';
 import { useGetNewContent } from 'state/api/user';
 import useUserStore from 'state/ui/user';
 import Permissions from 'utils/Permissions';
@@ -12,13 +12,23 @@ export const TrendingCommunitiesPreview = () => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
 
-  const { data } = useGetNewContent({ enabled: user.isLoggedIn });
+  const { data: newContent } = useGetNewContent({ enabled: user.isLoggedIn });
+  const { data: paginatedTrendingCommunities } = useFetchCommunitiesQuery({
+    cursor: 1,
+    limit: 3,
+    ...(user.isLoggedIn && {
+      relevance_by: 'membership',
+    }),
+    order_by: 'last_30_day_thread_count',
+    order_direction: 'DESC',
+  });
 
-  // TODO: https://github.com/hicommonwealth/commonwealth/issues/8760
-  const { data: activeCommunities } = useFetchActiveCommunitiesQuery();
-
-  const sortedCommunities = (activeCommunities?.communities || [])
+  const trendingCommunities = (
+    paginatedTrendingCommunities?.pages?.[0]?.results || []
+  )
     .filter((community) => {
+      // TODO: This XSS logic should be moved to API + we shouldn't allow users to choose community
+      // names with invalid chars
       const name = community.name.toLowerCase();
       //this filter is meant to not include any de facto communities that are actually xss attempts.
       //It's a way of keeping the front facing parts of the app clean looking for users
@@ -27,26 +37,23 @@ export const TrendingCommunitiesPreview = () => {
         !['"', '>', '<', "'", '/', '`'].includes(name[1])
       );
     })
-    .map((community) => {
-      const isMember = Permissions.isCommunityMember(community.id);
-
-      return {
-        community,
-        monthlyThreadCount: +community.recentThreadsCount,
-        isMember,
-        // TODO: should we remove the new label once user visits the community? -- ask from product
-        hasNewContent: (data?.joinedCommunityIdsWithNewContent || []).includes(
-          community.id,
-        ),
-        onClick: () => navigate(`/${community.id}`),
-      };
-    })
+    .map((community) => ({
+      community,
+      isMember: Permissions.isCommunityMember(community.id),
+      hasNewContent: (
+        newContent?.joinedCommunityIdsWithNewContent || []
+      ).includes(community.id || ''),
+      onClick: () => navigate(`/${community.id}`),
+    }))
     .sort((a, b) => {
       // display user-joined communities with new content first
       if (a.hasNewContent) return -1;
       if (b.hasNewContent) return 1;
 
-      return b.monthlyThreadCount - a.monthlyThreadCount;
+      return (
+        (b.community.last_30_day_thread_count || 0) -
+        (a.community.last_30_day_thread_count || 0)
+      );
     });
 
   return (
@@ -55,14 +62,16 @@ export const TrendingCommunitiesPreview = () => {
         Trending Communities
       </CWText>
       <div className="community-preview-cards-collection">
-        {(sortedCommunities.length > 3
-          ? sortedCommunities.slice(0, 3)
-          : sortedCommunities
-        ).map((sortedCommunity, index) => (
+        {trendingCommunities.map((sortedCommunity, index) => (
           <CommunityPreviewCard
             key={index}
-            community={sortedCommunity.community}
-            monthlyThreadCount={sortedCommunity.monthlyThreadCount}
+            community={{
+              name: sortedCommunity.community.name || '',
+              icon_url: sortedCommunity.community.icon_url || '',
+            }}
+            monthlyThreadCount={
+              sortedCommunity.community.last_30_day_thread_count || 0
+            }
             isCommunityMember={sortedCommunity.isMember}
             hasNewContent={sortedCommunity.hasNewContent}
             onClick={sortedCommunity.onClick}

--- a/packages/commonwealth/server/controllers/server_communities_methods/get_related_communities.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/get_related_communities.ts
@@ -17,14 +17,14 @@ export type GetRelatedCommunitiesQuery = { chainNodeId: number };
  * @property {string} id - The id of the community
  * @property {string} community - The name of the community
  * @property {string} icon_url - The icon url of the community
- * @property {number} thread_count - The Number of threads associated with the community
+ * @property {number} lifetime_thread_count - The Number of threads associated with the community
  * @property {number} profile_count - The Number of profiles with an address belonging to the community
  */
 export type GetRelatedCommunitiesResult = {
   id: string;
   community: string;
   icon_url: string;
-  thread_count: number;
+  lifetime_thread_count: number;
   profile_count: number;
   description: string;
 }[];
@@ -36,7 +36,7 @@ export async function __getRelatedCommunities(
   return await sequelize.query(
     `
       SELECT c.id, c.icon_url, c.name as community, c.description,
-      c.thread_count, c.profile_count, c.namespace, c.chain_node_id
+      c.lifetime_thread_count, c.profile_count, c.namespace, c.chain_node_id
       FROM "ChainNodes" as cn 
       JOIN "Communities" as c on c.chain_node_id = cn.id
       WHERE cn.id = :chainNodeId AND c.active = true

--- a/packages/commonwealth/server/migrations/20240820182459-rename-thread_count-to-lifetime_thread_count.js
+++ b/packages/commonwealth/server/migrations/20240820182459-rename-thread_count-to-lifetime_thread_count.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn(
+      'Communities',
+      'thread_count',
+      'lifetime_thread_count',
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn(
+      'Communities',
+      'lifetime_thread_count',
+      'thread_count',
+    );
+  },
+};

--- a/packages/commonwealth/test/integration/api/getRelatedCommunities.spec.ts
+++ b/packages/commonwealth/test/integration/api/getRelatedCommunities.spec.ts
@@ -36,7 +36,7 @@ describe('GetRelatedCommunities Tests', async () => {
     // @ts-expect-error StrictNullChecks
     assert.equal(ethereumCommunity.profile_count, 2);
     // @ts-expect-error StrictNullChecks
-    assert.equal(ethereumCommunity.thread_count, 0);
+    assert.equal(ethereumCommunity.lifetime_thread_count, 0);
     // @ts-expect-error StrictNullChecks
     assert.equal(ethereumCommunity.icon_url, 'assets/img/protocols/eth.png');
     // @ts-expect-error StrictNullChecks
@@ -46,7 +46,7 @@ describe('GetRelatedCommunities Tests', async () => {
     // @ts-expect-error StrictNullChecks
     assert.equal(sushiCommunity.profile_count, 0);
     // @ts-expect-error StrictNullChecks
-    assert.equal(sushiCommunity.thread_count, 0);
+    assert.equal(sushiCommunity.lifetime_thread_count, 0);
     // @ts-expect-error StrictNullChecks
     assert.equal(sushiCommunity.icon_url, 'assets/img/protocols/eth.png');
     // @ts-expect-error StrictNullChecks
@@ -58,7 +58,7 @@ describe('GetRelatedCommunities Tests', async () => {
     // @ts-expect-error StrictNullChecks
     assert.equal(yearnFinanceCommunity.profile_count, 0);
     // @ts-expect-error StrictNullChecks
-    assert.equal(yearnFinanceCommunity.thread_count, 0);
+    assert.equal(yearnFinanceCommunity.lifetime_thread_count, 0);
     assert.equal(
       // @ts-expect-error StrictNullChecks
       yearnFinanceCommunity.icon_url,

--- a/packages/commonwealth/test/integration/commonwealthConsumer/chainEventCreatedPolicy.spec.ts
+++ b/packages/commonwealth/test/integration/commonwealthConsumer/chainEventCreatedPolicy.spec.ts
@@ -88,7 +88,7 @@ describe('ChainEventCreated Policy', () => {
     [community] = await tester.seed('Community', {
       chain_node_id: chainNode?.id,
       namespace_address: namespaceAddress,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 1,
       Addresses: [
         {

--- a/packages/commonwealth/test/integration/knock/chainEventCreated.spec.ts
+++ b/packages/commonwealth/test/integration/knock/chainEventCreated.spec.ts
@@ -62,7 +62,7 @@ describe('chainEventCreated Event Handler', () => {
     [community] = await tester.seed('Community', {
       chain_node_id: chainNode!.id,
       namespace_address: namespaceAddress,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
       Addresses: [],
     });

--- a/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
+++ b/packages/commonwealth/test/integration/knock/commentCreated.spec.ts
@@ -61,7 +61,7 @@ describe('CommentCreated Event Handler', () => {
     [community] = await tester.seed('Community', {
       custom_domain: customDomain,
       chain_node_id: chainNode?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 2,
       Addresses: [
         {

--- a/packages/commonwealth/test/integration/knock/snapshotProposalCreated.spec.ts
+++ b/packages/commonwealth/test/integration/knock/snapshotProposalCreated.spec.ts
@@ -41,7 +41,7 @@ describe('snapshotProposalCreated Event Handler', () => {
     [user] = await tester.seed('User', {});
     [community] = await tester.seed('Community', {
       chain_node_id: null,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
       Addresses: [
         {

--- a/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
+++ b/packages/commonwealth/test/integration/knock/userMentioned.spec.ts
@@ -44,7 +44,7 @@ describe('userMentioned Event Handler', () => {
     [author] = await tester.seed('User', {});
     [community] = await tester.seed('Community', {
       chain_node_id: chainNode?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 2,
       Addresses: [
         {

--- a/packages/snapshot-listener/test/index.spec.ts
+++ b/packages/snapshot-listener/test/index.spec.ts
@@ -24,7 +24,7 @@ describe('Snapshot Listener API', { timeout: 5_000 }, () => {
 
     await tester.seed('Community', {
       chain_node_id: chainNode?.id,
-      thread_count: 0,
+      lifetime_thread_count: 0,
       profile_count: 0,
       Addresses: [],
       CommunityStakes: [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8760

## Description of Changes
- Moved trending communities algo from frontend to communities list API.
- Renamed `thread_count` to `lifetime_thread_count` in communities table
- Added `order_by: 'last_30_day_thread_count'` filter in communities list route
- Added `include_last_30_day_thread_count` as an optional param to communities list route

## "How We Fixed It"
N/A

## Test Plan
- Visit `/dashboard/global` with logged in state
- Verify the trending communities list displays valid suggestions
   - communities which user has joined and they have new thread/comment activity after user's last session will be display at the top
   - then communities with higher 30 day thread count would be displayed
- Verify there are no regressions relation to `thread_count` -> `lifetime_thread_count` renaming


## Deployment Plan
N/A

## Other Considerations
This leads to new cleanup/refinement 
- https://github.com/hicommonwealth/commonwealth/issues/8967
- https://github.com/hicommonwealth/commonwealth/issues/8966