### PR TITLE
Show quest time label in minutes if time remaining is less than an hour

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/quest.ts
+++ b/packages/commonwealth/client/scripts/helpers/quest.ts
@@ -14,6 +14,24 @@ import {
 export type QuestAction = z.infer<typeof QuestActionMeta>;
 export type XPLog = z.infer<typeof XpLogView>;
 
+const convertTimeRemainingToLabel = ({
+  days,
+  hours,
+  minutes,
+}: {
+  days: number;
+  hours: number;
+  minutes: number;
+}) => {
+  if (Math.abs(days) > 0)
+    return `${Math.abs(days)} day${Math.abs(days) ? 's' : ''}`;
+  if (Math.abs(hours) > 0)
+    return `${Math.abs(hours)} hour${Math.abs(hours) ? 's' : ''}`;
+  if (Math.abs(minutes) > 0)
+    return `${Math.abs(minutes)} minute${Math.abs(minutes) ? 's' : ''}`;
+  return ``;
+};
+
 export const calculateQuestTimelineLabel = ({
   startDate,
   endDate,
@@ -25,8 +43,10 @@ export const calculateQuestTimelineLabel = ({
   const isEnded = moment().isSameOrAfter(moment(endDate));
   const startHoursRemaining = moment(startDate).diff(moment(), 'hours');
   const startDaysRemaining = moment(startDate).diff(moment(), 'days');
+  const startMinutesRemaining = moment(startDate).diff(moment(), 'minutes');
   const endHoursRemaining = moment(endDate).diff(moment(), 'hours');
   const endDaysRemaining = moment(endDate).diff(moment(), 'days');
+  const endMinutesRemaining = moment(endDate).diff(moment(), 'minutes');
   const endYearsRemaining = moment(endDate).diff(moment(), 'years');
 
   if (isEnded) {
@@ -38,21 +58,11 @@ export const calculateQuestTimelineLabel = ({
     return `Ongoing`;
   }
 
-  if (isStarted) {
-    return `Ends in
-            ${
-              endHoursRemaining <= 24
-                ? `${endHoursRemaining} hours`
-                : `${endDaysRemaining} day${endDaysRemaining ? 's' : ''}`
-            }`;
-  }
-
-  // else it yet to start
-  return `Starts in ${
-    startHoursRemaining <= 24
-      ? `${startHoursRemaining} hour${startHoursRemaining > 1 ? 's' : ''}`
-      : `${startDaysRemaining} day${startDaysRemaining > 1 ? 's' : ''}`
-  }`;
+  return `${isStarted ? 'Ends' : 'Starts'} in ${convertTimeRemainingToLabel({
+    days: Math.abs(isStarted ? endDaysRemaining : startDaysRemaining),
+    hours: Math.abs(isStarted ? endHoursRemaining : startHoursRemaining),
+    minutes: Math.abs(isStarted ? endMinutesRemaining : startMinutesRemaining),
+  })}`;
 };
 
 export const calculateTotalXPForQuestActions = ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11483

## Description of Changes
Show quest time label in minutes if time remaining is less than an hour

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Create a quest as site admin from `/createQuest`, that starts in less than an hour
3. Visit `/explore` page
4. Verify you see that quest's card with time label showing minutes remaining, instead of `0 hours`

## Deployment Plan
N/A

## Other Considerations
N/A