### PR TITLE
Create groups button now shows upon new community creation

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -381,7 +381,7 @@ const CommunityMembersPage = () => {
           )}
 
         {/* Filter section */}
-        {selectedTab === TabValues.Leaderboard || groups?.length === 0 ? (
+        {selectedTab === TabValues.Leaderboard ? (
           <></>
         ) : (
           <section


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10890 

## Description of Changes
- Create groups button now shows upon new community creation
**NOTE: This is a quick fix to solve Rhy's bug. I am following up with Sachin to make sure Members(0) is correct when a user creates a new community and they are listed as a member. The logic that I took out was `|| groups?.length === 0` which would only allow the admin to create a group after at least one other member joins.** 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-deleted `|| groups?.length === 0` in the conditional rendering
## Test Plan
- create a new community and go to the Members page
- confirm that you can now see the Create group button
![Screenshot 2025-02-06 at 9 49 48 PM](https://github.com/user-attachments/assets/6fb17ee3-f496-4564-919c-36a5beff1fe9)
