### PR TITLE
Generate referral and handle opening up the link

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -44,10 +44,10 @@ export const splitAndDecodeURL = (locationPathname: string) => {
   //this is to check for malformed urls on a topics page in /discussions
   const splitURLPath = locationPathname.split('/');
   if (splitURLPath[2] === 'discussions') {
-    return decodeURIComponent(splitURLPath[3]);
+    return splitURLPath[3] ? decodeURIComponent(splitURLPath[3]) : null;
   }
   splitURLPath[1] === 'discussions';
-  return decodeURIComponent(splitURLPath[2]);
+  return splitURLPath[2] ? decodeURIComponent(splitURLPath[2]) : null;
 };
 
 export const getThreadUrl = (

--- a/packages/commonwealth/client/scripts/helpers/localStorage.ts
+++ b/packages/commonwealth/client/scripts/helpers/localStorage.ts
@@ -1,0 +1,39 @@
+const KEY_REFCODE = 'common-refcode';
+const REFCODE_EXPIRATION_DAYS = 7;
+
+export const getLocalStorageRefcode = () => {
+  const stored = localStorage.getItem(KEY_REFCODE);
+
+  if (!stored) {
+    return null;
+  }
+
+  const item = JSON.parse(stored);
+
+  if (new Date().getTime() > item.expires) {
+    localStorage.removeItem(KEY_REFCODE);
+    return null;
+  }
+
+  return item.value;
+};
+
+export const setLocalStorageRefcode = (refcode: string) => {
+  const stored = getLocalStorageRefcode();
+
+  if (stored) {
+    console.log('Reflink already stored');
+    return;
+  }
+
+  const expirationDate = new Date();
+  expirationDate.setDate(expirationDate.getDate() + REFCODE_EXPIRATION_DAYS);
+
+  localStorage.setItem(
+    KEY_REFCODE,
+    JSON.stringify({
+      value: refcode,
+      expires: expirationDate.getTime(),
+    }),
+  );
+};

--- a/packages/commonwealth/client/scripts/helpers/localStorage.ts
+++ b/packages/commonwealth/client/scripts/helpers/localStorage.ts
@@ -1,8 +1,11 @@
-const KEY_REFCODE = 'common-refcode';
-const REFCODE_EXPIRATION_DAYS = 7;
+export const REFCODE_EXPIRATION_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
-export const getLocalStorageRefcode = () => {
-  const stored = localStorage.getItem(KEY_REFCODE);
+export enum LocalStorageKeys {
+  ReferralCode = 'common-refcode',
+}
+
+export const getLocalStorageItem = (key: LocalStorageKeys) => {
+  const stored = localStorage.getItem(key);
 
   if (!stored) {
     return null;
@@ -11,29 +14,32 @@ export const getLocalStorageRefcode = () => {
   const item = JSON.parse(stored);
 
   if (new Date().getTime() > item.expires) {
-    localStorage.removeItem(KEY_REFCODE);
+    localStorage.removeItem(key);
     return null;
   }
 
   return item.value;
 };
 
-export const setLocalStorageRefcode = (refcode: string) => {
-  const stored = getLocalStorageRefcode();
+export const setLocalStorageItem = (
+  key: LocalStorageKeys,
+  value: string,
+  expirationMs?: number,
+) => {
+  const stored = getLocalStorageItem(key);
 
-  if (stored) {
+  if (key === LocalStorageKeys.ReferralCode && stored) {
     console.log('Reflink already stored');
     return;
   }
 
-  const expirationDate = new Date();
-  expirationDate.setDate(expirationDate.getDate() + REFCODE_EXPIRATION_DAYS);
+  const item: { value: string; expires?: number } = { value };
 
-  localStorage.setItem(
-    KEY_REFCODE,
-    JSON.stringify({
-      value: refcode,
-      expires: expirationDate.getTime(),
-    }),
-  );
+  if (expirationMs) {
+    const expirationDate = new Date();
+    expirationDate.setTime(expirationDate.getTime() + expirationMs);
+    item.expires = expirationDate.getTime();
+  }
+
+  localStorage.setItem(key, JSON.stringify(item));
 };

--- a/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
+++ b/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import { matchRoutes, useSearchParams } from 'react-router-dom';
+import { setLocalStorageRefcode } from '../helpers/localStorage';
+import app from '../state';
+import { useAuthModalStore } from '../state/ui/modals';
+import { useUserStore } from '../state/ui/user/user';
+// import useJoinCommunity from '../views/components/SublayoutHeader/useJoinCommunity';
+import { AuthModalType } from '../views/modals/AuthModal';
+
+export const useHandleInviteLink = ({
+  isInsideCommunity,
+}: {
+  isInsideCommunity?: boolean;
+}) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setAuthModalType, authModalType } = useAuthModalStore();
+  const user = useUserStore();
+  // const { handleJoinCommunity } = useJoinCommunity();
+  const refcode = searchParams.get('refcode');
+
+  const generalInviteRoute = matchRoutes(
+    [{ path: '/dashboard/global' }],
+    location,
+  );
+  const communityInviteRoute =
+    matchRoutes([{ path: '/:scope' }], location) && isInsideCommunity;
+
+  const activeChainId = app.activeChainId();
+
+  useEffect(() => {
+    if (!refcode) {
+      return;
+    }
+
+    if (user.isLoggedIn) {
+      if (generalInviteRoute) {
+        // do nothing
+      } else if (communityInviteRoute) {
+        if (!activeChainId) {
+          return;
+        }
+        setLocalStorageRefcode(refcode);
+        console.log('handleJoinCommunity');
+        // handleJoinCommunity();
+        console.log('handleJoinCommunity done');
+        // check if I joined community
+        // if not - join community automatically (OR display modal to join community)
+      }
+    } else {
+      if (generalInviteRoute) {
+        // do nothing
+        setLocalStorageRefcode(refcode);
+      } else if (communityInviteRoute) {
+        if (!activeChainId) {
+          console.log('No active chain id');
+          return;
+        }
+        setLocalStorageRefcode(refcode);
+        console.log('Active chain id', activeChainId);
+        // check if I joined community
+        // if not - join community automatically (OR display modal to join community)
+      }
+
+      searchParams.delete('refcode');
+      setSearchParams(searchParams);
+      setAuthModalType(AuthModalType.CreateAccount);
+    }
+  }, [
+    authModalType,
+    searchParams,
+    user.isLoggedIn,
+    setAuthModalType,
+    generalInviteRoute,
+    communityInviteRoute,
+    activeChainId,
+    refcode,
+    setSearchParams,
+  ]);
+};

--- a/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
+++ b/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
@@ -52,7 +52,7 @@ export const useHandleInviteLink = ({
 
         setLocalStorageRefcode(refcode);
         removeRefcodeFromUrl();
-        handleJoinCommunity();
+        handleJoinCommunity().catch(console.error);
       }
     } else {
       if (generalInviteRoute) {

--- a/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
+++ b/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
@@ -4,18 +4,18 @@ import { setLocalStorageRefcode } from '../helpers/localStorage';
 import app from '../state';
 import { useAuthModalStore } from '../state/ui/modals';
 import { useUserStore } from '../state/ui/user/user';
-// import useJoinCommunity from '../views/components/SublayoutHeader/useJoinCommunity';
 import { AuthModalType } from '../views/modals/AuthModal';
 
 export const useHandleInviteLink = ({
   isInsideCommunity,
+  handleJoinCommunity,
 }: {
   isInsideCommunity?: boolean;
+  handleJoinCommunity: () => Promise<boolean | undefined>;
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { setAuthModalType, authModalType } = useAuthModalStore();
   const user = useUserStore();
-  // const { handleJoinCommunity } = useJoinCommunity();
   const refcode = searchParams.get('refcode');
 
   const generalInviteRoute = matchRoutes(
@@ -23,7 +23,10 @@ export const useHandleInviteLink = ({
     location,
   );
   const communityInviteRoute =
-    matchRoutes([{ path: '/:scope' }], location) && isInsideCommunity;
+    matchRoutes(
+      [{ path: '/:scope' }, { path: '/:scope/discussions/*' }],
+      location,
+    ) && isInsideCommunity;
 
   const activeChainId = app.activeChainId();
 
@@ -39,12 +42,13 @@ export const useHandleInviteLink = ({
         if (!activeChainId) {
           return;
         }
+
         setLocalStorageRefcode(refcode);
-        console.log('handleJoinCommunity');
-        // handleJoinCommunity();
-        console.log('handleJoinCommunity done');
-        // check if I joined community
-        // if not - join community automatically (OR display modal to join community)
+
+        searchParams.delete('refcode');
+        setSearchParams(searchParams);
+
+        handleJoinCommunity();
       }
     } else {
       if (generalInviteRoute) {
@@ -66,6 +70,7 @@ export const useHandleInviteLink = ({
       setAuthModalType(AuthModalType.CreateAccount);
     }
   }, [
+    handleJoinCommunity,
     authModalType,
     searchParams,
     user.isLoggedIn,

--- a/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
+++ b/packages/commonwealth/client/scripts/hooks/useHandleInviteLink.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { matchRoutes, useSearchParams } from 'react-router-dom';
-import { setLocalStorageRefcode } from '../helpers/localStorage';
+import {
+  LocalStorageKeys,
+  REFCODE_EXPIRATION_MS,
+  setLocalStorageItem,
+} from '../helpers/localStorage';
 import app from '../state';
 import { useAuthModalStore } from '../state/ui/modals';
 import { useUserStore } from '../state/ui/user/user';
@@ -50,19 +54,31 @@ export const useHandleInviteLink = ({
           return;
         }
 
-        setLocalStorageRefcode(refcode);
+        setLocalStorageItem(
+          LocalStorageKeys.ReferralCode,
+          refcode,
+          REFCODE_EXPIRATION_MS,
+        );
         removeRefcodeFromUrl();
         handleJoinCommunity().catch(console.error);
       }
     } else {
       if (generalInviteRoute) {
-        setLocalStorageRefcode(refcode);
+        setLocalStorageItem(
+          LocalStorageKeys.ReferralCode,
+          refcode,
+          REFCODE_EXPIRATION_MS,
+        );
       } else if (communityInviteRoute) {
         if (!activeChainId) {
           return;
         }
 
-        setLocalStorageRefcode(refcode);
+        setLocalStorageItem(
+          LocalStorageKeys.ReferralCode,
+          refcode,
+          REFCODE_EXPIRATION_MS,
+        );
       }
 
       removeRefcodeFromUrl();

--- a/packages/commonwealth/client/scripts/state/api/user/createReferralLink.ts
+++ b/packages/commonwealth/client/scripts/state/api/user/createReferralLink.ts
@@ -1,0 +1,11 @@
+import { trpc } from 'utils/trpcClient';
+
+export const useCreateReferralLinkMutation = () => {
+  const utils = trpc.useUtils();
+
+  return trpc.user.createReferralLink.useMutation({
+    onSuccess: async () => {
+      await utils.user.getReferralLink.invalidate();
+    },
+  });
+};

--- a/packages/commonwealth/client/scripts/state/api/user/getReferralLink.ts
+++ b/packages/commonwealth/client/scripts/state/api/user/getReferralLink.ts
@@ -1,0 +1,5 @@
+import { trpc } from 'utils/trpcClient';
+
+export const useGetReferralLinkQuery = () => {
+  return trpc.user.getReferralLink.useQuery({});
+};

--- a/packages/commonwealth/client/scripts/state/api/user/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/user/index.ts
@@ -1,7 +1,9 @@
 import { useCreateApiKeyMutation } from './createApiKey';
+import { useCreateReferralLinkMutation } from './createReferralLink';
 import { useDeleteApiKeyMutation } from './deleteApiKey';
 import { useGetApiKeyQuery } from './getApiKey';
 import useGetNewContent from './getNewContent';
+import { useGetReferralLinkQuery } from './getReferralLink';
 import useUpdateUserActiveCommunityMutation from './updateActiveCommunity';
 import useUpdateUserEmailMutation from './updateEmail';
 import useUpdateUserEmailSettingsMutation from './updateEmailSettings';
@@ -9,9 +11,11 @@ import useUpdateUserMutation from './updateUser';
 
 export {
   useCreateApiKeyMutation,
+  useCreateReferralLinkMutation,
   useDeleteApiKeyMutation,
   useGetApiKeyQuery,
   useGetNewContent,
+  useGetReferralLinkQuery,
   useUpdateUserActiveCommunityMutation,
   useUpdateUserEmailMutation,
   useUpdateUserEmailSettingsMutation,

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -198,7 +198,6 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
           content={
             <InviteLinkModal
               onModalClose={() => setIsInviteLinkModalOpen(false)}
-              isInsideCommunity={!!isInsideCommunity}
             />
           }
           open={!isWindowExtraSmall && isInviteLinkModalOpen}

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -7,6 +7,7 @@ import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { SublayoutHeader } from 'views/components/SublayoutHeader';
 import { Sidebar } from 'views/components/sidebar';
+import { useHandleInviteLink } from '../hooks/useHandleInviteLink';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
 import useStickyHeader from '../hooks/useStickyHeader';
 import {
@@ -37,11 +38,14 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
   const { menuVisible, setMenu, menuName } = useSidebarStore();
   const [resizing, setResizing] = useState(false);
 
+  const location = useLocation();
+
   useStickyHeader({
     elementId: 'mobile-auth-buttons',
     stickyBehaviourEnabled: true,
     zIndex: 70,
   });
+
   const { isWindowSmallInclusive, isWindowExtraSmall, isWindowSmallToMedium } =
     useBrowserWindow({
       onResize: () => setResizing(true),
@@ -76,7 +80,7 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
     user.isLoggedIn,
   ]);
 
-  const location = useLocation();
+  useHandleInviteLink({ isInsideCommunity });
 
   useWindowResize({
     setMenu,

--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -22,6 +22,7 @@ import { AdminOnboardingSlider } from './components/AdminOnboardingSlider';
 import { Breadcrumbs } from './components/Breadcrumbs';
 import MobileNavigation from './components/MobileNavigation';
 import AuthButtons from './components/SublayoutHeader/AuthButtons';
+import useJoinCommunity from './components/SublayoutHeader/useJoinCommunity';
 import { UserTrainingSlider } from './components/UserTrainingSlider';
 import { CWModal } from './components/component_kit/new_designs/CWModal';
 import CollapsableSidebarButton from './components/sidebar/CollapsableSidebarButton';
@@ -37,6 +38,7 @@ type SublayoutProps = {
 const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
   const { menuVisible, setMenu, menuName } = useSidebarStore();
   const [resizing, setResizing] = useState(false);
+  const { JoinCommunityModals, handleJoinCommunity } = useJoinCommunity();
 
   const location = useLocation();
 
@@ -80,7 +82,7 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
     user.isLoggedIn,
   ]);
 
-  useHandleInviteLink({ isInsideCommunity });
+  useHandleInviteLink({ isInsideCommunity, handleJoinCommunity });
 
   useWindowResize({
     setMenu,
@@ -207,6 +209,7 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
           open={!isWindowExtraSmall && isInviteLinkModalOpen}
           onClose={() => setIsInviteLinkModalOpen(false)}
         />
+        {JoinCommunityModals}
       </div>
       {isWindowExtraSmall && <MobileNavigation />}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/MobileHeader/MobileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/MobileHeader/MobileHeader.tsx
@@ -138,7 +138,6 @@ const MobileHeader = ({
         }}
       >
         <InviteLinkModal
-          isInsideCommunity={isInsideCommunity}
           onModalClose={() => {
             setIsInviteLinkModalOpen(false);
           }}

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -18,6 +18,7 @@ import {
   useCreateReferralLinkMutation,
   useGetReferralLinkQuery,
 } from 'state/api/user';
+import useUserStore from 'state/ui/user';
 
 import './InviteLinkModal.scss';
 
@@ -29,7 +30,9 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
   const { data: refferalLinkData, isLoading: isLoadingReferralLink } =
     useGetReferralLinkQuery();
 
-  const communityId = app.activeChainId();
+  const user = useUserStore();
+  const hasJoinedCommunity = !!user.activeAccount;
+  const communityId = hasJoinedCommunity ? app.activeChainId() : '';
 
   const { mutate: createReferralLink, isLoading: isLoadingCreateReferralLink } =
     useCreateReferralLinkMutation();
@@ -37,7 +40,6 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
   const referralLink = refferalLinkData?.referral_link;
   const currentUrl = window.location.origin;
 
-  // TODO modify dashboard route and community route so the refcode is not vanished
   const inviteLink = referralLink
     ? `${currentUrl}${communityId ? `/${communityId}` : '/dashboard'}?refcode=${referralLink}`
     : '';

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -36,8 +36,10 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
 
   const referralLink = refferalLinkData?.referral_link;
   const currentUrl = window.location.origin;
+
+  // TODO modify dashboard route and community route so the refcode is not vanished
   const inviteLink = referralLink
-    ? `${currentUrl}/${communityId ? communityId + '/' : ''}invite/${referralLink}`
+    ? `${currentUrl}${communityId ? `/${communityId}` : '/dashboard'}?refcode=${referralLink}`
     : '';
 
   useRunOnceOnCondition({

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -13,6 +13,7 @@ import { ShareSkeleton } from './ShareSkeleton';
 import { getShareOptions } from './utils';
 
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
+import app from 'state';
 import {
   useCreateReferralLinkMutation,
   useGetReferralLinkQuery,
@@ -22,22 +23,22 @@ import './InviteLinkModal.scss';
 
 interface InviteLinkModalProps {
   onModalClose: () => void;
-  isInsideCommunity: boolean;
 }
 
-const InviteLinkModal = ({
-  onModalClose,
-  isInsideCommunity,
-}: InviteLinkModalProps) => {
+const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
   const { data: refferalLinkData, isLoading: isLoadingReferralLink } =
     useGetReferralLinkQuery();
+
+  const communityId = app.activeChainId();
 
   const { mutate: createReferralLink, isLoading: isLoadingCreateReferralLink } =
     useCreateReferralLinkMutation();
 
   const referralLink = refferalLinkData?.referral_link;
   const currentUrl = window.location.origin;
-  const inviteLink = referralLink ? `${currentUrl}/invite/${referralLink}` : '';
+  const inviteLink = referralLink
+    ? `${currentUrl}/${communityId ? communityId + '/' : ''}invite/${referralLink}`
+    : '';
 
   useRunOnceOnCondition({
     callback: () => createReferralLink({}),
@@ -50,22 +51,20 @@ const InviteLinkModal = ({
     }
   };
 
-  const shareOptions = getShareOptions(isInsideCommunity, inviteLink);
+  const shareOptions = getShareOptions(!!communityId, inviteLink);
 
   return (
     <div className="InviteLinkModal">
       <CWModalHeader
         label={
-          isInsideCommunity
-            ? 'Community invite link'
-            : 'Commonwealth invite link'
+          communityId ? 'Community invite link' : 'Commonwealth invite link'
         }
         onModalClose={onModalClose}
       />
       <CWModalBody>
         <div className="content">
           <CWText>
-            {isInsideCommunity
+            {communityId
               ? 'Get more voting power in your communities when people join with your referral link.'
               : `When you refer your friends to Common, you'll get a portion of any fees they pay to 
               Common over their lifetime engaging with web 3 native forums.`}

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -32,18 +32,20 @@ const InviteLinkModal = ({
   const { data: refferalLinkData, isLoading: isLoadingReferralLink } =
     useGetReferralLinkQuery();
 
-  const inviteLink = refferalLinkData?.referral_link;
-
   const { mutate: createReferralLink, isLoading: isLoadingCreateReferralLink } =
     useCreateReferralLinkMutation();
 
+  const referralLink = refferalLinkData?.referral_link;
+  const currentUrl = window.location.origin;
+  const inviteLink = referralLink ? `${currentUrl}/invite/${referralLink}` : '';
+
   useRunOnceOnCondition({
     callback: () => createReferralLink({}),
-    shouldRun: !isLoadingReferralLink && !inviteLink,
+    shouldRun: !isLoadingReferralLink && !referralLink,
   });
 
   const handleCopy = () => {
-    if (inviteLink) {
+    if (referralLink) {
       saveToClipboard(inviteLink, true).catch(console.error);
     }
   };
@@ -76,7 +78,7 @@ const InviteLinkModal = ({
               <CWTextInput
                 fullWidth
                 type="text"
-                value={inviteLink || ''}
+                value={inviteLink}
                 readOnly
                 onClick={handleCopy}
                 iconRight={<CWIcon iconName="copy" />}

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -41,7 +41,7 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
   const currentUrl = window.location.origin;
 
   const inviteLink = referralLink
-    ? `${currentUrl}${communityId ? `/${communityId}` : '/dashboard'}?refcode=${referralLink}`
+    ? `${currentUrl}${communityId ? `/${communityId}/discussions` : '/dashboard'}?refcode=${referralLink}`
     : '';
 
   useRunOnceOnCondition({

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/ShareSkeleton.scss
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/ShareSkeleton.scss
@@ -1,0 +1,11 @@
+.ShareSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  .share-options {
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+  }
+}

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/ShareSkeleton.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/ShareSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Skeleton } from 'views/components/Skeleton';
+
+import './ShareSkeleton.scss';
+
+export const ShareSkeleton = () => {
+  return (
+    <div className="ShareSkeleton">
+      <Skeleton height={40} />
+      <Skeleton height={24} width={65} />
+
+      <div className="share-options">
+        <Skeleton height={48} width={48} />
+        <Skeleton height={48} width={48} />
+        <Skeleton height={48} width={48} />
+        <Skeleton height={48} width={48} />
+        <Skeleton height={48} width={48} />
+        <Skeleton height={48} width={48} />
+      </div>
+    </div>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/index.ts
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/ShareSkeleton/index.ts
@@ -1,0 +1,3 @@
+import { ShareSkeleton } from './ShareSkeleton';
+
+export { ShareSkeleton };

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/utils.ts
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/utils.ts
@@ -23,54 +23,57 @@ interface ShareOption {
 
 export const getShareOptions = (
   isInsideCommunity: boolean,
-  inviteLink: string,
-): ShareOption[] => [
-  {
-    name: 'Messages',
-    icon: messagesImg,
-    onClick: () =>
-      window.open(
-        `sms:?&body=${encodeURIComponent(generatePermalink(isInsideCommunity, inviteLink))}`,
-      ),
-  },
-  {
-    name: 'Telegram',
-    icon: telegramImg,
-    onClick: () =>
-      window.open(
-        `https://t.me/share/url?url=${encodeURIComponent(
-          generatePermalink(isInsideCommunity, inviteLink),
-        )}`,
-      ),
-  },
-  {
-    name: 'X (Twitter)',
-    icon: twitterImg,
-    onClick: () =>
-      window.open(
-        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-          generatePermalink(isInsideCommunity, inviteLink),
-        )}`,
-      ),
-  },
-  {
-    name: 'Warpcast',
-    icon: warpcastImg,
-    onClick: () =>
-      window.open(
-        `https://warpcast.com/~/compose?text=${encodeURIComponent(
-          generatePermalink(isInsideCommunity, inviteLink),
-        )}`,
-      ),
-  },
-  {
-    name: 'Email',
-    icon: mailImg,
-    onClick: () =>
-      window.open(
-        `mailto:?body=${encodeURIComponent(
-          generatePermalink(isInsideCommunity, inviteLink),
-        )}`,
-      ),
-  },
-];
+  inviteLink?: string | null,
+): ShareOption[] =>
+  inviteLink
+    ? [
+        {
+          name: 'Messages',
+          icon: messagesImg,
+          onClick: () =>
+            window.open(
+              `sms:?&body=${encodeURIComponent(generatePermalink(isInsideCommunity, inviteLink))}`,
+            ),
+        },
+        {
+          name: 'Telegram',
+          icon: telegramImg,
+          onClick: () =>
+            window.open(
+              `https://t.me/share/url?url=${encodeURIComponent(
+                generatePermalink(isInsideCommunity, inviteLink),
+              )}`,
+            ),
+        },
+        {
+          name: 'X (Twitter)',
+          icon: twitterImg,
+          onClick: () =>
+            window.open(
+              `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+                generatePermalink(isInsideCommunity, inviteLink),
+              )}`,
+            ),
+        },
+        {
+          name: 'Warpcast',
+          icon: warpcastImg,
+          onClick: () =>
+            window.open(
+              `https://warpcast.com/~/compose?text=${encodeURIComponent(
+                generatePermalink(isInsideCommunity, inviteLink),
+              )}`,
+            ),
+        },
+        {
+          name: 'Email',
+          icon: mailImg,
+          onClick: () =>
+            window.open(
+              `mailto:?body=${encodeURIComponent(
+                generatePermalink(isInsideCommunity, inviteLink),
+              )}`,
+            ),
+        },
+      ]
+    : [];

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -193,7 +193,6 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       topicNameFromURL &&
       topicNameFromURL !== 'archived' &&
       topicNameFromURL !== 'overview' &&
-      topicNameFromURL !== 'undefined' &&
       tabStatus !== 'overview'
     ) {
       const validTopics = topics?.some(

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -193,6 +193,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
       topicNameFromURL &&
       topicNameFromURL !== 'archived' &&
       topicNameFromURL !== 'overview' &&
+      topicNameFromURL !== 'undefined' &&
       tabStatus !== 'overview'
     ) {
       const validTopics = topics?.some(

--- a/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions_redirect.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/function-component-definition */
 import React, { useEffect } from 'react';
-import { NavigateOptions } from 'react-router-dom';
+import { NavigateOptions, useLocation } from 'react-router-dom';
 
 import { DefaultPage } from '@hicommonwealth/shared';
 import { useCommonNavigate } from 'navigation/helpers';
@@ -9,9 +9,16 @@ import { PageLoading } from './loading';
 
 export default function DiscussionsRedirect() {
   const navigate = useCommonNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     if (!app.chain) return;
+
+    const searchParams = new URLSearchParams(location.search);
+    // Remove 'tab' if it exists as we'll be setting it explicitly
+    searchParams.delete('tab');
+    const existingParams = searchParams.toString();
+    const additionalParams = existingParams ? `&${existingParams}` : '';
 
     const view = app.chain.meta?.default_summary_view
       ? DefaultPage.Overview
@@ -22,15 +29,15 @@ export default function DiscussionsRedirect() {
     const dontAddHistory: NavigateOptions = { replace: true };
     switch (view) {
       case DefaultPage.Overview:
-        navigate('/overview?tab=overview', dontAddHistory);
+        navigate(`/overview?tab=overview${additionalParams}`, dontAddHistory);
         break;
       case DefaultPage.Discussions:
-        navigate('/discussions?tab=all', dontAddHistory);
+        navigate(`/discussions?tab=all${additionalParams}`, dontAddHistory);
         break;
       default:
-        navigate('/discussions?tab=all', dontAddHistory);
+        navigate(`/discussions?tab=all${additionalParams}`, dontAddHistory);
     }
-  }, [navigate]);
+  }, [navigate, location.search]);
 
   return <PageLoading />;
 }

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -8,6 +8,7 @@ import useBrowserWindow from 'hooks/useBrowserWindow';
 import { useFlag } from 'hooks/useFlag';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import useUserStore from 'state/ui/user';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import {
@@ -36,6 +37,7 @@ type UserDashboardProps = {
 const UserDashboard = ({ type }: UserDashboardProps) => {
   const user = useUserStore();
   const { isWindowExtraSmall } = useBrowserWindow({});
+  const location = useLocation();
 
   const [activePage, setActivePage] = React.useState<DashboardViews>(
     DashboardViews.Global,
@@ -62,13 +64,20 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
       isPWA: isAddedToHomeScreen,
     },
   });
+
   useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const existingParams = searchParams.toString();
+    const additionalParams = existingParams ? `&${existingParams}` : '';
+
     if (!type) {
-      navigate(`/dashboard/${user.isLoggedIn ? 'for-you' : 'global'}`);
+      navigate(
+        `/dashboard/${user.isLoggedIn ? 'for-you' : 'global'}${additionalParams}`,
+      );
     } else if (type === 'for-you' && !user.isLoggedIn) {
-      navigate('/dashboard/global');
+      navigate(`/dashboard/global${additionalParams}`);
     }
-  }, [user.isLoggedIn, navigate, type]);
+  }, [user.isLoggedIn, navigate, type, location.search]);
 
   const subpage: DashboardViews =
     user.isLoggedIn && type !== 'global'

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -68,7 +68,7 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     const existingParams = searchParams.toString();
-    const additionalParams = existingParams ? `&${existingParams}` : '';
+    const additionalParams = existingParams ? `?${existingParams}` : '';
 
     if (!type) {
       navigate(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10141 

## Description of Changes
- Added referral/invite link system functionality:
  - New localStorage helpers to manage referral codes with expiration
  - Added invite link handling hook (`useHandleInviteLink`)
  - Implemented referral link creation and retrieval via TRPC endpoints
  - Updated InviteLinkModal to use real referral links instead of hardcoded values
  - Added loading states and ShareSkeleton component for invite modal
- Improved URL parameter handling:
  - Preserved query parameters when redirecting in discussions
  - Maintained URL parameters during dashboard navigation

## "How We Fixed It"
The solution implements a complete referral system that allows users to:
1. Generate unique referral links that can be used to invite others
2. Store referral codes locally with 7-day expiration
3. Handle referral flows differently based on whether the invite is for Commonwealth generally or a specific community
4. Share referral links through various social platforms with proper deep linking

## Test Plan
- Hard to test as this still is not fully working, want to put up a PR, merge it and still work on further tickets

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a