### PR TITLE
Show correct prices on fund drawer after contest launch

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
@@ -83,6 +83,7 @@ const ManageContest = ({ contestAddress }: ManageContestProps) => {
             createdContestAddress={createdContestAddress}
             isFarcasterContest={!!contestFormData?.farcasterContestDuration}
             fundingTokenTicker={fundingTokenTicker}
+            fundingTokenAddress={contestFormData?.fundingTokenAddress || ''}
           />
         );
     }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/ContestLiveStep/ContestLiveStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/ContestLiveStep/ContestLiveStep.tsx
@@ -16,12 +16,14 @@ interface ContestLiveStepProps {
   createdContestAddress: string;
   isFarcasterContest: boolean;
   fundingTokenTicker: string;
+  fundingTokenAddress: string;
 }
 
 const ContestLiveStep = ({
   createdContestAddress,
   isFarcasterContest,
   fundingTokenTicker,
+  fundingTokenAddress,
 }: ContestLiveStepProps) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -69,6 +71,7 @@ const ContestLiveStep = ({
         isOpen={isDrawerOpen}
         contestAddress={createdContestAddress}
         fundingTokenTicker={fundingTokenTicker}
+        fundingTokenAddress={fundingTokenAddress}
       />
     </>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9374

## Description of Changes
Show correct prices on fund drawer which is showed immediately after contest launch

## "How We Fixed It"
N/A

## Test Plan
- Create a sushi contest
- On this screen open the funds drawer

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/14da55be-4bf5-4f7c-8b2c-7547f084920c">

- Verify you see correct prices for SUSHI token.


## Deployment Plan
N/A

## Other Considerations
N/A