### PR TITLE
Added XP progress bar

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -34,6 +34,7 @@ const featureFlags = {
   stickyEditor: buildFlag(process.env.FLAG_STICKY_EDITOR),
   newMobileNav: buildFlag(process.env.FLAG_NEW_MOBILE_NAV),
   rewardsPage: buildFlag(process.env.FLAG_REWARDS_PAGE),
+  xp: buildFlag(process.env.FLAG_XP),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -22,6 +22,7 @@ import AuthButtons from 'views/components/SublayoutHeader/AuthButtons';
 import { AuthModalType } from 'views/modals/AuthModal';
 import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
 import { CWText } from '../../component_kit/cw_text';
+import XPProgressIndicator from '../XPProgressIndicator';
 import './DesktopHeader.scss';
 
 interface DesktopHeaderProps {
@@ -32,6 +33,7 @@ interface DesktopHeaderProps {
 const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
   const navigate = useCommonNavigate();
   const rewardsEnabled = useFlag('rewardsPage');
+  const xpEnabled = useFlag('xp');
   const { menuVisible, setMenu, menuName, setUserToggledVisibility } =
     useSidebarStore();
   const user = useUserStore();
@@ -87,6 +89,7 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
               isLoggedIn: user.isLoggedIn,
             })}
           >
+            {xpEnabled && <XPProgressIndicator />}
             <CreateContentPopover />
             {!isWindowSmallInclusive(window.innerWidth) && (
               <CWTooltip

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.scss
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.scss
@@ -1,0 +1,53 @@
+@import '../../../../styles/shared';
+
+.XPProgressIndicator {
+  all: unset;
+  min-width: 150px;
+  width: 200px;
+  max-width: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  padding: 4px;
+
+  &:focus,
+  &:focus-within {
+    outline: none !important;
+  }
+
+  &:hover {
+    background-color: $neutral-100;
+    cursor: pointer;
+    border-radius: 6px;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0 4px;
+
+    .caption {
+      font-size: 10px !important;
+      color: $primary-500 !important;
+    }
+  }
+
+  .progress-bar {
+    height: 10px;
+    width: 100%;
+    border: 1px solid $neutral-100;
+
+    &::-webkit-progress-bar {
+      background-color: $neutral-200;
+      border-radius: $border-radius-corners;
+    }
+
+    &::-webkit-progress-value {
+      background-color: $primary-400;
+      border-radius: $border-radius-corners;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.tsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import useUserStore from 'state/ui/user';
+import { CWText } from '../../component_kit/cw_text';
+import './XPProgressIndicator.scss';
+
+type XPProgressIndicatorProps = {
+  className?: string;
+};
+
+const XPProgressIndicator = ({ className }: XPProgressIndicatorProps) => {
+  const sampleData = {
+    weeklyGoal: {
+      current: 170,
+      target: 400,
+    },
+  };
+
+  const currentProgress = parseInt(
+    (
+      (sampleData.weeklyGoal.current / sampleData.weeklyGoal.target) *
+      100
+    ).toFixed(0),
+  );
+
+  const user = useUserStore();
+
+  if (!user.isLoggedIn) return;
+
+  return (
+    <button className={clsx('XPProgressIndicator', className)}>
+      <div className="header">
+        <CWText type="caption" fontWeight="semiBold">
+          Weekly XP Goal
+        </CWText>
+        <CWText type="caption" fontWeight="semiBold">
+          {sampleData.weeklyGoal.current} / {sampleData.weeklyGoal.target} XP
+        </CWText>
+      </div>
+      <progress className="progress-bar" value={currentProgress} max={100} />
+    </button>
+  );
+};
+
+export default XPProgressIndicator;

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/index.ts
@@ -1,0 +1,3 @@
+import XPProgressIndicator from './XPProgressIndicator';
+
+export default XPProgressIndicator;

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
     'process.env.FLAG_REWARDS_PAGE': JSON.stringify(env.FLAG_REWARDS_PAGE),
     'process.env.FLAG_STICKY_EDITOR': JSON.stringify(env.FLAG_STICKY_EDITOR),
     'process.env.FLAG_NEW_MOBILE_NAV': JSON.stringify(env.FLAG_NEW_MOBILE_NAV),
+    'process.env.FLAG_XP': JSON.stringify(env.FLAG_XP),
   };
 
   const config = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9338

## Description of Changes
Added XP progress bar in header

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Visit any page with logged out state
3. Verify you don't see the XP progress bar in header
4. Now login and verify you see the XP progress bar

## Deployment Plan
N/A

## Other Considerations
N/A