### PR TITLE
Replaced `SignupCompleted` quest action with `WalletLinked` and `SSOLinked` quest action

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/string.ts
+++ b/packages/commonwealth/client/scripts/helpers/string.ts
@@ -1,5 +1,5 @@
 /**
- * Sample usage: Input = 'SignUpFlowCompleted', Output = 'Sign Up Flow Completed'
+ * Sample usage: Input = 'CommunityJoined', Output = 'Community Joined'
  * @param str
  * @returns
  */

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -18,13 +18,14 @@ const QuestActionSubForm = ({
   hiddenActions,
 }: QuestActionSubFormProps) => {
   const actionOptions = [
-    'SignUpFlowCompleted',
     'CommunityCreated',
     'CommunityJoined',
     'ThreadCreated',
     'ThreadUpvoted',
     'CommentCreated',
     'CommentUpvoted',
+    'WalletLinked',
+    'SSOLinked',
   ]
     .map((event) => ({
       value: event as QuestAction,

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -14,17 +14,16 @@ import './QuestActionCard.scss';
 // TODO: fix types with schemas.Events keys
 const actionCopies = {
   title: {
-    ['SignUpFlowCompleted']: 'Signup on Common',
     ['CommunityCreated']: 'Create a community',
     ['CommunityJoined']: 'Join a community',
     ['ThreadCreated']: 'Create a thread',
     ['ThreadUpvoted']: 'Upvote a thread',
     ['CommentCreated']: 'Create a comment',
     ['CommentUpvoted']: 'Upvote a comment',
-    ['UserMentioned']: 'Mention a user',
+    ['WalletLinked']: 'Link a Web3 wallet with your account',
+    ['SSOLinked']: 'Link an SSO method with your account',
   },
   shares: {
-    ['SignUpFlowCompleted']: '',
     ['CommunityCreated']: 'referrer',
     ['CommunityJoined']: 'referrer',
     ['ThreadCreated']: '',

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -130,8 +130,12 @@ const QuestDetails = ({ id }: { id: number }) => {
     actionContentId?: string,
   ) => {
     switch (actionName) {
-      case 'SignUpFlowCompleted': {
-        !user?.isLoggedIn && setAuthModalType(AuthModalType.CreateAccount);
+      case 'WalletLinked': {
+        setAuthModalType(AuthModalType.CreateAccount);
+        break;
+      }
+      case 'SSOLinked': {
+        setAuthModalType(AuthModalType.CreateAccount);
         break;
       }
       case 'CommunityCreated': {
@@ -385,12 +389,6 @@ const QuestDetails = ({ id }: { id: number }) => {
                   isActionCompleted={
                     !!xpProgressions.find((p) => p.action_meta_id === action.id)
                   }
-                  {...(user?.isLoggedIn &&
-                    action.event_name === 'SignUpFlowCompleted' && {
-                      isActionInEligible: true,
-                      inEligibilityReason:
-                        'You are already signed up with Common',
-                    })}
                   canStartAction={isStarted && !isEnded}
                   {...((!isStarted || isEnded) && {
                     actionStartBlockedReason: !isStarted


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11113

## Description of Changes
Replaced SignupCompleted quest action with WalletLinked and SSOLinked quest action

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Create a new quest with `WalletLinked` and `SSOLinked` actions
3. Start the quest
4. Ensure you gain xp after you complete those actions

## Deployment Plan
N/A

## Other Considerations
N/A