### PR TITLE
Fixed unnecessary wallet connect popup for contests

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
@@ -1,6 +1,7 @@
 import { ChainBase } from '@hicommonwealth/shared';
 import WebWalletController from 'controllers/app/web_wallets';
 import IWebWallet from 'models/IWebWallet';
+import { userStore } from 'state/ui/user';
 import Web3 from 'web3';
 import { AbiItem } from 'web3-utils';
 
@@ -32,7 +33,7 @@ abstract class ContractBase {
             ChainBase.Ethereum,
           )[0];
 
-          if (!this.wallet.api) {
+          if (!this.wallet.api && !userStore.getState().isLoggedIn) {
             await this.wallet.enable(chainId);
           }
           // @ts-expect-error StrictNullChecks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9036

## Description of Changes
Fixed unnecessary wallet connect popup for contests

## "How We Fixed It"
N/A

## Test Plan
1. Enable contests in a community
2. Visit a community topic that has contest enabled
3. Verify you don't see unnecessary metamask/wallet connect popups
4. Change wallet network to something else
5. Verify 3 again

## Deployment Plan
N/A

## Other Considerations
N/A