### PR TITLE
Fallback on community chain node for ERC20 upvotes

### DIFF
--- a/libs/model/src/services/stakeHelper.ts
+++ b/libs/model/src/services/stakeHelper.ts
@@ -72,7 +72,9 @@ export async function getVotingWeight(
 
     return commonProtocol.calculateVoteWeight(stakeBalance, stake.vote_weight);
   } else if (topic.weighted_voting === TopicWeightedVoting.ERC20) {
-    const { eth_chain_id, private_url, url } = topic.ChainNode!;
+    // if topic chain node is missing, fallback on community chain node
+    const chainNode = topic.ChainNode || community.ChainNode || ({} as any);
+    const { eth_chain_id, private_url, url } = chainNode;
     mustExist('Chain Node Eth Chain Id', eth_chain_id);
     const chainNodeUrl = private_url! || url!;
     mustExist('Chain Node URL', chainNodeUrl);

--- a/libs/model/src/services/stakeHelper.ts
+++ b/libs/model/src/services/stakeHelper.ts
@@ -73,7 +73,7 @@ export async function getVotingWeight(
     return commonProtocol.calculateVoteWeight(stakeBalance, stake.vote_weight);
   } else if (topic.weighted_voting === TopicWeightedVoting.ERC20) {
     // if topic chain node is missing, fallback on community chain node
-    const chainNode = topic.ChainNode || community.ChainNode || ({} as any);
+    const chainNode = topic.ChainNode || community.ChainNode!;
     const { eth_chain_id, private_url, url } = chainNode;
     mustExist('Chain Node Eth Chain Id', eth_chain_id);
     const chainNodeUrl = private_url! || url!;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10259 

## Description of Changes
- When checking erc20 balance for weighted upvote, fallback on community chain node if topic chain node isn't set.

## Test Plan
- Make an erc20 weighted topic with token `0x429ae85883f82203D736e8fc203A455990745ca1` and pick Base Sepolia chain node
- In the DB, delete the chain node id for that topic (to simulate missing chain node ID)
- Create thread on topic, upvote it, confirm it works without error

## Deployment Plan
N/A

## Other Considerations
- Another approach is to create a migration to fill the missing topic chain nodes, but it's better to have a programatic fallback because ERC20 voting must *always* use a chain node no matter what.