### PR TITLE
added char count to edit topic modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -55,6 +55,25 @@ export const EditTopicModal = ({
     featuredInSidebarProp,
   );
   const [name, setName] = useState<string>(nameProp);
+  // const [characterCount, setCharacterCount] = useState(0);
+  console.log('this is description', description);
+  // const getCharacterCount = (delta) => {
+  //   if (!delta || !delta.ops) {
+  //     return 0;
+  //   }
+  //   return delta.ops.reduce((count, op) => {
+  //     if (typeof op.insert === 'string') {
+  //       const cleanedText = op.insert.replace(/\n$/, '');
+  //       return count + cleanedText.length;
+  //     }
+  //     return count;
+  //   }, 0);
+  // };
+
+  // useEffect(() => {
+  //   const count = getCharacterCount(description);
+  //   setCharacterCount(count);
+  // }, [description]);
 
   const handleSaveChanges = async () => {
     setIsSaving(true);
@@ -175,6 +194,7 @@ export const EditTopicModal = ({
           })}
           isDisabled={!!topic.archived_at}
         />
+        <CWText type="caption">Character count: /250</CWText>
         <CWCheckbox
           label="Featured in Sidebar"
           checked={featuredInSidebar}

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -1,5 +1,5 @@
 import { pluralizeWithoutNumberPrefix } from 'helpers';
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { Topic } from '../../models/Topic';
 import { useCommonNavigate } from '../../navigation/helpers';
 import app from '../../state';
@@ -20,6 +20,7 @@ import { openConfirmation } from './confirmation_modal';
 
 import { notifySuccess } from 'controllers/app/notifications';
 import { DeltaStatic } from 'quill';
+import { MessageRow } from 'views/components/component_kit/new_designs/CWTextInput/MessageRow';
 import '../../../styles/modals/edit_topic_modal.scss';
 import { CWText } from '../components/component_kit/cw_text';
 import { ReactQuillEditor } from '../components/react_quill_editor';
@@ -55,25 +56,34 @@ export const EditTopicModal = ({
     featuredInSidebarProp,
   );
   const [name, setName] = useState<string>(nameProp);
-  // const [characterCount, setCharacterCount] = useState(0);
-  console.log('this is description', description);
-  // const getCharacterCount = (delta) => {
-  //   if (!delta || !delta.ops) {
-  //     return 0;
-  //   }
-  //   return delta.ops.reduce((count, op) => {
-  //     if (typeof op.insert === 'string') {
-  //       const cleanedText = op.insert.replace(/\n$/, '');
-  //       return count + cleanedText.length;
-  //     }
-  //     return count;
-  //   }, 0);
-  // };
+  const [characterCount, setCharacterCount] = useState(0);
+  const [descErrorMsg, setDescErrorMsg] = useState<string | null>(null);
 
-  // useEffect(() => {
-  //   const count = getCharacterCount(description);
-  //   setCharacterCount(count);
-  // }, [description]);
+  const getCharacterCount = (delta) => {
+    if (!delta || !delta.ops) {
+      return 0;
+    }
+    return delta.ops.reduce((count, op) => {
+      if (typeof op.insert === 'string') {
+        const cleanedText = op.insert.replace(/\n$/, '');
+        return count + cleanedText.length;
+      }
+      return count;
+    }, 0);
+  };
+
+  useEffect(() => {
+    const count = getCharacterCount(description);
+    setCharacterCount(count);
+  }, [description]);
+
+  useMemo(() => {
+    if ((description?.ops || [])?.[0]?.insert?.length > 250) {
+      setDescErrorMsg('Description must be 250 characters or less');
+    } else {
+      setDescErrorMsg(null);
+    }
+  }, [description]);
 
   const handleSaveChanges = async () => {
     setIsSaving(true);
@@ -194,7 +204,15 @@ export const EditTopicModal = ({
           })}
           isDisabled={!!topic.archived_at}
         />
-        <CWText type="caption">Character count: /250</CWText>
+        <div className="char-error-row">
+          <CWText type="caption">Character count: {characterCount}/250</CWText>
+          <MessageRow
+            // @ts-expect-error <StrictNullChecks/>
+            statusMessage={descErrorMsg}
+            hasFeedback={!!descErrorMsg}
+            validationStatus={descErrorMsg ? 'failure' : undefined}
+          />
+        </div>
         <CWCheckbox
           label="Featured in Sidebar"
           checked={featuredInSidebar}
@@ -229,7 +247,7 @@ export const EditTopicModal = ({
             buttonHeight="sm"
             onClick={handleSaveChanges}
             label="Save changes"
-            disabled={!!topic.archived_at}
+            disabled={!!topic.archived_at || !!descErrorMsg}
           />
         </div>
         {errorMsg && (

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -1,5 +1,5 @@
 import { pluralizeWithoutNumberPrefix } from 'helpers';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Topic } from '../../models/Topic';
 import { useCommonNavigate } from '../../navigation/helpers';
 import app from '../../state';
@@ -77,7 +77,7 @@ export const EditTopicModal = ({
     setCharacterCount(count);
   }, [description]);
 
-  useMemo(() => {
+  useEffect(() => {
     if ((description?.ops || [])?.[0]?.insert?.length > 250) {
       setDescErrorMsg('Description must be 250 characters or less');
     } else {
@@ -207,8 +207,7 @@ export const EditTopicModal = ({
         <div className="char-error-row">
           <CWText type="caption">Character count: {characterCount}/250</CWText>
           <MessageRow
-            // @ts-expect-error <StrictNullChecks/>
-            statusMessage={descErrorMsg}
+            statusMessage={descErrorMsg || ''}
             hasFeedback={!!descErrorMsg}
             validationStatus={descErrorMsg ? 'failure' : undefined}
           />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/CreateTopicSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/CreateTopicSection.tsx
@@ -1,6 +1,6 @@
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import { DeltaStatic } from 'quill';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import app from 'state';
 import { useFetchTopicsQuery } from 'state/api/topics';
 import { CWCheckbox } from 'views/components/component_kit/cw_checkbox';
@@ -85,7 +85,7 @@ export const CreateTopicSection = ({
     return ['success', 'Valid topic name'];
   };
 
-  useMemo(() => {
+  useEffect(() => {
     if ((descriptionDelta?.ops || [])?.[0]?.insert?.length > 250) {
       setDescErrorMsg('Description must be 250 characters or less');
     } else {
@@ -160,8 +160,7 @@ export const CreateTopicSection = ({
         </div>
         <div className="actions">
           <MessageRow
-            // @ts-expect-error <StrictNullChecks/>
-            statusMessage={descErrorMsg}
+            statusMessage={descErrorMsg || ''}
             hasFeedback={!!descErrorMsg}
             validationStatus={descErrorMsg ? 'failure' : undefined}
           />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/ManageTopicsSection/ManageTopicsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/ManageTopicsSection/ManageTopicsSection.tsx
@@ -81,7 +81,6 @@ export const ManageTopicsSection = () => {
     includeArchivedTopics: true,
     apiEnabled: !!communityId,
   });
-  console.log('rawTopics => ', rawTopics);
 
   const { mutateAsync: updateFeaturedTopicsOrder } =
     useUpdateFeaturedTopicsOrderMutation();

--- a/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
+++ b/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
@@ -29,11 +29,5 @@
         margin-right: auto;
       }
     }
-    // .error-message {
-    //   display: block;
-    //   align-items: center;
-    //   text-align: end;
-    //   margin-top: 0;
-    // }
   }
 }

--- a/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
+++ b/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
@@ -10,6 +10,12 @@
     overflow: auto;
   }
 
+  .char-error-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
   .EditTopicModalFooter {
     display: flex;
     flex-direction: column;
@@ -23,12 +29,11 @@
         margin-right: auto;
       }
     }
-
-    .error-message {
-      display: block;
-      align-items: center;
-      text-align: end;
-      margin-top: 0;
-    }
+    // .error-message {
+    //   display: block;
+    //   align-items: center;
+    //   text-align: end;
+    //   margin-top: 0;
+    // }
   }
 }

--- a/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
+++ b/packages/commonwealth/client/styles/modals/edit_topic_modal.scss
@@ -29,5 +29,11 @@
         margin-right: auto;
       }
     }
+    .error-message {
+      display: block;
+      align-items: center;
+      text-align: end;
+      margin-top: 0;
+    }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9987 

## Description of Changes
- Added char count functionality to Edit topic modal. User no longer able to add more than 250 characters to a topic description

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-implemented the same logic from Create topic into Edit topic modal

## Test Plan
- go to Topics in Admin Capabilities
- click Manage topics and click on the pencil in one of the topics listed
- type more than 250 characters into the editor inside Edit topic modal
- confirm that you now see the number of characters in the editor, an error if the count > 250, and the Save changes button is disabled. 
