### PR TITLE
editor no longer adds extras lines after pressing enter

### DIFF
--- a/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/markdown_formatted_text.scss
@@ -7,7 +7,6 @@
 
   position: relative;
   word-break: break-word;
-  white-space: pre-wrap;
   @include formatted-text();
   @include collapsible();
   @include hidden-formatting();

--- a/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
+++ b/packages/commonwealth/client/styles/components/react_quill/react_quill_editor.scss
@@ -14,8 +14,6 @@
     .MarkdownPreview {
       min-height: 255px;
       padding: 16px;
-      white-space: pre-wrap; /* This will render single newlines as line breaks */
-      word-wrap: break-word;
     }
 
     .CustomQuillToolbar {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9596 

## Description of Changes
- Editor no longer adds an extra new line after clciking enter

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-deleted some css
## Test Plan
- make a new thread
- give the thread a sentence, press enter twice and enter a new sentence
- confirm that preview reflects the correct spacing
- click Create thread and confirm that your thread has the correct spacing


https://github.com/user-attachments/assets/7f73f7da-b220-4b6d-b383-dfa02a0838ff

