### PR TITLE
Malik.11001.quest start time restriction update

### DIFF
--- a/libs/schemas/src/entities/quest.schemas.ts
+++ b/libs/schemas/src/entities/quest.schemas.ts
@@ -43,7 +43,7 @@ export const QuestActionMeta = z
     creator_reward_weight: z.number().min(0).max(1).default(0),
     participation_limit: z.nativeEnum(QuestParticipationLimit).optional(),
     participation_period: z.nativeEnum(QuestParticipationPeriod).optional(),
-    action_link: z.string().url().optional(),
+    action_link: z.string().url().optional().nullish(),
     participation_times_per_period: z.number().optional(),
     created_at: z.coerce.date().optional(),
     updated_at: z.coerce.date().optional(),

--- a/packages/commonwealth/client/scripts/helpers/quest.ts
+++ b/packages/commonwealth/client/scripts/helpers/quest.ts
@@ -32,7 +32,7 @@ export const calculateQuestTimelineLabel = ({
   // else it yet to start
   return `Starts in ${
     startHoursRemaining <= 24
-      ? `${startHoursRemaining} hours`
+      ? `${startHoursRemaining} hour${startHoursRemaining > 1 ? 's' : ''}`
       : `${startDaysRemaining} day${startDaysRemaining > 1 ? 's' : ''}`
   }`;
 };

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/CreateQuestForm.tsx
@@ -32,6 +32,8 @@ const CreateQuestForm = () => {
     isProcessingQuestImage,
     setIsProcessingQuestImage,
     minStartDate,
+    idealStartDate,
+    minEndDate,
     repetitionCycleRadio,
     formMethodsRef,
   } = useCreateQuestForm();
@@ -73,14 +75,14 @@ const CreateQuestForm = () => {
           hookToForm
           name="start_date"
           minDate={minStartDate}
-          selected={minStartDate}
+          selected={idealStartDate}
           showTimeInput
         />
         <CWDateTimeInput
           label="End Date"
           hookToForm
           name="end_date"
-          minDate={minStartDate}
+          minDate={minEndDate}
           selected={null}
           showTimeInput
         />

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/CreateQuestForm/useCreateQuestForm.ts
@@ -44,7 +44,11 @@ const useCreateQuestForm = () => {
     maxSubForms: MAX_ACTIONS_LIMIT,
   });
 
-  const minStartDate = new Date(new Date().getTime() + 1 * 24 * 60 * 60 * 1000); // 1 day date in future
+  const minStartDate = new Date(new Date().getTime() + 1 * 60 * 60 * 1000); // now + 1 hour in future
+  const idealStartDate = new Date(
+    new Date().getTime() + 1 * 24 * 60 * 60 * 1000,
+  ); // now + 1 day in future
+  const minEndDate = new Date(new Date().getTime() + 2 * 24 * 60 * 60 * 1000); // now + 1 day in future
 
   const [isProcessingQuestImage, setIsProcessingQuestImage] = useState(false);
 
@@ -201,7 +205,11 @@ const useCreateQuestForm = () => {
       } catch (e) {
         console.error(e);
 
-        notifyError('Failed to create quest!');
+        if (e.message.includes('must be at least 0 days in the future')) {
+          notifyError('Start date must be a future date');
+        } else {
+          notifyError('Failed to create quest!');
+        }
       }
     };
     const questStartHoursDiffFromNow = moment(values.start_date).diff(
@@ -232,6 +240,8 @@ const useCreateQuestForm = () => {
     isProcessingQuestImage,
     setIsProcessingQuestImage,
     minStartDate,
+    idealStartDate,
+    minEndDate,
     // custom radio button props
     repetitionCycleRadio: {
       error: repetitionCycleRadioError,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11001

## Description of Changes
Adds confirmation modal when quest is created <=6 hours in advance

<img width="576" alt="Screenshot 2025-02-19 at 12 31 38 AM" src="https://github.com/user-attachments/assets/6b92eb8d-6767-465a-9d86-34afa2181001" />


## "How We Fixed It"
N/A

## Test Plan
Ensure you can create quest <=6 hours in advance from the quest form and you see a confirmation dialog when its created for <=6 hours in advance

## Deployment Plan
N/A

## Other Considerations
N/A