### PR TITLE
Fix farcaster contest breadcrumbs

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/utils.ts
@@ -175,8 +175,18 @@ export const generateBreadcrumbs = (
     }
 
     if (pathSegments.includes('contests')) {
-      if (index === 2 && pathSegment !== 'launch') {
-        label = 'Edit';
+      if (pathSegments.includes('manage')) {
+        if (index === 2 && pathSegment !== 'launch') {
+          label = 'Edit';
+        }
+      } else {
+        if (index === 1 && pathSegment === 'contests') {
+          link = 'contests';
+        }
+
+        if (index === 2) {
+          label = 'Leaderboard';
+        }
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10023 

## Description of Changes
- added more conditions to the breadcrumbs generation function



## Test Plan
- create farcaster contest
- go to leaderboard page
- clilck on breadcrumbs
- everything should work 

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a