### PR TITLE
animated the sidebar for mobile

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useSidebarSwipe.ts
+++ b/packages/commonwealth/client/scripts/hooks/useSidebarSwipe.ts
@@ -9,11 +9,15 @@ const useSidebarSwipe = () => {
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
   const [left, setLeft] = useState('0px');
 
-  useEffect(() => {
-    const isDiscussionPage = /^\/[^/]+\/discussion\/[^/]+$/.test(
-      location.pathname,
+  const isBackNavigationEnabled = (pathname) => {
+    return (
+      /^\/[^/]+\/discussion\/[^/]+$/.test(pathname) ||
+      /^\/[^/]+\/snapshot\/[^/]+\/[^/]+$/.test(pathname) ||
+      /^\/[^/]+\/proposal\/[^/]+$/.test(pathname)
     );
-    const shouldTriggerBack = isDiscussionPage;
+  };
+  useEffect(() => {
+    const shouldTriggerBack = isBackNavigationEnabled(location.pathname);
     const screenWidth = window.innerWidth;
 
     const handleTouchStart = (e: TouchEvent) => {

--- a/packages/commonwealth/client/scripts/hooks/useSidebarSwipe.ts
+++ b/packages/commonwealth/client/scripts/hooks/useSidebarSwipe.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import useSidebarStore from 'state/ui/sidebar';
+
+const useSidebarSwipe = () => {
+  const { menuVisible, setMenu } = useSidebarStore();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [touchStartX, setTouchStartX] = useState<number | null>(null);
+  const [left, setLeft] = useState('0px');
+
+  useEffect(() => {
+    const isDiscussionPage = /^\/[^/]+\/discussion\/[^/]+$/.test(
+      location.pathname,
+    );
+    const shouldTriggerBack = isDiscussionPage;
+    const screenWidth = window.innerWidth;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      setTouchStartX(e.touches[0].clientX);
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!touchStartX) return;
+
+      const touchCurrentX = e.touches[0].clientX;
+      const swipeDistance = touchCurrentX - touchStartX;
+
+      if (menuVisible) {
+        if (swipeDistance < 0) {
+          const newLeft = Math.max(-100, (swipeDistance / screenWidth) * 100);
+          setLeft(`${newLeft}%`);
+        }
+      } else {
+        if (swipeDistance > 0 && !shouldTriggerBack) {
+          const newLeft = Math.min(
+            0,
+            ((swipeDistance - screenWidth) / screenWidth) * 100,
+          );
+          setLeft(`${newLeft}%`);
+        }
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (!touchStartX) return;
+
+      const touchEndX = e.changedTouches[0].clientX;
+      const swipeDistance = touchEndX - touchStartX;
+      const swipeThreshold = screenWidth * 0.3; // 30% of screen width
+
+      if (menuVisible) {
+        if (Math.abs(swipeDistance) > swipeThreshold && swipeDistance < 0) {
+          setMenu({ name: 'default', isVisible: false });
+          setLeft('0px');
+        } else {
+          setLeft('0px');
+        }
+      } else {
+        if (
+          Math.abs(swipeDistance) > swipeThreshold &&
+          swipeDistance > 0 &&
+          !shouldTriggerBack
+        ) {
+          setMenu({ name: 'default', isVisible: true });
+          setLeft('0');
+        } else if (shouldTriggerBack && swipeDistance > swipeThreshold) {
+          navigate(-1);
+        } else {
+          setLeft('0px');
+        }
+      }
+      setTouchStartX(null);
+    };
+
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchmove', handleTouchMove);
+    window.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [touchStartX, location.pathname, navigate, menuVisible, setMenu]);
+
+  return left;
+};
+
+export default useSidebarSwipe;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.scss
@@ -14,11 +14,18 @@
   &.onadd {
     animation: slidein 0.2s ease-in-out;
     display: flex;
+    @include smallInclusive {
+      animation: slidein 0.3s ease-in-out;
+    }
   }
 
   &.onremove {
     animation: slideout 0.2s ease-in-out;
     display: none;
+
+    @include smallInclusive {
+      animation: slideout 0.3s ease-in-out;
+    }
   }
 
   .sidebar-header-wrapper {
@@ -85,7 +92,6 @@
       padding: 8px 16px;
     }
   }
-
   @keyframes slidein {
     from {
       left: -100%;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -4,14 +4,15 @@ import React, { useEffect, useMemo } from 'react';
 import app from 'state';
 import useSidebarStore from 'state/ui/sidebar';
 import { CreateContentSidebar } from '../../menus/CreateContentMenu';
-import { SidebarHeader } from '../component_kit/CWSidebarHeader';
 import { KnockFeedWrapper } from '../KnockNotifications/KnockFeedWrapper';
+import { SidebarHeader } from '../component_kit/CWSidebarHeader';
 import { CommunitySection } from './CommunitySection';
 
+import useSidebarSwipe from 'client/scripts/hooks/useSidebarSwipe';
+import { SidebarProfileSection } from './SidebarProfileSection';
 import { ExploreCommunitiesSidebar } from './explore_sidebar';
 import './index.scss';
 import { SidebarQuickSwitcher } from './sidebar_quick_switcher';
-import { SidebarProfileSection } from './SidebarProfileSection';
 
 export type SidebarMenuName =
   | 'default'
@@ -33,6 +34,7 @@ export const Sidebar = ({
   } = useSidebarStore();
 
   const user = useUserStore();
+  const left = useSidebarSwipe();
 
   useEffect(() => {
     setRecentlyUpdatedVisibility(false);
@@ -47,7 +49,7 @@ export const Sidebar = ({
   }, [menuVisible, onMobile, recentlyUpdatedVisibility]);
 
   return (
-    <div className={sidebarClass}>
+    <div className={sidebarClass} style={{ left }}>
       {isInsideCommunity ? (
         <div className="sidebar-header-wrapper">
           <SidebarHeader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10857 

## Description of Changes
- made the sidebar drag-able  
- On Content Pages, i.e Thread or Content Pages: The sidebar should not be draggable. Instead, dragging should trigger a “back” navigation.
On FYP / Explore or Global Pages: The sidebar should remain draggable.
On Community Homepage or Listing Page: The sidebar should remain draggable.


## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
On Content Pages, i.e Thread or Content Pages: The sidebar should not be draggable. Instead, dragging should trigger a “back” navigation.
On FYP / Explore or Global Pages: The sidebar should remain draggable.
On Community Homepage or Listing Page: The sidebar should remain draggable.


## Test Plan

https://github.com/user-attachments/assets/4bd9fddc-3783-4fbb-a94f-0f893e2de193

