### PR TITLE
topics now show correct # threads

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -363,7 +363,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                   isOnArchivePage
                     ? filteredThreads.length || 0
                     : threads
-                      ? community?.lifetime_thread_count || 0
+                      ? threads.length || 0
                       : 0
                 }
                 isIncludingSpamThreads={includeSpamThreads}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9419 

## Description of Changes
- user now sees correct number of threads within each topic, not the total number of threads made by the community over its lifetime
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
changed the logic to look at `threads.length` instead of `community.lifetime_thread_count`
## Test Plan
-click around in topics and confirm that the number of discussions changes for each topic
-confirm that that number is correct/count threads in topic


https://github.com/user-attachments/assets/ce87e91c-6a9c-4433-8b25-9a5643961482

