### PR TITLE
Small prize fix

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -441,6 +441,11 @@ export const buildContestLeaderboardUrl = (
   return `${baseUrl}/${communityId}/contests/${contestAddress}`;
 };
 
+export const smallNumberFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'standard',
+  maximumFractionDigits: 20, // Allow up to 22 decimal places for small numbers
+});
+
 // returns balance with fee deducted
 export const calculateNetContestBalance = (originalBalance: number) => {
   const multiplier = (100 - CONTEST_FEE_PERCENT) / 100;
@@ -452,14 +457,16 @@ export const buildContestPrizes = (
   contestBalance: number,
   payoutStructure?: number[],
   decimals?: number,
-): number[] => {
+): string[] => {
   // 10% fee deducted from prize pool
   const netContestBalance = calculateNetContestBalance(Number(contestBalance));
   return netContestBalance && payoutStructure
-    ? payoutStructure.map(
-        (percentage) =>
+    ? payoutStructure.map((percentage) => {
+        const prize =
           (Number(netContestBalance) * (percentage / 100)) /
-          Math.pow(10, decimals || 18),
-      )
+          Math.pow(10, decimals || 18);
+
+        return smallNumberFormatter.format(prize);
+      })
     : [];
 };

--- a/packages/commonwealth/client/scripts/views/pages/Communities/ExploreContestList/ExploreContestCard/ExploreContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/ExploreContestList/ExploreContestCard/ExploreContestCard.tsx
@@ -8,7 +8,6 @@ import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import { useGetContestBalanceQuery } from 'state/api/contests';
 import { Skeleton } from 'views/components/Skeleton';
 import { CWCommunityAvatar } from 'views/components/component_kit/cw_community_avatar';
-import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
 
 import { CWText } from '../../../../components/component_kit/cw_text';
 import { CWButton } from '../../../../components/component_kit/new_designs/CWButton/CWButton';
@@ -141,7 +140,7 @@ const ExploreContestCard = ({
                     {moment.localeData().ordinal(index + 1)} Prize
                   </CWText>
                   <CWText fontWeight="bold">
-                    {capDecimals(String(prize))} {contest.ticker}
+                    {prize} {contest.ticker}
                   </CWText>
                 </div>
               ))

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.scss
@@ -71,9 +71,14 @@
       .prize-row {
         display: flex;
         justify-content: space-between;
+        gap: 8px;
 
         .label {
           color: $neutral-600;
+        }
+
+        .bold {
+          word-break: break-word;
         }
       }
     }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -19,7 +19,6 @@ import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { SharePopoverOld } from 'views/components/share_popover_old';
-import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 
 import { ContestType } from '../../types';
@@ -249,7 +248,7 @@ const ContestCard = ({
                         {moment.localeData().ordinal(index + 1)} Prize
                       </CWText>
                       <CWText fontWeight="bold">
-                        {capDecimals(String(prize))} {ticker}
+                        {prize} {ticker}
                       </CWText>
                     </div>
                   ))

--- a/packages/commonwealth/server/farcaster/frames/contest/contestPrizes.tsx
+++ b/packages/commonwealth/server/farcaster/frames/contest/contestPrizes.tsx
@@ -13,7 +13,7 @@ const PrizeRow = ({
   ticker = 'ETH',
 }: {
   index: number;
-  prize: number;
+  prize: string;
   ticker?: string;
 }) => {
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10593

## Description of Changes
- converted scientific notation to standard and removed capping after 8 decimals 


## Test Plan
- small contests like brium should display prize in standard notation instead of scientific

![image](https://github.com/user-attachments/assets/f1440728-6807-4466-b025-36226b19818e)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a