### PR TITLE
Fix vote weight rendering for tokens of different num decimals

### DIFF
--- a/libs/model/src/community/CreateTopic.command.ts
+++ b/libs/model/src/community/CreateTopic.command.ts
@@ -57,6 +57,7 @@ export function CreateTopic(): Command<typeof schemas.CreateTopic> {
           weighted_voting: payload.weighted_voting,
           token_address: payload.token_address || undefined,
           token_symbol: payload.token_symbol || undefined,
+          token_decimals: payload.token_decimals || undefined,
           vote_weight_multiplier: payload.vote_weight_multiplier || undefined,
           chain_node_id: payload.chain_node_id || undefined,
         };

--- a/libs/model/src/community/GetTopics.query.ts
+++ b/libs/model/src/community/GetTopics.query.ts
@@ -85,6 +85,7 @@ export function GetTopics(): Query<typeof schemas.GetTopics> {
                                      t.token_symbol,
                                      t.vote_weight_multiplier,
                                      t.token_address,
+                                     t.token_decimals,
                                      cn.url as chain_node_url,
                                      cn.eth_chain_id as eth_chain_id,
                                      t.created_at::text           AS created_at,

--- a/libs/model/src/models/topic.ts
+++ b/libs/model/src/models/topic.ts
@@ -54,6 +54,7 @@ export default (
       chain_node_id: { type: Sequelize.INTEGER, allowNull: true },
       token_address: { type: Sequelize.STRING, allowNull: true },
       token_symbol: { type: Sequelize.STRING, allowNull: true },
+      token_decimals: { type: Sequelize.INTEGER, allowNull: true },
       vote_weight_multiplier: { type: Sequelize.FLOAT, allowNull: true },
     },
     {

--- a/libs/model/src/thread/GetThreads.query.ts
+++ b/libs/model/src/thread/GetThreads.query.ts
@@ -110,7 +110,9 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                     'description', T.description,
                     'community_id', T.community_id,
                     'telegram', T.telegram,
-                    'weighted_voting', T.weighted_voting
+                    'weighted_voting', T.weighted_voting,
+                    'token_decimals', T.token_decimals,
+                    'vote_weight_multiplier', T.vote_weight_multiplier
                 ) as topic,
                 json_build_object(
                     'id', A.id,

--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -178,6 +178,7 @@ export const CreateTopic = {
         weighted_voting: true,
         token_address: true,
         token_symbol: true,
+        token_decimals: true,
         vote_weight_multiplier: true,
         chain_node_id: true,
       }),

--- a/libs/schemas/src/entities/topic.schemas.ts
+++ b/libs/schemas/src/entities/topic.schemas.ts
@@ -47,6 +47,11 @@ export const Topic = z.object({
     .gt(0)
     .nullish()
     .describe('vote weight multiplier, used for ERC20 topics'),
+  token_decimals: z
+    .number()
+    .gte(0)
+    .nullish()
+    .describe('number of decimals of ERC20 token'),
 
   created_at: z.coerce.date().optional(),
   updated_at: z.coerce.date().optional(),

--- a/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createReaction.ts
@@ -72,6 +72,7 @@ const useCreateThreadReactionMutation = ({
         type: 'like',
         updated_at: newReaction.updated_at,
         voting_weight: newReaction.calculated_voting_weight || 0,
+        calculated_voting_weight: newReaction.calculated_voting_weight || 0,
       };
       updateThreadInAllCaches(
         communityId,

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -23,6 +23,7 @@ type CommentReactionButtonProps = {
   tooltipText?: string;
   onReaction?: () => void;
   weightType?: TopicWeightedVoting | null;
+  tokenNumDecimals?: number;
 };
 
 export const CommentReactionButton = ({
@@ -31,6 +32,7 @@ export const CommentReactionButton = ({
   tooltipText = '',
   onReaction,
   weightType,
+  tokenNumDecimals,
 }: CommentReactionButtonProps) => {
   const [isAuthModalOpen, setIsAuthModalOpen] = useState<boolean>(false);
   const user = useUserStore();
@@ -114,6 +116,7 @@ export const CommentReactionButton = ({
 
   const formattedVoteCount = prettyVoteWeight(
     reactionWeightsSum.toString(),
+    tokenNumDecimals,
     weightType,
     1,
     6,

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -114,12 +114,6 @@ export const CommentReactionButton = ({
     }
   };
 
-  console.log({
-    reactionWeightsSum,
-    count: comment.reaction_count,
-    tokenNumDecimals,
-  });
-
   const formattedVoteCount = prettyVoteWeight(
     weightType
       ? reactionWeightsSum.toString()

--- a/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ReactionButton/CommentReactionButton.tsx
@@ -114,8 +114,16 @@ export const CommentReactionButton = ({
     }
   };
 
+  console.log({
+    reactionWeightsSum,
+    count: comment.reaction_count,
+    tokenNumDecimals,
+  });
+
   const formattedVoteCount = prettyVoteWeight(
-    reactionWeightsSum.toString(),
+    weightType
+      ? reactionWeightsSum.toString()
+      : comment.reaction_count.toString(),
     tokenNumDecimals,
     weightType,
     1,

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -69,6 +69,8 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
     apiEnabled: !!baseNode && !!uniqueAddresses[0],
   });
 
+  const balance = ethBalance === '0.' ? '0' : ethBalance;
+
   return (
     <div className="DesktopHeader">
       <div className="header-left">
@@ -173,7 +175,7 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
                           fontWeight="medium"
                           type="caption"
                         >
-                          {capDecimals(ethBalance || '0')} ETH
+                          {capDecimals(balance || '0')} ETH
                         </CWText>
                         <CWCustomIcon iconName="base" iconSize="xs" />
                       </div>

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewCommentUpvotesDrawer.tsx
@@ -9,6 +9,7 @@ type ViewCommentUpvotesDrawerProps = {
   comment?: CommentViewParams;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
+  tokenDecimals?: number | null | undefined;
   weightType?: TopicWeightedVoting | null;
 };
 
@@ -16,6 +17,7 @@ export const ViewCommentUpvotesDrawer = ({
   comment,
   isOpen,
   setIsOpen,
+  tokenDecimals,
   weightType,
 }: ViewCommentUpvotesDrawerProps) => {
   return (
@@ -38,6 +40,7 @@ export const ViewCommentUpvotesDrawer = ({
       }
       // @ts-expect-error <StrictNullChecks/>
       publishDate={(comment?.created_at as string) || ''} // TODO: fix type
+      tokenDecimals={tokenDecimals}
       topicWeight={weightType}
     />
   );

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewThreadUpvotesDrawer.tsx
@@ -41,6 +41,7 @@ export const ViewThreadUpvotesDrawer = ({
           ? app.chain.accounts.get(thread?.author)
           : null
       }
+      tokenDecimals={thread?.topic?.token_decimals}
       topicWeight={thread?.topic?.weighted_voting}
       publishDate={thread.createdAt}
     />

--- a/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/UpvoteDrawer/ViewUpvotesDrawer/ViewUpvotesDrawer.tsx
@@ -26,6 +26,7 @@ type ViewUpvotesDrawerProps = {
   publishDate: moment.Moment;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
+  tokenDecimals?: number | null | undefined;
   topicWeight?: TopicWeightedVoting | null | undefined;
 };
 
@@ -66,6 +67,7 @@ export const ViewUpvotesDrawer = ({
   publishDate,
   isOpen,
   setIsOpen,
+  tokenDecimals,
   topicWeight,
 }: ViewUpvotesDrawerProps) => {
   const tableState = useCWTableState({
@@ -73,6 +75,7 @@ export const ViewUpvotesDrawer = ({
       c.key === 'voteWeight'
         ? {
             ...c,
+            tokenDecimals,
             weightedVoting: topicWeight,
           }
         : c,
@@ -192,6 +195,7 @@ export const ViewUpvotesDrawer = ({
                   <CWText type="b2">
                     {prettyVoteWeight(
                       getVoteWeightTotal(reactorData).toString(),
+                      tokenDecimals,
                       topicWeight,
                       1,
                       6,

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTable/CWTable.tsx
@@ -113,6 +113,7 @@ export type CWTableColumnInfo = {
     content: string;
   };
   numeric: boolean;
+  tokenDecimals?: number | null | undefined;
   weightedVoting?: TopicWeightedVoting | null | undefined;
   sortable: boolean;
   chronological?: boolean;
@@ -196,7 +197,11 @@ export const CWTable = ({
                 return (
                   <div className="numeric">
                     {col.weightedVoting
-                      ? prettyVoteWeight(numericColVal, col.weightedVoting)
+                      ? prettyVoteWeight(
+                          numericColVal,
+                          col.tokenDecimals,
+                          col.weightedVoting,
+                        )
                       : numericColVal}
                   </div>
                 );

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/Topics.tsx
@@ -34,6 +34,7 @@ interface TopicFormRegular {
 export interface TopicFormERC20 {
   tokenAddress?: string;
   tokenSymbol?: string;
+  tokenDecimals?: number;
   voteWeightMultiplier?: number;
   chainNodeId?: number;
   weightedVoting?: TopicWeightedVoting | null;
@@ -103,6 +104,7 @@ export const Topics = () => {
           ? {
               token_address: erc20.tokenAddress,
               token_symbol: erc20.tokenSymbol,
+              token_decimals: erc20.tokenDecimals,
               vote_weight_multiplier: erc20.voteWeightMultiplier,
               chain_node_id: erc20.chainNodeId,
               weighted_voting: erc20.weightedVoting,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/WVERC20Details/WVERC20Details.tsx
@@ -53,6 +53,7 @@ const WVERC20Details = ({ onStepChange, onCreateTopic }: WVConsentProps) => {
       erc20: {
         tokenAddress: debouncedTokenValue,
         tokenSymbol: tokenMetadata?.symbol,
+        tokenDecimals: tokenMetadata?.decimals,
         voteWeightMultiplier: multiplier,
         chainNodeId: Number(selectedChain?.chainNodeId),
         weightedVoting: TopicWeightedVoting.ERC20,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -81,6 +81,8 @@ type CommentCardProps = {
   isStreamingAIReply?: boolean;
   parentCommentText?: string;
   onStreamingComplete?: () => void;
+  // voting
+  tokenNumDecimals?: number;
 };
 
 export const CommentCard = ({
@@ -121,6 +123,7 @@ export const CommentCard = ({
   isStreamingAIReply,
   parentCommentText,
   onStreamingComplete,
+  tokenNumDecimals,
 }: CommentCardProps) => {
   const user = useUserStore();
   const userOwnsComment = comment.user_id === user.id;
@@ -423,6 +426,7 @@ export const CommentCard = ({
                     }
                     onReaction={handleReaction}
                     weightType={weightType}
+                    tokenNumDecimals={tokenNumDecimals}
                   />
                 )}
 
@@ -438,6 +442,7 @@ export const CommentCard = ({
                       comment={comment}
                       isOpen={isUpvoteDrawerOpen}
                       setIsOpen={setIsUpvoteDrawerOpen}
+                      tokenDecimals={tokenNumDecimals}
                       weightType={weightType}
                     />
                   </>

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/TreeHierarchy.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/TreeHierarchy.tsx
@@ -194,6 +194,7 @@ export const TreeHierarchy = ({
                     comment={comment}
                     shareURL={`${window.location.origin}${window.location.pathname}?comment=${comment.id}`}
                     weightType={thread.topic?.weighted_voting}
+                    tokenNumDecimals={thread.topic?.token_decimals || undefined}
                   />
                 </div>
                 {comment.reply_count > 0 && (
@@ -254,6 +255,9 @@ export const TreeHierarchy = ({
                       canDelete={false}
                       canToggleSpam={false}
                       shareURL=""
+                      tokenNumDecimals={
+                        thread.topic?.token_decimals || undefined
+                      }
                     />
                   </div>
                 )}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -234,6 +234,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
     isTopicWeighted && voteBalance
       ? prettyVoteWeight(
           formatDecimalToWei(voteBalance),
+          topicObj!.token_decimals,
           topicObj!.weighted_voting,
           topicObj!.vote_weight_multiplier || 1,
         )

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -409,6 +409,7 @@ export const ThreadCard = ({
                       null,
                     )
                   }
+                  tokenNumDecimals={thread.topic?.token_decimals || undefined}
                 />
               </Link>
             ))}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -138,6 +138,7 @@ export const ReactionButton = ({
 
   const formattedVoteCount = prettyVoteWeight(
     reactionWeightsSum,
+    thread.topic!.token_decimals,
     thread.topic!.weighted_voting,
     1,
     size === 'big' ? 1 : 6,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -136,8 +136,12 @@ export const ReactionButton = ({
     }
   };
 
+  console.log({ thread });
+
   const formattedVoteCount = prettyVoteWeight(
-    reactionWeightsSum,
+    thread.topic!.weighted_voting
+      ? reactionWeightsSum
+      : thread.reactionCount.toString(),
     thread.topic!.token_decimals,
     thread.topic!.weighted_voting,
     1,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -136,8 +136,6 @@ export const ReactionButton = ({
     }
   };
 
-  console.log({ thread });
-
   const formattedVoteCount = prettyVoteWeight(
     thread.topic!.weighted_voting
       ? reactionWeightsSum

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -646,7 +646,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                   ) : thread && !isGloballyEditing && user.isLoggedIn ? (
                     <>
                       {threadOptionsComp}
-
                       {!stickyEditor && (
                         <CreateComment
                           rootThread={thread}

--- a/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
+++ b/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Topics', 'token_decimals', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Topics"
+      SET "token_decimals" = CASE
+        WHEN token_symbol = 'USDC' THEN 6
+        WHEN token_symbol IS NOT NULL THEN 18
+        ELSE NULL
+      END;
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Topics', 'token_decimals');
+  },
+};

--- a/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
+++ b/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
@@ -13,6 +13,7 @@ module.exports = {
       SET "token_decimals" = CASE
         WHEN token_symbol = 'USDC' THEN 6
         WHEN token_symbol = 'MOCHI' THEN 8
+        WHEN token_symbol = 'SKI' THEN 9
         WHEN token_symbol IS NOT NULL THEN 18
         ELSE NULL
       END;

--- a/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
+++ b/packages/commonwealth/server/migrations/20250304182014-add-topic-decimals.js
@@ -12,6 +12,7 @@ module.exports = {
       UPDATE "Topics"
       SET "token_decimals" = CASE
         WHEN token_symbol = 'USDC' THEN 6
+        WHEN token_symbol = 'MOCHI' THEN 8
         WHEN token_symbol IS NOT NULL THEN 18
         ELSE NULL
       END;

--- a/packages/commonwealth/shared/adapters/currency.ts
+++ b/packages/commonwealth/shared/adapters/currency.ts
@@ -68,9 +68,10 @@ export function formatBigNumberShort(num: number, numDecimals: number): string {
  */
 export const prettyVoteWeight = (
   wei: string,
+  tokenNumDecimals?: number | null | undefined, // ERC20 num decimals
   weightType?: TopicWeightedVoting | null | undefined,
   multiplier: number = 1,
-  decimalsOverride?: number,
+  decimalsOverride?: number, // number of digits after decimal
 ): string => {
   const weiStr = parseFloat(wei).toLocaleString('fullwide', {
     useGrouping: false,
@@ -85,7 +86,7 @@ export const prettyVoteWeight = (
     return parseFloat((weiValue || 0).toString()).toString();
   }
 
-  const n = Number(weiValue) / 1e18;
+  const n = Number(weiValue) / 10 ** (tokenNumDecimals || 18);
   if (n === 0) {
     return '0';
   }

--- a/packages/commonwealth/test/unit/shared_util/prettyVoteWeight.spec.ts
+++ b/packages/commonwealth/test/unit/shared_util/prettyVoteWeight.spec.ts
@@ -4,6 +4,15 @@ import { prettyVoteWeight } from 'shared/adapters/currency';
 import { describe, test } from 'vitest';
 
 describe('prettyVoteWeight', () => {
+  test('Unweighted', () => {
+    expect(prettyVoteWeight('0'), 'handle unweighted 0').to.eq('0');
+
+    expect(prettyVoteWeight('1'), 'handle unweighted 1').to.eq('1');
+
+    expect(prettyVoteWeight('5'), 'handle unweighted > 1').to.eq('5');
+
+    expect(prettyVoteWeight('5000'), 'handle unweighted > 1000').to.eq('5000');
+  });
   test('erc20 and native ETH', () => {
     expect(
       prettyVoteWeight('0', 18, TopicWeightedVoting.ERC20),

--- a/packages/commonwealth/test/unit/shared_util/prettyVoteWeight.spec.ts
+++ b/packages/commonwealth/test/unit/shared_util/prettyVoteWeight.spec.ts
@@ -6,33 +6,55 @@ import { describe, test } from 'vitest';
 describe('prettyVoteWeight', () => {
   test('erc20 and native ETH', () => {
     expect(
-      prettyVoteWeight('0', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('0', 18, TopicWeightedVoting.ERC20),
       'handle zero',
     ).to.eq('0');
 
     expect(
-      prettyVoteWeight('1000000000000000000', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('1000000000000000000', 18, TopicWeightedVoting.ERC20),
       'handle 1 with 18-decimals',
     ).to.eq('1');
 
     expect(
-      prettyVoteWeight('5123000000000000000', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('5123000000000000000', 18, TopicWeightedVoting.ERC20),
       'handle > 1 with 18 decimals',
     ).to.eq('5.123');
 
     expect(
-      prettyVoteWeight('5123000000000000000', TopicWeightedVoting.ERC20, 2),
+      prettyVoteWeight('5123000000000000000', 6, TopicWeightedVoting.ERC20),
+      'handle with different token decimals',
+    ).to.eq('5.123t');
+
+    expect(
+      prettyVoteWeight(
+        '5123000000000000000',
+        15, // 15 token decimals
+        TopicWeightedVoting.ERC20,
+        1, // multiplier
+        0, // no numbers after decimal
+      ),
+      'handle with different token decimals',
+    ).to.eq('5k');
+
+    expect(
+      prettyVoteWeight('5123000000000000000', 18, TopicWeightedVoting.ERC20, 2),
       'multiply > 1',
     ).to.eq('10.246');
 
     expect(
-      prettyVoteWeight('5123000000000000000', TopicWeightedVoting.ERC20, 0.5),
+      prettyVoteWeight(
+        '5123000000000000000',
+        18,
+        TopicWeightedVoting.ERC20,
+        0.5,
+      ),
       'multiply < 1',
     ).to.eq('2.5615');
 
     expect(
       prettyVoteWeight(
         '5123000000000000000',
+        18,
         TopicWeightedVoting.ERC20,
         0.5,
         2,
@@ -43,6 +65,7 @@ describe('prettyVoteWeight', () => {
     expect(
       prettyVoteWeight(
         '5123000000000000000',
+        18,
         TopicWeightedVoting.ERC20,
         0.5,
         0,
@@ -51,54 +74,66 @@ describe('prettyVoteWeight', () => {
     ).to.eq('3');
 
     expect(
-      prettyVoteWeight('5123456700000000000', TopicWeightedVoting.ERC20, 1, 7),
+      prettyVoteWeight(
+        '5123456700000000000',
+        18,
+        TopicWeightedVoting.ERC20,
+        1,
+        7,
+      ),
       'seven decimal places',
     ).to.eq('5.1234567');
 
     expect(
-      prettyVoteWeight('5123000000000000000', TopicWeightedVoting.ERC20, 1, 7),
+      prettyVoteWeight(
+        '5123000000000000000',
+        18,
+        TopicWeightedVoting.ERC20,
+        1,
+        7,
+      ),
       'seven decimal places with trailing zeros truncated',
     ).to.eq('5.123');
 
     expect(
-      prettyVoteWeight('5000000000000', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('5000000000000', 18, TopicWeightedVoting.ERC20),
       'small number',
     ).to.eq('0.000005');
 
     expect(
-      prettyVoteWeight('500000000000', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('500000000000', 18, TopicWeightedVoting.ERC20),
       'really small number',
     ).to.eq('0.0…');
 
     expect(
-      prettyVoteWeight('100', TopicWeightedVoting.ERC20),
+      prettyVoteWeight('100', 18, TopicWeightedVoting.ERC20),
       'tiny number',
     ).to.eq('0.0…');
   });
 
   test('stake', () => {
     expect(
-      prettyVoteWeight('0', TopicWeightedVoting.Stake),
+      prettyVoteWeight('0', 18, TopicWeightedVoting.Stake),
       'handle zero',
     ).to.eq('0');
 
     expect(
-      prettyVoteWeight('1', TopicWeightedVoting.Stake),
+      prettyVoteWeight('1', 18, TopicWeightedVoting.Stake),
       'handle one',
     ).to.eq('1');
 
     expect(
-      prettyVoteWeight('72', TopicWeightedVoting.Stake),
+      prettyVoteWeight('72', 18, TopicWeightedVoting.Stake),
       'handle > 1',
     ).to.eq('72');
 
     expect(
-      prettyVoteWeight('7', TopicWeightedVoting.Stake, 2),
+      prettyVoteWeight('7', 18, TopicWeightedVoting.Stake, 2),
       'multiply > 1',
     ).to.eq('14');
 
     expect(
-      prettyVoteWeight('20', TopicWeightedVoting.Stake, 0.5),
+      prettyVoteWeight('20', 18, TopicWeightedVoting.Stake, 0.5),
       'multiply < 1',
     ).to.eq('10');
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11278

## Description of Changes
- Fixes issue where unweighted threads show votes as zero
- Fixes rendering of weighted votes by taking into consideration the number of decimals of the ERC20 token

## Test Plan
- Create USDC weighted topic, vote on a thread– verify that vote weight renders correctly

## Deployment Plan
N/A

## Other Considerations
- The migration assumes that any token other than USDC/MOCHI/SKI has 18 decimals. New contests are guaranteed to have the correct num decimals.