### PR TITLE
Fix mark comment as spam

### DIFF
--- a/libs/model/src/models/comment_subscriptions.ts
+++ b/libs/model/src/models/comment_subscriptions.ts
@@ -19,12 +19,12 @@ export default (
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
     },
     {

--- a/libs/model/src/models/community_alerts.ts
+++ b/libs/model/src/models/community_alerts.ts
@@ -24,7 +24,7 @@ export default (
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
         get() {
           return (this.getDataValue(
             'created_at',
@@ -34,7 +34,7 @@ export default (
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
         get() {
           return (this.getDataValue(
             'updated_at',

--- a/libs/model/src/models/subscription_preference.ts
+++ b/libs/model/src/models/subscription_preference.ts
@@ -40,12 +40,12 @@ export default (
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
     },
     {

--- a/libs/model/src/models/thread_subscriptions.ts
+++ b/libs/model/src/models/thread_subscriptions.ts
@@ -33,12 +33,12 @@ export default (
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: new Date(),
       },
     },
     {

--- a/libs/model/src/thread/UpdateThread.command.ts
+++ b/libs/model/src/thread/UpdateThread.command.ts
@@ -5,7 +5,7 @@ import {
   type Command,
 } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
-import { Op, Sequelize } from 'sequelize';
+import { Op } from 'sequelize';
 import { z } from 'zod';
 import { models } from '../database';
 import { authThread } from '../middleware';
@@ -230,7 +230,7 @@ export function UpdateThread(): Command<typeof schemas.UpdateThread> {
             ...content,
             ...adminPatch,
             ...ownerPatch,
-            last_edited: Sequelize.literal('CURRENT_TIMESTAMP'),
+            last_edited: new Date(),
             ...searchUpdate,
             content_url: contentUrl,
           },

--- a/packages/commonwealth/server/routes/spam/markCommentAsSpam.ts
+++ b/packages/commonwealth/server/routes/spam/markCommentAsSpam.ts
@@ -1,7 +1,6 @@
 import { AppError } from '@hicommonwealth/core';
 import type { DB } from '@hicommonwealth/model';
 import type { Request, Response } from 'express';
-import { Sequelize } from 'sequelize';
 import { validateOwner } from 'server/util/validateOwner';
 import { success } from '../../types';
 
@@ -44,7 +43,7 @@ export default async (models: DB, req: Request, res: Response) => {
   }
 
   await comment.update({
-    marked_as_spam_at: Sequelize.literal('CURRENT_TIMESTAMP'),
+    marked_as_spam_at: new Date(),
   });
 
   // get comment with updated timestamp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10192 

## Description of Changes
- Removes references to `sequelize.literal('CURRENT_TIMESTAMP');` which seems to break in production but not in local environments.

## Test Plan
Mark any comment as spam

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 