### PR TITLE
more communities shown on explore page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Communities/Communities.scss
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/Communities.scss
@@ -7,6 +7,7 @@
 .CommunitiesPageLayout {
   padding-top: 0;
   height: 100%;
+  overflow-y: auto;
 
   .layout-container {
     height: 100%;

--- a/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
@@ -33,6 +33,8 @@ type ExtendedCommunitySliceType = [
 ];
 
 const CommunitiesPage = () => {
+  const containerRef = useRef();
+
   const {
     setModeOfManageCommunityStakeModal,
     modeOfManageCommunityStakeModal,
@@ -135,7 +137,8 @@ const CommunitiesPage = () => {
   };
 
   return (
-    <CWPageLayout className="CommunitiesPageLayout">
+    // @ts-expect-error <StrictNullChecks/>
+    <CWPageLayout ref={containerRef} className="CommunitiesPageLayout">
       <div className="CommunitiesPage">
         <div className="header-section">
           <div className="description">
@@ -203,6 +206,7 @@ const CommunitiesPage = () => {
             className="communities-list"
             style={{ height: '100%', width: '100%' }}
             data={isInitialCommunitiesLoading ? [] : communitiesList}
+            customScrollParent={containerRef.current}
             itemContent={(listIndex, slicedCommunities) => {
               return slicedCommunities.map((community, sliceIndex) => {
                 const canBuyStake = !!user.addresses.find?.(

--- a/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/Communities.tsx
@@ -33,8 +33,6 @@ type ExtendedCommunitySliceType = [
 ];
 
 const CommunitiesPage = () => {
-  const containerRef = useRef();
-
   const {
     setModeOfManageCommunityStakeModal,
     modeOfManageCommunityStakeModal,
@@ -137,8 +135,7 @@ const CommunitiesPage = () => {
   };
 
   return (
-    // @ts-expect-error <StrictNullChecks/>
-    <CWPageLayout ref={containerRef} className="CommunitiesPageLayout">
+    <CWPageLayout className="CommunitiesPageLayout">
       <div className="CommunitiesPage">
         <div className="header-section">
           <div className="description">
@@ -206,7 +203,6 @@ const CommunitiesPage = () => {
             className="communities-list"
             style={{ height: '100%', width: '100%' }}
             data={isInitialCommunitiesLoading ? [] : communitiesList}
-            customScrollParent={containerRef.current}
             itemContent={(listIndex, slicedCommunities) => {
               return slicedCommunities.map((community, sliceIndex) => {
                 const canBuyStake = !!user.addresses.find?.(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9522 

## Description of Changes
- User now sees more than 8 communities when viewing and searching on the Explore Communities page

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
removed useRef that was restricting the Virtuoso from showing the correct amount of communities
## Test Plan
-go to Explore Communities page
-confirm that you see more than 8 communities
-search for communities using a filter
-if there are more than 8 communities returned, confirm that you now see all of those communities 
