### PR TITLE
Reduce size of Welcome to Common! cards in slider

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.scss
@@ -72,4 +72,8 @@
       padding-left: 0 !important;
     }
   }
+
+  &.scaled-down {
+    transform: scale(0.85);
+  }
 }

--- a/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.scss
@@ -75,5 +75,6 @@
 
   &.scaled-down {
     transform: scale(0.85);
+    transform-origin: left;
   }
 }

--- a/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CardsSlider/ActionCard/ActionCard.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React from 'react';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../..//component_kit/cw_text';
@@ -14,6 +15,7 @@ type ActionCardProps = {
   onClose?: () => void;
   ctaText: string;
   onCTAClick: () => void;
+  className?: string;
 };
 
 export const ActionCard = ({
@@ -26,9 +28,10 @@ export const ActionCard = ({
   onClose,
   ctaText,
   onCTAClick,
+  className,
 }: ActionCardProps) => {
   return (
-    <section className="ActionCard">
+    <section className={clsx('ActionCard', className)}>
       <div className="header">
         {isActionCompleted ? (
           <CWIcon iconName="checkNew" className="check-icon" weight="bold" />

--- a/packages/commonwealth/client/scripts/views/components/CardsSlider/CardsSlider.scss
+++ b/packages/commonwealth/client/scripts/views/components/CardsSlider/CardsSlider.scss
@@ -46,4 +46,12 @@
       padding-bottom: 8px;
     }
   }
+
+  .CardsSlider.narrow-gap {
+    gap: 4px;
+
+    .cards {
+      gap: 4px;
+    }
+  }
 }

--- a/packages/commonwealth/client/scripts/views/components/CardsSlider/CardsSlider.scss
+++ b/packages/commonwealth/client/scripts/views/components/CardsSlider/CardsSlider.scss
@@ -52,6 +52,7 @@
 
     .cards {
       gap: 4px;
+      padding-bottom: 1px;
     }
   }
 }

--- a/packages/commonwealth/client/scripts/views/components/UserTrainingSlider/UserTrainingSlider.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UserTrainingSlider/UserTrainingSlider.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useEffect, useState } from 'react';
 import { useFetchProfileByIdQuery } from 'state/api/profiles';
@@ -152,7 +153,7 @@ export const UserTrainingSlider = () => {
     <>
       <CardsSlider
         containerClassName="UserTrainingSliderPageLayout"
-        className="UserTrainingSlider"
+        className={clsx('UserTrainingSlider', 'narrow-gap')}
         headerText="Welcome to Common!"
         subHeaderText="Get the most out of your experience by completing these steps"
         dismissBtnLabel="Dismiss all"
@@ -173,6 +174,7 @@ export const UserTrainingSlider = () => {
               UserTrainingCardTypes.GiveUpvote,
             )}
             onCTAClick={() => redirectToPage(UserTrainingCardTypes.GiveUpvote)}
+            className="scaled-down"
           />
         )}
         {isCardVisible(UserTrainingCardTypes.CreateContent) && (
@@ -194,6 +196,7 @@ export const UserTrainingSlider = () => {
             onCTAClick={() =>
               redirectToPage(UserTrainingCardTypes.CreateContent)
             }
+            className="scaled-down"
           />
         )}
         {isCardVisible(UserTrainingCardTypes.FinishProfile) && (
@@ -215,6 +218,7 @@ export const UserTrainingSlider = () => {
             onCTAClick={() =>
               redirectToPage(UserTrainingCardTypes.FinishProfile)
             }
+            className="scaled-down"
           />
         )}
         {isCardVisible(UserTrainingCardTypes.ExploreCommunities) && (
@@ -245,6 +249,7 @@ export const UserTrainingSlider = () => {
                 userId,
               );
             }}
+            className="scaled-down"
           />
         )}
       </CardsSlider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9459

## Description of Changes
- Reduced the size of the cards in the "Welcome to Common!" slider to improve screen real estate.

## "How We Fixed It"
- scaling of the card components to 85% of their original size.

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 