### PR TITLE
thread version box now smaller

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
@@ -7,14 +7,17 @@
 
   .SelectList {
     @include inputStyles;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     font-size: 14px;
     line-height: 20px;
     border: 1px solid $neutral-200 !important;
     border-radius: $border-radius-corners-wider;
-    min-height: 40px;
-    max-height: 40px;
+    min-height: 24px;
+    max-height: 24px;
     padding: 10px 16px;
-
+    margin: 15px;
     &.isMulti {
       max-height: initial !important;
     }

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
@@ -89,7 +89,7 @@
     .CWSelectList {
       min-width: 202px;
       margin-left: -20px;
-      margin-right: -8px;
+      margin-right: -18px;
 
       .SelectList:not(:focus):not(:focus-within) {
         border-color: transparent !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9107 

## Description of Changes
- makes the thread version box the same size as the other elements in the same line

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed some minimal css

## Test Plan
- go to a discussion that has been edited at least twice or edited a discussion at least twice. There needs to be a dropdown menu to see the changes
- click on the dropdown element so that it is highlighted, confirm that it is the same size as the boxes to the left and the right of it and that the highlighted area doesn't overlap any other element in the line. 

