### PR TITLE
removed all-overview page growl

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -37,7 +37,6 @@ import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCo
 import { isContestActive } from 'views/pages/CommunityManagement/Contests/utils';
 import useTokenMetadataQuery from '../../../state/api/tokens/getTokenMetadata';
 import { AdminOnboardingSlider } from '../../components/AdminOnboardingSlider';
-import { CWGrowlTemplate } from '../../components/SublayoutHeader/GrowlTemplate/CWGrowlTemplate';
 import { UserTrainingSlider } from '../../components/UserTrainingSlider';
 import { CWText } from '../../components/component_kit/cw_text';
 import CWIconButton from '../../components/component_kit/new_designs/CWIconButton';
@@ -397,13 +396,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
                     }
                     hideRecentComments
                     editingDisabled={isThreadTopicInContest}
-                  />
-                  <CWGrowlTemplate
-                    headerText="Attention!"
-                    bodyText="'Overview' page has been merged with the 'All' page"
-                    buttonText="test"
-                    growlType="discussion"
-                    blackCloseButton
                   />
                 </>
               );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #9853 

## Description of Changes
- removed the growl announcing the merge of the All and Overview pages

## Test Plan
- go to any discussion and confirm you no longer see the All/Overview merge growl