### PR TITLE
adds banner for informing users of spam if trust level is too low for the community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.scss
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.scss
@@ -183,7 +183,8 @@
     }
   }
 
-  .JoinCommunityBanner {
+  .JoinCommunityBanner,
+  .spam-trust-banner {
     margin-top: 8px;
   }
 

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -646,7 +646,10 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
                 userProfile.tier <= community.spam_tier_level && (
                   <CWBanner
                     type="warning"
-                    body="Your post will be marked as spam due to the Community's Trust Settings. You can increase your trust level by verifying an SSO or adding a wallet with Balance."
+                    body={
+                      "Your post will be marked as spam due to the Community's Trust Settings. " +
+                      'You can increase your trust level by verifying an SSO or adding a wallet with Balance.'
+                    }
                     className="spam-trust-banner"
                   />
                 )}

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -17,6 +17,7 @@ import app from 'state';
 import { useGetCommunityByIdQuery } from 'state/api/communities';
 import { useGetUserEthBalanceQuery } from 'state/api/communityStake';
 import { useFetchGroupsQuery } from 'state/api/groups';
+import useFetchProfileByIdQuery from 'state/api/profiles/fetchProfileById';
 import { useCreateThreadMutation } from 'state/api/threads';
 import { buildCreateThreadInput } from 'state/api/threads/createThread';
 import useFetchThreadsQuery from 'state/api/threads/fetchThreads';
@@ -50,6 +51,7 @@ import { convertAddressToDropdownOption } from '../../modals/TradeTokenModel/Com
 import { CWGatedTopicBanner } from '../component_kit/CWGatedTopicBanner';
 import { CWGatedTopicPermissionLevelBanner } from '../component_kit/CWGatedTopicPermissionLevelBanner';
 import { CWText } from '../component_kit/cw_text';
+import CWBanner from '../component_kit/new_designs/CWBanner';
 import { CWSelectList } from '../component_kit/new_designs/CWSelectList';
 import { CWThreadAction } from '../component_kit/new_designs/cw_thread_action';
 import { CWToggle } from '../component_kit/new_designs/cw_toggle';
@@ -75,6 +77,10 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
   const location = useLocation();
 
   const user = useUserStore();
+  const { data: userProfile } = useFetchProfileByIdQuery({
+    userId: user.id,
+    apiCallEnabled: !!user.id,
+  });
 
   const {
     aiInteractionsToggleEnabled,
@@ -633,6 +639,17 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
                 ${MIN_ETH_FOR_CONTEST_THREAD} ETH to participate.`}
                 validationStatus="failure"
               />
+
+              {community &&
+                userProfile &&
+                community.spam_tier_level >= 0 &&
+                userProfile.tier <= community.spam_tier_level && (
+                  <CWBanner
+                    type="warning"
+                    body="Your post will be marked as spam due to the Community's Trust Settings. You can increase your trust level by verifying an SSO or adding a wallet with Balance."
+                    className="spam-trust-banner"
+                  />
+                )}
 
               <div className="buttons-row">
                 <CWButton

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -324,6 +324,14 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
         return;
       }
 
+      if (err?.message?.includes('Exceeded content creation limit')) {
+        console.log('NewThreadForm: Content creation limit exceeded');
+        notifyError(
+          'Exceeded content creation limit. Please try again later based on your trust level.',
+        );
+        return;
+      }
+
       if (err?.message?.includes('limit')) {
         console.log('NewThreadForm: Contest limit exceeded');
         notifyError(

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/SpamLevel.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/SpamLevel.scss
@@ -32,3 +32,17 @@
     }
   }
 }
+
+.docs-link {
+  margin-top: 4px;
+
+  a {
+    color: var(--primary-blue);
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/SpamLevel.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/SpamLevel.tsx
@@ -94,6 +94,15 @@ const SpamLevel = () => {
         tier level. This is useful for communities that are not yet ready to be
         moderated.
       </CWText>
+      <CWText type="b1" className="docs-link">
+        <a
+          href="https://docs.common.xyz/commonwealth/account-overview/user-trust-levels"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn more about how trust levels work
+        </a>
+      </CWText>
 
       {isEnabled && (
         <div>

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/utils.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/SpamLevel/utils.ts
@@ -6,13 +6,18 @@ export enum SpamLevels {
 }
 
 export const SpamLevelOptions = [
-  { label: 'Unverified users', value: SpamLevels.Unverified },
   {
-    label: 'One week-old users with incomplete profiles',
+    label: '🚫: Users with unverified wallet will be flagged: ',
+    value: SpamLevels.Unverified,
+  },
+  {
+    label:
+      '🐣: Users with no balance or social account (and below) will be flagged',
     value: SpamLevels.OneWeekOld,
   },
   {
-    label: 'Users with incomplete profiles',
+    label:
+      '⏳: Users with 1 week old account, no balance, or social account (and below) will be flagged',
     value: SpamLevels.UsersWithIncompleteProfiles,
   },
 ];


### PR DESCRIPTION
https://www.loom.com/share/95c5b268854f47e0b6663c93cad20914

<img width="680" alt="image" src="https://github.com/user-attachments/assets/41d444ed-291b-4d25-aa5b-81e6ae602b69" />

<img width="742" alt="image" src="https://github.com/user-attachments/assets/dc6a9db7-5345-4f1e-9009-bbff5748c5a2" />


## Link to Issue
Closes: #11678 

## Description of Changes
- Adds banner if the user trust level is too low and will be marked as spam
- Updates the copy on the admin panel and links to docs
- Updates toast presented to user based on content limit (instead of prior contest related one)

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 