### PR TITLE
RabbitMQ queue purging config

### DIFF
--- a/libs/adapters/src/config.ts
+++ b/libs/adapters/src/config.ts
@@ -29,6 +29,7 @@ const {
   SEND_WEBHOOKS,
   SEND_WEBHOOKS_CONFIRMATION_TIMESTAMP,
   SEND_EMAILS,
+  DISABLE_LOCAL_QUEUE_PURGE,
 } = process.env;
 
 export const config = configure(
@@ -42,6 +43,7 @@ export const config = configure(
     },
     BROKER: {
       RABBITMQ_URI: CLOUDAMQP_URL ?? DEFAULTS.RABBITMQ_URI,
+      DISABLE_LOCAL_QUEUE_PURGE: DISABLE_LOCAL_QUEUE_PURGE === 'true',
     },
     NOTIFICATIONS: {
       FLAG_KNOCK_INTEGRATION_ENABLED:
@@ -95,6 +97,11 @@ export const config = configure(
           data === DEFAULTS.RABBITMQ_URI
         );
       }, 'RABBITMQ_URI is require in production, beta (QA), demo, and frick Heroku apps'),
+      DISABLE_LOCAL_QUEUE_PURGE: z
+        .boolean()
+        .describe(
+          'Disable purging all messages in queues when a consumer starts up',
+        ),
     }),
     NOTIFICATIONS: z
       .object({

--- a/libs/adapters/src/rabbitmq/rabbitMQConfig.ts
+++ b/libs/adapters/src/rabbitmq/rabbitMQConfig.ts
@@ -1,4 +1,5 @@
 import * as Rascal from 'rascal';
+import { config as EnvConfig } from '../config';
 import { getAllRascalConfigs } from './configuration/rascalConfig';
 import {
   RascalBindings,
@@ -31,7 +32,7 @@ export function getRabbitMQConfig(
     rabbitmq_uri.includes('127.0.0.1')
   ) {
     vhost = '/';
-    purge = true;
+    purge = !EnvConfig.BROKER.DISABLE_LOCAL_QUEUE_PURGE;
   } else {
     const count = (rabbitmq_uri.match(/\//g) || []).length;
     if (count == 3) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8925

## Description of Changes
- Adds `DISABLE_LOCAL_QUEUE_PURGE` env var
  - If set to `true` then RabbitMQ queues won't be clear when a new consumer starts up (only applies to local env)

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 