### PR TITLE
Adds query to fetch farcaster contest frames

### DIFF
--- a/common_knowledge/Farcaster-Contests.md
+++ b/common_knowledge/Farcaster-Contests.md
@@ -37,7 +37,10 @@ FLAG_FARCASTER_CONTEST=true
 NEYNAR_API_KEY=
 NEYNAR_REPLY_WEBHOOK_URL=https://YOUR_NGROK_DOMAIN/api/integration/farcaster/ReplyCastCreated
 FARCASTER_ACTION_URL=https://YOUR_NGROK_DOMAIN/api/integration/farcaster/CastUpvoteAction
+FARCASTER_NGROK_DOMAIN=https://YOUR_NGROK_DOMAIN
 ```
+
+Note: `FARCASTER_NGROK_DOMAIN` should only be used locally– not on QA or production.
 
 ## Run local services
 
@@ -57,10 +60,10 @@ Farcaster allows users to add a custom “action” to their account, which can 
 - Paste URL into browser, you’ll see the Warpcast page, then click `Add Action`
 
 ## How to test the Farcaster/Contests integration
-- For testing, you can use any contest that has an associated Topic.
-- First, post a farcaster contest URL on Warpcast. It has this format: `https://YOUR_DOMAIN/api/integration/farcaster/contests/CONTEST_ADDRESS/contestCard`
-	- Fill in your ngrok domain and contest address
-	- Upon posting, it should trigger the `CastCreated` webhook and associate the Cast (message) with the contest. It’ll also create a new programatic webhook for `CastReplyCreated`.
+- Create a Farcaster Contest with a funding token (e.g. CMN on Base Sepolia `0x429ae85883f82203D736e8fc203A455990745ca1`)
+- Copy the Farcaster Contest URL. It should have this format: `https://YOUR_DOMAIN/api/integration/farcaster/contests/CONTEST_ADDRESS/contestCard`
+- Post a the URL to WarpCast
+  - it should trigger the `CastCreated` webhook and associate the Cast (message) with the contest. It’ll also create a new programatic webhook for `CastReplyCreated`.
 - Then, add a reply message to the contest cast.
 	- This should trigger the `CastReplyCreated` webhook, which will create onchain content.
 - Finally, perform the custom Upvote action on your reply message (icon with 4 squares).

--- a/libs/model/src/contest/GetFarcasterContestCasts.ts
+++ b/libs/model/src/contest/GetFarcasterContestCasts.ts
@@ -41,7 +41,10 @@ export function GetFarcasterContestCasts(): Query<
       const frameHashesToFetch = [...parentCastHashes, ...replyCastHashes];
       const client = new NeynarAPIClient(config.CONTESTS.NEYNAR_API_KEY!);
       const castsResponse = await client.fetchBulkCasts(frameHashesToFetch, {
-        sortType: BulkCastsSortType.LIKES,
+        sortType:
+          payload.sort_by === 'likes'
+            ? BulkCastsSortType.LIKES
+            : BulkCastsSortType.RECENT,
       });
 
       const { casts } = castsResponse.result;

--- a/libs/model/src/contest/GetFarcasterContestCasts.ts
+++ b/libs/model/src/contest/GetFarcasterContestCasts.ts
@@ -1,0 +1,35 @@
+import { Query } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { BulkCastsSortType, NeynarAPIClient } from '@neynar/nodejs-sdk';
+import { config } from '../config';
+import { models } from '../database';
+import { mustExist } from '../middleware/guards';
+
+export function GetFarcasterContestCasts(): Query<
+  typeof schemas.GetFarcasterContestCasts
+> {
+  return {
+    ...schemas.GetFarcasterContestCasts,
+    auth: [],
+    secure: false,
+    body: async ({ payload }) => {
+      const contestManager = await models.ContestManager.findOne({
+        where: {
+          contest_address: payload.contest_address,
+        },
+      });
+      mustExist('Contest Manager', contestManager);
+      if (!contestManager.farcaster_frame_hashes?.length) {
+        return [];
+      }
+      const client = new NeynarAPIClient(config.CONTESTS.NEYNAR_API_KEY!);
+      const frames = await client.fetchBulkCasts(
+        contestManager.farcaster_frame_hashes,
+        {
+          sortType: BulkCastsSortType.LIKES,
+        },
+      );
+      return frames.result.casts;
+    },
+  };
+}

