### PR TITLE
added previous and active contest tabs to admin

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.scss
@@ -27,4 +27,14 @@
     flex-direction: column;
     gap: 16px;
   }
+
+  .active {
+    margin-top: 12px !important;
+    margin-bottom: 24px !important;
+  }
+
+  .ended {
+    margin-top: 36px !important;
+    margin-bottom: 24px !important;
+  }
 }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -24,6 +24,7 @@ import { PageNotFound } from 'views/pages/404';
 import EmptyCard from 'views/pages/CommunityManagement/Contests/EmptyContestsList/EmptyCard';
 import CommunityStakeStep from 'views/pages/CreateCommunity/steps/CommunityStakeStep';
 
+import { CWDivider } from '../../../../components/component_kit/cw_divider';
 import ContestsList from '../ContestsList';
 import { ContestType, ContestView } from '../types';
 import useCommunityContests from '../useCommunityContests';
@@ -135,14 +136,37 @@ const AdminContestsPage = () => {
                 isLoading={isFeeManagerBalanceLoading}
               />
             )}
+            <CWText type="h3" className="mb-12">
+              Active Contests
+            </CWText>
+            {isContestAvailable && contestsData.active.length === 0 ? (
+              <CWText>No active contests available</CWText>
+            ) : (
+              <ContestsList
+                contests={contestsData.active}
+                isAdmin={isAdmin}
+                isLoading={isContestDataLoading}
+                isContestAvailable={isContestAvailable}
+                onSetContestView={setContestView}
+              />
+            )}
 
-            <ContestsList
-              contests={contestsData.all}
-              isLoading={isContestDataLoading}
-              isAdmin={isAdmin}
-              isContestAvailable={isContestAvailable}
-              onSetContestView={setContestView}
-            />
+            <CWDivider className="ended" />
+            <CWText type="h3" className="mb-12">
+              Previous Contests
+            </CWText>
+            {isContestAvailable && contestsData.finished.length === 0 ? (
+              <CWText>No previous contests available</CWText>
+            ) : (
+              <ContestsList
+                contests={contestsData.finished}
+                isAdmin={isAdmin}
+                isLoading={isContestDataLoading}
+                isContestAvailable={isContestAvailable}
+                displayAllRecurringContests
+                onSetContestView={setContestView}
+              />
+            )}
           </>
         ) : contestView === ContestView.TypeSelection ? (
           <div className="type-selection-list">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10592 

## Description of Changes
- added Active and Previous tabs to Admin Capabilities -> Contests to reflect Apps -> Contests
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Go to a community that has contests and click into Admin Capabilities/Contests
- Confirm that you now see Active and Previous tabs for contests that is similar to Apps -> Contests

