### PR TITLE
React native bridge to give the react-native client the logged in user information. 

### DIFF
--- a/packages/commonwealth/client/scripts/App.tsx
+++ b/packages/commonwealth/client/scripts/App.tsx
@@ -9,6 +9,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import { RouterProvider } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import { queryClient } from 'state/api/config';
+import { ReactNativeBridge } from 'views/components/ReactNativeBridge';
 import { Splash } from './Splash';
 import { openFeatureProvider } from './helpers/feature-flags';
 import useAppStatus from './hooks/useAppStatus';
@@ -35,6 +36,7 @@ const App = () => {
               ) : (
                 <>
                   <Mava />
+                  <ReactNativeBridge />
                   <RouterProvider router={router()} />
                   {isAddedToHomeScreen || isMarketingPage ? null : (
                     <AddToHomeScreenPrompt

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
@@ -58,7 +58,7 @@ export const ReactNativeBridge = () => {
       data: userInfo,
     };
 
-    if (window.ReactNativeWebView) {
+    if (window.ReactNativeWebView && userInfo) {
       // send the user information to react native now.
       window.ReactNativeWebView.postMessage(JSON.stringify(message));
     }

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
@@ -1,0 +1,71 @@
+import useUserStore from 'client/scripts/state/ui/user';
+import { useEffect, useState } from 'react';
+
+interface ReactNativeWebView {
+  // allows us to send messages to ReactNative.
+  postMessage: (message: string) => void;
+}
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: ReactNativeWebView;
+  }
+}
+
+/**
+ * Typed message so that the react-native client knows how to handel this message.
+ *
+ * This is teh standard pattern of how to handle postMessage with multiple uses.
+ */
+type TypedData<Data> = {
+  type: string;
+  data: Data;
+};
+
+/**
+ * The actual user info that the client needs.
+ */
+type UserInfo = {
+  userId: number;
+};
+
+/**
+ * This acts as a bridge between the react-native client (mobile app) and our
+ * webapp.  Notifications only work with a userId and the react-native client
+ * doesn't do any auth or even know about auth.
+ *
+ * This way the webapp will send a message to the mobile app via the
+ * window.ReactNativeWebView.postMessage client.
+ *
+ * Note that NOTHING will happen in our normal app otherwise.  It will track
+ * the userInfo but not send it.
+ */
+export const ReactNativeBridge = () => {
+  const user = useUserStore();
+
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    if (user.id !== userInfo?.userId) {
+      if (user.id === 0) {
+        setUserInfo(null);
+      } else {
+        setUserInfo({ userId: user.id });
+      }
+    }
+  }, [user.id, userInfo?.userId]);
+
+  useEffect(() => {
+    const message: TypedData<UserInfo | null> = {
+      type: 'user',
+      data: userInfo,
+    };
+
+    if (window.ReactNativeWebView) {
+      // send the user information to react native now.
+      window.ReactNativeWebView.postMessage(JSON.stringify(message));
+    }
+  }, [userInfo]);
+
+  return null;
+};

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
@@ -54,7 +54,7 @@ export const ReactNativeBridge = () => {
         knockJWT: user.knockJWT,
       });
     }
-  }, [user.id, userInfo?.userId]);
+  }, [user.id, user.knockJWT, userInfo?.userId]);
 
   useEffect(() => {
     const message: TypedData<UserInfo | null> = {

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
@@ -27,6 +27,7 @@ type TypedData<Data> = {
  */
 type UserInfo = {
   userId: number;
+  // darkMode: 'dark' | 'light';
 };
 
 /**
@@ -47,11 +48,7 @@ export const ReactNativeBridge = () => {
 
   useEffect(() => {
     if (user.id !== userInfo?.userId) {
-      if (user.id === 0) {
-        setUserInfo(null);
-      } else {
-        setUserInfo({ userId: user.id });
-      }
+      setUserInfo({ userId: user.id });
     }
   }, [user.id, userInfo?.userId]);
 

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/ReactNativeBridge.tsx
@@ -27,6 +27,7 @@ type TypedData<Data> = {
  */
 type UserInfo = {
   userId: number;
+  knockJWT: string;
   // darkMode: 'dark' | 'light';
 };
 
@@ -48,7 +49,10 @@ export const ReactNativeBridge = () => {
 
   useEffect(() => {
     if (user.id !== userInfo?.userId) {
-      setUserInfo({ userId: user.id });
+      setUserInfo({
+        userId: user.id,
+        knockJWT: user.knockJWT,
+      });
     }
   }, [user.id, userInfo?.userId]);
 

--- a/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactNativeBridge/index.tsx
@@ -1,0 +1,1 @@
+export * from './ReactNativeBridge';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10272

## Description of Changes

- sends the current user information over react-native bridge to the mobile app

## Test Plan
- I tested it on the webapp and reacti-native.
- Nothing needs to be tested otherwise and it's only active when running within the react-native app and doesn't need a feature toggle.


## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 