### PR TITLE
created the new step in start terms and service

### DIFF
--- a/packages/commonwealth/client/scripts/navigation/GeneralRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/GeneralRoutes.tsx
@@ -8,13 +8,12 @@ const PrivacyPage = lazy(() => import('views/pages/privacy'));
 const ComponentsShowcasePage = lazy(
   () => import('views/pages/ComponentsShowcase'),
 );
-const isInIframe = window.self !== window.top;
 
 const GeneralRoutes = () => [
   <Route
     key="/terms"
     path="/terms"
-    element={withLayout(TermsPage, { type: isInIframe ? 'blank' : 'common' })}
+    element={withLayout(TermsPage, { type: 'common' })}
   />,
   <Route
     key="/privacy"

--- a/packages/commonwealth/client/scripts/navigation/GeneralRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/GeneralRoutes.tsx
@@ -8,12 +8,13 @@ const PrivacyPage = lazy(() => import('views/pages/privacy'));
 const ComponentsShowcasePage = lazy(
   () => import('views/pages/ComponentsShowcase'),
 );
+const isInIframe = window.self !== window.top;
 
 const GeneralRoutes = () => [
   <Route
     key="/terms"
     path="/terms"
-    element={withLayout(TermsPage, { type: 'common' })}
+    element={withLayout(TermsPage, { type: isInIframe ? 'blank' : 'common' })}
   />,
   <Route
     key="/privacy"

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.scss
@@ -3,6 +3,22 @@
 .WelcomeOnboardModal {
   overflow-y: scroll;
   position: relative;
+  .logo-container {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 10px 0px;
+    .logo {
+      height: auto;
+      margin: 0 auto;
+      width: 227px;
+
+      @include extraSmall {
+        display: none;
+      }
+    }
+  }
 
   .content {
     .close-btn {
@@ -18,6 +34,13 @@
       }
     }
 
+    .modal-heading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 10px 0px;
+    }
+
     padding: 48px;
 
     @include extraSmall {
@@ -26,7 +49,7 @@
 
     .progress {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
       gap: 8px;
       padding-bottom: 18px;
 

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -1,3 +1,4 @@
+import commonLogo from 'assets/img/branding/common-logo.svg';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
@@ -7,11 +8,12 @@ import './WelcomeOnboardModal.scss';
 import { JoinCommunityStep } from './steps/JoinCommunityStep';
 import { PersonalInformationStep } from './steps/PersonalInformationStep';
 import { PreferencesStep } from './steps/PreferencesStep';
+import { TermsOfServicesStep } from './steps/TermsOfServicesStep';
 import { WelcomeOnboardModalProps, WelcomeOnboardModalSteps } from './types';
 
 const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
   const [activeStep, setActiveStep] = useState<WelcomeOnboardModalSteps>(
-    WelcomeOnboardModalSteps.PersonalInformation,
+    WelcomeOnboardModalSteps.TermsOfServices,
   );
 
   const handleClose = () => {
@@ -23,9 +25,23 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
 
   const getCurrentStep = () => {
     switch (activeStep) {
-      case WelcomeOnboardModalSteps.PersonalInformation: {
+      case WelcomeOnboardModalSteps.TermsOfServices: {
         return {
           index: 1,
+          title: 'Terms of Service',
+          component: (
+            <TermsOfServicesStep
+              onComplete={() => {
+                setActiveStep(WelcomeOnboardModalSteps.PersonalInformation);
+              }}
+            />
+          ),
+        };
+      }
+      case WelcomeOnboardModalSteps.PersonalInformation: {
+        return {
+          index: 2,
+
           title: 'Welcome to Common!',
           component: (
             <PersonalInformationStep
@@ -39,7 +55,7 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
 
       case WelcomeOnboardModalSteps.Preferences: {
         return {
-          index: 2,
+          index: 3,
           title: 'Customize your experience',
           component: (
             <PreferencesStep
@@ -53,7 +69,7 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
 
       case WelcomeOnboardModalSteps.JoinCommunity: {
         return {
-          index: 3,
+          index: 4,
           title: 'Join a community',
           component: <JoinCommunityStep onComplete={handleClose} />,
         };
@@ -73,13 +89,18 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
             iconName="close"
             onClick={handleClose}
             className="close-btn"
-            disabled={
-              activeStep === WelcomeOnboardModalSteps.PersonalInformation
-            }
+            disabled={activeStep === WelcomeOnboardModalSteps.TermsOfServices}
           />
-          <CWText type="h2">{getCurrentStep().title}</CWText>
+
+          <div className="logo-container">
+            <img src={commonLogo} className="logo" />
+          </div>
+
+          <CWText type="h2" className="modal-heading">
+            {getCurrentStep().title}
+          </CWText>
           <div className="progress">
-            {[1, 2, 3].map((step) => (
+            {[1, 2, 3, 4].map((step) => (
               <span
                 key={step}
                 className={clsx({ completed: getCurrentStep().index >= step })}

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -4,12 +4,13 @@ import React, { useState } from 'react';
 import { CWIcon } from '../../components/component_kit/cw_icons/cw_icon';
 import { CWText } from '../../components/component_kit/cw_text';
 import { CWModal } from '../../components/component_kit/new_designs/CWModal';
-import './WelcomeOnboardModal.scss';
 import { JoinCommunityStep } from './steps/JoinCommunityStep';
 import { PersonalInformationStep } from './steps/PersonalInformationStep';
 import { PreferencesStep } from './steps/PreferencesStep';
 import { TermsOfServicesStep } from './steps/TermsOfServicesStep';
 import { WelcomeOnboardModalProps, WelcomeOnboardModalSteps } from './types';
+
+import './WelcomeOnboardModal.scss';
 
 const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
   const [activeStep, setActiveStep] = useState<WelcomeOnboardModalSteps>(

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.scss
@@ -23,9 +23,9 @@
       width: 175px;
     }
   }
-  .terms-frame {
+  .terms-container {
     width: 100%;
-    min-height: 300px;
+    max-height: 300px;
     border: 1px solid #e0dfe1;
     border-radius: 6px;
     overflow: auto;

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.scss
@@ -1,0 +1,58 @@
+@import '../../../../../../styles/shared.scss';
+
+.TermsOfServicesStep {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 16px;
+
+  .h4 {
+    color: $neutral-600;
+
+    .b1 {
+      color: $neutral-500;
+    }
+  }
+
+  .logo {
+    height: auto;
+    margin: auto;
+    width: 227px;
+
+    @include extraSmall {
+      width: 175px;
+    }
+  }
+  .terms-frame {
+    width: 100%;
+    min-height: 300px;
+    border: 1px solid #e0dfe1;
+    border-radius: 6px;
+    overflow: auto;
+  }
+
+  .notification-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+
+  .button-container {
+    display: flex;
+    gap: 8px;
+  }
+
+  .footer {
+    display: block;
+
+    a,
+    a:visited,
+    a:active,
+    a:hover {
+      color: $primary-600;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 
+import TermsPage from 'client/scripts/views/pages/terms';
 import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
@@ -37,13 +38,10 @@ const TermsOfServicesStep = ({ onComplete }: TermsOfServicesStepProps) => {
       {({ watch }) => {
         const isTermsChecked = watch('enableTermsOfServices');
         return (
-          <React.Fragment>
-            <iframe
-              className="terms-frame"
-              allowFullScreen={true}
-              src={`${window.location.origin}/terms`}
-              loading="eager"
-            />
+          <>
+            <div className="terms-container">
+              <TermsPage />
+            </div>
 
             <div className="notification-section">
               <CWCheckbox
@@ -67,7 +65,7 @@ const TermsOfServicesStep = ({ onComplete }: TermsOfServicesStepProps) => {
               For questions, please review our&nbsp;
               <Link to="/privacy">Privacy Policy</Link>
             </CWText>
-          </React.Fragment>
+          </>
         );
       }}
     </CWForm>

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/TermsOfServicesStep.tsx
@@ -1,0 +1,77 @@
+import React, { useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import {
+  CWForm,
+  CWFormRef,
+} from 'views/components/component_kit/new_designs/CWForm';
+import { termsOfServicesFormValidation } from './validations';
+
+import './TermsOfServicesStep.scss';
+
+type TermsOfServicesStepProps = {
+  onComplete: () => void;
+};
+
+const TermsOfServicesStep = ({ onComplete }: TermsOfServicesStepProps) => {
+  const formMethodsRef = useRef<CWFormRef>();
+
+  const handleSubmit = () => {
+    onComplete();
+  };
+
+  return (
+    <CWForm
+      // @ts-expect-error <StrictNullChecks/>
+      ref={formMethodsRef}
+      className="TermsOfServicesStep"
+      initialValues={{
+        enableTermsOfServices: true,
+      }}
+      validationSchema={termsOfServicesFormValidation}
+      onSubmit={handleSubmit}
+    >
+      {({ watch }) => {
+        const isTermsChecked = watch('enableTermsOfServices');
+        return (
+          <React.Fragment>
+            <iframe
+              className="terms-frame"
+              allowFullScreen={true}
+              src={`${window.location.origin}/terms`}
+              loading="eager"
+            />
+
+            <div className="notification-section">
+              <CWCheckbox
+                name="enableTermsOfServices"
+                hookToForm
+                label="I agree to the Common Terms of Service"
+              />
+            </div>
+
+            <CWButton
+              label="Next"
+              buttonWidth="full"
+              type="submit"
+              disabled={!isTermsChecked}
+            />
+
+            <CWText isCentered className="footer">
+              We will never share your contact information with third-party
+              services.
+              <br />
+              For questions, please review our&nbsp;
+              <Link to="/privacy">Privacy Policy</Link>
+            </CWText>
+          </React.Fragment>
+        );
+      }}
+    </CWForm>
+  );
+};
+
+export { TermsOfServicesStep };

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/index.ts
@@ -1,0 +1,1 @@
+export { TermsOfServicesStep } from './TermsOfServicesStep';

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/validations.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/TermsOfServicesStep/validations.ts
@@ -1,0 +1,5 @@
+import z from 'zod';
+
+export const termsOfServicesFormValidation = z.object({
+  enableTermsOfServices: z.boolean(),
+});

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/types.ts
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/types.ts
@@ -5,6 +5,7 @@ export type WelcomeOnboardModalProps = {
 
 export enum WelcomeOnboardModalSteps {
   PersonalInformation = 'PersonalInformation',
+  TermsOfServices = 'TermsOfServices',
   Preferences = 'Preferences',
   JoinCommunity = 'JoinCommunity',
 }

--- a/packages/commonwealth/client/styles/pages/privacy_and_terms.scss
+++ b/packages/commonwealth/client/styles/pages/privacy_and_terms.scss
@@ -98,7 +98,8 @@
     display: flex;
     flex-direction: column;
     gap: 16px;
-    width: 736px;
+    width: 100%;
+    max-width: 736px;
 
     @include smallInclusive {
       width: 100%;

--- a/packages/commonwealth/client/styles/pages/privacy_and_terms.scss
+++ b/packages/commonwealth/client/styles/pages/privacy_and_terms.scss
@@ -84,6 +84,8 @@
   flex-direction: column;
   padding: 24px;
   margin-top: 30px;
+  height: 100%;
+  overflow-y: auto;
 
   .link {
     text-decoration: underline;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9243 

## Description of Changes
- Created a modal step in the onboarding process post account creation which directly displays the ToS in the onboarding modal
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-  Created a new step on WelcomeOnBoardModal 
- show the user  ToS in iframe  user need to checked the checkbox in order to move next step.
- Hide layout on /terms page when load in iframe 


## Test Plan
  -  click on create account and after authentication it will redirect you modal . 
  -1st step of modal is to accept ToS .
  
  

https://github.com/user-attachments/assets/1c435ee3-e2db-4285-9b67-ea222023a7d3

