### PR TITLE
thread header now has more space away from tabs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
@@ -77,6 +77,10 @@
     width: 100%;
 
     @include mainBodyStyles;
+
+    .cw-tabs-row-container {
+      padding-bottom: 20px;
+    }
   }
 
   .hidden {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9448 

## Description of Changes
Thread header now has more space on the top, away from tabs in mobile view

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `padding-bottom: 20px` to `.cw-tabs-row-container`
## Test Plan
- go to a thread on mobile and confirm that there is now more space between the tabs and the thread header
  