### PR TITLE
Create Namespace Admins group

### DIFF
--- a/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
+++ b/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
@@ -20,24 +20,11 @@ export function CreateNamespaceAdminGroup(): Command<
         include: [
           {
             model: models.ChainNode,
-            required: false,
+            required: true,
           },
         ],
       });
       mustExist('Community', community);
-
-      if (!community.ChainNode) {
-        log.warn(
-          `Community namespace_address=(${namespace_address}) is missing ChainNode, skipping namespace admin group creation`,
-        );
-        return;
-      }
-      if (!community.namespace_address) {
-        log.warn(
-          `Community namespace_address=(${namespace_address}) is missing namespace_address, skipping namespace admin group creation`,
-        );
-        return;
-      }
 
       const group = await models.Group.create({
         community_id: community.id,
@@ -54,7 +41,7 @@ export function CreateNamespaceAdminGroup(): Command<
               threshold: '0',
               source: {
                 source_type: 'erc1155',
-                evm_chain_id: community.ChainNode.eth_chain_id,
+                evm_chain_id: community.ChainNode!.eth_chain_id,
                 contract_address: namespace_address,
                 token_id: '0',
               },

--- a/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
+++ b/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
@@ -1,10 +1,8 @@
-import { logger, type Command } from '@hicommonwealth/core';
+import { type Command } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { models } from '../database';
 import { mustExist } from '../middleware/guards';
 import { GroupAttributes } from '../models';
-
-const log = logger(import.meta);
 
 export function CreateNamespaceAdminGroup(): Command<
   typeof schemas.CreateNamespaceAdminGroup

--- a/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
+++ b/libs/model/src/community/CreateNamespaceAdminGroup.command.ts
@@ -1,0 +1,70 @@
+import { logger, type Command } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { models } from '../database';
+import { mustExist } from '../middleware/guards';
+import { GroupAttributes } from '../models';
+
+const log = logger(import.meta);
+
+export function CreateNamespaceAdminGroup(): Command<
+  typeof schemas.CreateNamespaceAdminGroup
+> {
+  return {
+    ...schemas.CreateNamespaceAdminGroup,
+    auth: [],
+    body: async ({ payload }) => {
+      const { namespace_address } = payload;
+
+      const community = await models.Community.findOne({
+        where: { namespace_address },
+        include: [
+          {
+            model: models.ChainNode,
+            required: false,
+          },
+        ],
+      });
+      mustExist('Community', community);
+
+      if (!community.ChainNode) {
+        log.warn(
+          `Community namespace_address=(${namespace_address}) is missing ChainNode, skipping namespace admin group creation`,
+        );
+        return;
+      }
+      if (!community.namespace_address) {
+        log.warn(
+          `Community namespace_address=(${namespace_address}) is missing namespace_address, skipping namespace admin group creation`,
+        );
+        return;
+      }
+
+      const group = await models.Group.create({
+        community_id: community.id,
+        metadata: {
+          name: 'Namespace Admins',
+          description: 'Users with onchain namespace admin privileges',
+          groupImageUrl: '',
+          required_requirements: 1,
+        },
+        requirements: [
+          {
+            rule: 'threshold',
+            data: {
+              threshold: '0',
+              source: {
+                source_type: 'erc1155',
+                evm_chain_id: community.ChainNode.eth_chain_id,
+                contract_address: namespace_address,
+                token_id: '0',
+              },
+            },
+          },
+        ],
+        is_system_managed: true,
+      } as GroupAttributes);
+
+      return group;
+    },
+  };
+}

--- a/libs/model/src/community/index.ts
+++ b/libs/model/src/community/index.ts
@@ -1,6 +1,7 @@
 export * from './BanAddress.command';
 export * from './CreateCommunity.command';
 export * from './CreateGroup.command';
+export * from './CreateNamespaceAdminGroup.command';
 export * from './CreateStakeTransaction.command';
 export * from './CreateTopic.command';
 export * from './DeleteAddress.command';

--- a/libs/model/src/policies/handlers/handleNamespaceDeployed.ts
+++ b/libs/model/src/policies/handlers/handleNamespaceDeployed.ts
@@ -1,12 +1,19 @@
-import { EventHandler, logger } from '@hicommonwealth/core';
+import { command, EventHandler } from '@hicommonwealth/core';
 import { ZodUndefined } from 'zod';
-
-const log = logger(import.meta);
+import { CreateNamespaceAdminGroup } from '../../community/CreateNamespaceAdminGroup.command';
+import { systemActor } from '../../middleware';
 
 export const handleNamespaceDeployed: EventHandler<
   'NamespaceDeployed',
   ZodUndefined
   // eslint-disable-next-line @typescript-eslint/require-await
-> = async ({ payload: _ }) => {
-  log.info('NamespaceDeployed event implementation not defined');
+> = async ({ payload }) => {
+  const { nameSpaceAddress } = payload.parsedArgs;
+
+  await command(CreateNamespaceAdminGroup(), {
+    actor: systemActor({}),
+    payload: {
+      namespace_address: nameSpaceAddress,
+    },
+  });
 };

--- a/libs/model/test/contest/contest-worker-policy-lifecycle.spec.ts
+++ b/libs/model/test/contest/contest-worker-policy-lifecycle.spec.ts
@@ -1,9 +1,11 @@
-import { config, dispose, handleEvent } from '@hicommonwealth/core';
+import { config, dispose, handleEvent, query } from '@hicommonwealth/core';
 import * as evm from '@hicommonwealth/evm-protocols';
 import { literal } from 'sequelize';
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { emitEvent, models } from '../../src';
+import { GetTopics } from '../../src/community';
 import { Contests } from '../../src/contest';
+import { systemActor } from '../../src/middleware';
 import { ContestWorker } from '../../src/policies';
 import { seed } from '../../src/tester';
 import { drainOutbox } from '../utils/outbox-drain';
@@ -179,6 +181,15 @@ describe('Contest Worker Policy Lifecycle', () => {
     ]);
 
     await drainOutbox(['ThreadUpvoted'], ContestWorker);
+
+    const topics = await query(GetTopics(), {
+      actor: systemActor({}),
+      payload: {
+        community_id: communityId,
+        with_contest_managers: true,
+      },
+    });
+    expect(topics).to.have.length(1);
 
     expect(voteContentStub).toHaveBeenCalled();
 

--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -252,6 +252,13 @@ export const CreateGroup = {
   context: AuthContext,
 };
 
+export const CreateNamespaceAdminGroup = {
+  input: z.object({
+    namespace_address: z.string(),
+  }),
+  output: Group,
+};
+
 export const UpdateGroup = {
   input: z.object({
     community_id: z.string(),

--- a/packages/commonwealth/server/migrations/20250303221132-add-namespace-admin-groups.js
+++ b/packages/commonwealth/server/migrations/20250303221132-add-namespace-admin-groups.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const now = new Date();
+
+    // get communities with chain node and namespace
+    const communities = await queryInterface.sequelize.query(
+      `SELECT c.id, c.namespace_address, cn.eth_chain_id
+       FROM "Communities" c
+       JOIN "ChainNodes" cn ON c.chain_node_id = cn.id
+       WHERE c.namespace_address IS NOT NULL`,
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+
+    if (!communities.length) {
+      console.warn(
+        'No communities found with a valid namespace_address and ChainNode.',
+      );
+      return;
+    }
+
+    // prepare groups and bulk insert
+    const groups = communities.map((community) => ({
+      community_id: community.id,
+      metadata: JSON.stringify({
+        name: 'Namespace Admins',
+        description: 'Users with onchain namespace admin privileges',
+        groupImageUrl: '',
+        required_requirements: 1,
+      }),
+      requirements: JSON.stringify([
+        {
+          rule: 'threshold',
+          data: {
+            threshold: '0',
+            source: {
+              source_type: 'erc1155',
+              evm_chain_id: community.eth_chain_id,
+              contract_address: community.namespace_address,
+              token_id: '0',
+            },
+          },
+        },
+      ]),
+      is_system_managed: true,
+      created_at: now,
+      updated_at: now,
+    }));
+
+    await queryInterface.bulkInsert('Groups', groups);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DELETE FROM "Groups"
+       WHERE metadata->>'name' = 'Namespace Admins'
+         AND is_system_managed = true`,
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11198

## Description of Changes
- Creates migration that adds Namespace Admins group to existing communities
- Adds logic to NamespaceDeployed policy to create group after namespace deployment

## Test Plan
- Run migration– check `common` community, confirm it has Namespace Admins groups
- Create a new community and create namespace– confirm that it has Namespace Admins group

## Deployment Plan
N/A

## Other Considerations
N/A