### PR TITLE
Adds profile details to actor in all notifs

### DIFF
--- a/libs/core/src/ports/interfaces.ts
+++ b/libs/core/src/ports/interfaces.ts
@@ -312,7 +312,13 @@ export type NotificationsProviderRecipient =
 
 type BaseNotifProviderOptions = {
   users: { id: string; email?: string }[];
-  actor?: { id: string; email?: string };
+  actor?: {
+    id: string;
+    profile_name: string;
+    profile_url: string;
+    email?: string;
+    profile_avatar_url?: string;
+  };
 };
 
 type WebhookProviderOptions = {

--- a/libs/core/src/ports/port.ts
+++ b/libs/core/src/ports/port.ts
@@ -317,7 +317,12 @@ export const notificationsProvider = port(function notificationsProviderFactory(
     notificationsProviderAdapter || {
       name: 'in-memory-notifications-provider',
       dispose: () => Promise.resolve(),
-      triggerWorkflow: () => Promise.resolve([]),
+      triggerWorkflow: (options) => {
+        log.info('triggerWorkflow', options);
+        return Promise.resolve([
+          { status: 'fulfilled', value: { workflow_run_id: '123' } },
+        ]);
+      },
       getMessages: () => Promise.resolve([]),
       getSchedules: () =>
         Promise.resolve([] as NotificationsProviderSchedulesReturn),

--- a/libs/model/src/policies/handlers/notifyCommentCreated.ts
+++ b/libs/model/src/policies/handlers/notifyCommentCreated.ts
@@ -96,15 +96,21 @@ export const notifyCommentCreated: EventHandler<
       key: WorkflowKeys.CommentCreation,
       users: users.map((u) => ({ id: String(u.user_id) })),
       data: {
-        // @ts-expect-error StrictNullChecks
-        author: author.User.profile.name || author.address.substring(0, 8),
+        author: author.User?.profile.name || author.address.substring(0, 8),
         comment_parent_name: payload.parent_id ? 'comment' : 'thread',
         community_name: community.name,
         comment_body: commentSummary,
         comment_url: commentUrl,
         comment_created_event: payload,
       },
-      actor: { id: String(author.user_id) },
+      actor: {
+        id: String(author.user_id),
+        profile_name:
+          author.User?.profile.name || author.address.substring(0, 8),
+        profile_url: getProfileUrl(author.user_id, community.custom_domain),
+        email: author.User?.profile.email ?? undefined,
+        profile_avatar_url: author.User?.profile.avatar_url ?? undefined,
+      },
     });
   }
 

--- a/libs/model/src/policies/handlers/notifyCommentUpvoted.ts
+++ b/libs/model/src/policies/handlers/notifyCommentUpvoted.ts
@@ -7,7 +7,7 @@ import {
 import { getDecodedString, safeTruncateBody } from '@hicommonwealth/shared';
 import z from 'zod';
 import { models } from '../../database';
-import { getCommentUrl } from '../utils/utils';
+import { getCommentUrl, getProfileUrl } from '../utils/utils';
 
 const log = logger(import.meta);
 const output = z.boolean();
@@ -100,6 +100,19 @@ export const notifyCommentUpvoted: EventHandler<
         payload.comment_id,
         thread.Community.custom_domain,
       ),
+    },
+    actor: {
+      id: String(commentAndAuthor.Address.User!.id),
+      profile_name:
+        commentAndAuthor.Address.User!.profile.name ||
+        commentAndAuthor.Address.address.substring(0, 8),
+      profile_url: getProfileUrl(
+        commentAndAuthor.Address.User!.id!,
+        thread.Community.custom_domain,
+      ),
+      email: commentAndAuthor.Address.User!.profile.email ?? undefined,
+      profile_avatar_url:
+        commentAndAuthor.Address.User!.profile.avatar_url ?? undefined,
     },
   });
 

--- a/libs/model/src/policies/handlers/notifyThreadUpvoted.ts
+++ b/libs/model/src/policies/handlers/notifyThreadUpvoted.ts
@@ -7,7 +7,7 @@ import {
 import { getDecodedString, safeTruncateBody } from '@hicommonwealth/shared';
 import z from 'zod';
 import { models } from '../../database';
-import { getThreadUrl } from '../utils/utils';
+import { getProfileUrl, getThreadUrl } from '../utils/utils';
 
 const log = logger(import.meta);
 const output = z.boolean();
@@ -81,6 +81,19 @@ export const notifyThreadUpvoted: EventHandler<
         payload.thread_id,
         community.custom_domain,
       ),
+    },
+    actor: {
+      id: String(threadAndAuthor.Address.User!.id),
+      profile_name:
+        threadAndAuthor.Address.User!.profile.name ||
+        threadAndAuthor.Address.address.substring(0, 8),
+      profile_url: getProfileUrl(
+        threadAndAuthor.Address.User!.id!,
+        community.custom_domain,
+      ),
+      email: threadAndAuthor.Address.User!.profile.email ?? undefined,
+      profile_avatar_url:
+        threadAndAuthor.Address.User!.profile.avatar_url ?? undefined,
     },
   });
 

