### PR TITLE
Adding custom stages should not delete snapshot spaces

### DIFF
--- a/libs/model/src/community/UpdateCommunity.command.ts
+++ b/libs/model/src/community/UpdateCommunity.command.ts
@@ -57,22 +57,32 @@ export function UpdateCommunity(): Command<
       mustExist('Community', community); // if authorized as admin, community is always found
 
       // Handle single string case and undefined case
-      const snapshots = !snapshot
-        ? []
-        : typeof snapshot === 'string'
-          ? [snapshot]
-          : snapshot;
-      if (snapshots.length > 0 && community.base !== ChainBase.Ethereum)
-        throw new InvalidInput(UpdateCommunityErrors.SnapshotOnlyOnEthereum);
+      if (snapshot !== undefined) {
+        const snapshots = typeof snapshot === 'string' ? [snapshot] : snapshot;
 
-      const newSpaces = snapshots.filter(
-        (s) => !community.snapshot_spaces.includes(s),
-      );
-      for (const space of newSpaces) {
-        if (!(await checkSnapshotObjectExists('space', space)))
-          throw new InvalidInput(UpdateCommunityErrors.SnapshotNotFound);
+        if (snapshots.length > 0 && community.base !== ChainBase.Ethereum) {
+          throw new InvalidInput(UpdateCommunityErrors.SnapshotOnlyOnEthereum);
+        }
+
+        if (snapshots.length) {
+          const newSpaces = snapshots.filter(
+            (s) => !community.snapshot_spaces.includes(s),
+          );
+
+          for (const space of newSpaces) {
+            if (!(await checkSnapshotObjectExists('space', space))) {
+              throw new InvalidInput(UpdateCommunityErrors.SnapshotNotFound);
+            }
+          }
+
+          community.snapshot_spaces = [
+            ...community.snapshot_spaces,
+            ...newSpaces,
+          ];
+        } else {
+          community.snapshot_spaces = [];
+        }
       }
-
       if (default_page && !has_homepage)
         throw new InvalidInput(UpdateCommunityErrors.InvalidDefaultPage);
 
@@ -91,7 +101,6 @@ export function UpdateCommunity(): Command<
       }
 
       default_page && (community.default_page = default_page);
-      community.snapshot_spaces = snapshots;
       name && (community.name = name);
       description && (community.description = description);
       default_symbol && (community.default_symbol = default_symbol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #7424

## Description of Changes
- Fixed the issue where adding Custom Stages through the Community Profile was clearing Snapshot spaces when returning to Integrations.
- Updated the logic to handle empty snapshot inputs while preserving existing Snapshot spaces.


## Test Plan
- Verified the behavior manually by:
- Adding Snapshot spaces, then adding Custom Stages, and checking the Snapshot spaces remained intact.
- Testing multiple scenarios (no snapshot, empty snapshot) to ensure proper handling.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 