### PR TITLE
Fixed issue with duplicate email sign in magic.

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -547,26 +547,31 @@ export async function handleSocialLoginCallback({
   }
 
   // Otherwise, skip Account.validate(), proceed directly to server login
-  const response = await axios.post(
-    `${SERVER_URL}/auth/magic`,
-    {
-      data: {
-        community_id: desiredChain?.id,
-        jwt: userStore.getState().jwt,
-        username: profileMetadata?.username,
-        avatarUrl: profileMetadata?.avatarUrl,
-        magicAddress,
-        session: session && serializeCanvas(session),
-        walletSsoSource,
+  let response;
+  try {
+    response = await axios.post(
+      `${SERVER_URL}/auth/magic`,
+      {
+        data: {
+          community_id: desiredChain?.id,
+          jwt: userStore.getState().jwt,
+          username: profileMetadata?.username,
+          avatarUrl: profileMetadata?.avatarUrl,
+          magicAddress,
+          session: session && serializeCanvas(session),
+          walletSsoSource,
+        },
       },
-    },
-    {
-      withCredentials: true,
-      headers: {
-        Authorization: `Bearer ${bearer}`,
+      {
+        withCredentials: true,
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+        },
       },
-    },
-  );
+    );
+  } catch (e) {
+    notifyError(e.response.data.error);
+  }
 
   if (response.data.status === 'Success') {
     await initAppState(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10123

## Description of Changes
- Catch when the duplicate email error happens and throw an error with related message.
- Show error toast for user on front end.


## Test Plan
- With magic sign in, first sign in through email.
- Then sign out
- Then using the same email address, sign in through google SSO
- You should receive the error toast

<img width="327" alt="image" src="https://github.com/user-attachments/assets/891c93be-9a7a-470e-9c9c-13fe2a28e6af">