### PR TITLE
Fix threads discussion page cache

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -130,9 +130,10 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       ...(featuredFilter && {
         orderBy: featuredFilter,
       }),
-      toDate: dateCursor.toDate,
-      // @ts-expect-error <StrictNullChecks/>
-      fromDate: dateCursor.fromDate,
+      ...(dateCursor.fromDate && {
+        toDate: dateCursor.toDate,
+        fromDate: dateCursor.fromDate,
+      }),
       includeArchivedThreads: isOnArchivePage || includeArchivedThreads,
       // @ts-expect-error <StrictNullChecks/>
       contestAddress,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9740

## Description of Changes
Updated thread cache keys on the community discussion page to correctly cache keys for thread cache time.

## "How We Fixed It"
N/A

## Test Plan
1. Open network tab
2. Visit any community discussions page
3. Look for the `/threads?bulk=true` call
4. Visit any other page
5. Come back to the same discussions page
6. Verify there isn't a new call to `/threads?bulk=true` in the network tab
7. Verify any updates to the threads displayed in the discussion list are reflected, when updates to the threads in that ist are done from any other page
8. Verity that after every 3 minutes, a new call to `/threads?bulk=true` is made when on the community discussions page.

## Deployment Plan
N/A

## Other Considerations
N/A