### PR TITLE
added Cancel button functionality to child comment

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
@@ -23,6 +23,7 @@ type CommentEditorProps = {
   editorValue: string;
   shouldFocus: boolean;
   tooltipText?: string;
+  isReplying?: boolean;
 };
 
 export const CommentEditor = ({
@@ -38,6 +39,7 @@ export const CommentEditor = ({
   editorValue,
   shouldFocus,
   tooltipText,
+  isReplying,
 }: CommentEditorProps) => {
   return (
     <div className="CommentEditor">
@@ -72,7 +74,7 @@ export const CommentEditor = ({
       />
       <div className="form-bottom">
         <div className="form-buttons">
-          {editorValue.length > 0 && (
+          {(editorValue.length > 0 || isReplying) && (
             <CWButton buttonType="tertiary" onClick={onCancel} label="Cancel" />
           )}
           <CWButton

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -25,6 +25,7 @@ type CreateCommentProps = {
   rootThread: Thread;
   canComment: boolean;
   tooltipText?: string;
+  isReplying?: boolean;
 };
 
 export const CreateComment = ({
@@ -34,13 +35,14 @@ export const CreateComment = ({
   rootThread,
   canComment,
   tooltipText = '',
+  isReplying,
 }: CreateCommentProps) => {
   const { saveDraft, restoreDraft, clearDraft } = useDraft<DeltaStatic>(
     !parentCommentId
       ? `new-thread-comment-${rootThread.id}`
       : `new-comment-reply-${parentCommentId}`,
   );
-
+  console.log('isReplying from CreateComment', isReplying);
   const user = useUserStore();
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
@@ -136,6 +138,7 @@ export const CreateComment = ({
   const handleCancel = (e) => {
     e.preventDefault();
     setContentDelta(createDeltaFromText(''));
+
     if (handleIsReplying) {
       handleIsReplying(false);
     }
@@ -161,6 +164,7 @@ export const CreateComment = ({
       author={author as Account}
       editorValue={editorValue}
       tooltipText={tooltipText}
+      isReplying={isReplying}
     />
   ) : (
     <ArchiveMsg archivedAt={rootThread.archivedAt} />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -264,7 +264,6 @@ export const CommentTree = ({
       setIsGloballyEditing(false);
     }
   };
-
   const handleEditStart = (comment: CommentType<any>) => {
     const editDraft = localStorage.getItem(
       `${app.activeChainId()}-edit-comment-${comment.id}-storedText`,
@@ -530,6 +529,7 @@ export const CommentTree = ({
                 parentCommentId={parentCommentId}
                 rootThread={thread}
                 canComment={canComment}
+                isReplying={isReplying}
               />
             )}
           </React.Fragment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9562 

## Description of Changes
- Added functionality to close editor when replying to a comment, without first entering text, to clean up the UI and make it more intuitive. 
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `|| isReplying` logic to the Cancel button to show Cancel when replying. 
## Test Plan
-go to a thread with at least 1 comment
-confirm that the editor at the top of the thread does not show a Cancel button without first entering text
-click Reply
-confirm that you now see the Cancel button below the editor and that you can close it without having to enter any text first



https://github.com/user-attachments/assets/15620b1c-ea34-4998-b517-d0f4c21a6b01



