### PR TITLE
show the all joinned community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -58,6 +58,21 @@ export const SidebarQuickSwitcher = ({
               }
             />
           ))}
+        {user.communities
+          .filter((x) => !x.isStarred)
+          .map((community) => (
+            <CWCommunityAvatar
+              key={community.id}
+              size="large"
+              community={{
+                iconUrl: community.iconUrl,
+                name: community.name,
+              }}
+              onClick={() =>
+                navigateToCommunity({ navigate, path: '', chain: community.id })
+              }
+            />
+          ))}
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_quick_switcher.tsx
@@ -58,6 +58,7 @@ export const SidebarQuickSwitcher = ({
               }
             />
           ))}
+        <CWDivider />
         {user.communities
           .filter((x) => !x.isStarred)
           .map((community) => (


### PR DESCRIPTION
first showed fav communities then the rest of communities

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10129 

## Description of Changes
- shows the all joined communities in side bar 
- sort by fav and then rest of communities

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- shows the all joined communities in side bar 
- sort by fav and then rest of communities


## Test Plan
on the side bar you will be able to see all the communities you joined .Here is the picture for Reference 
![Screenshot 2024-12-05 at 7 22 19 PM](https://github.com/user-attachments/assets/5cf7a854-5156-4c95-8a45-c1e4f2030071)

