### PR TITLE
added space between sign in copy and button in sidebar

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.scss
@@ -22,5 +22,10 @@
 
   .sign-in-text {
     text-align: center;
+    margin-top: -20px;
+  }
+
+  .sign-in-button {
+    margin-top: 20px;
   }
 }

--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarSignInButton/SidebarSignInButton.tsx
@@ -22,9 +22,10 @@ const SidebarSignInButton = ({
       )}
     >
       <CWText type="b2" className="sign-in-text">
-        Sign in to see your communities on Common.
+        Sign in to see your communities on Common
       </CWText>
       <CWButton
+        className="sign-in-button"
         buttonType="primary"
         label="Sign in"
         buttonWidth="full"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11528 

## Description of Changes
- adds spacing between sign in copy and button on sidebar

![Screenshot 2025-03-18 at 10 57 07 AM](https://github.com/user-attachments/assets/230e4c22-6ba3-4ffa-bc95-11bc98b07cb9)
