### PR TITLE
Fixed proposal status modal and cleaned it up

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/update_proposal_status_modal.tsx
@@ -369,7 +369,7 @@ export const UpdateProposalStatusModal = ({
             />
           </>
         ) : (
-          <CWText>Please connect your Snapshot space </CWText>
+          !isCosmos && <CWText>Please connect your Snapshot space </CWText>
         )}
         {isCosmos && (
           <CosmosProposalSelector
@@ -397,14 +397,12 @@ export const UpdateProposalStatusModal = ({
               buttonHeight="sm"
               onClick={onModalClose}
             />
-            {showSnapshot && (
-              <CWButton
-                buttonType="primary"
-                buttonHeight="sm"
-                label="Save changes"
-                onClick={handleSaveChanges}
-              />
-            )}
+            <CWButton
+              buttonType="primary"
+              buttonHeight="sm"
+              label="Save changes"
+              onClick={handleSaveChanges}
+            />
           </div>
         </div>
       </CWModalFooter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10520 

## Description of Changes
- Took our conditional statement to show save changes button which was blocking a user in a cosmos community from connecting a proposal
- cleaned up the logic around "Please connect your Snapshot space" to not show when a user is in a cosmos community

## Test Plan
- Go to a thread inside a cosmos community, Stargaze for example, and click "Link proposal" 
- confirm that you are able to link a proposal
- go to an evm community that doesnt have a snapshot integrated
- confirm that you see "Please connect you Snapshot space"
- go to community that has a snapshot space integrated, or add one to a community. commonspacetester.eth has been set up for testing purposes
-go to a thread and confirm that you are able to connect a snapshot proposal to that thread and you no longer see the "Please connect your snapshot space" text