### PR TITLE
generate img no longer triggers form submit

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
@@ -204,8 +204,9 @@ export const UploadControl = ({
           className="generate-image-section"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
             if (e.key === 'Enter' && imagePrompt.trim()) {
-              e.preventDefault();
               generateImage({ prompt: imagePrompt.trim() }).catch(
                 console.error,
               );
@@ -255,7 +256,7 @@ export const UploadControl = ({
             containerClassName="btn-focus-styles"
             disabled={areActionsDisabled}
             onClick={() => {
-              imagePrompt &&
+              imagePrompt.trim() &&
                 generateImage({ prompt: imagePrompt.trim() }).catch(
                   console.error,
                 );

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
@@ -203,6 +203,14 @@ export const UploadControl = ({
         <div
           className="generate-image-section"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && imagePrompt.trim()) {
+              e.preventDefault(); // Prevents any default form submission behavior
+              generateImage({ prompt: imagePrompt.trim() }).catch(
+                console.error,
+              );
+            }
+          }}
         >
           <CWIconButton
             onClick={(e) => {

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
@@ -205,7 +205,7 @@ export const UploadControl = ({
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && imagePrompt.trim()) {
-              e.preventDefault(); // Prevents any default form submission behavior
+              e.preventDefault();
               generateImage({ prompt: imagePrompt.trim() }).catch(
                 console.error,
               );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9812 

## Description of Changes
- If a user clicks on Generate Image, enters a prompt, then presses return/enter, the form is no longer submitted and the user is no longer redirected to the next page. Instead pressing return/enter triggers the onClick to generate an image. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
add an `onKeyDown` to the `<div>` holding the input and button for generating images. 

## Test Plan
- This was in contests because only there is `CWImageInput` used without being required
- create a contest
- select a topic and name your contest
- generate an image/input a prompt
- click return/enter instead of clicking on the Generate button
- confirm that your image is now being generated and you were not redirected to the next page


https://github.com/user-attachments/assets/0df307c9-d124-4b99-8350-65f54a8eae94

