### PR TITLE
fix the edit thread title

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -164,6 +164,9 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
       setIsGloballyEditing(true);
       setIsEditingBody(true);
     }
+    if (thread && thread?.title) {
+      setDraftTitle(thread.title);
+    }
   }, [isEdit, thread, isAdmin]);
 
   const { data: comments = [], error: fetchCommentsError } =
@@ -539,7 +542,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 onInput={(e) => {
                   setDraftTitle(e.target.value);
                 }}
-                value={draftTitle || thread?.title}
+                value={draftTitle}
               />
             ) : (
               thread?.title
@@ -611,11 +614,15 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                     cancelEditing={() => {
                       setIsGloballyEditing(false);
                       setIsEditingBody(false);
+                      if (!draftTitle.length) {
+                        setDraftTitle(thread?.title);
+                      }
                     }}
                     threadUpdatedCallback={() => {
                       setIsGloballyEditing(false);
                       setIsEditingBody(false);
                     }}
+                    isDisabled={draftTitle && draftTitle.length ? false : true}
                   />
                   {threadOptionsComp}
                 </>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/edit_body.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/edit_body.tsx
@@ -24,6 +24,7 @@ type EditBodyProps = {
   activeThreadBody: string; // body of the active/selected thread version
   cancelEditing: () => void;
   threadUpdatedCallback: (title: string, body: string) => void;
+  isDisabled?: boolean;
 };
 
 export const EditBody = (props: EditBodyProps) => {
@@ -35,6 +36,7 @@ export const EditBody = (props: EditBodyProps) => {
     activeThreadBody,
     cancelEditing,
     threadUpdatedCallback,
+    isDisabled = false,
   } = props;
 
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
@@ -144,7 +146,7 @@ export const EditBody = (props: EditBodyProps) => {
         <CWButton
           label="Save"
           buttonWidth="wide"
-          disabled={saving}
+          disabled={saving || isDisabled}
           onClick={save}
         />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9280 

@Israellund  this PR also closed the #9282 

## Description of Changes
- use the setDraftTitle  , remove the condition to setDraftTitle to   thread?.title when we clear every character .

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- use the setDraftTitle  useState
-remove the condition value={draftTitle || thread?.title} only used draftTitle
-disable the save button when title is empty 


## Test Plan
make sure you're an admin
-go to a thread and click the 3 dots, choose Edit
-in edit mode try to edit the modal 
- here is video of testing


https://github.com/user-attachments/assets/63a6bc54-fd66-4a0e-9e98-e3a09a5f12b1

