### PR TITLE
Updated token metadata display in community widget

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/TokenTradeWidget.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/TokenTradeWidget.scss
@@ -19,6 +19,30 @@
     }
   }
 
+  .token-metadata-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .token-img {
+      height: auto;
+      width: 50px;
+      border-radius: 50%;
+      cursor: pointer;
+      border: 1px solid $neutral-100;
+    }
+
+    .token-address {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 2px;
+      .Text {
+        color: $neutral-800;
+      }
+    }
+  }
+
   .pad-8 {
     padding: 0px 8px;
   }

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/TokenTradeWidget.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/TokenTradeWidget.tsx
@@ -1,26 +1,31 @@
 import { TokenView } from '@hicommonwealth/schemas';
 import { ChainBase } from '@hicommonwealth/shared';
 import clsx from 'clsx';
+import { formatAddressShort } from 'helpers';
 import { currencyNameToSymbolMap, SupportedCurrencies } from 'helpers/currency';
 import { calculateTokenPricing } from 'helpers/launchpad';
 import useDeferredConditionTriggerCallback from 'hooks/useDeferredConditionTriggerCallback';
 import React, { useState } from 'react';
 import { useFetchTokenUsdRateQuery } from 'state/api/communityStake';
 import useUserStore from 'state/ui/user';
+import { saveToClipboard } from 'utils/clipboard';
+import { CWDivider } from 'views/components/component_kit/cw_divider';
+import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
+import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { withTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
+import FractionalValue from 'views/components/FractionalValue';
+import MarketCapProgress from 'views/components/TokenCard/MarketCapProgress';
+import PricePercentageChange from 'views/components/TokenCard/PricePercentageChange';
 import { AuthModal } from 'views/modals/AuthModal';
 import TradeTokenModal, {
   TradingConfig,
   TradingMode,
 } from 'views/modals/TradeTokenModel';
+import { LaunchpadToken } from 'views/modals/TradeTokenModel/CommonTradeModal/types';
 import { ExternalToken } from 'views/modals/TradeTokenModel/UniswapTradeModal/types';
 import { z } from 'zod';
-import { CWDivider } from '../../../component_kit/cw_divider';
-import { CWIconButton } from '../../../component_kit/cw_icon_button';
-import { CWText } from '../../../component_kit/cw_text';
-import { CWButton } from '../../../component_kit/new_designs/CWButton';
-import FractionalValue from '../../../FractionalValue';
-import MarketCapProgress from '../../../TokenCard/MarketCapProgress';
-import PricePercentageChange from '../../../TokenCard/PricePercentageChange';
 import './TokenTradeWidget.scss';
 import { TokenTradeWidgetSkeleton } from './TokenTradeWidgetSkeleton';
 import { useTokenTradeWidget } from './useTokenTradeWidget';
@@ -93,6 +98,13 @@ export const TokenTradeWidget = ({
 
   if (!communityToken) return;
 
+  const tokenAddress =
+    (communityToken as LaunchpadToken)?.token_address ||
+    (communityToken as ExternalToken)?.contract_address;
+  const tokenIconUrl =
+    (communityToken as LaunchpadToken)?.icon_url ||
+    (communityToken as ExternalToken)?.logo;
+
   return (
     <section className="TokenTradeWidget">
       <div className="pad-8 header">
@@ -104,10 +116,42 @@ export const TokenTradeWidget = ({
         <CWText type="b2" fontWeight="semiBold">
           Token
         </CWText>
+
+        {isPinnedToken && (
+          <span className="ml-auto">
+            {withTooltip(
+              <CWIconButton
+                iconName="infoEmpty"
+                iconSize="small"
+                className="ml-auto cursor-pointer"
+              />,
+              'Swaps only supports token on base',
+              true,
+            )}
+          </span>
+        )}
       </div>
 
       {isWidgetExpanded && (
         <>
+          <div className="token-metadata-row pad-8">
+            {tokenIconUrl && <img className="token-img" src={tokenIconUrl} />}
+            <CWText type="b2" className="token-address">
+              {withTooltip(
+                formatAddressShort(tokenAddress),
+                tokenAddress,
+                true,
+              )}
+              <CWIcon
+                iconName="copyNew"
+                className="cursor-pointer"
+                iconSize="small"
+                onClick={() => {
+                  saveToClipboard(tokenAddress, true).catch(console.error);
+                }}
+              />
+            </CWText>
+          </div>
           <CWText type="h3" fontWeight="bold" className="pad-8">
             <CWText type="h3" fontWeight="bold">
               {communityToken.symbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10662

## Description of Changes
Updated metadata display for community token widget.

1. Pinned tokens updated look
<img width="243" alt="image" src="https://github.com/user-attachments/assets/9fba1a2b-8215-4cc1-bc26-392b05c6d8e6" />

2. Launchpad tokens updated look
<img width="243" alt="image" src="https://github.com/user-attachments/assets/3bc4311d-0af6-4bdc-9c68-cb17b58a613d" />


## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_LAUNCHPAD` and `FLAG_UNISWAP_TRADE`
2. Visit any launchpad community and verify you see token image and address in the community token widget
3. Visit any community with a pinned token and verify you see token image and address in the community token widget

## Deployment Plan
N/A

## Other Considerations
N/A