### PR TITLE
no more trpc length error

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -97,7 +97,7 @@ export const HeaderWithFilters = ({
   const contestAddress = searchParams.get('contest');
 
   const createButtonText =
-    activeContests.length || contestAddress ? 'Create' : 'Create thread';
+    activeContests?.length || contestAddress ? 'Create' : 'Create thread';
 
   const onFilterResize = () => {
     if (filterRowRef.current) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10206 

## Description of Changes
- User no longer gets a length error when searching for community without active contests
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added ? to account for undefined. `  const createButtonText =
    activeContests?.length || contestAddress ? 'Create' : 'Create thread';`
## Test Plan
- Go to Explore Communities and click around, see if you can find the length error described in the ticket. I found that Treasure DAO, Fei Protocol, and TEMCO all triggered. it. 

