### PR TITLE
Show token weight in contest card

### DIFF
--- a/libs/model/src/aggregates/contest/CreateContestManagerMetadata.command.ts
+++ b/libs/model/src/aggregates/contest/CreateContestManagerMetadata.command.ts
@@ -59,6 +59,7 @@ export function CreateContestManagerMetadata(): Command<
               is_farcaster_contest: !!is_farcaster_contest,
               image_url: rest.image_url || getDefaultContestImage(),
               environment: config.APP_ENV,
+              farcaster_author_cast_hash: undefined,
             },
             { transaction },
           );
@@ -67,10 +68,14 @@ export function CreateContestManagerMetadata(): Command<
       );
 
       mustExist('Contest Manager', contestManager);
+      const contestManagerData = contestManager.get({ plain: true });
+
       return {
         contest_managers: [
           {
-            ...contestManager.get({ plain: true }),
+            ...contestManagerData,
+            farcaster_author_cast_hash:
+              contestManagerData.farcaster_author_cast_hash || '',
             topic: topic?.get({ plain: true }),
           },
         ],

--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -258,6 +258,13 @@ const ContestCard = ({
             />
           </div>
         </div>
+        {ticker && (
+          <CWTag
+            label={`Weighted voting using ${ticker}`}
+            type="group"
+            classNames="contest-tag"
+          />
+        )}
         {!isFarcaster && topics?.length > 0 && (
           <CWText className="topics">
             Topic: {topics.map(({ name: topicName }) => topicName).join(', ')}

--- a/packages/commonwealth/server/farcaster/frames/contest/contestCard.tsx
+++ b/packages/commonwealth/server/farcaster/frames/contest/contestCard.tsx
@@ -65,8 +65,8 @@ export const contestCard = frames(async (ctx) => {
           style={{
             display: 'flex',
             flexDirection: 'column',
-            justifyContent: 'space-between',
-            flexGrow: 1,
+            padding: '0px',
+            height: '80%',
           }}
         >
           {contestManager.description && (
@@ -91,6 +91,17 @@ export const contestCard = frames(async (ctx) => {
               {endTime.toLocaleString(undefined, {
                 timeZoneName: 'longGeneric',
               })}
+            </p>
+          )}
+
+          {contestManager.ticker && (
+            <p
+              style={{
+                fontSize: '30px',
+                lineHeight: '1.2',
+              }}
+            >
+              Weighted voting using {contestManager.ticker}
             </p>
           )}
 

--- a/packages/commonwealth/server/farcaster/utils.tsx
+++ b/packages/commonwealth/server/farcaster/utils.tsx
@@ -152,6 +152,7 @@ export const FrameLayout = ({
           flexDirection: 'row',
           marginRight: '40px',
           gap: '20px',
+          height: '20%',
         }}
       >
         <p


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11219 

## Description of Changes
- Added token name to contest card (farcaster frame and common app)


## Test Plan
- run contest with token set for votitng
- observe if information about voting token is visible in contest card
  
  
![image](https://github.com/user-attachments/assets/8fe8f045-962d-4ab7-bd9d-4b2ba18fb547)

![image](https://github.com/user-attachments/assets/7fc94d13-c711-485b-8d61-c0c0f4af13e9)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a