### PR TITLE
made amount not truncated

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -304,7 +304,7 @@ const ContestCard = ({
                       <CWText fontWeight="bold">
                         <FractionalValue
                           fontWeight="bold"
-                          value={parseFloat(prize.replace(',', ''))}
+                          value={Number(prize.replace(/,/g, ''))}
                         />
                         &nbsp;{ticker}
                       </CWText>
@@ -338,7 +338,6 @@ const ContestCard = ({
               )}
             />
           )}
-
           {onFund && isActive && user.isLoggedIn && (
             <CWThreadAction
               label="Fund"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11371 

## Description of Changes
- This change makes it so that the prize amounts are not truncated. 

NOTE: The second bug in the ticket, the miscalculation of Based-Pepe to USD is because to get the conversion rate our code is reaching out to Coinbase and looking for a token symbol, and because there are dozens of PEPE tokens with the same symbol, it is pulling the normal Pepe and converting that to USD instead of Based=Pepe. I am making a more in depth ticket to handle this, and just pushing this change for now so that it can get on prod before the contest ends