### PR TITLE
Add output middleware to commit canvas signed data

### DIFF
--- a/libs/adapters/src/trpc/handlers.ts
+++ b/libs/adapters/src/trpc/handlers.ts
@@ -11,7 +11,7 @@ import {
 } from '@hicommonwealth/core';
 import { TRPCError } from '@trpc/server';
 import { ZodSchema, ZodUndefined, z } from 'zod';
-import { Tag, Track, buildproc, procedure } from './middleware';
+import { Commit, Tag, Track, buildproc, procedure } from './middleware';
 
 const trpcerror = (error: unknown): TRPCError => {
   if (error instanceof Error) {
@@ -42,6 +42,7 @@ const trpcerror = (error: unknown): TRPCError => {
  * @param factory command factory
  * @param tag command tag used for OpenAPI spec grouping
  * @param track analytics tracking metadata as tuple of [event, output mapper] or (input,output) => Promise<[event, data]|undefined>
+ * @param commit output middleware to commit actions to canvas (input,output) => undefined
  * @returns tRPC mutation procedure
  */
 export const command = <
@@ -52,9 +53,10 @@ export const command = <
   factory: () => Metadata<Input, Output, AuthContext>,
   tag: Tag,
   track?: Track<Input, Output>,
+  commit?: Commit<Input, Output>,
 ) => {
   const md = factory();
-  return buildproc('POST', factory.name, md, tag, track).mutation(
+  return buildproc('POST', factory.name, md, tag, track, commit).mutation(
     async ({ ctx, input }) => {
       try {
         return await coreCommand(

--- a/libs/adapters/src/trpc/middleware.ts
+++ b/libs/adapters/src/trpc/middleware.ts
@@ -50,6 +50,11 @@ export enum Tag {
   SuperAdmin = 'SuperAdmin',
 }
 
+export type Commit<Input extends ZodSchema, Output extends ZodSchema> = (
+  input: z.infer<Input>,
+  output: z.infer<Output>,
+) => Promise<[string, Record<string, unknown>] | undefined>;
+
 /**
  * Supports two options to track analytics
  * 1. A declarative tuple with [event name, optional output mapper]
@@ -137,6 +142,7 @@ export const buildproc = <Input extends ZodSchema, Output extends ZodSchema>(
   md: Metadata<Input, Output>,
   tag: Tag,
   track?: Track<Input, Output>,
+  commit?: Commit<Input, Output>,
 ) => {
   const secure = isSecure(md);
   return trpc.procedure
@@ -169,6 +175,7 @@ export const buildproc = <Input extends ZodSchema, Output extends ZodSchema>(
       track &&
         result.ok &&
         void trackAnalytics(track, ctx, rawInput, result.data);
+      commit && result.ok && void commit(rawInput, result.data);
       return result;
     })
     .meta({

--- a/packages/commonwealth/server/api/comment.ts
+++ b/packages/commonwealth/server/api/comment.ts
@@ -1,13 +1,24 @@
 import { trpc } from '@hicommonwealth/adapters';
 import { Comment } from '@hicommonwealth/model';
 import { MixpanelCommunityInteractionEvent } from '../../shared/analytics/types';
+import { applyCanvasSignedDataMiddleware } from '../federation';
 
 export const trpcRouter = trpc.router({
-  createComment: trpc.command(Comment.CreateComment, trpc.Tag.Comment, [
-    MixpanelCommunityInteractionEvent.CREATE_COMMENT,
-    (output) => ({ community: output.community_id }),
-  ]),
-  updateComment: trpc.command(Comment.UpdateComment, trpc.Tag.Comment),
+  createComment: trpc.command(
+    Comment.CreateComment,
+    trpc.Tag.Comment,
+    [
+      MixpanelCommunityInteractionEvent.CREATE_COMMENT,
+      (output) => ({ community: output.community_id }),
+    ],
+    applyCanvasSignedDataMiddleware,
+  ),
+  updateComment: trpc.command(
+    Comment.UpdateComment,
+    trpc.Tag.Comment,
+    undefined,
+    applyCanvasSignedDataMiddleware,
+  ),
   createCommentReaction: trpc.command(
     Comment.CreateCommentReaction,
     trpc.Tag.Comment,
@@ -15,6 +26,7 @@ export const trpcRouter = trpc.router({
       MixpanelCommunityInteractionEvent.CREATE_REACTION,
       (output) => ({ community: output.community_id }),
     ],
+    applyCanvasSignedDataMiddleware,
   ),
   searchComments: trpc.query(Comment.SearchComments, trpc.Tag.Comment),
   getComments: trpc.query(Comment.GetComments, trpc.Tag.Comment),

--- a/packages/commonwealth/server/api/threads.ts
+++ b/packages/commonwealth/server/api/threads.ts
@@ -1,18 +1,28 @@
 import { trpc } from '@hicommonwealth/adapters';
 import { Thread } from '@hicommonwealth/model';
 import { MixpanelCommunityInteractionEvent } from '../../shared/analytics/types';
+import { applyCanvasSignedDataMiddleware } from '../federation';
 
 export const trpcRouter = trpc.router({
-  createThread: trpc.command(Thread.CreateThread, trpc.Tag.Thread, [
-    MixpanelCommunityInteractionEvent.CREATE_THREAD,
-    ({ community_id }) => ({ community: community_id }),
-  ]),
-  updateThread: trpc.command(Thread.UpdateThread, trpc.Tag.Thread, (input) =>
-    Promise.resolve(
-      input.stage !== undefined
-        ? [MixpanelCommunityInteractionEvent.UPDATE_STAGE, {}]
-        : undefined,
-    ),
+  createThread: trpc.command(
+    Thread.CreateThread,
+    trpc.Tag.Thread,
+    [
+      MixpanelCommunityInteractionEvent.CREATE_THREAD,
+      ({ community_id }) => ({ community: community_id }),
+    ],
+    applyCanvasSignedDataMiddleware,
+  ),
+  updateThread: trpc.command(
+    Thread.UpdateThread,
+    trpc.Tag.Thread,
+    (input) =>
+      Promise.resolve(
+        input.stage !== undefined
+          ? [MixpanelCommunityInteractionEvent.UPDATE_STAGE, {}]
+          : undefined,
+      ),
+    applyCanvasSignedDataMiddleware,
   ),
   createThreadReaction: trpc.command(
     Thread.CreateThreadReaction,
@@ -21,5 +31,6 @@ export const trpcRouter = trpc.router({
       MixpanelCommunityInteractionEvent.CREATE_REACTION,
       ({ community_id }) => ({ community: community_id }),
     ],
+    applyCanvasSignedDataMiddleware,
   ),
 });

--- a/packages/commonwealth/server/federation/index.ts
+++ b/packages/commonwealth/server/federation/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '@hicommonwealth/core';
 import { CanvasSignedData, startCanvasNode } from '@hicommonwealth/shared';
+import { parse } from '@ipld/dag-json';
 
 const log = logger(import.meta);
 export const canvas = await startCanvasNode();
@@ -11,6 +12,13 @@ log.info(
       .map((m) => m.toString())
       .join(', '),
 );
+
+export const applyCanvasSignedDataMiddleware: (
+  input,
+  output,
+) => Promise<undefined> = async (input, output) => {
+  await applyCanvasSignedData(parse(output.canvas_signed_data));
+};
 
 export const applyCanvasSignedData = async (data: CanvasSignedData) => {
   let appliedSessionId: string | null = null;


### PR DESCRIPTION
## Link to Issue
Closes: #9247

## Description of Changes
- Adds an argument for Canvas output middleware to libs/adapters in the tRPC handler builder
- Calls it in the tRPC buildproc call
- Adds Canvas output middlewares to server API

## Test Plan
- Create a new thread, comment, thread reaction, and comment reaction on any chain
- Update a thread, update a comment
- Delete a thread, delete a comment, delete a reaction
- None of these can ever cause user-facing errors because they happen in middleware execution after writing to the Commonwealth database.

## Deployment Plan

None needed.

## Other Considerations
- n/a