### PR TITLE
Hide token launch CTA elements behind feature flag

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/MobileNavigation/CreateContentDrawer/CreateContentDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/MobileNavigation/CreateContentDrawer/CreateContentDrawer.tsx
@@ -7,6 +7,7 @@ import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import CWIconButton from 'views/components/component_kit/new_designs/CWIconButton';
 
+import { useFlag } from 'hooks/useFlag';
 import useUserStore from 'state/ui/user';
 import './CreateContentDrawer.scss';
 
@@ -18,6 +19,8 @@ const CreateContentDrawer = ({ onClose }: CreateContentDrawerProps) => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
   const scopedPage = app.activeChainId();
+
+  const tokenizedCommunityEnabled = useFlag('tokenizedCommunity');
 
   const handleCreateThread = () => {
     navigate('/new/discussion');
@@ -55,10 +58,12 @@ const CreateContentDrawer = ({ onClose }: CreateContentDrawerProps) => {
           <CWIcon iconName="peopleNew" />
           <CWText>Create community</CWText>
         </div>
-        <div className="item" onClick={handleCreateTokenCommunity}>
-          <CWIcon iconName="rocketLaunch" />
-          <CWText>Launch Token</CWText>
-        </div>
+        {tokenizedCommunityEnabled && (
+          <div className="item" onClick={handleCreateTokenCommunity}>
+            <CWIcon iconName="rocketLaunch" />
+            <CWText>Launch Token</CWText>
+          </div>
+        )}
       </div>
       <CWIconButton iconName="close" onClick={onClose} />
     </div>

--- a/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
@@ -1,4 +1,5 @@
 import { ChainBase, ChainNetwork } from '@hicommonwealth/shared';
+import { useFlag } from 'hooks/useFlag';
 import { uuidv4 } from 'lib/util';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
@@ -42,6 +43,7 @@ const getCreateContentMenuItems = (
     options?: NavigateOptions & { action?: string },
     prefix?: null | string,
   ) => void,
+  tokenizedCommunityEnabled: boolean,
   createDiscordBotConfig?: ReturnType<
     typeof useCreateDiscordBotConfigMutation
   >['mutateAsync'],
@@ -99,10 +101,14 @@ const getCreateContentMenuItems = (
         navigate('/createCommunity', {}, null);
       },
     },
-    {
-      type: 'element',
-      element: <TokenLaunchButton key={2} buttonHeight="sm" />,
-    },
+    ...(tokenizedCommunityEnabled
+      ? [
+          {
+            type: 'element',
+            element: <TokenLaunchButton key={2} buttonHeight="sm" />,
+          } as PopoverMenuItem,
+        ]
+      : []),
   ];
 
   const getDiscordBotConnectionItems = (): PopoverMenuItem[] => {
@@ -192,6 +198,8 @@ export const CreateContentSidebar = ({
   const { mutateAsync: createDiscordBotConfig } =
     useCreateDiscordBotConfigMutation();
 
+  const tokenizedCommunityEnabled = useFlag('tokenizedCommunity');
+
   return (
     <CWSidebarMenu
       className={getClasses<{
@@ -216,7 +224,11 @@ export const CreateContentSidebar = ({
           }, 200);
         },
       }}
-      menuItems={getCreateContentMenuItems(navigate, createDiscordBotConfig)}
+      menuItems={getCreateContentMenuItems(
+        navigate,
+        tokenizedCommunityEnabled,
+        createDiscordBotConfig,
+      )}
     />
   );
 };
@@ -225,6 +237,8 @@ export const CreateContentSidebar = ({
 export const CreateContentPopover = () => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
+
+  const tokenizedCommunityEnabled = useFlag('tokenizedCommunity');
 
   if (
     !user.isLoggedIn ||
@@ -237,7 +251,7 @@ export const CreateContentPopover = () => {
 
   return (
     <PopoverMenu
-      menuItems={getCreateContentMenuItems(navigate)}
+      menuItems={getCreateContentMenuItems(navigate, tokenizedCommunityEnabled)}
       className="create-content-popover"
       renderTrigger={(onClick, isMenuOpen) => (
         <CWTooltip

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -1,6 +1,7 @@
 import { notifyInfo } from 'controllers/app/notifications';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import useBrowserWindow from 'hooks/useBrowserWindow';
+import { useFlag } from 'hooks/useFlag';
 import useStickyHeader from 'hooks/useStickyHeader';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/user_dashboard/index.scss';
@@ -46,6 +47,8 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
   );
 
   const { isAddedToHomeScreen } = useAppStatus();
+
+  const tokenizedCommunityEnabled = useFlag('tokenizedCommunity');
 
   useBrowserAnalyticsTrack({
     payload: {
@@ -141,12 +144,12 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
           </div>
           {isWindowExtraSmall ? (
             <>
-              <LaunchTokenCard />
+              {tokenizedCommunityEnabled && <LaunchTokenCard />}
               <TrendingCommunitiesPreview />
             </>
           ) : (
             <div className="featured-cards">
-              <LaunchTokenCard />
+              {tokenizedCommunityEnabled && <LaunchTokenCard />}
               <TrendingCommunitiesPreview />
             </div>
           )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
Hide token launch CTA elements behind feature flag

## "How We Fixed It"
N/A

## Test Plan
- Disable `FLAG_TOKENIZED_COMMUNITY`
- Verify you don't see token CTA elements ex: `Launch token` buttons and cards

## Deployment Plan
N/A

## Other Considerations
N/A