### PR TITLE
Add referrer address support for Magic Link login

### DIFF
--- a/libs/schemas/src/commands/magic.schemas.ts
+++ b/libs/schemas/src/commands/magic.schemas.ts
@@ -10,4 +10,5 @@ export const MagicLogin = z.object({
   magicAddress: z.string(),
   session: z.string().nullish(),
   walletSsoSource: z.nativeEnum(WalletSsoSource),
+  referrer_address: z.string().nullish(),
 });

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -279,12 +279,14 @@ export async function startLoginWithMagicLink({
   provider,
   chain,
   isCosmos,
+  referrer_address,
 }: {
   email?: string;
   phoneNumber?: string;
   provider?: WalletSsoSource;
   chain?: string;
   isCosmos: boolean;
+  referrer_address?: string;
 }) {
   if (!email && !phoneNumber && !provider)
     throw new Error('Must provide email or SMS or SSO provider');
@@ -298,6 +300,7 @@ export async function startLoginWithMagicLink({
     const { address } = await handleSocialLoginCallback({
       bearer,
       walletSsoSource: WalletSsoSource.Email,
+      referrer_address,
     });
 
     return { bearer, address };
@@ -307,6 +310,7 @@ export async function startLoginWithMagicLink({
     const { address } = await handleSocialLoginCallback({
       bearer,
       walletSsoSource: WalletSsoSource.Farcaster,
+      referrer_address,
     });
 
     return { bearer, address };
@@ -319,6 +323,7 @@ export async function startLoginWithMagicLink({
     const { address } = await handleSocialLoginCallback({
       bearer,
       walletSsoSource: WalletSsoSource.SMS,
+      referrer_address,
     });
 
     return { bearer, address };
@@ -394,11 +399,13 @@ export async function handleSocialLoginCallback({
   chain,
   walletSsoSource,
   isCustomDomain,
+  referrer_address,
 }: {
   bearer?: string | null;
   chain?: string;
   walletSsoSource: WalletSsoSource;
   isCustomDomain?: boolean;
+  referrer_address?: string;
 }): Promise<{ address: string }> {
   // desiredChain may be empty if social login was initialized from
   // a page without a chain, in which case we default to an eth login
@@ -519,6 +526,7 @@ export async function handleSocialLoginCallback({
     magicAddress,
     session: session && serializeCanvas(session),
     walletSsoSource,
+    referrer_address,
   };
 
   try {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -147,6 +147,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
     isNew?: boolean,
     isUserFromWebView?: boolean,
   ) => {
+    removeLocalStorageItem(LocalStorageKeys.ReferralCode);
     await props?.onSuccess?.(authAddress, isNew, isUserFromWebView);
   };
 
@@ -182,6 +183,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
         phoneNumber: tempSMSToUse,
         isCosmos,
         chain: app.chain?.id,
+        referrer_address: refcode,
       });
       setIsMagicLoading(false);
 
@@ -214,6 +216,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
         email: tempEmailToUse,
         isCosmos,
         chain: app.chain?.id,
+        referrer_address: refcode,
       });
       setIsMagicLoading(false);
 
@@ -238,6 +241,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
         provider,
         isCosmos,
         chain: app.chain?.id,
+        referrer_address: refcode,
       });
       setIsMagicLoading(false);
 

--- a/packages/commonwealth/server/passport/magic.ts
+++ b/packages/commonwealth/server/passport/magic.ts
@@ -44,6 +44,7 @@ type MagicLoginContext = {
   existingUserInstance?: UserInstance | null;
   loggedInUser?: UserInstance | null;
   profileMetadata?: { username?: string | null; avatarUrl?: string | null };
+  referrer_address?: string | null;
 };
 
 const DEFAULT_ETH_COMMUNITY_ID = 'ethereum';
@@ -258,6 +259,7 @@ async function createNewMagicUser({
   profileMetadata,
   accessToken,
   walletSsoSource,
+  referrer_address,
 }: MagicLoginContext): Promise<UserInstance> {
   // completely new user: create user, profile, addresses
   return sequelize.transaction(async (transaction) => {
@@ -274,6 +276,7 @@ async function createNewMagicUser({
         // sign in with unverified email addresses)
         emailVerified: !!magicUserMetadata.email,
         profile: {},
+        referred_by_address: referrer_address,
       },
       { transaction },
     );
@@ -781,6 +784,7 @@ async function magicLoginRoute(
       username: body.username,
       avatarUrl: body.avatarUrl,
     },
+    referrer_address: body.referrer_address,
   };
   try {
     if (loggedInUser && existingUserInstance) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11186 

## Description of Changes
This PR adds referral tracking functionality to the Magic Link authentication system. Here's what's being changed:
- Adding a referrer_address field to the Magic Login schema
- Passing the referrer address through the authentication flow

## Test Plan
- using ref link from user A, create user B using magic flow
- you should see `referred_by_address` property in User set to address of user A

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a