### PR TITLE
changed community home icon again

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/discussion_section.tsx
@@ -153,7 +153,7 @@ export const DiscussionSection = ({
         );
       },
       displayData: null,
-      leftIcon: <CWIcon iconName="squaresFour" iconSize="small" />,
+      leftIcon: <CWIcon iconName="houseSimple" iconSize="small" />,
     },
     {
       title: 'All',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11378 

For some reason the previous PR that handled this only got partially merged and the new icon wasn't showing. This is a new PR to make sure the Community Home icon is changed to a small house instead of 4 squares. 
![Screenshot 2025-03-10 at 6 08 24 PM](https://github.com/user-attachments/assets/26e65499-698e-4c3a-9b21-d1d0b0bcf522)
