### PR TITLE
Fix decimals in launching contest

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/ManageContest.tsx
@@ -1,3 +1,4 @@
+import { commonProtocol } from '@hicommonwealth/shared';
 import { useFlag } from 'hooks/useFlag';
 import React, { useState } from 'react';
 import app from 'state';
@@ -53,7 +54,10 @@ const ManageContest = ({ contestAddress }: ManageContestProps) => {
     return <PageNotFound />;
   }
 
-  const fundingTokenTicker = tokenMetadata?.symbol || 'ETH';
+  const fundingTokenTicker =
+    tokenMetadata?.symbol || commonProtocol.Denominations.ETH;
+  const fundingTokenDecimals =
+    tokenMetadata?.decimals || commonProtocol.WeiDecimals.ETH;
 
   const getCurrentStep = () => {
     switch (launchContestStep) {
@@ -76,6 +80,7 @@ const ManageContest = ({ contestAddress }: ManageContestProps) => {
             contestFormData={contestFormData}
             onSetCreatedContestAddress={setCreatedContestAddress}
             fundingTokenTicker={fundingTokenTicker}
+            fundingTokenDecimals={fundingTokenDecimals}
           />
         );
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -40,6 +40,7 @@ interface SignTransactionsStepProps {
   contestFormData: ContestFormData;
   onSetCreatedContestAddress: (address: string) => void;
   fundingTokenTicker: string;
+  fundingTokenDecimals: number;
 }
 
 const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
@@ -50,6 +51,7 @@ const SignTransactionsStep = ({
   contestFormData,
   onSetCreatedContestAddress,
   fundingTokenTicker,
+  fundingTokenDecimals,
 }: SignTransactionsStepProps) => {
   const weightedTopicsEnabled = useFlag('weightedTopics');
 
@@ -182,6 +184,7 @@ const SignTransactionsStep = ({
               .filter((t) => t.checked)
               .map((t) => t.id!),
         ticker: fundingTokenTicker,
+        decimals: fundingTokenDecimals,
       });
 
       onSetLaunchContestStep('ContestLive');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9748 

## Description of Changes
- We didnt pass decimals to a contract launcher

## Test Plan
- create contest with token that has 6 decimals eg `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
- make sure that decimals are taken into consideration when displaying prizes

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a