### PR TITLE
Allow site admins to cancel and delete quests

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/quests/cancelQuest.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/cancelQuest.ts
@@ -1,0 +1,13 @@
+import { trpc } from 'utils/trpcClient';
+
+export function useCancelQuestMutation() {
+  const utils = trpc.useUtils();
+
+  return trpc.quest.cancelQuest.useMutation({
+    onSuccess: () => {
+      // reset xp cache
+      utils.quest.getQuests.invalidate().catch(console.error);
+      utils.user.getXps.invalidate().catch(console.error);
+    },
+  });
+}

--- a/packages/commonwealth/client/scripts/state/api/quests/deleteQuest.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/deleteQuest.ts
@@ -1,0 +1,13 @@
+import { trpc } from 'utils/trpcClient';
+
+export function useDeleteQuestMutation() {
+  const utils = trpc.useUtils();
+
+  return trpc.quest.deleteQuest.useMutation({
+    onSuccess: () => {
+      // reset xp cache
+      utils.quest.getQuests.invalidate().catch(console.error);
+      utils.user.getXps.invalidate().catch(console.error);
+    },
+  });
+}

--- a/packages/commonwealth/client/scripts/state/api/quests/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/quests/index.ts
@@ -1,4 +1,11 @@
+import { useCancelQuestMutation } from './cancelQuest';
 import { useCreateQuestMutation } from './createQuest';
+import { useDeleteQuestMutation } from './deleteQuest';
 import { useUpdateQuestMutation } from './updateQuest';
 
-export { useCreateQuestMutation, useUpdateQuestMutation };
+export {
+  useCancelQuestMutation,
+  useCreateQuestMutation,
+  useDeleteQuestMutation,
+  useUpdateQuestMutation,
+};

--- a/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
@@ -54,7 +54,11 @@ const QuestList = ({ minQuests = 8, questsForCommunityId }: QuestListProps) => {
   };
 
   const handleCTAClick = (questId: number, communityId?: string) => {
-    navigate(`/quest/${questId}`, {}, communityId);
+    if (communityId) {
+      navigate(`/${communityId}/quest/${questId}`, {}, '');
+    } else {
+      navigate(`/quest/${questId}`, {}, null);
+    }
   };
 
   const handleLeaderboardClick = () => {

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.scss
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.scss
@@ -39,6 +39,13 @@
           font-size: 14px;
           color: $neutral-700;
         }
+
+        .manage-options {
+          display: flex;
+          gap: 4;
+          align-items: center;
+          justify-content: flex-start;
+        }
       }
     }
 

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -223,7 +223,9 @@ const QuestDetails = ({ id }: { id: number }) => {
           label: 'Confirm',
           buttonType: 'destructive',
           buttonHeight: 'sm',
-          onClick: () => handleAsync().catch(console.error),
+          onClick: () => {
+            handleAsync().catch(console.error);
+          },
         },
       ],
     });

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -2,6 +2,7 @@ import {
   QuestActionMeta,
   QuestParticipationLimit,
 } from '@hicommonwealth/schemas';
+import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { questParticipationPeriodToCopyMap } from 'helpers/quest';
 import { useFlag } from 'hooks/useFlag';
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
@@ -9,6 +10,10 @@ import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
 import { useGetQuestByIdQuery } from 'state/api/quest';
+import {
+  useCancelQuestMutation,
+  useDeleteQuestMutation,
+} from 'state/api/quests';
 import { useGetRandomResourceIds, useGetXPs } from 'state/api/user';
 import { useAuthModalStore } from 'state/ui/modals';
 import useUserStore from 'state/ui/user';
