### PR TITLE
remove the thread and comment preview from ViewUpvotesDrawer

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
@@ -33,8 +33,6 @@ export const ViewCommentUpvotesDrawer = ({
     <ViewUpvotesDrawer
       isOpen={isOpen}
       setIsOpen={setIsOpen}
-      // @ts-expect-error <StrictNullChecks/>
-      contentBody={comment.text}
       header="Comment upvotes"
       // @ts-expect-error <StrictNullChecks/>
       reactorData={reactorData}

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
@@ -33,7 +33,6 @@ export const ViewThreadUpvotesDrawer = ({
     <ViewUpvotesDrawer
       isOpen={isOpen}
       setIsOpen={setIsOpen}
-      contentBody={thread.body}
       header="Thread upvotes"
       reactorData={reactorData}
       // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
@@ -4,7 +4,6 @@ import AddressInfo from 'models/AddressInfo';
 import MinimumProfile from 'models/MinimumProfile';
 import React, { Dispatch, SetStateAction } from 'react';
 import app from 'state';
-import { MarkdownViewerWithFallback } from 'views/components/MarkdownViewerWithFallback/MarkdownViewerWithFallback';
 import { User } from 'views/components/user/user';
 import { AuthorAndPublishInfo } from '../../../pages/discussions/ThreadCard/AuthorAndPublishInfo';
 import { CWText } from '../../component_kit/cw_text';
@@ -21,7 +20,6 @@ type Profile = Account | AddressInfo | MinimumProfile;
 type ViewUpvotesDrawerProps = {
   header: string;
   reactorData: any[];
-  contentBody: string;
   author: Profile;
   publishDate: moment.Moment;
   isOpen: boolean;
@@ -61,7 +59,6 @@ const columns: CWTableColumnInfo[] = [
 export const ViewUpvotesDrawer = ({
   header,
   reactorData,
-  contentBody,
   author,
   publishDate,
   isOpen,
@@ -139,12 +136,6 @@ export const ViewUpvotesDrawer = ({
                 showUserAddressWithInfo={false}
                 // @ts-expect-error <StrictNullChecks/>
                 profile={profile}
-              />
-            </div>
-            <div className="upvoted-content-body">
-              <MarkdownViewerWithFallback
-                markdown={contentBody}
-                cutoffLines={10}
               />
             </div>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9447

## Description of Changes
- Adds FIXME widget to TODO page.
- remove the content contentBody from the ViewUpvotesDrawer 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
remove the content contentBody from the ViewUpvotesDrawer 

## Test Plan

Go to thread and click the "ViewUpvotes" and you will see the drawer without comment and thread preview only table will be visible.

 