### PR TITLE
contest card title and topic truncation

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.scss
@@ -56,6 +56,9 @@
     position: relative;
 
     .header-row {
+      width: 100%;
+      box-sizing: border-box;
+      overflow: hidden;
       display: flex;
       justify-content: start;
       align-items: center;
@@ -66,6 +69,9 @@
         display: flex;
         align-items: self-start;
         gap: 8px;
+        overflow: hidden;
+        min-width: 0;
+        flex: 1;
 
         & > .Text {
           line-height: 1.2;

--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -20,6 +20,7 @@ import { IconName } from 'views/components/component_kit/cw_icons/cw_icon_lookup
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
+import { CWTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { CWThreadAction } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { SharePopoverOld } from 'views/components/share_popover_old';
 import { openConfirmation } from 'views/modals/confirmation_modal';
@@ -37,6 +38,8 @@ import FractionalValue from 'views/components/FractionalValue';
 import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 
 import './ContestCard.scss';
+
+const MAX_CHARS_FOR_TITLE = 28;
 
 const noFundsProps = {
   title: 'There are no funds for this contest',
@@ -239,6 +242,30 @@ const ContestCard = ({
     return null;
   }
 
+  const isTitleTrimmed = name.length > MAX_CHARS_FOR_TITLE;
+  const trimmedTitle = isTitleTrimmed
+    ? name.slice(0, MAX_CHARS_FOR_TITLE) + '...'
+    : name;
+
+  const renderTitleWithTooltip = (title: string, isTrimmed: boolean) => {
+    if (!isTrimmed) return <CWText type="h4">{title}</CWText>;
+
+    return (
+      <CWTooltip
+        placement="bottom"
+        content={name}
+        renderTrigger={(handleInteraction) => (
+          <span
+            onMouseEnter={handleInteraction}
+            onMouseLeave={handleInteraction}
+          >
+            <CWText type="h4">{trimmedTitle}</CWText>
+          </span>
+        )}
+      />
+    );
+  };
+
   return (
     <CWCard
       className={clsx('ContestCard', {
@@ -273,7 +300,7 @@ const ContestCard = ({
                 iconUrl: community?.iconUrl || '',
               }}
             />
-            <CWText type="h3">{name}</CWText>
+            {renderTitleWithTooltip(trimmedTitle, isTitleTrimmed)}
           </div>
           {finishDate ? (
             <CWCountDownTimer

--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -34,6 +34,7 @@ import ContestAlert from './ContestAlert';
 
 import { useGetContestBalanceQuery } from 'client/scripts/state/api/contests';
 import { useFlag } from 'hooks/useFlag';
+import { smartTrim } from 'shared/utils';
 import FractionalValue from 'views/components/FractionalValue';
 import { CWCommunityAvatar } from '../component_kit/cw_community_avatar';
 
@@ -243,9 +244,7 @@ const ContestCard = ({
   }
 
   const isTitleTrimmed = name.length > MAX_CHARS_FOR_TITLE;
-  const trimmedTitle = isTitleTrimmed
-    ? name.slice(0, MAX_CHARS_FOR_TITLE) + '...'
-    : name;
+  const trimmedTitle = smartTrim(name, MAX_CHARS_FOR_TITLE);
 
   const renderTitleWithTooltip = (title: string, isTrimmed: boolean) => {
     if (!isTrimmed) return <CWText type="h4">{title}</CWText>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
N/A

## Description of Changes
fixed the truncation issue for contests with longer card titles
<img width="315" alt="Screenshot 2025-04-16 at 1 30 35 PM" src="https://github.com/user-attachments/assets/b09f91c2-fc51-4dc0-b951-09bba90710f6" />
after:
<img width="826" alt="Screenshot 2025-04-17 at 4 04 12 PM" src="https://github.com/user-attachments/assets/de4bbcc9-822d-4a8d-89e5-58bb11c748c5" />



## "How We Fixed It"
fixed properties on .header-row

## Test Plan
N/A

## Deployment Plan
N/A

## Other Considerations
N/A