### PR TITLE
changed isPWA calls and stripped out old calls 

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
+++ b/packages/commonwealth/client/scripts/state/api/comments/createComment.ts
@@ -20,7 +20,6 @@ interface CreateCommentProps {
   parentCommentId: number | null;
   parentCommentMsgId: string | null;
   existingNumberOfComments: number;
-  isPWA?: boolean;
 }
 
 export const buildCreateCommentInput = async ({

--- a/packages/commonwealth/client/scripts/state/api/communities/updateCommunity.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/updateCommunity.ts
@@ -24,7 +24,6 @@ interface UpdateCommunityProps {
   defaultOverview?: boolean;
   chainNodeId?: string;
   type?: ChainType;
-  isPWA?: boolean;
 }
 
 export const buildUpdateCommunityInput = ({

--- a/packages/commonwealth/client/scripts/state/api/groups/createGroup.ts
+++ b/packages/commonwealth/client/scripts/state/api/groups/createGroup.ts
@@ -9,7 +9,6 @@ interface CreateGroupProps {
   groupDescription?: string;
   requirementsToFulfill: number | undefined;
   requirements?: any[];
-  isPWA?: boolean;
 }
 
 export const buildCreateGroupInput = ({

--- a/packages/commonwealth/client/scripts/state/api/threads/addThreadLinks.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/addThreadLinks.ts
@@ -9,27 +9,17 @@ interface AddThreadLinksProps {
   communityId: string;
   threadId: number;
   links: Link[];
-  isPWA?: boolean;
 }
 
 const addThreadLinks = async ({
   threadId,
   links,
-  isPWA,
 }: AddThreadLinksProps): Promise<Thread> => {
-  const response = await axios.post(
-    `${SERVER_URL}/linking/addThreadLinks`,
-    {
-      thread_id: threadId,
-      links,
-      jwt: userStore.getState().jwt,
-    },
-    {
-      headers: {
-        isPWA: isPWA?.toString(),
-      },
-    },
-  );
+  const response = await axios.post(`${SERVER_URL}/linking/addThreadLinks`, {
+    thread_id: threadId,
+    links,
+    jwt: userStore.getState().jwt,
+  });
 
   return new Thread(response.data.result);
 };
@@ -37,7 +27,6 @@ const addThreadLinks = async ({
 interface UseAddThreadLinksMutationProps {
   communityId: string;
   threadId: number;
-  isPWA?: boolean;
 }
 
 const useAddThreadLinksMutation = ({

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -18,7 +18,6 @@ interface IUseCreateThreadReactionMutation {
 interface CreateReactionProps extends IUseCreateThreadReactionMutation {
   address: string;
   reactionType?: 'like';
-  isPWA?: boolean;
 }
 
 export const buildCreateThreadReactionInput = async ({

--- a/packages/commonwealth/client/scripts/state/ui/user/user.ts
+++ b/packages/commonwealth/client/scripts/state/ui/user/user.ts
@@ -27,6 +27,7 @@ type CommonProps = {
   // contains accounts specific to that community
   activeAccount: Account | null;
   jwt: string | null;
+  isOnPWA: boolean;
   isSiteAdmin: boolean;
   isEmailVerified: boolean;
   isPromotionalEmailEnabled: boolean;
@@ -52,6 +53,7 @@ export const userStore = createStore<UserStoreProps>()(
     accounts: [],
     activeAccount: null,
     jwt: null,
+    isOnPWA: false,
     isSiteAdmin: false,
     isEmailVerified: false,
     isPromotionalEmailEnabled: false,

--- a/packages/commonwealth/client/scripts/utils/trpcClient.ts
+++ b/packages/commonwealth/client/scripts/utils/trpcClient.ts
@@ -11,10 +11,12 @@ export const trpcClient = trpc.createClient({
   links: [
     httpBatchLink({
       url: BASE_API_PATH,
+
       async headers() {
         const user = userStore.getState();
         return {
           authorization: user.jwt || '',
+          isPWA: user.isOnPWA?.toString(),
           address:
             user.addressSelectorSelectedAddress ??
             user.activeAccount?.address ??

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -10,7 +10,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import app from 'state';
 import { useCreateCommentMutation } from 'state/api/comments';
 import useUserStore from 'state/ui/user';
-import useAppStatus from '../../../hooks/useAppStatus';
 import Thread from '../../../models/Thread';
 import { useFetchProfilesByAddressesQuery } from '../../../state/api/profiles/index';
 import { jumpHighlightComment } from '../../pages/discussions/CommentTree/helpers';
@@ -42,7 +41,6 @@ export const CreateComment = ({
       : `new-comment-reply-${parentCommentId}`,
   );
 
-  const { isAddedToHomeScreen } = useAppStatus();
   const user = useUserStore();
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
@@ -100,7 +98,6 @@ export const CreateComment = ({
           parentCommentId: parentCommentId ?? null,
           parentCommentMsgId: parentCommentMsgId ?? null,
           existingNumberOfComments: rootThread.numberOfComments || 0,
-          isPWA: isAddedToHomeScreen,
         });
         const newComment = await createComment(input);
 

--- a/packages/commonwealth/client/scripts/views/modals/linked_thread_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/linked_thread_modal.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 
 import { notifyError } from '../../controllers/app/notifications';
 import { getAddedAndDeleted } from '../../helpers/threads';
-import useAppStatus from '../../hooks/useAppStatus';
 import type Thread from '../../models/Thread';
 import { LinkSource } from '../../models/Thread';
 import app from '../../state';
@@ -45,8 +44,6 @@ export const LinkedThreadModal = ({
     threadId: thread.id,
   });
 
-  const { isAddedToHomeScreen } = useAppStatus();
-
   const handleSaveChanges = async () => {
     const { toAdd, toDelete } = getAddedAndDeleted(
       tempLinkedThreads,
@@ -63,7 +60,6 @@ export const LinkedThreadModal = ({
             identifier: String(el.id),
             title: el.title,
           })),
-          isPWA: isAddedToHomeScreen,
         });
         links = updatedThread.links;
       }

--- a/packages/commonwealth/client/scripts/views/modals/linked_url_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/linked_url_modal.tsx
@@ -14,7 +14,6 @@ import {
   CWModalFooter,
   CWModalHeader,
 } from 'views/components/component_kit/new_designs/CWModal';
-import useAppStatus from '../../hooks/useAppStatus';
 import type Thread from '../../models/Thread';
 import { UrlSelector } from '../components/UrlLinkSelector/UrlSelector';
 import { CWText } from '../components/component_kit/cw_text';
@@ -51,8 +50,6 @@ export const LinkedUrlModal = ({
     threadId: thread.id,
   });
 
-  const { isAddedToHomeScreen } = useAppStatus();
-
   const handleSaveChanges = async () => {
     const { toAdd, toDelete } = getAddedAndDeleted(
       tempLinkedUrls,
@@ -71,7 +68,6 @@ export const LinkedUrlModal = ({
             identifier: String(el.identifier),
             title: el.title,
           })),
-          isPWA: isAddedToHomeScreen,
         });
 
         links = updatedThread.links;

--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -144,7 +144,6 @@ export const UpdateProposalStatusModal = ({
                       title: enrichedSnapshot.title,
                     },
                   ],
-                  isPWA: isAddedToHomeScreen,
                 }).then((updatedThread) => {
                   links = updatedThread.links;
                   return { toDelete, links };
@@ -175,7 +174,6 @@ export const UpdateProposalStatusModal = ({
                           title: enrichedSnapshot.title,
                         },
                       ],
-                      isPWA: isAddedToHomeScreen,
                     });
                   })
                   .then((updatedThread) => {
@@ -228,7 +226,6 @@ export const UpdateProposalStatusModal = ({
                   identifier: identifier,
                   title: title,
                 })),
-                isPWA: isAddedToHomeScreen,
               }).then((updatedThread) => {
                 // eslint-disable-next-line no-param-reassign
                 links = updatedThread.links;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Create/CreateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Create/CreateCommunityGroupPage.tsx
@@ -52,11 +52,7 @@ const CreateCommunityGroupPage = () => {
       onSubmit={async (values) => {
         try {
           const payload = buildCreateGroupInput(
-            makeGroupDataBaseAPIPayload(
-              values,
-              isAddedToHomeScreen,
-              allowedAddresses,
-            ),
+            makeGroupDataBaseAPIPayload(values, allowedAddresses),
           );
           await createGroup(payload);
           notifySuccess('Group Created');

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/helpers/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/helpers/index.ts
@@ -13,7 +13,6 @@ import { GroupResponseValuesType } from '../GroupForm/index.types';
 // Makes create/edit group api payload from provided form submit values
 export const makeGroupDataBaseAPIPayload = (
   formSubmitValues: GroupResponseValuesType,
-  isAddedToHomeScreen: boolean,
   allowedAddresses?: string[],
 ) => {
   // @ts-expect-error StrictNullChecks
@@ -30,7 +29,6 @@ export const makeGroupDataBaseAPIPayload = (
           formSubmitValues.requirements.length + extraRequrirements
         : formSubmitValues.requirementsToFulfill,
     requirements: [],
-    isPWA: isAddedToHomeScreen,
   };
 
   // @ts-expect-error StrictNullChecks

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Directory/Directory.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Directory/Directory.tsx
@@ -1,6 +1,5 @@
 import { buildUpdateCommunityInput } from 'client/scripts/state/api/communities/updateCommunity';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
-import useAppStatus from 'hooks/useAppStatus';
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback, useState } from 'react';
@@ -54,8 +53,6 @@ const Directory = () => {
     shouldRun: !isLoadingCommunity && !!community,
   });
 
-  const { isAddedToHomeScreen } = useAppStatus();
-
   const defaultChainNodeId = chainNodeId ?? communityDefaultChainNodeId;
   const defaultOption = chainNodeOptionsSorted?.find(
     (option) => option.value === String(defaultChainNodeId),
@@ -78,7 +75,6 @@ const Directory = () => {
           communityId: community?.id,
           directoryPageChainNodeId: chainNodeId || undefined,
           directoryPageEnabled: isEnabled,
-          isPWA: isAddedToHomeScreen,
         }),
       );
 
@@ -95,7 +91,6 @@ const Directory = () => {
     community?.directory_page_enabled,
     community?.directory_page_chain_node_id,
     isEnabled,
-    isAddedToHomeScreen,
     updateCommunity,
   ]);
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -115,7 +115,6 @@ export const ReactionButton = ({
         threadId: thread.id,
         threadMsgId: thread.canvasMsgId,
         reactionType: 'like',
-        isPWA: isAddedToHomeScreen,
       });
       createThreadReaction(input).catch((e) => {
         if (e instanceof SessionKeyError) {

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -47,6 +47,8 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
 
   const { isAddedToHomeScreen } = useAppStatus();
 
+  user.setData({ isOnPWA: isAddedToHomeScreen });
+
   useBrowserAnalyticsTrack({
     payload: {
       event: MixpanelPageViewEvent.DASHBOARD_VIEW,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9123 

## Description of Changes
-refactored where `isPWA` is being sent to the backend and stripped out `isPWA` from all headers on calls to the backend. 

## Test Plan
-open Mixpanel dev dashboard 
-click around the site and confirm that you are seeing `isPWA` property on the Mixpanel call
-Creating a comment is one of the calls that previously went through the backend, create a comment and confirm that you still see the `isPWA` property on the Mixpanel call labeled "Create New Comment"

