### PR TITLE
make sure that the only auth strategies that work on mobile are the supported ones.

### DIFF
--- a/packages/commonwealth/client/public/.well-known/apple-app-site-association
+++ b/packages/commonwealth/client/public/.well-known/apple-app-site-association
@@ -3,15 +3,15 @@
     "apps": [],
     "details": [
       {
-        "appID": "M7RA9XJ52W.commonwealth-mobile2",
+        "appID": "M7RA9XJ52W.xyz.common.mobile",
         "paths": ["/*"]
       }
     ]
   },
   "activitycontinuation": {
-    "apps": ["M7RA9XJ52W.commonwealth-mobile2"]
+    "apps": ["M7RA9XJ52W.xyz.common.mobile"]
   },
   "webcredentials": {
-    "apps": ["M7RA9XJ52W.commonwealth-mobile2"]
+    "apps": ["M7RA9XJ52W.xyz.common.mobile"]
   }
 }

--- a/packages/commonwealth/client/public/.well-known/assetlinks.json
+++ b/packages/commonwealth/client/public/.well-known/assetlinks.json
@@ -3,7 +3,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "com.kevin_common_xyz.commonxyz",
+      "package_name": "xyz.common.mobile",
       "sha256_cert_fingerprints": [
         "55:9F:D8:46:85:90:D5:C2:E6:46:88:A4:7F:10:5F:CD:73:15:1C:5A:12:41:08:3A:3A:65:9F:4C:15:69:5B:9A"
       ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10735

## Description of Changes
- Enables only the auth providers that work properly.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- I already tested but you would have to change isMobileApp to return true, then it will only show the auth providers that work on mobile.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 