### PR TITLE
TopicBanner now shows correct vote weight

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -481,9 +481,10 @@ export const formatWeiToDecimal = (wei: string): string => {
 
 export const formatDecimalToWei = (
   decimal: string,
+  numDecimals: number = 18,
   defaultValue: number = 0,
 ): string => {
-  const value = parseFloat(decimal) * 10 ** 18;
+  const value = parseFloat(decimal) * 10 ** numDecimals;
   return (value || defaultValue).toString();
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -254,7 +254,7 @@ const DiscussionsPage = ({ topicName }: DiscussionsPageProps) => {
   const voteWeight =
     isTopicWeighted && voteBalance
       ? prettyVoteWeight(
-          formatDecimalToWei(voteBalance),
+          formatDecimalToWei(voteBalance, topicObj!.token_decimals ?? 18),
           topicObj!.token_decimals,
           topicObj!.weighted_voting,
           topicObj!.vote_weight_multiplier || 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11331 

## Description of Changes
Before:
![Screenshot 2025-03-13 at 11 01 48 AM](https://github.com/user-attachments/assets/ade2a7ca-268d-4d72-b8b8-a88f4cecb509)
After:
![Screenshot 2025-03-13 at 11 32 41 AM](https://github.com/user-attachments/assets/6d712748-cad1-4359-bf6f-b1b5578e3d98)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
updated `formatDecimalToWei` to be dynamic and multiple based off of the numDecimal passed to it. It was adding too many 0's when it was hard coded. 