### PR TITLE
Refine FC chain node URL + contest projection

### DIFF
--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -242,6 +242,19 @@ export function Contests(): Projection<typeof inputs> {
       },
 
       ContestContentAdded: async ({ payload }) => {
+        const contestManager = await models.ContestManager.findOne({
+          where: {
+            contest_address: payload.contest_address,
+            environment: config.APP_ENV,
+          },
+        });
+        if (!contestManager) {
+          log.warn(
+            `ContestManager not found for contest ${payload.contest_address}`,
+          );
+          return;
+        }
+
         const { threadId, farcasterInfo } = decodeThreadContentUrl(
           payload.content_url,
         );
@@ -259,9 +272,6 @@ export function Contests(): Projection<typeof inputs> {
 
         // post confirmation via FC bot
         if (farcasterInfo) {
-          const contestManager = await models.ContestManager.findByPk(
-            payload.contest_address,
-          );
           const leaderboardUrl = buildContestLeaderboardUrl(
             getBaseUrl(config.APP_ENV),
             contestManager!.community_id,

--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -38,8 +38,7 @@ const inputs = {
 };
 
 /**
- * Makes sure initial contest (off-chain metadata) record exists
- * and adds EVM event sources
+ * Creates initial contest projection and adds EVM event sources
  */
 async function createInitialContest(
   namespace: string,

--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -12,6 +12,7 @@ import { events } from '@hicommonwealth/schemas';
 import { buildContestLeaderboardUrl, getBaseUrl } from '@hicommonwealth/shared';
 import { QueryTypes } from 'sequelize';
 import { models } from '../database';
+import { mustExist } from '../middleware/guards';
 import { EvmEventSourceAttributes } from '../models';
 import { getWeightedNumTokens } from '../services/stakeHelper';
 import { decodeThreadContentUrl, getChainNodeUrl, publishCast } from '../utils';
@@ -89,10 +90,7 @@ async function createInitialContest(
       },
       { where: { contest_address }, returning: true, transaction },
     );
-    if (!contestManager) {
-      log.error(`ContestManager not found for contest ${contest_address}`);
-      return;
-    }
+    mustExist('Contest Manager', contestManager);
 
     // create first contest instance
     await models.Contest.create(

--- a/libs/model/src/contest/Contests.projection.ts
+++ b/libs/model/src/contest/Contests.projection.ts
@@ -168,7 +168,7 @@ async function getContestDetails(
 
   return {
     ...result,
-    url: getChainNodeUrl({ url: result.url }),
+    url: getChainNodeUrl(result),
   };
 }
 

--- a/libs/model/src/policies/FarcasterWorker.policy.ts
+++ b/libs/model/src/policies/FarcasterWorker.policy.ts
@@ -94,6 +94,10 @@ export function FarcasterWorker(): Policy<typeof inputs> {
         );
         mustExist('Community with Chain Node', community?.ChainNode);
 
+        console.log(
+          `[FarcasterVoteCreated] CHAIN NODE: ${JSON.stringify(community.ChainNode)}`,
+        );
+
         const content_url = buildFarcasterContentUrl(
           payload.parent_hash!,
           payload.hash,
@@ -195,6 +199,10 @@ export function FarcasterWorker(): Policy<typeof inputs> {
           },
         );
         mustExist('Community with Chain Node', community?.ChainNode);
+
+        console.log(
+          `[FarcasterVoteCreated] CHAIN NODE: ${JSON.stringify(community.ChainNode)}`,
+        );
 
         const contestManagers = contestActions.map((ca) => ({
           url: getChainNodeUrl(community.ChainNode!),

--- a/libs/model/src/policies/FarcasterWorker.policy.ts
+++ b/libs/model/src/policies/FarcasterWorker.policy.ts
@@ -1,4 +1,4 @@
-import { command, Policy } from '@hicommonwealth/core';
+import { command, logger, Policy } from '@hicommonwealth/core';
 import { events } from '@hicommonwealth/schemas';
 import {
   buildFarcasterContestFrameUrl,
@@ -20,6 +20,8 @@ import {
   createOnchainContestContent,
   createOnchainContestVote,
 } from './utils/contest-utils';
+
+const log = logger(import.meta);
 
 const inputs = {
   FarcasterCastCreated: events.FarcasterCastCreated,
@@ -94,8 +96,8 @@ export function FarcasterWorker(): Policy<typeof inputs> {
         );
         mustExist('Community with Chain Node', community?.ChainNode);
 
-        console.log(
-          `[FarcasterVoteCreated] CHAIN NODE: ${JSON.stringify(community.ChainNode)}`,
+        log.error(
+          `[FarcasterReplyCastCreated] CHAIN NODE: ${community.ChainNode.id}`,
         );
 
         const content_url = buildFarcasterContentUrl(
@@ -200,8 +202,8 @@ export function FarcasterWorker(): Policy<typeof inputs> {
         );
         mustExist('Community with Chain Node', community?.ChainNode);
 
-        console.log(
-          `[FarcasterVoteCreated] CHAIN NODE: ${JSON.stringify(community.ChainNode)}`,
+        log.error(
+          `[FarcasterVoteCreated] CHAIN NODE: ${community.ChainNode.id!}`,
         );
 
         const contestManagers = contestActions.map((ca) => ({

--- a/libs/model/src/policies/FarcasterWorker.policy.ts
+++ b/libs/model/src/policies/FarcasterWorker.policy.ts
@@ -11,7 +11,11 @@ import { UpdateContestManagerFrameHashes } from '../contest/UpdateContestManager
 import { systemActor } from '../middleware';
 import { mustExist } from '../middleware/guards';
 import { DEFAULT_CONTEST_BOT_PARAMS } from '../services/openai/parseBotCommand';
-import { buildFarcasterContentUrl, publishCast } from '../utils';
+import {
+  buildFarcasterContentUrl,
+  getChainNodeUrl,
+  publishCast,
+} from '../utils';
 import {
   createOnchainContestContent,
   createOnchainContestVote,
@@ -83,7 +87,7 @@ export function FarcasterWorker(): Policy<typeof inputs> {
             include: [
               {
                 model: models.ChainNode.scope('withPrivateData'),
-                required: false,
+                required: true,
               },
             ],
           },
@@ -99,7 +103,7 @@ export function FarcasterWorker(): Policy<typeof inputs> {
         // create onchain content from reply cast
         const contestManagers = [
           {
-            url: community.ChainNode!.private_url! || community.ChainNode!.url!,
+            url: getChainNodeUrl(community.ChainNode!),
             contest_address: contestManager.contest_address,
             actions: [],
           },
@@ -193,7 +197,7 @@ export function FarcasterWorker(): Policy<typeof inputs> {
         mustExist('Community with Chain Node', community?.ChainNode);
 
         const contestManagers = contestActions.map((ca) => ({
-          url: community.ChainNode!.private_url! || community.ChainNode!.url!,
+          url: getChainNodeUrl(community.ChainNode!),
           contest_address: contestManager.contest_address,
           content_id: ca.content_id,
         }));

--- a/libs/model/test/contest/contests-projection-lifecycle.spec.ts
+++ b/libs/model/test/contest/contests-projection-lifecycle.spec.ts
@@ -1,5 +1,6 @@
 import {
   Actor,
+  config,
   DeepPartial,
   dispose,
   handleEvent,
@@ -108,6 +109,7 @@ describe('Contests projection lifecycle', () => {
               cancelled,
               topic_id,
               is_farcaster_contest: true,
+              environment: config.APP_ENV,
             },
             {
               contest_address: oneoff,
@@ -122,6 +124,7 @@ describe('Contests projection lifecycle', () => {
               cancelled,
               topics: [],
               is_farcaster_contest: false,
+              environment: config.APP_ENV,
             },
           ],
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11300

## Description of Changes
- Updates farcaster worker to use `getChainNodeUrl` to hopefully fix null chain url bug on prod
- Updates contest projection to remove contest manager fallback logic since the fallback contest manager will be broken anyway
  - This will implicitly fix the issue where contest bots from different environments respond to a single environment

## Test Plan
- Create FC contest locally, post content, upvote content– confirm content/vote shows on leaderboard page

## Deployment Plan
N/A

## Other Considerations
N/A