### PR TITLE
added padding to snapshot modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/new_snapshot_proposal_modal.scss
@@ -1,5 +1,5 @@
 .NewSnapshotProposalModal {
   .CWModalBody {
-    margin-bottom: 24px;
+    margin-bottom: 32px;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10183 

## Description of Changes
- Added padding to the bottom of the Create new Snapshot modal to make it look good when a user hasn't yet scrolled down the buttons aren't shown. The bottom of the modal felt too cramped before. 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-added 8px of padding

## Test Plan
- go to a thread and Create Snapshot
- confirm there is more padding on the Create new Snapshot modal