--- a/libs/model/src/contest/GetFarcasterContestCasts.ts
+++ b/libs/model/src/contest/GetFarcasterContestCasts.ts
@@ -1,6 +1,8 @@
 import { Query } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { BulkCastsSortType, NeynarAPIClient } from '@neynar/nodejs-sdk';
+import { CastWithInteractions } from '@neynar/nodejs-sdk/build/neynar-api/v2';
+import lo from 'lodash';
 import { config } from '../config';
 import { models } from '../database';
 import { mustExist } from '../middleware/guards';
@@ -22,14 +24,45 @@ export function GetFarcasterContestCasts(): Query<
       if (!contestManager.farcaster_frame_hashes?.length) {
         return [];
       }
-      const client = new NeynarAPIClient(config.CONTESTS.NEYNAR_API_KEY!);
-      const frames = await client.fetchBulkCasts(
-        contestManager.farcaster_frame_hashes,
-        {
-          sortType: BulkCastsSortType.LIKES,
+      const parentCastHashes = contestManager.farcaster_frame_hashes || [];
+      const actions = await models.ContestAction.findAll({
+        where: {
+          contest_address: payload.contest_address,
+          action: 'added',
         },
-      );
-      return frames.result.casts;
+      });
+      const replyCastHashes = actions.map((action) => {
+        /*
+          /farcaster/0x123/0x234
+        */
+        const [, , , replyCastHash] = action.content_url!.split('/');
+        return replyCastHash;
+      });
+      const frameHashesToFetch = [...parentCastHashes, ...replyCastHashes];
+      const client = new NeynarAPIClient(config.CONTESTS.NEYNAR_API_KEY!);
+      const castsResponse = await client.fetchBulkCasts(frameHashesToFetch, {
+        sortType: BulkCastsSortType.LIKES,
+      });
+
+      const { casts } = castsResponse.result;
+
+      const parentCasts = casts
+        .filter((cast) => parentCastHashes.includes(cast.hash))
+        .map((cast) => ({
+          ...cast,
+          replies: [] as Array<CastWithInteractions>,
+        }));
+
+      const replyCasts = lo.groupBy(casts, (cast) => {
+        return cast.parent_hash;
+      });
+      for (const parentCast of parentCasts) {
+        for (const replyCast of replyCasts[parentCast.hash]) {
+          parentCast.replies = parentCast.replies || [];
+          parentCast.replies.push(replyCast);
+        }
+      }
+      return parentCasts;
     },
   };
 }

--- a/libs/model/src/contest/GetFarcasterContestCasts.ts
+++ b/libs/model/src/contest/GetFarcasterContestCasts.ts
@@ -1,7 +1,6 @@
 import { Query } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { BulkCastsSortType, NeynarAPIClient } from '@neynar/nodejs-sdk';
-import { CastWithInteractions } from '@neynar/nodejs-sdk/build/neynar-api/v2';
 import lo from 'lodash';
 import { config } from '../config';
 import { models } from '../database';
@@ -49,22 +48,17 @@ export function GetFarcasterContestCasts(): Query<
 
       const { casts } = castsResponse.result;
 
+      const replyCasts = lo.groupBy(casts, (cast) => {
+        return cast.parent_hash;
+      });
+
       const parentCasts = casts
         .filter((cast) => parentCastHashes.includes(cast.hash))
         .map((cast) => ({
           ...cast,
-          replies: [] as Array<CastWithInteractions>,
+          replies: replyCasts[cast.hash],
         }));
 
-      const replyCasts = lo.groupBy(casts, (cast) => {
-        return cast.parent_hash;
-      });
-      for (const parentCast of parentCasts) {
-        for (const replyCast of replyCasts[parentCast.hash]) {
-          parentCast.replies = parentCast.replies || [];
-          parentCast.replies.push(replyCast);
-        }
-      }
       return parentCasts;
     },
   };

--- a/libs/model/src/contest/index.ts
+++ b/libs/model/src/contest/index.ts
@@ -7,6 +7,7 @@ export * from './FarcasterUpvoteAction.command';
 export * from './GetActiveContestManagers.query';
 export * from './GetAllContests.query';
 export * from './GetContestLog.query';
