### PR TITLE
Target market cap formula

### DIFF
--- a/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
+++ b/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
@@ -100,6 +100,9 @@ export const transferLiquidity = async (
   return txReceipt;
 };
 
+// Returns market cap in ETH. Default variables will always return ~29.5 ETH
+// Will need to be converted to USD on the client using APIs used for stake, etc
+// USD Mkt Cap = ETH * USD/ETH rate
 export const getTargetMarketCap = (
   initialReserve: number = 4.167e8,
   initialSupply: number = 1e18,
@@ -110,6 +113,5 @@ export const getTargetMarketCap = (
   const x = initialReserve / (initialSupply * connectorWeight);
   const y = (currentSupply / initialSupply) ** (1 / connectorWeight - 1);
   const price = x * y;
-  const mktCapWei = price * totalSupply;
-  return mktCapWei;
+  return price * totalSupply;
 };

--- a/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
+++ b/libs/shared/src/commonProtocol/contractHelpers/Launchpad.ts
@@ -99,3 +99,17 @@ export const transferLiquidity = async (
     .send({ value: amountIn, from: walletAddress });
   return txReceipt;
 };
+
+export const getTargetMarketCap = (
+  initialReserve: number = 4.167e8,
+  initialSupply: number = 1e18,
+  currentSupply: number = 4.3e26,
+  connectorWeight: number = 0.83,
+  totalSupply: number = 1e9,
+): number => {
+  const x = initialReserve / (initialSupply * connectorWeight);
+  const y = (currentSupply / initialSupply) ** (1 / connectorWeight - 1);
+  const price = x * y;
+  const mktCapWei = price * totalSupply;
+  return mktCapWei;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: N/A

## Description of Changes
- Add target mkt cap(in ETH) helper function
- includes the default params we are planning to hard-code into all launches 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- NOTE: This is ETH mkt cap. You will need to do something similar to what is done in the community stake modal to convert ETH to USD. 