### PR TITLE
Added time selection to date time input for quest

### DIFF
--- a/libs/model/src/models/quest.ts
+++ b/libs/model/src/models/quest.ts
@@ -68,6 +68,7 @@ export const QuestActionMeta = (
         type: Sequelize.INTEGER,
         allowNull: true,
       },
+      action_link: { type: Sequelize.STRING, allowNull: true },
     },
     {
       timestamps: true,

--- a/libs/model/src/quest/GetQuests.query.ts
+++ b/libs/model/src/quest/GetQuests.query.ts
@@ -62,6 +62,7 @@ export function GetQuests(): Query<typeof schemas.GetQuests> {
                 'quest_id', QAS.quest_id,
                 'event_name', QAS.event_name,
                 'reward_amount', QAS.reward_amount,
+                'action_link', QAS.action_link,
                 'creator_reward_weight', QAS.creator_reward_weight,
                 'participation_limit', QAS.participation_limit,
                 'participation_period', QAS.participation_period,

--- a/libs/schemas/src/entities/quest.schemas.ts
+++ b/libs/schemas/src/entities/quest.schemas.ts
@@ -39,6 +39,7 @@ export const QuestActionMeta = z
     creator_reward_weight: z.number().min(0).max(1).default(0),
     participation_limit: z.nativeEnum(QuestParticipationLimit).optional(),
     participation_period: z.nativeEnum(QuestParticipationPeriod).optional(),
+    action_link: z.string().url().optional(),
     participation_times_per_period: z.number().optional(),
     created_at: z.coerce.date().optional(),
     updated_at: z.coerce.date().optional(),

--- a/packages/commonwealth/client/scripts/helpers/formValidations/messages.ts
+++ b/packages/commonwealth/client/scripts/helpers/formValidations/messages.ts
@@ -7,6 +7,6 @@ export const VALIDATION_MESSAGES = {
   MUST_BE_GREATER: (value: string | number) => `Must be greater than ${value}`,
   MUST_BE_LESS_OR_EQUAL: (value: string | number) =>
     `Must be less or equal to ${value}`,
-  MUST_HAVE_DIFFERENCE: (fieldName: string, differenceValue: string | number) =>
-    `Must have difference of atleast ${differenceValue} from ${fieldName}`,
+  MUST_BE_APART: (fieldName: string, differenceValue: string | number) =>
+    `Must be atleast ${differenceValue} apart from ${fieldName}`,
 };

--- a/packages/commonwealth/client/scripts/helpers/number.ts
+++ b/packages/commonwealth/client/scripts/helpers/number.ts
@@ -1,7 +1,7 @@
 // Ex: oldValue = 100, newValue = 99, result = 0.01
-export const calculatePercentageChangeFractional = (
+export const calculateRemainingPercentageChangeFractional = (
   oldValue: number,
   newValue: number,
 ) => {
-  return Math.abs((newValue - oldValue) / oldValue);
+  return 1 - Math.abs((newValue - oldValue) / oldValue);
 };

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/TaskList/TaskList.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/TaskList/TaskList.tsx
@@ -44,7 +44,7 @@ const TaskList = ({ className }: TaskListProps) => {
               imageURL: quest.image_url,
               title: quest.name,
               isCompleted: quest.isCompleted,
-              xpPoints: { gained: quest.gainedXP, total: quest.totalXP },
+              xpPoints: { gained: quest.gainedXP, total: quest.totalUserXP },
             }))}
           />
           <Quests
@@ -57,7 +57,7 @@ const TaskList = ({ className }: TaskListProps) => {
               imageURL: quest.image_url,
               title: quest.name,
               isCompleted: quest.isCompleted,
-              xpPoints: { gained: quest.gainedXP, total: quest.totalXP },
+              xpPoints: { gained: quest.gainedXP, total: quest.totalUserXP },
             }))}
           />
         </>

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/useXPProgress.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/useXPProgress.tsx
@@ -39,9 +39,12 @@ const useXPProgress = () => {
             (accumulator, currentValue) => accumulator + currentValue,
             0,
           ) || 0;
-      const totalXP =
+      const totalUserXP =
         (quest.action_metas || [])
