### PR TITLE
update the growl design for mobile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/GrowlTemplate/CWGrowlTemplate.scss
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/GrowlTemplate/CWGrowlTemplate.scss
@@ -53,6 +53,12 @@
     gap: 1rem;
     cursor: default;
 
+    @include smallInclusive {
+      max-width: 20rem;
+      padding: 0.5rem;
+      gap: 0.3rem;
+    }
+
     .subtitle-text {
       margin-top: -12px;
     }

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/GrowlTemplate/CWGrowlTemplate.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/GrowlTemplate/CWGrowlTemplate.tsx
@@ -1,3 +1,4 @@
+import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import React, { useState } from 'react';
 import useGrowlStore from 'state/ui/growl';
 import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
@@ -32,7 +33,7 @@ export const CWGrowlTemplate = ({
   growlType,
 }: CWGrowlTemplateProps) => {
   const { setIsGrowlHidden, isGrowlHidden } = useGrowlStore();
-
+  const { isWindowSmallInclusive } = useBrowserWindow({});
   const [shouldHideGrowlPermanently, setShouldHideGrowlPermanently] =
     useState(false);
 
@@ -55,7 +56,10 @@ export const CWGrowlTemplate = ({
   };
 
   return (
-    <CWGrowl disabled={isDisabled} position="bottom-right">
+    <CWGrowl
+      disabled={isDisabled}
+      position={isWindowSmallInclusive ? 'center' : 'bottom-right'}
+    >
       <div className="CWGrowlTemplate">
         <CWIconButton
           iconName="close"
@@ -65,10 +69,19 @@ export const CWGrowlTemplate = ({
         />
         {growlImage && <img src={growlImage} alt="" className="img" />}
         <div className="container">
-          <CWText type="h2" fontWeight="bold" isCentered>
+          <CWText
+            type={isWindowSmallInclusive ? 'h4' : 'h2'}
+            fontWeight="bold"
+            isCentered
+          >
             {headerText}
           </CWText>
-          <CWText type="b1" fontWeight="medium" isCentered className="body">
+          <CWText
+            type={isWindowSmallInclusive ? 'b2' : 'b1'}
+            fontWeight="medium"
+            isCentered
+            className="body"
+          >
             {bodyText}
           </CWText>
           {buttonLink && (

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_growl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_growl.tsx
@@ -6,7 +6,7 @@ import { CWCard } from './cw_card';
 import { getClasses } from './helpers';
 import { ComponentType } from './types';
 
-type GrowlPosition = 'bottom-left' | 'bottom-right';
+type GrowlPosition = 'bottom-left' | 'bottom-right' | 'center';
 
 type GrowlAttrs = {
   className?: string;

--- a/packages/commonwealth/client/styles/components/component_kit/cw_growl.scss
+++ b/packages/commonwealth/client/styles/components/component_kit/cw_growl.scss
@@ -8,9 +8,9 @@ $growl-outside-right-padding: 32px; // accounts for scrollbar width
   bottom: $growl-outside-bottom-padding;
   display: flex;
   position: fixed;
-
+  max-width: 400px;
   @include smallInclusive {
-    max-width: 400px;
+    max-width: 320px;
     max-height: 100%;
   }
 
@@ -20,6 +20,13 @@ $growl-outside-right-padding: 32px; // accounts for scrollbar width
 
   &.bottom-right {
     right: $growl-outside-right-padding;
+  }
+  &.center {
+    top: 50%;
+    left: 48%;
+    transform: translate(-50%, -50%);
+    bottom: auto;
+    right: auto;
   }
 
   .growl-card.Card {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9916 

## Description of Changes
- use the  `  const { isWindowSmallInclusive } = useBrowserWindow({}); ` to pass text design 
- use the ` @include smallInclusive {
      max-width: 20rem;
      padding: 0.5rem;
      gap: 0.3rem; 
    }` on container to minimize the container

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- use the  `  const { isWindowSmallInclusive } = useBrowserWindow({}); ` to pass text design 
- use the ` @include smallInclusive {
      max-width: 20rem;
      padding: 0.5rem;
      gap: 0.3rem; 
    }` on container to minimize the container
