### PR TITLE
Allow delete contest

### DIFF
--- a/libs/model/src/aggregates/contest/DeleteContestManagerMetadata.command.ts
+++ b/libs/model/src/aggregates/contest/DeleteContestManagerMetadata.command.ts
@@ -1,0 +1,38 @@
+import { InvalidState, type Command } from '@hicommonwealth/core';
+import * as schemas from '@hicommonwealth/schemas';
+import { models } from '../../database';
+import { authRoles } from '../../middleware';
+import { mustExist } from '../../middleware/guards';
+
+const Errors = {
+  ContestNotCancelledOrEnded:
+    'Contest Manager must be cancelled or ended to delete',
+};
+
+export function DeleteContestManagerMetadata(): Command<
+  typeof schemas.DeleteContestManagerMetadata
+> {
+  return {
+    ...schemas.DeleteContestManagerMetadata,
+    auth: [authRoles('admin')],
+    body: async ({ payload }) => {
+      const contestManager = await models.ContestManager.findOne({
+        where: {
+          community_id: payload.community_id,
+          contest_address: payload.contest_address,
+        },
+      });
+      mustExist('Contest Manager', contestManager);
+
+      if (!contestManager.cancelled && !contestManager.ended) {
+        throw new InvalidState(Errors.ContestNotCancelledOrEnded);
+      }
+
+      contestManager.deleted_at = new Date();
+      await contestManager.save();
+      return {
+        contest_managers: [contestManager.get({ plain: true })],
+      };
+    },
+  };
+}

--- a/libs/model/src/aggregates/contest/GetAllContests.query.ts
+++ b/libs/model/src/aggregates/contest/GetAllContests.query.ts
@@ -71,10 +71,9 @@ from
     ${payload.contest_id ? `where c.contest_id = ${payload.contest_id}` : ''}
 	  group by c.contest_address
   ) as c on cm.contest_address = c.contest_address
-${payload.community_id || payload.contest_address ? 'where' : ''}
+  where cm.deleted_at is null ${payload.community_id || payload.contest_address ? 'and' : ''}
   ${payload.community_id ? 'cm.community_id = :community_id' : ''}
-  ${payload.community_id && payload.contest_address ? 'and' : ''}
-  ${payload.contest_address ? `cm.contest_address = :contest_address` : ''}
+  ${payload.community_id && payload.contest_address ? 'and cm.contest_address = :contest_address' : ''}
 group by
   cm.community_id,
   cm.contest_address,

--- a/libs/model/src/aggregates/contest/index.ts
+++ b/libs/model/src/aggregates/contest/index.ts
@@ -1,6 +1,7 @@
 export * from './CancelContestManagerMetadata.command';
 export * from './Contests.projection';
 export * from './CreateContestManagerMetadata.command';
+export * from './DeleteContestManagerMetadata.command';
 export * from './FarcasterCastWebhook.command';
 export * from './FarcasterNotificationsWebhook.command';
 export * from './FarcasterUpvoteAction.command';

--- a/libs/model/src/models/contest_manager.ts
+++ b/libs/model/src/models/contest_manager.ts
@@ -65,6 +65,7 @@ export default (
       vote_weight_multiplier: { type: Sequelize.FLOAT, allowNull: true },
       farcaster_author_cast_hash: { type: Sequelize.STRING, allowNull: true },
       environment: { type: Sequelize.STRING, allowNull: false },
+      deleted_at: { type: Sequelize.DATE, allowNull: true },
     },
     {
       tableName: 'ContestManagers',

--- a/libs/schemas/src/commands/contest.schemas.ts
+++ b/libs/schemas/src/commands/contest.schemas.ts
@@ -208,3 +208,14 @@ export const UpdateContestManagerFrameHashes = {
   }),
   output: z.object({}),
 };
+
+export const DeleteContestManagerMetadata = {
+  input: z.object({
+    community_id: z.string(),
+    contest_address: z.string(),
+  }),
+  output: z.object({
+    contest_managers: z.array(ContestManager),
+  }),
+  context: AuthContext,
+};

--- a/libs/schemas/src/entities/contest-manager.schemas.ts
+++ b/libs/schemas/src/entities/contest-manager.schemas.ts
@@ -84,5 +84,6 @@ export const ContestManager = z
         "For bot-created contests, the hash of the farcaster author's cast that created the contest",
       ),
     environment: ContestManagerEnvironmentsSchema.optional(),
