### PR TITLE
Commented out CD flow for external API

### DIFF
--- a/.github/workflows/Versioning.yml
+++ b/.github/workflows/Versioning.yml
@@ -43,8 +43,9 @@ jobs:
         with:
           node-version: 20
 
-      - name: Bump external API version if necessary
-        run: pnpm -F commonwealth validate-external-api-version
+#.     Openapi diff hanging. Blocks release. Commenting out for now
+#      - name: Bump external API version if necessary
+#        run: pnpm -F commonwealth validate-external-api-version
 
       - name: Check if version was updated
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: Hotfix

## Description of Changes
- openapi diff is hanging blocking release. Commented it out for now (This will disable auto updating of external api client)

## Other Considerations
- Need to follow up on this #10098