### PR TITLE
fixed environment variable check for SNAPSHOT_WEBHOOK_SECRET

### DIFF
--- a/packages/commonwealth/server/config.ts
+++ b/packages/commonwealth/server/config.ts
@@ -9,6 +9,7 @@ const {
   TELEGRAM_BOT_TOKEN,
   TELEGRAM_BOT_TOKEN_DEV,
   SESSION_SECRET,
+  SNAPSHOT_WEBHOOK_SECRET,
   NO_PRERENDER: _NO_PRERENDER,
   NO_GLOBAL_ACTIVITY_CACHE,
   PRERENDER_TOKEN,
@@ -95,6 +96,7 @@ export const config = configure(
       ),
     },
     PEER_ID,
+    SNAPSHOT_WEBHOOK_SECRET,
   },
   z.object({
     NO_PRERENDER: z.boolean(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9604

## Description of Changes
- Fix env check logic so that it passes if SNAPSHOT_WEBHOOK_SECRET is provided on demo.

## Test Plan
- Tested fix by reproducing the error by setting SNAPSHOT_WEBHOOK_SECRET and APP_ENV=demo, and then fixing it so it no longer throws an error