### PR TITLE
directory page grid view no longer sends a lot of get requests

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/CommunityDirectoryCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/CommunityDirectoryCard.tsx
@@ -1,48 +1,72 @@
 import { ExtendedCommunity } from '@hicommonwealth/schemas';
 import React from 'react';
-import { useGetCommunityByIdQuery } from 'state/api/communities';
 import useUserStore from 'state/ui/user';
-import { CWText } from 'views/components/component_kit/cw_text';
-import CWCircleMultiplySpinner from 'views/components/component_kit/new_designs/CWCircleMultiplySpinner';
 import { CWRelatedCommunityCard } from 'views/components/component_kit/new_designs/CWRelatedCommunityCard';
 import { z } from 'zod';
+import { CommunityData } from './DirectoryPageContent'; // Import CommunityData type
 
 interface CommunityDirectoryCardProps {
-  communityId: string;
-  threadsCount: number | string;
-  membersCount: number | string;
+  communityData: CommunityData;
 }
 
 const CommunityDirectoryCard = ({
-  communityId,
-  membersCount,
-  threadsCount,
+  communityData,
 }: CommunityDirectoryCardProps) => {
   const user = useUserStore();
 
-  const { data: community, isLoading: isCommunityLoading } =
-    useGetCommunityByIdQuery({
-      id: communityId,
-      enabled: !!communityId,
-      includeNodeInfo: true,
-    });
+  // Simplified community object for CWRelatedCommunityCard
+  const communityForCard = {
+    id: communityData.id,
+    name: communityData.name,
+    namespace: communityData.namespace,
+    icon_url: communityData.iconUrl,
+    description: communityData.description,
+    ChainNode: communityData.ChainNode, // Pass ChainNode through
+    // Add other necessary fields if CWRelatedCommunityCard needs them,
+    // mapping from communityData as required. Defaults/placeholders for now:
+    base: communityData.ChainNode?.cosmosChainId
+      ? 'cosmos'
+      : communityData.ChainNode?.ethChainId
+        ? 'ethereum'
+        : undefined,
+    last_30_day_thread_count: undefined, // Not available in CommunityData
+    banner_url: undefined, // Not available in CommunityData
+    directory_page_enabled: undefined, // Not available in CommunityData
+    directory_page_chain_node_id: undefined, // Not available in CommunityData
+    custom_domain: undefined, // Not available in CommunityData
+    pinned_token: undefined, // Not available in CommunityData
+    stake_enabled: undefined, // Not available in CommunityData
+    has_groups: undefined, // Not available in CommunityData
+    roles: undefined, // Not available in CommunityData
+    chain_type: communityData.ChainNode?.cosmosChainId
+      ? 'cosmos'
+      : communityData.ChainNode?.ethChainId
+        ? 'ethereum'
+        : undefined,
+  };
 
   // allow user to buy stake if they have a connected address that matches active community base chain
-  const canBuyStake = !!user.addresses.find?.(
-    (address) => address?.community?.base === community?.base,
-  );
-
-  if (isCommunityLoading) return <CWCircleMultiplySpinner />;
-
-  if (!community) return <CWText>Failed to load community</CWText>;
+  // Use ChainNode from communityData to determine base
+  const canBuyStake = !!user.addresses.find?.((address) => {
+    const communityBase = communityData.ChainNode?.cosmosChainId
+      ? 'cosmos'
+      : communityData.ChainNode?.ethChainId
+        ? 'ethereum'
+        : undefined;
+    return address?.community?.base === communityBase;
+  });
 
   return (
     <CWRelatedCommunityCard
-      key={communityId}
-      community={community as z.infer<typeof ExtendedCommunity>}
+      key={communityData.id}
+      // Cast is potentially unsafe, ensure CWRelatedCommunityCard handles potentially missing fields gracefully
+      // or adjust the mapping above to provide all required fields.
+      community={
+        communityForCard as unknown as z.infer<typeof ExtendedCommunity>
+      }
       canBuyStake={canBuyStake}
-      memberCount={membersCount}
-      threadCount={threadsCount}
+      memberCount={communityData.members}
+      threadCount={communityData.threads}
     />
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/CommunityDirectoryCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/CommunityDirectoryCard.tsx
@@ -46,7 +46,7 @@ const CommunityDirectoryCard = ({
   };
 
   // allow user to buy stake if they have a connected address that matches active community base chain
-  // Use ChainNode from communityData to determine base
+
   const canBuyStake = !!user.addresses.find?.((address) => {
     const communityBase = communityData.ChainNode?.cosmosChainId
       ? 'cosmos'
@@ -59,8 +59,6 @@ const CommunityDirectoryCard = ({
   return (
     <CWRelatedCommunityCard
       key={communityData.id}
-      // Cast is potentially unsafe, ensure CWRelatedCommunityCard handles potentially missing fields gracefully
-      // or adjust the mapping above to provide all required fields.
       community={
         communityForCard as unknown as z.infer<typeof ExtendedCommunity>
       }

--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPageContent.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPageContent.tsx
@@ -125,9 +125,7 @@ const DirectoryPageContent = ({
         return (
           <CommunityDirectoryCard
             key={community.id}
-            communityId={community.id}
-            membersCount={community.members}
-            threadsCount={community.threads}
+            communityData={community}
           />
         );
       })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11788 

## Description of Changes
- refactored code so that each `CommunityDirectoryCard.tsx` isn't calling `useGetCommunityByIdQuery` to get the community data

## Test Plan
- go to Ethereum community and go to Directory page
- click grid view for related communities and confirm you no longer see a large amount of GET requests in the terminal