### PR TITLE
put mava back on desktop

### DIFF
--- a/packages/commonwealth/client/index.html
+++ b/packages/commonwealth/client/index.html
@@ -225,5 +225,13 @@
   </head>
   <body>
     <div id="root"></div>
+    <script
+      defer
+      src="https://widget.mava.app"
+      widget-version="v2"
+      id="MavaWebChat"
+      enable-sdk="true"
+      data-token="28672714d1690a96717516beafd198d5dcacf85b19fde51e88b05ed8831640c9"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11548 

## Description of Changes
- Added Mava widget back to desktop

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
open any page and confirm you see the Mava widget on screen again. 
![Screenshot 2025-03-18 at 8 47 40 PM](https://github.com/user-attachments/assets/ef6dc866-d18c-45a2-a1f9-18e3ecc557dd)

