### PR TITLE
User Trust level UI 

### DIFF
--- a/libs/model/src/aggregates/comment/GetComments.query.ts
+++ b/libs/model/src/aggregates/comment/GetComments.query.ts
@@ -49,6 +49,7 @@ export function GetComments(): Query<typeof schemas.GetComments> {
             CA.last_active,
             CA.community_id,
             CU.id AS "user_id",
+            CU.tier AS "user_tier",
             COALESCE(CU.profile->>'name', '${DEFAULT_NAME}') AS "profile_name",
             COALESCE(CU.profile->>'avatar_url', '${getRandomAvatar()}') AS "avatar_url",
             CASE WHEN max(CVH.id) IS NOT NULL THEN
@@ -144,6 +145,11 @@ export function GetComments(): Query<typeof schemas.GetComments> {
           ),
         } as unknown as z.infer<typeof CommentsView>;
       });
+
+      console.log(
+        'sanitizedComments',
+        JSON.stringify(sanitizedComments, null, 2),
+      );
 
       return schemas.buildPaginatedResponse(
         sanitizedComments,

--- a/libs/model/src/aggregates/comment/GetComments.query.ts
+++ b/libs/model/src/aggregates/comment/GetComments.query.ts
@@ -146,11 +146,6 @@ export function GetComments(): Query<typeof schemas.GetComments> {
         } as unknown as z.infer<typeof CommentsView>;
       });
 
-      console.log(
-        'sanitizedComments',
-        JSON.stringify(sanitizedComments, null, 2),
-      );
-
       return schemas.buildPaginatedResponse(
         sanitizedComments,
         comments?.length ? parseInt(`${comments!.at(0)!.total_count}`) : 0,

--- a/libs/model/src/aggregates/thread/GetThreads.query.ts
+++ b/libs/model/src/aggregates/thread/GetThreads.query.ts
@@ -120,6 +120,7 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                     'community_id', A.community_id
                 ) as "Address",
                 U.id as user_id,
+                U.tier as user_tier,
                 A.last_active as address_last_active,
                 U.profile->>'avatar_url' as avatar_url,
                 U.profile->>'name' as profile_name
@@ -218,6 +219,7 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                   'profile_name', U.profile->>'name',
                   'profile_avatar', U.profile->>'avatar_url',
                   'user_id', U.id,
+                  'user_tier', U.tier,
                   'content_url', COM.content_url
               ))) as "recentComments"
               FROM (

--- a/libs/model/src/aggregates/user/GetUserAddresses.query.ts
+++ b/libs/model/src/aggregates/user/GetUserAddresses.query.ts
@@ -37,6 +37,7 @@ export function GetUserAddresses(): Query<typeof schemas.GetUserAddresses> {
         address: address.address,
         lastActive: address.last_active ?? address.User!.created_at!,
         avatarUrl: address.User?.profile.avatar_url,
+        tier: address.User?.tier,
       }));
     },
   };

--- a/libs/model/src/utils/getUserActivityFeed.ts
+++ b/libs/model/src/utils/getUserActivityFeed.ts
@@ -44,6 +44,7 @@ SELECT
       'community_icon', C.icon_url,
       'id', T.id,
       'user_id', U.id,
+      'user_tier', U.tier,
       'user_address', A.address,
       'profile_name', U.profile->>'name',
       'profile_avatar', U.profile->>'avatar_url',
@@ -75,6 +76,7 @@ SELECT
         'id', C.id,
         'address', C.address,
         'user_id', C.user_id,
+        'user_tier', C.user_tier,
         'profile_name', C.profile_name,
         'profile_avatar', C.profile_avatar,
         'body', C.body,
@@ -90,6 +92,7 @@ SELECT
             C.*,
             A.address,
             U.id as user_id,
+            U.tier as user_tier,
             U.profile->>'name' as profile_name, 
             U.profile->>'avatar_url' as profile_avatar, 
             ROW_NUMBER() OVER (PARTITION BY C.thread_id ORDER BY C.created_at DESC) AS rn

