### PR TITLE
addresses no longer overflow from modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/AccountSelector/AccountSelector.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/AccountSelector/AccountSelector.scss
@@ -5,6 +5,7 @@
   gap: 8px;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 
   .account-item {
     cursor: pointer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10828 

## Description of Changes
- wallet address no longer overflow on modal

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `overflow-y: auto;` to css on modal
## Test Plan
- either have at least 5+ wallets attached to an account and try to join a community
- or use the below array for testing, replacing `accounts.map` in `AccountSelector.tsx` with `accountsTest`
- confirm you can now scroll within the modal

`const accountsTest = [{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},{address: 0X111111111111111111111},]
`
![Screenshot 2025-02-04 at 6 27 07 PM](https://github.com/user-attachments/assets/d7839a47-4199-4b3e-961f-c2837e4738bf)
![Screenshot 2025-02-04 at 6 27 18 PM](https://github.com/user-attachments/assets/e6a5fbf8-ed11-4546-b7d9-12d8d930386a)

