### PR TITLE
Reduce contest rollbar error spam

### DIFF
--- a/libs/model/src/aggregates/contest/Contests.projection.ts
+++ b/libs/model/src/aggregates/contest/Contests.projection.ts
@@ -14,7 +14,6 @@ import {
   buildFarcasterContestFrameUrl,
   getBaseUrl,
 } from '@hicommonwealth/shared';
-import { findActiveContestManager } from 'model/src/utils/findActiveContestManager';
 import { QueryTypes } from 'sequelize';
 import { models } from '../../database';
 import { mustExist } from '../../middleware/guards';
@@ -26,6 +25,7 @@ import {
   getChainNodeUrl,
   publishCast,
 } from '../../utils';
+import { findActiveContestManager } from '../../utils/findActiveContestManager';
 
 const log = logger(import.meta);
 

--- a/libs/model/src/aggregates/contest/Contests.projection.ts
+++ b/libs/model/src/aggregates/contest/Contests.projection.ts
@@ -260,6 +260,7 @@ export function Contests(): Projection<typeof inputs> {
                 payoutStructure: [winner1, winner2, winner3],
                 voterShare,
               } = DEFAULT_CONTEST_BOT_PARAMS;
+              // eslint-disable-next-line max-len
               return `Hey @${username}, your contest has been created. The prize distribution is ${winner1}% to winner, ${winner2}% to second place, ${winner3}% to third , and ${voterShare}% going to voters. The contest will run for 7 days. Anyone who replies to a cast containing the frame enters the contest.`;
             },
             {

--- a/libs/model/src/utils/findActiveContestManager.ts
+++ b/libs/model/src/utils/findActiveContestManager.ts
@@ -1,9 +1,6 @@
-import { logger } from '@hicommonwealth/core';
 import { Op } from 'sequelize';
 import { config } from '../config';
 import { models } from '../database';
-
-const log = logger(import.meta);
 
 export function findActiveContestManager(
   contest_address: string,

--- a/libs/model/src/utils/findActiveContestManager.ts
+++ b/libs/model/src/utils/findActiveContestManager.ts
@@ -1,0 +1,30 @@
+import { logger } from '@hicommonwealth/core';
+import { Op } from 'sequelize';
+import { config } from '../config';
+import { models } from '../database';
+
+const log = logger(import.meta);
+
+export function findActiveContestManager(
+  contest_address: string,
+  where: Record<string, any> = {},
+) {
+  const contestManager = models.ContestManager.findOne({
+    where: {
+      contest_address,
+      environment: config.APP_ENV,
+      cancelled: {
+        [Op.not]: true,
+      },
+      ended: {
+        [Op.not]: true,
+      },
+      ...where,
+    },
+  });
+  if (!contestManager) {
+    log.warn(`ContestManager not found for contest ${contest_address}`);
+    return null;
+  }
+  return contestManager;
+}

--- a/libs/model/src/utils/findActiveContestManager.ts
+++ b/libs/model/src/utils/findActiveContestManager.ts
@@ -23,7 +23,6 @@ export function findActiveContestManager(
     },
   });
   if (!contestManager) {
-    log.warn(`ContestManager not found for contest ${contest_address}`);
     return null;
   }
   return contestManager;

--- a/libs/model/src/utils/findActiveContestManager.ts
+++ b/libs/model/src/utils/findActiveContestManager.ts
@@ -2,8 +2,8 @@ import { Op } from 'sequelize';
 import { config } from '../config';
 import { models } from '../database';
 
-export function findActiveContestManager(contest_address: string) {
-  const contestManager = models.ContestManager.findOne({
+export async function findActiveContestManager(contest_address: string) {
+  return await models.ContestManager.findOne({
     where: {
       contest_address,
       environment: config.APP_ENV,
@@ -15,8 +15,4 @@ export function findActiveContestManager(contest_address: string) {
       },
     },
   });
-  if (!contestManager) {
-    return null;
-  }
-  return contestManager;
 }

--- a/libs/model/src/utils/findActiveContestManager.ts
+++ b/libs/model/src/utils/findActiveContestManager.ts
@@ -2,10 +2,7 @@ import { Op } from 'sequelize';
 import { config } from '../config';
 import { models } from '../database';
 
-export function findActiveContestManager(
-  contest_address: string,
-  where: Record<string, any> = {},
-) {
+export function findActiveContestManager(contest_address: string) {
   const contestManager = models.ContestManager.findOne({
     where: {
       contest_address,
@@ -16,7 +13,6 @@ export function findActiveContestManager(
       ended: {
         [Op.not]: true,
       },
-      ...where,
     },
   });
   if (!contestManager) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11540

## Description of Changes
- Uses warnings instead of `mustExist` when checking contest managers in projection
- Adds missing check for `RecurringContestManagerDeployed` path
- Adds helper function to find active contest by address

## Test Plan
- Create contest, add content, vote on content– confirm events are processed

## Deployment Plan
N/A

## Other Considerations
N/A