### PR TITLE
Community name validation

### DIFF
--- a/libs/model/src/community/GetCommunities.query.ts
+++ b/libs/model/src/community/GetCommunities.query.ts
@@ -86,6 +86,17 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
                   }
           FROM    "Communities" AS "Community"
           WHERE  "Community"."active" = true
+                      ${
+                        relevance_by === 'membership'
+                          ? `
+                        AND name NOT LIKE '%<%'
+                        AND name NOT LIKE '%>%'
+                        AND name NOT LIKE '%\`%'
+                        AND name NOT LIKE '%"%'
+                        AND name NOT LIKE '%''%'
+                        `
+                          : ''
+                      }
                         ${
                           base
                             ? `

--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -2,12 +2,13 @@ import {
   ALL_COMMUNITIES,
   ChainBase,
   ChainType,
+  COMMUNITY_NAME_REGEX,
   MAX_SCHEMA_INT,
   MIN_SCHEMA_INT,
 } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import { Community, Group, StakeTransaction } from '../entities';
-import { PG_INT, checkIconSize } from '../utils';
+import { checkIconSize, PG_INT } from '../utils';
 
 export const CreateCommunity = {
   input: z.object({
@@ -15,6 +16,9 @@ export const CreateCommunity = {
     name: z
       .string()
       .max(255)
+      .regex(COMMUNITY_NAME_REGEX, {
+        message: `Invalid name, only a-z, A-Z, 0-9, !, @, #, &, (, ), :, _, $, /, \\, |, . and single spaces are allowed`,
+      })
       .refine((data) => !data.includes(ALL_COMMUNITIES), {
         message: `String must not contain '${ALL_COMMUNITIES}'`,
       }),

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './canvas';
 export * as commonProtocol from './commonProtocol';
 export * from './constants';
+export * from './regex';
 export * from './types';
 export * from './utils';

--- a/libs/shared/src/regex.ts
+++ b/libs/shared/src/regex.ts
@@ -1,0 +1,3 @@
+export const COMMUNITY_NAME_REGEX =
+  // eslint-disable-next-line no-useless-escape
+  /^(?!.* {2})[a-zA-Z0-9!@#&():_$\/\\|\.]+(?: [a-zA-Z0-9!@#&():_$\/\\|\.]+)*$/;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
@@ -1,3 +1,4 @@
+import { COMMUNITY_NAME_REGEX } from '@hicommonwealth/shared';
 import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
 import z from 'zod';
 
@@ -5,7 +6,10 @@ export const communityProfileValidationSchema = z.object({
   communityName: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })
-    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
+    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
+    .regex(COMMUNITY_NAME_REGEX, {
+      message: `Invalid name, only a-z, A-Z, 0-9, !, @, #, &, (, ), :, _, $, /, \\, |, . and single spaces are allowed`,
+    }),
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/BasicInformationStep/BasicInformationForm/validation.ts
@@ -1,3 +1,4 @@
+import { COMMUNITY_NAME_REGEX } from '@hicommonwealth/shared';
 import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
 import z from 'zod';
 
@@ -5,7 +6,10 @@ export const basicInformationFormValidationSchema = z.object({
   communityName: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })
-    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED }),
+    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
+    .regex(COMMUNITY_NAME_REGEX, {
+      message: `Invalid name, only a-z, A-Z, 0-9, !, @, #, &, (, ), :, _, $, /, \\, |, . and single spaces are allowed`,
+    }),
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.tsx
@@ -27,17 +27,6 @@ export const TrendingCommunitiesPreview = () => {
   const trendingCommunities = (
     paginatedTrendingCommunities?.pages?.[0]?.results || []
   )
-    .filter((community) => {
-      // TODO: This XSS logic should be moved to API + we shouldn't allow users to choose community
-      // names with invalid chars
-      const name = community.name.toLowerCase();
-      //this filter is meant to not include any de facto communities that are actually xss attempts.
-      //It's a way of keeping the front facing parts of the app clean looking for users
-      return (
-        !['"', '>', '<', "'", '/', '`'].includes(name[0]) &&
-        !['"', '>', '<', "'", '/', '`'].includes(name[1])
-      );
-    })
     .map((community) => ({
       community,
       isMember: Permissions.isCommunityMember(community.id),

--- a/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
+++ b/packages/commonwealth/server/controllers/server_communities_methods/update_community.ts
@@ -6,7 +6,7 @@ import {
   CommunityAttributes,
   UserInstance,
 } from '@hicommonwealth/model';
-import { ChainBase } from '@hicommonwealth/shared';
+import { ChainBase, COMMUNITY_NAME_REGEX } from '@hicommonwealth/shared';
 import { MixpanelCommunityInteractionEvent } from '../../../shared/analytics/types';
 import { urlHasValidHTTPPrefix } from '../../../shared/utils';
 import { ALL_COMMUNITIES } from '../../middleware/databaseValidationService';
@@ -14,6 +14,8 @@ import { TrackOptions } from '../server_analytics_controller';
 import { ServerCommunitiesController } from '../server_communities_controller';
 
 export const Errors = {
+  InvalidCommunityName:
+    'Invalid name, only a-z, A-Z, 0-9, !, @, #, &, (, ), :, _, $, /, \\, |, . and single spaces are allowed',
   NotLoggedIn: 'Not signed in',
   NoCommunityId: 'Must provide community ID',
   ReservedId: 'The id is reserved and cannot be used',
@@ -110,6 +112,10 @@ export async function __updateCommunity(
     namespace,
     transactionHash,
   } = rest;
+
+  if (name !== undefined && !COMMUNITY_NAME_REGEX.test(name)) {
+    throw new AppError(Errors.InvalidCommunityName);
+  }
 
   // Handle single string case and undefined case
   let { snapshot } = rest;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/8967

## Description of Changes
Added community name validation to only allow these characters in name
```
a-z A-Z 0-9 ! @ # & ( ) : _ $ \ / | .
```

and single spaces b/w chars

## "How We Fixed It"
N/A

## Test Plan
- Create a new community - verify you get errors on invalid chars in community name
- Update an existing community - verify you get errors on invalid chars in community name
- Verify trending communities response doesn't return existing communities with invalid chars in community name

## Deployment Plan
N/A

## Other Considerations
N/A