### PR TITLE
Subscribe icon should change color and text on click

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_thread_action.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/cw_thread_action.tsx
@@ -2,7 +2,6 @@ import {
   ArrowBendUpRight,
   ArrowFatUp,
   BellSimple,
-  BellSimpleSlash,
   ChatCenteredDots,
   Coins,
   DotsThree,
@@ -55,11 +54,7 @@ const renderPhosphorIcon = (
     case 'share':
       return <ArrowBendUpRight {...commonProps(disabled)} />;
     case 'subscribe':
-      return selected ? (
-        <BellSimple {...commonProps(disabled)} />
-      ) : (
-        <BellSimpleSlash {...commonProps(disabled)} />
-      );
+      return <BellSimple {...commonProps(disabled)} />;
     case 'overflow':
       return <DotsThree {...commonProps(disabled)} />;
     case 'leaderboard':

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import Thread from 'models/Thread';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useCreateThreadSubscriptionMutation } from 'state/api/trpc/subscription/useCreateThreadSubscriptionMutation';
@@ -76,7 +77,7 @@ export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
     <CWThreadAction
       action="subscribe"
       label={hasThreadSubscription ? 'Subscribed' : 'Subscribe'}
-      className={`subscribe ${hasThreadSubscription ? 'selected' : ''}`}
+      className={clsx('subscribe', { selected: hasThreadSubscription })}
       onClick={handleToggleSubscribe}
       selected={!hasThreadSubscription}
       disabled={!isCommunityMember}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ToggleThreadSubscribe.tsx
@@ -75,7 +75,8 @@ export const ToggleThreadSubscribe = (props: ToggleThreadSubscribeProps) => {
   return (
     <CWThreadAction
       action="subscribe"
-      label="Subscribe"
+      label={hasThreadSubscription ? 'Subscribed' : 'Subscribe'}
+      className={`subscribe ${hasThreadSubscription ? 'selected' : ''}`}
       onClick={handleToggleSubscribe}
       selected={!hasThreadSubscription}
       disabled={!isCommunityMember}

--- a/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
@@ -63,14 +63,14 @@
     }
 
     &.selected {
-      color: $blue-500;
+      color: $primary-500;
 
       &:hover {
-        color: $blue-500;
+        color: $primary-500;
       }
 
       .Text {
-        color: $blue-500 !important;
+        color: $primary-500 !important;
       }
     }
 

--- a/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/new_designs/cw_thread_action.scss
@@ -53,4 +53,29 @@
       color: $neutral-400;
     }
   }
+
+  &.subscribe {
+    color: $neutral-500;
+
+    &:hover {
+      background-color: $neutral-100;
+      color: $neutral-600;
+    }
+
+    &.selected {
+      color: $blue-500;
+
+      &:hover {
+        color: $blue-500;
+      }
+
+      .Text {
+        color: $blue-500 !important;
+      }
+    }
+
+    .Text {
+      color: $neutral-500;
+    }
+  }
 }

--- a/packages/commonwealth/client/styles/mixins/colors.module.scss
+++ b/packages/commonwealth/client/styles/mixins/colors.module.scss
@@ -83,6 +83,18 @@ $purple-600: #340095;
 $purple-700: #290075;
 $purple-800: #180044;
 
+$blue-25: #f2faff;
+$blue-50: #e6f5ff;
+$blue-100: #bfe7ff;
+$blue-200: #80ccff;
+$blue-300: #4db8ff;
+$blue-400: #1aa3ff;
+$blue-500: #2196f3;
+$blue-600: #006bb3;
+$blue-700: #005999;
+$blue-800: #004080;
+$blue-900: #002666;
+
 :export {
   neutral-25: $neutral-25;
   neutral-50: $neutral-50;
@@ -162,4 +174,16 @@ $purple-800: #180044;
   purple-600: $purple-600;
   purple-700: $purple-700;
   purple-800: $purple-800;
+
+  blue-25: $blue-25;
+  blue-50: $blue-50;
+  blue-100: $blue-100;
+  blue-200: $blue-200;
+  blue-300: $blue-300;
+  blue-400: $blue-400;
+  blue-500: $blue-500;
+  blue-600: $blue-600;
+  blue-700: $blue-700;
+  blue-800: $blue-800;
+  blue-900: $blue-900;
 }

--- a/packages/commonwealth/client/styles/mixins/colors.module.scss
+++ b/packages/commonwealth/client/styles/mixins/colors.module.scss
@@ -83,18 +83,6 @@ $purple-600: #340095;
 $purple-700: #290075;
 $purple-800: #180044;
 
-$blue-25: #f2faff;
-$blue-50: #e6f5ff;
-$blue-100: #bfe7ff;
-$blue-200: #80ccff;
-$blue-300: #4db8ff;
-$blue-400: #1aa3ff;
-$blue-500: #2196f3;
-$blue-600: #006bb3;
-$blue-700: #005999;
-$blue-800: #004080;
-$blue-900: #002666;
-
 :export {
   neutral-25: $neutral-25;
   neutral-50: $neutral-50;
@@ -174,16 +162,4 @@ $blue-900: #002666;
   purple-600: $purple-600;
   purple-700: $purple-700;
   purple-800: $purple-800;
-
-  blue-25: $blue-25;
-  blue-50: $blue-50;
-  blue-100: $blue-100;
-  blue-200: $blue-200;
-  blue-300: $blue-300;
-  blue-400: $blue-400;
-  blue-500: $blue-500;
-  blue-600: $blue-600;
-  blue-700: $blue-700;
-  blue-800: $blue-800;
-  blue-900: $blue-900;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9446

## Description of Changes
- Implemented logic that toggles the button label between "Subscribe" and "Subscribed" based on the subscription state.
- Updated the button and icon styling to reflect the subscription state:
   - Initially, the button is grey, and upon clicking, it turns blue (blue-500).
   - The label changes from "Subscribe" to "Subscribed".

## "How We Fixed It"
- Refactored the ToggleThreadSubscribe component to pass appropriate props (label and className) for styling and behavior.
- Adjusted SCSS to apply different styles for the subscribe and subscribed states.

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 