### PR TITLE
Added group membership action for quests

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/html.ts
+++ b/packages/commonwealth/client/scripts/helpers/html.ts
@@ -1,0 +1,21 @@
+type JumpHighlightElementProps = {
+  elementQuerySelecter: string;
+};
+
+export const jumpHighlightElement = ({
+  elementQuerySelecter,
+}: JumpHighlightElementProps) => {
+  const element = document.querySelector(elementQuerySelecter);
+  if (!element) {
+    console.warn(
+      `No element to highlight for selector: ${elementQuerySelecter}`,
+    );
+    return;
+  }
+
+  element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  element.classList.add('highlighted');
+  setTimeout(() => {
+    element.classList.remove('highlighted');
+  }, 2000);
+};

--- a/packages/commonwealth/client/scripts/helpers/quest.ts
+++ b/packages/commonwealth/client/scripts/helpers/quest.ts
@@ -35,7 +35,8 @@ export const doesActionAllowContentId = (action: QuestActionType) => {
     action === 'CommentUpvoted' ||
     action === 'ThreadUpvoted' ||
     action === 'TweetEngagement' ||
-    action === 'CommonDiscordServerJoined'
+    action === 'CommonDiscordServerJoined' ||
+    action === 'MembershipsRefreshed'
   );
 };
 