--- a/libs/schemas/src/queries/comment.schemas.ts
+++ b/libs/schemas/src/queries/comment.schemas.ts
@@ -20,6 +20,7 @@ export const SearchComments = {
 
 export const CommentsView = CommentView.extend({
   reactions: z.array(ReactionView).nullish(),
+  user_tier: z.number().nullish(),
 });
 
 export const GetCommentsOrderBy = z.enum(['newest', 'oldest', 'mostLikes']);

--- a/libs/schemas/src/queries/feed.schemas.ts
+++ b/libs/schemas/src/queries/feed.schemas.ts
@@ -22,6 +22,7 @@ export const ActivityThread = z.object({
   community_icon: z.string().nullish(),
   id: z.number(),
   user_id: z.number(),
+  user_tier: z.number(),
   user_address: z.string(),
   profile_name: z.string().nullish(),
   profile_avatar: z.string().nullish(),

--- a/libs/schemas/src/queries/thread.schemas.ts
+++ b/libs/schemas/src/queries/thread.schemas.ts
@@ -76,6 +76,7 @@ export const UserView = z.object({
   updated_at: z.date().or(z.string()).nullish(),
   ProfileTags: z.array(ProfileTagsView).optional(),
   unsubscribe_uuid: z.string().uuid().nullish().optional(),
+  tier: z.number().nullish().optional(),
 });
 type UserView = z.infer<typeof UserView>;
 

--- a/libs/schemas/src/queries/user.schemas.ts
+++ b/libs/schemas/src/queries/user.schemas.ts
@@ -102,6 +102,7 @@ export const GetUserAddresses = {
       address: z.string(),
       lastActive: z.date().or(z.string()),
       avatarUrl: z.string().nullish(),
+      tier: z.number().nullish(),
     }),
   ),
 };

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -36,6 +36,7 @@ const featureFlags = {
   governancePage: buildFlag(process.env.FLAG_NEW_GOVERNANCE_PAGE),
   privy: buildFlag(process.env.FLAG_PRIVY),
   judgeContest: buildFlag(process.env.FLAG_JUDGE_CONTEST),
+  trustLevel: buildFlag(process.env.FLAG_TRUST_LEVEL),
 };
 
 export type AvailableFeatureFlag = keyof typeof featureFlags;

