### PR TITLE
Focus create comment bar when clicking on padding

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/DesktopStickyInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/DesktopStickyInput.tsx
@@ -102,7 +102,7 @@ export const DesktopStickyInput = (props: CommentEditorProps) => {
   return (
     <div className="DesktopStickyInput">
       {!useExpandedEditor ? (
-        <div className="DesktopStickyInputCollapsed">
+        <div className="DesktopStickyInputCollapsed" onClick={handleFocused}>
           <div className="container">
             <input
               type="text"
@@ -114,7 +114,6 @@ export const DesktopStickyInput = (props: CommentEditorProps) => {
                     ? `Reply to ${replyingToAuthor}...`
                     : 'Write a comment...'
               }
-              onClick={handleFocused}
             />
           </div>
         </div>


### PR DESCRIPTION
Clicking on the comment bar sometimes doesn't pop open the editor, unless you click exactly on the placeholder text. This makes it so clicking on the padding of the collapsed bar also opens the editor.

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 