### PR TITLE
Updated base buy currency from USD to ETH in buy token trade modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeModal.tsx
@@ -26,7 +26,7 @@ const CommonTradeModal = ({
     useCommonTradeTokenForm({
       tradeConfig: {
         ...tradeConfig,
-        currency: TRADING_CURRENCY,
+        ethBuyCurrency: TRADING_CURRENCY,
         buyTokenPresetAmounts: [100, 300, 1000],
         sellTokenPresetAmounts: ['Max'],
       },

--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/AmountSelections/AmountSelections.scss
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/AmountSelections/AmountSelections.scss
@@ -22,6 +22,8 @@
       padding: 10px 8px;
       background-color: $neutral-200;
       color: $neutral-500;
+      display: flex;
+      align-items: center;
     }
 
     .amount-input,

--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/AmountSelections/BuyAmountSelection.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/AmountSelections/BuyAmountSelection.tsx
@@ -1,8 +1,4 @@
-import {
-  currencyNameToSymbolMap,
-  currencySymbolPlacements,
-  getAmountWithCurrencySymbol,
-} from 'helpers/currency';
+import { getAmountWithCurrencySymbol } from 'helpers/currency';
 import React from 'react';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -15,17 +11,12 @@ import './AmountSelections.scss';
 const BuyAmountSelection = ({ trading }: BuyAmountSelectionProps) => {
   const baseCurrencyName = trading.amounts.buy.invest.baseCurrency.name;
 
-  const buyAmountCurrenySymbol = (
-    <CWText className="amount-symbol">
-      {currencyNameToSymbolMap[baseCurrencyName]}
-    </CWText>
-  );
-
   return (
     <div className="AmountSelections">
       <div className="amount-input-with-currency-symbol">
-        {currencySymbolPlacements.onLeft.includes(baseCurrencyName) &&
-          buyAmountCurrenySymbol}
+        <CWText className="amount-symbol">
+          <CWIcon iconName="ethereum" iconSize="medium" /> {baseCurrencyName}
+        </CWText>
         <CWTextInput
           containerClassName="amount-input"
           placeholder="0"
@@ -34,14 +25,10 @@ const BuyAmountSelection = ({ trading }: BuyAmountSelectionProps) => {
             trading.amounts.buy.invest.baseCurrency.onAmountChange(e)
           }
         />
-        {currencySymbolPlacements.onRight.includes(baseCurrencyName) &&
-          buyAmountCurrenySymbol}
       </div>
 
       <CWText type="caption" className="invest-to-gain-amounts">
-        <CWIcon iconName="ethereum" iconSize="small" />
-        {trading.amounts.buy.invest.baseCurrency.toEth} ETH =
-        {trading.token.icon_url && <TokenIcon url={trading.token.icon_url} />}
+        = {trading.token.icon_url && <TokenIcon url={trading.token.icon_url} />}
         {trading.amounts.buy.gain.token} {trading.token.symbol}
       </CWText>
 
@@ -54,7 +41,7 @@ const BuyAmountSelection = ({ trading }: BuyAmountSelectionProps) => {
                 type="amount"
                 label={getAmountWithCurrencySymbol(
                   presetAmount as number,
-                  baseCurrencyName,
+                  trading.amounts.buy.invest.ethBuyCurrency,
                 )}
                 onClick={() =>
                   trading.amounts.buy.invest.baseCurrency.onAmountChange(

--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/ReceiptDetails/BuyReceipt.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/ReceiptDetails/BuyReceipt.tsx
@@ -11,15 +11,16 @@ const BuyReceipt = ({ trading }: ReceiptDetailsProps) => {
   const { invest, gain } = trading.amounts.buy;
   const baseCurrencyName = invest.baseCurrency.name;
   const baseCurrencySymbol = currencyNameToSymbolMap[baseCurrencyName];
+  const ethBuyCurrency = trading.amounts.buy.invest.ethBuyCurrency;
   const isLeftSymbolCurrency =
-    currencySymbolPlacements.onLeft.includes(baseCurrencyName);
+    currencySymbolPlacements.onLeft.includes(ethBuyCurrency);
   const isRightSymbolCurrency =
-    currencySymbolPlacements.onRight.includes(baseCurrencyName);
+    currencySymbolPlacements.onRight.includes(ethBuyCurrency);
 
   return (
     <div className="ReceiptDetails">
       <div className="entry">
-        <CWText type="caption">{baseCurrencyName} to ETH rate</CWText>
+        <CWText type="caption">{ethBuyCurrency} to ETH rate</CWText>
         <CWText type="caption">
           {isLeftSymbolCurrency ? baseCurrencySymbol : ''}{' '}
           {invest.baseCurrency.unitEthExchangeRate.toFixed(18)}
@@ -32,12 +33,6 @@ const BuyReceipt = ({ trading }: ReceiptDetailsProps) => {
           {isLeftSymbolCurrency ? baseCurrencySymbol : ''}{' '}
           {invest.baseCurrency.amount}
           {isRightSymbolCurrency ? baseCurrencySymbol : ''}
-        </CWText>
-      </div>
-      <div className="entry">
-        <CWText type="caption">ETH bought from invested amount</CWText>
-        <CWText type="caption">
-          {invest.baseCurrency.toEth.toFixed(18)} ETH
         </CWText>
       </div>
       <div className="entry">

--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/types.ts
@@ -10,7 +10,7 @@ export type TokenPresetAmounts = number | 'Max';
 
 export type UseCommonTradeTokenFormProps = {
   tradeConfig: TradingConfig & {
-    currency: SupportedCurrencies;
+    ethBuyCurrency: SupportedCurrencies;
     buyTokenPresetAmounts?: TokenPresetAmounts[];
     sellTokenPresetAmounts?: TokenPresetAmounts[]; // we could also do 25%, 50% etc
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10248

## Description of Changes
Updated base buy currency from USD to ETH in buy token trade modal

## "How We Fixed It"
N/A

## Test Plan
1. Set `FLAG_TOKENIZED_COMMUNITY=true` in `.env`
2. Visit `/communities` and press "Launch Token" to create a token-based community
3. Visit that community and attempt to open the buy token trade modal from the community token widget "Buy" button
4. Verify that the buy amounts are in `ETH`
5. Verify that changing buy amount correctly gets reflects in the modal (in pricing conversions, receipt details and the "bought token" amount)
6. Verify that buy the token works correctly and you received the correct buy amounts as specified in the buy receipt.

## Deployment Plan
N/A

## Other Considerations
N/A