-          ?.map((action) => action.reward_amount)
+          ?.map(
+            (action) =>
+              action.reward_amount - action.creator_reward_weight * 100,
+          )
           .reduce(
             (accumulator, currentValue) => accumulator + currentValue,
             0,
@@ -49,8 +52,8 @@ const useXPProgress = () => {
       return {
         ...quest,
         gainedXP,
-        totalXP,
-        isCompleted: gainedXP === totalXP,
+        totalUserXP,
+        isCompleted: gainedXP === totalUserXP,
       };
     });
   const upcomingWeeklyQuests = allWeeklyQuests.filter((q) =>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWDateTimeInput/CWDateTimeInput.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWDateTimeInput/CWDateTimeInput.scss
@@ -9,6 +9,11 @@
 
   .react-datepicker-wrapper {
     width: 100% !important;
+    min-width: 250px;
+
+    @include extraSmall {
+      min-width: 100%;
+    }
   }
 
   .react-datepicker__input-container {
@@ -20,6 +25,43 @@
 
       &.darkMode {
         @include darkModeInputStyles;
+      }
+    }
+  }
+
+  .react-datepicker__input-time-container {
+    margin: 0;
+    width: 100%;
+    padding: 8px;
+
+    .react-datepicker-time__caption {
+      color: $neutral-500;
+      font-size: 12px;
+      padding-bottom: 2px;
+      padding-left: 2px;
+    }
+
+    .react-datepicker-time__input-container {
+      margin-left: 0;
+      width: 100%;
+    }
+
+    .react-datepicker-time__input {
+      margin-left: 0;
+      width: 100% !important;
+    }
+
+    input {
+      border: 1px solid $neutral-300;
+      border-radius: 6px;
+      padding: 4px;
+      cursor: pointer;
+
+      &:focus,
+      &:focus-within,
+      &:focus-visible {
+        border: 1px solid $primary-300;
+        outline: none;
       }
     }
   }

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWDateTimeInput/CWDateTimeInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWDateTimeInput/CWDateTimeInput.tsx
@@ -73,6 +73,8 @@ export const CWDateTimeInput = ({
         closeOnScroll
         calendarClassName="calender"
         selected={startDate}
+        dateFormat="d MMMM, yyyy h:mm aa"
+        timeInputLabel="Select time (utc)"
         icon={
           <CWIcon
             iconName="calenderBlank"

--- a/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
@@ -60,9 +60,12 @@ const QuestList = () => {
       ) : (
         <div className="list">
           {(quests || []).map((quest) => {
-            const totalXP =
+            const totalUserXP =
               (quest.action_metas || [])
-                ?.map((action) => action.reward_amount)
+                ?.map(
+                  (action) =>
+                    action.reward_amount - action.creator_reward_weight * 100,
+                )
                 .reduce(
                   (accumulator, currentValue) => accumulator + currentValue,
                   0,
@@ -74,7 +77,7 @@ const QuestList = () => {
                 name={quest.name}
                 description={quest.description}
                 iconURL={quest.image_url}
-                xpPoints={totalXP}
+                xpPoints={totalUserXP}
                 startDate={new Date(quest.start_date)}
                 endDate={new Date(quest.end_date)}
                 onCTAClick={() => handleCTAClick(quest.id)}

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -74,6 +74,7 @@ const CreateQuestForm = () => {
           name="start_date"
           minDate={minStartDate}
           selected={minStartDate}
+          showTimeInput
         />
         <CWDateTimeInput
           label="End Date"
@@ -81,6 +82,7 @@ const CreateQuestForm = () => {
           name="end_date"
           minDate={minStartDate}
           selected={null}
+          showTimeInput
         />
       </div>
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -56,7 +56,7 @@ const QuestActionSubForm = ({
       />
 
       <CWTextInput
-        label="Reward Points"
+        label="Total Reward Points"
         placeholder="Points Earned"
         fullWidth
         {...(defaultValues?.rewardAmount && {
@@ -80,7 +80,8 @@ const QuestActionSubForm = ({
           }
           name="creatorRewardAmount"
           customError={errors?.creatorRewardAmount}
-          instructionalMessage="Number of reward points the action creator would get."
+          // eslint-disable-next-line max-len
+          instructionalMessage="Number of reward points the action creator would get. Deducted from total reward points."
         />
       )}
 

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -87,15 +87,15 @@ const QuestActionSubForm = ({
 
       <CWTextInput
         label="Relevant Quest Link (optional)"
-        name="questLink"
+        name="actionLink"
         placeholder="https://example.com"
         instructionalMessage="Note: Social media task links will appear here (e.g., follow on X, join Discord)"
         fullWidth
-        {...(defaultValues?.questLink && {
-          defaultValue: defaultValues?.questLink,
+        {...(defaultValues?.actionLink && {
+          defaultValue: defaultValues?.actionLink,
         })}
-        onInput={(e) => onChange?.({ questLink: e?.target?.value?.trim() })}
-        customError={errors?.questLink}
+        onInput={(e) => onChange?.({ actionLink: e?.target?.value?.trim() })}
+        customError={errors?.actionLink}
       />
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/types.ts
@@ -4,14 +4,14 @@ export type QuestAction = keyof typeof QuestEvents;
 
 export type QuestActionSubFormErrors = {
   action?: string;
-  questLink?: string;
+  actionLink?: string;
   rewardAmount?: string;
   creatorRewardAmount?: string;
 };
 
 export type QuestActionSubFormFields = {
   action?: QuestAction;
-  questLink?: string;
+  actionLink?: string;
   rewardAmount?: string | number;
   creatorRewardAmount?: string | number;
 };

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/QuestActionSubForm/validation.ts
@@ -11,7 +11,7 @@ export const questSubFormValidationSchema = z.object({
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
   rewardAmount: numberGTZeroValidationSchema,
-  questLink: linkValidationSchema.optional,
+  actionLink: linkValidationSchema.optional,
 });
 
 export const questSubFormValidationSchemaWithCreatorPoints =

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -162,6 +162,9 @@ const useCreateQuestForm = () => {
               participation_times_per_period: parseInt(
                 `${repetitionCycleRadioProps.repetitionCycleInputProps.value}`,
               ),
+              ...(subForm.values.actionLink && {
+                action_link: subForm.values.actionLink.trim(),
+              }),
             })),
           });
         }

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -5,7 +5,7 @@ import {
 } from '@hicommonwealth/schemas';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { numberGTZeroValidationSchema } from 'helpers/formValidations/common';
-import { calculatePercentageChangeFractional } from 'helpers/number';
+import { calculateRemainingPercentageChangeFractional } from 'helpers/number';
 import { useCommonNavigate } from 'navigation/helpers';
 import { useRef, useState } from 'react';
 import {
@@ -149,10 +149,11 @@ const useCreateQuestForm = () => {
               event_name: subForm.values.action as QuestAction,
               reward_amount: parseInt(`${subForm.values.rewardAmount}`, 10),
               ...(subForm.values.creatorRewardAmount && {
-                creator_reward_weight: calculatePercentageChangeFractional(
-                  parseInt(`${subForm.values.rewardAmount}`, 10),
-                  parseInt(`${subForm.values.creatorRewardAmount}`, 10),
-                ),
+                creator_reward_weight:
+                  calculateRemainingPercentageChangeFractional(
+                    parseInt(`${subForm.values.rewardAmount}`, 10),
+                    parseInt(`${subForm.values.creatorRewardAmount}`, 10),
+                  ),
               }),
               participation_limit: values.participation_limit,
               participation_period: repetitionCycleRadioProps

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/validation.ts
@@ -53,7 +53,7 @@ export const questFormValidationSchema = z
       }
     },
     {
-      message: VALIDATION_MESSAGES.MUST_HAVE_DIFFERENCE('start date', '1 day'),
+      message: VALIDATION_MESSAGES.MUST_BE_APART('start date', '1 day'),
       path: ['end_date'],
     },
   );

--- a/packages/commonwealth/client/scripts/views/pages/HomePage/XpQuestList/XpQuestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/XpQuestList/XpQuestList.tsx
@@ -69,9 +69,12 @@ const XpQuestList = ({ communityIdFilter }: XpQuestListProps) => {
         ) : (
           <div className="content">
             {quests.map((quest) => {
-              const totalXP =
+              const totalUserXP =
                 (quest.action_metas || [])
-                  ?.map((action) => action.reward_amount)
+                  ?.map(
+                    (action) =>
+                      action.reward_amount - action.creator_reward_weight * 100,
+                  )
                   .reduce(
                     (accumulator, currentValue) => accumulator + currentValue,
                     0,
@@ -84,7 +87,7 @@ const XpQuestList = ({ communityIdFilter }: XpQuestListProps) => {
                   description={quest.description}
                   community_id={quest.community_id}
                   iconURL={quest.image_url}
-                  xpPoints={totalXP}
+                  xpPoints={totalUserXP}
                   startDate={new Date(quest.start_date)}
                   endDate={new Date(quest.end_date)}
                   onCTAClick={handleCTAClick}

--- a/packages/commonwealth/client/scripts/views/pages/Leaderboard/QuestsExplorer/QuestsExplorer.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Leaderboard/QuestsExplorer/QuestsExplorer.tsx
@@ -48,9 +48,12 @@ const QuestsExplorer = () => {
             />
           </div>
           {quests.map((quest) => {
-            const totalXP =
+            const totalUserXP =
               (quest.action_metas || [])
-                ?.map((action) => action.reward_amount)
+                ?.map(
+                  (action) =>
+                    action.reward_amount - action.creator_reward_weight * 100,
+                )
                 .reduce(
                   (accumulator, currentValue) => accumulator + currentValue,
                   0,
@@ -61,7 +64,7 @@ const QuestsExplorer = () => {
                 key={quest.name}
                 label={quest.name}
                 description={quest.description}
-                xpPoints={totalXP}
+                xpPoints={totalUserXP}
                 featuredImgURL={quest.image_url}
                 onExploreClick={() => handleCTAClick(quest.id)}
               />

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.scss
@@ -50,9 +50,26 @@
         color: $neutral-700;
       }
 
-      .points {
+      .points-row {
         display: flex;
         gap: 12px;
+      }
+
+      .action-link {
+        color: $primary-500;
+        width: fit-content;
+        display: flex;
+        align-items: center;
+        font-size: 14px;
+        gap: 4px;
+
+        &:hover,
+        &:focus,
+        :focus-within,
+        :focus-within,
+        :active {
+          color: $primary-500;
+        }
       }
 
       .xp-shares {

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -1,5 +1,6 @@
 import { QuestActionMeta } from '@hicommonwealth/schemas';
 import React from 'react';
+import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
@@ -81,9 +82,23 @@ const QuestActionCard = ({
               XP
             </CWText>
           )}
-          <div className="points">
+          <div className="points-row">
             <CWTag label={`${questAction.reward_amount} XP`} type="proposal" />
-            {/* TODO: helper link here, next todo */}
+            {questAction.action_link && (
+              <a
+                target="_blank"
+                href={questAction.action_link}
+                rel="noreferrer"
+                className="action-link"
+              >
+                Instructions{' '}
+                <CWIcon
+                  iconName="externalLink"
+                  iconSize="small"
+                  weight="bold"
+                />
+              </a>
+            )}
           </div>
         </div>
         {isActionInEligible ? (

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -55,6 +55,8 @@ const QuestActionCard = ({
   inEligibilityReason,
   questAction,
 }: QuestActionCardProps) => {
+  const creatorXP = questAction.creator_reward_weight * 100;
+
   return (
     <div className="QuestActionCard">
       <div className="counter">
@@ -70,16 +72,10 @@ const QuestActionCard = ({
           {doesActionRequireCreatorReward(questAction.event_name) && (
             <CWText type="caption" className="xp-shares">
               <span className="creator-share">
-                {questAction.creator_reward_weight * 100}% (
-                {questAction.creator_reward_weight * 100} XP)
+                {creatorXP}% ({creatorXP} XP)
               </span>
               &nbsp; shared with {actionCopies.shares[questAction.event_name]}.
-              Your share ={' '}
-              {Math.abs(
-                questAction.reward_amount -
-                  questAction.creator_reward_weight * 100,
-              )}{' '}
-              XP
+              Your share = {Math.abs(questAction.reward_amount - creatorXP)} XP
             </CWText>
           )}
           <div className="points-row">

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -69,14 +69,21 @@ const QuestActionCard = ({
           {doesActionRequireCreatorReward(questAction.event_name) && (
             <CWText type="caption" className="xp-shares">
               <span className="creator-share">
-                {questAction.creator_reward_weight * 100}%
+                {questAction.creator_reward_weight * 100}% (
+                {questAction.creator_reward_weight * 100} XP)
               </span>
-              &nbsp; shared with {actionCopies.shares[questAction.event_name]}
+              &nbsp; shared with {actionCopies.shares[questAction.event_name]}.
+              Your share ={' '}
+              {Math.abs(
+                questAction.reward_amount -
+                  questAction.creator_reward_weight * 100,
+              )}{' '}
+              XP
             </CWText>
           )}
           <div className="points">
             <CWTag label={`${questAction.reward_amount} XP`} type="proposal" />
-            {/* TODO: helper link here */}
+            {/* TODO: helper link here, next todo */}
           </div>
         </div>
         {isActionInEligible ? (

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -69,7 +69,7 @@ const QuestActionCard = ({
           {doesActionRequireCreatorReward(questAction.event_name) && (
             <CWText type="caption" className="xp-shares">
               <span className="creator-share">
-                {questAction.creator_reward_weight}%
+                {questAction.creator_reward_weight * 100}%
               </span>
               &nbsp; shared with {actionCopies.shares[questAction.event_name]}
             </CWText>

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -86,13 +86,24 @@ const QuestDetails = ({ id }: { id: number }) => {
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
     0;
 
-  const totalXP =
+  const totalCreatorXP =
     (quest.action_metas || [])
-      ?.map((action) => action.reward_amount)
+      ?.map((action) => action.creator_reward_weight * 100)
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
     0;
 
-  const isCompleted = gainedXP === totalXP;
+  const totalUserXP =
+    (quest.action_metas || [])
+      ?.map(
+        (action) => action.reward_amount - action.creator_reward_weight * 100,
+      )
+      .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
+    0;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const totalXP = totalCreatorXP + totalUserXP;
+
+  const isCompleted = gainedXP === totalUserXP;
 
   const handleActionStart = (actionName: QuestAction) => {
     switch (actionName) {
@@ -219,7 +230,7 @@ const QuestDetails = ({ id }: { id: number }) => {
                 Complete tasks to earn XP
               </CWText>
               <CWTag
-                label={`${gainedXP > 0 ? `${gainedXP} / ` : ''}${totalXP} XP`}
+                label={`${gainedXP > 0 ? `${gainedXP} / ` : ''}${totalUserXP} XP`}
                 type="proposal"
               />
             </div>

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -86,12 +86,7 @@ const QuestDetails = ({ id }: { id: number }) => {
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
     0;
 
-  const totalCreatorXP =
-    (quest.action_metas || [])
-      ?.map((action) => action.creator_reward_weight * 100)
-      .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
-    0;
-
+  // this only includes end user xp gain, creator/referrer xp is not included in this
   const totalUserXP =
     (quest.action_metas || [])
       ?.map(
@@ -99,9 +94,6 @@ const QuestDetails = ({ id }: { id: number }) => {
       )
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0) ||
     0;
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const totalXP = totalCreatorXP + totalUserXP;
 
   const isCompleted = gainedXP === totalUserXP;
 

--- a/packages/commonwealth/server/migrations/20250218145237-add-action-link-to-quest-action.js
+++ b/packages/commonwealth/server/migrations/20250218145237-add-action-link-to-quest-action.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('QuestActionMetas', 'action_link', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.removeColumn('QuestActionMetas', 'action_link');
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/10984

## Description of Changes
1. Updated datetime selector for quest creation form
2. Made quest timezone validation message more verbose
3. Fixed creator reward share percentages display
4. Added (optional) quest action link.

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. As site admin, visit `/createQuest` and verify you see the new updated quest date/time selector with UTC timezone
3. Add a quest action that requires creator reward share i.e `Create Community`, and verify that after quest is created and is live, you see creator reward share percentages correctly on the quest details page and in every other view you only see the user share of xp
4. Ensure quest action link shows up as an "Instruction" link in the quest action on details page.

## Deployment Plan
N/A

## Other Considerations
N/A