### PR TITLE
improve the user profile popUp

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -1,5 +1,6 @@
 import { ChainBase, DEFAULT_NAME } from '@hicommonwealth/shared';
 import ghostSvg from 'assets/img/ghost.svg';
+import { saveToClipboard } from 'client/scripts/utils/clipboard';
 import clsx from 'clsx';
 import 'components/user/user.scss';
 import React, { useState } from 'react';
@@ -15,8 +16,10 @@ import CWPopover, {
 import { formatAddressShort } from '../../../../../shared/utils';
 import Permissions from '../../../utils/Permissions';
 import { BanUserModal } from '../../modals/ban_user_modal';
+import { CWIconButton } from '../component_kit/cw_icon_button';
 import { CWText } from '../component_kit/cw_text';
 import { CWModal } from '../component_kit/new_designs/CWModal';
+import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 import { UserSkeleton } from './UserSkeleton';
 import { FullUserAttrsWithSkeletonProp } from './user.types';
 
@@ -57,7 +60,6 @@ export const FullUser = ({
       />
     );
   }
-
   const fullAddress = formatAddressShort(userAddress, userCommunityId);
   const redactedAddress = formatAddressShort(
     userAddress,
@@ -65,6 +67,7 @@ export const FullUser = ({
     true,
     undefined,
     app.chain?.meta?.bech32_prefix || '',
+    true,
   );
   const showAvatar = profile ? !shouldHideAvatar : false;
   const loggedInUserIsAdmin =
@@ -172,7 +175,6 @@ export const FullUser = ({
       }
     </div>
   );
-
   const userPopover = (
     <>
       {profile && (
@@ -208,9 +210,43 @@ export const FullUser = ({
               </Link>
             )}
           </div>
-          {profile?.address && (
-            <div className="user-address">{redactedAddress}</div>
+          {profile?.name && (
+            <Link
+              className="user-address"
+              to={`/profile/id/${profile?.userId}`}
+            >
+              {profile?.name}
+            </Link>
           )}
+          {profile?.address && (
+            <div className="address-container">
+              <div className="user-address">
+                {redactedAddress}
+                <CWTooltip
+                  placement="top"
+                  content="address copied!"
+                  renderTrigger={(handleInteraction, isTooltipOpen) => {
+                    return (
+                      <CWIconButton
+                        iconName="copySimple"
+                        onClick={(event) => {
+                          saveToClipboard(userAddress).catch(console.error);
+                          handleInteraction(event);
+                        }}
+                        onMouseLeave={(e) => {
+                          if (isTooltipOpen) {
+                            handleInteraction(e);
+                          }
+                        }}
+                        className="copy-icon"
+                      />
+                    );
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
           {friendlyCommunityName && (
             <div className="user-chain">{friendlyCommunityName}</div>
           )}

--- a/packages/commonwealth/client/styles/components/user/user.scss
+++ b/packages/commonwealth/client/styles/components/user/user.scss
@@ -190,7 +190,20 @@
   .user-chain {
     color: $neutral-500 !important;
   }
+  .address-container {
+    display: 'flex';
+    justify-content: center;
+    align-items: 'center';
+    gap: 10;
+    padding: 6px;
 
+    .user-address,
+    .copy-icon {
+      margin-left: 2px;
+      padding-top: 2px;
+      cursor: pointer;
+    }
+  }
   .role-tag {
     margin-top: 10px !important;
   }

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -66,6 +66,7 @@ export function formatAddressShort(
   includeEllipsis?: boolean,
   maxCharLength?: number,
   prefix?: string,
+  firstAndLastDigit?: boolean,
 ) {
   if (!address) return;
   if (chain === 'near') {
@@ -77,6 +78,8 @@ export function formatAddressShort(
       totalLength - 4,
       totalLength,
     )}`;
+  } else if (firstAndLastDigit) {
+    return `${address.slice(0, 4)}...${address.slice(-2)}`;
   } else {
     return `${address.slice(0, maxCharLength || 5)}${
       includeEllipsis ? '…' : ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9426 

## Description of Changes
- improve the username hover pop up 
- added the userName and 1st 4 and last2 digit of address 
- added the copy_icon with tooltip message 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-In formatAddressShort function added the new optional condition to show 1st 4 and last2digit of address 
- used CWTooltip and CWIconButton to show copyIcon and show tooltip message 

## Test Plan
-go to a thread that has at least 1 comment
-hover over the user's name that made the comment
-notice that it looks like the video  below

https://github.com/user-attachments/assets/5eb86e12-1ade-4fcb-a872-8cf99aa8e29d


