### PR TITLE
Private ChainNode scope fix

### DIFF
--- a/libs/model/src/services/stakeHelper.ts
+++ b/libs/model/src/services/stakeHelper.ts
@@ -30,7 +30,7 @@ export async function getVotingWeight(
         required: true,
         include: [
           {
-            model: models.ChainNode,
+            model: models.ChainNode.scope('withPrivateData'),
             required: false,
           },
           {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9799 

## Description of Changes
- Fixes the scope for ChainNodes model query in stakeHelper

## "How We Fixed It"
Used the `withPrivateData` model scope to include `ChainNodes.private_url`

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 