### PR TITLE
Community id reference fix

### DIFF
--- a/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
+++ b/packages/commonwealth/server/workers/knock/eventHandlers/userMentioned.ts
@@ -62,17 +62,14 @@ export const processUserMentioned: EventHandler<
       object_url:
         'thread' in payload
           ? getThreadUrl(
-              payload.thread!.community_id,
+              payload.communityId,
               payload.thread!.id!,
               community.custom_domain,
             )
           : getCommentUrl(
-              // @ts-expect-error StrictNullChecks
-              payload.comment.community_id,
-              // @ts-expect-error StrictNullChecks
-              payload.comment.thread_id,
-              // @ts-expect-error StrictNullChecks
-              payload.comment.id,
+              payload.communityId,
+              payload.comment!.thread_id,
+              payload.comment!.id!,
               community.custom_domain,
             ),
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8916

## Description of Changes
- Fixes a reference to `comment.community_id` which is no longer valid but existed because of `// @ts-expect-error`

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 