### PR TITLE
added conditional logic to only show when contests data available

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -139,7 +139,7 @@ const AdminContestsPage = () => {
             <CWText type="h3" className="mb-12">
               Active Contests
             </CWText>
-            {isContestAvailable && contestsData.active.length === 0 ? (
+            {!isContestAvailable && contestsData.active.length === 0 ? (
               <CWText>No active contests available</CWText>
             ) : (
               <ContestsList
@@ -155,7 +155,7 @@ const AdminContestsPage = () => {
             <CWText type="h3" className="mb-12">
               Previous Contests
             </CWText>
-            {isContestAvailable && contestsData.finished.length === 0 ? (
+            {!isContestAvailable && contestsData.finished.length === 0 ? (
               <CWText>No previous contests available</CWText>
             ) : (
               <ContestsList

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -139,7 +139,7 @@ const AdminContestsPage = () => {
             <CWText type="h3" className="mb-12">
               Active Contests
             </CWText>
-            {!isContestAvailable && contestsData.active.length === 0 ? (
+            {!isContestAvailable && !contestsData.active.length ? (
               <CWText>No active contests available</CWText>
             ) : (
               <ContestsList
@@ -155,7 +155,7 @@ const AdminContestsPage = () => {
             <CWText type="h3" className="mb-12">
               Previous Contests
             </CWText>
-            {!isContestAvailable && contestsData.finished.length === 0 ? (
+            {isContestAvailable && !contestsData.active.length ? (
               <CWText>No previous contests available</CWText>
             ) : (
               <ContestsList


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10875 

## Description of Changes
- added conditional logic to only show when contests data available
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- go to Contests page in Admin Capabilities on a community that has no contests. 
- confirm you see "No active contest available" and "No previous contests available" in their respective tabs. 
![Screenshot 2025-02-07 at 10 03 00 AM](https://github.com/user-attachments/assets/e59b106c-0b09-489c-8a38-5e7ecc999d5d)

