### PR TITLE
Removed `numTotalThreads` from get communities response

### DIFF
--- a/libs/api-client/src/api.ts
+++ b/libs/api-client/src/api.ts
@@ -2196,12 +2196,6 @@ export interface GetCommunity200Response {
   numVotingThreads: number;
   /**
    *
-   * @type {number}
-   * @memberof GetCommunity200Response
-   */
-  numTotalThreads: number;
-  /**
-   *
    * @type {Array<GetCommunity200ResponseAdminsAndModsInner>}
    * @memberof GetCommunity200Response
    */

--- a/libs/model/src/community/GetCommunity.query.ts
+++ b/libs/model/src/community/GetCommunity.query.ts
@@ -44,13 +44,9 @@ export function GetCommunity(): Query<typeof schemas.GetCommunity> {
         return;
       }
 
-      const [adminsAndMods, numVotingThreads, numTotalThreads] = await (<
+      const [adminsAndMods, numVotingThreads] = await (<
         Promise<
-          [
-            Array<{ address: string; role: 'admin' | 'moderator' }>,
-            number,
-            number,
-          ]
+          [Array<{ address: string; role: 'admin' | 'moderator' }>, number]
         >
       >Promise.all([
         models.Address.findAll({
@@ -66,23 +62,15 @@ export function GetCommunity(): Query<typeof schemas.GetCommunity> {
             stage: 'voting',
           },
         }),
-        models.Thread.count({
-          where: {
-            community_id: payload.id,
-            marked_as_spam_at: null,
-          },
-        }),
       ]));
 
       return {
         ...result.toJSON(),
         adminsAndMods,
         numVotingThreads,
-        numTotalThreads,
         communityBanner: result.banner_text,
       } as CommunityAttributes & {
         numVotingThreads: number;
-        numTotalThreads: number;
         adminsAndMods: Array<{
           address: string;
           role: 'admin' | 'moderator';

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -78,7 +78,6 @@ export const Community = z.object({
 
 export const ExtendedCommunity = Community.extend({
   numVotingThreads: PG_INT,
-  numTotalThreads: PG_INT,
   adminsAndMods: z.array(
     z.object({
       address: z.string(),

--- a/packages/commonwealth/client/scripts/models/ChainInfo.ts
+++ b/packages/commonwealth/client/scripts/models/ChainInfo.ts
@@ -47,7 +47,6 @@ class ChainInfo {
   public directoryPageChainNodeId?: number;
   public namespace?: string;
   public redirect?: string;
-  public numTotalThreads?: number;
   public numVotingThreads?: number;
 
   public get node() {
@@ -282,7 +281,7 @@ class ChainInfo {
       snapshot_spaces: community.snapshot_spaces,
       stages_enabled: community.stages_enabled,
       terms: community.terms,
-      lifetime_thread_count: community.numTotalThreads,
+      lifetime_thread_count: community.lifetime_thread_count,
       social_links: community.social_links,
       ss58_prefix: community.ss58_prefix,
       type: community.type,

--- a/packages/commonwealth/client/scripts/models/IChainAdapter.ts
+++ b/packages/commonwealth/client/scripts/models/IChainAdapter.ts
@@ -51,7 +51,7 @@ abstract class IChainAdapter<C extends Coin, A extends Account> {
 
     // TODO: cleanup EXCEPTION_CASE_threadCountersStore in 8812
     EXCEPTION_CASE_threadCountersStore.setState({
-      totalThreadsInCommunity: this.meta.numTotalThreads,
+      totalThreadsInCommunity: this.meta.lifetimeThreadCount,
       totalThreadsInCommunityForVoting: this.meta.numVotingThreads,
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9056

## Description of Changes
Removed `numTotalThreads` from get communities response as we already use `lifetime_thread_counts` from the same response

## "How We Fixed It"
N/A

## Test Plan
- Visit any community - verify you see the total thread count on the community discussions page
- Verify creating/deleting a thread updates this count

## Deployment Plan
N/A

## Other Considerations
N/A