### PR TITLE
Fix contest projection error

### DIFF
--- a/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
+++ b/libs/evm-protocols/src/common-protocol/contractHelpers/contest.ts
@@ -108,9 +108,9 @@ export const getContestStatus = async (
   endTime: number;
   contestInterval: number;
   lastContentId: string;
-  prizeShare: number;
-  voterShare: number;
-  contestToken: `0x${string}`;
+  // prizeShare: number;
+  // voterShare: number;
+  // contestToken: `0x${string}`;
 }> => {
   const client = getPublicClient(chain);
   const contract = {
@@ -136,18 +136,18 @@ export const getContestStatus = async (
         ...contract,
         functionName: oneOff ? 'contestLength' : 'contestInterval',
       },
-      {
-        ...contract,
-        functionName: 'prizeShare',
-      },
-      {
-        ...contract,
-        functionName: 'voterShare',
-      },
-      {
-        ...contract,
-        functionName: 'contestToken',
-      },
+      // {
+      //   ...contract,
+      //   functionName: 'prizeShare',
+      // },
+      // {
+      //   ...contract,
+      //   functionName: 'voterShare',
+      // },
+      // {
+      //   ...contract,
+      //   functionName: 'contestToken',
+      // },
     ],
     allowFailure: false,
   });
@@ -157,9 +157,9 @@ export const getContestStatus = async (
     endTime: Number(promise[1]),
     contestInterval: Number(promise[2]),
     lastContentId: String(promise[3]),
-    prizeShare: Number(promise[4]),
-    voterShare: Number(promise[5]),
-    contestToken: promise[6] as `0x${string}`,
+    // prizeShare: Number(promise[4]),
+    // voterShare: Number(promise[5]),
+    // contestToken: promise[6] as `0x${string}`,
   };
 };
 

--- a/libs/model/src/utils/denormalizedCountUtils.ts
+++ b/libs/model/src/utils/denormalizedCountUtils.ts
@@ -55,8 +55,8 @@ export const refreshProfileCount = debounceRefresh(
       `
 UPDATE "Communities" C
 SET profile_count = (
-    SELECT COUNT(*)
-    FROM "Addresses" A
+    SELECT COUNT(*) 
+    FROM "Addresses" A 
     WHERE A.community_id = C.id AND A.user_id IS NOT NULL AND A.verified IS NOT NULL
 )
 WHERE C.id = :community_id;
@@ -67,15 +67,15 @@ WHERE C.id = :community_id;
   10_000,
 );
 
-export const refreshMemberships = async (
-  community_id: string,
-  group_id?: number,
-) => {
-  await command(RefreshCommunityMemberships(), {
-    actor: systemActor({}),
-    payload: { community_id, group_id },
-  });
-};
+export const refreshMemberships = debounceRefresh(
+  async (community_id: string, group_id?: number) => {
+    await command(RefreshCommunityMemberships(), {
+      actor: systemActor({}),
+      payload: { community_id, group_id },
+    });
+  },
+  10_000,
+);
 
 // TODO: check if we need a maintenance policy for this
 export async function assertAddressOwnership(address: string) {

--- a/libs/model/src/utils/denormalizedCountUtils.ts
+++ b/libs/model/src/utils/denormalizedCountUtils.ts
@@ -55,8 +55,8 @@ export const refreshProfileCount = debounceRefresh(
       `
 UPDATE "Communities" C
 SET profile_count = (
-    SELECT COUNT(*) 
-    FROM "Addresses" A 
+    SELECT COUNT(*)
+    FROM "Addresses" A
     WHERE A.community_id = C.id AND A.user_id IS NOT NULL AND A.verified IS NOT NULL
 )
 WHERE C.id = :community_id;
@@ -67,15 +67,15 @@ WHERE C.id = :community_id;
   10_000,
 );
 
-export const refreshMemberships = debounceRefresh(
-  async (community_id: string, group_id?: number) => {
-    await command(RefreshCommunityMemberships(), {
-      actor: systemActor({}),
-      payload: { community_id, group_id },
-    });
-  },
-  10_000,
-);
+export const refreshMemberships = async (
+  community_id: string,
+  group_id?: number,
+) => {
+  await command(RefreshCommunityMemberships(), {
+    actor: systemActor({}),
+    payload: { community_id, group_id },
+  });
+};
 
 // TODO: check if we need a maintenance policy for this
 export async function assertAddressOwnership(address: string) {

--- a/libs/model/test/contest/contests-projection-lifecycle.spec.ts
+++ b/libs/model/test/contest/contests-projection-lifecycle.spec.ts
@@ -207,9 +207,9 @@ describe('Contests projection lifecycle', () => {
       endTime: 100,
       contestInterval: 50,
       lastContentId: '1',
-      prizeShare: 10,
-      voterShare: 20,
-      contestToken: '0x000',
+      // prizeShare: 10,
+      // voterShare: 20,
+      // contestToken: '0x000',
     });
 
     await handleEvent(Contests(), {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11810

## Description of Changes
- Removes ABI properties that caused failure to create initial Contest entity: `Function \"prizeShare\" not found on ABI.\nMake sure you are using the correct ABI and that the function exists on it.`

## Test Plan
- Deploy a contest, wait a few seconds, confirm that consumer processes the `OneOffContestManagerDeployed` event and the `Contest` entity exists for it

## Deployment Plan
We'll need to replay the `OneOffContestManagerDeployed` outbox events from the last few days to retroactively fix any affected contests.

## Other Considerations
The commented out props are not used. Something about the ABI needs to be fixed. Until then, we need to remove the old logic because it breaks contests.