### PR TITLE
Fixed community trpc route breaking on invalid community id

### DIFF
--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -41,7 +41,7 @@ export const GetCommunity = {
     id: z.string(),
     include_node_info: z.boolean().optional(),
   }),
-  output: ExtendedCommunity,
+  output: z.union([ExtendedCommunity, z.undefined()]),
 };
 
 export const GetCommunityStake = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8962

## Description of Changes
Fixed community trpc route breaking on invalid community id

## "How We Fixed It"
By fixing zod return types to be undefined when community is not found

## Test Plan
- Visit community URL with an invalid community id. Ex: `localhost:8080/some-random-nonexistant-community/discussions`
- Verify there are no trpc errors for get community route in console

## Deployment Plan
N/A

## Other Considerations
N/A