### PR TITLE
Fixed contest tag

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/ThreadContestTagContainer.tsx
@@ -20,7 +20,7 @@ const ThreadContestTagContainer = ({
     <>
       {showContestWinnerTag &&
         contestWinners.map((winner, index) => {
-          if (!winner || winner?.prize === 0) {
+          if (!winner || winner?.prize === null || winner?.prize === -1) {
             return null;
           }
 
@@ -29,7 +29,7 @@ const ThreadContestTagContainer = ({
               date={winner.date}
               round={winner.round}
               title={winner.title ?? ''}
-              prize={winner.prize}
+              prize={winner.prize + 1}
               key={index}
             />
           );

--- a/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
+++ b/packages/commonwealth/client/scripts/views/components/ThreadContestTag/utils.ts
@@ -31,11 +31,11 @@ export const getWinnersFromAssociatedContests = (
         ? contest.score.findIndex(
             (s) => s.content_id === String(contest.content_id),
           )
-        : 0;
+        : null;
 
       return {
         date: moment(contest.end_time).format('DD/MM/YYYY'),
-        prize: Math.max(0, prize),
+        prize,
         // show only for recurring
         round:
           (contest.contest_interval ?? 0) > 0 ? contest.contest_id + 1 : null,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11061

## Description of Changes
- Incorrect prize value handling in contest winners
- Fixed the condition for hiding winners with invalid prizes (now checks for null or -1)
- Adjusted prize display by adding 1 to the value when showing it to users


## Test Plan
- run contest, add fund, upvote it, ideally with two accounts, two different threads
- you should be able to see tags properly marked as 1th 2nd etc depending on how did you setup contest winners and how many entries were added

![image](https://github.com/user-attachments/assets/3fd521c0-e19e-4379-adf3-e780328322f2)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a