### PR TITLE
added padding to the Preferences step of onboarding modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PreferencesStep/PreferencesStep.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/PreferencesStep/PreferencesStep.scss
@@ -26,10 +26,10 @@
     width: 80%;
     justify-content: space-between;
     display: flex;
-    position: absolute;
-    bottom: 8px;
-    margin-top: 10px;
+    margin-top: auto; // This pushes the buttons to the bottom
+    padding-top: 24px; // Add some space above the buttons
     gap: 10px;
+
     .primary {
       background-color: $primary-600 !important;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11068 

## Description of Changes
- Adds padding to the bottom of Preferences step of onboarding modal

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed the css in `PreferenceStep.scss`
![Screenshot 2025-02-19 at 7 24 55 PM](https://github.com/user-attachments/assets/d119e8fa-0850-47e0-a0f3-8e76b966fdb3)

