### PR TITLE
Prevent verification email after signup

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
@@ -130,11 +130,6 @@ const PersonalInformationStep = ({
       },
     });
 
-    // set email for notifications
-    if (values.email) {
-      await updateEmail({ email: values.email });
-    }
-
     if (values.enableAccountNotifications) {
       await updateSubscriptionPreferences({
         id: user.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #8870

## Description of Changes
- Prevents verification email from being sent after user signs up with magic

## Test Plan
- Sign up w/ magic– ensure that no email is sent after signing up (aside from the magic 3-digit code)

## Deployment Plan
N/A

## Other Considerations
N/A