### PR TITLE
Removed user mention action from client

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -22,7 +22,11 @@ const QuestActionSubForm = ({
       value: event as QuestAction,
       label: splitCamelOrPascalCase(event),
     }))
-    .filter((action) => !(hiddenActions || []).includes(action.value));
+    .filter(
+      (action) =>
+        !(hiddenActions || []).includes(action.value) &&
+        action.value !== 'UserMentioned',
+    );
 
   return (
     <div className={clsx('QuestActionSubForm', { isRemoveable })}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10825

## Description of Changes
Removed user mention action from client for creating quests. This will be added later on when platform implementation is completed.

## "How We Fixed It"
N/A

## Test Plan
1. Visit `/createQuest` page (pre-req: enable `FLAG_XP`)
2. Verify you don't see the `User Mentioned` action in quest creation form

## Deployment Plan
N/A

## Other Considerations
N/A