@@ -21,6 +26,7 @@ import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayou
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
 import { withTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { AuthModalType } from 'views/modals/AuthModal';
+import { openConfirmation } from 'views/modals/confirmation_modal';
 import { z } from 'zod';
 import { PageNotFound } from '../404';
 import { QuestAction } from '../CreateQuest/QuestForm/QuestActionSubForm';
@@ -54,6 +60,13 @@ const QuestDetails = ({ id }: { id: number }) => {
   const randomResourceId = randomResourceIds?.results?.[0];
 
   const { setAuthModalType } = useAuthModalStore();
+
+  const { mutateAsync: deleteQuest, isLoading: isDeletingQuest } =
+    useDeleteQuestMutation();
+  const { mutateAsync: cancelQuest, isLoading: isCancelingQuest } =
+    useCancelQuestMutation();
+
+  const isPendingAction = isDeletingQuest || isCancelingQuest;
 
   useRunOnceOnCondition({
     callback: () => {
@@ -165,8 +178,60 @@ const QuestDetails = ({ id }: { id: number }) => {
         return;
     }
   };
+
+  const handleQuestAbort = () => {
+    const handleAsync = async () => {
+      try {
+        if (isDeletionAllowed) {
+          await deleteQuest({ quest_id: quest.id });
+        } else {
+          await cancelQuest({ quest_id: quest.id });
+        }
+
+        notifySuccess(`Quest ${isDeletionAllowed ? 'deleted' : 'canceled'}!`);
+        navigate('/explore', {}, null);
+      } catch (e) {
+        console.log(e);
+        notifyError(
+          `Failed to ${isDeletionAllowed ? 'delete' : 'cancel'} quest`,
+        );
+      }
+    };
+
+    openConfirmation({
+      title: `Confirm Quest ${isDeletionAllowed ? 'Deletion' : 'Cancelation'}!`,
+      // eslint-disable-next-line max-len
+      description: (
+        <>
+          Are you sure you want to {isDeletionAllowed ? 'delete' : 'cancel'}{' '}
+          this quest. <br />
+          <br />
+          {isDeletionAllowed
+            ? 'Deletion would remove this quest and its sub-tasks entirely for every user.'
+            : // eslint-disable-next-line max-len
+              `With cancelation, users who earned XP for this quest will retain that XP. However new submissions to this quest won't be allowed and won't reward any XP to users.`}
+        </>
+      ),
+      buttons: [
+        {
+          label: 'Cancel',
+          buttonType: 'secondary',
+          buttonHeight: 'sm',
+          onClick: () => {},
+        },
+        {
+          label: 'Confirm',
+          buttonType: 'destructive',
+          buttonHeight: 'sm',
+          onClick: () => handleAsync().catch(console.error),
+        },
+      ],
+    });
+  };
+
   const isStarted = moment().isSameOrAfter(moment(quest.start_date));
   const isEnded = moment().isSameOrAfter(moment(quest.end_date));
+  const isDeletionAllowed = !isStarted || isEnded;
 
   const isRepeatableQuest =
     quest.action_metas?.[0]?.participation_limit ===
@@ -241,18 +306,35 @@ const QuestDetails = ({ id }: { id: number }) => {
               {isSiteAdmin && (
                 <>
                   <CWDivider />
-                  <div className="w-fit">
-                    {withTooltip(
-                      <CWButton
-                        label="Update"
-                        onClick={() => navigate(`/quest/${quest.id}/update`)}
-                        buttonType="primary"
-                        iconLeft="notePencil"
-                        disabled={isStarted || isEnded}
-                      />,
-                      'Updates only allowed in pre-live stage',
-                      isStarted || isEnded,
-                    )}
+                  <div className="manage-options">
+                    <div className="w-fit">
+                      {withTooltip(
+                        <CWButton
+                          label="Update"
+                          onClick={() => navigate(`/quest/${quest.id}/update`)}
+                          buttonType="primary"
+                          iconLeft="notePencil"
+                          disabled={isStarted || isEnded || isPendingAction}
+                        />,
+                        'Updates only allowed in pre-live stage',
+                        isStarted || isEnded,
+                      )}
+                    </div>
+                    <div className="w-fit">
+                      {withTooltip(
+                        <CWButton
+                          label={isDeletionAllowed ? 'Delete' : 'Cancel'}
+                          onClick={handleQuestAbort}
+                          buttonType="destructive"
+                          iconLeft="trash"
+                          disabled={isEnded || isPendingAction}
+                        />,
+                        isEnded
+                          ? 'Deletion not allowed for non-active quests'
+                          : '',
+                        isEnded,
+                      )}
+                    </div>
                   </div>
                 </>
               )}

--- a/packages/commonwealth/server/api/quest.ts
+++ b/packages/commonwealth/server/api/quest.ts
@@ -7,4 +7,5 @@ export const trpcRouter = trpc.router({
   getQuest: trpc.query(Quest.GetQuest, trpc.Tag.Quest),
   updateQuest: trpc.command(Quest.UpdateQuest, trpc.Tag.Quest),
   cancelQuest: trpc.command(Quest.CancelQuest, trpc.Tag.Quest),
+  deleteQuest: trpc.command(Quest.DeleteQuest, trpc.Tag.Quest),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11095

## Description of Changes
Allow site admins to cancel and delete quests

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. As site admin, visit `/createQuest` and create some quests
3. Try to visit details page of any quest and verify you are able to delete it if its in pre-live / live stages.
    1. In pre-live stage: verify you see a `Delete` option, this completely removes the quest from the app
    2. In live stage: verify you see a `Cancel` option, this allows users to retain xp for that quest, and this quest should still be viewable in the weekly quests section
4. Verify you are not able to cancel/delete a non-active quest (quest with end date in the past)

## Deployment Plan
N/A

## Other Considerations
N/A