### PR TITLE
removed padding on primary button

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWButton/CWButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWButton/CWButton.scss
@@ -17,7 +17,6 @@
   &.primary,
   &.destructive {
     border: 2px solid $transparent;
-    padding: 2px;
     border-radius: 10px;
     width: fit-content;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9777 

## Description of Changes
-removes padding on primary style button

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
I removed the padding: 2px on the primary button. The original ticket shows the padding through a Chrome extension called Pesticide https://chromewebstore.google.com/detail/pesticide-for-chrome/bakpbgckdnepkmkeaiomhmfcnejndkbi?hl=en&pli=1 if you want to install it and check this PR off of that. Below are screenshots to compare if you don't feel like doing that. 

Before:
![382499216-04d09e13-ddde-44df-b3e4-9d9b916b51bf](https://github.com/user-attachments/assets/d055ac8d-b733-45d4-8fd0-f20e98c23ae1)

After:
![Screenshot 2024-11-06 at 1 59 17 PM](https://github.com/user-attachments/assets/53706bc9-38bc-4386-8839-336e2e9cb87d)
