### PR TITLE
Thread now shows Published when created and not yet edited

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -283,9 +283,7 @@ export class Thread implements IUniqueId {
       ? moment(t.last_edited)
       : this.versionHistory && this.versionHistory?.length > 1
         ? moment(this.versionHistory[0].timestamp)
-        : t.updated_at
-          ? moment(t.updated_at)
-          : undefined;
+        : undefined;
     this.markedAsSpamAt = t.marked_as_spam_at
       ? moment(t.marked_as_spam_at)
       : undefined;

--- a/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/editThread.ts
@@ -153,6 +153,7 @@ const useEditThreadMutation = ({
       return updatedThread;
     },
     onError: (error) => checkForSessionKeyRevalidationErrors(error),
+    mutationFn: (input) => trpc.thread.updateThread.mutate({ input }),
   });
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11351 

## Description of Changes
- Thread now shows "Published" instead of "Edited" when thread is created or hasn't been edited. 

## Test Plan
- Create a thread
- confirm that you now see "Published"
- edit the thread
- confirm you now see "Edited"

