### PR TITLE
community name in Stake banner now correct case

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/StakeIntegration/StakeIntegration.tsx
@@ -79,7 +79,7 @@ const StakeIntegration = ({
       <section className="StakeIntegration">
         <CWText type="h2">Stake</CWText>
         <Status
-          communityName={app.activeChainId() || ''}
+          communityName={app.chain.meta.name || ''}
           isEnabled={stakeEnabled}
         />
         <CWDivider />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9175 

## Description of Changes
- Community name in Enable Stake banner now shows proper case

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed name to be displayed from id to name
## Test Plan
- enable stake through Integrations
- confirm that the Stake not enabled banner now shows the correct name and correct case of your community

![Screenshot 2024-10-09 at 12 46 56 PM](https://github.com/user-attachments/assets/0827eaea-518e-4781-9161-a786cf79fba6)
