### PR TITLE
173 update app implementations and abis for slippage parameter

### DIFF
--- a/libs/shared/src/commonProtocol/chainConfig.ts
+++ b/libs/shared/src/commonProtocol/chainConfig.ts
@@ -33,8 +33,8 @@ export const factoryContracts: {
   [ValidChains.SepoliaBase]: {
     factory: '0xD8a357847cABA76133D5f2cB51317D3C74609710',
     communityStake: '0xd097926d8765A7717206559E7d19EECCbBa68c18',
-    launchpad: '0x5045238a20f07acb34dd1265bb240eab8c8db7a9',
-    lpBondingCurve: '0x7Cc4d8902e3Ca342825D35b9C4ddb064582a910d',
+    launchpad: '0x6b118c6efa258903939ed981e6f644330effebab',
+    lpBondingCurve: '0x24634Cc9A0606b7927B3Fb44b782003B604dDDC4',
     chainId: 84532,
   },
   [ValidChains.Blast]: {

--- a/libs/shared/src/commonProtocol/chainConfig.ts
+++ b/libs/shared/src/commonProtocol/chainConfig.ts
@@ -33,6 +33,8 @@ export const factoryContracts: {
   [ValidChains.SepoliaBase]: {
     factory: '0xD8a357847cABA76133D5f2cB51317D3C74609710',
     communityStake: '0xd097926d8765A7717206559E7d19EECCbBa68c18',
+    launchpad: '0x5045238a20f07acb34dd1265bb240eab8c8db7a9',
+    lpBondingCurve: '0x7Cc4d8902e3Ca342825D35b9C4ddb064582a910d',
     chainId: 84532,
   },
   [ValidChains.Blast]: {

--- a/libs/shared/src/commonProtocol/chainConfig.ts
+++ b/libs/shared/src/commonProtocol/chainConfig.ts
@@ -20,6 +20,8 @@ export const factoryContracts: {
   [key in ValidChains]: {
     factory: string;
     communityStake: string;
+    launchpad?: string;
+    lpBondingCurve?: string;
     chainId: number;
   };
 } = {

--- a/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
+++ b/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
@@ -8,7 +8,7 @@ export const launchToken = async (
   totalSupply: number,
   walletAddress: string,
 ) => {
-  const txReceipt = await contract.mehtods
+  const txReceipt = await contract.methods
     .launchTokenWithLiquidity(
       name,
       symbol,
@@ -17,7 +17,8 @@ export const launchToken = async (
       totalSupply,
       0,
       0,
-      '0x12a35d50a7a12e92063e19d90186c95a10e3e311',
+      '0x0000000000000000000000000000000000000000',
+      '0x0000000000000000000000000000000000000000',
     )
     .send({ from: walletAddress });
   return txReceipt;
@@ -30,7 +31,7 @@ export const buyToken = async (
   walletAddress: string,
   value: number,
 ) => {
-  const txReceipt = await contract.methods.buyToken(tokenAddress).send({
+  const txReceipt = await contract.methods.buyToken(tokenAddress, 0).send({
     from: walletAddress,
     value,
   });
@@ -44,8 +45,8 @@ export const sellToken = async (
   amount: number,
   walletAddress: string,
 ) => {
-  const txReceipt = await contract.mehthods
-    .sellToken(tokenAddress, amount)
+  const txReceipt = await contract.methods
+    .sellToken(tokenAddress, amount, 0)
     .send({ from: walletAddress });
   return txReceipt;
 };
@@ -84,8 +85,7 @@ export const transferLiquidity = async (
   tokenAddress: string,
   walletAddress: string,
 ) => {
-  const remainingTokens =
-    await contract.methods._launchpadLiquidity(tokenAddress);
+  const remainingTokens = await contract.methods._poolLiquidity(tokenAddress);
   const amountIn = await getAmountIn(
     contract,
     tokenAddress,
@@ -94,7 +94,7 @@ export const transferLiquidity = async (
   );
 
   const txReceipt = await contract.methods
-    .transferLiquidity(tokenAddress)
+    .transferLiquidity(tokenAddress, remainingTokens)
     .send({ value: amountIn, from: walletAddress });
   return txReceipt;
 };

--- a/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
+++ b/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
@@ -1,5 +1,3 @@
-const lpHook = '';
-
 export const launchToken = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   contract: any,
@@ -19,7 +17,6 @@ export const launchToken = async (
       totalSupply,
       0,
       0,
-      lpHook,
       '',
     )
     .send({ from: walletAddress });

--- a/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
+++ b/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
@@ -17,7 +17,7 @@ export const launchToken = async (
       totalSupply,
       0,
       0,
-      '',
+      '0x12a35d50a7a12e92063e19d90186c95a10e3e311',
     )
     .send({ from: walletAddress });
   return txReceipt;

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/LpBondingCurveAbi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/LpBondingCurveAbi.ts
@@ -2,6 +2,7 @@ export const LpBondingCurve = [
   {
     inputs: [
       { internalType: 'address', name: 'tokenAddress', type: 'address' },
+      { internalType: 'uint256', name: 'minAmountOut', type: 'uint256' },
     ],
     stateMutability: 'payable',
     type: 'function',
@@ -12,6 +13,7 @@ export const LpBondingCurve = [
     inputs: [
       { internalType: 'address', name: 'tokenAddress', type: 'address' },
       { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint256', name: 'minAmountOut', type: 'uint256' },
     ],
     stateMutability: 'payable',
     type: 'function',
@@ -58,8 +60,18 @@ export const LpBondingCurve = [
     name: 'transferLiquidity',
     inputs: [
       { name: 'tokenAddress', type: 'address', internalType: 'address' },
+      { name: 'minAmountOut', type: 'uint256', internalType: 'uint256' },
     ],
     outputs: [],
     stateMutability: 'payable',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'tokenAddress', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+    name: '_poolLiquidity',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
   },
 ];

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/LpBondingCurveAbi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/LpBondingCurveAbi.ts
@@ -1,0 +1,65 @@
+export const LpBondingCurve = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'tokenAddress', type: 'address' },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+    name: 'buyToken',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'tokenAddress', type: 'address' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+    name: 'sellToken',
+  },
+  {
+    type: 'function',
+    name: 'getPrice',
+    inputs: [
+      { name: 'tokenAddress', type: 'address', internalType: 'address' },
+      { name: 'amountIn', type: 'uint256', internalType: 'uint256' },
+      { name: 'isBuy', type: 'bool', internalType: 'bool' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'tokenAddress', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+    name: '_getFloatingTokenSupply',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+  },
+  {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'liquidity',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: '_launchpadLiquidity',
+    inputs: [
+      { name: 'tokenAddress', type: 'address', internalType: 'address' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'transferLiquidity',
+    inputs: [
+      { name: 'tokenAddress', type: 'address', internalType: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+];

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'web3-eth-contract';
+import { Contract } from 'web3';
 import { AbiItem } from 'web3-utils';
 import {
   buyToken,

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -39,7 +39,8 @@ class LaunchpadBondingCurve extends ContractBase {
       name,
       symbol,
       [7000, 1250, 1500, 750], // 9181 parameters
-      [walletAddress, walletAddress], // should include at community treasury at [0] and contest creation util at [1] curr tbd
+      // should include at community treasury at [0] and contest creation util at [1] curr tbd
+      [walletAddress, walletAddress],
       1_000_000_000e18, // Default 1B tokens
       walletAddress,
     );

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -1,3 +1,4 @@
+import { Contract } from 'web3';
 import {
   buyToken,
   getPrice,
@@ -11,10 +12,20 @@ const LPBondingCurveAbi = {};
 
 class LaunchpadBondingCurve extends ContractBase {
   tokenAddress: string;
+  launchpadFactory: Contract<any>;
 
-  constructor(bondingCurveAddress: string, tokenAddress: string, rpc: string) {
+  constructor(
+    bondingCurveAddress: string,
+    launchpadFactoryAddress: string,
+    tokenAddress: string,
+    rpc: string,
+  ) {
     super(bondingCurveAddress, LPBondingCurveAbi, rpc);
     this.tokenAddress = tokenAddress;
+    this.launchpadFactory = new this.web3.eth.Contract(
+      lpFactoryAbi,
+      launchpadFactoryAddress,
+    );
   }
 
   async launchToken(name: string, symbol: string, walletAddress: string) {
@@ -23,12 +34,12 @@ class LaunchpadBondingCurve extends ContractBase {
     }
 
     const txReceipt = await launchToken(
-      this.contract,
+      this.launchpadFactory,
       name,
       symbol,
-      [], // TODO 9207: where do shares come from?
-      [], // TODO 9207: where do holders come from?
-      0, // TODO 9207: where does totalSupply come from?
+      [7000, 1250, 1500, 750], // 9181 parameters
+      [walletAddress, walletAddress], // should include at community treasury at [0] and contest creation util at [1] curr tbd
+      1_000_000_000e18, // Default 1B tokens
       walletAddress,
     );
     return txReceipt;

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -13,6 +13,7 @@ import { LaunchpadFactory } from './LaunchpadFactoryAbi';
 
 class LaunchpadBondingCurve extends ContractBase {
   tokenAddress: string;
+  launchpadFactoryAddress: string;
   launchpadFactory: Contract<typeof LaunchpadFactory>;
 
   constructor(
@@ -23,9 +24,17 @@ class LaunchpadBondingCurve extends ContractBase {
   ) {
     super(bondingCurveAddress, LpBondingCurve, rpc);
     this.tokenAddress = tokenAddress;
+    this.launchpadFactoryAddress = launchpadFactoryAddress;
+  }
+
+  async initialize(
+    withWallet?: boolean,
+    chainId?: string | undefined,
+  ): Promise<void> {
+    await super.initialize(withWallet, chainId);
     this.launchpadFactory = new this.web3.eth.Contract(
       LaunchpadFactory as AbiItem[],
-      launchpadFactoryAddress,
+      this.launchpadFactoryAddress,
     ) as unknown as Contract<typeof LaunchpadFactory>;
   }
 

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -1,4 +1,5 @@
-import { Contract } from 'web3';
+import { Contract } from 'web3-eth-contract';
+import { AbiItem } from 'web3-utils';
 import {
   buyToken,
   getPrice,
@@ -12,7 +13,7 @@ import { LaunchpadFactory } from './LaunchpadFactoryAbi';
 
 class LaunchpadBondingCurve extends ContractBase {
   tokenAddress: string;
-  launchpadFactory: Contract<any>;
+  launchpadFactory: Contract<typeof LaunchpadFactory>;
 
   constructor(
     bondingCurveAddress: string,
@@ -23,9 +24,9 @@ class LaunchpadBondingCurve extends ContractBase {
     super(bondingCurveAddress, LpBondingCurve, rpc);
     this.tokenAddress = tokenAddress;
     this.launchpadFactory = new this.web3.eth.Contract(
-      LaunchpadFactory,
+      LaunchpadFactory as AbiItem[],
       launchpadFactoryAddress,
-    );
+    ) as unknown as Contract<typeof LaunchpadFactory>;
   }
 
   async launchToken(name: string, symbol: string, walletAddress: string) {

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -6,9 +6,9 @@ import {
   sellToken,
   transferLiquidity,
 } from '../../../../../../libs/shared/src/commonProtocol';
+import { LpBondingCurve } from './Abi/LpBondingCurveAbi';
 import ContractBase from './ContractBase';
-
-const LPBondingCurveAbi = {};
+import { LaunchpadFactory } from './LaunchpadFactoryAbi';
 
 class LaunchpadBondingCurve extends ContractBase {
   tokenAddress: string;
@@ -20,10 +20,10 @@ class LaunchpadBondingCurve extends ContractBase {
     tokenAddress: string,
     rpc: string,
   ) {
-    super(bondingCurveAddress, LPBondingCurveAbi, rpc);
+    super(bondingCurveAddress, LpBondingCurve, rpc);
     this.tokenAddress = tokenAddress;
     this.launchpadFactory = new this.web3.eth.Contract(
-      lpFactoryAbi,
+      LaunchpadFactory,
       launchpadFactoryAddress,
     );
   }

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/LaunchpadFactoryAbi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/LaunchpadFactoryAbi.ts
@@ -1,0 +1,19 @@
+export const LaunchpadFactory = [
+  {
+    type: 'function',
+    name: 'launchTokenWithLiquidity',
+    inputs: [
+      { name: 'name', type: 'string', internalType: 'string' },
+      { name: 'symbol', type: 'string', internalType: 'string' },
+      { name: 'shares', type: 'uint256[]', internalType: 'uint256[]' },
+      { name: 'holders', type: 'address[]', internalType: 'address[]' },
+      { name: 'totalSupply', type: 'uint256', internalType: 'uint256' },
+      { name: 'curveId', type: 'uint256', internalType: 'uint256' },
+      { name: 'scalar', type: 'uint256', internalType: 'uint256' },
+      { name: 'lphook', type: 'address', internalType: 'address' },
+      { name: 'launchAction', type: 'address', internalType: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+];

--- a/packages/commonwealth/client/scripts/state/api/launchPad/launchToken.ts
+++ b/packages/commonwealth/client/scripts/state/api/launchPad/launchToken.ts
@@ -19,7 +19,8 @@ const launchToken = async ({
 }: LaunchTokenProps) => {
   const launchPad = new LaunchpadBondingCurve(
     '',
-    commonProtocol.factoryContracts[ethChainId].factory,
+    commonProtocol.factoryContracts[ethChainId].lpBondingCurve,
+    commonProtocol.factoryContracts[ethChainId].launchpad,
     chainRpc,
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/common-protocol/issues/173

## Description of Changes
- Adds slippage abis
- updates implementations to use slippage, either null or used in transfer liq to avoid MEV attacks 

## Test Plan
- Ensure merged token creation work still works 
