### PR TITLE
Added quest creation form

### DIFF
--- a/libs/adapters/src/trpc/types.ts
+++ b/libs/adapters/src/trpc/types.ts
@@ -30,6 +30,7 @@ export enum Tag {
   Token = 'Token',
   Contest = 'Contest',
   Poll = 'Poll',
+  Quest = 'Quest',
 }
 
 /**

--- a/libs/model/src/index.ts
+++ b/libs/model/src/index.ts
@@ -8,6 +8,7 @@ export * as Email from './emails';
 export * as Feed from './feed';
 export * as LoadTest from './load-testing';
 export * as Poll from './poll';
+export * as Quest from './quest';
 export * as Reaction from './reaction';
 export * as Snapshot from './snapshot';
 export * as Subscription from './subscription';

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -35,6 +35,7 @@ const featureFlags = {
   newMobileNav: buildFlag(process.env.FLAG_NEW_MOBILE_NAV),
   rewardsPage: buildFlag(process.env.FLAG_REWARDS_PAGE),
   growl: buildFlag(process.env.FLAG_GROWL),
+  xp: buildFlag(process.env.FLAG_XP),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/helpers/formValidations/common.ts
+++ b/packages/commonwealth/client/scripts/helpers/formValidations/common.ts
@@ -5,12 +5,14 @@ export const linkValidationSchema = {
   required: z.string().url({
     message: VALIDATION_MESSAGES.INVALID_INPUT,
   }),
-  optional: z.union([
-    z.literal(''),
-    z.string().url({
-      message: VALIDATION_MESSAGES.INVALID_INPUT,
-    }),
-  ]),
+  optional: z
+    .union([
+      z.literal(''),
+      z.string().url({
+        message: VALIDATION_MESSAGES.INVALID_INPUT,
+      }),
+    ])
+    .nullish(),
 };
 
 export const emailValidationSchema = z.union([

--- a/packages/commonwealth/client/scripts/helpers/string.ts
+++ b/packages/commonwealth/client/scripts/helpers/string.ts
@@ -1,0 +1,8 @@
+/**
+ * Sample usage: Input = 'SignUpFlowCompleted', Output = 'Sign Up Flow Completed'
+ * @param str
+ * @returns
+ */
+export function splitCamelOrPascalCase(str): string {
+  return str.replace(/([a-z])([A-Z])/g, '$1 $2');
+}

--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -16,6 +16,7 @@ const CommunitiesPage = lazy(() => import('views/pages/Communities'));
 const SearchPage = lazy(() => import('views/pages/search'));
 
 const CreateCommunityPage = lazy(() => import('views/pages/CreateCommunity'));
