### PR TITLE
Add referrals flag to WelcomeOnboardModal flow

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/WelcomeOnboardModal.tsx
@@ -15,11 +15,15 @@ import { LocalStorageKeys } from 'client/scripts/helpers/localStorage';
 import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import { isMobileApp } from 'client/scripts/hooks/useReactNativeWebView';
 import clsx from 'clsx';
+import { useFlag } from 'hooks/useFlag';
 import './WelcomeOnboardModal.scss';
 import { InviteModal } from './steps/InviteModal';
 import { NotificationModal } from './steps/NotificationModal';
+
 const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
   const { isWindowSmallInclusive } = useBrowserWindow({});
+  const referralsEnabled = useFlag('referrals');
+
   const [activeStep, setActiveStep] = useState<WelcomeOnboardModalSteps>(
     WelcomeOnboardModalSteps.OptionalWalletModal,
   );
@@ -132,13 +136,19 @@ const WelcomeOnboardModal = ({ isOpen, onClose }: WelcomeOnboardModalProps) => {
           component: (
             <JoinCommunityStep
               onComplete={() =>
-                setActiveStep(WelcomeOnboardModalSteps.InviteModal)
+                referralsEnabled
+                  ? setActiveStep(WelcomeOnboardModalSteps.InviteModal)
+                  : handleClose()
               }
             />
           ),
         };
       }
       case WelcomeOnboardModalSteps.InviteModal: {
+        if (!referralsEnabled) {
+          return handleClose();
+        }
+
         return {
           index: 8,
           title: '',


### PR DESCRIPTION
Conditionally render invite step based on referrals feature flag Ensure modal closes if referrals are disabled

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11207
## Description of Changes
- Adds feature flag to onboarding referrals step

## Test Plan
- set FLAG_REFERRALS=false
- start onboarding flow 
- referral step should not be visible

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a