### PR TITLE
Israel.10654.incorrect pfp on comments

### DIFF
--- a/libs/schemas/src/queries/thread.schemas.ts
+++ b/libs/schemas/src/queries/thread.schemas.ts
@@ -128,7 +128,7 @@ export const CommentView = Comment.extend({
   // this is returned by GetThreads
   address: z.string(),
   profile_name: z.string().optional(),
-  profile_avatar: z.string().optional(),
+  avatar_url: z.string().optional(),
   user_id: PG_INT,
   CommentVersionHistories: z.array(CommentVersionHistoryView).nullish(),
 });

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -147,7 +147,7 @@ export const CommentCard = ({
       contentUrlBody
     ) {
       setCommentText(contentUrlBody);
-      setCommentDelta({contentUrlBody);
+      setCommentDelta(contentUrlBody);
     }
   }, [contentUrlBody, contentUrlBodyToFetch, comment.content_url]);
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -147,7 +147,7 @@ export const CommentCard = ({
       contentUrlBody
     ) {
       setCommentText(contentUrlBody);
-      setCommentDelta({ contentUrlBody });
+      setCommentDelta({contentUrlBody);
     }
   }, [contentUrlBody, contentUrlBodyToFetch, comment.content_url]);
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -147,7 +147,7 @@ export const CommentCard = ({
       contentUrlBody
     ) {
       setCommentText(contentUrlBody);
-      setCommentDelta(contentUrlBody);
+      setCommentDelta({ contentUrlBody });
     }
   }, [contentUrlBody, contentUrlBodyToFetch, comment.content_url]);
 
@@ -219,7 +219,7 @@ export const CommentCard = ({
             showUserAddressWithInfo={false}
             profile={{
               address: comment.address,
-              avatarUrl: comment.profile_avatar || '',
+              avatarUrl: comment.avatar_url || '',
               name: comment.profile_name || DEFAULT_NAME,
               userId: comment.user_id,
               lastActive: comment.last_active as unknown as string,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -108,7 +108,7 @@ export const CommentCard = ({
 }: CommentCardProps) => {
   const user = useUserStore();
   const userOwnsComment = comment.user_id === user.id;
-
+  console.log('comment from CommentCard', comment);
   const [commentText, setCommentText] = useState(comment.body);
   const commentBody = React.useMemo(() => {
     const rawContent = editDraft || commentText || comment.body;

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -108,7 +108,7 @@ export const CommentCard = ({
 }: CommentCardProps) => {
   const user = useUserStore();
   const userOwnsComment = comment.user_id === user.id;
-  console.log('comment from CommentCard', comment);
+
   const [commentText, setCommentText] = useState(comment.body);
   const commentBody = React.useMemo(() => {
     const rawContent = editDraft || commentText || comment.body;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10654 

## Description of Changes
- correct pfp's now showing in comments
- NOTE: @masvelio @mzparacha Let me know if you'd like me to strip out the `CWJdenticon` component and it's implementation in `Avatar.tsx` as we should no longer need to use this. 
- 
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-corrected the schema and the property names that were being passed
## Test Plan
- go to a thread that has many comments
- confirm that you now see the individual pfp for each user, or one of the new default icons
![Screenshot 2025-02-04 at 1 53 17 PM](https://github.com/user-attachments/assets/5aedb4b1-ddc7-4f9f-be3b-4bbf60487ab7)

