### PR TITLE
changed api route back to /communities

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/chains/searchChains.ts
+++ b/packages/commonwealth/client/scripts/state/api/chains/searchChains.ts
@@ -34,7 +34,7 @@ const searchChains = async ({
   const {
     data: { result },
   } = await axios.get<{ result: SearchChainsResponse }>(
-    `${SERVER_URL}/explore`,
+    `${SERVER_URL}/communities`,
     {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10757 

## Description of Changes
- Fixes broken community search function

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the api route back to `/communities`
## Test Plan
- search for a community and confirm that you now see the community