### PR TITLE
editor no longer adds extra spacing

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/markdown_formatted_text.scss
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/markdown_formatted_text.scss
@@ -7,7 +7,6 @@
 
   position: relative;
   word-break: break-word;
-  white-space: pre-wrap;
   @include formatted-text();
   @include collapsible();
   @include hidden-formatting();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10276 

## Description of Changes
- editor no longer adds extra spacing between lines in Preview and when published.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
deleted white-space: pre-wrap; from markdown_formatted_text.scss
## Test Plan
- go to the editor and write a sentence.
-press enter twice and type another sentence.
- click preview and confirm that it no longer has extra padding below the lines
- publish and confirm that it no longer has extra padding below the lines