### PR TITLE
Hide skeleton for broken contests

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -175,9 +175,9 @@ const ContestCard = ({
           <CWText type="h3">{name}</CWText>
           {finishDate ? (
             <ContestCountdown finishTime={finishDate} isActive={isActive} />
-          ) : (
+          ) : isActive ? (
             <Skeleton width="70px" />
-          )}
+          ) : null}
         </div>
         <CWText className="topics">
           Topic: {topics.map(({ name: topicName }) => topicName).join(', ')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9826

## Description of Changes
- Hides loading indicator for cancelled contests that were never initialized