### PR TITLE
Fixed thread reaction counts in discussion page

### DIFF
--- a/libs/model/src/reaction/DeleteReaction.command.ts
+++ b/libs/model/src/reaction/DeleteReaction.command.ts
@@ -19,7 +19,7 @@ export function DeleteReaction(): Command<typeof schemas.DeleteReaction> {
         await reaction.destroy({ transaction });
         // TODO: move hook logic to command mutation
       });
-      return true;
+      return reaction;
     },
   };
 }

--- a/libs/model/src/reaction/DeleteReaction.command.ts
+++ b/libs/model/src/reaction/DeleteReaction.command.ts
@@ -19,7 +19,7 @@ export function DeleteReaction(): Command<typeof schemas.DeleteReaction> {
         await reaction.destroy({ transaction });
         // TODO: move hook logic to command mutation
       });
-      return reaction;
+      return { ...reaction!.toJSON() };
     },
   };
 }

--- a/libs/model/src/thread/GetThreads.query.ts
+++ b/libs/model/src/thread/GetThreads.query.ts
@@ -87,7 +87,7 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                 pinned, community_id, T.created_at, updated_at, locked_at as thread_locked, links,
                 has_poll, last_commented_on, comment_count as "numberOfComments",
                 marked_as_spam_at, archived_at, topic_id, reaction_weights_sum, canvas_signed_data,
-                canvas_msg_id, last_edited, address_id
+                canvas_msg_id, last_edited, address_id, reaction_count
             FROM "Threads" T
             WHERE
                 community_id = :community_id AND

--- a/libs/model/test/thread/thread-lifecycle.spec.ts
+++ b/libs/model/test/thread/thread-lifecycle.spec.ts
@@ -903,7 +903,11 @@ describe('Thread lifecycle', () => {
           reaction_id: reaction!.id!,
         },
       });
