### PR TITLE
Added option for site admins to update timestamps for resources

### DIFF
--- a/libs/model/src/super-admin/UpdateResourceTimestamps.command.ts
+++ b/libs/model/src/super-admin/UpdateResourceTimestamps.command.ts
@@ -1,0 +1,33 @@
+import { type Command } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { QueryTypes } from 'sequelize';
+import { models } from '../database';
+import { isSuperAdmin } from '../middleware';
+
+export function UpdateResourceTimestamps(): Command<
+  typeof schemas.UpdateResourceTimestamps
+> {
+  return {
+    ...schemas.UpdateResourceTimestamps,
+    auth: [isSuperAdmin],
+    body: async ({ payload }) => {
+      const { date_field_name, date_field_value, resource_id, resource_name } =
+        payload;
+
+      const sql = `UPDATE "${resource_name}" SET ${date_field_name} = :date_field_value WHERE id = :resource_id`;
+
+      const result = await models.sequelize.query(sql, {
+        replacements: {
+          date_field_name,
+          date_field_value,
+          resource_id,
+        },
+        type: QueryTypes.UPDATE,
+      });
+
+      return {
+        success: result[1] > 0,
+      };
+    },
+  };
+}

--- a/libs/model/src/super-admin/index.ts
+++ b/libs/model/src/super-admin/index.ts
@@ -1,2 +1,3 @@
 export * from './EnableDigestEmail';
 export * from './TriggerNotificationsWorkflow.command';
+export * from './UpdateResourceTimestamps.command';

--- a/libs/schemas/src/commands/super-admin.schemas.ts
+++ b/libs/schemas/src/commands/super-admin.schemas.ts
@@ -26,4 +26,55 @@ export const EnableDigestEmail = {
   }),
 };
 
+export const UpdateResourceTimestamps = {
+  input: z
+    .object({
+      resource_id: z.string().or(z.number()),
+      resource_name: z.enum(['Quests']), // add more resource/table names when needed
+      date_field_name: z.enum([
+        'start_date',
+        'end_date',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+      ]), // add more date fields as required
+      date_field_value: z.string(),
+    })
+    .refine(
+      (data) => {
+        if (
+          data.resource_name === 'Quests' &&
+          typeof data.resource_id !== 'number'
+        ) {
+          return false;
+        }
+        return true;
+      },
+      {
+        path: ['resource_id'],
+        message: `For resource_name=Quests, resource_id must be a number`,
+      },
+    )
+    .refine(
+      (data) => {
+        if (
+          data.resource_name === 'Quests' &&
+          !['start_date', 'end_date', 'created_at', 'updated_at'].includes(
+            data.date_field_name,
+          )
+        ) {
+          return false;
+        }
+        return true;
+      },
+      {
+        path: ['date_field_name'],
+        message: `For resource_name=Quests, date_field_name must be either 'start_date' or 'end_date'`,
+      },
+    ),
+  output: z.object({
+    success: z.boolean(),
+  }),
+};
+
 export type Type1 = z.infer<typeof TriggerNotificationsWorkflow.input>;

--- a/packages/commonwealth/client/scripts/state/api/superAdmin/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/superAdmin/index.ts
@@ -1,3 +1,8 @@
 import useEnableDigestEmail from './enableDigestEmail';
 import useTriggerNotificationsWorkflowMutation from './triggerNotificationsWorkflow';
-export { useEnableDigestEmail, useTriggerNotificationsWorkflowMutation };
+import useUpdateResourceTimestamps from './updateResourceTimestamps';
+export {
+  useEnableDigestEmail,
+  useTriggerNotificationsWorkflowMutation,
+  useUpdateResourceTimestamps,
+};

