### PR TITLE
Fix address revalidation flow

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
@@ -5,7 +5,6 @@ import Comment from 'models/Comment';
 import { ApiEndpoints } from 'state/api/config';
 import useUserOnboardingSliderMutationStore from 'state/ui/userTrainingCards';
 import { UserTrainingCardTypes } from 'views/components/UserTrainingSlider/types';
-import { UserProfile } from '../../../models/MinimumProfile';
 import { trpc } from '../../../utils/trpcClient';
 import { useAuthModalStore } from '../../ui/modals';
 import useUserStore from '../../ui/user';
@@ -14,7 +13,7 @@ import useFetchCommentsQuery from './fetchComments';
 
 interface CreateCommentProps {
   communityId: string;
-  profile: UserProfile;
+  address: string;
   threadId: number;
   threadMsgId: string;
   unescapedText: string;
@@ -25,14 +24,14 @@ interface CreateCommentProps {
 }
 
 export const buildCreateCommentInput = async ({
-  profile,
+  address,
   threadId,
   threadMsgId,
   unescapedText,
   parentCommentId = null,
   parentCommentMsgId = null,
 }: CreateCommentProps) => {
-  const canvasSignedData = await signComment(profile.address, {
+  const canvasSignedData = await signComment(address, {
     thread_id: threadMsgId,
     body: unescapedText,
     parent_comment_id: parentCommentMsgId,

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -93,7 +93,7 @@ export const CreateComment = ({
       try {
         const input = await buildCreateCommentInput({
           communityId,
-          profile: user.activeAccount!.profile!.toUserProfile(),
+          address: user.activeAccount!.address,
           threadId: rootThread.id,
           threadMsgId: rootThread.canvasMsgId,
           unescapedText: serializeDelta(contentDelta),

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -48,13 +48,12 @@ import { useBrowserAnalyticsTrack } from '../../../hooks/useBrowserAnalyticsTrac
 import Account from '../../../models/Account';
 import IWebWallet from '../../../models/IWebWallet';
 import { DISCOURAGED_NONREACTIVE_fetchProfilesByAddress } from '../../../state/api/profiles/fetchProfilesByAddress';
-import useAuthModalStore from '../../../state/ui/modals/authModal';
 
 type UseAuthenticationProps = {
   onSuccess?: (
     address?: string | null | undefined,
     isNewlyCreated?: boolean,
-  ) => void;
+  ) => Promise<void>;
   onModalClose: () => void;
   withSessionKeyLoginFlow?: boolean;
 };
@@ -95,8 +94,6 @@ const useAuthentication = (props: UseAuthenticationProps) => {
 
   const { mutateAsync: updateUser } = useUpdateUserMutation();
 
-  const { sessionKeyValidationError } = useAuthModalStore();
-
   useEffect(() => {
     if (process.env.ETH_RPC === 'e2e-test') {
       import('../../../helpers/mockMetaMaskUtil')
@@ -130,15 +127,11 @@ const useAuthentication = (props: UseAuthenticationProps) => {
     }
   }, []);
 
-  const formatAddress = (address: string) => {
-    return `${address.slice(0, 8)}...${address.slice(-5)}`;
-  };
-
   const handleSuccess = async (
     authAddress?: string | null | undefined,
     isNew?: boolean,
   ) => {
-    props?.onSuccess?.(authAddress, isNew);
+    await props?.onSuccess?.(authAddress, isNew);
   };
 
   const trackLoginEvent = (loginOption: string, isSocialLogin: boolean) => {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -297,7 +297,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
         // @ts-expect-error StrictNullChecks
         const session = await signSessionWithAccount(walletToUse, account);
         // Can't call authSession now, since chain.base is unknown, so we wait till action
-        props.onSuccess?.(account.address, newlyCreated);
+        await props.onSuccess?.(account.address, newlyCreated);
 
         // Create the account with default values
         // await onCreateNewAccount(walletToUse, session, account);


### PR DESCRIPTION
## Link to Issue
Closes: #9312

## Description of Changes

* The login flow was changed to always create an account, even for someone revalidating an address.
* This means that account revalidation should always "succeed" now, even if a different address is provided than the expected address - we should just switch the user to the address they just logged in with.
* This PR removes the old error message that would show up if you revalidated an account with a different address than your active address, and shows a success toast instead.

Exact changes:
- always call setActiveAddress after a successful login in the session key revalidation flow
- remove session revalidation error message for revalidating with a different address than expected

## Test Plan

This is an easy error condition to replicate using "Join community" and interchain addresses (Cosmos/Polkadot/etc.):

- Log in with a Cosmos address (e.g. osmo1pox...)
- Join a different Cosmos community, that encodes your address differently, e.g. c4e (c4e1pox...), with your osmo address
- Do any action in the community

Previously, this would trigger a revalidation error, which would never add the newly created account on the frontend. The frontend would start working again after a refresh at which point the address would appear in the menu.

Now, this entire flow should just work, as the active address gets set to the newly created address.

## Deployment Plan

n/a

## Other Considerations
- We should make sure that users only join a community with an address that can actually take actions in that community. This should be rolled into more general address management fixes.