### PR TITLE
Send correct selected address with api params when creating community

### DIFF
--- a/packages/commonwealth/client/scripts/state/ui/user/user.ts
+++ b/packages/commonwealth/client/scripts/state/ui/user/user.ts
@@ -26,6 +26,8 @@ type CommonProps = {
   accounts: Account[]; // contains full accounts list of the user - when in a active chain/community scope, only
   // contains accounts specific to that community
   activeAccount: Account | null;
+  createCommunityAddress: string | ''; // special case: this address is passed to trpc client when a specific address
+  // is selected for creating a community
   jwt: string | null;
   isSiteAdmin: boolean;
   isEmailVerified: boolean;
@@ -47,6 +49,7 @@ export const userStore = createStore<UserStoreProps>()(
     knockJWT: '',
     addresses: [],
     activeCommunity: null,
+    createCommunityAddress: '',
     communities: [],
     accounts: [],
     activeAccount: null,

--- a/packages/commonwealth/client/scripts/utils/trpcClient.ts
+++ b/packages/commonwealth/client/scripts/utils/trpcClient.ts
@@ -13,10 +13,16 @@ export const trpcClient = trpc.createClient({
       url: BASE_API_PATH,
       async headers() {
         const user = userStore.getState();
+
+        const isCreateCommunityFlow =
+          window.location.pathname.includes('/createCommunity');
+
+        const address = isCreateCommunityFlow
+          ? user.createCommunityAddress
+          : (user.activeAccount?.address ?? user.addresses?.at(0)?.address);
         return {
           authorization: user.jwt || '',
-          address:
-            user.activeAccount?.address ?? user.addresses?.at(0)?.address,
+          address,
         };
       },
     }),

--- a/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityTypeStep/CommunityTypeStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateCommunity/steps/CommunityTypeStep/CommunityTypeStep.tsx
@@ -76,7 +76,12 @@ const CommunityTypeStep = ({
     const pickedAddress = user.addresses.find(
       ({ addressId }) => String(addressId) === address,
     );
-    pickedAddress && setSelectedAddress(pickedAddress);
+    if (pickedAddress) {
+      setSelectedAddress(pickedAddress);
+      user.setData({
+        createCommunityAddress: pickedAddress.address,
+      });
+    }
     handleContinue();
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9369

## Description of Changes
Added logic to Send correct selected address with api params when creating community.

## "How We Fixed It"
N/A

## Test Plan
- Create a new ethereum account
- Now visit a cosmos community and try to join, when prompted for login, connect a cosmos account
- Now visit a solana community and try to join, when prompted for login, connect a solana account
- Now visit a substrate community and try to join, when prompted for login, connect a substrate account
- Visit the create community page
- Try to create all community types (cosmos, ethereum, solana etc) and verify the correct address you selected is being sent with API params (look for "Address" field in the create community request headers) 

## Deployment Plan
N/A

## Other Considerations
N/A