### PR TITLE
fixed breadcrumbs and zindex

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.scss
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.scss
@@ -10,7 +10,7 @@
     background-color: $white;
     padding-block: 16px;
     position: fixed;
-    z-index: 1 !important;
+    z-index: 100 !important;
     overflow: auto;
     width: 100%;
     max-width: 1040px;

--- a/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Breadcrumbs/Breadcrumbs.tsx
@@ -46,6 +46,7 @@ export const Breadcrumbs = () => {
   const getThreadId = location.pathname.match(/\/(\d+)-/);
 
   const communityId = app.activeChainId() || '';
+
   const { data: linkedThreads } = useGetThreadsByIdQuery({
     community_id: communityId,
     thread_ids: getThreadId ? [Number(getThreadId[1])] : [],
@@ -58,8 +59,12 @@ export const Breadcrumbs = () => {
   const currentDiscussion = {
     currentThreadName: linkedThreads?.[0]?.title || '',
     currentTopic: linkedThreads?.[0]?.topic?.name || '',
-    topicURL:
-      `/discussions/${encodeURI(linkedThreads?.[0]?.topic?.name || '')}` || '',
+    topicURL: communityId
+      ? `/${communityId}/discussions/${encodeURI(
+          linkedThreads?.[0]?.topic?.name || '',
+        )}`
+      : `/discussions/${encodeURI(linkedThreads?.[0]?.topic?.name || '')}` ||
+        '',
   };
 
   let standalone = false;
@@ -84,6 +89,7 @@ export const Breadcrumbs = () => {
   }
 
   const user = userData.addresses?.[0];
+
   const pathnames = generateBreadcrumbs(
     location.pathname,
     navigate,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11288 

## Description of Changes
- When a user clicks on the topic portion of the breadcrumbs while inside a thread, they are navigated to the correct topic and not to an unknown page.
- I also fixed a zIndex bug that was showing up on the breadcrumbs where the LaunchIdeaCard was on top of the breadcrumbs when scrolling. 
- NOTE: In the ticket for this there is a loom that shows a user clicking "Discussions" in the breadcrumbs and being directed to the users personal dashboard. This was not able to be replicated locally or on prod. 

## Test Plan
-Go to a community like Common and click on a topic
-click into a thread inside a topic
-now try to click the topic section of the breadcrumbs
-confirm you are brought to the correct page for the topic


https://github.com/user-attachments/assets/aab25215-386c-4eeb-a1e9-c8fcd1f27e65

For the zIndex bug:

https://github.com/user-attachments/assets/7b6b2563-e0d5-4a70-9d43-f760c4514c2f

