### PR TITLE
dropdown now overlaps

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_dropdown.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_dropdown.scss
@@ -9,7 +9,7 @@
     box-shadow: $elevation-3;
     margin-top: 5px;
     overflow: hidden;
-    position: relative;
+    position: absolute;
     width: 100%;
     z-index: 1001;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10400 

## Description of Changes
- dropdown in search now overlaps content instead of creating a new space

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `position: absolute;`
<img width="554" alt="Screenshot 2025-02-05 at 6 34 50 PM" src="https://github.com/user-attachments/assets/f51691f7-66b2-4121-b127-b731f537912c" />
