### PR TITLE
adds sso source to left

### DIFF
--- a/libs/model/src/models/address.ts
+++ b/libs/model/src/models/address.ts
@@ -122,7 +122,6 @@ export default (
             'block_info',
             'created_at',
             'updated_at',
-            'oauth_provider',
             'oauth_email',
             'oauth_username',
             'oauth_phone_number',

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -97,6 +97,7 @@ export async function completeClientLogin(account: Account) {
         address: account.address,
         community: account.community,
         walletId: account.walletId,
+        walletSsoSource: account.walletSsoSource,
       });
       user.addresses.push(addressInfo);
     }
@@ -210,22 +211,27 @@ export function updateActiveUser(data) {
       xpReferrerPoints: 0,
     });
   } else {
-    const addresses = data.addresses.map(
-      (a) =>
-        new AddressInfo({
-          userId: user.id,
-          id: a.id,
-          address: a.address,
-          community: {
-            id: a.community_id,
-            base: a.Community.base,
-            ss58Prefix: a.Community.ss58_prefix,
-          },
-          walletId: a.wallet_id,
-          ghostAddress: a.ghost_address,
-          lastActive: a.last_active,
-        }),
-    );
+    const addresses = data.addresses.map((a) => {
+      // Map the oauth_provider string to WalletSsoSource enum
+      const ssoSource = a.oauth_provider
+        ? (a.oauth_provider as WalletSsoSource)
+        : undefined;
+
+      return new AddressInfo({
+        userId: user.id,
+        id: a.id,
+        address: a.address,
+        community: {
+          id: a.community_id,
+          base: a.Community.base,
+          ss58Prefix: a.Community.ss58_prefix,
+        },
+        walletId: a.wallet_id,
+        ghostAddress: a.ghost_address,
+        lastActive: a.last_active,
+        walletSsoSource: ssoSource,
+      });
+    });
 
     user.setData({
       id: data.id || 0,

--- a/packages/commonwealth/client/scripts/models/Account.ts
+++ b/packages/commonwealth/client/scripts/models/Account.ts
@@ -3,6 +3,7 @@ import {
   UserTierMap,
   type ChainBase,
   type WalletId,
+  type WalletSsoSource,
 } from '@hicommonwealth/shared';
 import type momentType from 'moment';
 import moment from 'moment';
@@ -29,6 +30,7 @@ class Account {
 
   private _addressId?: number;
   private _walletId?: WalletId;
+  private _walletSsoSource?: WalletSsoSource;
 
   private _profile?: MinimumProfile;
 
@@ -53,6 +55,7 @@ class Account {
     signedInProfile,
     ignoreProfile = true,
     lastActive,
+    walletSsoSource,
   }: {
     // required args
     community: AccountCommunity;
@@ -66,6 +69,7 @@ class Account {
     validationBlockInfo?: string;
     profile?: MinimumProfile;
     lastActive?: string | momentType.Moment;
+    walletSsoSource?: WalletSsoSource;
     signedInProfile?: {
       userId: number;
       name?: string;
@@ -83,6 +87,7 @@ class Account {
     this.address = address;
     this._addressId = addressId;
     this._walletId = walletId;
+    this._walletSsoSource = walletSsoSource;
     this._validationToken = validationToken;
     // @ts-expect-error StrictNullChecks
     this._sessionPublicAddress = sessionPublicAddress;
@@ -123,6 +128,10 @@ class Account {
 
   public setWalletId(walletId: WalletId) {
     this._walletId = walletId;
+  }
+
+  get walletSsoSource() {
+    return this._walletSsoSource;
   }
 
   get validationToken() {

--- a/packages/commonwealth/client/scripts/models/AddressInfo.ts
+++ b/packages/commonwealth/client/scripts/models/AddressInfo.ts
@@ -17,6 +17,7 @@ class AddressInfo extends Account {
     address,
     community,
     walletId,
+    walletSsoSource,
     ghostAddress,
     lastActive,
   }: {
@@ -36,6 +37,7 @@ class AddressInfo extends Account {
       community,
       addressId: id,
       walletId,
+      walletSsoSource,
       ghostAddress,
       profile: (() => {
         if (!ignoreProfile) return undefined;

--- a/packages/commonwealth/client/scripts/utils/chainUtils.ts
+++ b/packages/commonwealth/client/scripts/utils/chainUtils.ts
@@ -1,4 +1,4 @@
-import { ChainBase, WalletId } from '@hicommonwealth/shared';
+import { ChainBase, WalletId, WalletSsoSource } from '@hicommonwealth/shared';
 import type AddressInfo from '../models/AddressInfo';
 import { CustomIconName } from '../views/components/component_kit/cw_icons/cw_icon_lookup';
 
@@ -55,4 +55,33 @@ export const getChainIcon = (
   }
 
   return 'eth'; // default fallback
+};
+
+// Helper function to map WalletSsoSource to CustomIconName
+export const getSsoIconName = (
+  source?: WalletSsoSource,
+): CustomIconName | undefined => {
+  if (!source) return undefined;
+
+  switch (source) {
+    case WalletSsoSource.Google:
+      return 'google';
+    case WalletSsoSource.Github:
+      return 'github';
+    case WalletSsoSource.Discord:
+      return 'discordIcon';
+    case WalletSsoSource.Twitter:
+      return 'twitterIcon';
+    case WalletSsoSource.Apple:
+      return 'apple';
+    case WalletSsoSource.Email:
+      return 'email';
+    case WalletSsoSource.Farcaster:
+      return 'farcaster';
+    case WalletSsoSource.SMS:
+      return 'SMS';
+    case WalletSsoSource.Unknown:
+    default:
+      return undefined;
+  }
 };

--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_icons/cw_icon_lookup.ts
@@ -337,6 +337,8 @@ export const iconLookup = {
 export const customIconLookup = {
   base: CustomIcons.CWBase,
   blast: CustomIcons.CWBlast,
+  google: Icons.CWGoogle,
+  github: Icons.CWGithub,
   email: CustomIcons.CWEmail,
   solana: CustomIcons.CWSolana,
   nearIcon: CustomIcons.CWNearIcon,
@@ -344,11 +346,8 @@ export const customIconLookup = {
   cosmos: CustomIcons.CWCosmos,
   polkadot: CustomIcons.CWPolkadot,
   discordIcon: CustomIcons.CWDiscord,
-  githubIcon: CustomIcons.CWGithub,
-  twitterIcon: CustomIcons.CWTwitter,
-  envelope: CustomIcons.CWEnvelop,
-  'keplr-ethereum': CustomIcons.CWKeplr,
-  'cosm-metamask': CustomIcons.CWMetaMask,
+  octocat: Icons.CWOctocat,
+  hamburger: Icons.CWHamburger,
   keplr: CustomIcons.CWKeplr,
   leap: CustomIcons.CWLeap,
   magic: CustomIcons.CWMagic,
@@ -368,6 +367,10 @@ export const customIconLookup = {
   SMS: withPhosphorIcon(ChatText),
   privy: CustomIcons.CWPrivy,
   okx: CustomIcons.CWOKX,
+  twitterIcon: CustomIcons.CWTwitter,
+  envelope: CustomIcons.CWEnvelop,
+  'keplr-ethereum': CustomIcons.CWKeplr,
+  'cosm-metamask': CustomIcons.CWMetaMask,
 };
 
 export type IconName = keyof typeof iconLookup;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWIdentificationTag.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWIdentificationTag.scss
@@ -10,7 +10,6 @@
 
   .icon-left {
     margin-right: 6px;
-    fill: none;
   }
 
   .icon-right {

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/AddressItem.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/AddressItem.tsx
@@ -14,7 +14,7 @@ import { CWIcon } from '../../component_kit/cw_icons/cw_icon';
 import { CWTooltip } from '../../component_kit/new_designs/CWTooltip';
 
 import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
-import { getChainIcon } from 'client/scripts/utils/chainUtils';
+import { getChainIcon, getSsoIconName } from 'client/scripts/utils/chainUtils';
 import { saveToClipboard } from 'client/scripts/utils/clipboard';
 import { formatAddressShort } from 'shared/utils';
 import { CWIdentificationTag } from '../../component_kit/new_designs/CWIdentificationTag';
@@ -35,7 +35,7 @@ type AddressItemProps = {
 const AddressItem = (props: AddressItemProps) => {
   const { addressInfo, toggleRemoveModal, isSelected, isInsideCommunity } =
     props;
-  const { address, walletId, community } = addressInfo;
+  const { address, walletId, community, walletSsoSource } = addressInfo;
 
   const { openMagicWallet } = useAuthentication({});
 
@@ -58,7 +58,11 @@ const AddressItem = (props: AddressItemProps) => {
             iconSize="small"
           />
           <CWIdentificationTag
-            iconLeft={walletId}
+            iconLeft={
+              walletId === WalletId.Magic
+                ? getSsoIconName(walletSsoSource)
+                : walletId
+            }
             address={`\u2022 ${formatAddressShort(address)}`}
           />
         </div>


### PR DESCRIPTION
**Link to Issue**

Closes: [Request](https://commonxyz.slack.com/archives/C052DMYFKDL/p1744834605369319)

<img width="315" alt="image" src="https://github.com/user-attachments/assets/4071c866-b403-4f9d-b8dc-fe2f46c1cdc5" />

**Description of Changes**

This PR updates the sidebar's `AddressItem` component to display the specific SSO provider icon (Google, Apple, SMS, etc.) instead of the generic Magic icon when a user is logged in via Magic Link SSO.

**How We Fixed It**

1.  **Server-side (`status.ts`, `address.ts`):** Modified the `/api/status` route and the `Address` model's default scope to correctly fetch and return the `oauth_provider` for each address.
2.  **Client-side Models/Logic (`Account.ts`, `AddressInfo.ts`, `login.ts`, `chainUtils.ts`):** Updated models to handle `walletSsoSource`, adjusted the login flow to map the `oauth_provider` from the server, and added a helper function (`getSsoIconName`) for icon mapping.
3.  **Client-side UI (`AddressItem.tsx`, `cw_icon_lookup.ts`, `CWIdentificationTag.scss`):** Modified the `AddressItem` to use the new logic and resolved issues with icon lookup and styling (`fill: none;`).

**Test Plan**

- [ ] Manually tested by logging in with various Magic Link SSO providers (Google, Apple, SMS, Email, etc.) and verifying the correct icon appears next to the address in the sidebar.
- [ ] Visually confirmed icons render correctly without regressions.

**Deployment Plan**

Standard deployment process. No specific infrastructure changes required.

**Other Considerations**

None.