### PR TITLE
Fixed get comment/thread subscriptions return types

### DIFF
--- a/libs/schemas/src/entities/notification.schemas.ts
+++ b/libs/schemas/src/entities/notification.schemas.ts
@@ -70,7 +70,8 @@ export const ThreadSubscription = z.object({
         }),
       }),
     )
-    .optional(),
+    .optional()
+    .nullish(),
 });
 
 export const CommentSubscription = z.object({
@@ -110,7 +111,8 @@ export const CommentSubscription = z.object({
               }),
             }),
           )
-          .optional(),
+          .optional()
+          .nullish(),
       }),
     )
     .optional(),

--- a/libs/schemas/src/entities/notification.schemas.ts
+++ b/libs/schemas/src/entities/notification.schemas.ts
@@ -70,7 +70,6 @@ export const ThreadSubscription = z.object({
         }),
       }),
     )
-    .optional()
     .nullish(),
 });
 
@@ -111,7 +110,6 @@ export const CommentSubscription = z.object({
               }),
             }),
           )
-          .optional()
           .nullish(),
       }),
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9059

## Description of Changes
Fixed get comment/thread subscriptions zod return types

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Visit any page
- Verify that calls to `subscriptions.getCommentSubscriptions` or `subscriptions.getThreadSubscriptions` are successful and contain a response.

## Deployment Plan
N/A

## Other Considerations
N/A