### PR TITLE
made the Discussion clickable and navigate to discussionAll

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
@@ -20,6 +20,21 @@ type BreadcrumbsProps = {
   tooltipStr?: string;
 };
 
+const handleNavigation = (label, navigate, isParent) => {
+  if (label === 'Discussions' && isParent) {
+    navigate(`/discussions`);
+  }
+};
+const handleMouseInteraction = (
+  label: string,
+  handleInteraction: (event: React.MouseEvent<HTMLSpanElement>) => void,
+  event: React.MouseEvent<HTMLSpanElement>,
+) => {
+  if (label !== 'Discussions') {
+    handleInteraction(event);
+  }
+};
+
 export const CWBreadcrumbs = ({
   breadcrumbs,
   tooltipStr,
@@ -36,14 +51,19 @@ export const CWBreadcrumbs = ({
                 placement="bottom"
                 renderTrigger={(handleInteraction) => (
                   <CWText
-                    onMouseEnter={handleInteraction}
-                    onMouseLeave={handleInteraction}
+                    onMouseEnter={(event) =>
+                      handleMouseInteraction(label, handleInteraction, event)
+                    }
+                    onMouseLeave={(event) =>
+                      handleMouseInteraction(label, handleInteraction, event)
+                    }
                     type="caption"
                     className={clsx({
                       'disable-active-cursor': index === 0,
                       'current-text': isCurrent,
                       'parent-text': !isCurrent,
                     })}
+                    onClick={() => handleNavigation(label, navigate, isParent)}
                   >
                     {truncateText(label)}
                   </CWText>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9260 

## Description of Changes
-Made the Discussions Breadcrumbs clickable
- add the navigation for Breadcrumbs when parent is Discussions 
-navigate to All discussions


## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- added handleNavigation function for navigation base on label and i




## Test Plan
N/A
  - 

## Deployment Plan
N/A

https://github.com/user-attachments/assets/b7b966ca-022c-485f-93bf-04601b3ae85e

