### PR TITLE
Hide reward share split for referred actions if user is not referred

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -205,6 +205,7 @@ export function updateActiveUser(data) {
       isPromotionalEmailEnabled: false,
       isWelcomeOnboardFlowComplete: false,
       isLoggedIn: false,
+      referredByAddress: undefined,
     });
   } else {
     const addresses = data.addresses.map(
@@ -243,6 +244,7 @@ export function updateActiveUser(data) {
         isStarred: c.is_starred || false,
       })),
       isLoggedIn: true,
+      referredByAddress: data?.referred_by_address,
     });
   }
 }

--- a/packages/commonwealth/client/scripts/state/ui/user/user.ts
+++ b/packages/commonwealth/client/scripts/state/ui/user/user.ts
@@ -36,6 +36,7 @@ type CommonProps = {
   isLoggedIn: boolean;
   addressSelectorSelectedAddress: string | undefined;
   hasMagicWallet: boolean;
+  referredByAddress?: string;
 };
 
 export type UserStoreProps = CommonProps & {
@@ -63,6 +64,7 @@ export const userStore = createStore<UserStoreProps>()(
     isLoggedIn: false,
     addressSelectorSelectedAddress: undefined,
     hasMagicWallet: false,
+    referredByAddress: undefined,
     // when logged-in, set the auth-user values
     setData: (data) => {
       if (Object.keys(data).length > 0) {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -6,6 +6,7 @@ import { CWIconButton } from 'views/components/component_kit/cw_icon_button';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
 import './QuestActionSubForm.scss';
+import { doesActionRewardShareForReferrer } from './helpers';
 import { QuestAction, QuestActionSubFormProps } from './types';
 
 const QuestActionSubForm = ({
@@ -92,7 +93,13 @@ const QuestActionSubForm = ({
 
         {config?.requires_creator_points && (
           <CWTextInput
-            label="Creater Reward Share"
+            label={`${
+              doesActionRewardShareForReferrer(
+                defaultValues?.action as QuestAction,
+              )
+                ? 'Referrer'
+                : 'Creater'
+            } Reward Share`}
             placeholder="Points Earned"
             fullWidth
             {...(defaultValues?.creatorRewardAmount && {
@@ -104,7 +111,13 @@ const QuestActionSubForm = ({
             name="creatorRewardAmount"
             customError={errors?.creatorRewardAmount}
             // eslint-disable-next-line max-len
-            instructionalMessage="Reward points for action creator. Deducted from total reward points."
+            instructionalMessage={`Deducted from total reward points. ${
+              doesActionRewardShareForReferrer(
+                defaultValues?.action as QuestAction,
+              )
+                ? 'Only applied for referred user.'
+                : ''
+            }`}
           />
         )}
       </div>

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/helpers.ts
@@ -1,12 +1,22 @@
 import { QuestAction } from './types';
 
-export const doesActionRequireCreatorReward = (action: QuestAction) => {
+export const doesActionRequireRewardShare = (action: QuestAction) => {
   // These are inferred from libs/model/src/user/Xp.projection.ts
   return (
     action === 'CommunityCreated' ||
     action === 'CommunityJoined' ||
     action === 'CommentUpvoted'
   );
+};
+
+export const doesActionRewardShareForReferrer = (action: QuestAction) => {
+  // These are inferred from libs/model/src/user/Xp.projection.ts
+  return action === 'CommunityCreated' || action === 'CommunityJoined';
+};
+
+export const doesActionRewardShareForCreator = (action: QuestAction) => {
+  // These are inferred from libs/model/src/user/Xp.projection.ts
+  return action === 'CommentUpvoted';
 };
 
 export const doesActionAllowContentId = (action: QuestAction) => {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -4,7 +4,7 @@ import { ZodError } from 'zod';
 import './QuestActionSubForm.scss';
 import {
   doesActionAllowContentId,
-  doesActionRequireCreatorReward,
+  doesActionRequireRewardShare,
 } from './helpers';
 import {
   QuestAction,
@@ -126,8 +126,7 @@ const useQuestActionMultiFormsState = ({
 
     const chosenAction = updatedSubForms[index].values.action as QuestAction;
     if (chosenAction) {
-      const requiresCreatorPoints =
-        doesActionRequireCreatorReward(chosenAction);
+      const requiresCreatorPoints = doesActionRequireRewardShare(chosenAction);
       const allowsContentId = doesActionAllowContentId(chosenAction);
 
       // update config based on chosen action

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -23,7 +23,7 @@ import { z } from 'zod';
 import { QuestAction } from './QuestActionSubForm';
 import {
   doesActionAllowContentId,
-  doesActionRequireCreatorReward,
+  doesActionRequireRewardShare,
 } from './QuestActionSubForm/helpers';
 import { useQuestActionMultiFormsState } from './QuestActionSubForm/useMultipleQuestActionForms';
 import './QuestForm.scss';
@@ -103,7 +103,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
                 errors: {},
                 config: {
                   requires_creator_points:
-                    doesActionRequireCreatorReward(chosenAction),
+                    doesActionRequireRewardShare(chosenAction),
                   with_optional_thread_id:
                     allowsContentId &&
                     (chosenAction === 'CommentCreated' ||

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -1,6 +1,7 @@
 import { QuestActionMeta } from '@hicommonwealth/schemas';
 import { roundDecimalsOrReturnWhole } from 'helpers/number';
 import React from 'react';
+import useUserStore from 'state/ui/user';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
@@ -8,7 +9,10 @@ import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
 import { withTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { z } from 'zod';
 import { QuestAction } from '../../CreateQuest/QuestForm/QuestActionSubForm';
-import { doesActionRequireCreatorReward } from '../../CreateQuest/QuestForm/QuestActionSubForm/helpers';
+import {
+  doesActionRequireRewardShare,
+  doesActionRewardShareForReferrer,
+} from '../../CreateQuest/QuestForm/QuestActionSubForm/helpers';
 import './QuestActionCard.scss';
 
 // TODO: fix types with schemas.Events keys
@@ -29,7 +33,7 @@ const actionCopies = {
     ['ThreadCreated']: '',
     ['ThreadUpvoted']: '',
     ['CommentCreated']: '',
-    ['CommentUpvoted']: 'comment owner',
+    ['CommentUpvoted']: 'comment creator',
     ['UserMentioned']: '',
   },
 };
@@ -63,6 +67,11 @@ const QuestActionCard = ({
     value: questAction.creator_reward_weight * questAction.reward_amount,
   };
 
+  const user = useUserStore();
+  const isUserReferred = !!user.referredByAddress;
+  const hideShareSplit =
+    doesActionRewardShareForReferrer(questAction.event_name) && !isUserReferred;
+
   return (
     <div className="QuestActionCard">
       <div className="counter">
@@ -75,7 +84,8 @@ const QuestActionCard = ({
           <CWText type="b1" fontWeight="semiBold">
             {actionCopies.title[questAction.event_name]}
           </CWText>
-          {doesActionRequireCreatorReward(questAction.event_name) &&
+          {!hideShareSplit &&
+            doesActionRequireRewardShare(questAction.event_name) &&
             creatorXP.percentage > 0 && (
               <CWText type="caption" className="xp-shares">
                 <span className="creator-share">

--- a/packages/commonwealth/server/routes/status.ts
+++ b/packages/commonwealth/server/routes/status.ts
@@ -37,6 +37,7 @@ type StatusResp = {
     isAdmin: boolean;
     disableRichText?: boolean;
     communities: StarredCommunityResponse[];
+    referred_by_address?: string;
   };
   communityWithRedirects?: CommunityWithRedirects[];
   evmTestEnv?: string;
@@ -124,6 +125,7 @@ export const getUserStatus = async (models: DB, user: UserInstance) => {
       isAdmin,
       disableRichText,
       communities: userCommunities || [],
+      referred_by_address: user.referred_by_address || undefined,
     },
     id: user.id,
     email: user.email,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11210

## Description of Changes
N/A

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Create a quest from `/createQuest` as site admin, add reward share for `Create Community` / `Join Community` actions
3. Now visit quest details page with 
    1. A referred account and verify you see referrer/user reward split
    2. A non-referred account and verify you don't see referrer/user reward split

## Deployment Plan
N/A

## Other Considerations
N/A