### PR TITLE
UI for weighted voting topic creation flow 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/CWPopover.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/CWPopover.tsx
@@ -37,7 +37,7 @@ type ComponentInteriorProps =
       body: React.ReactNode;
     };
 
-type CWPopoverProps = {
+export type CWPopoverProps = {
   placement?: PopperPlacementType;
   disablePortal?: boolean;
   modifiers?: PopperOwnProps['modifiers'];

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPopover/index.ts
@@ -1,6 +1,10 @@
-import type { AnchorType, PopoverTriggerProps } from './CWPopover';
+import type {
+  AnchorType,
+  CWPopoverProps,
+  PopoverTriggerProps,
+} from './CWPopover';
 import CWPopover, { usePopover } from './CWPopover';
 
 export { usePopover };
-export type { AnchorType, PopoverTriggerProps };
+export type { AnchorType, CWPopoverProps, PopoverTriggerProps };
 export default CWPopover;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanel.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanel.scss
@@ -1,0 +1,31 @@
+@import '../../../../../../styles/shared.scss';
+
+.RadioPanel {
+  display: flex;
+  flex-direction: column;
+  width: 292px;
+  border: 1px solid $neutral-200;
+  border-radius: 6px;
+  padding: 16px;
+  cursor: pointer;
+
+  &.selected {
+    background-color: $primary-50;
+    border-color: $primary-500;
+  }
+
+  .top-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .label {
+      font-size: 16px;
+      font-weight: 700;
+    }
+  }
+
+  .option-description {
+    margin-left: 24px;
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanel.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanel.tsx
@@ -1,0 +1,66 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import { CWText } from 'views/components/component_kit/cw_text';
+import CWIconButton from 'views/components/component_kit/new_designs/CWIconButton';
+import CWPopover, {
+  CWPopoverProps,
+  usePopover,
+} from 'views/components/component_kit/new_designs/CWPopover';
+import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
+import { ComponentType } from 'views/components/component_kit/types';
+
+import './CWRadioPanel.scss';
+
+interface CWRadioPanelProps<T> {
+  value: T;
+  popover?: Pick<CWPopoverProps, 'title' | 'body'>;
+  label: string;
+  description: string;
+  isSelected: boolean;
+  onSelect: (value: T) => void;
+}
+
+const CWRadioPanel = <T,>({
+  value,
+  label,
+  description,
+  popover,
+  isSelected,
+  onSelect,
+}: CWRadioPanelProps<T>) => {
+  const popoverProps = usePopover();
+
+  return (
+    <div
+      className={clsx(ComponentType.RadioPanel, { selected: isSelected })}
+      onClick={() => onSelect(value)}
+    >
+      <div className="top-row">
+        <CWRadioButton
+          checked={isSelected}
+          value={value as string}
+          label={label}
+        />
+        {popover && (
+          <>
+            <CWIconButton
+              iconName="infoEmpty"
+              buttonSize="sm"
+              onMouseEnter={popoverProps.handleInteraction}
+              onMouseLeave={popoverProps.handleInteraction}
+            />
+            <CWPopover
+              title={<>{popover.title}</>}
+              body={popover.body}
+              {...popoverProps}
+            />
+          </>
+        )}
+      </div>
+      <CWText className="option-description">{description}</CWText>
+    </div>
+  );
+};
+
+export default CWRadioPanel;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanelGroup.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanelGroup.scss
@@ -1,0 +1,14 @@
+@import '../../../../../../styles/shared.scss';
+
+.RadioPanelGroup {
+  display: flex;
+  gap: 16px;
+
+  @include extraSmall {
+    flex-direction: column;
+
+    .RadioPanel {
+      width: 100%;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanelGroup.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/CWRadioPanelGroup.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import './CWRadioPanelGroup.scss';
+
+interface CWRadioPanelGroupProps {
+  children: React.ReactNode;
+}
+
+export const CWRadioPanelGroup = ({ children }: CWRadioPanelGroupProps) => {
+  return <div className="RadioPanelGroup">{children}</div>;
+};

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRadioPanel/index.ts
@@ -1,0 +1,4 @@
+import CWRadioPanel from './CWRadioPanel';
+export { CWRadioPanelGroup } from './CWRadioPanelGroup';
+
+export default CWRadioPanel;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/types.ts
@@ -37,6 +37,7 @@ export enum ComponentType {
   ProgressBar = 'ProgressBar',
   RadioButton = 'RadioButton',
   RadioGroup = 'RadioGroup',
+  RadioPanel = 'RadioPanel',
   RelatedCommunityCard = 'RelatedCommunityCard',
   Searchbar = 'Searchbar',
   SidebarMenu = 'SidebarMenu',

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.scss
@@ -6,4 +6,17 @@
   gap: 24px;
   width: 100%;
   align-items: flex-start;
+
+  .action-buttons {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+
+    @include extraSmall {
+      justify-content: flex-end;
+    }
+  }
 }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.tsx
@@ -1,4 +1,5 @@
 import { commonProtocol } from '@hicommonwealth/shared';
+import clsx from 'clsx';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import app from 'state';
@@ -6,7 +7,9 @@ import useUserStore from 'state/ui/user';
 import { useCommunityStake } from 'views/components/CommunityStake';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
+import { CreateTopicStep } from 'views/pages/CommunityManagement/Topics/utils';
 import { PageNotFound } from '../../404';
 import CommunityStakeStep from '../../CreateCommunity/steps/CommunityStakeStep';
 import CanBeDisabled from './CanBeDisabled';
@@ -14,7 +17,15 @@ import ContractInfo from './ContractInfo';
 import './StakeIntegration.scss';
 import Status from './Status';
 
-const StakeIntegration = () => {
+interface StakeIntegrationProps {
+  isTopicFlow?: boolean;
+  onTopicFlowStepChange?: (step: CreateTopicStep) => void;
+}
+
+const StakeIntegration = ({
+  isTopicFlow,
+  onTopicFlowStepChange,
+}: StakeIntegrationProps) => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
   const { stakeEnabled, refetchStakeQuery } = useCommunityStake();
@@ -43,8 +54,14 @@ const StakeIntegration = () => {
       x.community?.id === community?.id,
   );
 
+  const createTopicHandler = () => {
+    console.log('create topic');
+    // TODO temp solution - will be integrated in upcoming PR
+    navigate('/discussions');
+  };
+
   return (
-    <CWPageLayout>
+    <CWPageLayout className={clsx({ 'topic-stake': isTopicFlow })}>
       <section className="StakeIntegration">
         <CWText type="h2">Stake</CWText>
         <Status communityName={app.activeChainId()} isEnabled={stakeEnabled} />
@@ -58,15 +75,40 @@ const StakeIntegration = () => {
             />
             <CWDivider />
             <CanBeDisabled />
+            {isTopicFlow && (
+              <>
+                <CWDivider />
+
+                <section className="action-buttons">
+                  <CWButton
+                    type="button"
+                    label="Back"
+                    buttonWidth="wide"
+                    buttonType="secondary"
+                    onClick={() =>
+                      onTopicFlowStepChange?.(CreateTopicStep.WVMethodSelection)
+                    }
+                  />
+                  <CWButton
+                    type="button"
+                    label="Create topic with stakes"
+                    buttonWidth="wide"
+                    onClick={createTopicHandler}
+                  />
+                </section>
+              </>
+            )}
           </>
         ) : (
           <CommunityStakeStep
             goToSuccessStep={handleStepChange}
+            onTopicFlowStepChange={onTopicFlowStepChange}
             createdCommunityName={community?.name}
             createdCommunityId={community?.id}
             // @ts-expect-error <StrictNullChecks/>
             selectedAddress={selectedAddress}
             chainId={communityChainId}
+            isTopicFlow={isTopicFlow}
           />
         )}
       </section>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.scss
@@ -4,4 +4,8 @@
   display: flex;
   gap: 32px;
   flex-direction: column;
+
+  .PageLayout.topic-stake {
+    padding-inline: 0;
+  }
 }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
@@ -6,6 +6,7 @@ import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayou
 import TopicDetails from './TopicDetails';
 import WVConsent from './WVConsent';
 import WVDetails from './WVDetails';
+import WVMethodSelection from './WVMethodSelection';
 import { CreateTopicStep, getCreateTopicSteps } from './utils';
 
 import './Topics.scss';
@@ -28,6 +29,8 @@ export const Topics = () => {
             topicName={topicName}
           />
         );
+      case CreateTopicStep.WVMethodSelection:
+        return <WVMethodSelection onStepChange={setCreateCommunityStep} />;
       case CreateTopicStep.WVDetails:
         return <WVDetails onStepChange={setCreateCommunityStep} />;
     }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import CWFormSteps from 'views/components/component_kit/new_designs/CWFormSteps';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
+import StakeIntegration from 'views/pages/CommunityManagement/StakeIntegration';
 
 import TopicDetails from './TopicDetails';
 import WVConsent from './WVConsent';
@@ -33,6 +34,13 @@ export const Topics = () => {
         return <WVMethodSelection onStepChange={setCreateCommunityStep} />;
       case CreateTopicStep.WVERC20Details:
         return <WVERC20Details onStepChange={setCreateCommunityStep} />;
+      case CreateTopicStep.WVStake:
+        return (
+          <StakeIntegration
+            isTopicFlow
+            onTopicFlowStepChange={setCreateCommunityStep}
+          />
+        );
     }
   };
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
@@ -5,7 +5,7 @@ import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayou
 
 import TopicDetails from './TopicDetails';
 import WVConsent from './WVConsent';
-import WVDetails from './WVDetails';
+import WVERC20Details from './WVERC20Details';
 import WVMethodSelection from './WVMethodSelection';
 import { CreateTopicStep, getCreateTopicSteps } from './utils';
 
@@ -31,8 +31,8 @@ export const Topics = () => {
         );
       case CreateTopicStep.WVMethodSelection:
         return <WVMethodSelection onStepChange={setCreateCommunityStep} />;
-      case CreateTopicStep.WVDetails:
-        return <WVDetails onStepChange={setCreateCommunityStep} />;
+      case CreateTopicStep.WVERC20Details:
+        return <WVERC20Details onStepChange={setCreateCommunityStep} />;
     }
   };
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVConsent/WVConsent.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVConsent/WVConsent.tsx
@@ -66,7 +66,7 @@ const WVConsent = ({ onStepChange, topicName }: WVConsentProps) => {
             type="button"
             buttonWidth="wide"
             label="Yes"
-            onClick={() => onStepChange(CreateTopicStep.WVDetails)}
+            onClick={() => onStepChange(CreateTopicStep.WVMethodSelection)}
           />
         </section>
       </section>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVDetails/WVDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVDetails/WVDetails.tsx
@@ -121,7 +121,7 @@ const WVDetails = ({ onStepChange }: WVConsentProps) => {
           label="Back"
           buttonWidth="wide"
           buttonType="secondary"
-          onClick={() => onStepChange(CreateTopicStep.WVConsent)}
+          onClick={() => onStepChange(CreateTopicStep.WVMethodSelection)}
         />
         <CWButton
           type="button"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVDetails/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVDetails/index.ts
@@ -1,3 +1,0 @@
-import WVDetails from './WVDetails';
-
-export default WVDetails;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.scss
@@ -1,6 +1,6 @@
 @import '../../../../../../styles/shared';
 
-.WVDetails {
+.WVERC20Details {
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.tsx
@@ -11,13 +11,13 @@ import TokenBanner from 'views/components/TokenBanner';
 
 import { CreateTopicStep } from '../utils';
 
-import './WVDetails.scss';
+import './WVERC20Details.scss';
 
 interface WVConsentProps {
   onStepChange: (step: CreateTopicStep) => void;
 }
 
-const WVDetails = ({ onStepChange }: WVConsentProps) => {
+const WVERC20Details = ({ onStepChange }: WVConsentProps) => {
   const navigate = useCommonNavigate();
   const [multiplier, setMultiplier] = useState(1);
   const [token, setToken] = useState('');
@@ -34,7 +34,7 @@ const WVDetails = ({ onStepChange }: WVConsentProps) => {
   };
 
   return (
-    <div className="WVDetails">
+    <div className="WVERC20Details">
       <CWText type="h2">Weighted voting</CWText>
       <CWText type="b1" className="description">
         Activate weighted voting to allow members to cast votes proportional to
@@ -133,4 +133,4 @@ const WVDetails = ({ onStepChange }: WVConsentProps) => {
     </div>
   );
 };
-export default WVDetails;
+export default WVERC20Details;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/index.ts
@@ -1,0 +1,3 @@
+import WVERC20Details from './WVERC20Details';
+
+export default WVERC20Details;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.scss
@@ -1,0 +1,36 @@
+@import '../../../../../../styles/shared';
+
+.WVMethodSelection {
+  display: flex;
+
+  .header {
+    width: 100%;
+    display: flex;
+    gap: 16px;
+    flex-direction: column;
+    max-width: 596px;
+    margin-right: 110px;
+
+    .Text.h4 {
+      margin-top: 16px;
+    }
+
+    @include smallInclusive {
+      margin-right: unset;
+    }
+
+    .description {
+      color: $neutral-500;
+      margin-top: -8px;
+    }
+
+    .Divider {
+      margin-block: 8px;
+    }
+
+    .action-buttons {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
@@ -25,6 +25,16 @@ const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
     null,
   );
 
+  const handleContinue = () => {
+    if (selectedWVMethod === WVMethod.ERC20) {
+      onStepChange(CreateTopicStep.WVERC20Details);
+      return;
+    }
+
+    // TODO go to stake enablement
+    // onStepChange(CreateTopicStep.WVERC20Details);
+  };
+
   return (
     <div className="WVMethodSelection">
       <section className="header">
@@ -68,10 +78,11 @@ const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
             onClick={() => onStepChange(CreateTopicStep.WVConsent)}
           />
           <CWButton
+            disabled={!selectedWVMethod}
             type="button"
             buttonWidth="wide"
             label="Continue"
-            onClick={() => onStepChange(CreateTopicStep.WVDetails)}
+            onClick={handleContinue}
           />
         </section>
       </section>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import CWRadioPanel, {
+  CWRadioPanelGroup,
+} from 'views/components/component_kit/new_designs/CWRadioPanel';
 
 import { CreateTopicStep } from '../utils';
 
@@ -12,7 +15,16 @@ interface WVMethodSelectionProps {
   onStepChange: (step: CreateTopicStep) => void;
 }
 
+enum WVMethod {
+  ERC20 = 'ERC20',
+  Stake = 'Stake',
+}
+
 const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
+  const [selectedWVMethod, setSelectedWVMethod] = useState<WVMethod | null>(
+    null,
+  );
+
   return (
     <div className="WVMethodSelection">
       <section className="header">
@@ -24,6 +36,26 @@ const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
         </CWText>
 
         <CWText type="h4">Choose weight voting method</CWText>
+
+        <CWRadioPanelGroup>
+          <CWRadioPanel
+            value={WVMethod.ERC20}
+            onSelect={setSelectedWVMethod}
+            label="Connect ERC20 token"
+            description="Only ERC20s"
+            popover={{ title: 'Example', body: <>lorem ipsum</> }}
+            isSelected={selectedWVMethod === WVMethod.ERC20}
+          />
+
+          <CWRadioPanel
+            value={WVMethod.Stake}
+            onSelect={setSelectedWVMethod}
+            label="Use Community stake"
+            description="Use non-transferable tokens"
+            popover={{ title: 'Example', body: <>lorem ipsum</> }}
+            isSelected={selectedWVMethod === WVMethod.Stake}
+          />
+        </CWRadioPanelGroup>
 
         <CWDivider />
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
@@ -31,8 +31,7 @@ const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
       return;
     }
 
-    // TODO go to stake enablement
-    // onStepChange(CreateTopicStep.WVERC20Details);
+    onStepChange(CreateTopicStep.WVStake);
   };
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/WVMethodSelection.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { CWDivider } from 'views/components/component_kit/cw_divider';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+
+import { CreateTopicStep } from '../utils';
+
+import './WVMethodSelection.scss';
+
+interface WVMethodSelectionProps {
+  onStepChange: (step: CreateTopicStep) => void;
+}
+
+const WVMethodSelection = ({ onStepChange }: WVMethodSelectionProps) => {
+  return (
+    <div className="WVMethodSelection">
+      <section className="header">
+        <CWText type="h2">Weighted voting</CWText>
+        <CWText type="b1" className="description">
+          Activate weighted voting to allow members to cast votes proportional
+          to their stake or contribution, ensuring decisions reflect the
+          community&apos;s investment levels.
+        </CWText>
+
+        <CWText type="h4">Choose weight voting method</CWText>
+
+        <CWDivider />
+
+        <section className="action-buttons">
+          <CWButton
+            type="button"
+            label="Back"
+            buttonWidth="wide"
+            buttonType="secondary"
+            onClick={() => onStepChange(CreateTopicStep.WVConsent)}
+          />
+          <CWButton
+            type="button"
+            buttonWidth="wide"
+            label="Continue"
+            onClick={() => onStepChange(CreateTopicStep.WVDetails)}
+          />
+        </section>
+      </section>
+    </div>
+  );
+};
+export default WVMethodSelection;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVMethodSelection/index.ts
@@ -1,0 +1,3 @@
+import WVMethodSelection from './WVMethodSelection';
+
+export default WVMethodSelection;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
@@ -4,7 +4,7 @@ export enum CreateTopicStep {
   TopicDetails = 'TopicDetails',
   WVMethodSelection = 'WVMethodSelection',
   WVConsent = 'WVConsent',
-  WVDetails = 'WVDetails',
+  WVERC20Details = 'WVERC20Details',
 }
 
 export const getCreateTopicSteps = (
@@ -23,7 +23,7 @@ export const getCreateTopicSteps = (
       state:
         createTopicStep === CreateTopicStep.WVConsent ||
         createTopicStep === CreateTopicStep.WVMethodSelection ||
-        createTopicStep === CreateTopicStep.WVDetails
+        createTopicStep === CreateTopicStep.WVERC20Details
           ? 'active'
           : 'inactive',
     },

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
@@ -5,6 +5,7 @@ export enum CreateTopicStep {
   WVMethodSelection = 'WVMethodSelection',
   WVConsent = 'WVConsent',
   WVERC20Details = 'WVERC20Details',
+  WVStake = 'WVStake',
 }
 
 export const getCreateTopicSteps = (
@@ -23,7 +24,8 @@ export const getCreateTopicSteps = (
       state:
         createTopicStep === CreateTopicStep.WVConsent ||
         createTopicStep === CreateTopicStep.WVMethodSelection ||
-        createTopicStep === CreateTopicStep.WVERC20Details
+        createTopicStep === CreateTopicStep.WVERC20Details ||
+        createTopicStep === CreateTopicStep.WVStake
           ? 'active'
           : 'inactive',
     },

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/utils.ts
@@ -2,6 +2,7 @@ import { CWFormStepsProps } from 'views/components/component_kit/new_designs/CWF
 
 export enum CreateTopicStep {
   TopicDetails = 'TopicDetails',
+  WVMethodSelection = 'WVMethodSelection',
   WVConsent = 'WVConsent',
   WVDetails = 'WVDetails',
 }
@@ -21,6 +22,7 @@ export const getCreateTopicSteps = (
       label: 'Weighted voting',
       state:
         createTopicStep === CreateTopicStep.WVConsent ||
+        createTopicStep === CreateTopicStep.WVMethodSelection ||
         createTopicStep === CreateTopicStep.WVDetails
           ? 'active'
           : 'inactive',

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/CommunityStakeStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/CommunityStakeStep.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import AddressInfo from 'models/AddressInfo';
+import { CreateTopicStep } from 'views/pages/CommunityManagement/Topics/utils';
 import EnableStake from './EnableStake';
 import SignStakeTransactions from './SignStakeTransactions';
 
@@ -10,6 +11,8 @@ interface CommunityStakeStepProps {
   createdCommunityId: string;
   selectedAddress: AddressInfo;
   chainId: string;
+  isTopicFlow?: boolean;
+  onTopicFlowStepChange?: (step: CreateTopicStep) => void;
 }
 
 const CommunityStakeStep = ({
@@ -18,6 +21,8 @@ const CommunityStakeStep = ({
   createdCommunityId,
   selectedAddress,
   chainId,
+  isTopicFlow,
+  onTopicFlowStepChange,
 }: CommunityStakeStepProps) => {
   const [enableStakePage, setEnableStakePage] = useState(true);
   const [communityStakeData, setCommunityStakeData] = useState({
@@ -30,22 +35,34 @@ const CommunityStakeStep = ({
     setEnableStakePage(false);
   };
 
+  const enableStakeHandler = () => {
+    isTopicFlow && onTopicFlowStepChange
+      ? onTopicFlowStepChange(CreateTopicStep.WVMethodSelection)
+      : goToSuccessStep();
+  };
+
+  const signStakeHandler = () => {
+    isTopicFlow ? setEnableStakePage(true) : goToSuccessStep();
+  };
+
   return (
     <div className="CommunityStakeStep">
       {enableStakePage ? (
         <EnableStake
-          goToSuccessStep={goToSuccessStep}
+          goToSuccessStep={enableStakeHandler}
           onOptInEnablingStake={handleOptInEnablingStake}
           communityStakeData={communityStakeData}
           chainId={chainId}
+          isTopicFlow={isTopicFlow}
         />
       ) : (
         <SignStakeTransactions
-          goToSuccessStep={goToSuccessStep}
+          goToSuccessStep={signStakeHandler}
           communityStakeData={communityStakeData}
           selectedAddress={selectedAddress}
           createdCommunityId={createdCommunityId}
           chainId={chainId}
+          isTopicFlow={isTopicFlow}
         />
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/EnableStake/EnableStake.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/EnableStake/EnableStake.tsx
@@ -18,6 +18,7 @@ const EnableStake = ({
   onOptInEnablingStake,
   communityStakeData,
   chainId,
+  isTopicFlow,
 }: EnableStakeProps) => {
   const [namespaceError, setNamespaceError] = useState('');
 
@@ -116,7 +117,7 @@ const EnableStake = ({
         <section className="action-buttons">
           <CWButton
             type="button"
-            label="No"
+            label={isTopicFlow ? 'Back' : 'No'}
             buttonWidth="wide"
             buttonType="secondary"
             onClick={goToSuccessStep}

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/SignStakeTransactions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/SignStakeTransactions.tsx
@@ -21,6 +21,7 @@ const SignStakeTransactions = ({
   selectedAddress,
   createdCommunityId,
   chainId,
+  isTopicFlow,
 }: SignStakeTransactionsProps) => {
   const { handleReserveCommunityNamespace, reserveNamespaceData } =
     useReserveCommunityNamespace({
@@ -77,24 +78,26 @@ const SignStakeTransactions = ({
   };
 
   const handleCancel = () => {
-    openConfirmation({
-      title: 'Are you sure you want to cancel?',
-      description:
-        'Community Stake has not been enabled for your community yet',
-      buttons: [
-        {
-          label: 'Cancel',
-          buttonType: 'destructive',
-          buttonHeight: 'sm',
-          onClick: goToSuccessStep,
-        },
-        {
-          label: 'Continue',
-          buttonType: 'primary',
-          buttonHeight: 'sm',
-        },
-      ],
-    });
+    isTopicFlow
+      ? goToSuccessStep()
+      : openConfirmation({
+          title: 'Are you sure you want to cancel?',
+          description:
+            'Community Stake has not been enabled for your community yet',
+          buttons: [
+            {
+              label: 'Cancel',
+              buttonType: 'destructive',
+              buttonHeight: 'sm',
+              onClick: goToSuccessStep,
+            },
+            {
+              label: 'Continue',
+              buttonType: 'primary',
+              buttonHeight: 'sm',
+            },
+          ],
+        });
   };
 
   const cancelDisabled =
@@ -126,7 +129,7 @@ const SignStakeTransactions = ({
         <section className="action-buttons">
           <CWButton
             type="button"
-            label="Cancel"
+            label={isTopicFlow ? 'Back' : 'Cancel'}
             buttonWidth="wide"
             buttonType="secondary"
             disabled={cancelDisabled}

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/types.ts
@@ -17,6 +17,7 @@ export interface SignStakeTransactionsProps {
   selectedAddress: AddressInfo;
   createdCommunityId: string;
   chainId: string;
+  isTopicFlow?: boolean;
 }
 
 export interface EnableStakeProps {
@@ -24,6 +25,7 @@ export interface EnableStakeProps {
   onOptInEnablingStake: ({ namespace, symbol }: StakeData) => void;
   communityStakeData: StakeData;
   chainId: string;
+  isTopicFlow?: boolean;
 }
 
 export const defaultActionState: ActionState = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8958 

## Description of Changes
- added CWRadioPanel to the component kit
- added method selection step to the flow (erc20 vs stake)
- integrated stake enablement into the topic creation flow
- created diagram with the whole flow ([see here](https://www.figma.com/board/xsXNa51D2oFNjOpXr5AveR/Weighted-Voting-topic-creation-flow?node-id=0-1&t=Vd0epjju6QAhTRFX-1))


## Test Plan
- enable FLAG_FARCASTER_CONTEST=true
- as an admin, go to topics and start creating a new topic
- follow the buttons and make sure that it is aligned with the flow in [figma file](https://www.figma.com/board/xsXNa51D2oFNjOpXr5AveR/Weighted-Voting-topic-creation-flow?node-id=0-1&t=Vd0epjju6QAhTRFX-1)
- this is only UI so topic wont be created if you finish the flow


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a