### PR TITLE
Fix update community auth

### DIFF
--- a/libs/model/src/community/UpdateCommunity.command.ts
+++ b/libs/model/src/community/UpdateCommunity.command.ts
@@ -7,7 +7,6 @@ import { mustExist } from '../middleware/guards';
 import { checkSnapshotObjectExists, commonProtocol } from '../services';
 
 export const UpdateCommunityErrors = {
-  NotAdmin: 'Not an admin',
   SnapshotOnlyOnEthereum:
     'Snapshot data may only be added to chains with Ethereum base',
   InvalidDefaultPage: 'Default page does not exist',
@@ -22,7 +21,7 @@ export function UpdateCommunity(): Command<
   return {
     ...schemas.UpdateCommunity,
     auth: [isAuthorized({ roles: ['admin'] })],
-    body: async ({ actor, payload }) => {
+    body: async ({ auth, actor, payload }) => {
       const {
         id,
         snapshot,
@@ -80,10 +79,6 @@ export function UpdateCommunity(): Command<
       if (namespace) {
         if (!transactionHash)
           throw new InvalidInput(UpdateCommunityErrors.InvalidTransactionHash);
-
-        // we only permit the community admin and not the site admin to create namespace
-        if (actor.user.isAdmin)
-          throw new InvalidInput(UpdateCommunityErrors.NotAdmin);
 
         community.namespace = namespace;
         community.namespace_address =

--- a/libs/model/src/community/UpdateCommunity.command.ts
+++ b/libs/model/src/community/UpdateCommunity.command.ts
@@ -21,7 +21,7 @@ export function UpdateCommunity(): Command<
   return {
     ...schemas.UpdateCommunity,
     auth: [isAuthorized({ roles: ['admin'] })],
-    body: async ({ auth, actor, payload }) => {
+    body: async ({ actor, payload }) => {
       const {
         id,
         snapshot,

--- a/libs/model/test/community/community-lifecycle.spec.ts
+++ b/libs/model/test/community/community-lifecycle.spec.ts
@@ -326,7 +326,7 @@ describe('Community lifecycle', () => {
     test('should throw if actor is not admin', async () => {
       await expect(() =>
         command(UpdateCommunity(), {
-          actor: superAdminActor,
+          actor: memberActor,
           payload: {
             ...baseRequest,
             id: community.id,
@@ -335,7 +335,7 @@ describe('Community lifecycle', () => {
             chain_node_id: edgewareNode!.id!,
           },
         }),
-      ).rejects.toThrow(UpdateCommunityErrors.NotAdmin);
+      ).rejects.toThrow('User is not admin in the community');
     });
 
     // TODO: implement when we can add members via commands

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
@@ -1,3 +1,6 @@
+import { ChainBase } from '@hicommonwealth/shared';
+import { setActiveAccount } from 'client/scripts/controllers/app/login';
+import Account from 'client/scripts/models/Account';
 import { buildUpdateCommunityInput } from 'client/scripts/state/api/communities/updateCommunity';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { useState } from 'react';
@@ -48,6 +51,17 @@ const useReserveCommunityNamespace = ({
         state: 'loading',
         errorText: '',
       });
+
+      // set active account so that updateCommunity works
+      setActiveAccount(
+        new Account({
+          community: {
+            id: communityId,
+            base: ChainBase.Ethereum, // namespaces only support EVM
+          },
+          address: userAddress,
+        }),
+      );
 
       const txReceipt = await namespaceFactory.deployNamespace(
         namespace,

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityStakeStep/SignStakeTransactions/useReserveCommunityNamespace.tsx
@@ -53,7 +53,7 @@ const useReserveCommunityNamespace = ({
       });
 
       // set active account so that updateCommunity works
-      setActiveAccount(
+      await setActiveAccount(
         new Account({
           community: {
             id: communityId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9286

## Description of Changes
- Fixes frontend to set active account, which fixes issue where `address` was not populated in header when `UpdateCommunity` request is made
- Fixes `UpdateCommunity` command to not reject superadmins

## Test Plan
- Create a community and enable stake via the create community flow, ensure you can go through the entire flow without error

## Deployment Plan
N/A

## Other Considerations
N/A