### PR TITLE
Adjust displaying ETH values on FE

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.scss
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.scss
@@ -64,6 +64,7 @@
 
         svg {
           fill: $neutral-500;
+          filter: grayscale(100%);
         }
 
         .rewards-button-container {
@@ -73,7 +74,7 @@
           cursor: pointer;
 
           .earnings {
-            margin-left: 4px;
+            margin-inline: 4px;
             font-family: $font-family-roboto;
             color: $neutral-500;
             white-space: nowrap;

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -15,20 +15,28 @@ import { HelpMenuPopover } from 'views/menus/help_menu';
 
 import UserDropdown from './UserDropdown';
 
+import { ChainBase } from '@hicommonwealth/shared';
+import { getUniqueUserAddresses } from 'client/scripts/helpers/user';
+import { useGetUserEthBalanceQuery } from 'client/scripts/state/api/communityStake';
+import { fetchCachedNodes } from 'client/scripts/state/api/nodes';
 import { useFlag } from 'hooks/useFlag';
 import { useFetchCustomDomainQuery } from 'state/api/configuration';
 import useUserStore from 'state/ui/user';
 import AuthButtons from 'views/components/SublayoutHeader/AuthButtons';
 import { AuthModalType } from 'views/modals/AuthModal';
 import { capDecimals } from 'views/modals/ManageCommunityStakeModal/utils';
+import { CWCustomIcon } from '../../component_kit/cw_icons/cw_custom_icon';
 import { CWText } from '../../component_kit/cw_text';
 import XPProgressIndicator from '../XPProgressIndicator';
+
 import './DesktopHeader.scss';
 
 interface DesktopHeaderProps {
   onMobile: boolean;
   onAuthModalOpen: (modalType?: AuthModalType) => void;
 }
+
+const baseNodeId = 1358;
 
 const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
   const navigate = useCommonNavigate();
@@ -46,6 +54,20 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
       setUserToggledVisibility(isVisible ? 'open' : 'closed');
     }, 200);
   };
+
+  const nodes = fetchCachedNodes();
+  const baseNode = nodes?.find((node) => node.id === baseNodeId);
+
+  const uniqueAddresses = getUniqueUserAddresses({
+    forChain: ChainBase.Ethereum,
+  });
+
+  const { data: ethBalance } = useGetUserEthBalanceQuery({
+    chainRpc: baseNode?.url || '',
+    walletAddress: uniqueAddresses[0] || '',
+    ethChainId: baseNode?.ethChainId || 0,
+    apiEnabled: !!baseNode && !!uniqueAddresses[0],
+  });
 
   return (
     <div className="DesktopHeader">
@@ -151,8 +173,9 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
                           fontWeight="medium"
                           type="caption"
                         >
-                          {capDecimals('0.125')} ETH
+                          {capDecimals(ethBalance || '0')} ETH
                         </CWText>
+                        <CWCustomIcon iconName="base" iconSize="xs" />
                       </div>
                     )}
                   />

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -1,4 +1,3 @@
-import { smallNumberFormatter } from '@hicommonwealth/shared';
 import { useGetMembersQuery } from 'client/scripts/state/api/communities';
 import { APIOrderDirection } from 'helpers/constants';
 import React, { useState } from 'react';
@@ -13,6 +12,7 @@ import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWTable } from 'views/components/component_kit/new_designs/CWTable';
 import { useCWTableState } from 'views/components/component_kit/new_designs/CWTable/useCWTableState';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
+import { fromWei } from 'web3-utils';
 import { MemberResultsOrderBy } from '../index.types';
 
 import './LeaderboardSection.scss';
@@ -96,10 +96,10 @@ const LeaderboardSection = () => {
         ),
       },
       earnings: {
-        sortValue: member.referral_eth_earnings,
+        sortValue: Number(member.referral_eth_earnings),
         customElement: (
           <div className="table-cell text-right">
-            ETH {smallNumberFormatter.format(member.referral_eth_earnings || 0)}
+            ETH {Number(fromWei(member.referral_eth_earnings || 0, 'ether'))}
           </div>
         ),
       },

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -43,9 +43,11 @@ interface SignTransactionsStepProps {
   isFarcasterContest: boolean;
 }
 
