### PR TITLE
Fixed get community call failing during app init

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -18,8 +18,10 @@ const SidebarHeader = ({
 }) => {
   const navigate = useCommonNavigate();
 
+  const communityId = app.activeChainId() || '';
   const { data: community } = useGetCommunityByIdQuery({
-    id: app.activeChainId()!,
+    id: communityId,
+    enabled: !!communityId,
   });
 
   return (

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -54,8 +54,10 @@ export const GovernanceSection = () => {
   const navigate = useCommonNavigate();
   const location = useLocation();
 
+  const communityId = app.activeChainId() || '';
   const { data: community } = useGetCommunityByIdQuery({
-    id: app.activeChainId()!,
+    id: communityId,
+    enabled: !!communityId,
   });
 
   // Conditional Render Details
@@ -127,8 +129,6 @@ export const GovernanceSection = () => {
     [{ path: '/members' }, { path: ':scope/members' }],
     location,
   );
-
-  const communityId = app.activeChainId() || '';
 
   // ---------- Build Section Props ---------- //
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9366

## Description of Changes
Fixed get community call failing during app init

## "How We Fixed It"
N/A

## Test Plan
- Visit any community
- Verify there are no failing calls to `community.getCommunity` and there console errors like this
```
WARN (utils.ts): BAD_REQUEST: [ZodError] community.getCommunity: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "id"
    ],
    "message": "Required"
  }
] {"fingerprint":"BAD_REQUEST-ZodError-community.getCommunity-invalid_type"}
```

## Deployment Plan
N/A

## Other Considerations
N/A