### PR TITLE
Judged contest admin flow (only UI)

### DIFF
--- a/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
+++ b/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
@@ -48,9 +48,6 @@ export const getTotalContestBalance = async (
     feeManagerAddressPromise,
   ]);
 
-  console.log('contestToken', contestToken);
-  console.log('contestAddress', contestAddress);
-
   let beneficiaryBalancePromise: Promise<bigint> | undefined;
   if (!oneOff && feeManagerAddress) {
     beneficiaryBalancePromise = client.readContract({

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -34,6 +34,7 @@ const featureFlags = {
   homePage: buildFlag(process.env.FLAG_HOMEPAGE),
   aiComments: buildFlag(process.env.FLAG_AI_COMMENTS),
   governancePage: buildFlag(process.env.FLAG_NEW_GOVERNANCE_PAGE),
+  judgeContest: buildFlag(process.env.FLAG_JUDGE_CONTEST),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 
 import commonUrl from 'assets/img/branding/common.svg';
 import farcasterUrl from 'assets/img/farcaster.svg';
+import shape2Url from 'assets/img/shapes/shape2.svg';
 import useAppStatus from 'hooks/useAppStatus';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
+import { useFlag } from 'hooks/useFlag';
 import { useCommonNavigate } from 'navigation/helpers';
 import {
   BaseMixpanelPayload,
@@ -37,6 +39,7 @@ const AdminContestsPage = () => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
   const { isAddedToHomeScreen } = useAppStatus();
+  const judgeContestEnabled = useFlag('judgeContest');
 
   const isAdmin = Permissions.isSiteAdmin() || Permissions.isCommunityAdmin();
 
@@ -114,6 +117,10 @@ const AdminContestsPage = () => {
 
   const goToLaunchCommonContest = () => {
     navigate(`/manage/contests/launch?type=${ContestType.Common}`);
+  };
+
+  const goToCreateTopicPage = () => {
+    navigate('/manage/topics');
   };
 
   // Check if there are any contests (active or finished)
@@ -201,28 +208,42 @@ const AdminContestsPage = () => {
           </>
         ) : contestView === ContestView.TypeSelection ? (
           <div className="type-selection-list">
-            <EmptyCard
-              img={commonUrl}
-              title="Launch on Common"
-              subtitle={
-                hasAtLeastOneWeightedVotingTopic
-                  ? 'Setting up a contest just takes a few minutes and can be a huge boost to your community.'
-                  : `For weighted contests, you need at least one topic with weighted voting enabled. 
-                    You can still proceed to set up your contest.`
-              }
-              button={{
-                label: 'Launch Common contest',
-                handler: goToLaunchCommonContest,
-              }}
-            />
+            {judgeContestEnabled || hasAtLeastOneWeightedVotingTopic ? (
+              <EmptyCard
+                img={commonUrl}
+                title="Launch on Common"
+                subtitle={
+                  hasAtLeastOneWeightedVotingTopic
+                    ? `Setting up a contest just takes a few minutes and can be a huge boost to your community.`
+                    : `For weighted contests, you need at least one topic with weighted voting enabled. 
+You can still proceed to set up your contest.`
+                }
+                button={{
+                  label: 'Launch Common contest',
+                  handler: goToLaunchCommonContest,
+                }}
+              />
+            ) : (
+              <EmptyCard
+                img={shape2Url}
+                title="Launch on Common"
+                subtitle={`You must have at least one topic with weighted voting enabled to run contest.
+Setting up a contest just takes a few minutes and can be a huge boost to your community.`}
+                button={{
+                  label: 'Create a topic',
+                  handler: goToCreateTopicPage,
+                }}
+              />
+            )}
 
             <EmptyCard
               img={farcasterUrl}
               title="Launch on Farcaster"
               subtitle={
                 community?.namespace
-                  ? 'Share your contest on Farcaster'
-                  : 'You need a namespace for your community to run Farcaster contests. Set one up first.'
+                  ? `Share your contest on Farcaster`
+                  : `You need a namespace for your community to run Farcaster contests.
+Set one up first.`
               }
               button={{
                 label: community?.namespace

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/AdminContestsPage/AdminContestsPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 
 import commonUrl from 'assets/img/branding/common.svg';
 import farcasterUrl from 'assets/img/farcaster.svg';
-import shape2Url from 'assets/img/shapes/shape2.svg';
 import useAppStatus from 'hooks/useAppStatus';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { useCommonNavigate } from 'navigation/helpers';
@@ -25,6 +24,7 @@ import CommunityStakeStep from 'views/pages/CreateCommunity/steps/CommunityStake
 
 import { CWDivider } from '../../../../components/component_kit/cw_divider';
 import ContestsList from '../ContestsList';
+import EmptyContestsList from '../EmptyContestsList';
 import { ContestType, ContestView } from '../types';
 import useCommunityContests from '../useCommunityContests';
 import FeeManagerBanner from './FeeManagerBanner';
@@ -112,127 +112,127 @@ const AdminContestsPage = () => {
     navigate(`/manage/contests/launch?type=${ContestType.Farcaster}`);
   };
 
+  const goToLaunchCommonContest = () => {
+    navigate(`/manage/contests/launch?type=${ContestType.Common}`);
+  };
+
+  // Check if there are any contests (active or finished)
+  const hasNoContests =
+    !isContestDataLoading &&
+    contestsData.active.length === 0 &&
+    contestsData.finished.length === 0;
+
   return (
     <CWPageLayout>
       <div className="AdminContestsPage">
         <div className="admin-header-row">
           <CWText type="h2">Contests</CWText>
 
-          {contestView === ContestView.List && isContestAvailable && (
-            <CWButton
-              iconLeft="plusPhosphor"
-              label="Create contest"
-              onClick={handleCreateContestClicked}
-            />
-          )}
+          {contestView === ContestView.List &&
+            isContestAvailable &&
+            !hasNoContests && (
+              <CWButton
+                iconLeft="plusPhosphor"
+                label="Create contest"
+                onClick={handleCreateContestClicked}
+              />
+            )}
         </div>
 
         {contestView === ContestView.List ? (
           <>
-            {showBanner && (
-              <FeeManagerBanner
-                feeManagerBalance={feeManagerBalance}
-                isLoading={isFeeManagerBalanceLoading}
-              />
-            )}
-            <CWText type="h3" className="mb-12">
-              Active Contests
-            </CWText>
-            {!isContestAvailable && !contestsData.active.length ? (
-              <CWText>No active contests available</CWText>
+            {hasNoContests ? (
+              <EmptyContestsList onSetContestView={setContestView} />
             ) : (
-              <ContestsList
-                contests={contestsData.active}
-                isAdmin={isAdmin}
-                isLoading={isContestDataLoading}
-                isContestAvailable={isContestAvailable}
-                onSetContestView={setContestView}
-                community={{
-                  id: community?.id || '',
-                  name: community?.name || '',
-                  iconUrl: community?.icon_url || '',
-                  ethChainId,
-                  chainNodeUrl,
-                }}
-              />
-            )}
+              <>
+                {showBanner && (
+                  <FeeManagerBanner
+                    feeManagerBalance={feeManagerBalance}
+                    isLoading={isFeeManagerBalanceLoading}
+                  />
+                )}
+                <CWText type="h3" className="mb-12">
+                  Active Contests
+                </CWText>
+                {!isContestAvailable && !contestsData.active.length ? (
+                  <CWText>No active contests available</CWText>
+                ) : (
+                  <ContestsList
+                    contests={contestsData.active}
+                    isAdmin={isAdmin}
+                    isLoading={isContestDataLoading}
+                    isContestAvailable={isContestAvailable}
+                    onSetContestView={setContestView}
+                    community={{
+                      id: community?.id || '',
+                      name: community?.name || '',
+                      iconUrl: community?.icon_url || '',
+                      ethChainId,
+                      chainNodeUrl,
+                    }}
+                  />
+                )}
 
-            <CWDivider className="ended" />
-            <CWText type="h3" className="mb-12">
-              Previous Contests
-            </CWText>
-            {isContestAvailable && contestsData.finished.length === 0 ? (
-              <CWText>No previous contests available</CWText>
-            ) : (
-              <ContestsList
-                contests={contestsData.finished}
-                isAdmin={isAdmin}
-                isLoading={isContestDataLoading}
-                isContestAvailable={isContestAvailable}
-                displayAllRecurringContests
-                onSetContestView={setContestView}
-                community={{
-                  id: community?.id || '',
-                  name: community?.name || '',
-                  iconUrl: community?.icon_url || '',
-                  ethChainId,
-                  chainNodeUrl,
-                }}
-              />
+                <CWDivider className="ended" />
+                <CWText type="h3" className="mb-12">
+                  Previous Contests
+                </CWText>
+                {isContestAvailable && contestsData.finished.length === 0 ? (
+                  <CWText>No previous contests available</CWText>
+                ) : (
+                  <ContestsList
+                    contests={contestsData.finished}
+                    isAdmin={isAdmin}
+                    isLoading={isContestDataLoading}
+                    isContestAvailable={isContestAvailable}
+                    displayAllRecurringContests
+                    onSetContestView={setContestView}
+                    community={{
+                      id: community?.id || '',
+                      name: community?.name || '',
+                      iconUrl: community?.icon_url || '',
+                      ethChainId,
+                      chainNodeUrl,
+                    }}
+                  />
+                )}
+              </>
             )}
           </>
         ) : contestView === ContestView.TypeSelection ? (
           <div className="type-selection-list">
-            {hasAtLeastOneWeightedVotingTopic ? (
-              <EmptyCard
-                img={commonUrl}
-                title="Launch on Common"
-                subtitle="Setting up a contest just takes a few minutes and can be a huge boost to your community."
-                button={{
-                  label: 'Launch Common contest',
-                  handler: () =>
-                    navigate(
-                      `/manage/contests/launch?type=${ContestType.Common}`,
-                    ),
-                }}
-              />
-            ) : (
-              <EmptyCard
-                img={shape2Url}
-                title="You must have at least one topic with weighted voting enabled to run contest"
-                subtitle="Setting up a contest just takes a few minutes and can be a huge boost to your community."
-                button={{
-                  label: 'Create a topic',
-                  handler: () => navigate('/manage/topics'),
-                }}
-              />
-            )}
+            <EmptyCard
+              img={commonUrl}
+              title="Launch on Common"
+              subtitle={
+                hasAtLeastOneWeightedVotingTopic
+                  ? 'Setting up a contest just takes a few minutes and can be a huge boost to your community.'
+                  : `For weighted contests, you need at least one topic with weighted voting enabled. 
+                    You can still proceed to set up your contest.`
+              }
+              button={{
+                label: 'Launch Common contest',
+                handler: goToLaunchCommonContest,
+              }}
+            />
 
-            {community?.namespace ? (
-              <EmptyCard
-                img={farcasterUrl}
-                title="Launch on Farcaster"
-                subtitle="Share your contest on Farcaster"
-                button={{
-                  label: 'Launch Farcaster contest',
-                  handler: () => {
-                    goToLaunchFarcasterContest();
-                  },
-                }}
-              />
-            ) : (
-              <EmptyCard
-                img={farcasterUrl}
-                title="You must have namespace reserved for your community to run farcaster contests"
-                subtitle="Share your contest on Farcaster platform"
-                button={{
-                  label: 'Create a namespace',
-                  handler: () => {
-                    setContestView(ContestView.NamespaceEnablemenement);
-                  },
-                }}
-              />
-            )}
+            <EmptyCard
+              img={farcasterUrl}
+              title="Launch on Farcaster"
+              subtitle={
+                community?.namespace
+                  ? 'Share your contest on Farcaster'
+                  : 'You need a namespace for your community to run Farcaster contests. Set one up first.'
+              }
+              button={{
+                label: community?.namespace
+                  ? 'Launch Farcaster contest'
+                  : 'Create a namespace',
+                handler: community?.namespace
+                  ? goToLaunchFarcasterContest
+                  : () => setContestView(ContestView.NamespaceEnablemenement),
+              }}
+            />
           </div>
         ) : contestView === ContestView.NamespaceEnablemenement ? (
           <CommunityStakeStep

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import { Skeleton } from 'views/components/Skeleton';
 
 import ContestCard from 'views/components/ContestCard';
-import EmptyContestsList from '../EmptyContestsList';
 import FundContestDrawer from '../FundContestDrawer';
 import { ContestView } from '../types';
 
@@ -81,73 +80,69 @@ const ContestsList = ({
   return (
     <>
       <div className="ContestsList">
-        {isAdmin && !isContestAvailable ? (
-          <EmptyContestsList onSetContestView={onSetContestView} />
-        ) : (
-          contests.map((contest) => {
-            const sortedContests = (contest?.contests || []).toSorted((a, b) =>
-              moment(a.end_time).isBefore(b.end_time) ? -1 : 1,
+        {contests.map((contest) => {
+          const sortedContests = (contest?.contests || []).toSorted((a, b) =>
+            moment(a.end_time).isBefore(b.end_time) ? -1 : 1,
+          );
+
+          if (!displayAllRecurringContests) {
+            // only last contest is relevant
+            const { end_time, score, contest_balance } =
+              sortedContests[sortedContests.length - 1] || {};
+
+            return (
+              <ContestCard
+                key={contest.contest_address}
+                isAdmin={isAdmin}
+                // @ts-expect-error <StrictNullChecks/>
+                address={contest.contest_address}
+                // @ts-expect-error <StrictNullChecks/>
+                name={contest.name}
+                imageUrl={contest.image_url}
+                // @ts-expect-error <StrictNullChecks/>
+                topics={contest.topics}
+                decimals={contest.decimals}
+                ticker={contest.ticker}
+                finishDate={end_time ? moment(end_time).toISOString() : ''}
+                isCancelled={contest.cancelled}
+                onFund={() => setFundDrawerContest(contest)}
+                isRecurring={!contest.funding_token_address}
+                payoutStructure={contest.payout_structure}
+                isFarcaster={contest.is_farcaster_contest}
+                score={score || []}
+                community={community}
+                contestBalance={parseInt(contest_balance || '0', 10)}
+              />
             );
-
-            if (!displayAllRecurringContests) {
-              // only last contest is relevant
-              const { end_time, score, contest_balance } =
-                sortedContests[sortedContests.length - 1] || {};
-
-              return (
-                <ContestCard
-                  key={contest.contest_address}
-                  isAdmin={isAdmin}
-                  // @ts-expect-error <StrictNullChecks/>
-                  address={contest.contest_address}
-                  // @ts-expect-error <StrictNullChecks/>
-                  name={contest.name}
-                  imageUrl={contest.image_url}
-                  // @ts-expect-error <StrictNullChecks/>
-                  topics={contest.topics}
-                  decimals={contest.decimals}
-                  ticker={contest.ticker}
-                  finishDate={end_time ? moment(end_time).toISOString() : ''}
-                  isCancelled={contest.cancelled}
-                  onFund={() => setFundDrawerContest(contest)}
-                  isRecurring={!contest.funding_token_address}
-                  payoutStructure={contest.payout_structure}
-                  isFarcaster={contest.is_farcaster_contest}
-                  score={score || []}
-                  community={community}
-                  contestBalance={parseInt(contest_balance || '0', 10)}
-                />
-              );
-            } else {
-              return sortedContests.map((sc) => (
-                <ContestCard
-                  key={contest.contest_address}
-                  isAdmin={isAdmin}
-                  // @ts-expect-error <StrictNullChecks/>
-                  address={contest.contest_address}
-                  // @ts-expect-error <StrictNullChecks/>
-                  name={contest.name}
-                  imageUrl={contest.image_url}
-                  // @ts-expect-error <StrictNullChecks/>
-                  topics={contest.topics}
-                  decimals={contest.decimals}
-                  ticker={contest.ticker}
-                  finishDate={
-                    sc.end_time ? moment(sc.end_time || {}).toISOString() : ''
-                  }
-                  isCancelled={contest.cancelled}
-                  onFund={() => setFundDrawerContest(contest)}
-                  isRecurring={!contest.funding_token_address}
-                  payoutStructure={contest.payout_structure}
-                  isFarcaster={contest.is_farcaster_contest}
-                  score={sc?.score || []}
-                  community={community}
-                  contestBalance={parseInt(sc.contest_balance || '0', 10)}
-                />
-              ));
-            }
-          })
-        )}
+          } else {
+            return sortedContests.map((sc) => (
+              <ContestCard
+                key={contest.contest_address}
+                isAdmin={isAdmin}
+                // @ts-expect-error <StrictNullChecks/>
+                address={contest.contest_address}
+                // @ts-expect-error <StrictNullChecks/>
+                name={contest.name}
+                imageUrl={contest.image_url}
+                // @ts-expect-error <StrictNullChecks/>
+                topics={contest.topics}
+                decimals={contest.decimals}
+                ticker={contest.ticker}
+                finishDate={
+                  sc.end_time ? moment(sc.end_time || {}).toISOString() : ''
+                }
+                isCancelled={contest.cancelled}
+                onFund={() => setFundDrawerContest(contest)}
+                isRecurring={!contest.funding_token_address}
+                payoutStructure={contest.payout_structure}
+                isFarcaster={contest.is_farcaster_contest}
+                score={sc?.score || []}
+                community={community}
+                contestBalance={parseInt(sc.contest_balance || '0', 10)}
+              />
+            ));
+          }
+        })}
       </div>
       <FundContestDrawer
         onClose={() => setFundDrawerContest(undefined)}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ContestsList/ContestsList.tsx
@@ -44,7 +44,7 @@ interface ContestsListProps {
   contests: Contest[];
   isAdmin: boolean;
   isLoading: boolean;
-  isContestAvailable: boolean;
+  isContestAvailable?: boolean;
   onSetContestView?: (type: ContestView) => void;
   displayAllRecurringContests?: boolean;
   community?: {
@@ -60,8 +60,6 @@ const ContestsList = ({
   contests,
   isAdmin,
   isLoading,
-  isContestAvailable,
-  onSetContestView,
   displayAllRecurringContests = false,
   community,
 }: ContestsListProps) => {

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/ContestTopicDescription.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Contests/ManageContest/steps/DetailsFormStep/ContestTopicDescription.tsx
@@ -9,8 +9,8 @@ import { getChainName } from './utils';
 
 interface ContestTopicDescriptionProps {
   topic: {
-    value: string;
-    weightedVoting: TopicWeightedVoting;
+    value: string | number;
+    weightedVoting: TopicWeightedVoting | null | undefined;
   };
   topicsData?: {
     id?: number;
@@ -44,43 +44,72 @@ const ContestTopicDescription = ({
   const weight = selectedTopic.vote_weight_multiplier;
   const communityStakeName = selectedTopic.community_id;
 
-  const getPopover = (weightedVoting: TopicWeightedVoting) => (
-    <span>
-      <CWIconButton
-        iconName="infoEmpty"
-        buttonSize="sm"
-        onMouseEnter={popoverProps.handleInteraction}
-        onMouseLeave={popoverProps.handleInteraction}
-      />
-      <CWPopover
-        title={
-          weightedVoting === TopicWeightedVoting.ERC20
-            ? 'ERC20 Topic'
-            : 'Stake Topic'
-        }
-        body={
-          <div className="explanation-container">
-            <CWText type="b2">
-              {weightedVoting === TopicWeightedVoting.ERC20
-                ? `The topic you selected is weighted using an ERC20. 
+  const getPopover = (
+    weightedVoting: TopicWeightedVoting | null | undefined,
+  ) => {
+    if (!weightedVoting) {
+      return (
+        <span>
+          <CWIconButton
+            iconName="infoEmpty"
+            buttonSize="sm"
+            onMouseEnter={popoverProps.handleInteraction}
+            onMouseLeave={popoverProps.handleInteraction}
+          />
+          <CWPopover
+            title="Judged Contest"
+            body={
+              <div className="explanation-container">
+                <CWText type="b2">
+                  {`In a judged contest, only judges nominated by an admin can vote on entries.
+Judges are nominated after the contest is launched.`}
+                </CWText>
+              </div>
+            }
+            {...popoverProps}
+          />
+        </span>
+      );
+    }
+
+    return (
+      <span>
+        <CWIconButton
+          iconName="infoEmpty"
+          buttonSize="sm"
+          onMouseEnter={popoverProps.handleInteraction}
+          onMouseLeave={popoverProps.handleInteraction}
+        />
+        <CWPopover
+          title={
+            weightedVoting === TopicWeightedVoting.ERC20
+              ? 'ERC20 Topic'
+              : 'Stake Topic'
+          }
+          body={
+            <div className="explanation-container">
+              <CWText type="b2">
+                {weightedVoting === TopicWeightedVoting.ERC20
+                  ? `The topic you selected is weighted using an ERC20. 
                 To change the weights, either choose another topic or create a new one.`
-                : `The topic you selected is weighted using Community Stake. 
+                  : `The topic you selected is weighted using Community Stake. 
                 To vote in the contest every user must buy stake, which they can do 
                 from the left side bar of your community.`}
-            </CWText>
-          </div>
-        }
-        {...popoverProps}
-      />
-    </span>
-  );
+              </CWText>
+            </div>
+          }
+          {...popoverProps}
+        />
+      </span>
+    );
+  };
 
   if (topic.weightedVoting === TopicWeightedVoting.ERC20) {
     return (
       <CWText className="contest-topic-description">
         Community members will vote with <b>{tokenName}</b> on{' '}
-        <b>{chainName}.</b> Each vote will have a weight of <b>{weight}.</b>{' '}
-        {getPopover(TopicWeightedVoting.ERC20)}
+        <b>{chainName}.</b> Each vote will have&nbsp;a&nbsp;weight&nbsp;of&nbsp;
+        <b>{weight}.</b> {getPopover(TopicWeightedVoting.ERC20)}
       </CWText>
     );
   }
@@ -93,6 +122,14 @@ const ContestTopicDescription = ({
       </CWText>
     );
   }
+
+  // This is for judged contests (non-weighted topics)
+  return (
+    <CWText className="contest-topic-description judged-description">
+      Only nominated judges will be able to vote on this contest.
+      {getPopover(null)}
+    </CWText>
+  );
 };
 
 export default ContestTopicDescription;

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig(({ mode }) => {
     'process.env.FLAG_NEW_GOVERNANCE_PAGE': JSON.stringify(
       env.FLAG_NEW_GOVERNANCE_PAGE,
     ),
+    'process.env.FLAG_JUDGE_CONTEST': JSON.stringify(env.FLAG_JUDGE_CONTEST),
   };
 
   const config = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11559

## Description of Changes

This PR implements a new "judged contest" feature for the Commonwealth platform, which allows for contests that are judged by nominated judges rather than using weighted voting. Key changes include:

1. Added a new feature flag `judgeContest` to control access to this functionality
2. Modified the contest creation flow to support non-weighted topics for judged contests
3. Updated the UI to display appropriate descriptions and information for judged contests
4. Improved the empty state handling when no contests exist
5. Refactored contest selection logic to accommodate both weighted voting and judge-nominated contests
6. Enhanced UI copy and flow for contest creation to clarify the difference between contest types

## Test Plan
- FLAG_JUDGE_CONTEST=true
- flow does not work yet, this is only UI
- when flag turned off, everything should be unchanged

![image](https://github.com/user-attachments/assets/c8233765-9d38-46bb-a004-a7f0c6e91f56)

![image](https://github.com/user-attachments/assets/9521e789-716e-44f3-b4b8-7862855e7c5a)

## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a