### PR TITLE
Show contest prices for non-authenticated users

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Contest.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Contest.ts
@@ -23,7 +23,7 @@ class Contest extends ContractBase {
       this.namespaceFactoryAddress,
       this.rpc,
     );
-    await this.namespaceFactory.initialize(true);
+    await this.namespaceFactory.initialize(withWallet);
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9755

## Description of Changes
Added changes to show contest prices for non-authenticated users

## "How We Fixed It"
N/A

## Test Plan
1. Open app with logged in account
2. Visit `/:communityId/contests` of any community with active + funded contests
3. Verify you are able to see contest prices
4. Logout
5. Repeat steps 2 and 3.
6. Open incognito tab (make sure you don't have any wallet extensions that are enabled in incognito)
7. Repeat steps 2 and 3 without login
8. Verify you don't get the walletconnect popup repeatedly.

## Deployment Plan
N/A

## Other Considerations
N/A