### PR TITLE
fixed my own css blunder

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSelectList/CWSelectList.scss
@@ -14,10 +14,9 @@
     line-height: 20px;
     border: 1px solid $neutral-200 !important;
     border-radius: $border-radius-corners-wider;
-    min-height: 24px;
-    max-height: 24px;
+    min-height: 40px;
+    max-height: 40px;
     padding: 10px 16px;
-    margin: 15px;
     &.isMulti {
       max-height: initial !important;
     }

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
@@ -88,9 +88,11 @@
 
     .CWSelectList {
       min-width: 202px;
-      margin-left: -20px;
-      margin-right: -18px;
 
+      .SelectList {
+        min-height: 24px !important;
+        max-height: 24px !important;
+      }
       .SelectList:not(:focus):not(:focus-within) {
         border-color: transparent !important;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9253 and #9107 

## Description of Changes
- Thread version box is now comparable to other boxes around it

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Added min/max heights to `AuthorAndPublishInfo.scss` instead of `CWSelect.scss`

## Test Plan
-go to a thread that has been edited at least twice or edit your own thread at least twice
-confirm that the blue highlighted area, when in focus, no longer overlaps any other element and that it is the same size as the "New"/"Trending" boxes