### PR TITLE
added xp column to members leaderboard

### DIFF
--- a/libs/model/src/aggregates/community/GetMembers.query.ts
+++ b/libs/model/src/aggregates/community/GetMembers.query.ts
@@ -179,6 +179,7 @@ function membersSqlWithSearch(
         COALESCE(U.referral_count, 0) AS referral_count,
         COALESCE(U.referral_eth_earnings, 0) AS referral_eth_earnings,
         COALESCE(U.xp_points, 0) AS xp_points,
+        COALESCE(U.xp_referrer_points, 0) AS xp_referrer_points,
         MAX(COALESCE(A.last_active, U.created_at)) AS last_active,
         JSONB_AGG(JSON_BUILD_OBJECT(
           'id', A.id,

--- a/libs/model/src/aggregates/community/GetMembers.query.ts
+++ b/libs/model/src/aggregates/community/GetMembers.query.ts
@@ -124,6 +124,7 @@ function membersSqlWithoutSearch(
         ) as referred_by,
         COALESCE(U.referral_count, 0) AS referral_count,
         COALESCE(U.referral_eth_earnings, 0) AS referral_eth_earnings,
+        COALESCE(U.xp_points, 0) AS xp_points,
         MAX(COALESCE(A.last_active, U.created_at)) AS last_active,
         JSONB_AGG(JSON_BUILD_OBJECT(
           'id', A.id,
@@ -176,6 +177,7 @@ function membersSqlWithSearch(
         ) AS referred_by,
         COALESCE(U.referral_count, 0) AS referral_count,
         COALESCE(U.referral_eth_earnings, 0) AS referral_eth_earnings,
+        COALESCE(U.xp_points, 0) AS xp_points,
         MAX(COALESCE(A.last_active, U.created_at)) AS last_active,
         JSONB_AGG(JSON_BUILD_OBJECT(
           'id', A.id,

--- a/libs/model/src/aggregates/community/GetMembers.query.ts
+++ b/libs/model/src/aggregates/community/GetMembers.query.ts
@@ -125,6 +125,7 @@ function membersSqlWithoutSearch(
         COALESCE(U.referral_count, 0) AS referral_count,
         COALESCE(U.referral_eth_earnings, 0) AS referral_eth_earnings,
         COALESCE(U.xp_points, 0) AS xp_points,
+        COALESCE(U.xp_referrer_points, 0) AS xp_referrer_points,
         MAX(COALESCE(A.last_active, U.created_at)) AS last_active,
         JSONB_AGG(JSON_BUILD_OBJECT(
           'id', A.id,

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -133,4 +133,5 @@ export const CommunityMember = z.object({
     .nullish(),
   referral_count: PG_INT.default(0).nullish(),
   referral_eth_earnings: z.number().nullish(),
+  xp_points: PG_INT.default(0).nullish(),
 });

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -131,8 +131,8 @@ export const CommunityMember = z.object({
       avatar_url: z.string().nullish(),
     })
     .nullish(),
-  referral_count: PG_INT.default(0).nullish(),
-  referral_eth_earnings: z.number().nullish(),
-  xp_points: PG_INT.default(0).nullish(),
-  xp_referrer_points: PG_INT.default(0).nullish(),
+  referral_count: PG_INT.default(0),
+  referral_eth_earnings: z.number(),
+  xp_points: PG_INT.default(0),
+  xp_referrer_points: PG_INT.default(0),
 });

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -134,4 +134,5 @@ export const CommunityMember = z.object({
   referral_count: PG_INT.default(0).nullish(),
   referral_eth_earnings: z.number().nullish(),
   xp_points: PG_INT.default(0).nullish(),
+  xp_referrer_points: PG_INT.default(0).nullish(),
 });

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -17,17 +17,6 @@ import { MemberResultsOrderBy } from '../index.types';
 
 import './LeaderboardSection.scss';
 
-interface Member {
-  user_id: number;
-  profile_name: string;
-  avatar_url: string;
-  xp_points: number;
-  xp_referrer_points: number;
-  referral_count: number;
-  referral_eth_earnings: string;
-  addresses: Array<{ address: string }>;
-}
-
 const columns = [
   {
     key: 'rank',
@@ -107,10 +96,10 @@ const LeaderboardSection = () => {
         ),
       },
       aura: {
-        sortValue: (member.xp_points || 0) + (member.xp_referrer_points || 0),
+        sortValue: member.xp_points + member.xp_referrer_points,
         customElement: (
           <div className="table-cell text-right">
-            {(member.xp_points || 0) + (member.xp_referrer_points || 0)}
+            {member.xp_points + member.xp_referrer_points}
           </div>
         ),
       },

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -31,6 +31,12 @@ const columns = [
     sortable: true,
   },
   {
+    key: 'xp',
+    header: 'XP',
+    numeric: true,
+    sortable: true,
+  },
+  {
     key: 'referrals',
     header: 'Referrals',
     numeric: true,
@@ -66,7 +72,7 @@ const LeaderboardSection = () => {
       search: debouncedSearchTerm,
     }),
   });
-
+  console.log('MEMEBERS: ', members);
   const formattedMembers =
     members?.pages?.[0]?.results.map((member, index) => ({
       ...member,
@@ -87,6 +93,12 @@ const LeaderboardSection = () => {
               <p>{member.profile_name}</p>
             </Link>
           </div>
+        ),
+      },
+      xp: {
+        sortValue: member.xp_points,
+        customElement: (
+          <div className="table-cell text-right">{member.xp_points}</div>
         ),
       },
       referrals: {

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -83,7 +83,7 @@ const LeaderboardSection = () => {
       search: debouncedSearchTerm,
     }),
   });
-  console.log('MEMBERS:: ', members);
+
   const formattedMembers =
     members?.pages?.[0]?.results.map((member, index) => ({
       ...member,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -72,7 +72,7 @@ const LeaderboardSection = () => {
       search: debouncedSearchTerm,
     }),
   });
-  console.log('MEMEBERS: ', members);
+
   const formattedMembers =
     members?.pages?.[0]?.results.map((member, index) => ({
       ...member,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/LeaderboardSection/LeaderboardSection.tsx
@@ -17,6 +17,17 @@ import { MemberResultsOrderBy } from '../index.types';
 
 import './LeaderboardSection.scss';
 
+interface Member {
+  user_id: number;
+  profile_name: string;
+  avatar_url: string;
+  xp_points: number;
+  xp_referrer_points: number;
+  referral_count: number;
+  referral_eth_earnings: string;
+  addresses: Array<{ address: string }>;
+}
+
 const columns = [
   {
     key: 'rank',
@@ -31,8 +42,8 @@ const columns = [
     sortable: true,
   },
   {
-    key: 'xp',
-    header: 'XP',
+    key: 'aura',
+    header: 'Aura',
     numeric: true,
     sortable: true,
   },
@@ -72,7 +83,7 @@ const LeaderboardSection = () => {
       search: debouncedSearchTerm,
     }),
   });
-
+  console.log('MEMBERS:: ', members);
   const formattedMembers =
     members?.pages?.[0]?.results.map((member, index) => ({
       ...member,
@@ -95,10 +106,12 @@ const LeaderboardSection = () => {
           </div>
         ),
       },
-      xp: {
-        sortValue: member.xp_points,
+      aura: {
+        sortValue: (member.xp_points || 0) + (member.xp_referrer_points || 0),
         customElement: (
-          <div className="table-cell text-right">{member.xp_points}</div>
+          <div className="table-cell text-right">
+            {(member.xp_points || 0) + (member.xp_referrer_points || 0)}
+          </div>
         ),
       },
       referrals: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10691 

## Description of Changes
- Adds a new column for XP in Members Leaderboard

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
-changed query to return user.xp_points from `useGetMembersQuery`
-added a new column to the frontend
## Test Plan
- go to a community members page and go to Leaderboard, I used the Common community
- confirm that you see the XP column in the Leaderboard
![Screenshot 2025-03-20 at 3 31 22 PM](https://github.com/user-attachments/assets/e19f4cb6-1a05-4c56-990f-b30fb762d8d9)
