### PR TITLE
Hotfix: prevent error when getCanvasClock fails

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -104,9 +104,13 @@ function getDidForCurrentAddress(
 }
 
 async function getClockFromAPI(): Promise<[number, string[]]> {
-  const response = await axios.get(`${SERVER_URL}/getCanvasClock`);
-  const { clock, heads: parents } = response.data.result;
-  return [clock, parents];
+  try {
+    const response = await axios.get(`${SERVER_URL}/getCanvasClock`);
+    const { clock, heads: parents } = response.data.result;
+    return [clock, parents];
+  } catch (err) {
+    return [1, []];
+  }
 }
 
 // Public signer methods


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10563 

## Description of Changes
- Use clock value of 0 if the client gets a 500 error when retrieving the latest clock

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 