### PR TITLE
Expose launchpad token endpoints through external API

### DIFF
--- a/packages/commonwealth/server/api/external-router.ts
+++ b/packages/commonwealth/server/api/external-router.ts
@@ -21,6 +21,7 @@ import {
   addRateLimiterMiddleware,
   apiKeyAuthMiddleware,
 } from './external-router-middleware';
+import * as launchpad from './launchpadToken';
 import * as thread from './thread';
 import * as user from './user';
 
@@ -56,6 +57,7 @@ const {
 const { getNewContent } = user.trpcRouter;
 const { createContestMetadata, updateContestMetadata, cancelContestMetadata } =
   contest.trpcRouter;
+const { createToken, createTrade, getTokens } = launchpad.trpcRouter;
 
 const api = {
   getGlobalActivity: trpc.query(Feed.GetGlobalActivity, trpc.Tag.User, {
@@ -113,6 +115,9 @@ const api = {
   joinCommunity,
   banAddress,
   toggleCommentSpam,
+  createToken,
+  createTrade,
+  getTokens,
 };
 
 const PATH = '/api/v1';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes
- Expose token endpoint through docs

## Test Plan
- Go to http://localhost:8080/api/v1/docs/
 
<img width="1464" alt="image" src="https://github.com/user-attachments/assets/8bb750c0-a10f-4d9f-81c3-77ade239e8e3" />
