### PR TITLE
fix: remove community stake reference under profile/transactions 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/TransactionsTab/NoTransactionHistory/NoTransactionHistory.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/TransactionsTab/NoTransactionHistory/NoTransactionHistory.tsx
@@ -1,4 +1,3 @@
-import { BLOG_SUBDOMAIN } from '@hicommonwealth/shared';
 import noTransactionHistory from 'assets/img/noTransactionHistory.svg';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
@@ -23,7 +22,7 @@ const NoTransactionHistory = ({
             You have not purchased assets in any communities{' '}
             {withSelectedAddress ? 'with the selected address' : ''}
           </CWText>
-          <CWText type="b1">
+          {/* <CWText type="b1">
             <span>
               Purchasing assets like community stake gives you more upvote power
               within your communities.{' '}
@@ -33,7 +32,7 @@ const NoTransactionHistory = ({
                 Learn more
               </a>
             </span>
-          </CWText>
+          </CWText> */}
         </div>
         <CWButton
           label="Explore"

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/TransactionsTab/NoTransactionHistory/NoTransactionHistory.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/TransactionsTab/NoTransactionHistory/NoTransactionHistory.tsx
@@ -22,17 +22,6 @@ const NoTransactionHistory = ({
             You have not purchased assets in any communities{' '}
             {withSelectedAddress ? 'with the selected address' : ''}
           </CWText>
-          {/* <CWText type="b1">
-            <span>
-              Purchasing assets like community stake gives you more upvote power
-              within your communities.{' '}
-              <a
-                href={`https://${BLOG_SUBDOMAIN}/community-stake-100-owners-around-any-idea/`}
-              >
-                Learn more
-              </a>
-            </span>
-          </CWText> */}
         </div>
         <CWButton
           label="Explore"


### PR DESCRIPTION
There was a reference to community stake under profile/transactions when the address did not have any transactions. That has been removed 

## Link to Issue
Closes: #11822 

## Description of Changes
- Remove references to "community stake" under profile/transactions when the address connected does not have transactions 

## "How We Fixed It"
commented out the copy

## Test Plan
- go to profile/transactions
- switch to an address that does not have any transactions
- Check the copy


## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 