### PR TITLE
Add role tag 

### DIFF
--- a/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
+++ b/packages/commonwealth/client/scripts/models/MinimumProfile.tsx
@@ -1,5 +1,5 @@
 import { AddressView } from '@hicommonwealth/schemas';
-import { DEFAULT_NAME } from '@hicommonwealth/shared';
+import { DEFAULT_NAME, UserTierMap } from '@hicommonwealth/shared';
 import jdenticon from 'jdenticon';
 import { z } from 'zod';
 
@@ -17,10 +17,10 @@ export function addressToUserProfile(
 ): UserProfile {
   return {
     userId: address.user_id ?? address.User?.id ?? 0,
-    avatarUrl: address.User?.profile.avatar_url ?? '',
-    name: address.User?.profile.name ?? DEFAULT_NAME,
+    avatarUrl: address.User?.profile?.avatar_url ?? '',
+    name: address.User?.profile?.name ?? DEFAULT_NAME,
     address: address?.address,
-    tier: address.User?.tier ?? 0,
+    tier: address.User?.tier ?? UserTierMap.IncompleteUser,
     lastActive: (
       address?.last_active ??
       address.User?.created_at ??

--- a/packages/commonwealth/client/scripts/utils/mapProfileThread.ts
+++ b/packages/commonwealth/client/scripts/utils/mapProfileThread.ts
@@ -55,6 +55,7 @@ export function mapProfileThread(thread): Thread {
     numberOfComments: thread.numberOfComments,
     is_linking_token: thread.isLinkingToken,
     launchpad_token_address: thread.tokenAddress,
+    user_tier: thread.user_tier,
     recentComments:
       thread.recentComments?.map((c) => ({
         id: c.id ?? 0,

--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -57,11 +57,29 @@ const Profile = ({ userId }: ProfileProps) => {
         data.threads.map((t) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { Comments, ...rest } = t; // comments aren't needed for display here
-          return new Thread({ ...rest });
+          return new Thread({ ...rest, user_tier: data.tier });
         }),
       );
-      // @ts-expect-error <StrictNullChecks/>
-      const responseComments = data.comments.map((c) => new Comment(c));
+      const responseComments = data.comments.map(
+        (c) =>
+          // @ts-expect-error <StrictNullChecks/>
+          new Comment({
+            ...c,
+            Address: {
+              ...c.Address,
+              User: {
+                ...(c.Address?.User || {}),
+                tier: data.tier,
+                profile: {
+                  ...(c.Address?.User?.profile || {}),
+                  tier: data.tier,
+                  name: data.profile.name,
+                  avatar_url: data.profile.avatar_url,
+                },
+              },
+            },
+          }),
+      );
 
       const commentsWithAssociatedThread = responseComments.map((c) => {
         const thread = data.commentThreads.find(

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.tsx
@@ -207,6 +207,7 @@ export const CWContentPage = ({
         versionHistory={thread?.versionHistory || []}
         activeThreadVersionId={activeThreadVersionId}
         onChangeVersionHistoryNumber={onChangeVersionHistoryNumber}
+        shouldShowRole
       />
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -51,8 +51,6 @@ export const FullUser = ({
       enabled: !!userCommunityId,
     });
 
-  console.log('userCommunity', userCommunity);
-
   if (showSkeleton || isLoadingUserCommunity) {
     return (
       <UserSkeleton
@@ -86,11 +84,11 @@ export const FullUser = ({
   const capitalizeRole = roleInCommunity
     ? roleInCommunity.charAt(0).toUpperCase() +
       roleInCommunity.slice(1).toLowerCase()
-    : '';
+    : 'Member';
 
   const roleTags = (
     <>
-      {shouldShowRole && roleInCommunity && (
+      {shouldShowRole && (
         <CWTag label={capitalizeRole} type="proposal" classNames="role-tag" />
       )}
     </>

--- a/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/fullUser.tsx
@@ -17,8 +17,8 @@ import Permissions from '../../../utils/Permissions';
 import { BanUserModal } from '../../modals/ban_user_modal';
 import TrustLevelRole from '../TrustLevelRole';
 import { CWIconButton } from '../component_kit/cw_icon_button';
-import { CWText } from '../component_kit/cw_text';
 import { CWModal } from '../component_kit/new_designs/CWModal';
+import { CWTag } from '../component_kit/new_designs/CWTag';
 import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 import { UserSkeleton } from './UserSkeleton';
 import './user.scss';
@@ -51,6 +51,8 @@ export const FullUser = ({
       enabled: !!userCommunityId,
     });
 
+  console.log('userCommunity', userCommunity);
+
   if (showSkeleton || isLoadingUserCommunity) {
     return (
       <UserSkeleton
@@ -81,12 +83,15 @@ export const FullUser = ({
     ({ address, ghostAddress }) => userAddress === address && ghostAddress,
   );
 
+  const capitalizeRole = roleInCommunity
+    ? roleInCommunity.charAt(0).toUpperCase() +
+      roleInCommunity.slice(1).toLowerCase()
+    : '';
+
   const roleTags = (
     <>
       {shouldShowRole && roleInCommunity && (
-        <div className="role-tag-container">
-          <CWText className="role-tag-text">{roleInCommunity}</CWText>
-        </div>
+        <CWTag label={capitalizeRole} type="proposal" classNames="role-tag" />
       )}
     </>
   );
@@ -246,7 +251,8 @@ export const FullUser = ({
                 level={profile?.tier || UserTierMap.IncompleteUser}
               />
             </Link>
-          )}
+          )}{' '}
+          {roleTags}
           {profile?.address && (
             <div className="address-container">
               <div className="user-address">
@@ -278,7 +284,6 @@ export const FullUser = ({
           {friendlyCommunityName && (
             <div className="user-chain">{friendlyCommunityName}</div>
           )}
-          {roleTags}
           {/* If Admin Allow Banning */}
           {loggedInUserIsAdmin && !isSelfSelected && (
             <div className="ban-wrapper">

--- a/packages/commonwealth/client/scripts/views/components/user/user.scss
+++ b/packages/commonwealth/client/scripts/views/components/user/user.scss
@@ -96,6 +96,7 @@
     cursor: inherit;
     text-decoration: initial;
     display: flex;
+    align-items: center;
   }
 
   .profile-name {
@@ -131,15 +132,8 @@
     @include roleIcon();
   }
 
-  .role-tag-container {
-    display: inline-block;
-
-    .role-tag-text.Text {
-      background-color: $neutral-200;
-      border-radius: $border-radius-rounded-corners;
-      margin-left: 6px;
-      padding: 2px 8px;
-    }
+  .role-tag {
+    margin-left: 6px;
   }
 }
 
@@ -157,6 +151,9 @@
   box-shadow: $elevation-3;
   padding: 8px;
   text-align: center !important;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   .user-avatar,
   .user-name {

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentCard/CommentCard.tsx
@@ -376,6 +376,7 @@ export const CommentCard = ({
                   content_url: cvh.content_url || '',
                 }),
               )}
+              shouldShowRole
               onChangeVersionHistoryNumber={handleVersionHistoryChange}
             />
           )}

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/AuthorAndPublishInfo/AuthorAndPublishInfo.tsx
@@ -62,6 +62,7 @@ export type AuthorAndPublishInfoProps = {
   hideSpamTag?: boolean;
   hideTrendingTag?: boolean;
   communityHomeLayout?: boolean;
+  shouldShowRole?: boolean;
 };
 
 export const AuthorAndPublishInfo = ({
@@ -93,6 +94,7 @@ export const AuthorAndPublishInfo = ({
   hideSpamTag,
   hideTrendingTag,
   communityHomeLayout = false,
+  shouldShowRole = false,
 }: AuthorAndPublishInfoProps) => {
   const popoverProps = usePopover();
   const containerRef = useRef(null);
@@ -176,6 +178,7 @@ export const AuthorAndPublishInfo = ({
           popoverPlacement={popoverPlacement}
           // @ts-expect-error <StrictNullChecks>
           profile={profile}
+          shouldShowRole={shouldShowRole}
         />
       )}
       {fromDiscordBot && (

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -200,6 +200,7 @@ export const ThreadCard = ({
               hideSpamTag={hideSpamTag}
               hideTrendingTag={hideTrendingTag}
               communityHomeLayout={communityHomeLayout}
+              shouldShowRole
             />
             <div className="content-header-icons">
               {thread.pinned && <CWIcon iconName="pin" />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11790

## Description of Changes

1. Added user tier handling with `UserTierMap.IncompleteUser` as default
2. Enhanced user profile data handling with better null checks
3. Added role display functionality across components using `CWTag`
4. Improved thread and comment mapping to include user tier information
5. Updated UI styling for user roles and profile displays

## Test Plan
Should show tag:
1. Within the community on hover of the user profile
2. Thread Page
3. On Discussions / Overview Pages

![image](https://github.com/user-attachments/assets/d58d1229-272c-4864-88f5-496b49161a4f)

![image](https://github.com/user-attachments/assets/051b715f-c0bb-4f4e-a554-5ca9499a5edb)

![image](https://github.com/user-attachments/assets/f814d92e-5c95-49e7-ad9d-ea700b5c6282)


## Deployment Plan
<!--- Omit if unneeded -->
1. n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a