### PR TITLE
Added validation enhancement for parent quest level xp

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/formValidations/messages.ts
+++ b/packages/commonwealth/client/scripts/helpers/formValidations/messages.ts
@@ -6,6 +6,8 @@ export const VALIDATION_MESSAGES = {
   INVALID_INPUT: 'Invalid input',
   MUST_BE_TYPE: (type: string) => `Must be of ${type} type`,
   MUST_BE_GREATER: (value: string | number) => `Must be greater than ${value}`,
+  MUST_BE_BETWEEN: (rangeStart: string | number, rangeEnd: string | number) =>
+    `Must be between ${rangeStart} - ${rangeEnd}`,
   MUST_BE_LESS_OR_EQUAL: (value: string | number) =>
     `Must be less or equal to ${value}`,
   MUST_BE_APART: (fieldName: string, differenceValue: string | number) =>

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
@@ -46,6 +46,9 @@ const CWForm = forwardRef<UseFormReturn, FormProps>(
     });
 
     // Expose formMethods to parent components using ref
+    // Note: this doesn't expose watchers/subscribers, i.e ref.watch(`field_name`) would act
+    // as a getter, and not a subscriber. For subscriber based functions, the callback signature
+    // will work as a proper subscriber i.e ref.watch((values) => values.field_name).
     useImperativeHandle(ref, () => formMethods);
 
     useEffect(() => {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestForm.tsx
@@ -22,7 +22,7 @@ import QuestActionSubForm, { QuestAction } from './QuestActionSubForm';
 import './QuestForm.scss';
 import { QuestFormProps } from './types';
 import useQuestForm from './useQuestForm';
-import { questFormValidationSchema } from './validation';
+import { buildDynamicQuestFormValidationSchema } from './validation';
 
 const QuestForm = (props: QuestFormProps) => {
   const { mode, initialValues } = props;
@@ -41,6 +41,7 @@ const QuestForm = (props: QuestFormProps) => {
     idealStartDate,
     minEndDate,
     formMethodsRef,
+    minQuestLevelXP,
   } = useQuestForm(props);
 
   const popoverProps = usePopover();
@@ -48,7 +49,9 @@ const QuestForm = (props: QuestFormProps) => {
   return (
     <CWForm
       ref={formMethodsRef}
-      validationSchema={questFormValidationSchema}
+      validationSchema={buildDynamicQuestFormValidationSchema({
+        max_xp_to_end_lower_limit: minQuestLevelXP || 0,
+      })}
       onSubmit={handleSubmit}
       onErrors={validateSubForms}
       {...(initialValues

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/types.ts
@@ -6,7 +6,7 @@ import {
   questSubFormValidationSchemaWithCreatorPoints,
   questSubFormValidationSchemaWithCreatorPointsWithContentLink,
 } from './QuestActionSubForm/validation';
-import { questFormValidationSchema } from './validation';
+import { buildDynamicQuestFormValidationSchema } from './validation';
 
 export type QuestActionSubFormValues = z.infer<
   typeof questSubFormValidationSchema
@@ -30,7 +30,9 @@ export type QuestFormProps =
   | {
       mode: 'update';
       questId: number;
-      initialValues: z.infer<typeof questFormValidationSchema> & {
+      initialValues: z.infer<
+        ReturnType<typeof buildDynamicQuestFormValidationSchema>
+      > & {
         participation_period?: QuestParticipationPeriod;
         participation_times_per_period?: number;
       } & {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -1,8 +1,13 @@
-import { QuestEvents, QuestParticipationPeriod } from '@hicommonwealth/schemas';
+import {
+  QuestEvents,
+  QuestParticipationLimit,
+  QuestParticipationPeriod,
+} from '@hicommonwealth/schemas';
 import { getDefaultContestImage } from '@hicommonwealth/shared';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { calculateRemainingPercentageChangeFractional } from 'helpers/number';
 import {
+  calculateTotalXPForQuestActions,
   doesActionAllowCommentId,
   doesActionAllowContentId,
   doesActionAllowThreadId,
@@ -12,7 +17,7 @@ import {
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
 import moment from 'moment';
 import { useCommonNavigate } from 'navigation/helpers';
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   useCreateQuestMutation,
   useUpdateQuestMutation,
@@ -29,7 +34,7 @@ import {
   QuestActionSubFormValuesWithCreatorPoints,
   QuestFormProps,
 } from './types';
-import { questFormValidationSchema } from './validation';
+import { buildDynamicQuestFormValidationSchema } from './validation';
 
 const MIN_ACTIONS_LIMIT = 1;
 const MAX_ACTIONS_LIMIT = Object.values(QuestEvents).length; // = 8 max actions
@@ -106,6 +111,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
   const minEndDate = new Date(new Date().getTime() + 2 * 24 * 60 * 60 * 1000); // now + 1 day in future
 
   const [isProcessingQuestImage, setIsProcessingQuestImage] = useState(false);
+  const [minQuestLevelXP, setMinQuestLevelXP] = useState(0);
 
   const { mutateAsync: createQuest } = useCreateQuestMutation();
   const { mutateAsync: updateQuest } = useUpdateQuestMutation();
@@ -113,6 +119,46 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
   const navigate = useCommonNavigate();
 
   const formMethodsRef = useRef<CWFormRef>(null);
+
+  const triggerCalculateTotalXPForQuestActions = useCallback(() => {
+    setMinQuestLevelXP(
+      calculateTotalXPForQuestActions({
+        isUserReferred: false, // we assume user is not referred to calculate the max lower/upper limit,
+        questActions: questActionSubForms.map(({ values }) => ({
+          creator_reward_weight: parseInt(`${values.creatorRewardAmount || 0}`),
+          event_name: values.action as any,
+          quest_id: Math.random(),
+          reward_amount: parseInt(`${values.rewardAmount || 0}`),
+          participation_times_per_period: parseInt(
+            `${values.participationTimesPerPeriod || 0}`,
+          ),
+          participation_limit:
+            values.participationLimit || QuestParticipationLimit.OncePerQuest,
+          participation_period:
+            values.participationPeriod || QuestParticipationPeriod.Daily,
+        })),
+        questEndDate:
+          formMethodsRef?.current?.getValues('end_date') || new Date(),
+        questStartDate:
+          formMethodsRef?.current?.getValues('start_date') || new Date(),
+      }),
+    );
+  }, [questActionSubForms]);
+
+  // recalculate `minQuestLevelXP` when parent form changes
+  formMethodsRef?.current?.watch(() =>
+    triggerCalculateTotalXPForQuestActions(),
+  );
+
+  // recalculate `minQuestLevelXP` when any subform changes
+  useEffect(() => {
+    triggerCalculateTotalXPForQuestActions();
+  }, [questActionSubForms, triggerCalculateTotalXPForQuestActions]);
+
+  // recalculate `max_xp_to_end` field error state when `minQuestLevelXP` changes
+  useEffect(() => {
+    formMethodsRef?.current?.trigger('max_xp_to_end').catch(console.error);
+  }, [minQuestLevelXP]);
 
   const handleQuestMutateConfirmation = async (hours: number) => {
     return new Promise((resolve, reject) => {
@@ -139,7 +185,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
   };
 
   const handleCreateQuest = async (
-    values: z.infer<typeof questFormValidationSchema>,
+    values: z.infer<ReturnType<typeof buildDynamicQuestFormValidationSchema>>,
   ) => {
     const quest = await createQuest({
       name: values.name.trim(),
@@ -199,7 +245,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
   };
 
   const handleUpdateQuest = async (
-    values: z.infer<typeof questFormValidationSchema>,
+    values: z.infer<ReturnType<typeof buildDynamicQuestFormValidationSchema>>,
   ) => {
     if (!questId) return;
 
@@ -257,7 +303,9 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
     });
   };
 
-  const handleSubmit = (values: z.infer<typeof questFormValidationSchema>) => {
+  const handleSubmit = (
+    values: z.infer<ReturnType<typeof buildDynamicQuestFormValidationSchema>>,
+  ) => {
     const subFormErrors = validateSubForms();
 
     if (subFormErrors || (mode === 'update' ? !questId : false)) {
@@ -376,6 +424,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
     updateSubFormByIndex,
     validateSubForms,
     // main form specific fields
+    minQuestLevelXP,
     handleSubmit,
     isProcessingQuestImage,
     setIsProcessingQuestImage,

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -126,7 +126,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
         isUserReferred: false, // we assume user is not referred to calculate the max lower/upper limit,
         questActions: questActionSubForms.map(({ values }) => ({
           creator_reward_weight: parseInt(`${values.creatorRewardAmount || 0}`),
-          event_name: values.action as any,
+          event_name: values.action as QuestAction,
           quest_id: Math.random(),
           reward_amount: parseInt(`${values.rewardAmount || 0}`),
           participation_times_per_period: parseInt(

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/validation.ts
@@ -8,80 +8,99 @@ import { z } from 'zod';
 // update in future if required
 export const MAX_XP_TO_END_UPPER_LIMIT = 10_000_000;
 
-export const questFormValidationSchema = z
-  .object({
-    start_date: z
-      .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-      .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
-    end_date: z
-      .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-      .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
-    name: z
-      .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-      .min(5, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(5) })
-      .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
-    description: z
-      .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
-      .min(10, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(10) })
-      .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
-      .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
-    image: linkValidationSchema.optional,
-    max_xp_to_end: numberNonDecimalGTZeroValidationSchema.refine(
-      (value) => {
-        const intVal = parseInt(value, 10);
-        return intVal <= MAX_XP_TO_END_UPPER_LIMIT;
+type BuildDynamicQuestFormValidationSchemaProps = {
+  max_xp_to_end_lower_limit: number;
+};
+
+export const buildDynamicQuestFormValidationSchema = ({
+  max_xp_to_end_lower_limit,
+}: BuildDynamicQuestFormValidationSchemaProps) => {
+  return z
+    .object({
+      start_date: z
+        .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+        .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+      end_date: z
+        .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+        .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+      name: z
+        .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+        .min(5, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(5) })
+        .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+      description: z
+        .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
+        .min(10, { message: VALIDATION_MESSAGES.MIN_CHAR_LIMIT_REQUIRED(10) })
+        .max(250, { message: VALIDATION_MESSAGES.MAX_CHAR_LIMIT_REACHED })
+        .nonempty({ message: VALIDATION_MESSAGES.NO_INPUT }),
+      image: linkValidationSchema.optional,
+      max_xp_to_end: numberNonDecimalGTZeroValidationSchema.refine(
+        (value) => {
+          const intVal = parseInt(value, 10);
+          if (max_xp_to_end_lower_limit) {
+            return (
+              intVal <= MAX_XP_TO_END_UPPER_LIMIT &&
+              intVal > max_xp_to_end_lower_limit
+            );
+          }
+          return intVal <= MAX_XP_TO_END_UPPER_LIMIT;
+        },
+        {
+          message: max_xp_to_end_lower_limit
+            ? VALIDATION_MESSAGES.MUST_BE_BETWEEN(
+                max_xp_to_end_lower_limit || 0,
+                MAX_XP_TO_END_UPPER_LIMIT,
+              )
+            : VALIDATION_MESSAGES.MUST_BE_LESS_OR_EQUAL(
+                MAX_XP_TO_END_UPPER_LIMIT,
+              ),
+        },
+      ),
+      community: z
+        .object(
+          {
+            value: z.string(),
+            label: z.object({
+              name: z.string(),
+              imageURL: z.string(),
+            }),
+          },
+          {
+            invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
+          },
+        )
+        .optional()
+        .nullish(),
+    })
+    .refine(
+      (data) => {
+        try {
+          const startDate = new Date(data.start_date);
+          const endDate = new Date(data.end_date);
+          // ensure end date is greater than start date
+          return endDate.getTime() > startDate.getTime();
+        } catch {
+          return false;
+        }
       },
       {
-        message: VALIDATION_MESSAGES.MUST_BE_LESS_OR_EQUAL(
-          MAX_XP_TO_END_UPPER_LIMIT,
-        ),
+        message: VALIDATION_MESSAGES.MUST_BE_GREATER('start date'),
+        path: ['end_date'],
       },
-    ),
-    community: z
-      .object(
-        {
-          value: z.string(),
-          label: z.object({
-            name: z.string(),
-            imageURL: z.string(),
-          }),
-        },
-        {
-          invalid_type_error: VALIDATION_MESSAGES.NO_INPUT,
-        },
-      )
-      .optional()
-      .nullish(),
-  })
-  .refine(
-    (data) => {
-      try {
-        const startDate = new Date(data.start_date);
-        const endDate = new Date(data.end_date);
-        // ensure end date is greater than start date
-        return endDate.getTime() > startDate.getTime();
-      } catch {
-        return false;
-      }
-    },
-    {
-      message: VALIDATION_MESSAGES.MUST_BE_GREATER('start date'),
-      path: ['end_date'],
-    },
-  )
-  .refine(
-    (data) => {
-      try {
-        const startDate = new Date(data.start_date);
-        const endDate = new Date(data.end_date);
-        // ensure diff b/w start/end date is at least 1 day
-        return endDate.getTime() - startDate.getTime() >= 86400000; // 86400000 ms = 1 day
-      } catch {
-        return false;
-      }
-    },
-    {
-      message: VALIDATION_MESSAGES.MUST_BE_APART('start date', '1 day'),
-      path: ['end_date'],
-    },
-  );
+    )
+    .refine(
+      (data) => {
+        try {
+          const startDate = new Date(data.start_date);
+          const endDate = new Date(data.end_date);
+          // ensure diff b/w start/end date is at least 1 day
+          return endDate.getTime() - startDate.getTime() >= 86400000; // 86400000 ms = 1 day
+        } catch {
+          return false;
+        }
+      },
+      {
+        message: VALIDATION_MESSAGES.MUST_BE_APART('start date', '1 day'),
+        path: ['end_date'],
+      },
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11489

## Description of Changes
Added validation enhancement for parent quest level xp

## "How We Fixed It"
N/A

## Test Plan
1. Enable `FLAG_XP`
2. Visit `/createQuest` as site admin
3. Verify that `XP limit` field updates to correctly reflect the min xp limit required for the quest, if your input value is less than the limit, when you perform any of the following actions
    1. Add multiple actions with different repetition counts and schedules 
    2. Change start and end dates for quest


## Deployment Plan
N/A

## Other Considerations
N/A