### PR TITLE
added validation to allow for snapshot spaces ending in .io

### DIFF
--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -127,7 +127,7 @@ export const UpdateCustomDomain = {
   context: AuthContext,
 };
 
-const Snapshot = z.string().regex(/.+\.(eth|xyz)$/);
+const Snapshot = z.string().regex(/.+\.(eth|xyz|io)$/);
 
 export const UpdateCommunity = {
   input: Community.omit({ id: true, network: true, custom_domain: true })

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
@@ -1,16 +1,20 @@
 import z from 'zod';
 
-const snapshotNameSchema = z.string().regex(/^[a-zA-Z0-9-.]+\.((xyz)|(eth))$/, {
-  message: 'Snapshot must be valid, and end in *.eth or *.xyz',
-});
+const snapshotNameSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-.]+\.((xyz)|(eth)|(io))$/, {
+    message: 'Snapshot must be valid, and end in *.eth, *.xyz, or *.io',
+  });
+
 const snapshotLinkSchema = z
   .string()
   .regex(
-    /^https:\/\/(\w+\.)?snapshot\.org\/#\/[a-zA-Z0-9-.]+\.((xyz)|(eth))$/,
+    /^https:\/\/(\w+\.)?snapshot\.org\/#\/[a-zA-Z0-9-.]+\.((xyz)|(eth)|(io))$/,
     {
-      message: 'Snapshot link be valid, and end in *.eth or *.xyz',
+      message: 'Snapshot link must be valid, and end in *.eth, *.xyz, or *.io',
     },
   );
+
 const snapshotValidationSchema = z.union([
   snapshotNameSchema,
   snapshotLinkSchema,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10578 

## Description of Changes
- user is now able to integrate a snapshot space ending with .io, instead of just .eth and .xyz

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-refactored the regex in the input validation on the front and back to allow for .io
## Test Plan
- go to a community you're an admin of and click into Integrations
- add a new snapshot space that ends with .io. you can use `goddog.io`
- confirm that you are able to add that snapshot space to Integrations

