### PR TITLE
increase the navbar height for mobile user

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/MobileNavigation/MobileNavigation.scss
+++ b/packages/commonwealth/client/scripts/views/components/MobileNavigation/MobileNavigation.scss
@@ -13,7 +13,7 @@
     justify-content: space-around;
     align-items: center;
     padding-inline: min(10px, 1%);
-    margin-top: 8px;
-    margin-bottom: 16px;
+    margin-top: 13px;
+    margin-bottom: 21px;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10640 
## Description of Changes
- Adds FIXME widget to TODO page.
- increase the height of bottom navbar on mobile by 10px 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- increase the height of bottom navbar on mobile by 10
<img width="1512" alt="Screenshot 2025-02-25 at 7 59 46 PM" src="https://github.com/user-attachments/assets/8c962a6f-5b94-4758-8376-eba564481116" />
