### PR TITLE
Fixed profile redirect bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -94,8 +94,6 @@ const useUserMenuItems = ({
 
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
-  const user = userData.addresses?.[0];
-
   const uniqueChainAddresses = getUniqueUserAddresses({
     forChain: app?.chain?.base,
   });
@@ -229,7 +227,7 @@ const useUserMenuItems = ({
       {
         type: 'default',
         label: 'View profile',
-        onClick: () => navigate(`/profile/id/${user.userId}`, {}, null),
+        onClick: () => navigate(`/profile/id/${userData.id}`, {}, null),
       },
       {
         type: 'default',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8909

## Description of Changes
- Fixed profile redirect bug using incorrect state value for profile id

## "How We Fixed It"
N/A

## Test Plan
- Login
- Visit profile from user dropdown
- Logout and login with a different account
- Visit profile from user dropdown -- verify it redirects you to correct profile and not to `/profile/0`

## Deployment Plan
N/A

## Other Considerations
N/A