### PR TITLE
Level4 projections (creators)

### DIFF
--- a/libs/model/src/aggregates/community/LinkNamespace.command.ts
+++ b/libs/model/src/aggregates/community/LinkNamespace.command.ts
@@ -24,7 +24,7 @@ async function updateReferralCount(
     (await referrer.update(
       {
         referral_count: models.sequelize.literal(`
-        (SELECT COUNT(DISTINCT referee_address) FROM "Referrals" 
+        (SELECT COUNT(DISTINCT referee_address) FROM "Referrals"
          WHERE referrer_address = ${models.sequelize.escape(referrer_address)})
       `),
       },
@@ -100,7 +100,11 @@ export function LinkNamespace(): Command<typeof schemas.LinkNamespace> {
       });
       mustExist('Community', community);
 
+      community.namespace_creator_address = deployer_address;
+
       await models.sequelize.transaction(async (transaction) => {
+        await community.save({ transaction });
+
         // create on-chain namespace admin group if not already created
         const GROUP_NAME = 'Namespace Admins';
         if (!log_removed) {

--- a/libs/model/src/aggregates/token/CreateToken.command.ts
+++ b/libs/model/src/aggregates/token/CreateToken.command.ts
@@ -19,11 +19,6 @@ export function CreateToken(): Command<typeof schemas.CreateToken> {
       const { chain_node_id, transaction_hash, description, icon_url } =
         payload;
 
-      const userAddress = actor.address;
-      if (!userAddress) {
-        throw new InvalidState('User address is required');
-      }
-
       const chainNode = await models.ChainNode.findOne({
         where: { id: chain_node_id },
         attributes: ['eth_chain_id', 'url', 'private_url'],
@@ -67,7 +62,7 @@ export function CreateToken(): Command<typeof schemas.CreateToken> {
           eth_market_cap_target: commonProtocol.getTargetMarketCap(),
           description: description ?? null,
           icon_url: icon_url ?? null,
-          creator_address: userAddress,
+          creator_address: actor.address,
         },
       });
 

--- a/libs/model/src/aggregates/token/CreateToken.command.ts
+++ b/libs/model/src/aggregates/token/CreateToken.command.ts
@@ -15,9 +15,14 @@ export function CreateToken(): Command<typeof schemas.CreateToken> {
   return {
     ...schemas.CreateToken,
     auth: [authRoles('admin')],
-    body: async ({ payload }) => {
+    body: async ({ actor, payload }) => {
       const { chain_node_id, transaction_hash, description, icon_url } =
         payload;
+
+      const userAddress = actor.address;
+      if (!userAddress) {
+        throw new InvalidState('User address is required');
+      }
 
       const chainNode = await models.ChainNode.findOne({
         where: { id: chain_node_id },
@@ -62,6 +67,7 @@ export function CreateToken(): Command<typeof schemas.CreateToken> {
           eth_market_cap_target: commonProtocol.getTargetMarketCap(),
           description: description ?? null,
           icon_url: icon_url ?? null,
+          creator_address: userAddress,
         },
       });
 

--- a/libs/model/src/models/community.ts
+++ b/libs/model/src/models/community.ts
@@ -132,6 +132,10 @@ export default (
         type: Sequelize.STRING,
         allowNull: true,
       },
+      namespace_creator_address: {
+        type: Sequelize.STRING,
+        allowNull: true,
+      },
       created_at: { type: Sequelize.DATE, allowNull: true },
       updated_at: { type: Sequelize.DATE, allowNull: true },
       redirect: { type: Sequelize.TEXT, allowNull: true },

--- a/libs/model/src/models/token.ts
+++ b/libs/model/src/models/token.ts
@@ -36,6 +36,7 @@ export default (
         type: Sequelize.FLOAT,
         allowNull: false,
       },
+      creator_address: { type: Sequelize.STRING, allowNull: true },
       created_at: { type: Sequelize.DATE, allowNull: false },
       updated_at: { type: Sequelize.DATE, allowNull: false },
 

--- a/libs/model/test/community/community-lifecycle.spec.ts
+++ b/libs/model/test/community/community-lifecycle.spec.ts
@@ -944,9 +944,15 @@ describe('Community lifecycle', () => {
   });
   describe('namespace', () => {
     test('should set namespace creator address on NamespaceDeployed event', async () => {
+      const namespaceAddress =
+        '0x1235761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`;
+
+      const namespaceCreatorAddress =
+        '0x2345761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`;
+
       await models.Community.update(
         {
-          namespace_address: '0x1234',
+          namespace_address: namespaceAddress,
         },
         {
           where: {
@@ -960,11 +966,11 @@ describe('Community lifecycle', () => {
           hash: '0xf26c4aeb50fb6350e280c2443b086ef8034a8c81ea49f7483862c928541468dc',
           miner: '0x4200000000000000000000000000000000000011',
           nonce: '0x0000000000000000',
-          number: BigInt('27208156'),
-          gasLimit: BigInt('112000000'),
+          number: '27208156',
+          gasLimit: '112000000',
           logsBloom:
             '0xeb31f7dabdd3d8b9ceebf798ee0bfb46f7f5febf3dfbdfcf62c706aeabff9f57df7afbee17b8fdbe3e5afe5ffec77ffe63fddebfd5bf72ceeeebf6fff7bca7dee56feebee7ffce5ed3cddfeff76efbbc85dffdeddefdcaff37fafdd0bff9ff6ff7ec7ef5bedcb7e2f1e6dfeeff6eddbff76fff63acffdfec77feda5ef7bfb6fa76976be7ddf97e5b47afcfbfb74f0edf6dfbd76bedfdeca8f0ffdf7e74f5f53e9fcbfff7eab5bcdaeff0d3773fedd4cf7d97fd7b22df7d7f9dff67dffdfec9d7cc777d7fefcb6d6fbdebdeffaffb15da5ebaf35ef77cff3efb79dfdeeefcefe7c77699f94dfffbf7f9f76feedf87eff4fbf6defe7f726edaff57cf54eeefee7f',
-          timestamp: BigInt('1741205659'),
+          timestamp: '1741205659',
           parentHash:
             '0x3ae6e694f44c7827c498abdb8bbfbcd75ef88dc7fb382681aa87da2cbc2b2708',
         },
@@ -978,7 +984,7 @@ describe('Community lifecycle', () => {
           logIndex: 701,
           blockHash:
             '0xf26c4aeb50fb6350e280c2443b086ef8034a8c81ea49f7483862c928541468dc',
-          blockNumber: BigInt('27208156'),
+          blockNumber: '27208156',
           transactionHash:
             '0x1b4523eddb2ad5904b8b0b5b9ae4cf3d5b6d4853c6dccf1c9a0d118f2c3abc38',
           transactionIndex: 357,
@@ -988,9 +994,8 @@ describe('Community lifecycle', () => {
           _signature: '0x' as `0x${string}`,
           _feeManager:
             '0x7485761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`,
-          nameSpaceAddress: '0x1234' as `0x${string}`,
-          _namespaceDeployer:
-            '0x7485761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`,
+          nameSpaceAddress: namespaceAddress as `0x${string}`,
+          _namespaceDeployer: namespaceCreatorAddress as `0x${string}`,
         },
         eventSource: {
           ethChainId: 8453,
@@ -1002,7 +1007,7 @@ describe('Community lifecycle', () => {
       await emitEvent(models.Outbox, [
         {
           event_name: 'NamespaceDeployed',
-          event_payload: namespaceDeployedPayload,
+          event_payload: namespaceDeployedPayload as any,
         },
       ]);
       await drainOutbox(['NamespaceDeployed'], ChainEventPolicy);
@@ -1012,7 +1017,12 @@ describe('Community lifecycle', () => {
           id: community.id,
         },
       });
-      expect(communityAfterNamespaceDeployed?.namespace_address).toBe('0x1234');
+      expect(communityAfterNamespaceDeployed?.namespace_address).toBe(
+        namespaceAddress,
+      );
+      expect(communityAfterNamespaceDeployed?.namespace_creator_address).toBe(
+        namespaceCreatorAddress,
+      );
     });
   });
 });

--- a/libs/model/test/community/community-lifecycle.spec.ts
+++ b/libs/model/test/community/community-lifecycle.spec.ts
@@ -7,6 +7,7 @@ import {
   dispose,
   query,
 } from '@hicommonwealth/core';
+import { ChainEventPolicy, emitEvent } from '@hicommonwealth/model';
 import { PermissionEnum, TopicWeightedVoting } from '@hicommonwealth/schemas';
 import { ChainBase, ChainType } from '@hicommonwealth/shared';
 import { Chance } from 'chance';
@@ -39,6 +40,7 @@ import type {
   TopicAttributes,
 } from '../../src/models';
 import { seed } from '../../src/tester';
+import { drainOutbox } from '../utils';
 
 const chance = Chance();
 
@@ -938,6 +940,79 @@ describe('Community lifecycle', () => {
           payload: { address: ethActor.address!, community_id: community.id! },
         }),
       ).rejects.toThrow(BanAddressErrors.AlreadyExists);
+    });
+  });
+  describe('namespace', () => {
+    test('should set namespace creator address on NamespaceDeployed event', async () => {
+      await models.Community.update(
+        {
+          namespace_address: '0x1234',
+        },
+        {
+          where: {
+            id: community.id,
+          },
+        },
+      );
+
+      const namespaceDeployedPayload = {
+        block: {
+          hash: '0xf26c4aeb50fb6350e280c2443b086ef8034a8c81ea49f7483862c928541468dc',
+          miner: '0x4200000000000000000000000000000000000011',
+          nonce: '0x0000000000000000',
+          number: BigInt('27208156'),
+          gasLimit: BigInt('112000000'),
+          logsBloom:
+            '0xeb31f7dabdd3d8b9ceebf798ee0bfb46f7f5febf3dfbdfcf62c706aeabff9f57df7afbee17b8fdbe3e5afe5ffec77ffe63fddebfd5bf72ceeeebf6fff7bca7dee56feebee7ffce5ed3cddfeff76efbbc85dffdeddefdcaff37fafdd0bff9ff6ff7ec7ef5bedcb7e2f1e6dfeeff6eddbff76fff63acffdfec77feda5ef7bfb6fa76976be7ddf97e5b47afcfbfb74f0edf6dfbd76bedfdeca8f0ffdf7e74f5f53e9fcbfff7eab5bcdaeff0d3773fedd4cf7d97fd7b22df7d7f9dff67dffdfec9d7cc777d7fefcb6d6fbdebdeffaffb15da5ebaf35ef77cff3efb79dfdeeefcefe7c77699f94dfffbf7f9f76feedf87eff4fbf6defe7f726edaff57cf54eeefee7f',
+          timestamp: BigInt('1741205659'),
+          parentHash:
+            '0x3ae6e694f44c7827c498abdb8bbfbcd75ef88dc7fb382681aa87da2cbc2b2708',
+        },
+        rawLog: {
+          data: '0x00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000007485761a3770ddceed4156e2fb603072a34044d900000000000000000000000000000000000000000000000000000000000000e00000000000000000000000007485761a3770ddceed4156e2fb603072a34044d90000000000000000000000009e091d81053af8f6dce46d42e5c04a4a8f0f0cba000000000000000000000000000000000000000000000000000000000000000561737261660000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+          topics: [
+            '0xc8451dcd95e7ca3d8608dfc9d43e7bf4187f43cf5e07d5143b6c2be3cf73d175',
+          ],
+          address: '0xedf43c919f59900c82d963e99d822da3f95575ea',
+          removed: false,
+          logIndex: 701,
+          blockHash:
+            '0xf26c4aeb50fb6350e280c2443b086ef8034a8c81ea49f7483862c928541468dc',
+          blockNumber: BigInt('27208156'),
+          transactionHash:
+            '0x1b4523eddb2ad5904b8b0b5b9ae4cf3d5b6d4853c6dccf1c9a0d118f2c3abc38',
+          transactionIndex: 357,
+        },
+        parsedArgs: {
+          name: 'asraf',
+          _signature: '0x' as `0x${string}`,
+          _feeManager:
+            '0x7485761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`,
+          nameSpaceAddress: '0x1234' as `0x${string}`,
+          _namespaceDeployer:
+            '0x7485761A3770DdceED4156E2Fb603072a34044d9' as `0x${string}`,
+        },
+        eventSource: {
+          ethChainId: 8453,
+          eventSignature:
+            '0xc8451dcd95e7ca3d8608dfc9d43e7bf4187f43cf5e07d5143b6c2be3cf73d175',
+        },
+      };
+
+      await emitEvent(models.Outbox, [
+        {
+          event_name: 'NamespaceDeployed',
+          event_payload: namespaceDeployedPayload,
+        },
+      ]);
+      await drainOutbox(['NamespaceDeployed'], ChainEventPolicy);
+
+      const communityAfterNamespaceDeployed = await models.Community.findOne({
+        where: {
+          id: community.id,
+        },
+      });
+      expect(communityAfterNamespaceDeployed?.namespace_address).toBe('0x1234');
     });
   });
 });

--- a/libs/model/test/launchpad/launchpad-lifecycle.spec.ts
+++ b/libs/model/test/launchpad/launchpad-lifecycle.spec.ts
@@ -132,6 +132,7 @@ describe('Launchpad Lifecycle', () => {
 
     expect(equalEvmAddresses(results?.token_address, TOKEN_ADDRESS)).to.be.true;
     expect(results?.symbol).to.equal('DMLND');
+    expect(results?.creator_address).to.equal(actor.address);
   });
 
   test('Get a launchpad trade txn and project it', async () => {

--- a/libs/schemas/src/entities/community.schemas.ts
+++ b/libs/schemas/src/entities/community.schemas.ts
@@ -54,6 +54,7 @@ export const Community = z.object({
   directory_page_chain_node_id: PG_INT.nullish(),
   namespace: z.string().nullish(),
   namespace_address: z.string().nullish(),
+  namespace_creator_address: z.string().nullish(),
   redirect: z.string().nullish(),
   snapshot_spaces: z.array(z.string().max(255)).default([]),
   include_in_digest_email: z.boolean().nullish(),

--- a/libs/schemas/src/entities/launchpad-token.schemas.ts
+++ b/libs/schemas/src/entities/launchpad-token.schemas.ts
@@ -33,6 +33,10 @@ export const LaunchpadToken = z.object({
     .string()
     .nullish()
     .describe('description of the token (platform only)'),
+  creator_address: z
+    .string()
+    .nullish()
+    .describe('Address of the user who created the token'),
 
   created_at: z.coerce.date().optional().describe('Date the token was created'),
   updated_at: z.coerce

--- a/packages/commonwealth/server/migrations/20250331175132-add-community-namespace-creator.js
+++ b/packages/commonwealth/server/migrations/20250331175132-add-community-namespace-creator.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'Communities',
+        'namespace_creator_address',
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn(
+        'Communities',
+        'namespace_creator_address',
+        { transaction },
+      );
+    });
+  },
+};

--- a/packages/commonwealth/server/migrations/20250331205559-add-launchpadtoken-creator-address.js
+++ b/packages/commonwealth/server/migrations/20250331205559-add-launchpadtoken-creator-address.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('LaunchpadTokens', 'creator_address', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('LaunchpadTokens', 'creator_address');
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11632 

## Description of Changes
-  Adds projections for tier 4
    - Namespace creator address
    - Launchpad token creator address
    - Contests already have a creator address

## Test Plan
- Added lifecycle tests

## Deployment Plan
N/A

## Other Considerations
- Community nominations aren't relevant yet because that functionality isn't fully implemented
- There's no ContestFunded event emitted from onchain, so we'd need a more crude solution
- Not sure which event would be best to capture "coin trade amount"