### PR TITLE
Fix knock errors when not enabled or not authenticated.

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
+++ b/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
@@ -34,6 +34,11 @@ export const KnockNotifications = () => {
       return;
     }
 
+    if (!user.knockJWT) {
+      console.warn('user knockJWT not set!');
+      return;
+    }
+
     const timezone = getBrowserTimezone();
     async function doAsync() {
       knock.authenticate(`${user.id}`, user.knockJWT);

--- a/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
+++ b/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
@@ -35,7 +35,7 @@ export const KnockNotifications = () => {
     }
 
     if (!user.knockJWT) {
-      console.warn('user knockJWT not set!');
+      console.warn('user knockJWT not set!  Will not attempt to identify.');
       return;
     }
 

--- a/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
+++ b/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.tsx
@@ -30,7 +30,7 @@ export const KnockNotifications = () => {
   const notifButtonRef = useRef(null);
 
   useEffect(() => {
-    if (!user.id) {
+    if (!user.id || !user.isLoggedIn) {
       return;
     }
 
@@ -51,9 +51,9 @@ export const KnockNotifications = () => {
     }
 
     doAsync().catch(console.error);
-  }, [user.email, user.id, user.knockJWT]);
+  }, [user.email, user.id, user.isLoggedIn, user.knockJWT]);
 
-  if (user.id === 0) {
+  if (!user.id || !user.isLoggedIn) {
     return null;
   }
 

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -99,7 +99,7 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
 
             <HelpMenuPopover />
           </div>
-          <KnockNotifications />
+          {user.isLoggedIn && <KnockNotifications />}
         </div>
 
         {user.isLoggedIn && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes:

- https://github.com/hicommonwealth/commonwealth/issues/9614
- https://github.com/hicommonwealth/commonwealth/issues/9643

@masvelio and @kurtisassad have two points that I wanted to address:

> is this i proper solution? Platform team mentioned about env flag not being set correctly?

Yes.  The flag should definitely be set but the code shouldn't *break* when the flag is off.

> Yeah I agree with Marcin here. Both knockInAppNotifications and knockPushNotifications are not set on the demo environment. I will set them now

Yes.  Definitely set the flag BUT the code also shouldn't break when the flag is off.

The change by @timolegros broke because the component would be mounted, then the useEffect would be called which would then identify with knock but the feature toggle was off.

This fixes the useEffect call. 


## Description of Changes
- Log it and don't attempt to identify.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- It's a small PR but if you want to test just stay unauthenticated OR don't enable knock. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 