### PR TITLE
Add Community Home "About Section" to Community Home

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/AuthButton/AuthButton.scss
@@ -102,3 +102,8 @@
     }
   }
 }
+
+.AuthButton.autoWidth {
+  width: auto !important;
+  padding: 4px 12px 4px 12px !important;
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/CommunityHomePage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/CommunityHomePage.tsx
@@ -1,4 +1,5 @@
 import app from 'client/scripts/state';
+import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
 import { useFetchGlobalActivityQuery } from 'client/scripts/state/api/feeds/fetchUserActivity';
 import { findDenominationString } from 'helpers/findDenomination';
 import { useFlag } from 'hooks/useFlag';
@@ -23,6 +24,12 @@ const CommunityHome = () => {
   const xpEnabled = useFlag('xp');
   const chain = app.chain.meta.id;
 
+  const communityId = app.activeChainId() || '';
+  const { data: community } = useGetCommunityByIdQuery({
+    id: communityId,
+    enabled: !!communityId,
+  });
+
   const {
     setModeOfManageCommunityStakeModal,
     modeOfManageCommunityStakeModal,
@@ -46,9 +53,9 @@ const CommunityHome = () => {
               Community Home
             </CWText>
             <TokenDetails
-              communityId={chain}
+              communityDescription={community?.description || ''}
               communityMemberCount={app.chain.meta.profile_count || 0}
-              communityThreadCount={app.chain.meta.numVotingThreads || 0}
+              communityThreadCount={community?.lifetime_thread_count || 0}
             />
           </div>
         </div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.scss
@@ -1,0 +1,6 @@
+.SocialLinks {
+  margin: 5px;
+  display: flex;
+  justify-content: start;
+  gap: 8px;
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.tsx
@@ -1,0 +1,52 @@
+import { categorizeSocialLinks } from 'client/scripts/helpers/link';
+import app from 'client/scripts/state';
+import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
+import AuthButton from 'client/scripts/views/components/AuthButton';
+import React from 'react';
+import './SocialLinks.scss';
+
+const SocialLinks = () => {
+  const { data: community, isLoading } = useGetCommunityByIdQuery({
+    id: app.activeChainId() || '',
+    enabled: !!app.activeChainId(),
+  });
+
+  if (!app.chain || !community) return;
+
+  const { discords, githubs, twitters } = categorizeSocialLinks(
+    (community.social_links || [])
+      .filter((link) => link)
+      .map((link) => link || ''),
+  );
+
+  return (
+    <div className="SocialLinks">
+      {discords.map((link) => (
+        <AuthButton
+          className="autoWidth"
+          key={link}
+          type="discord"
+          onClick={() => window.open(link)}
+        />
+      ))}
+      {twitters.map((link) => (
+        <AuthButton
+          className="autoWidth"
+          key={link}
+          type="x"
+          onClick={() => window.open(link)}
+        />
+      ))}
+      {githubs.map((link) => (
+        <AuthButton
+          className="autoWidth"
+          key={link}
+          type="github"
+          onClick={() => window.open(link)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SocialLinks;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/SocialLinks/SocialLinks.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import './SocialLinks.scss';
 
 const SocialLinks = () => {
-  const { data: community, isLoading } = useGetCommunityByIdQuery({
+  const { data: community } = useGetCommunityByIdQuery({
     id: app.activeChainId() || '',
     enabled: !!app.activeChainId(),
   });

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.tsx
@@ -1,55 +1,53 @@
 import { TokenView } from '@hicommonwealth/schemas';
 import { formatAddressShort } from 'client/scripts/helpers';
 import { calculateTokenPricing } from 'client/scripts/helpers/launchpad';
-import { useFlag } from 'client/scripts/hooks/useFlag';
+import app from 'client/scripts/state';
+import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
 import { useFetchTokenUsdRateQuery } from 'client/scripts/state/api/communityStake';
-import { useFetchTokensQuery } from 'client/scripts/state/api/tokens';
 import { saveToClipboard } from 'client/scripts/utils/clipboard';
 import PricePercentageChange from 'client/scripts/views/components/TokenCard/PricePercentageChange';
 import { CWIconButton } from 'client/scripts/views/components/component_kit/cw_icon_button';
 import { CWIcon } from 'client/scripts/views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
 import { CWTooltip } from 'client/scripts/views/components/component_kit/new_designs/CWTooltip';
+import { useTokenTradeWidget } from 'client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/useTokenTradeWidget';
+import { LaunchpadToken } from 'client/scripts/views/modals/TradeTokenModel/CommonTradeModal/types';
+import { ExternalToken } from 'client/scripts/views/modals/TradeTokenModel/UniswapTradeModal/types';
 import React from 'react';
 import { z } from 'zod';
+import SocialLinks from './SocialLinks/SocialLinks';
 import './TokenDetails.scss';
 
 interface TokenDetailsProbs {
-  communityId: string;
   communityMemberCount: number;
   communityThreadCount: number;
+  communityDescription: string;
 }
 
 const TokenDetails = ({
-  communityId,
   communityMemberCount,
   communityThreadCount,
+  communityDescription,
 }: TokenDetailsProbs) => {
-  const launchpadEnabled = useFlag('launchpad');
-
-  const { data: tokensList } = useFetchTokensQuery({
-    cursor: 1,
-    limit: 8,
-    with_stats: true,
-    enabled: launchpadEnabled,
+  const { data: community, isLoading } = useGetCommunityByIdQuery({
+    id: app.activeChainId() || '',
+    enabled: !!app.activeChainId(),
   });
 
-  const tokens = (tokensList?.pages || []).flatMap((page) => page.results);
-  const communityToken = tokens.find(
-    (token) => token.community_id === communityId,
-  );
+  if (!app.chain || !community) return;
 
-  const { data: ethToCurrencyRateData, isLoading: isLoadingETHToCurrencyRate } =
-    useFetchTokenUsdRateQuery({
-      tokenSymbol: 'ETH',
-    });
+  const { communityToken, isLoadingToken, isPinnedToken } =
+    useTokenTradeWidget();
+
+  const { data: ethToCurrencyRateData } = useFetchTokenUsdRateQuery({
+    tokenSymbol: 'ETH',
+  });
 
   const ethToUsdRate = parseFloat(
     ethToCurrencyRateData?.data?.data?.amount || '0',
   );
 
-  if (!communityToken || !communityToken.icon_url || isLoadingETHToCurrencyRate)
-    return <></>;
+  if (isLoadingToken) return;
 
   const tokenPricing = communityToken
     ? calculateTokenPricing(
@@ -58,30 +56,53 @@ const TokenDetails = ({
       )
     : null;
 
+  const address = communityToken
+    ? isPinnedToken
+      ? (communityToken as ExternalToken).contract_address
+      : (communityToken as LaunchpadToken).token_address
+    : undefined;
+
+  const tokenIcon = communityToken
+    ? isPinnedToken
+      ? (communityToken as ExternalToken).logo
+      : (communityToken as LaunchpadToken).icon_url
+    : undefined;
+
+  const marketCap = communityToken
+    ? isPinnedToken
+      ? 'N/A'
+      : (communityToken as LaunchpadToken).eth_market_cap_target
+    : undefined;
+
   return (
     <div className="token-details">
       <div className="token-info">
-        <div className="token-header">
-          <img
-            src={communityToken.icon_url}
-            alt={communityToken.name}
-            className="token-icon"
-          />
-          <div>
-            <CWText type="h4" fontWeight="semiBold">
-              {communityToken.name}
-            </CWText>
-            <CWText type="b1" className="faded">
-              {communityToken.symbol}
-            </CWText>
+        {communityToken ? (
+          <div className="token-header">
+            <img
+              src={tokenIcon!}
+              alt={communityToken.name}
+              className="token-icon"
+            />
+            <div>
+              <CWText type="h4" fontWeight="semiBold">
+                {communityToken.name}
+              </CWText>
+              <CWText type="b1" className="faded">
+                {communityToken.symbol}
+              </CWText>
+            </div>
           </div>
-        </div>
+        ) : (
+          <></>
+        )}
         <div className="token-description">
           <CWText type="h4" fontWeight="semiBold">
             About
           </CWText>
-          <CWText type="b1">{communityToken.description}</CWText>
+          <CWText type="b1">{communityDescription}</CWText>
         </div>
+        <SocialLinks />
       </div>
 
       <div className="token-stats">
@@ -90,14 +111,21 @@ const TokenDetails = ({
             24h Change
           </CWText>
           <div>
-            {tokenPricing && (
-              <PricePercentageChange
-                pricePercentage24HourChange={
-                  tokenPricing.pricePercentage24HourChange
-                }
-                alignment="left"
-                className="pad-8"
-              />
+            {communityToken ? (
+              <>
+                {' '}
+                {tokenPricing && (
+                  <PricePercentageChange
+                    pricePercentage24HourChange={
+                      tokenPricing.pricePercentage24HourChange
+                    }
+                    alignment="left"
+                    className="pad-8"
+                  />
+                )}
+              </>
+            ) : (
+              <CWText>N/A</CWText>
             )}
           </div>
         </div>
@@ -106,37 +134,41 @@ const TokenDetails = ({
             Address
           </CWText>
           <CWText>
-            {formatAddressShort(communityToken.token_address)}
-            <CWTooltip
-              placement="top"
-              content="address copied!"
-              renderTrigger={(handleInteraction, isTooltipOpen) => {
-                return (
-                  <CWIconButton
-                    iconName="copySimple"
-                    onClick={(event) => {
-                      saveToClipboard(communityToken.token_address).catch(
-                        console.error,
-                      );
-                      handleInteraction(event);
-                    }}
-                    onMouseLeave={(e) => {
-                      if (isTooltipOpen) {
-                        handleInteraction(e);
-                      }
-                    }}
-                    className="copy-icon"
-                  />
-                );
-              }}
-            />
+            {communityToken && address ? (
+              <>
+                {formatAddressShort(address)}
+                <CWTooltip
+                  placement="top"
+                  content="address copied!"
+                  renderTrigger={(handleInteraction, isTooltipOpen) => {
+                    return (
+                      <CWIconButton
+                        iconName="copySimple"
+                        onClick={(event) => {
+                          saveToClipboard(address).catch(console.error);
+                          handleInteraction(event);
+                        }}
+                        onMouseLeave={(e) => {
+                          if (isTooltipOpen) {
+                            handleInteraction(e);
+                          }
+                        }}
+                        className="copy-icon"
+                      />
+                    );
+                  }}
+                />
+              </>
+            ) : (
+              <CWText>N/A</CWText>
+            )}
           </CWText>
         </div>
         <div className="stat-item">
           <CWText type="b1" className="faded">
             Market Cap
           </CWText>
-          <CWText>{communityToken.eth_market_cap_target}</CWText>
+          {communityToken ? <CWText>{marketCap}</CWText> : <CWText>N/A</CWText>}
         </div>
         <div className="token-footer">
           <CWText type="b1" className="faded">

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.tsx
@@ -1,8 +1,6 @@
 import { TokenView } from '@hicommonwealth/schemas';
 import { formatAddressShort } from 'client/scripts/helpers';
 import { calculateTokenPricing } from 'client/scripts/helpers/launchpad';
-import app from 'client/scripts/state';
-import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
 import { useFetchTokenUsdRateQuery } from 'client/scripts/state/api/communityStake';
 import { saveToClipboard } from 'client/scripts/utils/clipboard';
 import PricePercentageChange from 'client/scripts/views/components/TokenCard/PricePercentageChange';
@@ -10,10 +8,10 @@ import { CWIconButton } from 'client/scripts/views/components/component_kit/cw_i
 import { CWIcon } from 'client/scripts/views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
 import { CWTooltip } from 'client/scripts/views/components/component_kit/new_designs/CWTooltip';
-import { useTokenTradeWidget } from 'client/scripts/views/components/sidebar/CommunitySection/TokenTradeWidget/useTokenTradeWidget';
 import { LaunchpadToken } from 'client/scripts/views/modals/TradeTokenModel/CommonTradeModal/types';
 import { ExternalToken } from 'client/scripts/views/modals/TradeTokenModel/UniswapTradeModal/types';
 import React from 'react';
+import { useTokenTradeWidget } from 'views/components/sidebar/CommunitySection/TokenTradeWidget/useTokenTradeWidget';
 import { z } from 'zod';
 import SocialLinks from './SocialLinks/SocialLinks';
 import './TokenDetails.scss';
@@ -29,13 +27,6 @@ const TokenDetails = ({
   communityThreadCount,
   communityDescription,
 }: TokenDetailsProbs) => {
-  const { data: community, isLoading } = useGetCommunityByIdQuery({
-    id: app.activeChainId() || '',
-    enabled: !!app.activeChainId(),
-  });
-
-  if (!app.chain || !community) return;
-
   const { communityToken, isLoadingToken, isPinnedToken } =
     useTokenTradeWidget();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11128

## Description of Changes
- Show Community Description in about section insted of Token Description.
- Display Token Details with both launchpad and external token.

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Navigate to community home page.
- In the community where launchpad token is attached it should display complete token details.
- In communities where external token is attached it displays token details except market cap.
- In communities where no token is attached it display the about section and member & thread count & all the token details are N/A.

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 