### PR TITLE
Allow external token integrations in all ethereum communities that don't have a native (launchpad) token.

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/TokenIntegration/TokenIntegration.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/TokenIntegration/TokenIntegration.tsx
@@ -1,4 +1,4 @@
-import { commonProtocol } from '@hicommonwealth/evm-protocols';
+import { ChainBase } from '@hicommonwealth/shared';
 import { useFlag } from 'hooks/useFlag';
 import React from 'react';
 import app from 'state';
@@ -46,14 +46,11 @@ const TokenIntegration = () => {
   const isLoading =
     isLoadingPinnedToken || (isLoadingTokenMetadata && isExternalTokenLinked);
 
-  const contractInfo =
-    commonProtocol?.factoryContracts[
-      app?.chain?.meta?.ChainNode?.eth_chain_id || 0
-    ];
+  const isEthCommunity = app?.chain?.meta?.base === ChainBase.Ethereum;
 
   if (
     !uniswapTradeEnabled ||
-    !contractInfo ||
+    !isEthCommunity ||
     // if a community already has a launchpad token, don't allow pinning
     communityLaunchpadToken
   ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10903

## Description of Changes
Allow external token integrations in all ethereum communities that don't have a native(launchpad) token.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
1. Enable `FLAG_UNISWAP_TRADE`
2. Visit `/soneium` community as site admin
3. Add a token via community integrations settings i.e add `0x7d49a065d17d6d4a55dc13649901fdbb98b2afba` => sushi on base
4. Verify you see the swap widget in community sidebar, once you add the token
5. Verify you are able to swap via uniswap modal (Important: real tokens will be involved in tx)

## Deployment Plan
1. `FLAG_UNISWAP_TRADE` needs to be enabled.

## Other Considerations
N/A