--- a/packages/commonwealth/client/scripts/state/api/superAdmin/updateResourceTimestamps.ts
+++ b/packages/commonwealth/client/scripts/state/api/superAdmin/updateResourceTimestamps.ts
@@ -1,0 +1,5 @@
+import { trpc } from 'utils/trpcClient';
+const useUpdateResourceTimestamps = () => {
+  return trpc.superAdmin.updateResourceTimestamps.useMutation({});
+};
+export default useUpdateResourceTimestamps;

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanel.scss
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanel.scss
@@ -76,6 +76,7 @@
             background-color: $neutral-100;
           }
         }
+
         .CommunityName.no-hover:hover {
           background-color: transparent;
         }
@@ -90,7 +91,8 @@
         padding: 8px;
 
         .Stat {
-          flex: 1 0 200px; /* Adjust to your preference */
+          flex: 1 0 200px;
+          /* Adjust to your preference */
 
           .StatValue {
             color: $neutral-500;
@@ -98,5 +100,17 @@
         }
       }
     }
+  }
+
+  .ResourceTimestampsUpdateForm {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: initial !important;
+    width: 100% !important;
+    gap: 12px !important;
+  }
+
+  .danger {
+    color: $rorange-600;
   }
 }

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/AdminPanelPage.tsx
@@ -9,6 +9,7 @@ import { CWText } from '../../components/component_kit/cw_text';
 import { CWButton } from '../../components/component_kit/new_designs/CWButton';
 import './AdminPanel.scss';
 import Analytics from './Analytics';
+import ChangeResourceTimestamps from './ChangeResourceTimestamps';
 import ConnectChainToCommunity from './ConnectChainToCommunityTask';
 import DeleteChainTask from './DeleteChainTask';
 import DownloadMembersListTask from './DownloadMembersListTask';
@@ -54,6 +55,7 @@ const AdminPanelPage = () => {
         <TopUsers />
         <TriggerNotificationsWorkflow />
         <EnableDigestEmail />
+        <ChangeResourceTimestamps />
       </div>
     </CWPageLayout>
   );

