### PR TITLE
pressing enter no longer freezes page

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
@@ -84,11 +84,15 @@ export const CWSearchBar: FC<SearchBarProps> = ({
 
   const resetSearchBar = () => setSearchTerm('');
 
-  const handleOnInput = (e: ChangeEvent<HTMLInputElement>) =>
+  const handleOnInput = (e: ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
     setSearchTerm(e.target.value);
+  };
 
   const handleOnKeyUp = (e) => {
+    e.stopPropagation();
     if (e.key === 'Enter') {
+      e.preventDefault();
       handleGoToSearchPage();
 
       if (size === 'small') {
@@ -112,6 +116,7 @@ export const CWSearchBar: FC<SearchBarProps> = ({
   };
 
   const handleOnKeyDown = (e: any) => {
+    e.stopPropagation();
     if (e.key === 'Backspace' && searchTerm.length === 0) {
       setShowTag(false);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10058 

## Description of Changes
- when a user presses enter on the main search bar it no longer freezes the site

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `e.preventDefault()` and `e.stopPropagation()` to functions handling the search input

## Test Plan
- go to the dashboard and search anything in the Search Common search bar
- confirm that the site no longer freezes and you are still able to navigate around the site