### PR TITLE
Fixes an issue where Virtuoso was not initializing correctly

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -27,6 +27,7 @@ import AccountConnectionIndicator from '../AccountConnectionIndicator';
 import { AdminSection } from '../AdminSection';
 import CreateCommunityButton from '../CreateCommunityButton';
 import DirectoryMenuItem from '../DirectoryMenuItem';
+import SidebarSignInButton from '../SidebarSignInButton/SidebarSignInButton';
 import { DiscussionSection } from '../discussion_section';
 import { ExternalLinksModule } from '../external_links_module';
 import { GovernanceSection } from '../governance_section';
@@ -134,6 +135,9 @@ export const CommunitySection = ({
   return (
     <>
       <div className="community-menu">
+        {!user.isLoggedIn && isInsideCommunity && (
+          <SidebarSignInButton isInsideCommunity />
+        )}
         {user.isLoggedIn && <ProfileCard />}
         {user.isLoggedIn && (
           <>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.scss
@@ -1,0 +1,22 @@
+@import '../../../../styles/shared';
+
+.SidebarSignInButton {
+  display: flex;
+  width: $sidebar-width;
+  margin-top: 60px;
+  flex-direction: column;
+  padding: 10px;
+  align-items: center;
+  height: 114px;
+  border-bottom: 1px solid $neutral-200;
+
+  &.isInsideCommunity {
+    width: auto;
+  }
+  @include isWindowSmallToMediumInclusive {
+    width: 100vw;
+    &.isInsideCommunity {
+      width: auto;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { useAuthModalStore } from 'client/scripts/state/ui/modals';
+import { AuthModalType } from 'client/scripts/views/modals/AuthModal';
+import clsx from 'clsx';
+import { CWText } from '../../component_kit/cw_text';
+import { CWButton } from '../../component_kit/new_designs/CWButton';
+import './SidebarSignInButton.scss';
+
+interface SidebarSignInButtonProps {
+  isInsideCommunity: boolean;
+}
+const SidebarSignInButton = ({
+  isInsideCommunity,
+}: SidebarSignInButtonProps) => {
+  const { setAuthModalType } = useAuthModalStore();
+  return (
+    <div
+      className={clsx(
+        'SidebarSignInButton',
+        isInsideCommunity ? 'isInsideCommunity' : '',
+      )}
+    >
+      <CWText type="b2">Sign in to see your communities on Common.</CWText>
+      <CWButton
+        buttonType="primary"
+        label="Sign in"
+        buttonWidth="full"
+        buttonHeight="sm"
+        onClick={() => setAuthModalType(AuthModalType.SignIn)}
+      />
+    </div>
+  );
+};
+
+export default SidebarSignInButton;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/index.tsx
@@ -10,6 +10,7 @@ import { CommunitySection } from './CommunitySection';
 
 import useSidebarSwipe from 'client/scripts/hooks/useSidebarSwipe';
 import { SidebarProfileSection } from './SidebarProfileSection';
+import SidebarSignInButton from './SidebarSignInButton/SidebarSignInButton';
 import { ExploreCommunitiesSidebar } from './explore_sidebar';
 import './index.scss';
 import { SidebarQuickSwitcher } from './sidebar_quick_switcher';
@@ -58,14 +59,12 @@ export const Sidebar = ({
           />
         </div>
       ) : (
-        user.isLoggedIn && (
-          <div className="sidebar-header-wrapper">
-            <SidebarHeader
-              isInsideCommunity={isInsideCommunity}
-              onMobile={onMobile}
-            />
-          </div>
-        )
+        <div className="sidebar-header-wrapper">
+          <SidebarHeader
+            isInsideCommunity={isInsideCommunity}
+            onMobile={onMobile}
+          />
+        </div>
       )}
       <div className="sidebar-default-menu">
         <KnockFeedWrapper>
@@ -86,6 +85,10 @@ export const Sidebar = ({
               isInsideCommunity={isInsideCommunity}
             />
           )
+        )}
+
+        {!user.isLoggedIn && !isInsideCommunity && (
+          <SidebarSignInButton isInsideCommunity={isInsideCommunity} />
         )}
         {menuName === 'createContent' && (
           <CreateContentSidebar isInsideCommunity={isInsideCommunity} />

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/index.tsx
@@ -41,11 +41,15 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
   const user = useUserStore();
   const { isWindowExtraSmall } = useBrowserWindow({});
   const location = useLocation();
-
+  const [containerReady, setContainerReady] = React.useState(false);
   const [activePage, setActivePage] = React.useState<DashboardViews>(
     DashboardViews.Global,
   );
-
+  useEffect(() => {
+    if (containerRef.current) {
+      setContainerReady(true);
+    }
+  }, []);
   const { isAddedToHomeScreen } = useAppStatus();
 
   const launchpadEnabled = useFlag('launchpad');
@@ -130,7 +134,7 @@ const UserDashboard = ({ type }: UserDashboardProps) => {
                 />
               </CWTabsRow>
             </div>
-            {activePage === DashboardViews.Global ? (
+            {containerReady && activePage === DashboardViews.Global ? (
               <Feed
                 query={useFetchGlobalActivityQuery}
                 // @ts-expect-error <StrictNullChecks/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10854 

## Description of Changes
- Adds FIXME widget to TODO page.
- Fixes an issue where Virtuoso was not initializing correctly due to customScrollParent being null on initial render.
- Ensures customScrollParent is properly set before Feed is rendered, preventing unnecessary re-renders.
- Improves stability & prevents layout shift issues that previously required forcing a re-render.
- added the signbtn in sidebar when user is not signIn

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
- Introduced containerReady state to ensure the component waits until containerRef is assigned before rendering Feed.
- Used useEffect to update containerReady once containerRef.current is available.
- Conditionally rendered Feed only when containerReady is true.

## Test Plan
goto commonWealth home page for-you and global  unauthenticated or authenticated


https://github.com/user-attachments/assets/ec87daa1-6a95-4053-8258-97d306de0877

<img width="415" alt="image" src="https://github.com/user-attachments/assets/e6056b0b-cf2d-425e-8454-4f6c4075de12" />
