### PR TITLE
added tiktok logo

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/link.ts
+++ b/packages/commonwealth/client/scripts/helpers/link.ts
@@ -6,6 +6,7 @@ export type LinkType =
   | 'slack'
   | 'telegram'
   | 'x (twitter)'
+  | 'tiktok'
   | 'github'
   | 'matrix'
   | '';
@@ -17,6 +18,7 @@ export const getLinkType = (link: string): LinkType => {
   if (link.includes('slack.com')) return 'slack';
   if (link.includes('telegram.com')) return 'telegram';
   if (link.includes('t.me')) return 'telegram';
+  if (link.includes('tiktok.com')) return 'tiktok';
   if (link.includes('twitter.com') || link.includes('x.com'))
     return 'x (twitter)';
   if (link.includes('github.com')) return 'github';
@@ -28,6 +30,7 @@ export type CategorizedSocialLinks = {
   discords: string[];
   githubs: string[];
   telegrams: string[];
+  tiktoks: string[];
   twitters: string[];
   elements: string[];
   slacks: string[];
@@ -41,6 +44,7 @@ export const categorizeSocialLinks = (
     discords: [],
     githubs: [],
     telegrams: [],
+    tiktoks: [],
     twitters: [],
     elements: [],
     slacks: [],
@@ -61,6 +65,9 @@ export const categorizeSocialLinks = (
         break;
       case 'telegram':
         categorized.telegrams.push(link);
+        break;
+      case 'tiktok':
+        categorized.tiktoks.push(link);
         break;
       case 'x (twitter)':
         categorized.twitters.push(link);

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
@@ -271,6 +271,7 @@ export const iconLookup = {
   star: Icons.CWStar,
   sun: Icons.CWSun,
   telegram: Icons.CWTelegram,
+  tiktok: Icons.CWTiktok,
   trophy: withPhosphorIcon(Trophy),
   timer: withPhosphorIcon(Timer),
   transfer: Icons.CWTransfer,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icons.tsx
@@ -3134,6 +3134,35 @@ export const CWTelegram = (props: IconProps) => {
 };
 
 // eslint-disable-next-line react/no-multi-comp
+export const CWTiktok = (props: IconProps) => {
+  const {
+    className,
+    componentType,
+    disabled,
+    iconButtonTheme,
+    iconSize,
+    selected,
+    ...otherProps
+  } = props;
+  return (
+    <svg
+      className={getClasses<IconStyleProps>(
+        { className, disabled, iconButtonTheme, iconSize, selected },
+        componentType,
+      )}
+      xmlns="http://www.w3.org/2000/svg"
+      width="32"
+      height="32"
+      fill="#000000"
+      viewBox="0 0 24 24"
+      {...otherProps}
+    >
+      <path d="M19.589 6.686a4.793 4.793 0 0 1-3.77-4.245V2h-3.445v13.672a2.896 2.896 0 0 1-5.201 1.743l-.002-.001.002.001a2.895 2.895 0 0 1 3.183-4.51v-3.5a6.329 6.329 0 0 0-5.394 10.692 6.33 6.33 0 0 0 10.857-4.424V8.687a8.182 8.182 0 0 0 4.773 1.526V6.79a4.831 4.831 0 0 1-1.003-.104z"></path>
+    </svg>
+  );
+};
+
+// eslint-disable-next-line react/no-multi-comp
 export const CWTransfer = (props: IconProps) => {
   const {
     className,

--- a/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.scss
@@ -15,6 +15,16 @@
     cursor: pointer;
   }
 
+  .tiktok-link {
+    color: $neutral-800;
+    cursor: pointer;
+  }
+
+  .twitter-link {
+    color: $neutral-800;
+    cursor: pointer;
+  }
+
   .element-link {
     color: $green-500;
     cursor: pointer;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/external_links_module.tsx
@@ -23,6 +23,7 @@ export const ExternalLinksModule = () => {
     remainingLinks,
     slacks,
     telegrams,
+    tiktoks,
     twitters,
   } = categorizeSocialLinks(
     (community.social_links || [])
@@ -53,6 +54,14 @@ export const ExternalLinksModule = () => {
           key={link}
           iconName="telegram"
           className="telegram-link"
+          onClick={() => window.open(link)}
+        />
+      ))}
+      {tiktoks.map((link) => (
+        <CWIcon
+          key={link}
+          iconName="tiktok"
+          className="tiktok-link"
           onClick={() => window.open(link)}
         />
       ))}

--- a/packages/commonwealth/client/scripts/views/components/social_accounts.tsx
+++ b/packages/commonwealth/client/scripts/views/components/social_accounts.tsx
@@ -28,6 +28,8 @@ export const SocialAccounts = (props: SocialAccountsProps) => {
           return <SocialAccount link={social} iconName="telegram" key={i} />;
         } else if (social.includes('github')) {
           return <SocialAccount link={social} iconName="github" key={i} />;
+        } else if (social.includes('tiktok')) {
+          return <SocialAccount link={social} iconName="tiktok" key={i} />;
         } else {
           return <SocialAccount link={social} iconName="website" key={i} />;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10187 

## Description of Changes
- added tiktok logo and logic to show when tiktok link is added
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
-add tiktok link https://www.tiktok.com/@uniswaplabs?_t=ZT-8s53p0NxJOw&_r=1
to Community Profile, Edit Profile
- go to all places social links are displayed dynamically. In Community Profile, View Profile, Edit Profile, and Community sidebar and confirm you now either see the tiktok logo or the button label as "Tiktok"
- click all instances of the logo and confirm a new tab opens and the correct page is shown. 

![Screenshot 2024-12-09 at 3 56 20 PM](https://github.com/user-attachments/assets/d894770a-0be9-44e2-9384-f4b1e1c447ad)
![Screenshot 2024-12-09 at 3 56 38 PM](https://github.com/user-attachments/assets/aeee4cb3-8b4c-4257-b0cc-40c6144f303f)
![Screenshot 2024-12-09 at 3 56 01 PM](https://github.com/user-attachments/assets/ec46e43b-19be-4626-a754-80c7f5cf550b)

