### PR TITLE
1 found community copy change

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Communities/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/helpers.ts
@@ -1,9 +1,10 @@
+import { pluralize } from 'helpers';
 import numeral from 'numeral';
-
 export const getCommunityCountsString = (totalCommunities: number) => {
-  return `${
+  const formattedCount =
     totalCommunities >= 1000
       ? numeral(totalCommunities).format('0.0a')
-      : totalCommunities
-  } ${totalCommunities === 1 ? 'community' : 'communities'}`;
+      : totalCommunities;
+
+  return pluralize(formattedCount, 'community');
 };

--- a/packages/commonwealth/client/scripts/views/pages/Communities/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/helpers.ts
@@ -5,5 +5,5 @@ export const getCommunityCountsString = (totalCommunities: number) => {
     totalCommunities >= 1000
       ? numeral(totalCommunities).format('0.0a')
       : totalCommunities
-  } communities`;
+  } ${totalCommunities === 1 ? 'community' : 'communities'}`;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9543 

## Description of Changes
- If only 1 community is found through Explore it now reads "1 community" not "1 communities"

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added logic to look for count of 1 and show proper wording

## Test Plan
-go to Explore page
-put dApp in filter
-confirm that you see proper wording based on number of communities


https://github.com/user-attachments/assets/f84bcb3f-4e02-4e60-a7e7-8cf769bc1b83

