### PR TITLE
Sign in modal now closes on tos and privacy click

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -357,9 +357,13 @@ const ModalBase = ({
               <CWText isCentered>
                 By connecting to Common you agree to our&nbsp;
                 <br />
-                <Link to="/terms">Terms of Service</Link>
+                <Link to="/terms" onClick={() => onClose()}>
+                  Terms of Service
+                </Link>
                 &nbsp;and&nbsp;
-                <Link to="/privacy">Privacy Policy</Link>
+                <Link to="/privacy" onClick={() => onClose()}>
+                  Privacy Policy
+                </Link>
               </CWText>
 
               {copy.showExistingAccountSignInFooter && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9776 

## Description of Changes
- Sign in modal now closes on tos and privacy click
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added an onClick to the `<Link>` to close modal when links are clicked
## Test Plan
-click sign in
-click ToS in the Sign in modal
-confirm that you are redirected to the ToS page and the modal is closed
-click Sign in
-click Privacy Policy in the Sign in modal
-confirm that you are redirected to the Privacy Policy page and the modal is closed