### PR TITLE
Fix get threads pagination query for contests

### DIFF
--- a/libs/model/src/thread/GetThreads.query.ts
+++ b/libs/model/src/thread/GetThreads.query.ts
@@ -66,16 +66,6 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
         pastWinners: ' AND CON.end_time <= NOW()',
         all: '',
       };
-      const baseWhereClause = `
-      community_id = :community_id AND
-      deleted_at IS NULL AND
-      archived_at IS ${archived ? 'NOT' : ''} NULL
-      ${topic_id ? ' AND topic_id = :topic_id' : ''}
-      ${stage ? ' AND stage = :stage' : ''}
-      ${from_date ? ' AND T.created_at > :from_date' : ''}
-      ${to_date ? ' AND T.created_at < :to_date' : ''}
-      ${contestAddress ? ' AND id IN (SELECT * FROM "contest_ids")' : ''}
-    `;
       const responseThreadsQuery = models.sequelize.query<
         z.infer<typeof schemas.ThreadView>
       >(
@@ -96,10 +86,18 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                 pinned, community_id, T.created_at, updated_at, locked_at as thread_locked, links,
                 has_poll, last_commented_on, comment_count as "numberOfComments",
                 marked_as_spam_at, archived_at, topic_id, reaction_weights_sum, canvas_signed_data,
-                canvas_msg_id, last_edited, address_id, reaction_count
+                canvas_msg_id, last_edited, address_id, reaction_count,
+                (COUNT(id) OVER())::INTEGER AS total_num_thread_results
             FROM "Threads" T
-            WHERE ${baseWhereClause}
-              
+            WHERE
+              community_id = :community_id AND
+              deleted_at IS NULL AND
+              archived_at IS ${archived ? 'NOT' : ''} NULL
+              ${topic_id ? ' AND topic_id = :topic_id' : ''}
+              ${stage ? ' AND stage = :stage' : ''}
+              ${from_date ? ' AND T.created_at > :from_date' : ''}
+              ${to_date ? ' AND T.created_at < :to_date' : ''}
+              ${contestAddress ? ' AND id IN (SELECT * FROM "contest_ids")' : ''}
             ORDER BY pinned DESC, ${orderByQueries[order_by ?? 'newest']}
             LIMIT :limit OFFSET :offset
         ), thread_metadata AS (
@@ -252,18 +250,6 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
         },
       );
 
-      const countThreadsQuery = models.sequelize.query<{ count: number }>(
-        `
-          SELECT COUNT(*) AS count
-          FROM "Threads" T
-          WHERE ${baseWhereClause}
-        `,
-        {
-          replacements,
-          type: QueryTypes.SELECT,
-        },
-      );
-
       const numVotingThreadsQuery = models.Thread.count({
         where: {
           community_id,
@@ -271,10 +257,9 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
         },
       });
 
-      const [threads, numVotingThreads, countResult] = await Promise.all([
+      const [threads, numVotingThreads] = await Promise.all([
         responseThreadsQuery,
         numVotingThreadsQuery,
-        countThreadsQuery,
       ]);
 
       return {
@@ -282,7 +267,7 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
         page: replacements.page,
         threads,
         numVotingThreads,
-        threadCount: Number(countResult[0]?.count) || 0,
+        threadsCount: threads.at(0)?.total_num_thread_results || 0,
       };
     },
   };

--- a/libs/schemas/src/queries/thread.schemas.ts
+++ b/libs/schemas/src/queries/thread.schemas.ts
@@ -152,6 +152,10 @@ export const ThreadView = Thread.extend({
   Comments: z.array(CommentView).optional(),
   ThreadVersionHistories: z.array(ThreadVersionHistoryView).nullish(),
   search: z.union([z.string(), z.record(z.any())]).nullish(),
+  total_num_thread_results: z
+    .number()
+    .nullish()
+    .describe('total number of thread results for the query'),
 });
 
 export const OrderByQueriesKeys = z.enum([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10350

## Description of Changes
- Fixes issue where query breaks when filtering by contest address

## Test Plan
- Check that community threads list renders correctly: http://localhost:8080/common/discussions
- Create contest, add 2 threads to the contest, wait until action is projected
  - Go to contest leaderboard page, confirm that results show up without error

## Deployment Plan
N/A

## Other Considerations
- I'm not sure how the data is supposed to be used in the UI, but the API now returns the thread count according to the original schema.