### PR TITLE
Fixed crash when topic is updated

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/ManageTopicsSection/ManageTopicsSection.tsx
@@ -162,7 +162,7 @@ export const ManageTopicsSection = () => {
           buttonHeight="med"
           onClick={handleReversion}
           disabled={initialFeaturedTopics.every(
-            (value, index) => value.id === featuredTopics[index].id,
+            (value, index) => value.id === featuredTopics?.[index]?.id,
           )}
         />
         <CWButton

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicsOld/ManageTopicsSectionOld/ManageTopicsSectionOld.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicsOld/ManageTopicsSectionOld/ManageTopicsSectionOld.tsx
@@ -160,7 +160,7 @@ export const ManageTopicsSectionOld = () => {
           buttonHeight="med"
           onClick={handleReversion}
           disabled={initialFeaturedTopics.every(
-            (value, index) => value.id === featuredTopics[index].id,
+            (value, index) => value.id === featuredTopics?.[index]?.id,
           )}
         />
         <CWButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9217 

## Description of Changes
- used optional chain operator to prevent crash

## Test Plan
- Create 2 topics that are not featured in the sidebar
- Go to manage topics
- Edit one of the topics and add it as featured in the sidebar
- Edit the second topic to feature it in the sidebar 
- Page should work without crash

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a