### PR TITLE
Fix group membership refresh

### DIFF
--- a/libs/model/src/utils/denormalizedCountUtils.ts
+++ b/libs/model/src/utils/denormalizedCountUtils.ts
@@ -55,8 +55,8 @@ export const refreshProfileCount = debounceRefresh(
       `
 UPDATE "Communities" C
 SET profile_count = (
-    SELECT COUNT(*) 
-    FROM "Addresses" A 
+    SELECT COUNT(*)
+    FROM "Addresses" A
     WHERE A.community_id = C.id AND A.user_id IS NOT NULL AND A.verified IS NOT NULL
 )
 WHERE C.id = :community_id;
@@ -67,15 +67,15 @@ WHERE C.id = :community_id;
   10_000,
 );
 
-export const refreshMemberships = debounceRefresh(
-  async (community_id: string, group_id?: number) => {
-    await command(RefreshCommunityMemberships(), {
-      actor: systemActor({}),
-      payload: { community_id, group_id },
-    });
-  },
-  10_000,
-);
+export const refreshMemberships = async (
+  community_id: string,
+  group_id?: number,
+) => {
+  await command(RefreshCommunityMemberships(), {
+    actor: systemActor({}),
+    payload: { community_id, group_id },
+  });
+};
 
 // TODO: check if we need a maintenance policy for this
 export async function assertAddressOwnership(address: string) {


### PR DESCRIPTION
When groups are created/updated, it triggers membership refresh. The debounce implementation had a bug that crashed the app.

Test:
- Create a group– should succeed
- Update the group– should succeed
- Navigate to other parts of the app– should work fine, no errors