### PR TITLE
Fixed topic selection for `/common` community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/helpers/useNewThreadForm.ts
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/helpers/useNewThreadForm.ts
@@ -39,7 +39,11 @@ const useNewThreadForm = (communityId: string, topicsForSelector: Topic[]) => {
     if (restoredDraft?.topicId) {
       return topicsForSelector.find((t) => t.id === restoredDraft.topicId);
     }
-    return topicsForSelector.find((t) => t.name.includes('General')) || null;
+    return (
+      topicsForSelector.find(
+        (t) => t.name.includes('General') || t.order === 1,
+      ) || null
+    );
   }, [topicIdFromUrl, restoredDraft, topicsForSelector]);
 
   const [threadKind, setThreadKind] = useState<ThreadKind>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11486

## Description of Changes
Fixed topic selection for `/common` community

## "How We Fixed It"
N/A

## Test Plan
1. Visit `/common` community
2. Verify you see the topic selector in new thread creation page, and verify it has a default topic selected.

## Deployment Plan
N/A

## Other Considerations
N/A