### PR TITLE
fixed sidebar carrots overlapping banner text

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/RenderTextWithLink/RenderTextWithLink.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/RenderTextWithLink/RenderTextWithLink.scss
@@ -18,6 +18,7 @@
 
     .text {
       margin-right: 2px;
+      padding-left: 20px;
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10497 

Before:
<img width="1415" alt="Screenshot 2025-01-07 at 5 26 54 PM" src="https://github.com/user-attachments/assets/095fef49-7c1f-4a8b-8a82-f4027b1c1d09" />

After:
![Screenshot 2025-01-07 at 5 38 41 PM](https://github.com/user-attachments/assets/7a033c16-5dc9-4618-bd1c-f3a7305b3825)
