### PR TITLE
Added new start action UI affordances for repeatable quest actions

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Communities/QuestList/QuestList.tsx
@@ -114,6 +114,8 @@ const QuestList = ({
                   completed: (quest.action_metas || [])
                     .map((action) =>
                       isQuestActionComplete(
+                        new Date(quest.start_date),
+                        new Date(quest.end_date),
                         action as QuestAction,
                         xpProgressions as unknown as XPLog[],
                       ),

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -7,6 +7,7 @@ import { roundDecimalsOrReturnWhole } from 'helpers/number';
 import {
   doesActionRequireRewardShare,
   doesActionRewardShareForReferrer,
+  getTotalRepititionCountsForQuestAction,
 } from 'helpers/quest';
 import React from 'react';
 import useUserStore from 'state/ui/user';
@@ -31,6 +32,8 @@ type QuestActionCardProps = {
   inEligibilityReason?: string;
   canStartAction?: boolean;
   actionStartBlockedReason?: string;
+  questStartDate: Date;
+  questEndDate: Date;
 };
 
 const QuestActionCard = ({
@@ -43,6 +46,8 @@ const QuestActionCard = ({
   canStartAction,
   inEligibilityReason,
   questAction,
+  questStartDate,
+  questEndDate,
 }: QuestActionCardProps) => {
   const creatorXP = {
     percentage: roundDecimalsOrReturnWhole(
@@ -62,8 +67,12 @@ const QuestActionCard = ({
   const questRepeatitionCycle = questAction?.participation_period;
   const questParticipationLimitPerCycle =
     questAction?.participation_times_per_period || 0;
-  const attemptsLeft =
-    questParticipationLimitPerCycle - (xpLogsForActions || []).length;
+  const totalActionRepititions = getTotalRepititionCountsForQuestAction(
+    questStartDate,
+    questEndDate,
+    questAction,
+  ).totalRepititions;
+  const attemptsLeft = totalActionRepititions - (xpLogsForActions || []).length;
 
   return (
     <div className="QuestActionCard">
@@ -133,7 +142,7 @@ const QuestActionCard = ({
               />
               {isRepeatableQuest &&
                 attemptsLeft !== 0 &&
-                attemptsLeft !== questParticipationLimitPerCycle && (
+                attemptsLeft !== totalActionRepititions && (
                   <CWTag
                     type="group"
                     label={`${attemptsLeft}x attempt${attemptsLeft > 1 ? 's' : ''} left`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11840

## Description of Changes
Added new start action UI affordances for repeatable quest actions


## "How We Fixed It"
N/A

## Test Plan
1. Create a repeatable quest
2. Verify you see remaining total attempts left on the quest action card and not the remaining attempts left for the current repitition period

## Deployment Plan
N/A

## Other Considerations
N/A