### PR TITLE
Add contest status check to rollover

### DIFF
--- a/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
+++ b/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
@@ -415,7 +415,7 @@ export const rollOverContest = async ({
       } else {
         const endTime = await contestInstance.methods.endTime().call();
         const currentTime = Math.floor(Date.now() / 1000);
-        if (endTime > Number(currentTime)) {
+        if (Number(endTime) > currentTime) {
           return false;
         }
       }

--- a/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
+++ b/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
@@ -415,7 +415,7 @@ export const rollOverContest = async ({
       } else {
         const endTime = await contestInstance.methods.endTime().call();
         const currentTime = Math.floor(Date.now() / 1000);
-        if (endTime > currentTime) {
+        if (endTime > Number(currentTime)) {
           return false;
         }
       }

--- a/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
+++ b/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
@@ -408,6 +408,18 @@ export const rollOverContest = async ({
       contest,
     );
 
+    if (oneOff) {
+      const contestEnded = await contestInstance.methods.contestEnded().call();
+      if (contestEnded) {
+        return false;
+      } else {
+        const endTime = await contestInstance.methods.endTime().call();
+        const currentTime = Math.floor(Date.now() / 1000);
+        if (endTime > currentTime) {
+          return false;
+        }
+      }
+    }
     const contractCall = oneOff
       ? contestInstance.methods.endContest()
       : contestInstance.methods.newContest();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10925 

## Description of Changes
- Adds respective checks for recurring and single contests for ended contests

## Test Plan
- Ensure regular rollover works
- Attempt to call on an already rolledover contest and ensure no error and a false return value
up tickets, breaking changes, etc -->
- 