### PR TITLE
added charCount and validation to Community Profile

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -285,6 +285,7 @@ const CommunityProfileForm = () => {
             />
 
             <CWTextArea
+              charCount={250}
               hookToForm
               name="communityDescription"
               label="Community Description"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
@@ -15,7 +15,7 @@ export const communityProfileValidationSchema = z.object({
     }),
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
+    .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
   communityProfileImageURL: z.string({
     invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/validation.ts
@@ -15,6 +15,7 @@ export const communityProfileValidationSchema = z.object({
     }),
   communityDescription: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .max(255, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
   communityProfileImageURL: z.string({
     invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9172 

## Description of Changes
- Adds FIXME widget to TODO page.
- added character count and validation to the Community Description input in Community Profile, now a user isn't able to click Save changes and get a vague error message without knowing what they did wrong. The page now scrolls to the input field where the error is happening when a user clicks Save changes. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added character count and validation to the Community Description input in Community Profile
## Test Plan
-go to Community Profile
-in the Community Description input try to enter more than 250 characters
-confirm that you see an error under the input
-click Save changes
-confirm that the page scrolls to the input with the error and no error toast is shown
