### PR TITLE
Use blacklist instead of whitelist for events

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,6 @@ env:
   NODE_ENV: 'test'
   ROLLBAR_ENV: 'GitHubCI'
   TEST_WITHOUT_LOGS: 'true'
-  ALLOWED_EVENTS: 'ChainEventCreated,SnapshotProposalCreated,ThreadCreated,ThreadUpvoted,SubscriptionPreferencesUpdated,CommentCreated,UserMentioned'
   PRIVATE_KEY: 'web3-pk'
   USES_DOCKER_PGSQL: true
   PORT: 8080

--- a/common_knowledge/Farcaster-Contests.md
+++ b/common_knowledge/Farcaster-Contests.md
@@ -39,10 +39,6 @@ NEYNAR_REPLY_WEBHOOK_URL=https://YOUR_NGROK_DOMAIN/api/integration/farcaster/Rep
 FARCASTER_ACTION_URL=https://YOUR_NGROK_DOMAIN/api/integration/farcaster/CastUpvoteAction
 ```
 
-The `ALLOWED_EVENTS` env var contains a comma-seperated list of outbox events. Add these to the list:
-
-`FarcasterCastCreated,FarcasterReplyCastCreated,FarcasterVoteCreated`
-
 ## Run local services
 
 Run services required for testing contests:

--- a/libs/model/src/config.ts
+++ b/libs/model/src/config.ts
@@ -12,7 +12,7 @@ const {
   NO_SSL,
   PRIVATE_KEY,
   TBC_BALANCE_TTL_SECONDS,
-  ALLOWED_EVENTS,
+  BLACKLISTED_EVENTS,
   INIT_TEST_DB,
   MAX_USER_POSTS_PER_CONTEST,
   JWT_SECRET,
@@ -79,7 +79,9 @@ export const config = configure(
         : 300,
     },
     OUTBOX: {
-      ALLOWED_EVENTS: ALLOWED_EVENTS ? ALLOWED_EVENTS.split(',') : [],
+      BLACKLISTED_EVENTS: BLACKLISTED_EVENTS
+        ? BLACKLISTED_EVENTS.split(',')
+        : [],
     },
     STAKE: {
       REACTION_WEIGHT_OVERRIDE: REACTION_WEIGHT_OVERRIDE
@@ -189,7 +191,7 @@ export const config = configure(
       TTL_SECS: z.number().int(),
     }),
     OUTBOX: z.object({
-      ALLOWED_EVENTS: z.array(z.string()),
+      BLACKLISTED_EVENTS: z.array(z.string()),
     }),
     STAKE: z.object({
       REACTION_WEIGHT_OVERRIDE: z.number().int().nullish(),

--- a/libs/model/src/utils/utils.ts
+++ b/libs/model/src/utils/utils.ts
@@ -45,15 +45,15 @@ export async function emitEvent(
 ) {
   const records: Array<EventPairs> = [];
   for (const event of values) {
-    if (config.OUTBOX.ALLOWED_EVENTS.includes(event.event_name)) {
+    if (!config.OUTBOX.BLACKLISTED_EVENTS.includes(event.event_name)) {
       records.push(event);
     } else {
       log.warn(
         `Event not inserted into outbox! ` +
-          `Add ${event.event_name} to the ALLOWED_EVENTS env var to enable emitting this event.`,
+          `The event "${event.event_name}" is blacklisted. Remove it from BLACKLISTED_EVENTS env in order to allow it.`,
         {
           event_name: event.event_name,
-          allowed_events: config.OUTBOX.ALLOWED_EVENTS,
+          allowed_events: config.OUTBOX.BLACKLISTED_EVENTS,
         },
       );
     }

--- a/libs/model/src/utils/utils.ts
+++ b/libs/model/src/utils/utils.ts
@@ -50,7 +50,7 @@ export async function emitEvent(
     } else {
       log.warn(
         `Event not inserted into outbox! ` +
-          `The event "${event.event_name}" is blacklisted. Remove it from BLACKLISTED_EVENTS env in order to allow it.`,
+          `The event "${event.event_name}" is blacklisted. Remove it from BLACKLISTED_EVENTS env in order to allow emitting this event.`,
         {
           event_name: event.event_name,
           allowed_events: config.OUTBOX.BLACKLISTED_EVENTS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9815

## Description of Changes
- Replaced `ALLOWED_EVENTS` env with `BLACKLISTED_EVENTS`


## Test Plan
- CA test
  - Set `BLACKLISTED_EVENTS=CommentCreated`
  - Create a thread– confirm that the `ThreadCreated` event is emitted to the outbox
  - Create a comment– confirm that the `CommentCreated` event is *not* emitted to the outbox

## Deployment Plan
- AFTER the deployment is finished:
  - Remove env `ALLOWED_EVENTS`
  - Add env `BLACKLISTED_EVENTS=FarcasterCastCreated,FarcasterReplyCastCreated,FarcasterVoteCreated`

## Other Considerations
N/A