### PR TITLE
Fix referrals query join condition for Communities table

### DIFF
--- a/libs/model/src/user/GetUserReferrals.query.ts
+++ b/libs/model/src/user/GetUserReferrals.query.ts
@@ -38,7 +38,7 @@ SELECT
 FROM referrals R
   JOIN referee_addresses RA ON RA.address = R.referee_address
   JOIN "Users" U ON U.id = RA.user_id
-  LEFT JOIN "Communities" C ON C.namespace = R.namespace_address
+  LEFT JOIN "Communities" C ON C.namespace_address = R.namespace_address
   ;
 `;
 


### PR DESCRIPTION
Update the join condition in the GetUserReferrals query to use the correct column name 'namespace_address' when joining with the Communities table

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11214 

## Description of Changes
- changed namespace to namespace_address in sql query

## Test Plan
- referrals table should show proper name and avatar for communitiy 

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a