### PR TITLE
conditionally show author on cosmos proposals

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -149,25 +149,26 @@ export const AuthorAndPublishInfo = ({
           )}
         </>
       )}
-      <FullUser
-        className={isCommunityFirstLayout ? 'community-user-info' : ''}
-        avatarSize={24}
-        userAddress={authorAddress}
-        userCommunityId={authorCommunityId}
-        shouldShowPopover
-        shouldLinkProfile
-        shouldHideAvatar={isCommunityFirstLayout}
-        shouldShowAsDeleted={!authorAddress && !authorCommunityId}
-        shouldShowAddressWithDisplayName={
-          fromDiscordBot || isCommunityFirstLayout
-            ? false
-            : showUserAddressWithInfo
-        }
-        popoverPlacement={popoverPlacement}
-        // @ts-expect-error <StrictNullChecks>
-        profile={profile}
-      />
-
+      {authorAddress && (
+        <FullUser
+          className={isCommunityFirstLayout ? 'community-user-info' : ''}
+          avatarSize={24}
+          userAddress={authorAddress}
+          userCommunityId={authorCommunityId}
+          shouldShowPopover
+          shouldLinkProfile
+          shouldHideAvatar={isCommunityFirstLayout}
+          shouldShowAsDeleted={!authorAddress && !authorCommunityId}
+          shouldShowAddressWithDisplayName={
+            fromDiscordBot || isCommunityFirstLayout
+              ? false
+              : showUserAddressWithInfo
+          }
+          popoverPlacement={popoverPlacement}
+          // @ts-expect-error <StrictNullChecks>
+          profile={profile}
+        />
+      )}
       {fromDiscordBot && (
         <>
           {dotIndicator}
@@ -182,7 +183,6 @@ export const AuthorAndPublishInfo = ({
           </CWText>
         </>
       )}
-
       {/*@ts-expect-error <StrictNullChecks>*/}
       {collaboratorsInfo?.length > 0 && (
         <>
@@ -225,7 +225,6 @@ export const AuthorAndPublishInfo = ({
           </CWText>
         </>
       )}
-
       {publishDate && (
         <>
           {dotIndicator}
@@ -277,7 +276,6 @@ export const AuthorAndPublishInfo = ({
           )}
         </>
       )}
-
       {/*@ts-expect-error <StrictNullChecks>*/}
       {viewsCount !== null && viewsCount >= 0 && (
         <>
@@ -288,9 +286,7 @@ export const AuthorAndPublishInfo = ({
           </CWText>
         </>
       )}
-
       {archivedAt && <ArchiveTrayWithTooltip archivedAt={moment(archivedAt)} />}
-
       {threadStage && (
         <>
           {dotIndicator}
@@ -310,17 +306,13 @@ export const AuthorAndPublishInfo = ({
           </CWText>
         </>
       )}
-
       {!hidePublishDate && (
         <NewThreadTag threadCreatedAt={moment(publishDate)} />
       )}
-
       {!hideTrendingTag && isHot && (
         <CWTag iconName="trendUp" label="Trending" type="trending" />
       )}
-
       {!hideSpamTag && isSpamThread && <CWTag label="SPAM" type="disabled" />}
-
       {isLocked && lockedAt && lastUpdated && (
         <LockWithTooltip
           lockedAt={moment(lockedAt)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10521 

## Description of Changes
- After speaking with Rhys, he suggested I just not show the author for Cosmos proposals so the name and avatar are now being conditionally shown on if there is an author return or not. 

## Test Plan
-go to a cosmos community, Stargaze is what I was using 
-go to proposals and click into an individual proposal
-confirm you no longer see the place for an author's name or avatar
![Screenshot 2025-01-29 at 9 44 19 PM](https://github.com/user-attachments/assets/5895c3b8-c23c-44c8-b9e5-ca3ac7e781bc)
