### PR TITLE
Convert `govgen` addresses to `atone`

### DIFF
--- a/packages/commonwealth/server/migrations/20241219235431-convert-gov-gen-addresses.js
+++ b/packages/commonwealth/server/migrations/20241219235431-convert-gov-gen-addresses.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { bech32 } = require('bech32');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const addresses = await queryInterface.sequelize.query(
+        `
+          SELECT address, user_id
+          FROM "Addresses"
+          WHERE community_id = 'atomone' AND address LIKE 'govgen%';
+      `,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
+      );
+
+      for (const address of addresses) {
+        const { words } = bech32.decode(address.address);
+        const encodedAddress = bech32.encode('atone', words);
+
+        await queryInterface.sequelize.query(
+          `
+            UPDATE "Addresses"
+            SET address = '${encodedAddress}'
+            WHERE address = '${address.address}' AND community_id = 'atomone';
+        `,
+          { transaction },
+        );
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10411

## Description of Changes
- Migrates `govgen` addresses to `atone` and makes one of the addresses admin (see Telegram chat)

## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 