### PR TITLE
fixing Admin Contests page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -155,7 +155,7 @@ const AdminContestsPage = () => {
             <CWText type="h3" className="mb-12">
               Previous Contests
             </CWText>
-            {isContestAvailable && !contestsData.active.length ? (
+            {isContestAvailable && contestsData.finished.length === 0 ? (
               <CWText>No previous contests available</CWText>
             ) : (
               <ContestsList


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10991 

## Description of Changes
- Admin Contests should now properly show previous contests
## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
added `contestsData.finished.length === 0` in previous contests to mirror logic in `Contests.tsx`
## Test Plan
- Compare Apps/Contest with Admin Capabilities/Contests in one community and confirm they look the same