### PR TITLE
weighted topic voting power shows as 0

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/ERC20Abi.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Abi/ERC20Abi.ts
@@ -16,4 +16,11 @@ export const Erc20Abi = [
     name: 'balanceOf',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
   },
+  {
+    inputs: [],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'decimals',
+    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
+  },
 ];

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/ERC20Helper.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/ERC20Helper.ts
@@ -1,6 +1,6 @@
-import Web3 from 'web3';
 import { Erc20Abi } from './Abi/ERC20Abi';
 import ContractBase from './ContractBase';
+
 class ERC20Helper extends ContractBase {
   constructor(contractAddress: string, rpc: string) {
     super(contractAddress, Erc20Abi, rpc);
@@ -11,7 +11,11 @@ class ERC20Helper extends ContractBase {
     }
     const balance = await this.contract.methods.balanceOf(userAddress).call();
 
-    return Web3.utils.fromWei(balance, 'ether');
+    const decimals = await this.contract.methods.decimals().call();
+
+    const adjustedBalance = Number(balance) / 10 ** Number(decimals);
+
+    return adjustedBalance.toString();
   }
 }
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/FundContestDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/FundContestDrawer.tsx
@@ -39,7 +39,6 @@ const FundContestDrawer = ({
   const [txHash, setTxHash] = useState('');
 
   const chainRpc = app?.chain?.meta?.ChainNode?.url || '';
-  const chainNodeId = app?.chain?.meta?.ChainNode?.id || 0;
   const ethChainId = app?.chain?.meta?.ChainNode?.eth_chain_id || 0;
 
   const { addressOptions, selectedAddress, setSelectedAddress } =
@@ -59,7 +58,6 @@ const FundContestDrawer = ({
     contestAddress,
     chainRpc,
     ethChainId,
-    chainNodeId,
     userAddress: selectedAddress.value,
   });
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/useFundContestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/useFundContestForm.ts
@@ -5,7 +5,10 @@ import {
   useGetUserEthBalanceQuery,
 } from 'state/api/communityStake';
 import { useGetContestBalanceQuery } from 'state/api/contests';
-import { useTokenBalanceQuery, useTokenMetadataQuery } from 'state/api/tokens';
+import {
+  useGetERC20BalanceQuery,
+  useTokenMetadataQuery,
+} from 'state/api/tokens';
 import { convertTokenAmountToUsd } from 'views/modals/ManageCommunityStakeModal/utils';
 import { calculateNewContractBalance, getAmountError } from './utils';
 
@@ -14,7 +17,6 @@ export const INITIAL_AMOUNT = '0.0001';
 interface UseFundContestFormProps {
   contestAddress: string;
   chainRpc: string;
-  chainNodeId: number;
   ethChainId: number;
   userAddress: string;
   fundingTokenAddress?: string;
@@ -23,7 +25,6 @@ interface UseFundContestFormProps {
 const useFundContestForm = ({
   contestAddress,
   chainRpc,
-  chainNodeId,
   ethChainId,
   userAddress,
   fundingTokenAddress,
@@ -48,16 +49,13 @@ const useFundContestForm = ({
     ethChainId,
   });
 
-  const { data: tokenBalances } = useTokenBalanceQuery({
-    chainId: chainNodeId,
-    tokenId: userAddress,
+  const { data: tokenBalance } = useGetERC20BalanceQuery({
+    tokenAddress: fundingTokenAddress || '',
+    userAddress,
+    nodeRpc: chainRpc,
   });
 
-  const userTokenBalance = fundingTokenAddress
-    ? tokenBalances?.tokenBalances?.find(
-        (token) => +token.contractAddress === +fundingTokenAddress,
-      )?.tokenBalance
-    : userEthBalance;
+  const userTokenBalance = fundingTokenAddress ? tokenBalance : userEthBalance;
 
   const { data: contestBalanceData } = useGetContestBalanceQuery({
     contestAddress,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
@@ -1,3 +1,4 @@
+import { commonProtocol } from '@hicommonwealth/shared';
 import { useFlag } from 'hooks/useFlag';
 import React, { useState } from 'react';
 import app from 'state';
@@ -53,7 +54,10 @@ const ManageContest = ({ contestAddress }: ManageContestProps) => {
     return <PageNotFound />;
   }
 
-  const fundingTokenTicker = tokenMetadata?.symbol || 'ETH';
+  const fundingTokenTicker =
+    tokenMetadata?.symbol || commonProtocol.Denominations.ETH;
+  const fundingTokenDecimals =
+    tokenMetadata?.decimals || commonProtocol.WeiDecimals.ETH;
 
   const getCurrentStep = () => {
     switch (launchContestStep) {
@@ -76,6 +80,7 @@ const ManageContest = ({ contestAddress }: ManageContestProps) => {
             contestFormData={contestFormData}
             onSetCreatedContestAddress={setCreatedContestAddress}
             fundingTokenTicker={fundingTokenTicker}
+            fundingTokenDecimals={fundingTokenDecimals}
           />
         );
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -40,6 +40,7 @@ interface SignTransactionsStepProps {
   contestFormData: ContestFormData;
   onSetCreatedContestAddress: (address: string) => void;
   fundingTokenTicker: string;
+  fundingTokenDecimals: number;
 }
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
@@ -50,6 +51,7 @@ const SignTransactionsStep = ({
   contestFormData,
   onSetCreatedContestAddress,
   fundingTokenTicker,
+  fundingTokenDecimals,
 }: SignTransactionsStepProps) => {
   const weightedTopicsEnabled = useFlag('weightedTopics');
 
@@ -182,6 +184,7 @@ const SignTransactionsStep = ({
               .filter((t) => t.checked)
               .map((t) => t.id!),
         ticker: fundingTokenTicker,
+        decimals: fundingTokenDecimals,
       });
 
       onSetLaunchContestStep('ContestLive');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9747 
Closes: #9748
Closes: #9749

## Description of Changes
- Automatically convert decimals in the helper

- [commit](https://github.com/hicommonwealth/commonwealth/pull/9752/commits/7e6047bded64f4167dfef7fe9b272afb1a86d68e) => We didnt pass decimals to a contract launcher. Now we do. Fixes #9748


- [commit](https://github.com/hicommonwealth/commonwealth/pull/9752/commits/ed181311f3186b196ad8046f0a9bc197f22f4b57) => For some reason we had two implementation for fetching erc20 balance. One using contract, another using alchemy and there were some differences not in the balance itself but in the conversions. In this commit I used contract helper to fetch erc20 balance so that it would work the same way in the topic banner and in the fund form. Closes #9749

![image](https://github.com/user-attachments/assets/0ebb8fa8-8c73-4214-8c63-4f45d350236f)

![image](https://github.com/user-attachments/assets/d4765700-cda2-4ed9-9294-b6deffa76203)


## Test Plan
- USDC topic
- confirm balance shows


## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- Fixes balance checks in funding drawer issue