### PR TITLE
Add warning message to contest without upvotes

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -103,7 +103,7 @@ export const CommunitySection = ({ showSkeleton }: CommunitySectionProps) => {
 
         <CWDivider />
         <DiscussionSection
-          isContestAvailable={stakeEnabled && isContestAvailable}
+          isContestAvailable={isContestAvailable}
           // @ts-expect-error <StrictNullChecks/>
           topicIdsIncludedInContest={topicIdsIncludedInContest}
         />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -33,6 +33,13 @@ const noFundsProps = {
   iconName: 'coins' as IconName,
 };
 
+const noUpvotesWarningProps = {
+  title: 'Upvote contests to avoid return of funds',
+  description:
+    "The prize amount will be returned to Common and then to admin's wallet if there are no upvotes",
+  iconName: 'warning' as IconName,
+};
+
 interface ContestCardProps {
   address: string;
   name: string;
@@ -50,6 +57,7 @@ interface ContestCardProps {
   isHorizontal?: boolean;
   isFarcaster?: boolean;
   payoutStructure?: number[];
+  hasVotes?: boolean;
 }
 
 const ContestCard = ({
@@ -69,6 +77,7 @@ const ContestCard = ({
   isHorizontal = false,
   isFarcaster = false,
   payoutStructure,
+  hasVotes = false,
 }: ContestCardProps) => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
@@ -152,6 +161,16 @@ const ContestCard = ({
 
   const showNoFundsInfo = isActive && (contestBalance || 0) <= 0;
 
+  const isLessThan24HoursLeft =
+    moment(finishDate).diff(moment(), 'hours') <= 24;
+
+  const showNoUpvotesWarning =
+    isActive &&
+    isAdmin &&
+    isLessThan24HoursLeft &&
+    (contestBalance || 0) > 0 &&
+    !hasVotes;
+
   return (
     <CWCard
       className={clsx('ContestCard', {
@@ -197,6 +216,9 @@ const ContestCard = ({
             />
           ) : (
             <>
+              {showNoUpvotesWarning && (
+                <ContestAlert {...noUpvotesWarningProps} />
+              )}
               <CWText className="prizes-header" fontWeight="bold">
                 Current Prizes
               </CWText>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -168,7 +168,12 @@ const ContestCard = ({
   const hasVotes = score.length > 0;
   const hasLessVotesThanPrizes = (payoutStructure || []).length > score.length;
 
+  // TODO remove this flag during the bacakend
+  // implementation in https://github.com/hicommonwealth/commonwealth/issues/9922
+  const showNoUpvotesWarningFlag = false;
+
   const showNoUpvotesWarning =
+    showNoUpvotesWarningFlag &&
     isActive &&
     isAdmin &&
     isLessThan24HoursLeft &&

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -108,7 +108,7 @@ const ContestsList = ({
                   isFarcaster={
                     farcasterContestEnabled && contest.is_farcaster_contest
                   }
-                  hasVotes={(score || []).length > 0}
+                  score={score || []}
                 />
               );
             } else {
@@ -135,7 +135,7 @@ const ContestsList = ({
                   isFarcaster={
                     farcasterContestEnabled && contest.is_farcaster_contest
                   }
-                  hasVotes={(sc?.score || [])?.length > 0}
+                  score={sc?.score || []}
                 />
               ));
             }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -84,7 +84,7 @@ const ContestsList = ({
 
             if (!displayAllRecurringContests) {
               // only last contest is relevant
-              const { end_time } =
+              const { end_time, score } =
                 sortedContests[sortedContests.length - 1] || {};
 
               return (
@@ -108,6 +108,7 @@ const ContestsList = ({
                   isFarcaster={
                     farcasterContestEnabled && contest.is_farcaster_contest
                   }
+                  hasVotes={(score || []).length > 0}
                 />
               );
             } else {
@@ -134,6 +135,7 @@ const ContestsList = ({
                   isFarcaster={
                     farcasterContestEnabled && contest.is_farcaster_contest
                   }
+                  hasVotes={(sc?.score || [])?.length > 0}
                 />
               ));
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9923 

## Description of Changes
- added two types of messages for admin in contest card according to the requirements in the ticket #9923 

<img width="636" alt="Topic erc20" src="https://github.com/user-attachments/assets/cc729847-decf-48ac-8578-d9a2f595ac81">

<img width="642" alt="Topic erc20" src="https://github.com/user-attachments/assets/1e205049-b9fd-4bf5-9ce7-1d0b1a43e41b">


## Test Plan
- it won't be visible to the user until #9922 will be done on BE side


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a