### PR TITLE
made changes to stop undefined length error when loading communities

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useTopicGating.ts
+++ b/packages/commonwealth/client/scripts/hooks/useTopicGating.ts
@@ -33,7 +33,7 @@ const useTopicGating = ({
         acc.push(current);
         // IMP: this logic can break if `PermissionEnum` or the `GroupPermissions`
         // schema is changed substantially and might not give off a ts issue.
-      } else if (current.permissions.length > existing.permissions.length) {
+      } else if (current?.permissions?.length > existing?.permissions?.length) {
         // Replace with the current item if it has a longer permission string
         const index = acc.indexOf(existing);
         acc[index] = current;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9956 

## Description of Changes
**Shout out to @mzparacha for fixing this. I'm just making a PR for it because his local branch is messed up at the moment.** 

NOTE:
This bug was unable to be replicated, but this is the likely cause of it. This change should prevent it from breaking every so often when length is undefined. 

Added ?'s to account for undefined length
