### PR TITLE
fixed the new line preview issue

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.scss
@@ -83,6 +83,7 @@
         word-break: break-word;
         font-size: 16px !important;
         overflow: hidden;
+        white-space: pre-wrap;
 
         @include extraSmall {
           overflow: hidden !important;

--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -7,7 +7,7 @@
 
   position: relative;
   word-break: break-word;
-
+  white-space: pre-wrap;
   @include formatted-text();
   @include collapsible();
   @include hidden-formatting();

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -14,6 +14,8 @@
     .MarkdownPreview {
       min-height: 255px;
       padding: 16px;
+      white-space: pre-wrap; /* This will render single newlines as line breaks */
+      word-wrap: break-word;
     }
 
     .CustomQuillToolbar {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9277

## Description of Changes

Uploading Screen Recording 2024-10-10 at 12.10.38 AM.mov…


- added the two new css property in react_quill_editor.scss 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added the two new css property in react_quill_editor.scss 
      white-space: pre-wrap
      word-wrap: break-word

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 