### PR TITLE
added the query to get thread count

### DIFF
--- a/libs/schemas/src/queries/thread.schemas.ts
+++ b/libs/schemas/src/queries/thread.schemas.ts
@@ -224,6 +224,7 @@ export const GetThreads = {
     limit: z.number(),
     numVotingThreads: z.number(),
     threads: z.array(ThreadView),
+    threadCount: z.number().optional(),
   }),
 };
 

--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -234,13 +234,12 @@ const useFetchThreadsQuery = (
       { threads: [] },
     );
 
-    const newData = {
+    const formattedData = {
       ...chosenQueryType,
       data: reducedData.threads,
       threadCount: chosenQueryType?.data?.pages[0].data.threadCount,
     };
-    console.log({ newData });
-    return newData;
+    return formattedData;
   }
 
   if (isFetchActiveThreadsProps(props)) return chosenQueryType;

--- a/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/fetchThreads.ts
@@ -136,6 +136,7 @@ const fetchBulkThreads = (props) => {
       limit: number;
       page: number;
       threads: Thread[];
+      threadCount: number;
     };
     pageParam: number | undefined;
   }> => {
@@ -165,11 +166,11 @@ const fetchBulkThreads = (props) => {
         }),
       },
     });
-
     // transform the response
     const transformedData = {
       ...res.data.result,
       threads: res.data.result.threads.map((c) => new Thread(c)),
+      threadCount: res.data.result.threadCount,
     };
 
     return {
@@ -233,10 +234,13 @@ const useFetchThreadsQuery = (
       { threads: [] },
     );
 
-    return {
+    const newData = {
       ...chosenQueryType,
       data: reducedData.threads,
+      threadCount: chosenQueryType?.data?.pages[0].data.threadCount,
     };
+    console.log({ newData });
+    return newData;
   }
 
   if (isFetchActiveThreadsProps(props)) return chosenQueryType;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -25,7 +25,6 @@ import useBrowserWindow from 'hooks/useBrowserWindow';
 import useManageDocumentTitle from 'hooks/useManageDocumentTitle';
 import useTopicGating from 'hooks/useTopicGating';
 import 'pages/discussions/index.scss';
-import { useGetCommunityByIdQuery } from 'state/api/communities';
 import { useFetchCustomDomainQuery } from 'state/api/configuration';
 import { useGetERC20BalanceQuery } from 'state/api/tokens';
 import Permissions from 'utils/Permissions';
@@ -74,12 +73,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const dateRange: ThreadTimelineFilterTypes = searchParams.get(
     'dateRange',
   ) as ThreadTimelineFilterTypes;
-
-  const { data: community } = useGetCommunityByIdQuery({
-    id: communityId,
-    enabled: !!communityId,
-    includeNodeInfo: true,
-  });
 
   const { data: topics, isLoading: isLoadingTopics } = useFetchTopicsQuery({
     communityId,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -134,7 +134,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     nodeEthChainId: app?.chain.meta?.ChainNode?.eth_chain_id || 0,
   });
 
-  const { fetchNextPage, data, isInitialLoading, hasNextPage } =
+  const { fetchNextPage, data, isInitialLoading, hasNextPage, threadCount } =
     useFetchThreadsQuery({
       communityId: communityId,
       queryType: 'bulk',
@@ -283,7 +283,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
             isOnArchivePage
               ? filteredThreads.length || 0
               : threads
-                ? community?.lifetime_thread_count || 0
+                ? threadCount || 0
                 : 0
           }
           isIncludingSpamThreads={includeSpamThreads}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9419 

## Description of Changes
- added new database query to fetch the thread count with selected filters and sort options 
- Replace thread count  
`     : threads
                ? community?.lifetime_thread_count || 0
                ? threadCount || 0`
                to 
                `threads
                ? threadCount || 0`

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

-Previously we are getting the count from this api request  useGetCommunityByIdQuery  and we are using this api in many places so i did not change it .
- I made the changes in useFetchThreadsQuery  , in server side i added new query to fetch the count base on user selected filters .


## Test Plan
-Go to any community page and change topic and apply other filter you will see the changes in thread count.

Uploading Screen Recording 2024-11-18 at 7.07.34 PM.mov…


  