### PR TITLE
user no longer redirected to /undefinded/discussion/etc from profile

### DIFF
--- a/packages/commonwealth/client/scripts/models/Comment.ts
+++ b/packages/commonwealth/client/scripts/models/Comment.ts
@@ -49,6 +49,7 @@ export class Comment<T extends IUniqueId> {
     text,
     author,
     Address,
+    community_id,
     thread_id,
     parent_id,
     reactions,
@@ -65,7 +66,7 @@ export class Comment<T extends IUniqueId> {
     content_url,
   }) {
     const versionHistory = CommentVersionHistories;
-    this.communityId = Address?.community_id;
+    this.communityId = community_id;
     this.author = Address?.address || author;
     this.text = deleted_at?.length > 0 ? '[deleted]' : getDecodedString(text);
     this.versionHistory = versionHistory;

--- a/packages/commonwealth/client/scripts/models/Comment.ts
+++ b/packages/commonwealth/client/scripts/models/Comment.ts
@@ -48,7 +48,6 @@ export class Comment<T extends IUniqueId> {
     id,
     text,
     author,
-    community_id,
     Address,
     thread_id,
     parent_id,

--- a/packages/commonwealth/client/scripts/models/Comment.ts
+++ b/packages/commonwealth/client/scripts/models/Comment.ts
@@ -66,7 +66,7 @@ export class Comment<T extends IUniqueId> {
     content_url,
   }) {
     const versionHistory = CommentVersionHistories;
-    this.communityId = community_id;
+    this.communityId = Address?.community_id;
     this.author = Address?.address || author;
     this.text = deleted_at?.length > 0 ? '[deleted]' : getDecodedString(text);
     this.versionHistory = versionHistory;

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -437,7 +437,6 @@ export class Thread implements IUniqueId {
       (rc) =>
         new Comment({
           authorChain: this.authorCommunity,
-          community_id: this.authorCommunity,
           id: rc?.id,
           thread_id: id,
           author: rc?.address,

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -437,6 +437,7 @@ export class Thread implements IUniqueId {
       (rc) =>
         new Comment({
           authorChain: this.authorCommunity,
+          community_id: this.authorCommunity,
           id: rc?.id,
           thread_id: id,
           author: rc?.address,

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -49,18 +49,19 @@ const Profile = ({ userId }: ProfileProps) => {
       setProfile(
         new NewProfile({ ...data.profile, userId, isOwner: isOwner ?? false }),
       );
-
+      // @ts-expect-error <StrictNullChecks/>
       setThreads(data.threads.map((t) => new Thread(t)));
-
+      // @ts-expect-error <StrictNullChecks/>
       const responseComments = data.comments.map((c) => new Comment(c));
 
       const commentsWithAssociatedThread = responseComments.map((c) => {
         const thread = data.commentThreads.find(
+          // @ts-expect-error <StrictNullChecks/>
           (t) => t.id === parseInt(c.threadId, 10),
         );
         return { ...c, thread };
       });
-
+      // @ts-expect-error <StrictNullChecks/>
       setComments(commentsWithAssociatedThread);
       setIsOwner(data.isOwner);
       setErrorCode(ProfileError.None);

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -30,7 +30,6 @@ const Profile = ({ userId }: ProfileProps) => {
   const [threads, setThreads] = useState<Thread[]>([]);
   const [isOwner, setIsOwner] = useState<boolean>();
   const [comments, setComments] = useState<CommentWithAssociatedThread[]>([]);
-
   const { data, error, isLoading } = useFetchProfileByIdQuery({
     userId,
     apiCallEnabled: !!userId,

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -49,19 +49,18 @@ const Profile = ({ userId }: ProfileProps) => {
       setProfile(
         new NewProfile({ ...data.profile, userId, isOwner: isOwner ?? false }),
       );
-      // @ts-expect-error <StrictNullChecks/>
+
       setThreads(data.threads.map((t) => new Thread(t)));
 
-      // @ts-expect-error <StrictNullChecks/>
       const responseComments = data.comments.map((c) => new Comment(c));
+
       const commentsWithAssociatedThread = responseComments.map((c) => {
         const thread = data.commentThreads.find(
-          // @ts-expect-error <StrictNullChecks/>
           (t) => t.id === parseInt(c.threadId, 10),
         );
         return { ...c, thread };
       });
-      // @ts-expect-error <StrictNullChecks/>
+
       setComments(commentsWithAssociatedThread);
       setIsOwner(data.isOwner);
       setErrorCode(ProfileError.None);

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -23,7 +23,6 @@ type ProfileActivityRowProps = {
 const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
   const { createdAt, author, id } = activity;
-  // @ts-expect-error: Allows usage of any
   const communityId =
     (activity as any)?.thread?.community_id || activity?.communityId;
   let title: string;

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -22,7 +22,9 @@ type ProfileActivityRowProps = {
 
 const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
-  const { communityId, createdAt, author, id } = activity;
+  const { createdAt, author, id } = activity;
+  const communityId =
+    (activity as any)?.thread?.community_id || activity?.communityId;
   let title: string;
   let body: string = '';
   if (activity instanceof Thread) {

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -16,6 +16,9 @@ import { CWText } from '../component_kit/cw_text';
 import { CWTag } from '../component_kit/new_designs/CWTag';
 import type { CommentWithAssociatedThread } from './ProfileActivity';
 
+type CommentWithThreadCommunity = CommentWithAssociatedThread & {
+  thread?: { community_id?: string };
+};
 type ProfileActivityRowProps = {
   activity: CommentWithAssociatedThread | Thread;
 };
@@ -25,7 +28,8 @@ const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
   const { createdAt, author, id } = activity;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const communityId =
-    (activity as any)?.thread?.community_id || activity?.communityId;
+    (activity as CommentWithThreadCommunity)?.thread?.community_id ||
+    activity?.communityId;
   let title: string;
   let body: string = '';
   if (activity instanceof Thread) {

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -23,6 +23,7 @@ type ProfileActivityRowProps = {
 const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
   const { createdAt, author, id } = activity;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const communityId =
     (activity as any)?.thread?.community_id || activity?.communityId;
   let title: string;

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivityRow.tsx
@@ -23,6 +23,7 @@ type ProfileActivityRowProps = {
 const ProfileActivityRow = ({ activity }: ProfileActivityRowProps) => {
   const navigate = useCommonNavigate();
   const { createdAt, author, id } = activity;
+  // @ts-expect-error: Allows usage of any
   const communityId =
     (activity as any)?.thread?.community_id || activity?.communityId;
   let title: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9681 

## Description of Changes
user no longer redirected to /undefinded/discussion/etc from profile

Previously if a user is in their profile and they try to click into a thread they created they would be correctly redirected, but if they tried to click into a comment they made they would be taken to /undefined/discussion/etc. because the communityId was incorrectly set when creating `new Comment` in `ProfileActivityRow`

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the model to use `Address?.community_id` instead of just `community_id`
-cleaned up unused // @ts-expect-error <StrictNullChecks/> in `Profile` that were causing an error in the file

## Test Plan
- go to your profile
- in All Activity click on a thread you commented on
- confirm that you are redirected to that comment
- go back to All Activity and click on a thread that you made
- confirm that you are redirected to that thread

NOTE: You can test the error on master to see where it was breaking

