### PR TITLE
Add navigation between contests with prev/next buttons

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/ContestPage/NewContestPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/ContestPage/NewContestPage.scss
@@ -26,6 +26,7 @@
         .Button {
           border-radius: 0;
           max-width: 260px;
+          cursor: default;
         }
       }
 

--- a/packages/commonwealth/client/scripts/views/pages/ContestPage/NewContestPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ContestPage/NewContestPage.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { useCommonNavigate } from 'navigation/helpers';
 import React, { useState } from 'react';
 
 import useCommunityContests from 'views/pages/CommunityManagement/Contests/useCommunityContests';
@@ -13,6 +14,7 @@ import { MobileTabType } from './ContestPage';
 import EntriesTab from './tabs/Entries';
 import PriceChartTab from './tabs/PriceChart';
 import TokenSwapTab from './tabs/TokenSwap';
+import { getCurrentContestIndex, getSortedContests } from './utils';
 
 import './NewContestPage.scss';
 
@@ -24,8 +26,9 @@ const NewContestPage = ({ contestAddress }: NewContestPageProps) => {
   const [selectedMobileTab, setSelectedMobileTab] = useState<MobileTabType>(
     MobileTabType.Entries,
   );
+  const navigate = useCommonNavigate();
 
-  const { getContestByAddress } = useCommunityContests();
+  const { getContestByAddress, contestsData } = useCommunityContests();
   const contest = getContestByAddress(contestAddress);
 
   const [fundDrawerContest, setFundDrawerContest] = useState<
@@ -33,6 +36,23 @@ const NewContestPage = ({ contestAddress }: NewContestPageProps) => {
   >();
 
   const { end_time } = contest?.contests[0] || {};
+
+  const sortedContests = getSortedContests(contestsData?.all);
+  const currentContestIndex = getCurrentContestIndex(
+    sortedContests,
+    contestAddress,
+  );
+
+  const handleNavigateContest = (direction: 'prev' | 'next') => {
+    const newIndex =
+      direction === 'prev' ? currentContestIndex - 1 : currentContestIndex + 1;
+
+    const targetContest = sortedContests[newIndex];
+
+    if (targetContest) {
+      navigate(`/contests/${targetContest.contest_address}`);
+    }
+  };
 
   return (
     <CWPageLayout>
@@ -65,20 +85,18 @@ const NewContestPage = ({ contestAddress }: NewContestPageProps) => {
               buttonType="secondary"
               iconLeft="arrowLeftPhosphor"
               label="Previous Contest"
-              onClick={() => {
-                console.log('previous contest');
-              }}
+              onClick={() => handleNavigateContest('prev')}
               containerClassName="previous-btn"
+              disabled={currentContestIndex <= 0}
             />
             <CWButton label={contest?.name} containerClassName="contest-name" />
             <CWButton
               buttonType="secondary"
               label="Next Contest"
               iconRight="arrowRightPhosphor"
-              onClick={() => {
-                console.log('next contest');
-              }}
+              onClick={() => handleNavigateContest('next')}
               containerClassName="next-btn"
+              disabled={currentContestIndex >= sortedContests.length - 1}
             />
           </div>
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/ContestPage/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/ContestPage/utils.ts
@@ -1,0 +1,15 @@
+import moment from 'moment';
+import { Contest } from 'views/pages/CommunityManagement/Contests/ContestsList';
+
+export const getSortedContests = (contests: Contest[] | undefined) => {
+  return [...(contests || [])].sort(
+    (a, b) => moment(a.created_at).valueOf() - moment(b.created_at).valueOf(),
+  );
+};
+
+export const getCurrentContestIndex = (
+  sortedContests: Contest[],
+  contestAddress: string,
+) => {
+  return sortedContests.findIndex((c) => c.contest_address === contestAddress);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10624 

## Description of Changes
- Added navigation between contests using prev/next buttons
- Added utility functions for sorting contests and finding current contest index

## Test Plan
- have multiple contests in the community 
- go to new contest page 
- use left / right arrow buttons to navigate through the contests


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a