### PR TITLE
X now shows on All/Overview model desktop and mobile

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -403,6 +403,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                     bodyText="'Overview' page has been merged with the 'All' page"
                     buttonText="test"
                     growlType="discussion"
+                    blackCloseButton
                   />
                 </>
               );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9975 

X now shows on All/Overview model desktop and mobile

![Screenshot 2024-11-20 at 1 31 36 PM](https://github.com/user-attachments/assets/e7c6df7a-785c-46f9-9851-863314467fdf)
![Screenshot 2024-11-20 at 1 31 22 PM](https://github.com/user-attachments/assets/c4e216c4-8316-4f15-ab23-4544d071b822)

