### PR TITLE
frontend mixpanel calls now hit dashboard

### DIFF
--- a/libs/adapters/src/mixpanel/index.ts
+++ b/libs/adapters/src/mixpanel/index.ts
@@ -16,10 +16,7 @@ export const MixpanelAnalytics = (): Analytics => {
       mixpanelNode = MixpanelLib.init(config.ANALYTICS.MIXPANEL_DEV_TOKEN!);
     }
   } catch (e) {
-    log.error(
-      'Unable to initialized the backend mixpanel client: ',
-      e as Error,
-    );
+    log.error('Unable to initialize the backend mixpanel: ', e as Error);
   }
 
   return {
@@ -29,7 +26,10 @@ export const MixpanelAnalytics = (): Analytics => {
       try {
         mixpanelNode?.track(event, payload);
       } catch (e) {
-        log.error(`Failed to track event, ${event.toString()}:`, e as Error);
+        log.error(
+          `Failed to track backend mixpanel event, ${event.toString()}:`,
+          e as Error,
+        );
       }
     },
   };

--- a/packages/commonwealth/shared/analytics/client-track.ts
+++ b/packages/commonwealth/shared/analytics/client-track.ts
@@ -4,14 +4,16 @@ import { AnalyticsPayload, BaseMixpanelPayload, providers } from './types';
 // WARN: Using process.env to avoid webpack failures
 try {
   if (process.env.APP_ENV === 'production') {
-    mixpanel.init(process.env.MIXPANEL_PROD_TOKEN, { debug: true });
-  } else if (process.env.APP_ENV === 'development') {
-    // NOTE: Only works if NODE_ENV defined in .env
-    // Make sure that is set to development if you want to use backend Mixpanel locally.
-    mixpanel.init(process.env.MIXPANEL_DEV_TOKEN, { debug: true });
+    mixpanel.init(process.env.MIXPANEL_PROD_TOKEN, {
+      debug: true,
+    });
+  } else if (process.env.APP_ENV === 'local') {
+    mixpanel.init(process.env.MIXPANEL_DEV_TOKEN, {
+      debug: true,
+    });
   }
 } catch (e) {
-  console.log('Unable to initialized the backend mixpanel client: ', e);
+  console.log('Unable to initialize the frontend mixpanel: ', e);
 }
 
 // ----- Client Side Mixpanel Library Utils ------ //
@@ -20,7 +22,10 @@ export function mixpanelBrowserTrack<T extends BaseMixpanelPayload>(data: T) {
   try {
     mixpanel.track(event, payload);
   } catch (e) {
-    console.log(`Failed to track event, ${event.toString()}:`, e.message);
+    console.log(
+      `Failed to track frontend mixpanel event, ${event.toString()}:`,
+      e.message,
+    );
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10064 

## Description of Changes
- Frontend Mixpanel calls now hit the Mixpanel dashboard

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-Changed code to look for `process.env.APP_ENV === 'local'` and changed error messages to reflect frontend and backend inits 

NOTE: The original error shown in the ticket, "Failed to track event, Cannot read properties of 'undefined'" came from the code looking for `process.env.APP_ENV === 'development'` within the init function, and since the env var isn't 'development' anymore it was throwing that error. If you review this PR and you're seeing an error of `Bad HTTP status: 0` that is most likely because an ad blocker you have is blocking the frontend mixpanel calls. Try disabling any ad blockers and trying again. 

## Test Plan
- Click around locally and try to trigger some of the frontend mixpanel calls found in `shared/analytics.types.ts`
- confirm that you see the event on the Mixpanel Dev dashboard (If you need access to Mixpanel or if you'd like for me to confirm the events in real time while you're testing just let me know.)