### PR TITLE
contests tab only shown when there is contest data

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/governance_section.tsx
@@ -232,6 +232,7 @@ export const GovernanceSection = ({ isContestAvailable }: AppSectionProps) => {
     isActive: !!matchesProposalRoute,
     displayData: null,
   };
+
   //Contests
   const contestData: SectionGroupAttrs = {
     title: 'Contests',
@@ -239,7 +240,7 @@ export const GovernanceSection = ({ isContestAvailable }: AppSectionProps) => {
     displayData: null,
     hasDefaultToggle: false,
     isActive: !!matchesContestsRoute,
-    isVisible: true,
+    isVisible: isContestAvailable,
     isUpdated: true,
     onClick: (e, toggle: boolean) => {
       e.preventDefault();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10379 

## Description of Changes
- Contests tab not shown unless there is contest data

## Test Plan
- Go to a community that has contests, confirm you can see the tab under Apps
- Go to a community that doesn't have contests, confirm that you do not see Contests tab under Apps