### PR TITLE
Show create contest button

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -102,7 +102,7 @@ const AdminContestsPage = () => {
         <div className="admin-header-row">
           <CWText type="h2">Contests</CWText>
 
-          {(farcasterContestEnabled
+          {(weightedTopicsEnabled
             ? hasAtLeastOneWeightedVotingTopic
             : stakeEnabled) &&
             contestView !== ContestView.TypeSelection && (


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9607 

## Description of Changes
- wrong feature flag was used to show create contest button

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- create community
- create erc20 topic
- create contest
- (do not enable stake)
- go to contest list page
- button should be visible

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a