### PR TITLE
Referrals UI fixes

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.scss
@@ -6,6 +6,11 @@
     flex-direction: column;
     gap: 16px;
 
+    .b2 {
+      color: $neutral-400;
+      margin-top: -12px;
+    }
+
     .invite-link-input {
       padding-right: 32px !important;
       text-overflow: ellipsis;

--- a/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InviteLinkModal/InviteLinkModal.tsx
@@ -56,9 +56,7 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
   return (
     <div className="InviteLinkModal">
       <CWModalHeader
-        label={
-          communityId ? 'Community invite link' : 'Commonwealth invite link'
-        }
+        label={communityId ? 'Community invite link' : 'Common invite link'}
         onModalClose={onModalClose}
       />
       <CWModalBody>
@@ -66,8 +64,11 @@ const InviteLinkModal = ({ onModalClose }: InviteLinkModalProps) => {
           <CWText>
             {communityId
               ? 'Get more voting power in your communities when people join with your referral link.'
-              : `When you refer your friends to Common, you'll get a portion of any fees they pay to 
-              Common over their lifetime engaging with web 3 native forums.`}
+              : `When you refer your friends to Common, you'll get XP and a portion of any unchain 
+               fees from trades, swaps, and transactions they make on Common.`}
+          </CWText>
+          <CWText type="b2">
+            Fees are Base only for now, more networks coming soon!
           </CWText>
           <>
             <CWSelectList

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.scss
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.scss
@@ -25,57 +25,74 @@
       max-width: 266px;
     }
   }
