### PR TITLE
Remove eth requirement when creating thread

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -238,9 +238,11 @@ export const NewThreadForm = () => {
   const contestTopicAffordanceVisible =
     isContestAvailable && hasTopicOngoingContest;
 
+  const isWalletBalanceErrorEnabled = false;
   const walletBalanceError =
     isContestAvailable &&
     hasTopicOngoingContest &&
+    isWalletBalanceErrorEnabled &&
     parseFloat(userEthBalance || '0') < MIN_ETH_FOR_CONTEST_THREAD;
 
   useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
@@ -222,9 +222,11 @@ export const NewThreadForm = () => {
   const contestTopicAffordanceVisible =
     isContestAvailable && hasTopicOngoingContest;
 
+  const isWalletBalanceErrorEnabled = false;
   const walletBalanceError =
     isContestAvailable &&
     hasTopicOngoingContest &&
+    isWalletBalanceErrorEnabled &&
     parseFloat(userEthBalance || '0') < MIN_ETH_FOR_CONTEST_THREAD;
 
   useEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9769

## Description of Changes
Remove eth requirement when creating thread

## "How We Fixed It"
N/A

## Test Plan
Verify you are able to create thread without having minimum eth

## Deployment Plan
N/A

## Other Considerations
N/A