### PR TITLE
Fix window.ethereum usage to avoid phantom pop up

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/metamask_web_wallet.ts
@@ -222,7 +222,7 @@ class MetamaskWebWalletController implements IWebWallet<string> {
       const communityChain = chainId ?? this.getChainId();
       const chainIdHex = `0x${parseInt(communityChain, 10).toString(16)}`;
       try {
-        await window.ethereum.request({
+        await this._web3.givenProvider.request({
           method: 'wallet_switchEthereumChain',
           params: [{ chainId: chainIdHex }],
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9177

## Description of Changes
- Uses the specific metamask provider found in earlier wallet enablement steps to call the switch network command 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- replaced downstream(beyond finding metamask) usage of window.ethereum 

## Test Plan
- Set metamask on wrong network for any transaction(create namespace/stake, etc)
- ensure switch network pop-up occurs on click
