### PR TITLE
Remaining Raymond UI bug fixes / scroll to correct comment

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/CommentTree.tsx
@@ -159,29 +159,22 @@ export const CommentTree = ({
     isLoggedIn: user.isLoggedIn,
   });
 
-  const scrollToRef = useRef(null);
-  const scrollToEditorRef = useRef(null);
+  const commentRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [expandedComment, setExpandedComment] = useState<number | null>(null);
 
-  const scrollToElement = () => {
-    if (scrollToRef.current) {
-      // @ts-expect-error <StrictNullChecks/>
-      scrollToRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-      });
-    }
-  };
-
-  const scrollToEditor = () => {
-    // @ts-expect-error <StrictNullChecks/>
-    scrollToEditorRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const handleScrollToComment = (index: number) => {
+    setExpandedComment(index);
   };
 
   useEffect(() => {
-    if (isReplying) {
-      scrollToEditor();
+    if (expandedComment !== null && commentRefs.current[expandedComment]) {
+      commentRefs.current[expandedComment]?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest',
+      });
     }
-  }, [isReplying]);
+  }, [expandedComment]);
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const handleIsReplying = (isReplying: boolean, id?: number) => {
@@ -467,7 +460,12 @@ export const CommentTree = ({
         const nextCommentThreadLevel = nextComment?.threadLevel;
 
         return (
-          <React.Fragment key={comment.id + '' + comment.markedAsSpamAt}>
+          <div
+            key={comment.id + '' + comment.markedAsSpamAt}
+            ref={(el) => {
+              commentRefs.current[index] = el;
+            }}
+          >
             <div className={`Comment comment-${comment.id}`}>
               {comment.threadLevel > 0 && (
                 <div className="thread-connectors-container">
@@ -522,7 +520,7 @@ export const CommentTree = ({
                 onReply={() => {
                   setParentCommentId(comment.id);
                   setIsReplying(true);
-                  scrollToElement();
+                  handleScrollToComment(index);
                 }}
                 onDelete={() => handleDeleteComment(comment)}
                 isSpam={!!comment.markedAsSpamAt}
@@ -534,7 +532,6 @@ export const CommentTree = ({
                 shareURL={`${window.location.origin}${window.location.pathname}?comment=${comment.id}`}
               />
             </div>
-            <div ref={scrollToRef}></div>
             {isReplying && parentCommentId === comment.id && (
               <CreateComment
                 handleIsReplying={handleIsReplying}
@@ -549,7 +546,7 @@ export const CommentTree = ({
                 }
               />
             )}
-          </React.Fragment>
+          </div>
         );
       })}
     </div>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/helpers.ts
@@ -10,7 +10,11 @@ export const jumpHighlightComment = (commentId: number) => {
     commentEle.classList.remove('highlighted');
     commentEle.classList.remove('highlightAnimationComplete');
     // scroll to comment
-    commentEle.scrollIntoView();
+    commentEle.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest',
+    });
     // add new highlight classes
     commentEle.classList.add('highlighted');
     setTimeout(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9627

## Description of Changes
- Fixed scrolling behavior after creating a comment to ensure the new comment is correctly positioned on screen.
- Corrected scrolling issue when replying to a child comment so that the comment box remains within the viewport.

## "How We Fixed It"
- Adjusted the scroll logic to ensure the correct element is targeted and scrolled into view.
- Ensured that DOM is updated before triggering the scroll, preventing the wrong position.

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 