### PR TITLE
Fixed profile count

### DIFF
--- a/libs/model/src/community/JoinCommunity.command.ts
+++ b/libs/model/src/community/JoinCommunity.command.ts
@@ -3,7 +3,6 @@ import * as schemas from '@hicommonwealth/schemas';
 import { ChainBase, addressSwapper } from '@hicommonwealth/shared';
 import { models } from '../database';
 import { mustExist } from '../middleware/guards';
-import { incrementProfileCount } from '../utils';
 import { findCompatibleAddress } from '../utils/findBaseAddress';
 
 export const JoinCommunityErrors = {
@@ -102,11 +101,11 @@ export function JoinCommunity(): Command<typeof schemas.JoinCommunity> {
             { transaction },
           );
 
-          await incrementProfileCount(
-            community.id,
-            actor.user.id!,
+          await models.Community.increment('profile_count', {
+            by: 1,
+            where: { id: community_id },
             transaction,
-          );
+          });
 
           return created.id!;
         },

--- a/packages/commonwealth/server/migrations/20241119145300-recompute-profile-counts.js
+++ b/packages/commonwealth/server/migrations/20241119145300-recompute-profile-counts.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+        UPDATE "Communities" C
+        SET profile_count = (SELECT COUNT(DISTINCT (user_id)) FROM "Addresses" WHERE community_id = C.id);
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};

--- a/packages/commonwealth/server/util/verifySessionSignature.ts
+++ b/packages/commonwealth/server/util/verifySessionSignature.ts
@@ -91,8 +91,17 @@ const verifySessionSignature = async (
         });
         if (!user || !user.id) throw new Error('Failed to create user');
         addressModel.user_id = user!.id;
+
+        await addressModel.save();
+        return;
       }
     }
+
+    // user already exists but new community joined
+    await incrementProfileCount(
+      addressModel.community_id!,
+      addressModel.user_id!,
+    );
   } else {
     // mark the address as verified
     addressModel.verification_token_expires = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9721

## Description of Changes
- Adds migration script to fix all profile counts
Fixes login in 2 places:
1. Due to the isolation level, since we were updating the user and the profile_count (which depended on the user) in the same transaction, the Read Committed isolation level did not read the state of the DB at the time of the command, but instead the state before the transaction started.
2. When existing user joins a community, it now handles with a incrementProfile

## Test Plan
For both fixes, check the before and after on some community (say we are testing the skale-testing community. We would check http://localhost:8080/skale-testing/members?tab=all-members).

Testing the two fixes:
1. Create a user and join any community from the "Join community button".  Check that this member count has incremented. (corresponds with fix 1)
2. Sign in on a scoped page (say http://localhost:8080/skale-testing/dydx). This will automatically join you to a community and should increment the member count.
