### PR TITLE
removed growl temporarily for new release

### DIFF
--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -7,7 +7,6 @@ import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { SublayoutHeader } from 'views/components/SublayoutHeader';
 import { Sidebar } from 'views/components/sidebar';
-import farcasterContestImage from '../../assets/img/farcasterContestImage.png';
 import { useHandleInviteLink } from '../hooks/useHandleInviteLink';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
 import useStickyHeader from '../hooks/useStickyHeader';
@@ -23,7 +22,6 @@ import { AdminOnboardingSlider } from './components/AdminOnboardingSlider';
 import { Breadcrumbs } from './components/Breadcrumbs';
 import MobileNavigation from './components/MobileNavigation';
 import AuthButtons from './components/SublayoutHeader/AuthButtons';
-import { CWGrowlTemplate } from './components/SublayoutHeader/GrowlTemplate';
 import useJoinCommunity from './components/SublayoutHeader/useJoinCommunity';
 import { CWModal } from './components/component_kit/new_designs/CWModal';
 import CollapsableSidebarButton from './components/sidebar/CollapsableSidebarButton';
@@ -190,17 +188,6 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
             )}
             {children}
           </div>
-          <CWGrowlTemplate
-            headerText="Launch Contests On Farcaster!"
-            bodyText="You can now host contests directly on Farcaster to reach and engage your followers.
-            They can submit entries,
-            vote for their favorites, and earn rewards, all without leaving the page."
-            buttonText="Enter $MOCHI Contest"
-            buttonLink="https://www.google.com/"
-            growlType="farcasterContest"
-            growlImage={farcasterContestImage}
-            extraText="Enter the first Farcaster Contest hosted by our friends at Mochi"
-          />
         </div>
         <WelcomeOnboardModal
           isOpen={isWelcomeOnboardModalOpen}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10506 

## Description of Changes
- This is to temporarily remove the mochi contest growl so Ilija can release newest version without the growl since the contest itself hasn't started yet. 
NOTE: I only removed the growl from `Sublayout.tsx` and not the image, as the image will be used again for when the growl goes back intot he codebase and the contest runs. 