### PR TITLE
Add new deployment chains to ChainConfig

### DIFF
--- a/libs/shared/src/commonProtocol/chainConfig.ts
+++ b/libs/shared/src/commonProtocol/chainConfig.ts
@@ -4,6 +4,10 @@ export enum ValidChains {
   SepoliaBase = 84532,
   Sepolia = 11155111,
   Blast = 81457,
+  Linea = 59144,
+  Optimism = 10,
+  Mainnet = 1,
+  Arbitrum = 42161,
 }
 
 export const STAKE_ID = 2;
@@ -38,5 +42,25 @@ export const factoryContracts: {
     factory: '0xedf43C919f59900C82d963E99d822dA3F95575EA',
     communityStake: '0xcc752fd15A7Dd0d5301b6A626316E7211352Cf62',
     chainId: 8453,
+  },
+  [ValidChains.Linea]: {
+    factory: '0xe3ae9569f4523161742414480f87967e991741bd',
+    communityStake: '0xcc752fd15a7dd0d5301b6a626316e7211352cf62',
+    chainId: 59144,
+  },
+  [ValidChains.Optimism]: {
+    factory: '0xe3ae9569f4523161742414480f87967e991741bd',
+    communityStake: '0xcc752fd15a7dd0d5301b6a626316e7211352cf62',
+    chainId: 10,
+  },
+  [ValidChains.Mainnet]: {
+    factory: '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
+    communityStake: '0x9ed281e62db1b1d98af90106974891a4c1ca3a47',
+    chainId: 1,
+  },
+  [ValidChains.Arbitrum]: {
+    factory: '0xE3AE9569f4523161742414480f87967e991741bd',
+    communityStake: '0xcc752fd15A7Dd0d5301b6A626316E7211352Cf62',
+    chainId: 42161,
   },
 };

--- a/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
+++ b/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
@@ -15,7 +15,6 @@ module.exports = {
         },
       );
 
