### PR TITLE
Tier 3 API Keys

### DIFF
--- a/libs/core/src/ports/interfaces.ts
+++ b/libs/core/src/ports/interfaces.ts
@@ -86,7 +86,8 @@ export enum CacheNamespaces {
   Community_Thread_Count_Changed = 'community_thread_count_changed',
   Thread_Reaction_Count_Changed = 'thread_reaction_count_changed',
   Community_Profile_Count_Changed = 'community_profile_count_changed',
-  TieredCounter = 'tiered_counter',
+  Tiered_Counter = 'tiered_counter',
+  External_Api_Usage_Counter = 'api_key_counter',
 }
 
 /**

--- a/libs/model/src/aggregates/user/CreateApiKey.command.ts
+++ b/libs/model/src/aggregates/user/CreateApiKey.command.ts
@@ -3,12 +3,12 @@ import { getSaltedApiKeyHash } from '@hicommonwealth/model';
 import * as schemas from '@hicommonwealth/schemas';
 import { randomBytes } from 'crypto';
 import { models } from '../../database';
-import { authVerified } from '../../middleware/auth';
+import { authVerified, tiered } from '../../middleware';
 
 export function CreateApiKey(): Command<typeof schemas.CreateApiKey> {
   return {
     ...schemas.CreateApiKey,
-    auth: [authVerified()],
+    auth: [authVerified(), tiered({ minTier: 3 })],
     secure: true,
     body: async ({ actor }) => {
       const apiKey = randomBytes(32).toString('base64url');

--- a/libs/model/src/middleware/tiered.ts
+++ b/libs/model/src/middleware/tiered.ts
@@ -26,7 +26,7 @@ function builtKey(user_id: number, counter: 'creates' | 'upvotes') {
 
 async function getUserCount(user_id: number, counter: 'creates' | 'upvotes') {
   const cacheKey = builtKey(user_id, counter);
-  const count = await cache().getKey(CacheNamespaces.TieredCounter, cacheKey);
+  const count = await cache().getKey(CacheNamespaces.Tiered_Counter, cacheKey);
   return +(count ?? '0');
 }
 
@@ -36,7 +36,7 @@ export async function incrementUserCount(
 ) {
   const cacheKey = builtKey(user_id, counter);
   const value = await cache().incrementKey(
-    CacheNamespaces.TieredCounter,
+    CacheNamespaces.Tiered_Counter,
     cacheKey,
     1,
     60,
@@ -48,10 +48,12 @@ export function tiered({
   creates = false,
   upvotes = false,
   ai = { images: false, text: false },
+  minTier = 0,
 }: {
   creates?: boolean;
   upvotes?: boolean;
   ai?: { images?: boolean; text?: boolean };
+  minTier?: number;
 }) {
   return async function ({ actor }: Context<ZodSchema, ZodSchema>) {
     if (!actor.user.id) throw new InvalidActor(actor, 'Must be a user');
@@ -76,6 +78,12 @@ export function tiered({
     if (tier < 1) tier = 1;
     if (tier > user.tier)
       await models.User.update({ tier }, { where: { id: user.id } });
+
+    if (tier < minTier)
+      throw new InvalidActor(
+        actor,
+        `Must be a user with tier above ${minTier}`,
+      );
 
     // allow users with tiers above limits
     if (tier >= tierLimitsPerHour.length) return;

--- a/packages/commonwealth/server/api/external-router-middleware.ts
+++ b/packages/commonwealth/server/api/external-router-middleware.ts
@@ -180,6 +180,7 @@ export function addRateLimiterMiddleware() {
   });
 
   // count all authenticated, non-rate-limited requests for analytics
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   router.use(async (req: Request, _, next: NextFunction) => {
     // This theoretically will never happen since the key is validated during auth
     if (!req.user || !req.user.id) throw new AppError('Unauthorized', 401);

--- a/packages/commonwealth/server/migrations/20250404152427-disallow-low-tier-api-keys.js
+++ b/packages/commonwealth/server/migrations/20250404152427-disallow-low-tier-api-keys.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DELETE
+      FROM "ApiKeys"
+        USING "Users"
+      WHERE "ApiKeys".user_id = "Users".id
+        AND "Users".tier < 3
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Note: Cannot restore deleted API keys as the data is permanently removed
+  },
+};


### PR DESCRIPTION

## Link to Issue
Closes: #11705

## Description of Changes
- Remove tier < 3 API Keys
- Require tier 3 for API key creation
- add per user external api usage counter

## Test Plan
- 

## Deployment Plan
<!--- Omit if unneeded -->
1. After deployment - re-release API package

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 