### PR TITLE
update gas fallback

### DIFF
--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -352,7 +352,10 @@ export const rollOverContest = async (
       gasResult = await contractCall.estimateGas({
         from: web3.eth.defaultAccount,
       });
-    } catch {}
+    } catch {
+      //eslint-disable-next-line
+      //@ts-ignore no-empty
+    }
 
     const maxFeePerGasEst = await estimateGas(web3);
 

--- a/libs/model/src/services/commonProtocol/contestHelper.ts
+++ b/libs/model/src/services/commonProtocol/contestHelper.ts
@@ -347,15 +347,19 @@ export const rollOverContest = async (
       ? contestInstance.methods.endContest()
       : contestInstance.methods.newContest();
 
-    let gasResult;
+    let gasResult = BigInt(300000);
     try {
       gasResult = await contractCall.estimateGas({
         from: web3.eth.defaultAccount,
       });
-    } catch {
-      return false;
-    }
+    } catch {}
+
     const maxFeePerGasEst = await estimateGas(web3);
+
+    if (gasResult < BigInt(100000)) {
+      gasResult = BigInt(300000);
+    }
+
     await contractCall.send({
       from: web3.eth.defaultAccount,
       gas: gasResult.toString(),

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
@@ -39,7 +39,7 @@ import ContestTopicBanner from './ContestTopicBanner';
 import './NewThreadForm.scss';
 import { checkNewThreadErrors, useNewThreadForm } from './helpers';
 
-const MIN_ETH_FOR_CONTEST_THREAD = 0.0005;
+const MIN_ETH_FOR_CONTEST_THREAD = 0.0;
 
 export const NewThreadForm = () => {
   const navigate = useCommonNavigate();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10088

## Description of Changes
- Support fallback to hardcoded value if gas estimation fails/is incorrect 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
Used a max gas set to support all contests in an average range of winners. Resets gas to default if estimation results in a value that is invalid(as seen in production