--- a/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
+++ b/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
@@ -9,6 +9,7 @@ export type UserProfile = {
   address: string;
   lastActive: string;
   avatarUrl: string;
+  tier?: number;
 };
 
 export function addressToUserProfile(
@@ -35,6 +36,7 @@ class MinimumProfile {
   private _chain: string;
   private _lastActive: Date | null;
   private _initialized: boolean;
+  private _tier: number;
 
   get userId() {
     return this._userId;
@@ -65,6 +67,10 @@ class MinimumProfile {
     return this._initialized;
   }
 
+  get tier() {
+    return this._tier;
+  }
+
   constructor(address, chain) {
     this._address = address;
     this._chain = chain;
@@ -77,6 +83,7 @@ class MinimumProfile {
     avatarUrl: string,
     chain: string,
     lastActive: Date | null,
+    tier: number,
   ) {
     this._userId = userId;
     this._name = name;
@@ -84,6 +91,7 @@ class MinimumProfile {
     this._avatarUrl = avatarUrl;
     this._chain = chain;
     this._lastActive = lastActive;
+    this._tier = tier;
     this._initialized = true;
   }
 
@@ -102,6 +110,7 @@ class MinimumProfile {
       address: this._address,
       lastActive: this._lastActive?.toString() ?? '',
       avatarUrl: this._avatarUrl,
+      tier: this._tier,
     };
   }
 }

--- a/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
+++ b/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
@@ -20,6 +20,7 @@ export function addressToUserProfile(
     avatarUrl: address.User?.profile.avatar_url ?? '',
     name: address.User?.profile.name ?? DEFAULT_NAME,
     address: address?.address,
+    tier: address.User?.tier ?? 0,
     lastActive: (
       address?.last_active ??
       address.User?.created_at ??

--- a/packages/commonwealth/client/scripts/models/NewProfile.ts
+++ b/packages/commonwealth/client/scripts/models/NewProfile.ts
@@ -12,6 +12,7 @@ class NewProfile {
   private _socials: string[];
   private _isOwner: boolean;
   private _backgroundImage: z.infer<typeof Image>;
+  private _tier: number;
 
   get userId() {
     return this._userId;
@@ -53,6 +54,10 @@ class NewProfile {
     return this._backgroundImage;
   }
 
+  get tier() {
+    return this._tier;
+  }
+
   constructor({
     userId,
     isOwner,
@@ -64,7 +69,12 @@ class NewProfile {
     slug,
     socials,
     background_image,
-  }: z.infer<typeof UserProfile> & { userId: number; isOwner: boolean }) {
+    tier,
+  }: z.infer<typeof UserProfile> & {
+    userId: number;
+    isOwner: boolean;
+    tier: number;
+  }) {
     this._userId = userId;
     this._isOwner = isOwner;
     this._name = name!;
@@ -75,6 +85,7 @@ class NewProfile {
     this._slug = slug!;
     this._socials = socials!;
     this._backgroundImage = background_image ?? { url: '', imageBehavior: '' };
+    this._tier = tier!;
   }
 
   public static fromJSON(json) {

--- a/packages/commonwealth/client/scripts/models/Thread.ts
+++ b/packages/commonwealth/client/scripts/models/Thread.ts
@@ -237,6 +237,7 @@ export class Thread implements IUniqueId {
       reactionWeights?: number[];
       userId?: number;
       user_id?: number;
+      user_tier?: number;
       avatar_url?: string | null;
       address_last_active?: string;
       associatedReactions?: ReactionView[];
@@ -374,6 +375,7 @@ export class Thread implements IUniqueId {
         address: t.Address?.address ?? '',
         lastActive: t.address_last_active ?? '',
         avatarUrl: t.avatar_url ?? '',
+        tier: t.user_tier ?? 0,
       };
     }
   }

--- a/packages/commonwealth/client/scripts/state/api/profiles/fetchProfilesByAddress.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/fetchProfilesByAddress.ts
@@ -41,6 +41,7 @@ const useFetchProfilesByAddressesQuery = ({
             t.avatarUrl ?? '',
             currentChainId,
             new Date(t.lastActive),
+            t.tier ?? 0,
           );
           return profile;
         }),
@@ -116,6 +117,7 @@ export const DISCOURAGED_NONREACTIVE_fetchProfilesByAddress = async (
       t.avatarUrl,
       communities[0],
       t.lastActive,
+      t.tier ?? 0,
     );
     return profile;
   });

--- a/packages/commonwealth/client/scripts/utils/trustLevel.ts
+++ b/packages/commonwealth/client/scripts/utils/trustLevel.ts
@@ -13,13 +13,13 @@ export interface CommunityTrustLevel extends TrustLevel {}
 const USER_TRUST_LEVELS: Record<number, UserTrustLevel> = {
   0: {
     level: 0,
-    icon: '👤',
+    icon: '🚫',
     name: 'Unverified',
     description: 'Basic account without verification.',
   },
   1: {
     level: 1,
-    icon: '👶',
+    icon: '🐣',
     name: 'Social Verified',
     description: 'Basic verification through social media accounts.',
   },
@@ -52,7 +52,7 @@ const USER_TRUST_LEVELS: Record<number, UserTrustLevel> = {
 const COMMUNITY_TRUST_LEVELS: Record<number, CommunityTrustLevel> = {
   0: {
     level: 0,
-    icon: '👤',
+    icon: '🚫',
     name: 'Unverified',
     description: 'Basic community without verification.',
   },

--- a/packages/commonwealth/client/scripts/utils/trustLevel.ts
+++ b/packages/commonwealth/client/scripts/utils/trustLevel.ts
@@ -3,7 +3,7 @@ import { COMMUNITY_TIER, USER_TIER } from '@hicommonwealth/schemas';
 interface TrustLevel {
   level: number;
   icon: string;
-  type: string;
+  name: string;
   description: string;
 }
 
@@ -14,37 +14,37 @@ const USER_TRUST_LEVELS: Record<number, UserTrustLevel> = {
   0: {
     level: 0,
     icon: '👤',
-    type: 'Unverified',
+    name: 'Unverified',
     description: 'Basic account without verification.',
   },
   1: {
     level: 1,
     icon: '👶',
-    type: 'Social Verified',
+    name: 'Social Verified',
     description: 'Basic verification through social media accounts.',
   },
   2: {
     level: 2,
     icon: '⌛',
-    type: 'Namespace Verified',
+    name: 'Namespace Verified',
     description: 'Verified ownership of namespace or domain',
   },
   3: {
     level: 3,
     icon: '🌐',
-    type: 'Manual Verification',
+    name: 'Manual Verification',
     description: 'Manually reviewed and verified by our team',
   },
   4: {
     level: 4,
     icon: '🔗',
-    type: 'Premium Verification',
+    name: 'Premium Verification',
     description: 'Highest level of trust with additional benefits.',
   },
   5: {
     level: 5,
     icon: '⭐',
-    type: 'Premium Verification',
+    name: 'Premium Verification',
     description: 'Highest level of trust with additional benefits.',
   },
 };
@@ -53,31 +53,31 @@ const COMMUNITY_TRUST_LEVELS: Record<number, CommunityTrustLevel> = {
   0: {
     level: 0,
     icon: '👤',
-    type: 'Unverified',
+    name: 'Unverified',
     description: 'Basic community without verification.',
   },
   1: {
     level: 1,
     icon: '🌐',
-    type: 'Social Verified',
+    name: 'Social Verified',
     description: 'Basic verification through social media accounts.',
   },
   2: {
     level: 2,
     icon: '🔗',
-    type: 'Community Verified',
+    name: 'Community Verified',
     description: 'Ownership of verified community or domain',
   },
   3: {
     level: 3,
     icon: '✅',
-    type: 'Manual Verification',
+    name: 'Manual Verification',
     description: 'Manually reviewed and verified by our team',
   },
   4: {
     level: 4,
     icon: '⭐',
-    type: 'Premium Verification',
+    name: 'Premium Verification',
     description: 'Highest level of trust with additional benefits.',
   },
 };

--- a/packages/commonwealth/client/scripts/utils/trustLevel.ts
+++ b/packages/commonwealth/client/scripts/utils/trustLevel.ts
@@ -1,0 +1,103 @@
+import { COMMUNITY_TIER, USER_TIER } from '@hicommonwealth/schemas';
+
+interface TrustLevel {
+  level: number;
+  icon: string;
+  type: string;
+  description: string;
+}
+
+export interface UserTrustLevel extends TrustLevel {}
+export interface CommunityTrustLevel extends TrustLevel {}
+
+const USER_TRUST_LEVELS: Record<number, UserTrustLevel> = {
+  0: {
+    level: 0,
+    icon: '👤',
+    type: 'Unverified',
+    description: 'Basic account without verification.',
+  },
+  1: {
+    level: 1,
+    icon: '👶',
+    type: 'Social Verified',
+    description: 'Basic verification through social media accounts.',
+  },
+  2: {
+    level: 2,
+    icon: '⌛',
+    type: 'Namespace Verified',
+    description: 'Verified ownership of namespace or domain',
+  },
+  3: {
+    level: 3,
+    icon: '🌐',
+    type: 'Manual Verification',
+    description: 'Manually reviewed and verified by our team',
+  },
+  4: {
+    level: 4,
+    icon: '🔗',
+    type: 'Premium Verification',
+    description: 'Highest level of trust with additional benefits.',
+  },
+  5: {
+    level: 5,
+    icon: '⭐',
+    type: 'Premium Verification',
+    description: 'Highest level of trust with additional benefits.',
+  },
+};
+
+const COMMUNITY_TRUST_LEVELS: Record<number, CommunityTrustLevel> = {
+  0: {
+    level: 0,
+    icon: '👤',
+    type: 'Unverified',
+    description: 'Basic community without verification.',
+  },
+  1: {
+    level: 1,
+    icon: '🌐',
+    type: 'Social Verified',
+    description: 'Basic verification through social media accounts.',
+  },
+  2: {
+    level: 2,
+    icon: '🔗',
+    type: 'Community Verified',
+    description: 'Ownership of verified community or domain',
+  },
+  3: {
+    level: 3,
+    icon: '✅',
+    type: 'Manual Verification',
+    description: 'Manually reviewed and verified by our team',
+  },
+  4: {
+    level: 4,
+    icon: '⭐',
+    type: 'Premium Verification',
+    description: 'Highest level of trust with additional benefits.',
+  },
+};
+
+export const getUserTrustLevel = (tier?: number | null): UserTrustLevel => {
+  if (tier === undefined || tier === null) {
+    return USER_TRUST_LEVELS[0];
+  }
+
+  const validTier = USER_TIER.safeParse(tier).success ? tier : 0;
+  return USER_TRUST_LEVELS[validTier] || USER_TRUST_LEVELS[0];
+};
+
+export const getCommunityTrustLevel = (
+  tier?: number | null,
+): CommunityTrustLevel => {
+  if (tier === undefined || tier === null) {
+    return COMMUNITY_TRUST_LEVELS[0];
+  }
+
+  const validTier = COMMUNITY_TIER.safeParse(tier).success ? tier : 0;
+  return COMMUNITY_TRUST_LEVELS[validTier] || COMMUNITY_TRUST_LEVELS[0];
+};

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
@@ -106,6 +106,7 @@ const EditProfile = () => {
           ...data.profile,
           userId: data.userId,
           isOwner: data.userId === user.id,
+          tier: data.tier,
         }),
       );
       // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -46,7 +46,12 @@ const Profile = ({ userId }: ProfileProps) => {
     }
     if (data) {
       setProfile(
-        new NewProfile({ ...data.profile, userId, isOwner: isOwner ?? false }),
+        new NewProfile({
+          ...data.profile,
+          userId,
+          isOwner: isOwner ?? false,
+          tier: data.tier,
+        }),
       );
       setThreads(
         data.threads.map((t) => {

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.scss
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.scss
@@ -74,9 +74,14 @@
       justify-content: center;
       word-break: break-word;
       text-align: center;
+      display: inline-block;
 
       &.hasMargin {
         margin-bottom: 24px;
+      }
+
+      .TrustLevelRole {
+        margin-left: 8px;
       }
     }
 

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.tsx
@@ -16,6 +16,7 @@ import { MarkdownViewerWithFallback } from 'views/components/MarkdownViewerWithF
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import type NewProfile from '../../../../models/NewProfile';
 import { SharePopover } from '../../SharePopover';
+import TrustLevelRole from '../../TrustLevelRole';
 import { CWText } from '../../component_kit/cw_text';
 import { SocialAccounts } from '../../social_accounts';
 
@@ -70,6 +71,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
       <div className="profile-name-and-bio">
         <CWText type="h3" className="name">
           {name || DEFAULT_NAME}
+          <TrustLevelRole type="user" level={profile.tier} />
         </CWText>
 
         {referralsEnabled && isCurrentUser && (

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.scss
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.scss
@@ -1,0 +1,2 @@
+.TrustLevelRole {
+}

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.scss
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.scss
@@ -1,2 +1,0 @@
-.TrustLevelRole {
-}

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { getCommunityTrustLevel, getUserTrustLevel } from 'utils/trustLevel';
+
+import './TrustLevelRole.scss';
+
+interface TrustLevelRoleProps {
+  type: 'community' | 'user';
+  level: number;
+}
+
+const TrustLevelRole = ({ type, level }: TrustLevelRoleProps) => {
+  const { icon } =
+    type === 'community'
+      ? getCommunityTrustLevel(level)
+      : getUserTrustLevel(level);
+
+  return <span className="TrustLevelRole">{icon}</span>;
+};
+
+export default TrustLevelRole;

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { useFlag } from 'hooks/useFlag';
 import { getCommunityTrustLevel, getUserTrustLevel } from 'utils/trustLevel';
 
-import './TrustLevelRole.scss';
-
 interface TrustLevelRoleProps {
   type: 'community' | 'user';
   level: number;

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useFlag } from 'hooks/useFlag';
 import { getCommunityTrustLevel, getUserTrustLevel } from 'utils/trustLevel';
 
 import './TrustLevelRole.scss';
@@ -10,6 +11,10 @@ interface TrustLevelRoleProps {
 }
 
 const TrustLevelRole = ({ type, level }: TrustLevelRoleProps) => {
+  const isTrustLevelEnabled = useFlag('trustLevel');
+
+  if (!isTrustLevelEnabled) return null;
+
   const { icon } =
     type === 'community'
       ? getCommunityTrustLevel(level)

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/index.ts
@@ -1,0 +1,3 @@
+import TrustLevelRole from './TrustLevelRole';
+
+export default TrustLevelRole;

--- a/packages/commonwealth/client/scripts/views/components/feed.tsx
+++ b/packages/commonwealth/client/scripts/views/components/feed.tsx
@@ -171,6 +171,7 @@ function mapThread(thread: z.infer<typeof ActivityThread>): Thread {
     profile_name: thread.profile_name ?? '',
     avatar_url: thread.profile_avatar ?? '',
     user_id: thread.user_id,
+    user_tier: thread.user_tier,
     userId: thread.user_id,
     last_edited: thread.updated_at ?? '',
     last_commented_on: '',

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -114,6 +114,7 @@ export const CommunitySection = ({
           ...data.profile,
           userId: data.userId,
           isOwner: data.userId === user.id,
+          tier: data.tier,
         }),
       );
       return;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.scss
@@ -48,7 +48,6 @@
     }
 
     .profile-name {
-      @include multiline-text-ellipsis(1);
       margin-top: 20px;
       font-size: 18px;
       font-weight: bold;
@@ -60,6 +59,10 @@
 
       &:hover {
         color: $neutral-600;
+      }
+
+      .TrustLevelRole {
+        margin-left: 8px;
       }
     }
     white-space: nowrap;

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
@@ -5,7 +5,10 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
 import { CWTooltip } from '../../../components/component_kit/new_designs/CWTooltip';
+import TrustLevelRole from '../../TrustLevelRole';
+
 import './ProfileCard.scss';
+
 enum ImageBehavior {
   Cover = 'cover',
   Fill = 'fill',
@@ -66,7 +69,10 @@ const ProfileCard = () => {
               to={`/profile/id/${userData.id}`}
               className="user-info"
             >
-              <h3 className="profile-name">{data?.profile.name}</h3>
+              <h3 className="profile-name">
+                {data?.profile.name}
+                <TrustLevelRole type="user" level={data?.tier} />
+              </h3>
             </Link>
           )}
         />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarProfileSection/SidebarProfileSection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarProfileSection/SidebarProfileSection.tsx
@@ -58,6 +58,7 @@ export const SidebarProfileSection = ({
           ...data.profile,
           userId: data.userId,
           isOwner: data.userId === user.id,
+          tier: data.tier,
         }),
       );
       return;

--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -225,7 +225,8 @@ export const FullUser = ({
               className="user-address"
               to={`/profile/id/${profile?.userId}`}
             >
-              {profile?.name} {/* // add here */}
+              {profile?.name}{' '}
+              <TrustLevelRole type="user" level={profile?.tier || 0} />
             </Link>
           )}
           {profile?.address && (
@@ -300,6 +301,7 @@ export const FullUser = ({
           content={userPopover}
           {...popoverProps}
           placement={popoverPlacement}
+          open={true}
         />
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -15,6 +15,7 @@ import CWPopover, {
 import { formatAddressShort } from '../../../../../shared/utils';
 import Permissions from '../../../utils/Permissions';
 import { BanUserModal } from '../../modals/ban_user_modal';
+import TrustLevelRole from '../TrustLevelRole';
 import { CWIconButton } from '../component_kit/cw_icon_button';
 import { CWText } from '../component_kit/cw_text';
 import { CWModal } from '../component_kit/new_designs/CWModal';
@@ -108,7 +109,10 @@ export const FullUser = ({
         profile?.name
       ) : (
         <>
-          <div className="profile-name">{profile?.name}</div>
+          <div className="profile-name">
+            {profile?.name}{' '}
+            <TrustLevelRole type="user" level={profile?.tier || 0} />
+          </div>
           <div className="id-short">{fullAddress}</div>
         </>
       )}
@@ -200,10 +204,16 @@ export const FullUser = ({
                     redactedAddress
                   )
                 ) : !shouldShowAddressWithDisplayName ? (
-                  profile?.name
+                  <>
+                    {profile?.name}{' '}
+                    <TrustLevelRole type="user" level={profile?.tier || 0} />
+                  </>
                 ) : (
                   <>
-                    {profile?.name}
+                    <>
+                      {profile?.name}{' '}
+                      <TrustLevelRole type="user" level={profile?.tier || 0} />
+                    </>
                     <div className="id-short">{redactedAddress}</div>
                   </>
                 )}
@@ -215,7 +225,7 @@ export const FullUser = ({
               className="user-address"
               to={`/profile/id/${profile?.userId}`}
             >
-              {profile?.name}
+              {profile?.name} {/* // add here */}
             </Link>
           )}
           {profile?.address && (
@@ -246,7 +256,6 @@ export const FullUser = ({
               </div>
             </div>
           )}
-
           {friendlyCommunityName && (
             <div className="user-chain">{friendlyCommunityName}</div>
           )}

--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -106,7 +106,10 @@ export const FullUser = ({
       ) : !profile?.userId ? (
         redactedAddress
       ) : !shouldShowAddressWithDisplayName ? (
-        profile?.name
+        <>
+          {profile?.name} &nbsp;
+          <TrustLevelRole type="user" level={profile?.tier || 0} />
+        </>
       ) : (
         <>
           <div className="profile-name">
@@ -301,7 +304,6 @@ export const FullUser = ({
           content={userPopover}
           {...popoverProps}
           placement={popoverPlacement}
-          open={true}
         />
       )}
     </div>

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -13,6 +13,7 @@ import CWPopover, {
 import { formatAddressShort } from '../../../../../shared/utils';
 import Permissions from '../../../utils/Permissions';
 import { BanUserModal } from '../../modals/ban_user_modal';
+import TrustLevelRole from '../TrustLevelRole';
 import { CWText } from '../component_kit/cw_text';
 import { CWButton } from '../component_kit/new_designs/CWButton';
 import { CWModal } from '../component_kit/new_designs/CWModal';
@@ -110,10 +111,16 @@ export const User = ({
       ) : !profile?.userId ? (
         redactedAddress
       ) : !shouldShowAddressWithDisplayName ? (
-        profile?.name
+        <>
+          {profile?.name} &nbsp;
+          <TrustLevelRole type="user" level={profile?.tier} />
+        </>
       ) : (
         <>
-          <div>{profile?.name}</div>
+          <div>
+            {profile?.name} &nbsp;
+            <TrustLevelRole type="user" level={profile?.tier} />
+          </div>
           <div className="id-short">{fullAddress}</div>
         </>
       )}
@@ -208,10 +215,14 @@ export const User = ({
                     redactedAddress
                   )
                 ) : !shouldShowAddressWithDisplayName ? (
-                  profile?.name
+                  <>
+                    {profile?.name} &nbsp;
+                    <TrustLevelRole type="user" level={profile?.tier} />
+                  </>
                 ) : (
                   <>
-                    {profile?.name}
+                    {profile?.name} &nbsp;
+                    <TrustLevelRole type="user" level={profile?.tier} />
                     <div className="id-short">{redactedAddress}</div>
                   </>
                 )}

--- a/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingThreadList/TrendingThreadList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingThreadList/TrendingThreadList.tsx
@@ -182,6 +182,7 @@ function mapThread(thread: z.infer<typeof ActivityThread>): Thread {
     profile_name: thread.profile_name ?? '',
     avatar_url: thread.profile_avatar ?? '',
     user_id: thread.user_id,
+    user_tier: thread.user_tier,
     userId: thread.user_id,
     last_edited: thread.updated_at ?? '',
     last_commented_on: '',

--- a/packages/commonwealth/client/scripts/views/pages/Leaderboard/XPTable/XPTable.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Leaderboard/XPTable/XPTable.tsx
@@ -8,6 +8,8 @@ import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTable } from 'views/components/component_kit/new_designs/CWTable';
 import { CWTableColumnInfo } from 'views/components/component_kit/new_designs/CWTable/CWTable';
 import { useCWTableState } from 'views/components/component_kit/new_designs/CWTable/useCWTableState';
+import TrustLevelRole from 'views/components/TrustLevelRole';
+
 import './XPTable.scss';
 
 const columns: CWTableColumnInfo[] = [
@@ -41,6 +43,7 @@ type RankProfile = {
     id: number;
     name: string;
     avatar_url: string;
+    tier: number;
   };
   xp: number;
   rank: number;
@@ -102,7 +105,13 @@ const XPTable = () => {
                       size={24}
                       address={rank.user_profile.id}
                     />
-                    <p>{rank.user_profile.name}</p>
+                    <p>
+                      {rank.user_profile.name}
+                      <TrustLevelRole
+                        type="user"
+                        level={rank.user_profile.tier}
+                      />
+                    </p>
                   </Link>
                 </div>
               ),

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -362,6 +362,7 @@ export const CommentCard = ({
                 name: comment.profile_name || DEFAULT_NAME,
                 userId: comment.user_id,
                 lastActive: comment.last_active as unknown as string,
+                tier: comment.user_tier || 0,
               }}
               versionHistory={(comment.CommentVersionHistories || []).map(
                 (cvh) => ({

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig(({ mode }) => {
     ),
     'process.env.FLAG_PRIVY': JSON.stringify(env.FLAG_PRIVY),
     'process.env.FLAG_JUDGE_CONTEST': JSON.stringify(env.FLAG_JUDGE_CONTEST),
+    'process.env.FLAG_TRUST_LEVEL': JSON.stringify(env.FLAG_TRUST_LEVEL),
   };
 
   const config = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11624

## Description of Changes


1. **Schemas**: Added `tier` fields to `UserView`, `CommentsView`, `ActivityThread`, and `GetUserAddresses` schemas.
2. **Models**: Extended `MinimumProfile`, `NewProfile`, and `Thread` models to include `tier` or `user_tier`.
3. **Utility**: Created `trustLevel.ts` with `getUserTrustLevel` and `getCommunityTrustLevel` functions to map tiers to icons, names, and descriptions.
4. **UI**: Added `TrustLevelRole` component to display trust level icons in profile headers, cards, and other UI elements.
5. **Feature Flag**: Introduced `FLAG_TRUST_LEVEL` to toggle the feature.
6. **Queries**: Updated `GetComments`, `GetThreads`, and `GetUserAddresses` to fetch `tier` data.
7. **Styling**: Adjusted CSS to accommodate the new component.



## Test Plan
- FLAG_TRUST_LEVEL=true
- click around the app, there are multiple places where icon has been added eg
  - top nav bar
  - inner side bar
  - profile page
  - threads
  - comments
  - home page
  - explore page

![image](https://github.com/user-attachments/assets/b11c8ea3-6d0a-451e-be6a-28a8914fb756)
![image](https://github.com/user-attachments/assets/315c4a32-feed-44f2-ae61-e2fb6c2ac411)
![image](https://github.com/user-attachments/assets/fbf12c49-e389-4990-86f5-0fee87722b7b)
![image](https://github.com/user-attachments/assets/b93b9734-d2e6-4884-a6cb-86a7c85148e8)
![image](https://github.com/user-attachments/assets/1111a078-3d5a-442f-96ff-fca3a709a7e8)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a