### PR TITLE
Israel.9546.incorrect 404 redirect

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/404.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/404.tsx
@@ -1,3 +1,4 @@
+import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import useUserStore from 'state/ui/user';
 import { useAuthModalStore } from '../../state/ui/modals';
@@ -13,25 +14,32 @@ export const PageNotFound = (props: PageNotFoundProps) => {
 
   const user = useUserStore();
 
+  const navigate = useCommonNavigate();
+
+  const default404Message = user.isLoggedIn
+    ? "This page doesn't exist. Please go to Home to view or join a conversation."
+    : "This page is private or doesn't exist. Please Sign in to view or join the conversation.";
+
   const { authModalType, setAuthModalType } = useAuthModalStore();
 
   return (
     <div className="PageNotFound">
       <CWEmptyState
         iconName="cautionCircle"
-        content={
-          message ||
-          `
-            This page is private or doesn't exist.
-            Please Sign in to view or join the conversation.
-            `
-        }
+        content={message || default404Message}
       />
       {!user.isLoggedIn && (
         <CWButton
           buttonType="primary"
           label="Sign in"
           onClick={() => setAuthModalType(AuthModalType.SignIn)}
+        />
+      )}
+      {user.isLoggedIn && (
+        <CWButton
+          buttonType="primary"
+          label="Home"
+          onClick={() => navigate('/dashboard/for-you')}
         />
       )}
       <AuthModal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9546 

## Description of Changes
- User is now shown a message if they aren't signed in along with a Sign in button, and a different message if they are signed in but they go to a page that doesn't exist, with a Home button that redirects them to `/dashboard/for-you`

NOTE: I chose this method of redirection based off of the multiple ways we are using/showing the 404 page. @masvelio In regards to [this comment you made on my previous PR](https://github.com/hicommonwealth/commonwealth/pull/9503#pullrequestreview-2359789826), I chose to do it this way instead of possibly doing an automatic redirect if the url is incorrect, because I worried that if I did that it would cause a lot of downstream bugs because we show this page in many different places and use it in different ways. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-made a check to see if user was logged in and changed messages based on that, and added Sign in and Home buttons to correspond with the different messages.

## Test Plan
- with a signed in user go to a page that doesn't exist. Ex: http://localhost:8080/dashb
- confirm that you now see the 404 page with a message that reads "This page doesn't exist. Please go to Home to view or join a conversation." with a Home button
- Click the Home button and confirm that you are redirected to `/dashboard/for-you`
- log out
- go to page that doesn't exist
- confirm that you now see a 404 page with the message "This page is private or doesn't exist. Please Sign in to view or join the conversation." with a Sign in button
- click the Sign in button and go through the sign in process
- after you're signed in confirm that you are still on the page that doesn't exist, but now you are shown the message about the page not existing and the Home button is shown. 