-      expect(deleted).to.be.true;
+      if (reaction) {
+        if (reaction.community_id) delete reaction.community_id;
+        if (reaction.Address) delete reaction.Address;
+      }
+      expect(deleted).to.toEqual(reaction);
     });
 
     test('should throw error when reaction not found', () => {
@@ -1024,7 +1028,11 @@ describe('Thread lifecycle', () => {
           reaction_id: reaction!.id!,
         },
       });
-      expect(deleted).to.be.true;
+      if (reaction) {
+        if (reaction.community_id) delete reaction.community_id;
+        if (reaction.Address) delete reaction.Address;
+      }
+      expect(deleted).to.toEqual(reaction);
     });
 
     test('should throw when trying to delete a reaction that is not yours', async () => {

--- a/libs/model/test/thread/thread-lifecycle.spec.ts
+++ b/libs/model/test/thread/thread-lifecycle.spec.ts
@@ -903,11 +903,12 @@ describe('Thread lifecycle', () => {
           reaction_id: reaction!.id!,
         },
       });
-      if (reaction) {
-        if (reaction.community_id) delete reaction.community_id;
-        if (reaction.Address) delete reaction.Address;
+      const tempReaction = { ...reaction };
+      if (tempReaction) {
+        if (tempReaction.community_id) delete tempReaction.community_id;
+        if (tempReaction.Address) delete tempReaction.Address;
       }
-      expect(deleted).to.toEqual(reaction);
+      expect(deleted).to.toEqual(tempReaction);
     });
 
     test('should throw error when reaction not found', () => {
@@ -1028,11 +1029,12 @@ describe('Thread lifecycle', () => {
           reaction_id: reaction!.id!,
         },
       });
-      if (reaction) {
-        if (reaction.community_id) delete reaction.community_id;
-        if (reaction.Address) delete reaction.Address;
+      const tempReaction = { ...reaction };
+      if (tempReaction) {
+        if (tempReaction.community_id) delete tempReaction.community_id;
+        if (tempReaction.Address) delete tempReaction.Address;
       }
-      expect(deleted).to.toEqual(reaction);
+      expect(deleted).to.toEqual(tempReaction);
     });
 
     test('should throw when trying to delete a reaction that is not yours', async () => {

--- a/libs/schemas/src/commands/thread.schemas.ts
+++ b/libs/schemas/src/commands/thread.schemas.ts
@@ -87,6 +87,6 @@ export const DeleteReaction = {
     canvas_signed_data: z.string().optional(),
     canvas_msg_id: z.string().optional(),
   }),
-  output: z.boolean(),
+  output: Reaction,
   context: ReactionContext,
 };

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -46,8 +46,10 @@ const useCreateThreadReactionMutation = ({
   communityId,
   threadId,
   currentReactionCount,
+  currentReactionWeightsSum,
 }: IUseCreateThreadReactionMutation & {
   currentReactionCount: number;
+  currentReactionWeightsSum: string;
 }) => {
   const { markTrainingActionAsComplete } =
     useUserOnboardingSliderMutationStore();
@@ -73,6 +75,10 @@ const useCreateThreadReactionMutation = ({
       );
       updateThreadInAllCaches(communityId, threadId, {
         reactionCount: currentReactionCount + 1,
+        reactionWeightsSum: `${
+          parseInt(currentReactionWeightsSum) +
+          parseInt(newReaction.calculated_voting_weight || `0`)
+        }`,
       });
 
       const userId = user.addresses?.[0]?.profile?.userId;

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -45,7 +45,10 @@ export const buildCreateThreadReactionInput = async ({
 const useCreateThreadReactionMutation = ({
   communityId,
   threadId,
-}: IUseCreateThreadReactionMutation) => {
+  currentReactionCount,
+}: IUseCreateThreadReactionMutation & {
+  currentReactionCount: number;
+}) => {
   const { markTrainingActionAsComplete } =
     useUserOnboardingSliderMutationStore();
 
@@ -68,6 +71,9 @@ const useCreateThreadReactionMutation = ({
         { associatedReactions: [reaction] },
         'combineAndRemoveDups',
       );
+      updateThreadInAllCaches(communityId, threadId, {
+        reactionCount: currentReactionCount + 1,
+      });
 
       const userId = user.addresses?.[0]?.profile?.userId;
       userId &&

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -49,8 +49,8 @@ const useDeleteThreadReactionMutation = ({
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
   return trpc.thread.deleteReaction.useMutation({
-    onSuccess: (deleted, variables) => {
-      if (deleted) {
+    onSuccess: (deletedReaction, variables) => {
+      if (deletedReaction) {
         updateThreadInAllCaches(
           communityId,
           threadId,
@@ -73,7 +73,7 @@ const useDeleteThreadReactionMutation = ({
           reactionWeightsSum: `${
             parseInt(currentReactionWeightsSum) -
             // TODO: need to get vote weight of deleted reaction from delete reaction response
-            parseInt(deleted?.calculated_voting_weight || `0`)
+            parseInt(deletedReaction?.calculated_voting_weight || `0`)
           }`,
         });
       }

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -40,12 +40,15 @@ export const buildDeleteThreadReactionInput = async ({
 const useDeleteThreadReactionMutation = ({
   communityId,
   threadId,
-}: UseDeleteThreadReactionMutationProps) => {
+  currentReactionCount,
+}: UseDeleteThreadReactionMutationProps & {
+  currentReactionCount: number;
+}) => {
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
   return trpc.thread.deleteReaction.useMutation({
     onSuccess: (deleted, variables) => {
-      deleted &&
+      if (deleted) {
         updateThreadInAllCaches(
           communityId,
           threadId,
@@ -62,6 +65,11 @@ const useDeleteThreadReactionMutation = ({
           },
           'removeFromExisting',
         );
+
+        updateThreadInAllCaches(communityId, threadId, {
+          reactionCount: currentReactionCount - 1,
+        });
+      }
     },
     onError: (error) => checkForSessionKeyRevalidationErrors(error),
   });

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -72,7 +72,6 @@ const useDeleteThreadReactionMutation = ({
           reactionCount: currentReactionCount - 1,
           reactionWeightsSum: `${
             parseInt(currentReactionWeightsSum) -
-            // TODO: need to get vote weight of deleted reaction from delete reaction response
             parseInt(deletedReaction?.calculated_voting_weight || `0`)
           }`,
         });

--- a/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/deleteReaction.ts
@@ -41,8 +41,10 @@ const useDeleteThreadReactionMutation = ({
   communityId,
   threadId,
   currentReactionCount,
+  currentReactionWeightsSum,
 }: UseDeleteThreadReactionMutationProps & {
   currentReactionCount: number;
+  currentReactionWeightsSum: string;
 }) => {
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
 
@@ -68,6 +70,11 @@ const useDeleteThreadReactionMutation = ({
 
         updateThreadInAllCaches(communityId, threadId, {
           reactionCount: currentReactionCount - 1,
+          reactionWeightsSum: `${
+            parseInt(currentReactionWeightsSum) -
+            // TODO: need to get vote weight of deleted reaction from delete reaction response
+            parseInt(deleted?.calculated_voting_weight || `0`)
+          }`,
         });
       }
     },

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -65,6 +65,7 @@ export const ReactionButton = ({
       threadId: thread.id,
       threadMsgId: thread.canvasMsgId!,
       currentReactionCount: thread.reactionCount || 0,
+      currentReactionWeightsSum: `${thread?.reactionWeightsSum || 0}`,
     });
   const { mutateAsync: deleteThreadReaction, isLoading: isDeletingReaction } =
     useDeleteThreadReactionMutation({
@@ -73,6 +74,7 @@ export const ReactionButton = ({
       threadId: thread.id,
       threadMsgId: thread.canvasMsgId!,
       currentReactionCount: thread.reactionCount || 0,
+      currentReactionWeightsSum: `${thread?.reactionWeightsSum || 0}`,
     });
 
   if (showSkeleton) return <ReactionButtonSkeleton />;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -64,6 +64,7 @@ export const ReactionButton = ({
       communityId,
       threadId: thread.id,
       threadMsgId: thread.canvasMsgId!,
+      currentReactionCount: thread.reactionCount || 0,
     });
   const { mutateAsync: deleteThreadReaction, isLoading: isDeletingReaction } =
     useDeleteThreadReactionMutation({
@@ -71,6 +72,7 @@ export const ReactionButton = ({
       address: user.activeAccount?.address || '',
       threadId: thread.id,
       threadMsgId: thread.canvasMsgId!,
+      currentReactionCount: thread.reactionCount || 0,
     });
 
   if (showSkeleton) return <ReactionButtonSkeleton />;

--- a/packages/commonwealth/test/integration/api/createReactions.spec.ts
+++ b/packages/commonwealth/test/integration/api/createReactions.spec.ts
@@ -37,7 +37,7 @@ describe('createReaction Integration Tests', () => {
       .set('address', address)
       .send(validRequest);
     assert.equal((res as any).statusCode, 200);
-    return res.text === 'true';
+    return res?.statusCode === 200;
   };
 
   const getUniqueCommentText = async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9807

## Description of Changes
Fixed thread reaction counts on the community discussion page

## "How We Fixed It"
N/A

## Test Plan
- Verify you are correctly able to add/remove reactions from the thread discussions page in a non-staked community
- Verify you are correctly able to add/remove weighted reactions from the thread discussions page in a staked community where you have some vote weight.

## Deployment Plan
N/A

## Other Considerations
N/A