--- a/libs/model/src/policies/handlers/notifyUserMentioned.ts
+++ b/libs/model/src/policies/handlers/notifyUserMentioned.ts
@@ -79,6 +79,13 @@ export const notifyUserMentioned: EventHandler<
           : safeTruncateBody(getDecodedString(payload.comment!.body), 255),
       object_url,
     },
+    actor: {
+      id: String(user.id),
+      profile_name: user.profile.name || payload.authorAddress.substring(0, 8),
+      profile_url: getProfileUrl(user.id!, community.custom_domain),
+      email: user.profile.email ?? undefined,
+      profile_avatar_url: user.profile.avatar_url ?? undefined,
+    },
   });
 
   // Don't send Eliza webhooks for mentions in comments

--- a/libs/model/test/policies/commentCreated.spec.ts
+++ b/libs/model/test/policies/commentCreated.spec.ts
@@ -23,7 +23,7 @@ import {
 import z from 'zod';
 import { models, tester } from '../../src';
 import { notifyCommentCreated } from '../../src/policies/handlers/notifyCommentCreated';
-import { getCommentUrl } from '../../src/policies/utils/utils';
+import { getCommentUrl, getProfileUrl } from '../../src/policies/utils/utils';
 import {
   ProviderError,
   SpyNotificationsProvider,
@@ -198,8 +198,7 @@ describe('CommentCreated Event Handler', () => {
     expect(provider.triggerWorkflow as Mock).toHaveBeenCalledOnce();
     expect((provider.triggerWorkflow as Mock).mock.calls[0][0]).to.deep.equal({
       key: WorkflowKeys.CommentCreation,
-      // @ts-expect-error StrictNullChecks
-      users: [{ id: String(subscriber.id) }],
+      users: [{ id: String(subscriber!.id) }],
       data: {
         author: author?.profile.name,
         comment_parent_name: 'thread',
@@ -212,8 +211,13 @@ describe('CommentCreated Event Handler', () => {
           community_id: community!.id,
         },
       },
-      // @ts-expect-error StrictNullChecks
-      actor: { id: String(author.id) },
+      actor: {
+        id: String(author!.id),
+        email: author!.profile.email,
+        profile_name: author!.profile.name,
+        profile_url: getProfileUrl(author!.id!, customDomain),
+        profile_avatar_url: author!.profile.avatar_url,
+      },
     });
   });
 
@@ -259,8 +263,13 @@ describe('CommentCreated Event Handler', () => {
           community_id: community!.id,
         },
       },
-      // @ts-expect-error StrictNullChecks
-      actor: { id: String(author.id) },
+      actor: {
+        id: String(author!.id),
+        email: author!.profile.email,
+        profile_name: author!.profile.name,
+        profile_url: getProfileUrl(author!.id!, customDomain),
+        profile_avatar_url: author!.profile.avatar_url,
+      },
     });
   });
 
@@ -335,7 +344,13 @@ describe('CommentCreated Event Handler', () => {
           community_id: community!.id,
         },
       },
-      actor: { id: String(author!.id) },
+      actor: {
+        id: String(author!.id),
+        email: author!.profile.email,
+        profile_name: author!.profile.name,
+        profile_url: getProfileUrl(author!.id!, customDomain),
+        profile_avatar_url: author!.profile.avatar_url,
+      },
     });
   });
 });

--- a/libs/model/test/policies/userMentioned.spec.ts
+++ b/libs/model/test/policies/userMentioned.spec.ts
@@ -22,7 +22,7 @@ import {
 import z from 'zod';
 import { tester } from '../../src';
 import { notifyUserMentioned } from '../../src/policies/handlers/notifyUserMentioned';
-import { getThreadUrl } from '../../src/policies/utils/utils';
+import { getProfileUrl, getThreadUrl } from '../../src/policies/utils/utils';
 import {
   ProviderError,
   SpyNotificationsProvider,
@@ -134,6 +134,13 @@ describe('userMentioned Event Handler', () => {
         author: author?.profile.name,
         object_body: safeTruncateBody(thread!.body!, 255),
         object_url: getThreadUrl(community!.id!, thread!.id!),
+      },
+      actor: {
+        id: String(author!.id),
+        profile_name: author!.profile.name,
+        profile_url: getProfileUrl(author!.id!, community!.custom_domain),
+        email: author!.profile.email,
+        profile_avatar_url: author!.profile.avatar_url,
       },
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10279

## Description of Changes
- Adds profile details to schema

 
## Test Plan
- TBD - we probably need to update knock workflows @kurtisassad 
- With the async infra set up (start-knock, start-message-relayer)
- Create a thread while mentioning yourself in it. Check that it sends a notification to you.

 