### PR TITLE
Fix leaderboard navigation bug

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -170,7 +170,8 @@ const ContestCard = ({
   };
 
   const handleLeaderboardClick = () => {
-    newContestPage
+    // after removing feature flag, we can remove the isFarcaster check as well
+    newContestPage || isFarcaster
       ? navigate(`/contests/${address}`, {}, community?.id)
       : navigate(
           `/discussions?featured=mostLikes&contest=${address}`,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11484

## Description of Changes
- There was an oversight when I added feature flag for new contest page
- when feature flag is off, we have two different pages for contest (farcaster vs common)
- when flag is on, we have only one, unified page

## Test Plan
- have flag off
- common leaderboard button should take you to the discussions page
- fc leaderboard button should take you to the contest page

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a