### PR TITLE
Fixed thread edit when no threadMsgId

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
@@ -67,7 +67,7 @@ export const buildUpdateThreadInput = async ({
   collaborators,
 }: EditThreadProps) => {
   let canvasSignedData;
-  if (newBody || newTitle) {
+  if ((newBody || newTitle) && threadMsgId) {
     canvasSignedData = await signUpdateThread(address, {
       thread_id: threadMsgId,
       title: newTitle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10737

## Description of Changes
- Skips canvas thread signing for threads without message ids (old threads)

## Test Plan
- Make yourself an author of a thread without canvas_msg_id in the thread table
- Try to edit a thread. After save, it should edit successfully.