### PR TITLE
move the contests tab to governance and change governance to apps

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -125,12 +125,11 @@ export const CommunitySection = ({ showSkeleton }: CommunitySectionProps) => {
 
         <CWDivider />
         <DiscussionSection
-          isContestAvailable={isContestAvailable}
           // @ts-expect-error <StrictNullChecks/>
           topicIdsIncludedInContest={topicIdsIncludedInContest}
         />
         <CWDivider />
-        <GovernanceSection />
+        <GovernanceSection isContestAvailable={isContestAvailable} />
         <CWDivider />
         <DirectoryMenuItem />
         <CWDivider />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -43,11 +43,9 @@ function setDiscussionsToggleTree(path: string, toggle: boolean) {
     JSON.stringify(newTree);
 }
 interface DiscussionSectionProps {
-  isContestAvailable: boolean;
   topicIdsIncludedInContest: number[];
 }
 export const DiscussionSection = ({
-  isContestAvailable,
   topicIdsIncludedInContest,
 }: DiscussionSectionProps) => {
   const navigate = useCommonNavigate();
@@ -56,10 +54,7 @@ export const DiscussionSection = ({
     [{ path: '/discussions' }, { path: ':scope/discussions' }],
     location,
   );
-  const matchesContestsRoute = matchRoutes(
-    [{ path: '/contests' }, { path: ':scope/contests' }],
-    location,
-  );
+
   const matchesArchivedRoute = matchRoutes(
     [{ path: '/archived' }, { path: ':scope/archived' }],
     location,
@@ -134,35 +129,6 @@ export const DiscussionSection = ({
       },
       displayData: null,
     },
-    ...(isContestAvailable
-      ? [
-          {
-            title: 'Contests',
-            containsChildren: false,
-            displayData: null,
-            hasDefaultToggle: false,
-            isActive: !!matchesContestsRoute,
-            isVisible: true,
-            isUpdated: true,
-            onClick: (e, toggle: boolean) => {
-              e.preventDefault();
-              resetSidebarState();
-              handleRedirectClicks(
-                navigate,
-                e,
-                `/contests`,
-                communityId,
-                () => {
-                  setDiscussionsToggleTree(
-                    `children.Contests.toggledState`,
-                    toggle,
-                  );
-                },
-              );
-            },
-          },
-        ]
-      : []),
   ];
 
   for (const topic of topics) {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -18,7 +18,9 @@ import type {
   SidebarSectionAttrs,
   ToggleTree,
 } from './types';
-
+interface AppSectionProps {
+  isContestAvailable: boolean;
+}
 const resetSidebarState = () => {
   if (isWindowSmallInclusive(window.innerWidth)) {
     sidebarStore.getState().setMenu({ name: 'default', isVisible: false });
@@ -50,7 +52,7 @@ function setGovernanceToggleTree(path: string, toggle: boolean) {
     JSON.stringify(newTree);
 }
 
-export const GovernanceSection = () => {
+export const GovernanceSection = ({ isContestAvailable }: AppSectionProps) => {
   const navigate = useCommonNavigate();
   const location = useLocation();
 
@@ -97,6 +99,12 @@ export const GovernanceSection = () => {
           children: {},
         },
       }),
+      ...(isContestAvailable && {
+        Contests: {
+          toggledState: false,
+          children: {},
+        },
+      }),
     },
   };
 
@@ -129,7 +137,10 @@ export const GovernanceSection = () => {
     [{ path: '/members' }, { path: ':scope/members' }],
     location,
   );
-
+  const matchesContestsRoute = matchRoutes(
+    [{ path: '/contests' }, { path: ':scope/contests' }],
+    location,
+  );
   // ---------- Build Section Props ---------- //
 
   // Members
@@ -221,18 +232,38 @@ export const GovernanceSection = () => {
     isActive: !!matchesProposalRoute,
     displayData: null,
   };
-
+  //Contests
+  const contestData: SectionGroupAttrs = {
+    title: 'Contests',
+    containsChildren: false,
+    displayData: null,
+    hasDefaultToggle: false,
+    isActive: !!matchesContestsRoute,
+    isVisible: true,
+    isUpdated: true,
+    onClick: (e, toggle: boolean) => {
+      e.preventDefault();
+      resetSidebarState();
+      handleRedirectClicks(navigate, e, `/contests`, communityId, () => {
+        setGovernanceToggleTree('children.Contests.toggledState', toggle);
+      });
+    },
+  };
   let governanceGroupData: SectionGroupAttrs[] = [
     membersData,
     snapshotData,
     proposalsData,
+    contestData,
   ];
 
   if (!hasProposals) governanceGroupData = [membersData];
+  if (isContestAvailable) {
+    governanceGroupData.push(contestData);
+  }
 
   const sidebarSectionData: SidebarSectionAttrs = {
-    title: 'Governance',
-    className: 'GovernanceSection',
+    title: 'Apps',
+    className: 'AppsSection',
     hasDefaultToggle: toggleTreeState['toggledState'],
     onClick: (e, toggle: boolean) => {
       e.preventDefault();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10056 

## Description of Changes
- Remove the "Contests"  from discussions and moved to governance Section
-Rename the governance Section to "Apps"

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Remove the "Contests"  from discussions and moved to governance Section
-Rename the governance Section to "Apps"

## Test Plan
Goto any community which have the contests ability  you will see the  governance Section rename to Apps and also see the Contests navigation there 