### PR TITLE
user redirected to discussions after deleting thread

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -1,4 +1,4 @@
-import { ContentType, getThreadUrl, slugify } from '@hicommonwealth/shared';
+import { ContentType, getThreadUrl } from '@hicommonwealth/shared';
 import { notifyError } from 'controllers/app/notifications';
 import { extractDomain, isDefaultStage } from 'helpers';
 import { commentsByDate } from 'helpers/dates';
@@ -6,8 +6,6 @@ import { filterLinks, getThreadActionTooltipText } from 'helpers/threads';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import useJoinCommunityBanner from 'hooks/useJoinCommunityBanner';
-import useNecessaryEffect from 'hooks/useNecessaryEffect';
-import { getProposalUrlPath } from 'identifiers';
 import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/view_thread/index.scss';
@@ -214,23 +212,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       isPWA: isAddedToHomeScreen,
     },
   });
-
-  // TODO: unnecessary code - must be in a redirect hook
-  useNecessaryEffect(() => {
-    if (!thread) {
-      return;
-    }
-
-    if (thread && identifier !== `${threadId}-${slugify(thread?.title)}`) {
-      const url = getProposalUrlPath(
-        thread.slug,
-        `${threadId}-${slugify(thread?.title)}${window.location.search}`,
-        true,
-      );
-      navigate(url, { replace: true });
-    }
-  }, [identifier, navigate, thread, thread?.slug, thread?.title, threadId]);
-  // ------------
 
   useManageDocumentTitle('View thread', thread?.title);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9190 

## Description of Changes
- User now redirected to `/discussions` after deleting a thread

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-deleted the `useNecessaryEffect` that was calling `getProposalUrlPath`. I did't understand why that was being called when the `onDelete` already redirected the user to `/discussions`
## Test Plan
- create a thread or go to an existing thread
- click into the thread
- delete the thread
- confirm that you are now redirected to `/discussions` 

