### PR TITLE
Fixed archived threads filter in community discussions page

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -23,7 +23,7 @@ const queryTypeToRQMap = {
 };
 
 interface CommonProps {
-  queryType: typeof QueryTypes[keyof typeof QueryTypes];
+  queryType: (typeof QueryTypes)[keyof typeof QueryTypes];
   communityId: string;
   apiEnabled?: boolean;
 }
@@ -37,7 +37,7 @@ interface FetchBulkThreadsProps extends CommonProps {
   topicId?: number;
   stage?: string;
   includePinnedThreads?: boolean;
-  isOnArchivePage?: boolean;
+  includeArchivedThreads?: boolean;
   contestAddress?: string;
   contestStatus?: string;
   orderBy?:
@@ -165,7 +165,7 @@ const fetchBulkThreads = (props) => {
         ...(props.fromDate && { from_date: props.fromDate }),
         to_date: props.toDate,
         orderBy: props.orderBy || 'newest',
-        ...(props.isOnArchivePage && { archived: true }),
+        ...(props.includeArchivedThreads && { archived: true }),
         ...(props.contestAddress && {
           contestAddress: props.contestAddress,
         }),

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -106,7 +106,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       toDate: dateCursor.toDate,
       // @ts-expect-error <StrictNullChecks/>
       fromDate: dateCursor.fromDate,
-      isOnArchivePage: isOnArchivePage,
+      includeArchivedThreads: isOnArchivePage || includeArchivedThreads,
       // @ts-expect-error <StrictNullChecks/>
       contestAddress,
       // @ts-expect-error <StrictNullChecks/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9098

## Description of Changes
Fixed archived threads filter in the community discussions page

## "How We Fixed It"
N/A

## Test Plan
- Visit any community
- Create a thread
- Go to the community discussions page
- Archived that thread you created
- Use the "Include archived threads" filter and verify you see the archived thread.

## Deployment Plan
N/A

## Other Considerations
N/A