### PR TITLE
Poll contest if it is not initialised

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -54,7 +54,7 @@ const AdminContestsPage = () => {
     contestsData,
     isContestAvailable,
     isContestDataLoading,
-  } = useCommunityContests();
+  } = useCommunityContests({ shouldPolling: true });
 
   const { data: topicData } = useFetchTopicsQuery({
     communityId,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/useCommunityContests.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/useCommunityContests.ts
@@ -3,12 +3,20 @@ import { useGetContestsQuery } from 'state/api/contests';
 import { useCommunityStake } from 'views/components/CommunityStake';
 import { Contest } from 'views/pages/CommunityManagement/Contests/ContestsList';
 
-const useCommunityContests = () => {
+type UseCommunityContestsProps =
+  | {
+      shouldPolling?: boolean;
+    }
+  | undefined;
+
+const useCommunityContests = (props?: UseCommunityContestsProps) => {
+  const { shouldPolling = false } = props || {};
   const { stakeEnabled } = useCommunityStake();
 
   const { data: contestsData, isLoading: isContestDataLoading } =
     useGetContestsQuery({
       community_id: app.activeChainId() || '',
+      shouldPolling,
     });
 
   // @ts-expect-error StrictNullChecks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9765 

## Description of Changes
- added conditional polling to the trpc query 
- if contest is not initialised onchain (`contestManager.contests` array is empty), poll until it is initialised

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- create contest
- go to contests list page 
- skeleton loader should be visible
- after 10/20/30 seconds you should see countdown counter
- after this time, if loader is keep spinning, it means that something is wrong with our services, because contest is not getting initialised but for this we would need to have probably another solution  
 

https://github.com/user-attachments/assets/1d5cb39b-afcf-4721-adc4-cc05964b93d8


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- enhance UX when contest is not getting initialised because of consumer/relayer/event-listeners 