### PR TITLE
only run libp2p in production

### DIFF
--- a/libs/shared/src/canvas/runtime/node.ts
+++ b/libs/shared/src/canvas/runtime/node.ts
@@ -10,7 +10,7 @@ export const CANVAS_TOPIC = contractTopic;
 
 export const startCanvasNode = async (config: {
   LIBP2P_PRIVATE_KEY?: string;
-}): Promise<{ app: Canvas; libp2p: Libp2p }> => {
+}): Promise<{ app: Canvas; libp2p: Libp2p | null }> => {
   const path =
     process.env.FEDERATION_POSTGRES_DB_URL ??
     (process.env.APP_ENV === 'local'
@@ -57,14 +57,18 @@ export const startCanvasNode = async (config: {
     signers: getSessionSigners(),
   });
 
-  const libp2p = await app.startLibp2p({
-    announce: [announce],
-    listen: [listen],
-    bootstrapList: [explorerNode],
-    denyDialMultiaddr: (multiaddr) => multiaddr.toString() !== explorerNode,
-    privateKey,
-    start: true,
-  });
+  const libp2p =
+    process.env.APP_ENV === 'production'
+      ? await app.startLibp2p({
+          announce: [announce],
+          listen: [listen],
+          bootstrapList: [explorerNode],
+          denyDialMultiaddr: (multiaddr) =>
+            multiaddr.toString() !== explorerNode,
+          privateKey,
+          start: true,
+        })
+      : null;
 
   return { app, libp2p };
 };

--- a/packages/commonwealth/server/federation/index.ts
+++ b/packages/commonwealth/server/federation/index.ts
@@ -6,13 +6,15 @@ import { config } from '../config';
 const log = logger(import.meta);
 export const { app: canvas, libp2p } = await startCanvasNode(config);
 
-log.info(
-  'canvas: started libp2p with multiaddrs: ' +
-    libp2p
-      .getMultiaddrs()
-      .map((m) => m.toString())
-      .join(', '),
-);
+if (libp2p) {
+  log.info(
+    'canvas: started libp2p with multiaddrs: ' +
+      libp2p
+        .getMultiaddrs()
+        .map((m) => m.toString())
+        .join(', '),
+  );
+}
 
 export const applyCanvasSignedDataMiddleware: (
   input,


### PR DESCRIPTION
Prevent local and test environments from sending data to the Canvas node.

## Link to Issue
Closes: #9872

## Description of Changes
- Check for APP_ENV=production before starting libp2p.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- n/a

## Deployment Plan
- n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 