### PR TITLE
Page should scroll to comments after "X comments" button clicked

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -81,6 +81,7 @@ type ContentPageProps = {
   sidebarComponentsSkeletonCount?: number;
   setThreadBody?: (body: string) => void;
   editingDisabled?: boolean;
+  onCommentClick?: () => void;
 };
 
 export const CWContentPage = ({
@@ -119,6 +120,7 @@ export const CWContentPage = ({
   sidebarComponentsSkeletonCount = 2,
   setThreadBody,
   editingDisabled,
+  onCommentClick,
 }: ContentPageProps) => {
   const navigate = useNavigate();
   const [urlQueryParams] = useSearchParams();
@@ -261,6 +263,7 @@ export const CWContentPage = ({
             upvoteBtnVisible={!thread?.readOnly}
             upvoteDrawerBtnBelow={true}
             commentBtnVisible={!thread?.readOnly}
+            onCommentClick={onCommentClick}
             // @ts-expect-error <StrictNullChecks/>
             thread={thread}
             totalComments={thread?.numberOfComments}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -6,7 +6,7 @@ import { SessionKeyError } from 'controllers/server/sessions';
 import { GetThreadActionTooltipTextResponse } from 'helpers/threads';
 import { CommentsFeaturedFilterTypes } from 'models/types';
 import type { DeltaStatic } from 'quill';
-import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import app from 'state';
 import {
   useDeleteCommentMutation,
@@ -46,7 +46,6 @@ type CommentsTreeAttrs = {
   canComment: boolean;
   commentSortType: CommentsFeaturedFilterTypes;
   disabledActionsTooltipText?: GetThreadActionTooltipTextResponse;
-  commentsRef?: MutableRefObject<HTMLDivElement | null>;
 };
 
 export const CommentTree = ({
@@ -64,7 +63,6 @@ export const CommentTree = ({
   canComment,
   commentSortType,
   disabledActionsTooltipText,
-  commentsRef,
 }: CommentsTreeAttrs) => {
   const urlParams = new URLSearchParams(location.search);
   const focusCommentsParam = urlParams.get('focusComments') === 'true';
@@ -458,10 +456,7 @@ export const CommentTree = ({
 
         return (
           <React.Fragment key={comment.id + '' + comment.markedAsSpamAt}>
-            <div
-              className={`Comment comment-${comment.id}`}
-              ref={index === commentsList.length - 1 ? commentsRef : null}
-            >
+            <div className={`Comment comment-${comment.id}`}>
               {comment.threadLevel > 0 && (
                 <div className="thread-connectors-container">
                   {Array(comment.threadLevel)

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -6,7 +6,7 @@ import { SessionKeyError } from 'controllers/server/sessions';
 import { GetThreadActionTooltipTextResponse } from 'helpers/threads';
 import { CommentsFeaturedFilterTypes } from 'models/types';
 import type { DeltaStatic } from 'quill';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
 import app from 'state';
 import {
   useDeleteCommentMutation,
@@ -46,6 +46,7 @@ type CommentsTreeAttrs = {
   canComment: boolean;
   commentSortType: CommentsFeaturedFilterTypes;
   disabledActionsTooltipText?: GetThreadActionTooltipTextResponse;
+  commentsRef?: MutableRefObject<HTMLDivElement | null>;
 };
 
 export const CommentTree = ({
@@ -63,6 +64,7 @@ export const CommentTree = ({
   canComment,
   commentSortType,
   disabledActionsTooltipText,
+  commentsRef,
 }: CommentsTreeAttrs) => {
   const urlParams = new URLSearchParams(location.search);
   const focusCommentsParam = urlParams.get('focusComments') === 'true';
@@ -456,7 +458,10 @@ export const CommentTree = ({
 
         return (
           <React.Fragment key={comment.id + '' + comment.markedAsSpamAt}>
-            <div className={`Comment comment-${comment.id}`}>
+            <div
+              className={`Comment comment-${comment.id}`}
+              ref={index === commentsList.length - 1 ? commentsRef : null}
+            >
               {comment.threadLevel > 0 && (
                 <div className="thread-connectors-container">
                   {Array(comment.threadLevel)

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ThreadOptions.tsx
@@ -36,6 +36,7 @@ type OptionsProps = AdminActionsProps & {
   hideUpvoteDrawerButton?: boolean;
   setIsUpvoteDrawerOpen?: Dispatch<SetStateAction<boolean>>;
   editingDisabled?: boolean;
+  onCommentClick?: () => void;
 };
 
 export const ThreadOptions = ({
@@ -64,6 +65,7 @@ export const ThreadOptions = ({
   hideUpvoteDrawerButton = false,
   setIsUpvoteDrawerOpen,
   editingDisabled,
+  onCommentClick,
 }: OptionsProps) => {
   const isCommunityMember = Permissions.isCommunityMember(thread.communityId);
   const userStore = useUserStore();
@@ -128,6 +130,7 @@ export const ThreadOptions = ({
               onClick={(e) => {
                 e.preventDefault();
                 onCommentBtnClick();
+                onCommentClick && onCommentClick();
               }}
               tooltipText={
                 typeof disabledActionsTooltipText === 'function'

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -675,7 +675,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 </div>
               )}
               <CommentTree
-                commentsRef={commentsRef}
                 comments={sortedComments}
                 includeSpams={includeSpamThreads}
                 // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -373,9 +373,10 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const scrollToFirstComment = () => {
     if (commentsRef?.current) {
-      commentsRef.current.scrollIntoView({
+      const ref = document.getElementsByClassName('Body')[0];
+      ref.scrollTo({
+        top: commentsRef?.current.offsetTop - 105,
         behavior: 'smooth',
-        block: 'start',
       });
     }
   };

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -11,7 +11,7 @@ import useTopicGating from 'hooks/useTopicGating';
 import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
 import 'pages/view_thread/index.scss';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import app from 'state';
 import { useFetchCommentsQuery } from 'state/api/comments';
@@ -92,6 +92,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
 
   const user = useUserStore();
+  const commentsRef = useRef<HTMLDivElement | null>(null);
 
   const { isAddedToHomeScreen } = useAppStatus();
 
@@ -370,6 +371,14 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       : getMetaDescription(thread?.body || '');
   const ogImageUrl = app?.chain?.meta?.icon_url || '';
 
+  const ScrollToLastComment = () => {
+    if (commentsRef?.current) {
+      commentsRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    }
+  };
   return (
     // TODO: the editing experience can be improved (we can remove a stale code and make it smooth) - create a ticket
     <>
@@ -459,6 +468,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             isAuthor ||
             !!hasWebLinks
           }
+          onCommentClick={ScrollToLastComment}
           // @ts-expect-error <StrictNullChecks/>
           isSpamThread={!!thread.markedAsSpamAt}
           title={
@@ -665,6 +675,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 </div>
               )}
               <CommentTree
+                commentsRef={commentsRef}
                 comments={sortedComments}
                 includeSpams={includeSpamThreads}
                 // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -371,11 +371,11 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       : getMetaDescription(thread?.body || '');
   const ogImageUrl = app?.chain?.meta?.icon_url || '';
 
-  const ScrollToLastComment = () => {
+  const scrollToFirstComment = () => {
     if (commentsRef?.current) {
       commentsRef.current.scrollIntoView({
         behavior: 'smooth',
-        block: 'center',
+        block: 'start',
       });
     }
   };
@@ -468,7 +468,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
             isAuthor ||
             !!hasWebLinks
           }
-          onCommentClick={ScrollToLastComment}
+          onCommentClick={scrollToFirstComment}
           // @ts-expect-error <StrictNullChecks/>
           isSpamThread={!!thread.markedAsSpamAt}
           title={
@@ -643,7 +643,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
           comments={
             <>
               {comments.length > 0 && (
-                <div className="comments-filter-row">
+                <div className="comments-filter-row" ref={commentsRef}>
                   <Select
                     key={commentSortType}
                     size="compact"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9458

## Description of Changes
- Implemented functionality to scroll to the first comment of a thread when the user clicks on the "X comments"button under the thread.
- Passed a reference to the comment section to the component to enable smooth scrolling behavior.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 