### PR TITLE
truncated long community names in sidebar header and added tooltip

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -5,9 +5,12 @@ import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
 import { useGetCommunityByIdQuery } from 'state/api/communities';
 import CollapsableSidebarButton from 'views/components/sidebar/CollapsableSidebarButton';
+import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
+import { smartTrim } from '../../../../../../shared/utils';
 import { Skeleton } from '../../Skeleton';
 import { CWCommunityAvatar } from '../../component_kit/cw_community_avatar';
 import { CWText } from '../../component_kit/cw_text';
+import { CWTooltip } from '../../component_kit/new_designs/CWTooltip';
 
 const SidebarHeader = ({
   isInsideCommunity,
@@ -23,7 +26,7 @@ const SidebarHeader = ({
     id: communityId,
     enabled: !!communityId,
   });
-
+  console.log('community', community?.name);
   return (
     <div className="SidebarHeader">
       <CWCommunityAvatar
@@ -37,18 +40,30 @@ const SidebarHeader = ({
           navigateToCommunity({ navigate, path: '', chain: app.chain.id })
         }
       />
-
-      <CWText
-        className="header"
-        type="h5"
-        onClick={() =>
-          app.chain.id &&
-          navigateToCommunity({ navigate, path: '', chain: app.chain.id })
+      <CWTooltip
+        content={
+          community?.name && community.name.length > 17 ? community.name : null
         }
-      >
-        {community?.name || <Skeleton width="70%" />}
-      </CWText>
-
+        placement="top"
+        renderTrigger={(handleInteraction, isTooltipOpen) => (
+          <CWText
+            className="header"
+            type="h5"
+            onClick={() =>
+              app.chain.id &&
+              navigateToCommunity({ navigate, path: '', chain: app.chain.id })
+            }
+            onMouseEnter={(e) => {
+              handleMouseEnter({ e, isTooltipOpen, handleInteraction });
+            }}
+            onMouseLeave={(e) => {
+              handleMouseLeave({ e, isTooltipOpen, handleInteraction });
+            }}
+          >
+            {smartTrim(community?.name, 17) || <Skeleton width="70%" />}
+          </CWText>
+        )}
+      />
       {isInsideCommunity && (
         <CollapsableSidebarButton
           isInsideCommunity={isInsideCommunity}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -26,7 +26,7 @@ const SidebarHeader = ({
     id: communityId,
     enabled: !!communityId,
   });
-  console.log('community', community?.name);
+
   return (
     <div className="SidebarHeader">
       <CWCommunityAvatar

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -29,7 +29,11 @@ export const getCommunityUrl = (community: string): string => {
     : `http://localhost:8080/${community}`;
 };
 
-export const smartTrim = (text, maxLength = 200) => {
+export const smartTrim = (
+  text: string | undefined,
+  maxLength = 200,
+): string => {
+  if (!text) return '';
   if (text.length > maxLength) {
     const smartTrimmedText = text.slice(0, maxLength).replace(/\W+$/, '');
     if (smartTrimmedText.length === 0) return `${text.slice(0, maxLength)}...`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9598 

## Description of Changes
- Added a function to community names that truncates any name longer than 17 characters and adds "..."
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Added a function to community names that truncates any name longer than 17 characters and adds "..."
-added tooltip for truncated community names so user can see full name
## Test Plan
-if you don't have a community with a name longer than 17 characters create one
-go to communities sidebar and click on long named community
-confirm that you now see truncated community name with "..." at the end and that the community name doesn't visually fall behind the arrows.
-hover over name and confirm you see a tooltip with the full community name
