### PR TITLE
changed collaborators to names and made clickable

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.scss
@@ -120,4 +120,13 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+
+  .collaborator-user-name {
+    color: $neutral-600;
+  }
+
+  .collaborator-user-name:hover {
+    text-decoration: underline;
+    text-decoration-color: $neutral-600;
+  }
 }

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -2,6 +2,7 @@ import { PopperPlacementType } from '@mui/base/Popper';
 import { threadStageToLabel } from 'helpers';
 import moment from 'moment';
 import React, { useRef } from 'react';
+import { Link } from 'react-router-dom';
 import { useGetCommunityByIdQuery } from 'state/api/communities';
 import { ArchiveTrayWithTooltip } from 'views/components/ArchiveTrayWithTooltip';
 import { LockWithTooltip } from 'views/components/LockWithTooltip';
@@ -188,17 +189,23 @@ export const AuthorAndPublishInfo = ({
               content={
                 <div className="collaborators">
                   {/*@ts-expect-error <StrictNullChecks>*/}
-                  {collaboratorsInfo.map(({ address, community_id, User }) => {
-                    return (
-                      <FullUser
-                        shouldLinkProfile
-                        key={address}
-                        userAddress={address}
-                        userCommunityId={community_id}
-                        profile={User.profile}
-                      />
-                    );
-                  })}
+                  {collaboratorsInfo.map(
+                    ({
+                      User,
+                    }: {
+                      address: string;
+                      community_id: string;
+                      User: { id: number; profile: UserProfile };
+                    }) => {
+                      return (
+                        <Link key={User.id} to={`/profile/id/${User.id}`}>
+                          <CWText className="collaborator-user-name">
+                            {User.profile.name}
+                          </CWText>
+                        </Link>
+                      );
+                    },
+                  )}
                 </div>
               }
               {...popoverProps}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9571 

## Description of Changes
-I made the collaborators popover show their profile names instead of wallet address, and made their names clickable, redirecting to their respective profiles. 

NOTE: I tried desperately to use the `FullUser` component that was in place, but for whatever reason, when I passed `User.profile`  from `AuthorAndPublishInfo.tsx` into `FullUser` the profile information would change. Inside `AuthorAndPublishInfo.tsx` it is correct but inside `FullUser` it is showing my `profile.userId`. I assume this is from some deep rerendering somewhere that I was unable to track down. On production you can see that if you add collaborators to a thread, the dropdown with show the correct wallet address for each user, but if you click on the white space where an avatar should be, you are redirected to your profile. And that is the case for each iteration of collaborators in the dropdown.  

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Added logic to look for name, and used Link to link to their profile

## Test Plan
-create a thread or go to an existing one
-add at least one collaborator to the thread
-confirm that it now shows "X other(s)" in the Author and Publisher info
-hover over that text and confirm you see the name of your collaborator(s)
-click one of those names and confirm that you are redirected to their profile. 


https://github.com/user-attachments/assets/ca953ff7-9587-4518-a1ed-bcebecf122e9



