### PR TITLE
snapshot integration only shown to ethereum communities

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import app from 'state';
 import CommunityManagementLayout from '../common/CommunityManagementLayout';
 import CustomTOS from './CustomTOS';
 import CustomURL from './CustomURL';
@@ -10,6 +11,8 @@ import Stake from './Stake';
 import Webhooks from './Webhooks';
 
 const Integrations = () => {
+  const showSnapshotIntegration = app.chain.meta.base === 'ethereum';
+
   return (
     <CommunityManagementLayout
       title="Integrations"
@@ -25,7 +28,7 @@ const Integrations = () => {
       <section className="Integrations">
         <Directory />
         <Stake />
-        <Snapshots />
+        {showSnapshotIntegration && <Snapshots />}
         <Discord />
         <Webhooks />
         <CustomTOS />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Integrations.tsx
@@ -1,3 +1,4 @@
+import { ChainBase } from '@hicommonwealth/shared';
 import React from 'react';
 import app from 'state';
 import CommunityManagementLayout from '../common/CommunityManagementLayout';
@@ -11,7 +12,7 @@ import Stake from './Stake';
 import Webhooks from './Webhooks';
 
 const Integrations = () => {
-  const showSnapshotIntegration = app.chain.meta.base === 'ethereum';
+  const showSnapshotIntegration = app.chain.meta.base === ChainBase.Ethereum;
 
   return (
     <CommunityManagementLayout

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/Snapshots.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/Snapshots.tsx
@@ -1,4 +1,4 @@
-import { notifySuccess } from 'controllers/app/notifications';
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
 import React from 'react';
 import app from 'state';
@@ -87,7 +87,7 @@ const Snapshots = () => {
 
       notifySuccess('Snapshot links updated!');
     } catch {
-      notifySuccess('Failed to update snapshot links!');
+      notifyError('Failed to update snapshot links!');
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10184 

## Description of Changes
- Integrating Snapshot is now only only shown to communities that have a base of Ethereum

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added a conditional check for ethereum base 
## Test Plan
- be an admin
- go to a non-ethereum based community, Evmos for example
- go to Integrations tab
- confirm you no longer see the ability to connect a snapshot space 

