### PR TITLE
Fix ERC20 decimal + reaction weight rendering

### DIFF
--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -69,7 +69,11 @@ async function updateOrCreateWithAlert(
   }
 
   const { ticker, decimals } =
-    await protocol.contractHelpers.getTokenAttributes(contest_address, url);
+    await protocol.contractHelpers.getTokenAttributes(
+      contest_address,
+      url,
+      true,
+    );
 
   const { startTime, endTime } = await protocol.contestHelper.getContestStatus(
     url,

--- a/libs/model/src/services/commonProtocol/contractHelpers.ts
+++ b/libs/model/src/services/commonProtocol/contractHelpers.ts
@@ -89,17 +89,16 @@ export const getNamespaceBalance = async (
  * @param rpcNodeUrl Note this MUST be a private_url with no associated whitelist.
  */
 export const getTokenAttributes = async (
-  contestAddress: string,
+  address: string,
   rpcNodeUrl: string,
+  fetchFromContest: boolean,
 ): Promise<TokenAttributes> => {
   const web3 = new Web3(rpcNodeUrl);
-  const contest = new web3.eth.Contract(
-    contestABI as AbiItem[],
-    contestAddress,
-  );
-  const contestToken: string = await contest.methods.contestToken().call();
-
-  if (contestToken === ZERO_ADDRESS) {
+  if (fetchFromContest) {
+    const contest = new web3.eth.Contract(contestABI as AbiItem[], address);
+    address = await contest.methods.contestToken().call();
+  }
+  if (address === ZERO_ADDRESS) {
     return Promise.resolve({
       ticker: commonProtocol.Denominations.ETH,
       decimals: commonProtocol.WeiDecimals[commonProtocol.Denominations.ETH],
@@ -127,7 +126,7 @@ export const getTokenAttributes = async (
         type: 'function',
       },
     ] as AbiItem[],
-    contestToken,
+    address,
   );
 
   const [symbol, decimals] = await Promise.all([

--- a/libs/model/src/services/stakeHelper.ts
+++ b/libs/model/src/services/stakeHelper.ts
@@ -7,6 +7,7 @@ import { config } from '../config';
 import { models } from '../database';
 import { mustExist } from '../middleware/guards';
 import { contractHelpers } from '../services/commonProtocol';
+import { getTokenAttributes } from './commonProtocol/contractHelpers';
 
 /**
  * Calculates voting weight of address based on the topic
@@ -67,6 +68,8 @@ export async function getVotingWeight(
     return commonProtocol.calculateVoteWeight(stakeBalance, stake.vote_weight);
   } else if (topic.weighted_voting === TopicWeightedVoting.ERC20) {
     mustExist('Chain Node Eth Chain Id', chain_node?.eth_chain_id);
+    const chainNodeUrl = chain_node!.url! || chain_node!.private_url!;
+    mustExist('Chain Node URL', chainNodeUrl);
 
     const balances = await tokenBalanceCache.getBalances({
       balanceSourceType: BalanceSourceType.ERC20,
@@ -87,8 +90,15 @@ export async function getVotingWeight(
       tokenBalance,
       topic.vote_weight_multiplier!,
     );
+
+    const { decimals } = await getTokenAttributes(
+      topic.token_address!,
+      chainNodeUrl,
+      false,
+    );
+
     // only count full ERC20 tokens
-    return result?.div(BigNumber.from(10).pow(18)) || null;
+    return result?.div(BigNumber.from(10).pow(decimals)) || null;
   }
 
   // no weighted voting

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -3,7 +3,6 @@ import { buildDeleteThreadReactionInput } from 'client/scripts/state/api/threads
 import { useAuthModalStore } from 'client/scripts/state/ui/modals';
 import { notifyError } from 'controllers/app/notifications';
 import { SessionKeyError } from 'controllers/server/sessions';
-import { BigNumber } from 'ethers';
 import type Thread from 'models/Thread';
 import React, { useState } from 'react';
 import app from 'state';
@@ -45,11 +44,7 @@ export const ReactionButton = ({
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
   const user = useUserStore();
 
-  const reactionWeightsSum =
-    thread?.associatedReactions?.reduce(
-      (acc, reaction) => acc.add(reaction.calculated_voting_weight || 1),
-      BigNumber.from(0),
-    ) || BigNumber.from(0);
+  const reactionWeightsSum = thread?.reactionWeightsSum;
 
   const activeAddress = user.activeAccount?.address;
   const thisUserReaction = thread?.associatedReactions?.filter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9768

## Description of Changes
- Fixes voting weight for ERC20 by using correct decimal count
- Fixes reaction count rendering in UI

## Test Plan
- Create an ERC20 topic on Base mainnet with USDC token: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
- Create a thread on the topic, upvote it– confirm that reaction count matches num tokens you own

## Deployment Plan
N/A

## Other Considerations
N/A