--- a/packages/commonwealth/client/scripts/views/pages/AdminPanel/ChangeResourceTimestamps.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/AdminPanel/ChangeResourceTimestamps.tsx
@@ -1,0 +1,186 @@
+import {
+  notifyError,
+  notifySuccess,
+} from 'client/scripts/controllers/app/notifications';
+import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
+import { z } from 'node_modules/zod';
+import React from 'react';
+import { useUpdateResourceTimestamps } from 'state/api/superAdmin';
+import CWDateTimeInput from 'views/components/component_kit/CWDateTimeInput';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { CWForm } from 'views/components/component_kit/new_designs/CWForm';
+import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
+import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import './AdminPanel.scss';
+
+const validationSchema = z
+  .object({
+    resource_id: z
+      .string({ invalid_type_error: VALIDATION_MESSAGES.INVALID_INPUT })
+      .nonempty({ message: VALIDATION_MESSAGES.INVALID_INPUT })
+      .or(z.number({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })),
+    resource_name: z.object(
+      {
+        value: z.enum(['Quests']),
+        label: z.string(),
+      },
+      {
+        invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
+        required_error: VALIDATION_MESSAGES.NO_INPUT,
+      },
+    ),
+    date_field_name: z.object(
+      {
+        value: z.enum([
+          'start_date',
+          'end_date',
+          'created_at',
+          'updated_at',
+          'deleted_at',
+        ]),
+        label: z.string(),
+      },
+      {
+        invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
+        required_error: VALIDATION_MESSAGES.NO_INPUT,
+      },
+    ), // add more date fields as required
+    date_field_value: z
+      .string({ invalid_type_error: VALIDATION_MESSAGES.INVALID_INPUT })
+      .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+  })
+  .refine(
+    (data) => {
+      if (
+        data.resource_name.value === 'Quests' &&
+        typeof data.resource_id !== 'number' &&
+        typeof parseInt(data.resource_id) !== 'number'
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      path: ['resource_id'],
+      message: `For resource_name=Quests, resource_id must be a number`,
+    },
+  )
+  .refine(
+    (data) => {
+      if (
+        data.resource_name.value === 'Quests' &&
+        !['start_date', 'end_date', 'created_at', 'updated_at'].includes(
+          data.date_field_name.value,
+        )
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      path: ['date_field_name'],
+      message: `For resource_name=Quests, date_field_name must be either 'start_date' or 'end_date'`,
+    },
+  );
+
+const ChangeResourceTimestamps = () => {
+  const { mutateAsync: updateResourceTimestamps, isLoading } =
+    useUpdateResourceTimestamps();
+
+  const resourceNames = ['Quests'].map((x) => ({
+    label: x,
+    value: x,
+  }));
+  const dateFieldNames = [
+    'created_at',
+    'updated_at',
+    'start_date',
+    'end_date',
+  ].map((x) => ({
+    label: x,
+    value: x,
+  }));
+
+  const handleSubmit = (values: z.infer<typeof validationSchema>) => {
+    const handleAsync = async () => {
+      try {
+        const response = await updateResourceTimestamps({
+          date_field_name: values.date_field_name.value,
+          resource_name: values.resource_name.value,
+          date_field_value: values.date_field_value,
+          resource_id: ['Quests'].includes(values.resource_name.value)
+            ? parseInt(`${values.resource_id}`)
+            : values.resource_id,
+        });
+        if (response.success) {
+          notifySuccess('Updated resource timestamp');
+        } else {
+          notifyError(
+            'Failed to update resource timestamp, please ensure resource id is valid',
+          );
+        }
+      } catch (error) {
+        console.log('Failed to update resource timestamp: ', error);
+        notifyError('Failed to update resource timestamp');
+      }
+    };
+    handleAsync().catch(console.error);
+  };
+
+  return (
+    <div className="TaskGroup">
+      <CWText type="h4">Update resource timestamps</CWText>
+      <CWText type="b2">
+        Update timestamps and more dates for resources on common.
+      </CWText>
+      <CWText type="b2" className="danger" fontWeight="bold">
+        Important: this is a dangerous action and should be avoided in
+        production environments.
+      </CWText>
+      <CWForm
+        className="TaskRow ResourceTimestampsUpdateForm"
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+      >
+        <CWTextInput
+          label="Resource id"
+          hookToForm
+          name="resource_id"
+          placeholder="Enter resource id"
+          fullWidth
+        />
+        <CWSelectList
+          name="resource_name"
+          hookToForm
+          isClearable={false}
+          label="Select resource name"
+          placeholder="Select resource name"
+          options={resourceNames}
+        />
+        <CWSelectList
+          name="date_field_name"
+          hookToForm
+          isClearable={false}
+          label="Select timestamp field"
+          placeholder="Select timestamp field"
+          options={dateFieldNames}
+        />
+        <CWDateTimeInput
+          label="New timestamp value"
+          hookToForm
+          name="date_field_value"
+          fullWidth
+        />
+        <CWButton
+          label="Submit"
+          type="submit"
+          disabled={isLoading}
+          buttonWidth="wide"
+        />
+      </CWForm>
+    </div>
+  );
+};
+
+export default ChangeResourceTimestamps;

--- a/packages/commonwealth/server/api/super-admin.ts
+++ b/packages/commonwealth/server/api/super-admin.ts
@@ -11,4 +11,9 @@ export const trpcRouter = trpc.router({
     SuperAdmin.EnableDigestEmail,
     trpc.Tag.SuperAdmin,
   ),
+
+  updateResourceTimestamps: trpc.command(
+    SuperAdmin.UpdateResourceTimestamps,
+    trpc.Tag.SuperAdmin,
+  ),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10962

## Description of Changes
Added option for site admins to update timestamps for resources

## "How We Fixed It"
N/A

## Test Plan
1. Visit admin panel as site admin
2. Scroll to the last section where you'd see option to update resource dates
3. Complete the form and attempt to update a quest timestamp
4. Ensure it works if quest id is valid, else ensure it properly indicates failure via error toast

## Deployment Plan
N/A

## Other Considerations
N/A