@@ -65,6 +66,10 @@ export const doesActionRequireDiscordServerURL = (action: QuestActionType) => {
 
 export const doesActionAllowRepetition = (action: QuestActionType) => {
   return action !== 'TweetEngagement';
+};
+
+export const doesActionRequireGroupId = (action: QuestActionType) => {
+  return action === 'MembershipsRefreshed';
 };
 
 const convertTimeRemainingToLabel = ({

--- a/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
+++ b/packages/commonwealth/client/scripts/navigation/CommonDomainRoutes.tsx
@@ -60,6 +60,9 @@ const ViewThreadPage = lazy(
 );
 const TopicRedirectPage = lazy(() => import('views/pages/topic_redirect'));
 const ThreadRedirectPage = lazy(() => import('views/pages/thread_redirect'));
+const GroupRedirectPage = lazy(
+  () => import('views/pages/Redirects/GroupRedirect'),
+);
 const CommentRedirectPage = lazy(() => import('views/pages/comment_redirect'));
 const NewThreadPage = lazy(() => import('views/pages/new_thread'));
 const DiscussionsRedirectPage = lazy(
@@ -451,6 +454,13 @@ const CommonDomainRoutes = () => [
     key="/discussion/:identifier"
     path="/discussion/:identifier"
     element={withLayout(ThreadRedirectPage, {
+      scoped: false,
+    })}
+  />,
+  <Route
+    key="/group/:id"
+    path="/group/:id"
+    element={withLayout(GroupRedirectPage, {
       scoped: false,
     })}
   />,

--- a/packages/commonwealth/client/scripts/styles/utils.scss
+++ b/packages/commonwealth/client/scripts/styles/utils.scss
@@ -48,3 +48,14 @@
 .w-fit {
   width: fit-content;
 }
+
+// this is required for `client/scripts/helpers/html.ts#jumpHighlightElement()`
+.highlighted {
+  background-color: $yellow-200;
+  border-radius: $border-radius-corners;
+
+  &.highlightAnimationComplete {
+    background-color: transparent;
+    transition: background-color 1s ease-in-out;
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -292,7 +292,7 @@ const CommunityMembersPage = () => {
   const totalResults = members?.pages?.[0]?.totalResults || 0;
 
   const updateActiveTab = (activeTab: TabValues) => {
-    const params = new URLSearchParams();
+    const params = new URLSearchParams(window.location.search);
     params.set('tab', activeTab);
     navigate(`${window.location.pathname}?${params.toString()}`, {}, null);
     setSelectedTab(activeTab);

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.scss
@@ -20,24 +20,31 @@
       margin-right: auto;
     }
 
-    .group-edit-button {
+    .right {
       display: flex;
-      justify-content: center;
+      flex-direction: row;
       align-items: center;
-      color: $neutral-500;
-      cursor: pointer;
-      outline: none;
-      border: none;
-      background-color: transparent;
       gap: 4px;
 
-      .Icon {
+      .group-edit-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         color: $neutral-500;
-        font-size: 18px;
-      }
+        cursor: pointer;
+        outline: none;
+        border: none;
+        background-color: transparent;
+        gap: 4px;
 
-      .caption {
-        color: $neutral-500;
+        .Icon {
+          color: $neutral-500;
+          font-size: 18px;
+        }
+
+        .caption {
+          color: $neutral-500;
+        }
       }
     }
   }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/GroupCard.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import useBrowserWindow from 'hooks/useBrowserWindow';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -6,6 +7,7 @@ import { CWDivider } from 'views/components/component_kit/cw_divider';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
+import { SharePopover } from 'views/components/SharePopover';
 import { formatAddressShort } from '../../../../../../helpers';
 import CWPagination from '../../../../../components/component_kit/new_designs/CWPagination/CWPagination';
 import { convertGranularPermissionsToAccumulatedPermissions } from '../../../Groups/common/GroupForm/helpers';
@@ -17,6 +19,7 @@ const ALLOWLIST_MEMBERS_PER_PAGE = 7;
 
 const GroupCard = ({
   isJoined,
+  groupId,
   groupName,
   groupDescription,
   requirements,
@@ -34,8 +37,14 @@ const GroupCard = ({
     ALLOWLIST_MEMBERS_PER_PAGE * (currentAllowlistPage - 1),
     ALLOWLIST_MEMBERS_PER_PAGE * currentAllowlistPage,
   );
+
+  const url = new URL(window.location.href);
+  const search = new URLSearchParams(url.search);
+  search.set(`groupId`, String(groupId));
+  const shareURL = `${url.origin}${url.pathname}?${search.toString()}`;
+
   return (
-    <section className="GroupCard">
+    <section className={clsx('GroupCard', `group-${groupId}`)}>
       {/* Join status */}
       <CWTag
         type={isJoined ? 'passed' : 'referendum'}
@@ -47,12 +56,15 @@ const GroupCard = ({
         <CWText type="h3" className="group-name-text">
           {groupName}
         </CWText>
-        {canEdit && (
-          <button className="group-edit-button" onClick={onEditClick}>
-            <CWIcon iconName="notePencil" iconSize="medium" />
-            <CWText type="caption">Edit</CWText>
-          </button>
-        )}
+        <div className="right">
+          <SharePopover linkToShare={shareURL} buttonLabel="Share" />
+          {canEdit && (
+            <button className="group-edit-button" onClick={onEditClick}>
+              <CWIcon iconName="notePencil" iconSize="medium" />
+              <CWText type="caption">Edit</CWText>
+            </button>
+          )}
+        </div>
       </div>
       {groupDescription && <CWText type="b2">{groupDescription}</CWText>}
 

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupCard/types.ts
@@ -12,6 +12,7 @@ export type RequirementCardProps = {
 
 export type GroupCardProps = {
   isJoined?: boolean;
+  groupId: number;
   groupName: string;
   groupDescription?: string;
   requirements?: RequirementCardProps[]; // This represents erc requirements

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupsSection.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/GroupsSection/GroupsSection.tsx
@@ -1,3 +1,5 @@
+import { jumpHighlightElement } from 'helpers/html';
+import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
 import Group from 'models/Group';
 import MinimumProfile from 'models/MinimumProfile';
 import { useCommonNavigate } from 'navigation/helpers';
@@ -40,15 +42,32 @@ const GroupsSection = ({
     profiles?.map((p) => [p.address, p]),
   );
 
+  useRunOnceOnCondition({
+    callback: () => {
+      const groupIdToHighlight = new URLSearchParams(
+        window.location.search,
+      ).get(`groupId`);
+      if (groupIdToHighlight) {
+        setTimeout(() => {
+          jumpHighlightElement({
+            elementQuerySelecter: `.group-${groupIdToHighlight}`,
+          });
+        }, 200);
+      }
+    },
+    shouldRun: filteredGroups?.length > 0,
+  });
+
   return (
     <section className="GroupsSection">
       {hasNoGroups && <TopicGatingHelpMessage />}
 
       {filteredGroups?.length > 0 && (
         <section className="list-container">
-          {filteredGroups?.map((group, index) => (
+          {filteredGroups?.map((group) => (
             <GroupCard
-              key={index}
+              key={group.id}
+              groupId={group.id}
               groupName={group.name}
               groupDescription={group.description}
               // @ts-expect-error <StrictNullChecks/>

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/QuestActionSubForm.tsx
@@ -63,6 +63,7 @@ const QuestActionSubForm = ({
       sampleTopicLink: `https://${PRODUCTION_DOMAIN}/common/discussions/Proposals`,
       twitterTweetUrl: `https://x.com/user/status/1904060455158428146`,
       discordServerUrl: `https://discord.gg/commonwealth`,
+      groupId: `https://${PRODUCTION_DOMAIN}/common/members?tab=groups&groupId=1234`,
     },
     labels: {
       threadId: 'Thread Link (optional)',
@@ -70,6 +71,7 @@ const QuestActionSubForm = ({
       topicId: 'Topic Link (optional)',
       twitterTweetUrl: 'Tweet URL',
       discordServerUrl: 'Discord Server URL',
+      groupId: 'Group Link',
     },
   };
 
@@ -95,6 +97,10 @@ const QuestActionSubForm = ({
 
     if (config?.requires_discord_server_url) {
       return contentIdInputConfig.labels.discordServerUrl;
+    }
+
+    if (config?.requires_group_id) {
+      return contentIdInputConfig.labels.groupId;
     }
 
     return 'Content Id';
@@ -124,6 +130,10 @@ const QuestActionSubForm = ({
       return contentIdInputConfig.placeholders.discordServerUrl;
     }
 
+    if (config?.requires_group_id) {
+      return contentIdInputConfig.placeholders.groupId;
+    }
+
     return 'Content Id';
   };
 
@@ -132,7 +142,8 @@ const QuestActionSubForm = ({
     config?.with_optional_thread_id ||
     config?.with_optional_topic_id ||
     config?.requires_twitter_tweet_link ||
-    config?.requires_discord_server_url;
+    config?.requires_discord_server_url ||
+    config?.requires_group_id;
 
   const repetitionCycleOptions = Object.keys(QuestParticipationPeriod).map(
     (k) => ({

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/types.ts
@@ -13,6 +13,7 @@ export enum QuestActionContentIdScope {
   Thread = 'thread',
   TwitterTweet = 'twitter_tweet',
   DiscordServer = 'discord_server',
+  Group = 'group',
 }
 
 export type QuestActionSubFormErrors = {
@@ -55,6 +56,7 @@ export type QuestActionSubFormConfig = {
   with_optional_comment_id: boolean;
   requires_twitter_tweet_link: boolean;
   requires_discord_server_url: boolean;
+  requires_group_id: boolean;
 };
 
 export type QuestActionSubFormInternalRefs = {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -6,6 +6,7 @@ import {
   doesActionAllowThreadId,
   doesActionAllowTopicId,
   doesActionRequireDiscordServerURL,
+  doesActionRequireGroupId,
   doesActionRequireRewardShare,
   doesActionRequireTwitterTweetURL,
 } from 'helpers/quest';
@@ -148,6 +149,7 @@ const useQuestActionMultiFormsState = ({
         allowsContentId && doesActionRequireTwitterTweetURL(chosenAction);
       const requiresDiscordServerURL =
         doesActionRequireDiscordServerURL(chosenAction);
+      const requiresGroupId = doesActionRequireGroupId(chosenAction);
       const isActionRepeatable = doesActionAllowRepetition(chosenAction);
 
       // update config based on chosen action
@@ -162,6 +164,7 @@ const useQuestActionMultiFormsState = ({
         requires_twitter_tweet_link:
           allowsContentId && doesActionRequireTwitterTweetURL(chosenAction),
         requires_discord_server_url: requiresDiscordServerURL,
+        requires_group_id: requiresGroupId,
       };
 
       // set fixed action repitition per certain actions
@@ -200,6 +203,11 @@ const useQuestActionMultiFormsState = ({
             QuestActionContentIdScope.DiscordServer;
           break;
         }
+        case 'MembershipsRefreshed': {
+          updatedSubForms[index].values.contentIdScope =
+            QuestActionContentIdScope.Group;
+          break;
+        }
         default: {
           break;
         }
@@ -221,7 +229,10 @@ const useQuestActionMultiFormsState = ({
             !allowsTwitterTweetUrl) ||
           (updatedSubForms[index].values.contentIdScope ===
             QuestActionContentIdScope.DiscordServer &&
-            !requiresDiscordServerURL)
+            !requiresDiscordServerURL) ||
+          (updatedSubForms[index].values.contentIdScope ===
+            QuestActionContentIdScope.Group &&
+            !requiresGroupId)
         ) {
           updatedSubForms[index].values.contentIdScope =
             QuestActionContentIdScope.Thread;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/validation.ts
@@ -36,13 +36,15 @@ export const buildQuestSubFormValidationSchema = (
     config?.with_optional_topic_id;
   const requiresTwitterEngagement = config?.requires_twitter_tweet_link;
   const requiresDiscordServerURL = config?.requires_discord_server_url;
+  const requiresGroupId = config?.requires_group_id;
   const requiresCreatorPoints = config?.requires_creator_points;
 
   const needsExtension =
     requiresCreatorPoints ||
     allowsOptionalContentId ||
     requiresTwitterEngagement ||
-    requiresDiscordServerURL;
+    requiresDiscordServerURL ||
+    requiresGroupId;
 
   if (!needsExtension) return questSubFormValidationSchema;
 
@@ -79,6 +81,11 @@ export const buildQuestSubFormValidationSchema = (
   if (allowsOptionalContentId) {
     baseSchema = baseSchema.extend({
       contentLink: linkValidationSchema.optional,
+    }) as unknown as typeof baseSchema;
+  }
+  if (requiresGroupId) {
+    baseSchema = baseSchema.extend({
+      contentLink: linkValidationSchema.required,
     }) as unknown as typeof baseSchema;
   }
   if (requiresTwitterEngagement) {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/helpers.ts
@@ -3,6 +3,7 @@ import {
   doesActionAllowThreadId,
   doesActionAllowTopicId,
   doesActionRequireDiscordServerURL,
+  doesActionRequireGroupId,
   doesActionRequireTwitterTweetURL,
 } from 'helpers/quest';
 import { SERVER_URL } from 'state/api/config';
@@ -12,6 +13,7 @@ export type ContentIdType =
   | 'comment'
   | 'thread'
   | 'topic'
+  | 'group'
   | 'tweet_url'
   | 'discord_server_url';
 
@@ -28,6 +30,8 @@ export const inferContentIdTypeFromContentId = (
       return QuestActionContentIdScope.DiscordServer;
     if (doesActionAllowThreadId(action as QuestAction))
       return QuestActionContentIdScope.Thread;
+    if (doesActionRequireGroupId(action as QuestAction))
+      return QuestActionContentIdScope.Group;
     return undefined;
   }
 
@@ -39,6 +43,8 @@ export const inferContentIdTypeFromContentId = (
       return QuestActionContentIdScope.TwitterTweet;
     case 'discord_server_url':
       return QuestActionContentIdScope.DiscordServer;
+    case 'group':
+      return QuestActionContentIdScope.Group;
     default:
       return QuestActionContentIdScope.Thread;
   }
@@ -91,6 +97,13 @@ export const buildContentIdFromURL = async (
     if (foundTopic) return `${idType}:${foundTopic.id}`;
     throw new Error(`invalid topic url ${url}`);
   }
+  if (idType === 'group') {
+    return `${idType}:${parseInt(
+      url.includes('group/')
+        ? new URL(url).pathname.split('/').at(-1) || '' // get group id from url pathname
+        : new URLSearchParams(new URL(url).search).get('groupId') || '', // get group id from url search params
+    )}`;
+  }
   if (idType === 'tweet_url') {
     return `${idType}:${url}`;
   }
@@ -117,6 +130,9 @@ export const buildURLFromContentId = (contentId: string, withParams = {}) => {
   if (idType === 'discord_server_url') return `${idOrURL}${params}`;
   if (idType === 'topic') {
     return `${origin}/discussion/topic/${idOrURL}${params}`;
+  }
+  if (idType === 'group') {
+    return `${origin}/group/${idOrURL}${params}`;
   }
 
   return '';

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
@@ -14,6 +14,7 @@ export const actionCopies = {
     ['SSOLinked']: 'Link a new social (SSO)',
     ['TweetEngagement']: 'Engage on Tweet',
     ['CommonDiscordServerJoined']: "Join Common's Discord Community",
+    ['MembershipsRefreshed']: 'Join a Group',
   },
   pre_reqs: {
     ['SignUpFlowCompleted']: '',
@@ -29,6 +30,7 @@ export const actionCopies = {
       `Requires Twitter/X profile linked to ${displayFor === 'admin' ? "user's" : 'your'} Common profile.`,
     ['CommonDiscordServerJoined']: (displayFor: 'user' | 'admin' = 'user') =>
       `Requires Discord SSO sign-in/linked-to ${displayFor === 'admin' ? 'user' : 'your'} account.`,
+    ['MembershipsRefreshed']: '',
   },
   explainer: {
     ['SignUpFlowCompleted']: '',
@@ -78,6 +80,7 @@ export const actionCopies = {
       </div>
     ),
     ['CommonDiscordServerJoined']: '',
+    ['MembershipsRefreshed']: '',
   },
   shares: {
     ['SignUpFlowCompleted']: '',
@@ -92,5 +95,6 @@ export const actionCopies = {
     ['UserMentioned']: '',
     ['TweetEngagement']: '',
     ['CommonDiscordServerJoined']: '',
+    ['MembershipsRefreshed']: '',
   },
 };

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -238,6 +238,14 @@ const QuestDetails = ({ id }: { id: number }) => {
         }
         break;
       }
+      case 'MembershipsRefreshed': {
+        if (actionContentId) {
+          navigate(buildURLFromContentId(actionContentId), {}, null);
+        } else {
+          notifyError(`Linked group url is invalid`);
+        }
+        break;
+      }
       default:
         return;
     }

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -240,7 +240,13 @@ const QuestDetails = ({ id }: { id: number }) => {
       }
       case 'MembershipsRefreshed': {
         if (actionContentId) {
-          navigate(buildURLFromContentId(actionContentId), {}, null);
+          navigate(
+            buildURLFromContentId(actionContentId).split(
+              window.location.origin,
+            )[1],
+            {},
+            null,
+          );
         } else {
           notifyError(`Linked group url is invalid`);
         }

--- a/packages/commonwealth/client/scripts/views/pages/Redirects/GroupRedirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Redirects/GroupRedirect.tsx
@@ -1,0 +1,32 @@
+import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
+import { useCommonNavigate } from 'navigation/helpers';
+import React from 'react';
+import { useFetchGroupsQuery } from 'state/api/groups';
+import { PageLoading } from '../loading';
+
+const GroupRedirect = ({ id }: { id: string }) => {
+  const navigate = useCommonNavigate();
+
+  const { data: groups, error } = useFetchGroupsQuery({
+    groupId: `${id || '0'}`,
+    enabled: !!id.trim(),
+  });
+  const group = groups?.[0];
+
+  useRunOnceOnCondition({
+    callback: () => {
+      !group || error
+        ? navigate('/error')
+        : navigate(
+            `/members?tab=groups&groupId=${group.id}`,
+            { replace: true },
+            group?.communityId,
+          );
+    },
+    shouldRun: !!(group || error),
+  });
+
+  return <PageLoading />;
+};
+
+export default GroupRedirect;

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -514,7 +514,6 @@ function setupRouter(
     router,
     'get',
     '/groups',
-    databaseValidationService.validateCommunity,
     getGroupsHandler.bind(this, serverControllers),
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11604 https://github.com/hicommonwealth/commonwealth/issues/11864

## Description of Changes
- Added group membership action for quests
- Added redirect and share urls for groups ex: `https://common.xyx/common/members?tab=groups&groupId=1234` and  `https://common.xyz/group/1234`


https://github.com/user-attachments/assets/5cacb75b-4d96-4409-8900-8352ccc655e2



## "How We Fixed It"
N/A

## Test Plan
1. Create a new quest with `Membership Refreshed` action, add a group share url, then submit, verify it creates the quest successfully and throws errors if the group share url is incorrectly formatted or if url is mutated.
2. Verify you can update this quest
3. Verify you see correct data display on quest details page for this quest
4. Verify you can start this quest
5. Verify you get xp for this quest
6. Verify you get redirected to group section with the specified group highlighted in the community members page by using both the resolved/redirect group share urls.

## Deployment Plan
N/A

## Other Considerations
N/A