### PR TITLE
community name now uses smarttrim

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/community_label.scss
+++ b/packages/commonwealth/client/scripts/views/components/community_label.scss
@@ -5,4 +5,11 @@
   display: flex;
   gap: 8px;
   width: 100%;
+
+  .community-name {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/packages/commonwealth/client/scripts/views/components/community_label.tsx
+++ b/packages/commonwealth/client/scripts/views/components/community_label.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-
-import { smartTrim } from '../../../../shared/utils';
+import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
+import { CWTooltip } from '../components/component_kit/new_designs/CWTooltip';
 import './community_label.scss';
 import { CWCommunityAvatar } from './component_kit/cw_community_avatar';
 import type { IconSize } from './component_kit/cw_icons/types';
-
 import { CWText } from './component_kit/cw_text';
 
 type CommunityLabelProps = {
@@ -27,9 +26,27 @@ export const CommunityLabel = ({
         }}
         size={size}
       />
-      <CWText noWrap type="b1" fontWeight="medium" title={name}>
-        {smartTrim(name, 25)}
-      </CWText>
+      <CWTooltip
+        content={name && name.length > 17 ? name : null}
+        placement="top"
+        renderTrigger={(handleInteraction, isTooltipOpen) => (
+          <CWText
+            className="community-name"
+            noWrap
+            type="b1"
+            fontWeight="medium"
+            title={name}
+            onMouseEnter={(e) => {
+              handleMouseEnter({ e, isTooltipOpen, handleInteraction });
+            }}
+            onMouseLeave={(e) => {
+              handleMouseLeave({ e, isTooltipOpen, handleInteraction });
+            }}
+          >
+            {name}
+          </CWText>
+        )}
+      />
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/components/community_label.tsx
+++ b/packages/commonwealth/client/scripts/views/components/community_label.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { smartTrim } from '../../../../shared/utils';
 import './community_label.scss';
 import { CWCommunityAvatar } from './component_kit/cw_community_avatar';
 import type { IconSize } from './component_kit/cw_icons/types';
@@ -27,7 +28,7 @@ export const CommunityLabel = ({
         size={size}
       />
       <CWText noWrap type="b1" fontWeight="medium" title={name}>
-        {name}
+        {smartTrim(name, 25)}
       </CWText>
     </div>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10894 

## Description of Changes
- Community name in sidebar no longer too long

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added the use of `smartTrim()` with a limit of 20
## Test Plan
- find a community with a long name, ex: Luna Classic Community Forum and join it
- confirm that the name is now truncated and all of the stars are aligned on the right

![Screenshot 2025-02-06 at 10 17 13 PM](https://github.com/user-attachments/assets/d329b4c8-d8af-4719-a903-5b1a6c46e61c)
