### PR TITLE
Fix stake history

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useTransactionHistory.ts
+++ b/packages/commonwealth/client/scripts/hooks/useTransactionHistory.ts
@@ -13,7 +13,7 @@ const useTransactionHistory = ({
   addressFilter,
 }: TransactionHistoryProps) => {
   const { data } = trpc.community.getStakeTransaction.useQuery({
-    addresses: addressFilter.length === 1 ? addressFilter.join(',') : undefined,
+    addresses: addressFilter.length >= 1 ? addressFilter.join(',') : undefined,
   });
 
   let filteredData = !data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9757

## Description of Changes
Fixed stake history to only show transactions of the auth user

## "How We Fixed It"
N/A

## Test Plan
- Visit stakes transaction history page
- Verify that you only see transactions that you are a part of

## Deployment Plan
N/A

## Other Considerations
N/A