### PR TITLE
Fixed undefined key when joining a community during onboarding

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useJoinCommunity.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useJoinCommunity.tsx
@@ -119,8 +119,8 @@ const useJoinCommunity = () => {
               ...user.communities,
               {
                 id: community.id,
-                iconUrl: activeChainInfo.iconUrl || '',
-                name: activeChainInfo.name || '',
+                iconUrl: activeChainInfo?.iconUrl || community.iconUrl || '',
+                name: activeChainInfo?.name || community.name || '',
                 isStarred: false,
               },
             ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9137

## Description of Changes
Fixed undefined key when joining a community during onboarding

## "How We Fixed It"
N/A

## Test Plan
- Create a new account
- On the welcome onboard modal -> Join community step -> join any community and verify it works without any errors.

## Deployment Plan
N/A

## Other Considerations
N/A