### PR TITLE
z-index and flex changes to fix desktop issues with the sticky editor…

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/DesktopStickyInput.scss
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/DesktopStickyInput.scss
@@ -4,8 +4,7 @@
   position: sticky;
   bottom: 0;
   display: flex;
-  flex-grow: 1;
-  z-index: 100;
+  z-index: 70;
   background: $white;
 
   .DesktopStickyInputPending {

--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/MobileStickyInput.scss
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/MobileStickyInput.scss
@@ -13,7 +13,7 @@
 
 .MobileStickyInputFocused {
   background: white;
-  z-index: 1000;
+  z-index: 70;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
… being too large and a fix for clashing with the z-index of dialogs.

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes:
- https://github.com/hicommonwealth/commonwealth/issues/10314

## Description of Changes

- fixes an issue with the comment dialog will grow too large on desktop 
- fixes z-index conflict with dialogs.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- went through and verified that the sticky behavior works and that these dialogs were fixed. 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 