+export * from './GetFarcasterContestCasts';
 export * from './GetFarcasterUpvoteActionMetadata.query';
 export * from './PerformContestRollovers.command';
 export * from './UpdateContestManagerMetadata.command';

--- a/libs/schemas/src/commands/contest.schemas.ts
+++ b/libs/schemas/src/commands/contest.schemas.ts
@@ -127,7 +127,7 @@ export const FarcasterCast = z.object({
   replies: z.object({
     count: z.number(),
   }),
-  channel: z.string().nullable(),
+  channel: z.any().nullable(),
   mentioned_profiles: z.array(z.unknown()),
   event_timestamp: z.string(),
 });

--- a/libs/schemas/src/queries/contests.schemas.ts
+++ b/libs/schemas/src/queries/contests.schemas.ts
@@ -86,3 +86,10 @@ export const GetFarcasterUpvoteActionMetadata = {
     }),
   }),
 };
+
+export const GetFarcasterContestCasts = {
+  input: z.object({
+    contest_address: z.string(),
+  }),
+  output: z.array(z.any()),
+};

--- a/libs/schemas/src/queries/contests.schemas.ts
+++ b/libs/schemas/src/queries/contests.schemas.ts
@@ -90,6 +90,7 @@ export const GetFarcasterUpvoteActionMetadata = {
 export const GetFarcasterContestCasts = {
   input: z.object({
     contest_address: z.string(),
+    sort_by: z.enum(['likes', 'recent']).optional().default('likes'),
   }),
   output: z.array(z.any()),
 };

--- a/packages/commonwealth/server/api/contest.ts
+++ b/packages/commonwealth/server/api/contest.ts
@@ -16,8 +16,12 @@ export const trpcRouter = trpc.router({
     trpc.Tag.Community,
   ),
   getContestLog: trpc.query(Contest.GetContestLog, trpc.Tag.Community),
+  getFarcasterCasts: trpc.query(
+    Contest.GetFarcasterContestCasts,
+    trpc.Tag.Community,
+  ),
   farcasterWebhook: trpc.command(
     Contest.FarcasterCastCreatedWebhook,
-    trpc.Tag.Community,
-  ), // TODO: Use different tag?
+    trpc.Tag.Integration,
+  ),
 });

--- a/packages/commonwealth/server/api/integration-router.ts
+++ b/packages/commonwealth/server/api/integration-router.ts
@@ -30,6 +30,7 @@ function build() {
 
   if (config.CONTESTS.FLAG_FARCASTER_CONTEST) {
     // Farcaster frames
+    // WARNING: do not change this because cloudflare may route to it
     router.use('/farcaster/contests', farcasterRouter);
 
     // Farcaster webhooks/actions

--- a/packages/commonwealth/server/farcaster/router.tsx
+++ b/packages/commonwealth/server/farcaster/router.tsx
@@ -8,6 +8,7 @@ import { resultGame, startGame } from './frames/gameExample';
 
 const farcasterRouter = express.Router();
 
+// WARNING: do not change these paths because cloudflare may route to it
 farcasterRouter.get('/:contest_address/contestCard', contestCard);
 farcasterRouter.post('/:contest_address/contestCard', contestCard);
 farcasterRouter.post('/:contest_address/viewLeaderboard', viewLeaderboard);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9472

## Description of Changes
- Adds query to fetch farcaster casts by contest
- Updates Farcaster docs with latest instructions

## Test Plan
- Follow the instructions to create a farcaster contest, post a cast, then a cast reply: https://github.com/hicommonwealth/commonwealth/blob/master/common_knowledge/Farcaster-Contests.md
- Make GET request to `http://localhost:3000/api/internal/GetFarcasterContestCasts?contest_address=YOUR_CONTEST_ADDRESS`
  - Confirm that payload contains the parent cast and reply cast

## Deployment Plan
N/A

## Other Considerations
For the Cast type, there's a native TS type, but converting to Zod would be rather complex. Also, Zod will remove any properties not specified in the schema. In order to preserve the full payload, it's using `Array<z.any()>` for the output schema.