### PR TITLE
Caps search limit to 50 per schema

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PersonalInformationStep/PersonalInformationStep.tsx
@@ -83,7 +83,7 @@ const PersonalInformationStep = ({
 
   const { data: profiles, isLoading: isCheckingUsernameUniqueness } =
     useSearchProfilesQuery({
-      limit: 1000,
+      limit: 50,
       searchTerm: debouncedSearchTerm,
       communityId: 'all_communities',
       orderBy: APIOrderBy.LastActive,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/AdminsAndModerators/AdminsAndModerators.tsx
@@ -35,7 +35,7 @@ const AdminsAndModerators = () => {
   const { data: searchResults, refetch } = useSearchProfilesQuery({
     communityId,
     searchTerm: debouncedSearchTerm,
-    limit: 100,
+    limit: 50,
     orderBy: APIOrderBy.LastActive,
     orderDirection: APIOrderDirection.Desc,
     enabled: !!communityId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9824

## Description of Changes
- New search endpoints are using a generic pagination schema that caps the search limit to 50 results
- Changed two references that exceeded 50

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 