### PR TITLE
Fixed duplicate trending communities

### DIFF
--- a/libs/model/src/community/GetCommunities.query.ts
+++ b/libs/model/src/community/GetCommunities.query.ts
@@ -233,7 +233,10 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
         ${
           relevance_by === 'membership' && replacements.user_id
             ? // eslint-disable-next-line max-len
-              `LEFT OUTER JOIN "Addresses" authUserAddresses ON "community_CTE"."id" = authUserAddresses.community_id AND authUserAddresses.user_id = :user_id`
+              `LEFT OUTER JOIN 
+              (SELECT DISTINCT ON (community_id) * FROM "Addresses" WHERE user_id = :user_id) authUserAddresses 
+              ON "community_CTE"."id" = authUserAddresses.community_id 
+              AND authUserAddresses.user_id = :user_id`
             : ``
         }
         ${


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9081

## Description of Changes
Fixed duplicate trending communities

## "How We Fixed It"
If a user has multiple addresses joined to a community, the trending community query utilizes each of those addresses/communities to find trending communities for that specific user. We updated the query to use unique community ids/addresses in finding trending communities for that user.

## Test Plan
- Login
- Join a community with multiple addresses
- Visit the dashboard page
- Verify you don't see duplicate trending communities

## Deployment Plan
N/A

## Other Considerations
N/A