### PR TITLE
Add erc20 contest deployment helper

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/NamespaceFactoryAbi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/NamespaceFactoryAbi.ts
@@ -1,5 +1,19 @@
 export const namespaceFactoryAbi = [
   {
+    type: 'function',
+    name: 'newSingleERC20Contest',
+    inputs: [
+      { name: 'name', type: 'string', internalType: 'string' },
+      { name: 'length', type: 'uint256', internalType: 'uint256' },
+      { name: 'winnerShares', type: 'uint256[]', internalType: 'uint256[]' },
+      { name: 'token', type: 'address', internalType: 'address' },
+      { name: 'voterShare', type: 'uint256', internalType: 'uint256' },
+      { name: 'exhangeToken', type: 'address', internalType: 'address' },
+    ],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'nonpayable',
+  },
+  {
     inputs: [],
     stateMutability: 'view',
     type: 'function',

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Contest.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Contest.ts
@@ -130,6 +130,43 @@ class Contest extends ContractBase {
     }
   }
 
+  async newSingleERC20Contest(
+    namespaceName: string,
+    contestInterval: number,
+    winnerShares: number[],
+    voteToken: string,
+    voterShare: number,
+    walletAddress: string,
+    exchangeToken: string,
+  ): Promise<string> {
+    if (!this.initialized || !this.walletEnabled) {
+      await this.initialize(true);
+    }
+
+    try {
+      const txReceipt = await this.namespaceFactory.newERC20Contest(
+        namespaceName,
+        contestInterval,
+        winnerShares,
+        voteToken,
+        voterShare,
+        walletAddress,
+        exchangeToken,
+      );
+      // @ts-expect-error StrictNullChecks
+      const eventLog = txReceipt.logs.find((log) => log.topics[0] == TOPIC_LOG);
+      const newContestAddress = this.web3.eth.abi.decodeParameters(
+        ['address', 'address', 'uint256', 'bool'],
+        // @ts-expect-error StrictNullChecks
+        eventLog.data.toString(),
+      )['0'] as string;
+      this.contractAddress = newContestAddress;
+      return newContestAddress;
+    } catch (error) {
+      throw new Error('Failed to initialize contest ' + error);
+    }
+  }
+
   /**
    * Allows for deposit of contest token(ETH or ERC20) to contest
    * @param amount amount in ether to send to contest

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/NamespaceFactory.ts
@@ -218,6 +218,42 @@ class NamespaceFactory extends ContractBase {
     return txReceipt;
   }
 
+  async newERC20Contest(
+    namespaceName: string,
+    contestInterval: number,
+    winnerShares: number[],
+    voteToken: string,
+    voterShare: number,
+    walletAddress: string,
+    exchangeToken: string,
+  ): Promise<TransactionReceipt> {
+    if (!this.initialized || !this.walletEnabled) {
+      await this.initialize(true);
+    }
+    const maxFeePerGasEst = await this.estimateGas();
+    let txReceipt;
+    try {
+      txReceipt = await this.contract.methods
+        .newSingleERC20Contest(
+          namespaceName,
+          contestInterval,
+          winnerShares,
+          voteToken,
+          voterShare,
+          exchangeToken,
+        )
+        .send({
+          from: walletAddress,
+          type: '0x2',
+          maxFeePerGas: maxFeePerGasEst?.toString(),
+          maxPriorityFeePerGas: this.web3.utils.toWei('0.001', 'gwei'),
+        });
+    } catch {
+      throw new Error('Transaction failed');
+    }
+    return txReceipt;
+  }
+
   async getFeeManagerBalance(
     namespace: string,
     token?: string,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9510

## Description of Changes
- Creates an ERC20 Contest Deployment helper
- Adds Abi for new function

## Test Plan
- Use method in place of contest methods and confirm new contest can deploy

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- I am going to deploy a mock erc20 we can use for testing. When you are testing you can give me your address and I can send tokens for future development 