### PR TITLE
cosmos proposals now shown

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -204,7 +204,7 @@ export const CWContentPage = ({
         // @ts-expect-error <StrictNullChecks/>
         isHot={isHot(thread)}
         profile={thread?.profile}
-        versionHistory={thread!.versionHistory!}
+        versionHistory={thread?.versionHistory || []}
         activeThreadVersionId={activeThreadVersionId}
         onChangeVersionHistoryNumber={onChangeVersionHistoryNumber}
       />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10166 

## Description of Changes
- When Cosmos proposals are clicked the user is now redirected to the individual proposal and no error is shown.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-used ? to handle undefined and added a default [ ]
## Test Plan
- go to a Cosmos community, Evmos for example
- go to proposals
- click any current or past proposals and confirm you now see the individual proposal 

