### PR TITLE
packages/commonwealth: handle case where threadId is null

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -94,7 +94,7 @@ export const CreateComment = ({
         const input = await buildCreateCommentInput({
           communityId,
           address: user.activeAccount!.address,
-          threadId: rootThread.id,
+          threadId: rootThread.id ?? null,
           threadMsgId: rootThread.canvasMsgId!,
           unescapedText: serializeDelta(contentDelta),
           parentCommentId: parentCommentId ?? null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10025

## Description of Changes
- threadId may be undefined when commenting on a legacy thread, or a thread created by someone without a session key

## "How We Fixed It"
- prevent error by replacing undefined with null instead

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 