### PR TITLE
user can now drag image in firefox

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/use_image_drop_and_paste.tsx
@@ -66,9 +66,8 @@ export const useImageDropAndPaste = ({
           user.jwt || '',
         );
 
-        const selectedIndex = editor.getSelection()?.index;
+        const selectedIndex = editor.getSelection()?.index || 0;
 
-        // @ts-expect-error <StrictNullChecks/>
         editor.insertText(selectedIndex, `![image](${uploadedFileUrl})`);
 
         setContentDelta({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9302 

## Description of Changes
-user can now drag and drop an image into an empty editor within Firefox

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- added `|| 0` so that `index` wasn't undefined

## Test Plan
-open localhost in Firefox
-open firefox dev tools
-create a thread
-drag/drop an image into the empty editor
-confirm that you now see the image as markdown and there is no longer an error in the dev tools
-save thread and confirm you see this in the thread
For good measure, do the same sequence in Chrome to confirm it still works as expected there. 