### PR TITLE
Updated to show aura gains from system quests in all views

### DIFF
--- a/libs/model/src/aggregates/user/GetXps.query.ts
+++ b/libs/model/src/aggregates/user/GetXps.query.ts
@@ -8,7 +8,7 @@ export function GetXps(): Query<typeof schemas.GetXps> {
   return {
     ...schemas.GetXps,
     auth: [],
-    secure: true,
+    secure: false,
     body: async ({ payload }) => {
       const {
         user_id,

--- a/libs/model/src/aggregates/user/GetXps.query.ts
+++ b/libs/model/src/aggregates/user/GetXps.query.ts
@@ -45,7 +45,7 @@ export function GetXps(): Query<typeof schemas.GetXps> {
               attributes: ['id', 'name'],
               where: {
                 ...(community_id && { community_id }),
-                ...(quest_id ? { id: quest_id } : { id: { [Op.gt]: 0 } }),
+                ...(quest_id && { id: quest_id }),
               },
             },
           ],

--- a/libs/model/test/user/user-lifecycle.spec.ts
+++ b/libs/model/test/user/user-lifecycle.spec.ts
@@ -535,7 +535,7 @@ describe('User lifecycle', () => {
         actor: admin,
         payload: { from: xps2!.at(-1)!.created_at },
       });
-      expect(xps3!.length).to.equal(4);
+      expect(xps3!.length).to.equal(5);
 
       // 4 events for member (ThreadCreated and CommentUpvoted)
       const xps4 = await query(GetXps(), {
@@ -553,8 +553,8 @@ describe('User lifecycle', () => {
         actor: admin,
         payload: { user_id: new_actor.user.id },
       });
-      expect(xps5!.length).to.equal(1);
-      xps5?.forEach((xp) => {
+      expect(xps5!.length).to.equal(2);
+      xps5?.filter(x => x.action_meta_id > 0)?.forEach((xp) => {
         expect(['CommunityJoined'].includes(xp.event_name)).to.be.true;
       });
 

--- a/libs/model/test/user/user-lifecycle.spec.ts
+++ b/libs/model/test/user/user-lifecycle.spec.ts
@@ -514,7 +514,7 @@ describe('User lifecycle', () => {
         actor: admin,
         payload: {},
       });
-      expect(xps1!.length).to.equal(8);
+      expect(xps1!.length).to.equal(9);
       xps1?.forEach((xp) => {
         expect(xp.quest_id).to.be.a('number');
         expect(xp.quest_action_meta_id).to.be.a('number');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11737

## Description of Changes
1. Updated to show aura gains from system quests in all views
2. Leaderboard is now visible for all users, both authenticated and not.

## "How We Fixed It"
N/A

## Test Plan
Ensure changes mentioned in description are reflected

## Deployment Plan
N/A

## Other Considerations
N/A