### PR TITLE
Fix quest redirection from rewards page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/QuestSummaryCard/QuestSummaryCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/cards/QuestSummaryCard/QuestSummaryCard.tsx
@@ -55,7 +55,7 @@ const QuestSummaryCard = () => {
     navigate('/explore?tab=quests');
   };
 
-  const handleCTAClick = (questId: number, communityId?: string) => {
+  const handleCTAClick = (questId: number, communityId?: string | null) => {
     navigate(`/quests/${questId}`, {}, communityId);
   };
 
@@ -106,7 +106,7 @@ const QuestSummaryCard = () => {
                   isActive={isShowingActiveQuests}
                   name={quest.name}
                   onCTAClick={() =>
-                    handleCTAClick(quest.id, quest.community_id || '')
+                    handleCTAClick(quest.id, quest.community_id)
                   }
                 />
               );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11865

## Description of Changes
Fix quest redirection from rewards page

## "How We Fixed It"
N/A

## Test Plan
Ensure quest redirection from `/rewards` page work correctly.

## Deployment Plan
N/A

## Other Considerations
N/A