### PR TITLE
made the notification clickable

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/KnockNotifications/CustomNotificationCell.tsx
+++ b/packages/commonwealth/client/scripts/views/components/KnockNotifications/CustomNotificationCell.tsx
@@ -7,7 +7,34 @@ import { Avatar, NotificationCellProps } from '@knocklabs/react';
 import '@knocklabs/react-notification-feed/dist/index.css';
 import moment from 'moment';
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { CWText } from '../component_kit/cw_text';
+type WorkflowKey =
+  | 'comment-creation'
+  | 'snapshot-proposals'
+  | 'user-mentioned'
+  | 'community-stake'
+  | 'chain-event-proposals'
+  | 'new-upvote';
+
+const getLinkUrl = (source: { key: WorkflowKey }, data): string => {
+  switch (source.key) {
+    case 'comment-creation':
+      return data?.comment_url;
+    case 'user-mentioned':
+      return data?.object_url;
+    case 'community-stake':
+      return data?.community_stakes_url;
+    case 'chain-event-proposals':
+      return data?.proposal_url;
+    case 'new-upvote':
+      return data?.object_url;
+    case 'snapshot-proposals':
+      return data?.snapshot_proposal_url;
+    default:
+      return `${window.location.origin}/${data?.community_name}`;
+  }
+};
 
 const CustomNotificationCell = ({ item }: NotificationCellProps) => {
   const contentBlock = item.blocks[0];
@@ -15,26 +42,28 @@ const CustomNotificationCell = ({ item }: NotificationCellProps) => {
     block: ContentBlock,
   ): block is MarkdownContentBlock | TextContentBlock =>
     block.type === 'markdown' || block.type === 'text';
-
+  const url = getLinkUrl({ key: item.source.key as WorkflowKey }, item.data);
   return (
-    <div className="container">
-      {item?.data?.author && (
-        <div className="avatar">
-          <Avatar name={item?.data?.author} />
-        </div>
-      )}
-      <div className="content">
-        {isRenderableBlock(contentBlock) && (
-          <div
-            className="main-container"
-            dangerouslySetInnerHTML={{ __html: contentBlock.rendered }}
-          />
+    <Link to={url} className="CustomNotificationCell container">
+      <div className="container">
+        {item?.data?.author && (
+          <div className="avatar">
+            <Avatar name={item?.data?.author} />
+          </div>
         )}
-        <CWText fontWeight="regular" type="b2">
-          {moment(item?.inserted_at).fromNow()}
-        </CWText>
+        <div className="content">
+          {isRenderableBlock(contentBlock) && (
+            <div
+              className="main-container"
+              dangerouslySetInnerHTML={{ __html: contentBlock.rendered }}
+            />
+          )}
+          <CWText fontWeight="regular" type="b2">
+            {moment(item?.inserted_at).fromNow()}
+          </CWText>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 };
 export default CustomNotificationCell;

--- a/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.scss
+++ b/packages/commonwealth/client/scripts/views/components/KnockNotifications/KnockNotifications.scss
@@ -43,31 +43,37 @@
       }
     }
   }
-  .container {
-    display: flex;
-    gap: 10px;
-    padding: 10px;
-    flex-direction: row;
-    border-bottom: 1px solid $neutral-200;
-    align-items: flex-start;
-
-    .avatar {
+  .CustomNotificationCell {
+    text-decoration: none;
+    color: unset !important;
+    cursor: pointer;
+    .container {
       display: flex;
       gap: 10px;
-      padding-top: 4px;
-      height: 100%;
-    }
-    .content {
-      gap: 10px;
-      display: flex;
-      flex-direction: column;
+      padding: 10px;
+      flex-direction: row;
+      border-bottom: 1px solid $neutral-200;
+      align-items: flex-start;
+      cursor: pointer;
+      .avatar {
+        display: flex;
+        gap: 10px;
+        padding-top: 4px;
+        height: 100%;
+      }
+      .content {
+        gap: 10px;
+        display: flex;
+        flex-direction: column;
 
-      .Text {
-        font-size: 12px;
-        color: #656167;
+        .Text {
+          font-size: 12px;
+          color: #656167;
+        }
       }
     }
   }
+
   .rnf-notification-feed__type {
     display: none;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #101719

## Description of Changes
- Adds FIXME widget to TODO page.
- made the notification clickable and navigated to the related link . we are getting the link in data from backend 
i.e comment_url in case of comment-creation and snapshot_proposal_url in case of snapshot-proposals

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

- made the notification clickable and navigated to the related link . we are getting the link in data from backend 
i.e comment_url in case of comment-creation and snapshot_proposal_url in case of snapshot-proposals

## Test Plan
login into commonwealth click the notification icon and it will navigate to related page 