### PR TITLE
RMQ Purge Fix

### DIFF
--- a/libs/adapters/src/rabbitmq/createRmqConfig.ts
+++ b/libs/adapters/src/rabbitmq/createRmqConfig.ts
@@ -46,18 +46,15 @@ export function createRmqConfig({
   // TODO: @Roger - add types so that override keys are a partial record of consumer input type
   map: Array<Consumers>;
 }) {
-  let vhost: string, purge: boolean;
-
+  let vhost: string;
   if (rabbitMqUri.includes('localhost') || rabbitMqUri.includes('127.0.0.1')) {
     vhost = '/';
-    purge = !EnvConfig.BROKER.DISABLE_LOCAL_QUEUE_PURGE;
   } else {
     const count = (rabbitMqUri.match(/\//g) || []).length;
     if (count == 3) {
       // this matches for a production URL
       const res = rabbitMqUri.split('/');
       vhost = res[res.length - 1];
-      purge = false;
     } else {
       throw new Error(
         "Can't create Rascal RabbitMQ Config with an invalid URI!",
@@ -67,7 +64,9 @@ export function createRmqConfig({
 
   const queueConfig = {
     assert: true,
-    purge: purge,
+    purge:
+      ['local', 'CI'].includes(EnvConfig.APP_ENV) &&
+      !EnvConfig.BROKER.DISABLE_LOCAL_QUEUE_PURGE,
   };
   const deadLetterRoutingKey = 'DeadLetter';
   const exchangeConfig = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11084 

## Description of Changes
- Purge when APP_ENV === local and purge is not disabled
	- Motivation: some devs use remote CloudAMQP RabbitMQ instances with their local environment

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 