### PR TITLE
Minimized calls to `/getAddressProfile` for auth user addresses

### DIFF
--- a/packages/commonwealth/client/scripts/models/AddressInfo.ts
+++ b/packages/commonwealth/client/scripts/models/AddressInfo.ts
@@ -40,10 +40,7 @@ class AddressInfo extends Account {
 
         // if this is auth user, use already fetched address/profile data
         const foundAddress = authUser.addresses.find(
-          (a) =>
-            a.address === address &&
-            a.community.id === community.id &&
-            a.profile,
+          (a) => a.address === address && a.community.id === community.id,
         );
         const profile = new MinimumProfile(address, community.id);
         profile.initialize(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9053

## Description of Changes
We were making a request to `/getAddressProfile` for each address per community of the auth user. This PR minimizes those API calls and utilizes the auth user profile/addresses data that was already fetched on mount.

## "How We Fixed It"
N/A

## Test Plan
- Ensure auth user profile data (specially username, profile link and avatar) displayed anywhere has no regressions.
- Ensure there are minimal calls to `/getAddressProfile` after app load.

## Deployment Plan
N/A

## Other Considerations
N/A