-const ONE_HOUR_IN_SECONDS =
-  process.env.NODE_ENV === 'development' ? 180 : 60 * 60;
-console.log({ ONE_HOUR_IN_SECONDS });
+const ONE_HOUR_IN_SECONDS = 60 * 60;
+
+const CUSTOM_CONTEST_DURATION_IN_SECONDS =
+  Number(process.env.CONTEST_DURATION_IN_SEC) ?? ONE_HOUR_IN_SECONDS;
+console.log({ CUSTOM_CONTEST_DURATION_IN_SECONDS });
 
 const SignTransactionsStep = ({
   onSetLaunchContestStep,
@@ -87,7 +89,7 @@ const SignTransactionsStep = ({
     const chainRpc = app?.chain?.meta?.ChainNode?.url || '';
     const namespaceName = app?.chain?.meta?.namespace;
     const contestLength = devContest
-      ? ONE_HOUR_IN_SECONDS
+      ? CUSTOM_CONTEST_DURATION_IN_SECONDS
       : contestFormData?.contestDuration;
 
     const stakeId = stakeData?.stake_id;
@@ -95,7 +97,7 @@ const SignTransactionsStep = ({
     const feeShare = commonProtocol.CONTEST_FEE_SHARE;
     const weight = stakeData?.vote_weight;
     const contestInterval = devContest
-      ? ONE_HOUR_IN_SECONDS
+      ? CUSTOM_CONTEST_DURATION_IN_SECONDS
       : contestFormData?.contestDuration;
     const prizeShare = contestFormData?.prizePercentage;
     const walletAddress = user.activeAccount?.address;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/SignTransactionsStep/SignTransactionsStep.tsx
@@ -46,7 +46,7 @@ interface SignTransactionsStepProps {
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 
 const CUSTOM_CONTEST_DURATION_IN_SECONDS =
-  Number(process.env.CONTEST_DURATION_IN_SEC) ?? ONE_HOUR_IN_SECONDS;
+  Number(process.env.CONTEST_DURATION_IN_SEC) || ONE_HOUR_IN_SECONDS;
 console.log({ CUSTOM_CONTEST_DURATION_IN_SECONDS });
 
 const SignTransactionsStep = ({

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.tsx
@@ -1,6 +1,6 @@
-import { smallNumberFormatter } from '@hicommonwealth/shared';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { fromWei } from 'web3-utils';
 
 import { APIOrderDirection } from 'helpers/constants';
 import { Avatar } from 'views/components/Avatar';
@@ -9,7 +9,6 @@ import CWCircleMultiplySpinner from 'views/components/component_kit/new_designs/
 import { CWTable } from 'views/components/component_kit/new_designs/CWTable';
 import { useCWTableState } from 'views/components/component_kit/new_designs/CWTable/useCWTableState';
 import { Referral } from '../../types';
-
 import { columns } from './columns';
 
 import './ReferralTable.scss';
@@ -69,14 +68,12 @@ export const ReferralTable = ({ referrals, isLoading }: ReferralTableProps) => {
                 ),
               },
               earnings: {
-                sortValue: parseFloat(
-                  String(item.referrer_received_eth_amount),
-                ),
+                sortValue: Number(item.referrer_received_eth_amount),
                 customElement: (
                   <div className="table-cell text-right">
                     ETH{' '}
-                    {smallNumberFormatter.format(
-                      Number(item.referrer_received_eth_amount),
+                    {Number(
+                      fromWei(item.referrer_received_eth_amount, 'ether'),
                     )}
                   </div>
                 ),

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/utils.ts
@@ -1,21 +1,16 @@
 import moment from 'moment';
+import { fromWei } from 'web3-utils';
 import { MobileTabType, ReferralFee, TabParam, TableType } from './types';
 
 export const calculateTotalEarnings = (referralFees: ReferralFee[]) => {
   if (!referralFees?.length) return 0;
-  const maxDecimals = Math.max(
-    ...referralFees.map((fee) => {
-      const amount = fee.referrer_received_amount || 0;
-      const decimalStr = amount.toString().split('.')[1];
-      return decimalStr ? decimalStr.length : 0;
-    }),
+
+  const totalWei = referralFees.reduce(
+    (sum, fee) => sum + BigInt(fee.referrer_received_amount),
+    0n,
   );
 
-  return Number(
-    referralFees
-      .reduce((sum, fee) => sum + Number(fee.referrer_received_amount), 0)
-      .toFixed(maxDecimals),
-  );
+  return Number(fromWei(totalWei.toString(), 'ether'));
 };
 
 const getMonthEarnings = (
@@ -30,7 +25,7 @@ const getMonthEarnings = (
         feeDate.year() === targetDate.year()
       );
     })
-    .reduce((sum, fee) => sum + Number(fee.referrer_received_amount), 0);
+    .reduce((sum, fee) => sum + BigInt(fee.referrer_received_amount), 0n);
 };
 
 export const calculateReferralTrend = (referralFees: ReferralFee[]) => {
@@ -42,10 +37,11 @@ export const calculateReferralTrend = (referralFees: ReferralFee[]) => {
   const currentMonthEarnings = getMonthEarnings(referralFees, now);
   const lastMonthEarnings = getMonthEarnings(referralFees, lastMonth);
 
-  if (lastMonthEarnings === 0) return currentMonthEarnings > 0 ? 100 : 0;
+  if (lastMonthEarnings === 0n) return currentMonthEarnings > 0 ? 100 : 0;
 
-  const percentageChange =
-    ((currentMonthEarnings - lastMonthEarnings) / lastMonthEarnings) * 100;
+  const percentageChange = Number(
+    ((currentMonthEarnings - lastMonthEarnings) * 100n) / lastMonthEarnings,
+  );
 
   return Math.round(percentageChange);
 };

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -73,6 +73,9 @@ export default defineConfig(({ mode }) => {
     'process.env.FARCASTER_NGROK_DOMAIN': JSON.stringify(
       env.FARCASTER_NGROK_DOMAIN,
     ),
+    'process.env.CONTEST_DURATION_IN_SEC': JSON.stringify(
+      env.CONTEST_DURATION_IN_SEC,
+    ),
     'process.env.MIXPANEL_DEV_TOKEN':
       JSON.stringify(env.MIXPANEL_DEV_TOKEN) ||
       JSON.stringify('312b6c5fadb9a88d98dc1fb38de5d900'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10982
Closes: #10983

## Description of Changes

1. **ETH Balance Integration**
   - Added ETH balance display in DesktopHeader with Base network icon

2. **Contest Duration**
   - Added `CONTEST_DURATION_IN_SEC` env variable
   - Replaced hardcoded duration with configurable value

3. **Web3 Updates**
   - Switched to `fromWei` for ETH conversions
   - Enhanced referral earnings display with proper ETH unit handling

## Test Plan
- have some base eth in wallet - you should see this value in top navbar
- if you get referal fee they should be properly formatted

![image](https://github.com/user-attachments/assets/2ff75cc0-aa93-446b-8c3b-398209f7ac1f)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a