+const CreateQuestPage = lazy(() => import('views/pages/CreateQuest'));
 const LaunchToken = lazy(() => import('views/pages/LaunchToken'));
 const OverviewPage = lazy(() => import('views/pages/overview'));
 const MembersPage = lazy(
@@ -120,7 +121,10 @@ const CommunityNotFoundPage = lazy(
 const UnSubscribePage = lazy(() => import('views/pages/UnSubscribePage'));
 const RewardsPage = lazy(() => import('views/pages/RewardsPage'));
 
-const CommonDomainRoutes = ({ launchpadEnabled }: RouteFeatureFlags) => [
+const CommonDomainRoutes = ({
+  launchpadEnabled,
+  xpEnabled,
+}: RouteFeatureFlags) => [
   <Route
     key="/_internal/quill"
     path="/_internal/quill"
@@ -155,6 +159,15 @@ const CommonDomainRoutes = ({ launchpadEnabled }: RouteFeatureFlags) => [
     path="/createCommunity"
     element={withLayout(CreateCommunityPage, { type: 'common' })}
   />,
+  ...(xpEnabled
+    ? [
+        <Route
+          key="/createQuest"
+          path="/createQuest"
+          element={withLayout(CreateQuestPage, { type: 'common' })}
+        />,
+      ]
+    : []),
   <Route
     key="/unSubscribe/:userId"
     path="/unSubscribe/:userId"

--- a/packages/commonwealth/client/scripts/navigation/CustomDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CustomDomainRoutes.tsx
@@ -7,6 +7,7 @@ import { RouteFeatureFlags } from './Router';
 const SearchPage = lazy(() => import('views/pages/search'));
 
 const CreateCommunityPage = lazy(() => import('views/pages/CreateCommunity'));
+const CreateQuestPage = lazy(() => import('views/pages/CreateQuest'));
 const LaunchTokenPage = lazy(() => import('views/pages/LaunchToken'));
 const OverviewPage = lazy(() => import('views/pages/overview'));
 const MembersPage = lazy(
@@ -105,7 +106,10 @@ const UnSubscribePage = lazy(() => import('views/pages/UnSubscribePage'));
 
 const RewardsPage = lazy(() => import('views/pages/RewardsPage'));
 
-const CustomDomainRoutes = ({ launchpadEnabled }: RouteFeatureFlags) => {
+const CustomDomainRoutes = ({
+  launchpadEnabled,
+  xpEnabled,
+}: RouteFeatureFlags) => {
   return [
     <Route
       key="/"
@@ -120,6 +124,15 @@ const CustomDomainRoutes = ({ launchpadEnabled }: RouteFeatureFlags) => {
       path="/createCommunity"
       element={withLayout(CreateCommunityPage, { type: 'common' })}
     />,
+    ...(xpEnabled
+      ? [
+          <Route
+            key="/createQuest"
+            path="/createQuest"
+            element={withLayout(CreateQuestPage, { type: 'common' })}
+          />,
+        ]
+      : []),
     <Route
       key="/unSubscribe/:userId"
       path="/unSubscribe/:userId"

--- a/packages/commonwealth/client/scripts/navigation/Router.tsx
+++ b/packages/commonwealth/client/scripts/navigation/Router.tsx
@@ -14,15 +14,18 @@ import GeneralRoutes from './GeneralRoutes';
 
 export type RouteFeatureFlags = {
   launchpadEnabled: boolean;
+  xpEnabled: boolean;
 };
 
 const Router = () => {
   const client = OpenFeature.getClient();
 
   const launchpadEnabled = client.getBooleanValue('launchpad', false);
+  const xpEnabled = client.getBooleanValue('xp', false);
 
   const flags = {
     launchpadEnabled,
+    xpEnabled,
   };
 
   const { isCustomDomain } = fetchCachedCustomDomain() || {};

--- a/packages/commonwealth/client/scripts/state/api/quests/createQuest.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/createQuest.ts
@@ -1,0 +1,5 @@
+import { trpc } from 'utils/trpcClient';
+
+export function useCreateQuestMutation() {
+  return trpc.quest.createQuest.useMutation();
+}

--- a/packages/commonwealth/client/scripts/state/api/quests/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/index.ts
@@ -1,0 +1,4 @@
+import { useCreateQuestMutation } from './createQuest';
+import { useUpdateQuestMutation } from './updateQuest';
+
+export { useCreateQuestMutation, useUpdateQuestMutation };

--- a/packages/commonwealth/client/scripts/state/api/quests/updateQuest.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/updateQuest.ts
@@ -1,0 +1,5 @@
+import { trpc } from 'utils/trpcClient';
+
+export function useUpdateQuestMutation() {
+  return trpc.quest.updateQuest.useMutation();
+}

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
@@ -6,6 +6,7 @@ import UpdateCommunityIdTask from 'views/pages/AdminPanel/UpdateCommunityIdTask'
 import UpdateCustomDomainTask from 'views/pages/AdminPanel/UpdateCustomDomainTask';
 import { CWDivider } from '../../components/component_kit/cw_divider';
 import { CWText } from '../../components/component_kit/cw_text';
+import { CWButton } from '../../components/component_kit/new_designs/CWButton';
 import './AdminPanel.scss';
 import Analytics from './Analytics';
 import ConnectChainToCommunity from './ConnectChainToCommunityTask';
@@ -30,6 +31,13 @@ const AdminPanelPage = () => {
   return (
     <CWPageLayout>
       <div className="AdminPanel">
+        <CWText type="h2">Create Site Assets</CWText>
+        <CWButton
+          label="Create Quests"
+          iconRight="arrowRightPhosphor"
+          onClick={() => navigate('/createQuest')}
+        />
+        <CWDivider />
         <CWText type="h2">Site Analytics</CWText>
         <Analytics />
         <CWDivider />

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuest.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuest.scss
@@ -1,0 +1,18 @@
+@import '../../../styles/shared';
+
+.CreateQuest {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+
+  .header {
+    .h2 {
+      color: $neutral-800 !important;
+    }
+
+    .b1 {
+      margin-top: 4px;
+      color: $neutral-600 !important;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuest.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuest.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import useUserStore from 'state/ui/user';
+import Permissions from 'utils/Permissions';
+import { CWText } from 'views/components/component_kit/cw_text';
+import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
+import { PageNotFound } from '../404';
+import './CreateQuest.scss';
+import CreateQuestForm from './CreateQuestForm';
+
+const CreateQuest = () => {
+  const user = useUserStore();
+
+  if (!user.isLoggedIn || !Permissions.isSiteAdmin()) return <PageNotFound />;
+
+  return (
+    <CWPageLayout>
+      <div className="CreateQuest">
+        <div className="header">
+          <CWText type="h2">Create a Quest</CWText>
+          <CWText type="b1">
+            Create community-focused tasks to increase engagement! Note: All
+            requirements must be fulfilled for users to earn XP, so we encourage
+            relevant quest items to be grouped into multiple quests.
+          </CWText>
+        </div>
+        <CreateQuestForm />
+      </div>
+    </CWPageLayout>
+  );
+};
+
+export default CreateQuest;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.scss
@@ -1,0 +1,75 @@
+@import '../../../../styles/shared';
+
+.CreateQuestForm {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  @include extraSmall {
+    gap: 18px;
+  }
+
+  .quest-period-section,
+  .basic-information-section,
+  .reward-section,
+  .actions-section {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+
+    @include extraSmall {
+      gap: 18px;
+    }
+
+    > .b1 {
+      color: $neutral-600 !important;
+    }
+  }
+
+  .quest-period-section {
+    .repeatition-selector {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      width: 100%;
+
+      .b1 {
+        color: $neutral-600 !important;
+      }
+
+      .radio-btn .Text {
+        color: $neutral-800 !important;
+      }
+    }
+  }
+
+  .actions-section {
+    .header {
+      .b2 {
+        margin-top: 8px;
+      }
+    }
+
+    .add-action-btn {
+      border: 1px solid $black;
+    }
+  }
+
+  .action-btns {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+
+    @include extraSmall {
+      .btn-border {
+        width: 100% !important;
+
+        > button {
+          width: 100% !important;
+        }
+      }
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.scss
@@ -51,8 +51,15 @@
       }
     }
 
-    .add-action-btn {
-      border: 1px solid $black;
+    .add-action-btn-outline {
+      &:focus-within {
+        border-width: 0px !important;
+        padding: 2px !important;
+      }
+
+      .add-action-btn {
+        border: 1px solid $black;
+      }
     }
   }
 
@@ -61,6 +68,24 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
+
+    .btn {
+      &.secondary {
+        &:focus-within {
+          border-width: 1px !important;
+          padding: 0px !important;
+          margin: 3px !important;
+        }
+      }
+
+      &.primary {
+        &:focus-within {
+          border-color: transparent !important;
+          padding: 0px !important;
+          margin: 0px !important;
+        }
+      }
+    }
 
     @include extraSmall {
       .btn-border {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -1,0 +1,110 @@
+import { QuestParticipationLimit } from '@hicommonwealth/schemas';
+import React, { useState } from 'react';
+import { CWDivider } from 'views/components/component_kit/cw_divider';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWTextArea } from 'views/components/component_kit/cw_text_area';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
+import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
+import './CreateQuestForm.scss';
+
+const MAX_ACTIONS_LIMIT = 8;
+
+const CreateQuestForm = () => {
+  const [subActions] = useState([]);
+
+  return (
+    <CWForm validationSchema={{} as any} className="CreateQuestForm">
+      <div className="quest-period-section">
+        <div className="repeatition-selector">
+          <CWText type="b1" fontWeight="semiBold">
+            Quests can be completed by members
+          </CWText>
+          <CWRadioButton
+            className="radio-btn"
+            value={QuestParticipationLimit.OncePerPeriod}
+            label="Repeatable daily"
+            groupName="quest"
+          />
+          <CWRadioButton
+            className="radio-btn"
+            value={QuestParticipationLimit.OncePerQuest}
+            label="One time only"
+            groupName="quest"
+          />
+        </div>
+        {/* TODO: need a proper input for dates */}
+        <CWTextInput label="Start Date" placeholder="TODO" />
+        <CWTextInput label="End Date" placeholder="TODO" />
+      </div>
+
+      <CWDivider />
+
+      <div className="basic-information-section">
+        <CWText type="b1" fontWeight="semiBold">
+          Basic information
+        </CWText>
+
+        <CWTextInput label="Quest name" placeholder="Quest name" fullWidth />
+
+        <CWTextArea
+          label="Description (Optional)"
+          placeholder="Add a description for your Quest"
+        />
+      </div>
+
+      <CWDivider />
+
+      <div className="reward-section">
+        <CWText type="b1" fontWeight="semiBold">
+          Reward
+        </CWText>
+
+        <CWTextInput
+          label="Points Earned"
+          placeholder="Amount per action"
+          fullWidth
+        />
+      </div>
+
+      <CWDivider />
+
+      <div className="actions-section">
+        <div className="header">
+          <CWText type="b1" fontWeight="semiBold">
+            Actions
+          </CWText>
+          <CWText type="b2">
+            Add actions that users should take to earn points
+          </CWText>
+        </div>
+
+        {/* TODO: action sub-form here */}
+
+        <CWButton
+          className="add-action-btn"
+          label="Add action"
+          buttonWidth="full"
+          type="submit"
+          buttonAlt="green"
+          disabled={subActions.length >= MAX_ACTIONS_LIMIT}
+        />
+      </div>
+
+      <CWDivider />
+
+      <div className="action-btns">
+        <CWButton
+          label="Back"
+          buttonType="secondary"
+          buttonWidth="wide"
+          type="button"
+        />
+        <CWButton label="Create Quest" buttonWidth="wide" type="submit" />
+      </div>
+    </CWForm>
+  );
+};
+
+export default CreateQuestForm;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -36,9 +36,18 @@ const CreateQuestForm = () => {
       onSubmit={handleSubmit}
       onErrors={validateSubForms}
       className="CreateQuestForm"
+      // TODO: remove initial values, only added for quick testing
       initialValues={{
+        name: `Quest-${Math.random()}`,
+        description: `Quest-description-${Math.random()}`,
+        image:
+          // eslint-disable-next-line max-len
+          'https://media.istockphoto.com/id/1973365581/vector/sample-ink-rubber-stamp.jpg?s=612x612&w=0&k=20&c=_m6hNbFtLdulg3LK5LRjJiH6boCb_gcxPvRLytIz0Ws=',
+        reward_amount: '500',
         // TODO: this will be updated via a date/calender selector component in #TODO-TICKET
-        start_date: new Date().toISOString(),
+        start_date: new Date(
+          Date.now() + 2 * 24 * 60 * 60 * 1000,
+        ).toISOString(), // 2 days from now
         end_date: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 days from now
       }}
     >

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -1,5 +1,5 @@
 import { QuestParticipationLimit } from '@hicommonwealth/schemas';
-import React, { useState } from 'react';
+import React from 'react';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTextArea } from 'views/components/component_kit/cw_text_area';
@@ -8,14 +8,29 @@ import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
 import './CreateQuestForm.scss';
-
-const MAX_ACTIONS_LIMIT = 8;
+import QuestActionSubForm from './QuestActionSubForm';
+import useCreateQuestForm from './useCreateQuestForm';
+import { questFormValidationSchema } from './validation';
 
 const CreateQuestForm = () => {
-  const [subActions] = useState([]);
+  const {
+    addSubForm,
+    questActionSubForms,
+    removeSubFormByIndex,
+    updateSubFormByIndex,
+    MAX_ACTIONS_LIMIT,
+    MIN_ACTIONS_LIMIT,
+    validateSubForms,
+    handleSubmit,
+  } = useCreateQuestForm();
 
   return (
-    <CWForm validationSchema={{} as any} className="CreateQuestForm">
+    <CWForm
+      validationSchema={questFormValidationSchema}
+      onSubmit={handleSubmit}
+      onErrors={validateSubForms}
+      className="CreateQuestForm"
+    >
       <div className="quest-period-section">
         <div className="repeatition-selector">
           <CWText type="b1" fontWeight="semiBold">
@@ -26,17 +41,32 @@ const CreateQuestForm = () => {
             value={QuestParticipationLimit.OncePerPeriod}
             label="Repeatable daily"
             groupName="quest"
+            name="participation_limit"
+            hookToForm
           />
           <CWRadioButton
             className="radio-btn"
             value={QuestParticipationLimit.OncePerQuest}
             label="One time only"
             groupName="quest"
+            name="participation_limit"
+            hookToForm
+            checked
           />
         </div>
         {/* TODO: need a proper input for dates */}
-        <CWTextInput label="Start Date" placeholder="TODO" />
-        <CWTextInput label="End Date" placeholder="TODO" />
+        <CWTextInput
+          label="Start Date"
+          placeholder="TODO"
+          hookToForm
+          name="start_date"
+        />
+        <CWTextInput
+          label="End Date"
+          placeholder="TODO"
+          hookToForm
+          name="end_date"
+        />
       </div>
 
       <CWDivider />
@@ -46,11 +76,19 @@ const CreateQuestForm = () => {
           Basic information
         </CWText>
 
-        <CWTextInput label="Quest name" placeholder="Quest name" fullWidth />
+        <CWTextInput
+          label="Quest name"
+          placeholder="Quest name"
+          fullWidth
+          name="name"
+          hookToForm
+        />
 
         <CWTextArea
           label="Description (Optional)"
           placeholder="Add a description for your Quest"
+          name="description"
+          hookToForm
         />
       </div>
 
@@ -65,6 +103,8 @@ const CreateQuestForm = () => {
           label="Points Earned"
           placeholder="Amount per action"
           fullWidth
+          name="reward_amount"
+          hookToForm
         />
       </div>
 
@@ -80,15 +120,24 @@ const CreateQuestForm = () => {
           </CWText>
         </div>
 
-        {/* TODO: action sub-form here */}
+        {questActionSubForms.map((subForm, index) => (
+          <QuestActionSubForm
+            key={index}
+            errors={subForm.errors}
+            onChange={(updateBody) => updateSubFormByIndex(updateBody, index)}
+            isRemoveable={questActionSubForms.length !== MIN_ACTIONS_LIMIT}
+            onRemove={() => removeSubFormByIndex(index)}
+          />
+        ))}
 
         <CWButton
           className="add-action-btn"
           label="Add action"
           buttonWidth="full"
-          type="submit"
+          type="button"
           buttonAlt="green"
-          disabled={subActions.length >= MAX_ACTIONS_LIMIT}
+          onClick={addSubForm}
+          disabled={questActionSubForms.length >= MAX_ACTIONS_LIMIT}
         />
       </div>
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -1,5 +1,9 @@
 import { QuestParticipationLimit } from '@hicommonwealth/schemas';
 import React from 'react';
+import {
+  CWImageInput,
+  ImageBehavior,
+} from 'views/components/component_kit/CWImageInput';
 import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTextArea } from 'views/components/component_kit/cw_text_area';
@@ -22,6 +26,8 @@ const CreateQuestForm = () => {
     MIN_ACTIONS_LIMIT,
     validateSubForms,
     handleSubmit,
+    isProcessingQuestImage,
+    setIsProcessingQuestImage,
   } = useCreateQuestForm();
 
   return (
@@ -30,6 +36,11 @@ const CreateQuestForm = () => {
       onSubmit={handleSubmit}
       onErrors={validateSubForms}
       className="CreateQuestForm"
+      initialValues={{
+        // TODO: this will be updated via a date/calender selector component in #TODO-TICKET
+        start_date: new Date().toISOString(),
+        end_date: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 days from now
+      }}
     >
       <div className="quest-period-section">
         <div className="repeatition-selector">
@@ -89,6 +100,17 @@ const CreateQuestForm = () => {
           placeholder="Add a description for your Quest"
           name="description"
           hookToForm
+        />
+
+        <CWImageInput
+          label="Quest Image (Accepts JPG and PNG files)"
+          onImageProcessingChange={({ isGenerating, isUploading }) => {
+            setIsProcessingQuestImage(isGenerating || isUploading);
+          }}
+          name="image"
+          hookToForm
+          imageBehavior={ImageBehavior.Fill}
+          withAIImageGeneration
         />
       </div>
 
@@ -162,6 +184,7 @@ const CreateQuestForm = () => {
           buttonWidth="wide"
           type="submit"
           containerClassName="btn"
+          disabled={isProcessingQuestImage}
         />
       </div>
     </CWForm>

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -36,15 +36,8 @@ const CreateQuestForm = () => {
       onSubmit={handleSubmit}
       onErrors={validateSubForms}
       className="CreateQuestForm"
-      // TODO: remove initial values, only added for quick testing
       initialValues={{
-        name: `Quest-${Math.random()}`,
-        description: `Quest-description-${Math.random()}`,
-        image:
-          // eslint-disable-next-line max-len
-          'https://media.istockphoto.com/id/1973365581/vector/sample-ink-rubber-stamp.jpg?s=612x612&w=0&k=20&c=_m6hNbFtLdulg3LK5LRjJiH6boCb_gcxPvRLytIz0Ws=',
-        reward_amount: '500',
-        // TODO: this will be updated via a date/calender selector component in #TODO-TICKET
+        // TODO: this will be updated via a date/calender selector component in #10674
         start_date: new Date(
           Date.now() + 2 * 24 * 60 * 60 * 1000,
         ).toISOString(), // 2 days from now
@@ -74,7 +67,7 @@ const CreateQuestForm = () => {
             checked
           />
         </div>
-        {/* TODO: need a proper input for dates */}
+        {/* TODO: proper component for picking dates in #10674 */}
         <CWTextInput
           label="Start Date"
           placeholder="TODO"

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -96,7 +96,7 @@ const CreateQuestForm = () => {
         />
 
         <CWTextArea
-          label="Description (Optional)"
+          label="Description"
           placeholder="Add a description for your Quest"
           name="description"
           hookToForm

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -8,7 +8,7 @@ import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import { CWRadioButton } from 'views/components/component_kit/new_designs/cw_radio_button';
 import './CreateQuestForm.scss';
-import QuestActionSubForm from './QuestActionSubForm';
+import QuestActionSubForm, { QuestAction } from './QuestActionSubForm';
 import useCreateQuestForm from './useCreateQuestForm';
 import { questFormValidationSchema } from './validation';
 
@@ -127,6 +127,11 @@ const CreateQuestForm = () => {
             onChange={(updateBody) => updateSubFormByIndex(updateBody, index)}
             isRemoveable={questActionSubForms.length !== MIN_ACTIONS_LIMIT}
             onRemove={() => removeSubFormByIndex(index)}
+            hiddenActions={
+              questActionSubForms
+                .filter((form) => !!form.values.action)
+                .map((form) => form.values.action) as QuestAction[]
+            }
           />
         ))}
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -136,6 +136,7 @@ const CreateQuestForm = () => {
         ))}
 
         <CWButton
+          containerClassName="add-action-btn-outline"
           className="add-action-btn"
           label="Add action"
           buttonWidth="full"
@@ -154,8 +155,14 @@ const CreateQuestForm = () => {
           buttonType="secondary"
           buttonWidth="wide"
           type="button"
+          containerClassName="btn"
         />
-        <CWButton label="Create Quest" buttonWidth="wide" type="submit" />
+        <CWButton
+          label="Create Quest"
+          buttonWidth="wide"
+          type="submit"
+          containerClassName="btn"
+        />
       </div>
     </CWForm>
   );

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -144,8 +144,9 @@ const CreateQuestForm = () => {
 
         {questActionSubForms.map((subForm, index) => (
           <QuestActionSubForm
-            key={index}
+            key={subForm.id}
             errors={subForm.errors}
+            defaultValues={subForm.values}
             onChange={(updateBody) => updateSubFormByIndex(updateBody, index)}
             isRemoveable={questActionSubForms.length !== MIN_ACTIONS_LIMIT}
             onRemove={() => removeSubFormByIndex(index)}

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.scss
@@ -1,0 +1,22 @@
+@import '../../../../../styles/shared';
+
+.QuestActionSubForm {
+  background-color: $neutral-50;
+  padding: 16px;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  position: relative;
+
+  &.isRemoveable {
+    padding-top: 28px !important;
+  }
+
+  .remove-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -1,0 +1,66 @@
+import { QuestEvents } from '@hicommonwealth/schemas';
+import clsx from 'clsx';
+import { splitCamelOrPascalCase } from 'helpers/string';
+import React from 'react';
+import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
+import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
+import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import './QuestActionSubForm.scss';
+import { QuestAction, QuestActionSubFormProps } from './types';
+
+const QuestActionSubForm = ({
+  isRemoveable = true,
+  onRemove,
+  errors,
+  defaultValues,
+  onChange,
+}: QuestActionSubFormProps) => {
+  const actionOptions = Object.keys(QuestEvents).map((event) => ({
+    value: event as QuestAction,
+    label: splitCamelOrPascalCase(event),
+  }));
+
+  return (
+    <div className={clsx('QuestActionSubForm', { isRemoveable })}>
+      {isRemoveable && (
+        <CWIconButton
+          iconName="close"
+          onClick={onRemove}
+          className="ml-auto cursor-pointer remove-btn"
+        />
+      )}
+
+      <CWSelectList
+        isClearable={false}
+        label="Action"
+        placeholder="Select an action"
+        name="action"
+        options={actionOptions}
+        onChange={(newValue) =>
+          newValue && onChange?.({ action: newValue.value })
+        }
+        {...(defaultValues?.action && {
+          defaultValue: actionOptions.find(
+            (a) => a.value === defaultValues.action,
+          ),
+        })}
+        customError={errors?.action}
+      />
+
+      <CWTextInput
+        label="Relevant Quest Link (optional)"
+        name="questLink"
+        placeholder="https://example.com"
+        instructionalMessage="Note: Social media task links will appear here (e.g., follow on X, join Discord)"
+        fullWidth
+        {...(defaultValues?.questLink && {
+          defaultValue: defaultValues?.questLink,
+        })}
+        onInput={(e) => onChange?.({ questLink: e?.target?.value?.trim() })}
+        customError={errors?.questLink}
+      />
+    </div>
+  );
+};
+
+export default QuestActionSubForm;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -14,11 +14,14 @@ const QuestActionSubForm = ({
   errors,
   defaultValues,
   onChange,
+  hiddenActions,
 }: QuestActionSubFormProps) => {
-  const actionOptions = Object.keys(QuestEvents).map((event) => ({
-    value: event as QuestAction,
-    label: splitCamelOrPascalCase(event),
-  }));
+  const actionOptions = Object.keys(QuestEvents)
+    .map((event) => ({
+      value: event as QuestAction,
+      label: splitCamelOrPascalCase(event),
+    }))
+    .filter((action) => !(hiddenActions || []).includes(action.value));
 
   return (
     <div className={clsx('QuestActionSubForm', { isRemoveable })}>

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/index.ts
@@ -1,0 +1,5 @@
+import QuestActionSubForm from './QuestActionSubForm';
+export * from './types';
+export * from './useMultipleQuestActionForms';
+
+export default QuestActionSubForm;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
@@ -1,0 +1,32 @@
+import { QuestEvents } from '@hicommonwealth/schemas';
+
+export type QuestAction = keyof typeof QuestEvents;
+
+export type QuestActionSubFormErrors = {
+  action?: string;
+  questLink?: string;
+};
+
+export type QuestActionSubFormFields = {
+  action?: QuestAction;
+  questLink?: string;
+};
+
+export type QuestActionSubFormProps = {
+  errors?: QuestActionSubFormErrors;
+  defaultValues?: QuestActionSubFormFields;
+  onChange?: ({ action, questLink }: QuestActionSubFormFields) => void;
+  isRemoveable?: boolean;
+  onRemove?: () => void;
+};
+
+export type QuestActionSubFormState = {
+  values: QuestActionSubFormFields;
+  errors?: QuestActionSubFormErrors;
+};
+
+export type useQuestActionMultiFormsStateProps = {
+  minSubForms: number;
+  maxSubForms: number;
+  validateAfterUpdate?: boolean;
+};

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
@@ -22,6 +22,7 @@ export type QuestActionSubFormProps = {
 };
 
 export type QuestActionSubFormState = {
+  id: number;
   values: QuestActionSubFormFields;
   errors?: QuestActionSubFormErrors;
 };

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
@@ -18,6 +18,7 @@ export type QuestActionSubFormProps = {
   onChange?: ({ action, questLink }: QuestActionSubFormFields) => void;
   isRemoveable?: boolean;
   onRemove?: () => void;
+  hiddenActions?: QuestAction[];
 };
 
 export type QuestActionSubFormState = {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -45,7 +45,7 @@ const useQuestActionMultiFormsState = ({
     let errors = {};
     try {
       questSubFormValidationSchema.parse(values);
-    } catch (e: any) {
+    } catch (e) {
       const zodError = e as ZodError;
       zodError.errors.map((error) => {
         errors = {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -1,0 +1,113 @@
+import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
+import { useState } from 'react';
+import { ZodError } from 'zod';
+import './QuestActionSubForm.scss';
+import {
+  QuestActionSubFormFields,
+  QuestActionSubFormState,
+  useQuestActionMultiFormsStateProps,
+} from './types';
+import { questSubFormValidationSchema } from './validation';
+
+const useQuestActionMultiFormsState = ({
+  minSubForms,
+  maxSubForms,
+  validateAfterUpdate = true,
+}: useQuestActionMultiFormsStateProps) => {
+  const [questActionSubForms, setQuestActionSubForms] = useState<
+    QuestActionSubFormState[]
+  >([]);
+
+  const hasSubFormErrors = questActionSubForms.find(
+    (subForm) => Object.keys(subForm.errors || {}).length > 0,
+  );
+
+  useRunOnceOnCondition({
+    callback: () => {
+      if (minSubForms) {
+        setQuestActionSubForms(
+          Array.from({ length: minSubForms }, (_) => ({
+            values: {},
+          })),
+        );
+      }
+    },
+    shouldRun: true,
+  });
+
+  const addSubForm = () => {
+    if (maxSubForms && questActionSubForms.length >= maxSubForms) return;
+
+    setQuestActionSubForms((a) => [...a, { values: {} }]);
+  };
+
+  const validateFormValues = (values: QuestActionSubFormFields) => {
+    let errors = {};
+    try {
+      questSubFormValidationSchema.parse(values);
+    } catch (e: any) {
+      const zodError = e as ZodError;
+      zodError.errors.map((error) => {
+        errors = {
+          ...errors,
+          [error.path[0]]: error.message,
+        };
+      });
+    }
+    return errors;
+  };
+
+  const validateSubFormByIndex = (index: number) => {
+    const updatedSubForms = [...questActionSubForms];
+    updatedSubForms[index].errors = validateFormValues(
+      updatedSubForms[index].values,
+    );
+    setQuestActionSubForms([...updatedSubForms]);
+  };
+
+  const validateSubForms = (): boolean => {
+    const updatedSubForms = [...questActionSubForms];
+    updatedSubForms.map((form) => {
+      form.errors = validateFormValues(form.values);
+    });
+    setQuestActionSubForms([...updatedSubForms]);
+    const hasErrors = updatedSubForms.find(
+      (subForm) => Object.keys(subForm.errors || {}).length > 0,
+    );
+    return !!hasErrors;
+  };
+
+  const updateSubFormByIndex = (
+    updateBody: QuestActionSubFormFields,
+    index: number,
+  ) => {
+    const updatedSubForms = [...questActionSubForms];
+    updatedSubForms[index].values = {
+      ...updatedSubForms[index].values,
+      ...updateBody,
+    };
+    setQuestActionSubForms([...updatedSubForms]);
+
+    if (validateAfterUpdate) validateSubFormByIndex(index);
+  };
+
+  const removeSubFormByIndex = (index: number) => {
+    if (minSubForms && questActionSubForms.length === minSubForms) return;
+
+    const updatedSubForms = [...questActionSubForms];
+    updatedSubForms.splice(index, 1);
+    setQuestActionSubForms([...updatedSubForms]);
+  };
+
+  return {
+    hasSubFormErrors,
+    questActionSubForms,
+    addSubForm,
+    removeSubFormByIndex,
+    updateSubFormByIndex,
+    validateSubFormByIndex,
+    validateSubForms,
+  };
+};
+
+export { useQuestActionMultiFormsState };

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -26,8 +26,9 @@ const useQuestActionMultiFormsState = ({
     callback: () => {
       if (minSubForms) {
         setQuestActionSubForms(
-          Array.from({ length: minSubForms }, (_) => ({
+          Array.from({ length: minSubForms }, (_, index) => ({
             values: {},
+            id: index + 1,
           })),
         );
       }
@@ -38,7 +39,10 @@ const useQuestActionMultiFormsState = ({
   const addSubForm = () => {
     if (maxSubForms && questActionSubForms.length >= maxSubForms) return;
 
-    setQuestActionSubForms((a) => [...a, { values: {} }]);
+    setQuestActionSubForms((a) => [
+      ...a,
+      { values: {}, id: questActionSubForms.length + 1 },
+    ]);
   };
 
   const validateFormValues = (values: QuestActionSubFormFields) => {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/validation.ts
@@ -1,0 +1,10 @@
+import { linkValidationSchema } from 'helpers/formValidations/common';
+import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
+import { z } from 'zod';
+
+export const questSubFormValidationSchema = z.object({
+  action: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  questLink: linkValidationSchema.optional,
+});

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/index.ts
@@ -1,0 +1,3 @@
+import CreateQuestForm from './CreateQuestForm';
+
+export default CreateQuestForm;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -1,10 +1,11 @@
+import { QuestEvents } from '@hicommonwealth/schemas';
 import { z } from 'zod';
 import './CreateQuestForm.scss';
 import { useQuestActionMultiFormsState } from './QuestActionSubForm/useMultipleQuestActionForms';
 import { questFormValidationSchema } from './validation';
 
 const MIN_ACTIONS_LIMIT = 1;
-const MAX_ACTIONS_LIMIT = 8;
+const MAX_ACTIONS_LIMIT = Object.values(QuestEvents).length; // = 8 max actions
 
 const useCreateQuestForm = () => {
   const {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -1,7 +1,14 @@
-import { QuestEvents } from '@hicommonwealth/schemas';
+import { QuestEvents, QuestParticipationPeriod } from '@hicommonwealth/schemas';
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import { useCommonNavigate } from 'navigation/helpers';
 import { useState } from 'react';
+import {
+  useCreateQuestMutation,
+  useUpdateQuestMutation,
+} from 'state/api/quests';
 import { z } from 'zod';
 import './CreateQuestForm.scss';
+import { QuestAction } from './QuestActionSubForm';
 import { useQuestActionMultiFormsState } from './QuestActionSubForm/useMultipleQuestActionForms';
 import { questFormValidationSchema } from './validation';
 
@@ -22,15 +29,57 @@ const useCreateQuestForm = () => {
 
   const [isProcessingQuestImage, setIsProcessingQuestImage] = useState(false);
 
+  const { mutateAsync: createQuest } = useCreateQuestMutation();
+  const { mutateAsync: updateQuest } = useUpdateQuestMutation();
+
+  const navigate = useCommonNavigate();
+
   const handleSubmit = (values: z.infer<typeof questFormValidationSchema>) => {
     const hasErrors = validateSubForms();
     if (hasErrors) return;
 
-    // TODO: integrate API
-    console.log('submit values => ', {
-      ...values,
-      subForms: questActionSubForms.map((f) => f.values),
-    });
+    const handleAsync = async () => {
+      try {
+        console.log('submit values => ', {
+          ...values,
+          subForms: questActionSubForms.map((f) => f.values),
+        });
+
+        const quest = await createQuest({
+          community_id: 'dydx', // TBD: do we need this if super admin is creating quest?,
+          // adding sample community for now
+          description: values.description.trim(),
+          end_date: new Date(values.end_date),
+          start_date: new Date(values.start_date),
+          name: values.name.trim(),
+          // TODO: add image support
+        });
+
+        if (quest && quest.id && quest.community_id) {
+          await updateQuest({
+            community_id: quest.community_id,
+            quest_id: quest.id,
+            action_metas: questActionSubForms.map((subForm) => ({
+              event_name: subForm.values.action as QuestAction,
+              reward_amount: parseInt(`${values.reward_amount}`, 10),
+              participation_limit: values.participation_limit,
+              participation_period: QuestParticipationPeriod.Daily,
+              participation_times_per_period: 1,
+            })),
+          });
+        }
+
+        notifySuccess('Quest created!');
+
+        // TODO: quests exploration will come in https://github.com/hicommonwealth/commonwealth/issues/9348
+        navigate('/communities');
+      } catch (e) {
+        console.error(e);
+
+        notifyError('Failed to create quest!');
+      }
+    };
+    handleAsync().catch(console.error);
   };
 
   return {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -40,19 +40,13 @@ const useCreateQuestForm = () => {
 
     const handleAsync = async () => {
       try {
-        console.log('submit values => ', {
-          ...values,
-          subForms: questActionSubForms.map((f) => f.values),
-        });
-
         const quest = await createQuest({
-          community_id: 'dydx', // TBD: do we need this if super admin is creating quest?,
-          // adding sample community for now
+          community_id: 'dydx', // TODO: API logic will update in #10673 to not require community id
           description: values.description.trim(),
           end_date: new Date(values.end_date),
           start_date: new Date(values.start_date),
           name: values.name.trim(),
-          // TODO: add image support
+          // TODO: add image support in api (needs ticketing).
         });
 
         if (quest && quest.id && quest.community_id) {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -1,4 +1,5 @@
 import { QuestEvents } from '@hicommonwealth/schemas';
+import { useState } from 'react';
 import { z } from 'zod';
 import './CreateQuestForm.scss';
 import { useQuestActionMultiFormsState } from './QuestActionSubForm/useMultipleQuestActionForms';
@@ -18,6 +19,8 @@ const useCreateQuestForm = () => {
     minSubForms: MIN_ACTIONS_LIMIT,
     maxSubForms: MAX_ACTIONS_LIMIT,
   });
+
+  const [isProcessingQuestImage, setIsProcessingQuestImage] = useState(false);
 
   const handleSubmit = (values: z.infer<typeof questFormValidationSchema>) => {
     const hasErrors = validateSubForms();
@@ -41,6 +44,8 @@ const useCreateQuestForm = () => {
     validateSubForms,
     // main form specific fields
     handleSubmit,
+    isProcessingQuestImage,
+    setIsProcessingQuestImage,
   };
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import './CreateQuestForm.scss';
+import { useQuestActionMultiFormsState } from './QuestActionSubForm/useMultipleQuestActionForms';
+import { questFormValidationSchema } from './validation';
+
+const MIN_ACTIONS_LIMIT = 1;
+const MAX_ACTIONS_LIMIT = 8;
+
+const useCreateQuestForm = () => {
+  const {
+    addSubForm,
+    questActionSubForms,
+    removeSubFormByIndex,
+    updateSubFormByIndex,
+    validateSubForms,
+  } = useQuestActionMultiFormsState({
+    minSubForms: MIN_ACTIONS_LIMIT,
+    maxSubForms: MAX_ACTIONS_LIMIT,
+  });
+
+  const handleSubmit = (values: z.infer<typeof questFormValidationSchema>) => {
+    const hasErrors = validateSubForms();
+    if (hasErrors) return;
+
+    // TODO: integrate API
+    console.log('submit values => ', {
+      ...values,
+      subForms: questActionSubForms.map((f) => f.values),
+    });
+  };
+
+  return {
+    // subform specific fields
+    MIN_ACTIONS_LIMIT,
+    MAX_ACTIONS_LIMIT,
+    addSubForm,
+    questActionSubForms,
+    removeSubFormByIndex,
+    updateSubFormByIndex,
+    validateSubForms,
+    // main form specific fields
+    handleSubmit,
+  };
+};
+
+export default useCreateQuestForm;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
@@ -1,0 +1,35 @@
+import { QuestParticipationLimit } from '@hicommonwealth/schemas';
+import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
+import { z } from 'zod';
+
+export const questFormValidationSchema = z.object({
+  participation_limit: z.nativeEnum(QuestParticipationLimit, {
+    invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
+  }),
+  // TODO: start/end dates must be a string
+  start_date: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  end_date: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  name: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .min(5, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(5) })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  description: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .min(10, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(10) })
+    .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  reward_amount: z
+    .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+    .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })
+    .refine(
+      (value) => {
+        const intVal = parseInt(value, 10);
+        return !isNaN(intVal) && intVal.toString() === value.trim();
+      },
+      { message: VALIDATION_MESSAGES.INVALID_INPUT },
+    ),
+});

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
@@ -1,4 +1,5 @@
 import { QuestParticipationLimit } from '@hicommonwealth/schemas';
+import { linkValidationSchema } from 'helpers/formValidations/common';
 import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
 import { z } from 'zod';
 
@@ -22,6 +23,7 @@ export const questFormValidationSchema = z.object({
     .min(10, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(10) })
     .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  image: linkValidationSchema.required,
   reward_amount: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT })

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
@@ -7,7 +7,6 @@ export const questFormValidationSchema = z.object({
   participation_limit: z.nativeEnum(QuestParticipationLimit, {
     invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
   }),
-  // TODO: start/end dates must be a string
   start_date: z
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/index.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/index.ts
@@ -1,0 +1,3 @@
+import CreateQuest from './CreateQuest';
+
+export default CreateQuest;

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
     'process.env.FLAG_REWARDS_PAGE': JSON.stringify(env.FLAG_REWARDS_PAGE),
     'process.env.FLAG_STICKY_EDITOR': JSON.stringify(env.FLAG_STICKY_EDITOR),
     'process.env.FLAG_NEW_MOBILE_NAV': JSON.stringify(env.FLAG_NEW_MOBILE_NAV),
+    'process.env.FLAG_XP': JSON.stringify(env.FLAG_XP),
   };
 
   const config = {

--- a/packages/commonwealth/server/api/internal-router.ts
+++ b/packages/commonwealth/server/api/internal-router.ts
@@ -12,6 +12,7 @@ import * as integrations from './integrations';
 import * as launchpadToken from './launchpadToken';
 import * as loadTest from './load-test';
 import * as poll from './poll';
+import * as quest from './quest';
 import * as subscription from './subscription';
 import * as superAdmin from './super-admin';
 import * as thread from './thread';
@@ -34,6 +35,7 @@ const api = {
   discordBot: discordBot.trpcRouter,
   launchpadToken: launchpadToken.trpcRouter,
   poll: poll.trpcRouter,
+  quest: quest.trpcRouter,
 };
 
 if (config.NOTIFICATIONS.FLAG_KNOCK_INTEGRATION_ENABLED) {

--- a/packages/commonwealth/server/api/quest.ts
+++ b/packages/commonwealth/server/api/quest.ts
@@ -1,0 +1,7 @@
+import { trpc } from '@hicommonwealth/adapters';
+import { Quest } from '@hicommonwealth/model';
+
+export const trpcRouter = trpc.router({
+  createQuest: trpc.command(Quest.CreateQuest, trpc.Tag.Quest),
+  updateQuest: trpc.command(Quest.UpdateQuest, trpc.Tag.Quest),
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/9341

## Description of Changes
Added quest creation flows for super admins.

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Visit `/createQuest` as site admin, or visit `/admin-panel` and click on "Create quest" button to visit quest creation form.
3. Notice the pre-filled form (temporarily), attempt to update some values (excluding dates, they need a new component), and submit the form
4. Verify quest is created and you get redirected to `/communities`




https://github.com/user-attachments/assets/02d53d0b-1b1d-475a-9e58-414c45768749



## Deployment Plan
N/A

## Other Considerations
- Date selection inputs need to be updated with a newer component coming in https://github.com/hicommonwealth/commonwealth/issues/10674