-  .address_container {
-    width: 100%;
-    margin: auto;
-    display: flex;
-    background: #f7f7f7;
-    height: 60px;
-    max-height: 70px;
-    padding: 2px;
-    border-radius: 5px;
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: row;
-    .Text {
-      max-width: 80%;
-      overflow: hidden;
+
+  .invite-link-input {
+    padding-right: 32px !important;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  input,
+  svg {
+    cursor: pointer !important;
+  }
+
+  input:read-only {
+    background-color: $neutral-50;
+    border-color: $neutral-200;
+    color: $neutral-400;
+
+    &:hover {
+      border-color: $neutral-200;
+    }
+
+    &:focus-within {
+      border-color: $neutral-200 !important;
+      box-shadow: none !important;
     }
   }
-  .share_container {
+
+  .share-section {
     width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-    .share_content {
-      gap: 1rem;
+
+    .Text.bold {
+      margin-block: 16px;
+    }
+
+    .share-options {
       display: flex;
-      flex-direction: column;
-      align-items: center;
-      .icon_container {
-        cursor: pointer;
-        border-radius: 100%;
-        padding: 1rem;
+      justify-content: space-evenly;
+      overflow-y: auto;
+
+      .share-option {
         display: flex;
+        flex-direction: column;
         align-items: center;
-        justify-content: center;
-        width: 55px;
-        height: 55px;
-        .Icon.large {
-          color: white;
+        gap: 8px;
+        cursor: pointer;
+        padding: 12px;
+        transition: background-color 0.2s;
+
+        .icon {
+          width: 48px;
+          height: 48px;
+        }
+
+        .Text.caption {
+          color: $neutral-400;
+          white-space: nowrap;
+          justify-content: center;
+        }
+
+        &:hover {
+          background-color: $neutral-50;
+          transition: background-color 0.2s;
         }
       }
-      .label {
-        font-size: 14px;
-        font-weight: 500;
-        line-height: 24px;
-        color: #000000;
-      }
     }
   }
+
   .buttons_container {
     margin-top: 20px;
     display: flex;

--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.tsx
@@ -1,24 +1,28 @@
 import referralImage from 'assets/img/referral-background-mobile.png';
+import messagesImg from 'assets/img/share/messages.png';
+import telegramImg from 'assets/img/share/telegram.png';
+import twitterImg from 'assets/img/share/x.png';
 import useUserStore from 'client/scripts/state/ui/user';
 import { saveToClipboard } from 'client/scripts/utils/clipboard';
 import { CWIcon } from 'client/scripts/views/components/component_kit/cw_icons/cw_icon';
-import { IconName } from 'client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup';
 import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
 import { CWButton } from 'client/scripts/views/components/component_kit/new_designs/CWButton';
+import { CWTextInput } from 'client/scripts/views/components/component_kit/new_designs/CWTextInput';
 import React from 'react';
+
 import './InviteModal.scss';
+
 type InviteModalProps = {
   onComplete: () => void;
 };
+
 type ReferralShare = {
   id: number;
   title: string;
-  icon: IconName;
-  iconStyle: {
-    backgroundColor: string;
-  };
+  imgSrc: string;
   onClick: () => void;
 };
+
 const InviteModal = ({ onComplete }: InviteModalProps) => {
   const user = useUserStore();
   const currentUrl = window.location.origin;
@@ -35,19 +39,20 @@ const InviteModal = ({ onComplete }: InviteModalProps) => {
     return `${message} \n${link}`;
   };
 
-  const handleDiscordShare = () => {
-    window.open(`https://discord.com/channels/@me`, '_blank');
-    navigator.clipboard
-      .writeText(`Check this out: ${generatePermalink(inviteLink)}`)
-      .catch(console.error);
-  };
-
-  const referrals_Share: ReferralShare[] = [
+  const referralsShare: ReferralShare[] = [
     {
       id: 1,
-      title: 'Share On X',
-      icon: 'xTwitter',
-      iconStyle: { backgroundColor: '#000000' },
+      title: 'Messages',
+      imgSrc: messagesImg,
+      onClick: () =>
+        window.open(
+          `sms:?&body=${encodeURIComponent(generatePermalink(inviteLink))}`,
+        ),
+    },
+    {
+      id: 2,
+      title: 'X',
+      imgSrc: twitterImg,
       onClick: () =>
         window.open(
           `https://twitter.com/intent/tweet?url=${encodeURIComponent(
@@ -56,18 +61,15 @@ const InviteModal = ({ onComplete }: InviteModalProps) => {
         ),
     },
     {
-      id: 2,
-      title: 'Share On Discord',
-      icon: 'discordLogo',
-      iconStyle: { backgroundColor: '#9555AC' },
-      onClick: handleDiscordShare,
-    },
-    {
       id: 3,
-      title: 'Copy Link',
-      icon: 'linkPhosphor',
-      iconStyle: { backgroundColor: '#0079CC' },
-      onClick: handleCopy,
+      title: 'Telegram',
+      imgSrc: telegramImg,
+      onClick: () =>
+        window.open(
+          `https://t.me/share/url?url=${encodeURIComponent(
+            generatePermalink(inviteLink),
+          )}`,
+        ),
     },
   ];
 
@@ -78,28 +80,39 @@ const InviteModal = ({ onComplete }: InviteModalProps) => {
       <CWText type="h2" className="title" isCentered>
         Get a referral bonus for inviting friends to common!{' '}
       </CWText>
-      <div className="share_container">
-        {referrals_Share.map((referral: ReferralShare, index: number) => {
-          return (
-            <div
-              className="share_content"
-              key={index.toString()}
-              onClick={referral.onClick}
-            >
-              <div className="icon_container" style={referral.iconStyle}>
-                <CWIcon iconSize="large" iconName={referral?.icon} />
+
+      <div className="share-section">
+        <CWText fontWeight="bold">Share to</CWText>
+        <div className="share-options">
+          {referralsShare.map((referral: ReferralShare, index: number) => {
+            return (
+              <div
+                className="share-option"
+                key={index.toString()}
+                onClick={referral.onClick}
+              >
+                <img
+                  src={referral.imgSrc}
+                  alt={referral.title}
+                  className="icon"
+                />
+                <CWText type="caption">{referral.title}</CWText>
               </div>
-              <CWText type="h5" className="label">
-                {referral.title}
-              </CWText>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
-      <div className="address_container">
-        <CWText className="label">{inviteLink}</CWText>
-        <CWIcon iconSize="large" iconName="linkPhosphor" />
-      </div>
+
+      <CWTextInput
+        inputClassName="invite-link-input"
+        fullWidth
+        type="text"
+        value={inviteLink}
+        readOnly
+        onClick={handleCopy}
+        iconRight={<CWIcon iconName="copy" />}
+      />
+
       <div className="buttons_container">
         <CWButton
           label="Skip"

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsCard/RewardsCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsCard/RewardsCard.scss
@@ -17,6 +17,12 @@
       margin-left: auto;
       color: $primary-500;
       white-space: nowrap;
+
+      &.disabled {
+        cursor: default;
+        color: $neutral-400;
+        opacity: 0.7;
+      }
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsCard/RewardsCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsCard/RewardsCard.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React from 'react';
 
 import { CWCard } from 'views/components/component_kit/cw_card';
@@ -12,6 +13,7 @@ interface RewardsCardProps {
   description?: string;
   icon: IconName;
   onSeeAllClick?: () => void;
+  isAlreadySelected?: boolean;
   children?: React.ReactNode;
 }
 
@@ -20,6 +22,7 @@ const RewardsCard = ({
   description,
   icon,
   onSeeAllClick,
+  isAlreadySelected = false,
   children,
 }: RewardsCardProps) => {
   return (
@@ -30,7 +33,11 @@ const RewardsCard = ({
           {title}
         </CWText>
         {onSeeAllClick && (
-          <CWText className="see-all-text" onClick={onSeeAllClick} type="b2">
+          <CWText
+            className={clsx('see-all-text', { disabled: isAlreadySelected })}
+            onClick={isAlreadySelected ? undefined : onSeeAllClick}
+            type="b2"
+          >
             See all
           </CWText>
         )}

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
@@ -99,6 +99,7 @@ const RewardsPage = () => {
               trendValue={trendValue}
               totalEarnings={totalEarnings}
               isLoading={isReferralsLoading}
+              isReferralsTabSelected={tableTab === TableType.Referrals}
             />
           )}
           {(!isWindowSmallInclusive ||

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/ReferralCard/ReferralCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/ReferralCard/ReferralCard.tsx
@@ -22,6 +22,7 @@ interface ReferralCardProps {
   trendValue: number;
   totalEarnings: number;
   isLoading?: boolean;
+  isReferralsTabSelected?: boolean;
 }
 
 const ReferralCard = ({
@@ -29,6 +30,7 @@ const ReferralCard = ({
   trendValue,
   totalEarnings,
   isLoading = false,
+  isReferralsTabSelected = false,
 }: ReferralCardProps) => {
   const [currentTab, setCurrentTab] = useState<ReferralTabs>(
     ReferralTabs.Total,
@@ -41,6 +43,7 @@ const ReferralCard = ({
       description="Track your referral rewards"
       icon="userSwitch"
       onSeeAllClick={onSeeAllClick}
+      isAlreadySelected={isReferralsTabSelected}
     >
       <div className="ReferralCard">
         <CWTabsRow>

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.scss
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.scss
@@ -1,45 +1,92 @@
 @import '../../../../../styles/shared';
 
 .ReferralTable {
-  table {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .table-wrapper {
     width: 100%;
-    @include table-cell;
+    overflow-x: auto;
   }
 
   .loading-state {
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 200px;
+    height: 200px;
   }
 
   .empty-state {
     display: flex;
     flex-direction: column;
+    justify-content: center;
     align-items: center;
+    height: 200px;
     gap: 8px;
-    padding: 24px;
+
+    .empty-state-text {
+      color: $neutral-400;
+    }
   }
 
   .table-cell {
     display: flex;
     align-items: center;
     gap: 8px;
+    padding: 8px 0;
+    width: 100%;
 
     &.text-right {
       justify-content: flex-end;
     }
+  }
 
-    .user-info {
+  .user-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .community-cell {
+    .community-info {
       display: flex;
       align-items: center;
       gap: 8px;
       text-decoration: none;
       color: inherit;
 
+      .community-icon {
+        width: 24px;
+        height: 24px;
+        border-radius: 4px;
+        object-fit: cover;
+      }
+
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    .no-community {
+      color: $neutral-400;
+      font-style: italic;
+    }
+  }
+
+  .namespace-cell {
+    .no-namespace {
+      color: $neutral-400;
+      font-style: italic;
     }
   }
 }

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/ReferralTable.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { fromWei } from 'web3-utils';
 
+import { formatAddressShort } from 'helpers';
 import { APIOrderDirection } from 'helpers/constants';
 import { Avatar } from 'views/components/Avatar';
+import { CWCommunityAvatar } from 'views/components/component_kit/cw_community_avatar';
 import { CWText } from 'views/components/component_kit/cw_text';
 import CWCircleMultiplySpinner from 'views/components/component_kit/new_designs/CWCircleMultiplySpinner';
 import { CWTable } from 'views/components/component_kit/new_designs/CWTable';
 import { useCWTableState } from 'views/components/component_kit/new_designs/CWTable/useCWTableState';
+import { withTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { Referral } from '../../types';
 import { columns } from './columns';
 
@@ -33,53 +36,103 @@ export const ReferralTable = ({ referrals, isLoading }: ReferralTableProps) => {
             <CWCircleMultiplySpinner />
           </div>
         ) : referrals && referrals.length > 0 ? (
-          <CWTable
-            columnInfo={tableState.columns}
-            sortingState={tableState.sorting}
-            setSortingState={tableState.setSorting}
-            rowData={referrals.map((item, index) => ({
-              ...item,
-              rank: {
-                sortValue: index + 1,
-                customElement: <div className="table-cell">{index + 1}</div>,
-              },
-              username: {
-                sortValue: item.referee_profile?.name?.toLowerCase(),
-                customElement: (
-                  <div className="table-cell">
-                    <Link
-                      to={`/profile/id/${item.referee_user_id}`}
-                      className="user-info"
-                    >
-                      <Avatar
-                        url={item.referee_profile?.avatar_url ?? ''}
-                        size={24}
-                        address={+item.referee_address}
-                      />
-                      <p>{item.referee_profile?.name}</p>
-                    </Link>
-                  </div>
-                ),
-              },
-              address: {
-                sortValue: item.referee_address,
-                customElement: (
-                  <div className="table-cell">{item.referee_address}</div>
-                ),
-              },
-              earnings: {
-                sortValue: Number(item.referrer_received_eth_amount),
-                customElement: (
-                  <div className="table-cell text-right">
-                    ETH{' '}
-                    {Number(
-                      fromWei(item.referrer_received_eth_amount, 'ether'),
-                    )}
-                  </div>
-                ),
-              },
-            }))}
-          />
+          <div className="table-wrapper">
+            <CWTable
+              columnInfo={tableState.columns}
+              sortingState={tableState.sorting}
+              setSortingState={tableState.setSorting}
+              rowData={referrals.map((item, index) => {
+                const namespaceAddress =
+                  typeof item.namespace_address === 'string'
+                    ? item.namespace_address
+                    : null;
+
+                return {
+                  ...item,
+                  rank: {
+                    sortValue: index + 1,
+                    customElement: (
+                      <div className="table-cell">{index + 1}</div>
+                    ),
+                  },
+                  username: {
+                    sortValue: item.referee_profile?.name?.toLowerCase(),
+                    customElement: (
+                      <div className="table-cell">
+                        <Link
+                          to={`/profile/id/${item.referee_user_id}`}
+                          className="user-info"
+                        >
+                          <Avatar
+                            url={item.referee_profile?.avatar_url ?? ''}
+                            size={24}
+                            address={+item.referee_address}
+                          />
+                          <p>{item.referee_profile?.name}</p>
+                        </Link>
+                      </div>
+                    ),
+                  },
+                  address: {
+                    sortValue: item.referee_address,
+                    customElement: (
+                      <div className="table-cell">
+                        {withTooltip(
+                          formatAddressShort(item.referee_address, 6, 4),
+                          item.referee_address,
+                          true,
+                        )}
+                      </div>
+                    ),
+                  },
+                  community: {
+                    sortValue: item.community_name || '',
+                    customElement: (
+                      <div className="table-cell community-cell">
+                        <Link
+                          to={`/${item.community_id}`}
+                          className="community-info"
+                        >
+                          <CWCommunityAvatar
+                            community={{
+                              id: item.community_id || '',
+                              name: item.community_name || '',
+                              iconUrl: item.community_icon_url || '',
+                            }}
+                            size="medium"
+                          />
+                          <p>{item.community_name}</p>
+                        </Link>
+                      </div>
+                    ),
+                  },
+                  namespace: {
+                    sortValue: namespaceAddress || '',
+                    customElement: (
+                      <div className="table-cell namespace-cell">
+                        {withTooltip(
+                          formatAddressShort(namespaceAddress || '', 6, 4),
+                          namespaceAddress || '',
+                          true,
+                        )}
+                      </div>
+                    ),
+                  },
+                  earnings: {
+                    sortValue: Number(item.referrer_received_eth_amount),
+                    customElement: (
+                      <div className="table-cell text-right">
+                        ETH{' '}
+                        {Number(
+                          fromWei(item.referrer_received_eth_amount, 'ether'),
+                        )}
+                      </div>
+                    ),
+                  },
+                };
+              })}
+            />
+          </div>
         ) : (
           <div className="empty-state">
             <CWText className="empty-state-text">

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/columns.ts
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/tables/ReferralTable/columns.ts
@@ -20,6 +20,18 @@ export const columns: CWTableColumnInfo[] = [
     sortable: false,
   },
   {
+    key: 'community',
+    header: 'Community',
+    numeric: false,
+    sortable: true,
+  },
+  {
+    key: 'namespace',
+    header: 'Namespace',
+    numeric: false,
+    sortable: false,
+  },
+  {
     key: 'earnings',
     header: 'Earnings',
     numeric: true,

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/types.ts
@@ -27,6 +27,10 @@ export interface Referral {
   referee_address: ReferralViewType['referee_address'];
   referee_profile: ReferralViewType['referee_profile'];
   referrer_received_eth_amount: ReferralViewType['referrer_received_eth_amount'];
+  community_id: ReferralViewType['community_id'];
+  community_name: ReferralViewType['community_name'];
+  community_icon_url: ReferralViewType['community_icon_url'];
+  namespace_address: string | null;
 }
 
 export interface ReferralFee {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11157 
Closes: #11156 
Closes: #11155 
Closes: #11153

## Description of Changes

- **InviteLinkModal**: Updated terminology from "Commonwealth" to "Common", added Base network support note, and revised referral benefit text to mention XP and unchain fees.

- **InviteModal**: Redesigned with styling similar to InviteLinkModal, replacing icon-based sharing with image-based options and adding Messages and Telegram as sharing options.

- **RewardsPage**: Enhanced with a disabled state for the "See all" button, improved ReferralTable with community and namespace information, and better responsive design.

- **Data Structure**: Added community_id, community_name, community_icon_url, and namespace_address to the Referral interface to provide more context about referrals.

## Test Plan
- just UI minor changes

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a