-      // Define three sets of hard-coded values
       const hardCodedValueSetsL2 = [
         {
           contract_address: '0xedf43C919f59900C82d963E99d822dA3F95575EA',
@@ -70,7 +69,6 @@ module.exports = {
         },
       ];
 
-      // Prepare records for insertion
       const records = chainNodes.flatMap((node) => {
         if (node.eth_chain_id == 1) {
           return hardCodedValueSetsETH.map((valueSet) => ({
@@ -84,7 +82,7 @@ module.exports = {
           }));
         }
       });
-      // Insert records into EvmEventSource table
+
       await queryInterface.bulkInsert('EvmEventSources', records, {
         transaction,
       });
@@ -93,7 +91,6 @@ module.exports = {
 
   down: async (queryInterface, Sequelize) => {
     await queryInterface.sequelize.transaction(async (transaction) => {
-      // Fetch the chain_node_ids that were inserted
       const chainNodes = await queryInterface.sequelize.query(
         'SELECT id, eth_chain_id FROM "ChainNodes" WHERE eth_chain_id IN (:evmChainIds)',
         {
@@ -117,7 +114,6 @@ module.exports = {
         '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
       ];
 
-      // Remove inserted records
       await queryInterface.bulkDelete(
         'EvmEventSources',
         {

--- a/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
+++ b/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
@@ -15,13 +15,31 @@ module.exports = {
         },
       );
 
+      const contractAbis = await queryInterface.sequelize.query(
+        'SELECT id, nickname FROM "ContractAbis" WHERE nickname IN (:nicknames)',
+        {
+          replacements: { nicknames: ['NamespaceFactory', 'CommunityStakes'] },
+          type: Sequelize.QueryTypes.SELECT,
+          transaction,
+        },
+      );
+
+      const abiIds = {
+        NamespaceFactory: contractAbis.find(
+          (abi) => abi.nickname === 'NamespaceFactory',
+        ).id,
+        CommunityStakes: contractAbis.find(
+          (abi) => abi.nickname === 'CommunityStakes',
+        ).id,
+      };
+
       const hardCodedValueSetsL2 = [
         {
           contract_address: '0xedf43C919f59900C82d963E99d822dA3F95575EA',
           event_signature:
             '0x8870ba2202802ce285ce6bead5ac915b6dc2d35c8a9d6f96fa56de9de12829d5',
           kind: 'DeployedNamespace',
-          abi_id: 53,
+          abi_id: abiIds.NamespaceFactory,
           active: true,
         },
         {
@@ -29,7 +47,7 @@ module.exports = {
           event_signature:
             '0xfc13c9a8a9a619ac78b803aecb26abdd009182411d51a986090f82519d88a89e',
           kind: 'Trade',
-          abi_id: 52,
+          abi_id: abiIds.CommunityStakes,
           active: true,
         },
         {
@@ -37,7 +55,7 @@ module.exports = {
           event_signature:
             '0x990f533044dbc89b838acde9cd2c72c400999871cf8f792d731edcae15ead693',
           kind: 'NewContest',
-          abi_id: 53,
+          abi_id: abiIds.NamespaceFactory,
           active: true,
         },
       ];
@@ -48,7 +66,7 @@ module.exports = {
           event_signature:
             '0x8870ba2202802ce285ce6bead5ac915b6dc2d35c8a9d6f96fa56de9de12829d5',
           kind: 'DeployedNamespace',
-          abi_id: 53,
+          abi_id: abiIds.NamespaceFactory,
           active: true,
         },
         {
@@ -56,7 +74,7 @@ module.exports = {
           event_signature:
             '0xfc13c9a8a9a619ac78b803aecb26abdd009182411d51a986090f82519d88a89e',
           kind: 'Trade',
-          abi_id: 52,
+          abi_id: abiIds.CommunityStakes,
           active: true,
         },
         {
@@ -64,7 +82,7 @@ module.exports = {
           event_signature:
             '0x990f533044dbc89b838acde9cd2c72c400999871cf8f792d731edcae15ead693',
           kind: 'NewContest',
-          abi_id: 53,
+          abi_id: abiIds.NamespaceFactory,
           active: true,
         },
       ];

--- a/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
+++ b/packages/commonwealth/server/migrations/20240904153821-new-chain-event-sources.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const specificEvmChainIds = [59144, 10, 42161, 1];
+
+      const chainNodes = await queryInterface.sequelize.query(
+        'SELECT id, eth_chain_id FROM "ChainNodes" WHERE eth_chain_id IN (:evmChainIds)',
+        {
+          replacements: { evmChainIds: specificEvmChainIds },
+          type: Sequelize.QueryTypes.SELECT,
+          transaction,
+        },
+      );
+
+      // Define three sets of hard-coded values
+      const hardCodedValueSetsL2 = [
+        {
+          contract_address: '0xedf43C919f59900C82d963E99d822dA3F95575EA',
+          event_signature:
+            '0x8870ba2202802ce285ce6bead5ac915b6dc2d35c8a9d6f96fa56de9de12829d5',
+          kind: 'DeployedNamespace',
+          abi_id: 53,
+          active: true,
+        },
+        {
+          contract_address: '0xcc752fd15A7Dd0d5301b6A626316E7211352Cf62',
+          event_signature:
+            '0xfc13c9a8a9a619ac78b803aecb26abdd009182411d51a986090f82519d88a89e',
+          kind: 'Trade',
+          abi_id: 52,
+          active: true,
+        },
+        {
+          contract_address: '0xedf43C919f59900C82d963E99d822dA3F95575EA',
+          event_signature:
+            '0x990f533044dbc89b838acde9cd2c72c400999871cf8f792d731edcae15ead693',
+          kind: 'NewContest',
+          abi_id: 53,
+          active: true,
+        },
+      ];
+
+      const hardCodedValueSetsETH = [
+        {
+          contract_address: '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
+          event_signature:
+            '0x8870ba2202802ce285ce6bead5ac915b6dc2d35c8a9d6f96fa56de9de12829d5',
+          kind: 'DeployedNamespace',
+          abi_id: 53,
+          active: true,
+        },
+        {
+          contract_address: '0x9ed281e62db1b1d98af90106974891a4c1ca3a47',
+          event_signature:
+            '0xfc13c9a8a9a619ac78b803aecb26abdd009182411d51a986090f82519d88a89e',
+          kind: 'Trade',
+          abi_id: 52,
+          active: true,
+        },
+        {
+          contract_address: '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
+          event_signature:
+            '0x990f533044dbc89b838acde9cd2c72c400999871cf8f792d731edcae15ead693',
+          kind: 'NewContest',
+          abi_id: 53,
+          active: true,
+        },
+      ];
+
+      // Prepare records for insertion
+      const records = chainNodes.flatMap((node) => {
+        if (node.eth_chain_id == 1) {
+          return hardCodedValueSetsETH.map((valueSet) => ({
+            chain_node_id: node.id,
+            ...valueSet,
+          }));
+        } else {
+          return hardCodedValueSetsL2.map((valueSet) => ({
+            chain_node_id: node.id,
+            ...valueSet,
+          }));
+        }
+      });
+      // Insert records into EvmEventSource table
+      await queryInterface.bulkInsert('EvmEventSources', records, {
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Fetch the chain_node_ids that were inserted
+      const chainNodes = await queryInterface.sequelize.query(
+        'SELECT id, eth_chain_id FROM "ChainNodes" WHERE eth_chain_id IN (:evmChainIds)',
+        {
+          replacements: { evmChainIds: [59144, 10, 42161, 1] },
+          type: Sequelize.QueryTypes.SELECT,
+          transaction,
+        },
+      );
+
+      const chainNodeIds = chainNodes.map((node) => node.id);
+
+      const contractAddressesL2 = [
+        '0xedf43C919f59900C82d963E99d822dA3F95575EA',
+        '0xcc752fd15A7Dd0d5301b6A626316E7211352Cf62',
+        '0xedf43C919f59900C82d963E99d822dA3F95575EA',
+      ];
+
+      const contractAddressesETH = [
+        '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
+        '0x9ed281e62db1b1d98af90106974891a4c1ca3a47',
+        '0x90aa47bf6e754f69ee53f05b5187b320e3118b0f',
+      ];
+
+      // Remove inserted records
+      await queryInterface.bulkDelete(
+        'EvmEventSources',
+        {
+          chain_node_id: chainNodeIds,
+          [Sequelize.Op.or]: [
+            { contract_address: contractAddressesL2 },
+            { contract_address: contractAddressesETH },
+          ],
+        },
+        { transaction },
+      );
+    });
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8970

## Description of Changes
- Adds the following chains to ChainConfig
    - Arbitrum
    - Linea
    - Optimism
    - Eth mainnet


## Deployment Plan
<!--- Omit if unneeded -->
1. Important to note, once this is merged + RPCs exist in Db these will technically be live options in create community and it appears all RPCs are available in ChainNodes 
2. NOTE: All chainNodes have been checked/updated for private_urls and ce_block. No further DB action other then evm event source migration should be required


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- This may want to await merge until platform work is complete