### PR TITLE
Fix proposal details page displays infinite loader when visiting a proposal url that doesn't exist

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -102,7 +102,7 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
   if (cosmosError) {
     return (
       <PageNotFound
-        message={"We coun't find what you searched for. Try searching again"}
+        message={"We couldn't find what you searched for. Try searching again."}
       />
     );
   }

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -24,9 +24,9 @@ import { CollapsibleProposalBody } from '../../components/collapsible_body_text'
 import { CWContentPage } from '../../components/component_kit/CWContentPage';
 import { VotingActions } from '../../components/proposals/voting_actions';
 import { VotingResults } from '../../components/proposals/voting_results';
+import { PageNotFound } from '../404';
 import { JSONDisplay } from './JSONDisplay';
 import { ProposalSubheader } from './proposal_components';
-import { PageNotFound } from '../404';
 
 type ViewProposalPageAttrs = {
   identifier: string;
@@ -46,11 +46,15 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
   const [description, setDescription] = useState<string>(proposal?.description);
   const [votingModalOpen, setVotingModalOpen] = useState(false);
   const [isAdapterLoaded, setIsAdapterLoaded] = useState(!!app.chain?.loaded);
-  const { data: cosmosProposal , error: cosmosError , isFetching: isFetchingProposal} = useCosmosProposalQuery({
+  const {
+    data: cosmosProposal,
+    error: cosmosError,
+    isFetching: isFetchingProposal,
+  } = useCosmosProposalQuery({
     isApiReady: !!app.chain.apiInitialized,
     proposalId,
   });
-  const { data: metadata, isFetching: isFetchingMetadata} =
+  const { data: metadata, isFetching: isFetchingMetadata } =
     useCosmosProposalMetadataQuery(proposal);
   const { data: poolData } = usePoolParamsQuery();
   // @ts-expect-error <StrictNullChecks/>
@@ -96,7 +100,11 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
   }
 
   if (cosmosError) {
-    return <PageNotFound message={`We coun't find what you searched for. Try searching again`}/>;
+    return (
+      <PageNotFound
+        message={"We coun't find what you searched for. Try searching again"}
+      />
+    );
   }
 
   const proposalTitle = title || proposal?.title;

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -91,11 +91,11 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
     }
   }, [isAdapterLoaded, proposalId]);
 
-  if (isFetchingProposal ) {
+  if (isFetchingProposal || !isAdapterLoaded) {
     return <PageLoading message="Loading..." />;
   }
 
-  if (cosmosError  || !isAdapterLoaded) {
+  if (cosmosError) {
     return <PageNotFound message={`We coun't find what you searched for. Try searching again`}/>;
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_proposal/index.tsx
@@ -26,6 +26,7 @@ import { VotingActions } from '../../components/proposals/voting_actions';
 import { VotingResults } from '../../components/proposals/voting_results';
 import { JSONDisplay } from './JSONDisplay';
 import { ProposalSubheader } from './proposal_components';
+import { PageNotFound } from '../404';
 
 type ViewProposalPageAttrs = {
   identifier: string;
@@ -45,11 +46,11 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
   const [description, setDescription] = useState<string>(proposal?.description);
   const [votingModalOpen, setVotingModalOpen] = useState(false);
   const [isAdapterLoaded, setIsAdapterLoaded] = useState(!!app.chain?.loaded);
-  const { data: cosmosProposal } = useCosmosProposalQuery({
+  const { data: cosmosProposal , error: cosmosError , isFetching: isFetchingProposal} = useCosmosProposalQuery({
     isApiReady: !!app.chain.apiInitialized,
     proposalId,
   });
-  const { data: metadata, isFetching: isFetchingMetadata } =
+  const { data: metadata, isFetching: isFetchingMetadata} =
     useCosmosProposalMetadataQuery(proposal);
   const { data: poolData } = usePoolParamsQuery();
   // @ts-expect-error <StrictNullChecks/>
@@ -90,8 +91,12 @@ const ViewProposalPage = ({ identifier }: ViewProposalPageAttrs) => {
     }
   }, [isAdapterLoaded, proposalId]);
 
-  if (!isAdapterLoaded) {
+  if (isFetchingProposal ) {
     return <PageLoading message="Loading..." />;
+  }
+
+  if (cosmosError  || !isAdapterLoaded) {
+    return <PageNotFound message={`We coun't find what you searched for. Try searching again`}/>;
   }
 
   const proposalTitle = title || proposal?.title;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8734

## Description of Changes
- Fixed the issue where the skeleton loader would display indefinitely for non-existent proposal URLs.
- Added a "Not Found" message when visiting a proposal URL that doesn't exist.

## Test Plan
  - Go to the proposal details page and add a wrong identifier in the URL.
  - Verified the "Not Found" message is shown correctly when visiting a non-existent proposal.

## Deployment Plan
<!--- Omit if unneeded -->
1.

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 