### PR TITLE
Referrals flags

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -32,6 +32,7 @@ const featureFlags = {
   newContestPage: buildFlag(process.env.FLAG_NEW_CONTEST_PAGE),
   manageApiKeys: buildFlag(process.env.FLAG_MANAGE_API_KEYS),
   referrals: buildFlag(process.env.FLAG_REFERRALS),
+  onchainReferrals: buildFlag(process.env.FLAG_ONCHAIN_REFERRALS),
   stickyEditor: buildFlag(process.env.FLAG_STICKY_EDITOR),
   newMobileNav: buildFlag(process.env.FLAG_NEW_MOBILE_NAV),
   rewardsPage: buildFlag(process.env.FLAG_REWARDS_PAGE),

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
@@ -68,8 +68,6 @@ const RewardsPage = () => {
     return <PageNotFound />;
   }
 
-  const showOtherCards = true;
-
   return (
     <CWPageLayout>
       <section className="RewardsPage">
@@ -79,15 +77,18 @@ const RewardsPage = () => {
 
         {/* visible only on mobile */}
         <div className="rewards-button-tabs">
-          {Object.values(MobileTabType).map((type) => (
-            <CWMobileTab
-              key={type}
-              icon={typeToIcon[type] as IconName}
-              label={type}
-              isActive={mobileTab === type}
-              onClick={() => handleTabChange(type)}
-            />
-          ))}
+          {Object.values(MobileTabType).map((type) => {
+            if (type === MobileTabType.Quests && !xpEnabled) return null;
+            return (
+              <CWMobileTab
+                key={type}
+                icon={typeToIcon[type] as IconName}
+                label={type}
+                isActive={mobileTab === type}
+                onClick={() => handleTabChange(type)}
+              />
+            );
+          })}
         </div>
 
         {/* on mobile show only one card */}
@@ -105,7 +106,7 @@ const RewardsPage = () => {
           {(!isWindowSmallInclusive ||
             mobileTab === MobileTabType.WalletBalance) && <WalletCard />}
           {(!isWindowSmallInclusive || mobileTab === MobileTabType.Quests) &&
-            showOtherCards && <QuestSummaryCard />}
+            xpEnabled && <QuestSummaryCard />}
         </div>
 
         <div className="rewards-tab-container">

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/ReferralCard/ReferralCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/ReferralCard/ReferralCard.tsx
@@ -1,3 +1,4 @@
+import { useFlag } from 'hooks/useFlag';
 import React, { useState } from 'react';
 import { useInviteLinkModal } from 'state/ui/modals';
 import { CWText } from 'views/components/component_kit/cw_text';
@@ -37,6 +38,8 @@ const ReferralCard = ({
   );
   const { setIsInviteLinkModalOpen } = useInviteLinkModal();
 
+  const xpEnabled = useFlag('xp');
+
   return (
     <RewardsCard
       title="Referrals"
@@ -47,15 +50,17 @@ const ReferralCard = ({
     >
       <div className="ReferralCard">
         <CWTabsRow>
-          {Object.values(ReferralTabs).map((tab) => (
-            <CWTab
-              key={tab}
-              label={tab}
-              isSelected={currentTab === tab}
-              onClick={() => setCurrentTab(tab)}
-              isDisabled={tab === ReferralTabs.XP}
-            />
-          ))}
+          {Object.values(ReferralTabs).map((tab) => {
+            if (tab === ReferralTabs.XP && !xpEnabled) return null;
+            return (
+              <CWTab
+                key={tab}
+                label={tab}
+                isSelected={currentTab === tab}
+                onClick={() => setCurrentTab(tab)}
+              />
+            );
+          })}
         </CWTabsRow>
         <div className="referral-card-body">
           {currentTab === ReferralTabs.Total && (

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -50,6 +50,9 @@ export default defineConfig(({ mode }) => {
       env.FLAG_MANAGE_API_KEYS,
     ),
     'process.env.FLAG_REFERRALS': JSON.stringify(env.FLAG_REFERRALS),
+    'process.env.FLAG_ONCHAIN_REFERRALS': JSON.stringify(
+      env.FLAG_ONCHAIN_REFERRALS,
+    ),
     'process.env.FLAG_REWARDS_PAGE': JSON.stringify(env.FLAG_REWARDS_PAGE),
     'process.env.FLAG_STICKY_EDITOR': JSON.stringify(env.FLAG_STICKY_EDITOR),
     'process.env.FLAG_NEW_MOBILE_NAV': JSON.stringify(env.FLAG_NEW_MOBILE_NAV),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11221
Closes: #11223 

## Description of Changes
- /rewards page includes both referrals and xp work. Because referrals goes out first, xp content inside rewards page was hidden behind xp feature flag.
- introduced new FLAG_ONCHAIN_REFERRALS. For now and after production referrals deployment it should be turned off.
  - `FLAG_ONCHAIN_REFERRALS=false` => namespace creation WITHOUT referrer => distribution fee IS NOT generated
  -  `FLAG_ONCHAIN_REFERRALS=true` => namespace creation WITH referrer => distribution fee IS generated

## Test Plan
- FLAG_REFERRALS=true
- FLAG_REWARDS_PAGE=true
- FLAG_ONCHAIN_REFERRALS=false
- you should not see XP/Quest card/table in rewards oage
- as a referee, you are able to create community and namespace but namespace won't be created with referrer (not possible to test it with UI)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a