### PR TITLE
Fix topics not showing during contest

### DIFF
--- a/libs/model/src/community/GetTopics.query.ts
+++ b/libs/model/src/community/GetTopics.query.ts
@@ -11,7 +11,19 @@ const includeContestManagersQuery = `
                                                 '{content}', -- Set the 'content' key in the resulting JSONB
                                                 coalesce(
                                                     -- Aggregates the filtered actions into content
-                                                        (SELECT jsonb_agg(ca)
+                                                        (SELECT jsonb_agg(json_build_object(
+                                                          'contest_address', ca.contest_address,
+                                                          'contest_id', ca.contest_id,
+                                                          'content_id', ca.content_id,
+                                                          'actor_address', ca.actor_address,
+                                                          'action', ca.action,
+                                                          'content_url', ca.content_url,
+                                                          'voting_power', ca.voting_power::text,
+                                                          'created_at', ca.created_at,
+                                                          'thread_id', ca.thread_id,
+                                                          'calculated_voting_weight', ca.calculated_voting_weight,
+                                                          'cast_deleted_at', ca.cast_deleted_at
+                                                        ))
                                                          FROM "ContestActions" ca
                                                          WHERE ca.contest_address = cm.contest_address
                                                            AND ca.action = 'added'

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -179,7 +179,7 @@ export const ConstestManagerView = ContestManager.extend({
   contests: z.undefined(),
   content: z.array(
     projections.ContestAction.extend({
-      cast_deleted_at: z.string(),
+      cast_deleted_at: z.string().nullish(),
       created_at: z.string(),
     }),
   ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11206 

## Description of Changes
- Fixes output validation issues for the GetTopics query, related to contests

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Pull latest dump
 - Go to http://localhost:8080/common/new/discussion
 - Confirm you can see topics

## Deployment Plan
N/A

## Other Considerations
N/A