### PR TITLE
Prevent setting email to profile on user create

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
@@ -127,7 +127,6 @@ const PersonalInformationStep = ({
       promotional_emails_enabled: values.enableProductUpdates,
       profile: {
         name: values.username.trim(),
-        email: values.email.trim(),
       },
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8769 

## Description of Changes
- Prevents setting profile email when creating user with Magic

## Test Plan
- Create new account with email (magic)
- Ensure profile email is not set