### PR TITLE
popover no longer blank if no upvotes

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWUpvoteSmall.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWUpvoteSmall.tsx
@@ -14,6 +14,7 @@ interface CWUpvoteSmallProps {
   popoverContent: JSX.Element;
   isThreadArchived?: boolean;
   tooltipText?: string;
+  reactors?: string[];
 }
 
 const CWUpvoteSmall = ({
@@ -24,6 +25,7 @@ const CWUpvoteSmall = ({
   popoverContent,
   tooltipText = '',
   isThreadArchived,
+  reactors = [],
 }: CWUpvoteSmallProps) => {
   const popoverProps = usePopover();
   const handleClick = (e) => {
@@ -51,7 +53,9 @@ const CWUpvoteSmall = ({
               disabled={disabled}
               onClick={handleClick}
             />
-            <CWPopover body={popoverContent} {...popoverProps} />
+            {reactors.length > 0 && (
+              <CWPopover body={popoverContent} {...popoverProps} />
+            )}
           </>
         ) : (
           <CWThreadAction

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -140,6 +140,7 @@ export const ReactionButton = ({
             reactors,
           })}
           tooltipText={tooltipText}
+          reactors={reactors}
         />
       ) : tooltipText ? (
         <TooltipWrapper disabled={disabled} text={tooltipText}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9647 

## Description of Changes
- popover no longer blank if no upvotes

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added logic to only trigger popover when  reactors.length > 0.
## Test Plan
- go to a thread with no upvotes
- hover over the upvotes and confirm that there is no longer a blank popever
- click the upvote
- hover over upvotes again and confirm you see a popover with your name in it. 


https://github.com/user-attachments/assets/76877b7e-567f-482e-b2dd-4f0405394352

