### PR TITLE
Add possibility to fund contest without being part of the community

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestCard/ContestCard.tsx
@@ -281,7 +281,7 @@ const ContestCard = ({
             />
           )}
 
-          {onFund && isActive && user.activeAccount && (
+          {onFund && isActive && user.isLoggedIn && (
             <CWThreadAction
               label="Fund"
               action="fund"

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/steps/FundContestForm/FundContestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/steps/FundContestForm/FundContestForm.tsx
@@ -153,7 +153,7 @@ const FundContestForm = ({
             buttonType="secondary"
             buttonAlt="green"
             onClick={handleTransferFunds}
-            disabled={!!amountError}
+            disabled={!!amountError || !selectedAddress?.value}
           />
         </div>
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/useUserAddressesForFundForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/FundContestDrawer/useUserAddressesForFundForm.ts
@@ -1,29 +1,37 @@
+import { uniqBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import useUserStore from 'state/ui/user';
 
 const useUserAddressesForFundForm = () => {
   const user = useUserStore();
-  const activeAccount = user.activeAccount;
 
-  const addressOptions = user.accounts.map((account) => ({
-    value: String(account.address),
-    label: account.address,
+  const filteredAddresses = useMemo(() => {
+    const filtered = user.addresses.filter(
+      (address) => address.community?.base === user.activeCommunity?.base,
+    );
+
+    return uniqBy(filtered, 'address');
+  }, [user.addresses, user.activeCommunity?.base]);
+
+  const addressOptions = filteredAddresses.map((address) => ({
+    value: String(address.address),
+    label: address.address,
   }));
 
-  const activeAccountOption = useMemo(
-    () => ({
-      value: activeAccount?.address || '',
-      label: activeAccount?.address || '',
-    }),
-    [activeAccount?.address],
-  );
+  const activeAddressOption = useMemo(() => {
+    const activeAddress = filteredAddresses[0];
+    return {
+      value: activeAddress?.address || '',
+      label: activeAddress?.address || '',
+    };
+  }, [filteredAddresses]);
 
-  const [selectedAddress, setSelectedAddress] = useState(activeAccountOption);
+  const [selectedAddress, setSelectedAddress] = useState(activeAddressOption);
 
   // this is needed because drawer is not unmounted on close
   useEffect(() => {
-    setSelectedAddress(activeAccountOption);
-  }, [activeAccountOption]);
+    setSelectedAddress(activeAddressOption);
+  }, [activeAddressOption]);
 
   return {
     addressOptions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10887

## Description of Changes
- Update contest funding to check `user.isLoggedIn` instead of `activeAccount`
- Add validation requiring selected address for fund button
- Use `user.addresses` instead of `user.accounts` for consistency

rief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- go to contest page but not being part of the community
- fund button should be visible and should open fund drawer

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- user has to be logged in, otherwise, we dont have access to the addresses and it is necessary to fund the contest