### PR TITLE
Added copy changes for contests

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/CommunityStake/VoteWeightModule/VoteWeightModule.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CommunityStake/VoteWeightModule/VoteWeightModule.tsx
@@ -136,7 +136,7 @@ export const VoteWeightModule = ({
       <CWPopover
         title={
           <>
-            Vote Weight Explainer
+            Your Community Stake vote weight
             {isMobile && (
               <div className="close">
                 <CWIconButton

--- a/packages/commonwealth/client/scripts/views/components/TokenFinder/TokenFinder.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TokenFinder/TokenFinder.tsx
@@ -27,7 +27,7 @@ const TokenFinder = ({
       <CWTextInput
         // can be overridden by `...rest`
         label="Token"
-        placeholder="Please enter primary token"
+        placeholder="Enter Token Address"
         {...rest}
         // not changeable
         value={tokenValue}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9759

## Description of Changes
- Changed Primary Token copy for the token address field placeholder to "Enter Token Address" from "Enter primary token"
- Update copy for Community Stake vote weight module to say "Your Community Stake vote weight" instead of "VOTE WEIGHT EXPLAINER"


## "How We Fixed It"
N/A

## Test Plan
- Verify copy changes are reflected in UI

## Deployment Plan
N/A

## Other Considerations
N/A