### PR TITLE
Remove `Addresses.wallet_sso_source`

### DIFF
--- a/libs/model/src/models/address.ts
+++ b/libs/model/src/models/address.ts
@@ -52,7 +52,6 @@ export default (
         defaultValue: false,
       },
       wallet_id: { type: Sequelize.STRING, allowNull: true },
-      wallet_sso_source: { type: Sequelize.STRING, allowNull: true },
       block_info: { type: Sequelize.STRING, allowNull: true },
       is_banned: {
         type: Sequelize.BOOLEAN,

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -1,4 +1,4 @@
-import { Roles, WalletId, WalletSsoSource } from '@hicommonwealth/shared';
+import { Roles, WalletId } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import { PG_INT } from '../utils';
 
@@ -61,9 +61,6 @@ export const Address = z.object({
   block_info: z.string().max(255).nullish(),
   is_user_default: z.boolean().default(false),
   role: z.enum(Roles).default('member'),
-  wallet_sso_source: z
-    .union([z.nativeEnum(WalletSsoSource), z.literal('')])
-    .nullish(),
   is_banned: z.boolean().default(false),
   hex: z.string().max(64).nullish(),
 

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -61,7 +61,9 @@ export const Address = z.object({
   block_info: z.string().max(255).nullish(),
   is_user_default: z.boolean().default(false),
   role: z.enum(Roles).default('member'),
-  wallet_sso_source: z.nativeEnum(WalletSsoSource).nullish(),
+  wallet_sso_source: z
+    .union([z.nativeEnum(WalletSsoSource), z.literal('')])
+    .nullish(),
   is_banned: z.boolean().default(false),
   hex: z.string().max(64).nullish(),
 

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -256,10 +256,9 @@ export function updateActiveUser(data) {
 export async function createUserWithAddress(
   address: string,
   walletId: WalletId,
-  walletSsoSource: WalletSsoSource,
   chain: string,
   sessionPublicAddress?: string,
-  validationBlockInfo?: BlockInfo,
+  validationBlockInfo?: BlockInfo | null,
 ): Promise<{
   account: Account;
   newlyCreated: boolean;
@@ -270,7 +269,6 @@ export async function createUserWithAddress(
     community_id: chain,
     jwt: userStore.getState().jwt,
     wallet_id: walletId,
-    wallet_sso_source: walletSsoSource,
     block_info: validationBlockInfo
       ? JSON.stringify(validationBlockInfo)
       : null,

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -536,8 +536,6 @@ const useAuthentication = (props: UseAuthenticationProps) => {
       } = await createUserWithAddress(
         address,
         wallet.name,
-        // @ts-expect-error <StrictNullChecks>
-        null, // no sso source
         chainIdentifier,
         session.publicKey,
         validationBlockInfo,
@@ -578,8 +576,6 @@ const useAuthentication = (props: UseAuthenticationProps) => {
     const { account } = await createUserWithAddress(
       address,
       wallet.name,
-      // @ts-expect-error <StrictNullChecks>
-      null, // no sso source?
       chainIdentifier,
       // TODO: I don't think we need this field in Account at all
       session.publicKey,

--- a/packages/commonwealth/server/migrations/20240905195339-clean-wallet-sso-source.js
+++ b/packages/commonwealth/server/migrations/20240905195339-clean-wallet-sso-source.js
@@ -3,11 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.sequelize.query(`
-      UPDATE "Addresses"
-      SET wallet_sso_source = NULL
-      WHERE wallet_sso_source = '';
-    `);
+    await queryInterface.removeColumn('Addresses', 'wallet_sso_source');
   },
 
   async down(queryInterface, Sequelize) {},

--- a/packages/commonwealth/server/migrations/20240905195339-clean-wallet-sso-source.js
+++ b/packages/commonwealth/server/migrations/20240905195339-clean-wallet-sso-source.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      UPDATE "Addresses"
+      SET wallet_sso_source = NULL
+      WHERE wallet_sso_source = '';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -14,7 +14,6 @@ import {
   CANVAS_TOPIC,
   ChainBase,
   WalletId,
-  WalletSsoSource,
   deserializeCanvas,
   getSessionSignerForAddress,
 } from '@hicommonwealth/shared';
@@ -37,7 +36,6 @@ type MagicLoginContext = {
   existingUserInstance?: UserInstance;
   loggedInUser?: UserInstance;
   profileMetadata?: { username?: string; avatarUrl?: string };
-  walletSsoSource: WalletSsoSource;
 };
 
 const DEFAULT_ETH_COMMUNITY_ID = 'ethereum';
@@ -47,7 +45,6 @@ async function createMagicAddressInstances(
   models: DB,
   generatedAddresses: Array<{ address: string; community_id: string }>,
   user: UserAttributes,
-  walletSsoSource: WalletSsoSource,
   decodedMagicToken: MagicUser,
   t?: Transaction,
 ): Promise<AddressInstance[]> {
@@ -91,16 +88,6 @@ async function createMagicAddressInstances(
     if (!created) {
       // Update used magic token to prevent replay attacks
       addressInstance.verification_token = decodedMagicToken.claim.tid;
-
-      if (
-        addressInstance.wallet_sso_source === WalletSsoSource.Unknown ||
-        // set wallet_sso_source if it was unknown before
-        addressInstance.wallet_sso_source === undefined ||
-        addressInstance.wallet_sso_source === null
-      ) {
-        addressInstance.wallet_sso_source = walletSsoSource;
-      }
-
       await addressInstance.save({ transaction: t });
     }
     addressInstances.push(addressInstance);
@@ -115,7 +102,6 @@ async function createNewMagicUser({
   magicUserMetadata,
   generatedAddresses,
   profileMetadata,
-  walletSsoSource,
 }: MagicLoginContext): Promise<UserInstance> {
   // completely new user: create user, profile, addresses
   return sequelize.transaction(async (transaction) => {
@@ -151,7 +137,6 @@ async function createNewMagicUser({
         models,
         generatedAddresses,
         newUser,
-        walletSsoSource,
         decodedMagicToken,
         transaction,
       );
@@ -235,7 +220,6 @@ async function loginExistingMagicUser({
   existingUserInstance,
   decodedMagicToken,
   generatedAddresses,
-  walletSsoSource,
 }: MagicLoginContext): Promise<UserInstance> {
   if (!existingUserInstance) {
     throw new Error('No user provided to sign in');
@@ -273,7 +257,6 @@ async function loginExistingMagicUser({
         models,
         generatedAddresses,
         existingUserInstance,
-        walletSsoSource,
         decodedMagicToken,
         transaction,
       );
@@ -346,15 +329,12 @@ async function addMagicToUser({
   generatedAddresses,
   loggedInUser,
   decodedMagicToken,
-  walletSsoSource,
 }: MagicLoginContext): Promise<UserInstance> {
   // create new address on logged-in user
   const addressInstances = await createMagicAddressInstances(
     models,
     generatedAddresses,
-    // @ts-expect-error StrictNullChecks
-    loggedInUser,
-    walletSsoSource,
+    loggedInUser!,
     decodedMagicToken,
   );
 
@@ -386,7 +366,6 @@ async function magicLoginRoute(
     signature: string;
     session?: string;
     magicAddress?: string; // optional because session keys are feature-flagged
-    walletSsoSource: WalletSsoSource;
   }>,
   decodedMagicToken: MagicUser,
   cb: DoneFunc,
@@ -394,7 +373,6 @@ async function magicLoginRoute(
   log.trace(`MAGIC TOKEN: ${JSON.stringify(decodedMagicToken, null, 2)}`);
   let communityToJoin: CommunityInstance, error, loggedInUser: UserInstance;
 
-  const walletSsoSource = req.body.walletSsoSource;
   const generatedAddresses = [
     {
       address: decodedMagicToken.publicAddress,
@@ -596,7 +574,6 @@ async function magicLoginRoute(
       models,
       generatedAddresses,
       loggedInUser,
-      walletSsoSource,
       decodedMagicToken,
     );
     return cb(null, existingUserInstance);
@@ -616,7 +593,6 @@ async function magicLoginRoute(
       username: req.body.username,
       avatarUrl: req.body.avatarUrl,
     },
-    walletSsoSource,
   };
   try {
     // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/server/routes/createAddress.ts
+++ b/packages/commonwealth/server/routes/createAddress.ts
@@ -1,12 +1,7 @@
 import { AppError } from '@hicommonwealth/core';
 import type { AddressAttributes, DB } from '@hicommonwealth/model';
 import { AddressInstance } from '@hicommonwealth/model';
-import {
-  ChainBase,
-  WalletId,
-  addressSwapper,
-  type WalletSsoSource,
-} from '@hicommonwealth/shared';
+import { ChainBase, WalletId, addressSwapper } from '@hicommonwealth/shared';
 import { bech32 } from 'bech32';
 import crypto from 'crypto';
 import { Op } from 'sequelize';
@@ -29,7 +24,6 @@ export type CreateAddressReq = {
   address: string;
   community_id?: string;
   wallet_id: WalletId;
-  wallet_sso_source: WalletSsoSource;
   block_info?: string;
 };
 
@@ -175,7 +169,6 @@ const createAddress = async (
 
     // we update addresses with the wallet used to sign in
     existingAddress.wallet_id = req.body.wallet_id;
-    existingAddress.wallet_sso_source = req.body.wallet_sso_source;
 
     const updatedObj = await existingAddress.save();
 
@@ -211,7 +204,6 @@ const createAddress = async (
           block_info: req.body.block_info,
           last_active,
           wallet_id: req.body.wallet_id,
-          wallet_sso_source: req.body.wallet_sso_source,
           role: 'member',
           is_user_default: false,
           ghost_address: false,

--- a/packages/commonwealth/server/routes/linkExistingAddressToCommunity.ts
+++ b/packages/commonwealth/server/routes/linkExistingAddressToCommunity.ts
@@ -164,7 +164,6 @@ const linkExistingAddressToCommunity = async (
           verification_token_expires: verificationTokenExpires,
           verified: originalAddress.verified,
           wallet_id: originalAddress.wallet_id,
-          wallet_sso_source: originalAddress.wallet_sso_source,
           last_active: new Date(),
           role: 'member',
           is_user_default: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9106

## Description of Changes
- Removes the `Addresses.wallet_sso_source` column in the DB since it is unused and the data inside it is corrupted (contains 3 'falsy' values: empty strings, NULL, and 'unknown').
  - This column was added in https://github.com/hicommonwealth/commonwealth/pull/3426 so I confirmed with Raymond that we should remove it.

## Test Plan
- Use a variety of sign-in methods both with native wallets and with Magic
  - You can use `pnpm delete-user [user_id OR email]` to delete users for testing creating a new account vs sign-in

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 