### PR TITLE
ERC20 zero balance check + community switch crash fix

### DIFF
--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -62,10 +62,10 @@ async function updateOrCreateWithAlert(
     },
   });
   const url = community?.ChainNode?.private_url;
-  if (!url)
-    throw new InvalidState(
-      `Chain node url not found on namespace ${namespace}`,
-    );
+  if (!url) {
+    log.warn(`Chain node url not found on namespace ${namespace}`);
+    return;
+  }
 
   const { ticker, decimals } =
     await protocol.contractHelpers.getTokenAttributes(contest_address, url);

--- a/libs/model/src/services/stakeHelper.ts
+++ b/libs/model/src/services/stakeHelper.ts
@@ -77,8 +77,14 @@ export async function getVotingWeight(
       },
       cacheRefresh: true,
     });
+
+    const tokenBalance = balances[address];
+
+    if (BigNumber.from(tokenBalance).lte(0))
+      throw new InvalidState('Insufficient token balance');
+
     const result = commonProtocol.calculateVoteWeight(
-      balances[address],
+      tokenBalance,
       topic.vote_weight_multiplier!,
     );
     // only count full ERC20 tokens

--- a/libs/shared/src/commonProtocol/utils.ts
+++ b/libs/shared/src/commonProtocol/utils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 export const calculateVoteWeight = (
   balance: string, // should be in wei
-  voteWeight: number,
+  voteWeight: number = 0,
 ): BigNumber | null => {
   if (!balance || voteWeight <= 0) return null;
   const bigBalance = BigNumber.from(balance);

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -105,8 +105,14 @@ export const CommentReactionButton = ({
           checkForSessionKeyRevalidationErrors(err);
           return;
         }
+        if ((err.message as string)?.includes('Insufficient token balance')) {
+          notifyError(
+            'You must have the requisite tokens to upvote in this topic',
+          );
+        } else {
+          notifyError('Failed to save reaction');
+        }
         console.error(err?.message);
-        notifyError('Failed to save reaction');
       });
     }
   };

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -121,7 +121,13 @@ export const ReactionButton = ({
           checkForSessionKeyRevalidationErrors(e);
           return;
         }
-        notifyError('Failed to upvote');
+        if ((e.message as string)?.includes('Insufficient token balance')) {
+          notifyError(
+            'You must have the requisite tokens to upvote in this topic',
+          );
+        } else {
+          notifyError('Failed to upvote');
+        }
         console.error(e?.response?.data?.error || e?.message);
       });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9632
Closes: #9610

## Description of Changes
- When voting on erc20 topic, validates that user has non-zero balance in order to react
- Fixes issue where switching communities would result in BigNumber crash
- When chain node not found in contest projection, prints warning instead of throwing error

## Test Plan
- Create ERC20 topic with token you don't have (e.g. Base Sepolia USDC `0x5deac602762362fe5f135fa5904351916053cf70`)
  - Create thread in topic, vote on it– confirm that vote fails
- Switch between multiple communities– confirm that no error shows in page

## Deployment Plan
N/A

## Other Considerations
N/A