### PR TITLE
char count now shown on community description

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_area.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_area.tsx
@@ -21,7 +21,7 @@ type TextAreaStyleProps = {
 type TextAreaFormValidationProps = {
   name?: string;
   hookToForm?: boolean;
-  charCount?: boolean;
+  charCount?: number;
 };
 
 type TextAreaProps = BaseTextInputProps &
@@ -164,7 +164,9 @@ export const CWTextArea = (props: TextAreaProps) => {
       )}
       {charCount && (
         <div className="character-count">
-          <CWText type="caption">Character count: {characterCount}/250</CWText>
+          <CWText type="caption">
+            Character count: {characterCount}/{charCount}
+          </CWText>
         </div>
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_area.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_text_area.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import 'components/component_kit/cw_text_area.scss';
 
 import { useFormContext } from 'react-hook-form';
+import { CWText } from 'views/components/component_kit/cw_text';
 import type { BaseTextInputProps } from './cw_text_input';
 import { MessageRow, useTextInputWithValidation } from './cw_text_input';
 import type { ValidationStatus } from './cw_validation_text';
@@ -20,6 +21,7 @@ type TextAreaStyleProps = {
 type TextAreaFormValidationProps = {
   name?: string;
   hookToForm?: boolean;
+  charCount?: boolean;
 };
 
 type TextAreaProps = BaseTextInputProps &
@@ -31,6 +33,7 @@ export const CWTextArea = (props: TextAreaProps) => {
   const textareaRef = useRef(null);
 
   const {
+    charCount = false,
     autoComplete,
     autoFocus,
     value,
@@ -46,6 +49,8 @@ export const CWTextArea = (props: TextAreaProps) => {
     hookToForm,
     instructionalMessage,
   } = props;
+
+  const [characterCount, setCharacterCount] = useState(0);
 
   useEffect(() => {
     if (resizeWithText) {
@@ -120,6 +125,7 @@ export const CWTextArea = (props: TextAreaProps) => {
                 }
               }, timeout),
             );
+            setCharacterCount(e.currentTarget.value.length);
           }
         }}
         onBlur={(e) => {
@@ -155,6 +161,11 @@ export const CWTextArea = (props: TextAreaProps) => {
             (formFieldErrorMessage ? 'failure' : undefined)
           }
         />
+      )}
+      {charCount && (
+        <div className="character-count">
+          <CWText type="caption">Character count: {characterCount}/250</CWText>
+        </div>
       )}
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -258,6 +258,7 @@ const BasicInformationForm = ({
         hookToForm
         label="Community Description"
         placeholder="Enter a description of your community or project"
+        charCount
       />
 
       <CWCoverImageUploader

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/BasicInformationForm.tsx
@@ -258,7 +258,7 @@ const BasicInformationForm = ({
         hookToForm
         label="Community Description"
         placeholder="Enter a description of your community or project"
-        charCount
+        charCount={250}
       />
 
       <CWCoverImageUploader

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/validation.ts
@@ -8,7 +8,8 @@ export const basicInformationFormValidationSchema = z.object({
     .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })
+    .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
   communityProfileImageURL: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),

--- a/packages/commonwealth/client/styles/components/component_kit/cw_text_area.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_text_area.scss
@@ -15,4 +15,8 @@
 
     @include inputStyles;
   }
+
+  .character-count {
+    margin-top: 12px;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8972 

## Description of Changes
- added a character count below Community Description in the Create Community flow

## Test Plan
- create a community
- in community description area confirm that you see a character count under the text area and that it matches the number of characters typed
- exceed 250 characters and confirm you see an error message. 

