### PR TITLE
Add copy button to erc20 token address

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/TokenBanner/TokenBanner.scss
+++ b/packages/commonwealth/client/scripts/views/components/TokenBanner/TokenBanner.scss
@@ -3,6 +3,7 @@
 .TokenBanner {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 24px;
   border-radius: 6px;
   border: 1px solid $neutral-200;
@@ -56,6 +57,20 @@
     margin-left: 8px;
     .vote-weight-label {
       color: $neutral-500;
+    }
+  }
+}
+
+.TokenBannerPopover {
+  .token-description {
+    display: inline-block;
+    line-height: 2;
+    align-items: center;
+
+    .token-address {
+      word-break: break-all;
+      font-weight: 500;
+      margin-right: 8px;
     }
   }
 }

--- a/packages/commonwealth/client/scripts/views/components/TokenBanner/TokenBanner.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TokenBanner/TokenBanner.tsx
@@ -85,19 +85,18 @@ const TokenBanner = ({
       )}
 
       {popover && (
-        <>
-          <CWIconButton
-            iconName="infoEmpty"
-            buttonSize="sm"
-            onMouseEnter={popoverProps.handleInteraction}
-            onMouseLeave={popoverProps.handleInteraction}
-          />
+        <div
+          onMouseEnter={popoverProps.handleInteraction}
+          onMouseLeave={popoverProps.handleInteraction}
+        >
+          <CWIconButton iconName="infoEmpty" buttonSize="sm" />
           <CWPopover
+            className="TokenBannerPopover"
             title={<>{popover.title}</>}
             body={popover.body}
             {...popoverProps}
           />
-        </>
+        </div>
       )}
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -353,9 +353,12 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                           </span>
                           <CWIconButton
                             iconName="copy"
-                            onClick={() =>
-                              saveToClipboard(topicObj.token_address!, true)
-                            }
+                            onClick={() => {
+                              saveToClipboard(
+                                topicObj.token_address!,
+                                true,
+                              ).catch(console.error);
+                            }}
                           />
                         </CWText>
                       </>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -19,8 +19,6 @@ import { ThreadCard } from './ThreadCard';
 import { sortByFeaturedFilter, sortPinned } from './helpers';
 
 import { slugify, splitAndDecodeURL } from '@hicommonwealth/shared';
-import { useGetERC20BalanceQuery } from 'client/scripts/state/api/tokens';
-import { formatAddressShort } from 'helpers';
 import { getThreadActionTooltipText } from 'helpers/threads';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import { useFlag } from 'hooks/useFlag';
@@ -29,8 +27,10 @@ import useTopicGating from 'hooks/useTopicGating';
 import 'pages/discussions/index.scss';
 import { useGetCommunityByIdQuery } from 'state/api/communities';
 import { useFetchCustomDomainQuery } from 'state/api/configuration';
+import { useGetERC20BalanceQuery } from 'state/api/tokens';
 import useUserStore from 'state/ui/user';
 import Permissions from 'utils/Permissions';
+import { saveToClipboard } from 'utils/clipboard';
 import { checkIsTopicInContest } from 'views/components/NewThreadFormLegacy/helpers';
 import TokenBanner from 'views/components/TokenBanner';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
@@ -40,6 +40,7 @@ import useTokenMetadataQuery from '../../../state/api/tokens/getTokenMetadata';
 import { AdminOnboardingSlider } from '../../components/AdminOnboardingSlider';
 import { UserTrainingSlider } from '../../components/UserTrainingSlider';
 import { CWText } from '../../components/component_kit/cw_text';
+import CWIconButton from '../../components/component_kit/new_designs/CWIconButton';
 import { DiscussionsFeedDiscovery } from './DiscussionsFeedDiscovery';
 import { EmptyThreadsPlaceholder } from './EmptyThreadsPlaceholder';
 
@@ -344,10 +345,20 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                   popover={{
                     title: tokenMetadata?.name,
                     body: (
-                      <CWText type="b2">
-                        This topic has weighted voting enabled using{' '}
-                        {formatAddressShort(topicObj.token_address!, 6, 6)}
-                      </CWText>
+                      <>
+                        <CWText type="b2" className="token-description">
+                          This topic has weighted voting enabled using{' '}
+                          <span className="token-address">
+                            {topicObj.token_address}
+                          </span>
+                          <CWIconButton
+                            iconName="copy"
+                            onClick={() =>
+                              saveToClipboard(topicObj.token_address!, true)
+                            }
+                          />
+                        </CWText>
+                      </>
                     ),
                   }}
                 />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9679

## Description of Changes
- added copy button to the popover

## Test Plan
- open topic page with erc20 token enabled
- hover over the info icon
- full address of erc20 token should be visible + possibility to copy it to the clipboard

![image](https://github.com/user-attachments/assets/17af84d6-6370-4c6d-877e-9475467e287a)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a