+    deleted_at: z.coerce.date().nullish().describe('Soft deletion timestamp'),
   })
   .describe('On-Chain Contest Manager');

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -175,6 +175,7 @@ export const GetStakeHistoricalPrice = {
 
 export const ConstestManagerView = ContestManager.extend({
   created_at: z.string(),
+  deleted_at: z.string().nullish(),
   topics: z.undefined(),
   contests: z.undefined(),
   content: z.array(

--- a/packages/commonwealth/client/scripts/state/api/contests/deleteContest.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/deleteContest.ts
@@ -1,0 +1,13 @@
+import { trpc } from 'utils/trpcClient';
+
+const useDeleteContestMutation = () => {
+  const utils = trpc.useUtils();
+
+  return trpc.contest.deleteContestMetadata.useMutation({
+    onSuccess: async () => {
+      await utils.contest.getAllContests.invalidate();
+    },
+  });
+};
+
+export default useDeleteContestMutation;

--- a/packages/commonwealth/client/scripts/state/api/contests/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/contests/index.ts
@@ -1,4 +1,5 @@
 import useCreateContestMutation from './createContest';
+import useDeleteContestMutation from './deleteContest';
 import useDeployRecurringContestOnchainMutation from './deployRecurringContestOnchain';
 import useDeploySingleERC20ContestOnchainMutation from './deploySingleERC20ContestOnchain';
 import useFundContestOnchainMutation from './fundContestOnchain';
@@ -8,6 +9,7 @@ import useFetchFarcasterCastsQuery from './getFarcasterCasts';
 
 export {
   useCreateContestMutation,
+  useDeleteContestMutation,
   useDeployRecurringContestOnchainMutation,
   useDeploySingleERC20ContestOnchainMutation,
   useFetchFarcasterCastsQuery,

--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -10,6 +10,7 @@ import useRerender from 'hooks/useRerender';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
 import app from 'state';
 import useCancelContestMutation from 'state/api/contests/cancelContest';
+import useDeleteContestMutation from 'state/api/contests/deleteContest';
 import useUserStore from 'state/ui/user';
 import { Skeleton } from 'views/components/Skeleton';
 import CWCountDownTimer from 'views/components/component_kit/CWCountDownTimer';
@@ -103,6 +104,7 @@ const ContestCard = ({
   const user = useUserStore();
 
   const { mutateAsync: cancelContest } = useCancelContestMutation();
+  const { mutateAsync: deleteContest } = useDeleteContestMutation();
 
   const newContestPage = useFlag('newContestPage');
 
@@ -140,6 +142,15 @@ const ContestCard = ({
     });
   };
 
+  const handleDelete = () => {
+    deleteContest({
+      contest_address: address,
+      community_id: app.activeChainId() || '',
+    }).catch((error) => {
+      console.error('Failed to delete contest: ', error);
+    });
+  };
+
   const handleCancelContest = () => {
     openConfirmation({
       title: 'You are about to end your contest',
@@ -156,6 +167,27 @@ const ContestCard = ({
           buttonType: 'destructive',
           buttonHeight: 'sm',
           onClick: handleCancel,
+        },
+      ],
+    });
+  };
+
+  const handleDeleteContest = () => {
+    openConfirmation({
+      title: 'You are about to delete your contest',
+      description:
+        'Are you sure you want to delete your contest? This action cannot be undone.',
+      buttons: [
+        {
+          label: 'Keep contest',
+          buttonType: 'secondary',
+          buttonHeight: 'sm',
+        },
+        {
+          label: 'Delete contest',
+          buttonType: 'destructive',
+          buttonHeight: 'sm',
+          onClick: handleDelete,
         },
       ],
     });
@@ -365,6 +397,14 @@ const ContestCard = ({
         <div className="contest-footer">
           <CWDivider />
           <div className="buttons">
+            {!isActive && (
+              <CWButton
+                containerClassName="cta-btn"
+                label="Delete contest"
+                buttonType="destructive"
+                onClick={handleDeleteContest}
+              />
+            )}
             <CWButton
               containerClassName="cta-btn"
               label="Cancel contest"

--- a/packages/commonwealth/server/api/contest.ts
+++ b/packages/commonwealth/server/api/contest.ts
@@ -15,6 +15,10 @@ export const trpcRouter = trpc.router({
     Contest.CancelContestManagerMetadata,
     trpc.Tag.Community,
   ),
+  deleteContestMetadata: trpc.command(
+    Contest.DeleteContestManagerMetadata,
+    trpc.Tag.Community,
+  ),
   getContestLog: trpc.query(Contest.GetContestLog, trpc.Tag.Community),
   getFarcasterCasts: trpc.query(
     Contest.GetFarcasterContestCasts,

--- a/packages/commonwealth/server/migrations/20250312130636-add-contest-manager-deleted-at.js
+++ b/packages/commonwealth/server/migrations/20250312130636-add-contest-manager-deleted-at.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('ContestManagers', 'deleted_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('ContestManagers', 'deleted_at');
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11389 

## Description of Changes
- Allows deleting a contest *only if* the contest was already cancelled/ended

## Test Plan
- Go to a community with contests, find a cancelled/ended contest
- Confirm that the "Delete contest" button shows and clicking it removes the contest from the list

## Deployment Plan
N/A

## Other Considerations
N/A