### PR TITLE
threads now show Published after creation and when not edited

### DIFF
--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -283,7 +283,7 @@ export class Thread implements IUniqueId {
       ? moment(t.last_edited)
       : this.versionHistory && this.versionHistory?.length > 1
         ? moment(this.versionHistory[0].timestamp)
-        : t.updated_at
+        : t.updated_at && moment(t.updated_at).isAfter(moment(t.created_at))
           ? moment(t.updated_at)
           : undefined;
     this.markedAsSpamAt = t.marked_as_spam_at


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11351 

## Description of Changes
-  Thread now shows "Published" instead of "Edited" when thread is created or hasn't been edited.

## Test Plan
* Create a thread
* confirm that you now see "Published"
* edit the thread
* confirm you now see "Edited"