### PR TITLE
Prevents Mobile Weird Scroll Behavior on Native Mobile Apps

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/commonwealth/client/scripts/views/components/MobileNavigation/MobileNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { matchRoutes, useLocation } from 'react-router-dom';
 
 import { useCommonNavigate } from 'navigation/helpers';
@@ -20,6 +20,7 @@ const MobileNavigation = () => {
   const rewardsEnabled = useFlag('rewardsPage');
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const navigationRef = useRef<HTMLDivElement>(null);
 
   const matchesDashboard = matchRoutes([{ path: '/dashboard/*' }], location);
   const matchesExplore = matchRoutes([{ path: '/explore' }], location);
@@ -75,10 +76,25 @@ const MobileNavigation = () => {
   const isDiscussionsPage = window.location?.pathname?.includes('/discussion');
   const shouldHideQuickPost = isNewThreadPage || isDiscussionsPage;
 
+  useEffect(() => {
+    const node = navigationRef.current;
+    if (!node) return;
+
+    const preventScroll = (event: TouchEvent) => {
+      event.preventDefault();
+    };
+
+    node.addEventListener('touchmove', preventScroll, { passive: false });
+
+    return () => {
+      node.removeEventListener('touchmove', preventScroll);
+    };
+  }, []);
+
   return (
     <>
       {newMobileNav && !shouldHideQuickPost && <QuickPostButton />}
-      <div className="MobileNavigation">
+      <div className="MobileNavigation" ref={navigationRef}>
         <div id="MobileNavigationHead">
           {/*react portal container for anyone that wants to put content*/}
           {/*into the bottom nav.*/}

--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/MobileStickyInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/MobileStickyInput.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import useSidebarStore from 'state/ui/sidebar/sidebar';
 import { useLocalAISettingsStore } from 'state/ui/user';
@@ -22,6 +28,7 @@ export const MobileStickyInput = (props: CommentEditorProps) => {
   const { aiCommentsToggleEnabled } = useLocalAISettingsStore();
   const [streamingReplyIds, setStreamingReplyIds] = useState<number[]>([]);
   const menuVisible = useSidebarStore((state) => state.menuVisible);
+  const stickyInputRef = useRef<HTMLDivElement>(null);
 
   const handleCancel = useCallback(() => {
     setFocused(false);
@@ -63,6 +70,21 @@ export const MobileStickyInput = (props: CommentEditorProps) => {
   const handleFocused = useCallback(() => {
     setFocused(true);
   }, []);
+
+  useEffect(() => {
+    const node = stickyInputRef.current;
+    if (!node) return;
+
+    const preventScroll = (event: TouchEvent) => {
+      event.preventDefault();
+    };
+
+    node.addEventListener('touchmove', preventScroll, { passive: false });
+
+    return () => {
+      node.removeEventListener('touchmove', preventScroll);
+    };
+  }, [focused]);
 
   const parent = document.getElementById('MobileNavigationHead');
 
@@ -110,7 +132,7 @@ export const MobileStickyInput = (props: CommentEditorProps) => {
   }
 
   return createPortal(
-    <div className="MobileStickyInput">
+    <div className="MobileStickyInput" ref={stickyInputRef}>
       <MobileInput
         {...props}
         onFocus={handleFocused}

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.scss
@@ -1,8 +1,24 @@
 @import '../../../styles/shared';
 
+// Layout class using viewport units minus nav height
+.RewardsPageLayout {
+  min-height: calc(100vh - 80px); // Adjust 80px if nav height differs
+  // height: 100%; // Replaced with min-height calc
+  overflow-y: auto; // Allow layout to scroll if content exceeds min-height
+
+  .layout-container {
+    // height: 100%; // No longer needed as parent controls height
+    display: flex; // Ensure children can use flex: 1
+    flex-direction: column; // Match RewardsPage direction
+  }
+}
+
 .RewardsPage {
   display: flex;
   flex-direction: column;
+  // min-height: 100%; // Replaced by flex: 1
+  flex: 1; // Make it fill the height-constrained layout
+  overflow: hidden;
   width: 100%;
   gap: 16px;
 

--- a/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/RewardsPage/RewardsPage.tsx
@@ -69,7 +69,7 @@ const RewardsPage = () => {
   }
 
   return (
-    <CWPageLayout>
+    <CWPageLayout className="RewardsPageLayout">
       <section className="RewardsPage">
         <CWText type="h2" className="header">
           Rewards

--- a/packages/commonwealth/client/scripts/views/pages/notifications/index.scss
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/index.scss
@@ -1,0 +1,21 @@
+@import '../../../styles/shared';
+
+// Layout class using viewport units minus nav height
+.NotificationsPageLayout {
+  min-height: calc(100vh - 80px); // Adjust 80px if nav height differs
+  overflow-y: auto; // Allow layout to scroll if content exceeds min-height
+
+  .layout-container {
+    display: flex; // Ensure children can use flex: 1
+    flex-direction: column; // Match KnockNotifications direction
+    height: 100%; // Make container fill the layout height
+  }
+}
+
+.KnockNotifications {
+  display: flex; // Needed for flex: 1 to work
+  flex-direction: column; // Assume vertical layout
+  flex: 1; // Make it fill the height-constrained layout
+  overflow: hidden; // Hide internal scroll if any
+  // Add any other necessary base styles for this container
+}

--- a/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/notifications/index.tsx
@@ -3,6 +3,7 @@ import useUserStore from 'state/ui/user';
 import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayout';
 import PageError from 'views/pages/error';
 import { KnockNotificationsContent } from 'views/pages/notifications/KnockNotificationsContent';
+import './index.scss';
 
 const NotificationsPage = () => {
   const user = useUserStore();
@@ -12,7 +13,7 @@ const NotificationsPage = () => {
   }
 
   return (
-    <CWPageLayout>
+    <CWPageLayout className="NotificationsPageLayout">
       <KnockNotificationsContent />
     </CWPageLayout>
   );


### PR DESCRIPTION
Fix mobile vertical scroll/drag issues on sticky elements and short pages

## Link to Issue
Closes: #TODO

### After

https://github.com/user-attachments/assets/6032f294-d301-4fb3-bc21-dd4a552c1985

## Description of Changes

This PR addresses issues on mobile devices where unwanted vertical scrolling or dragging could occur in several scenarios:

1.  When interacting with the sticky comment/thread input (`MobileStickyInput`) located within the bottom navigation bar.
2.  When initiating a drag gesture from the bottom navigation bar (`MobileNavigation`) itself.
3.  On pages with potentially short content, such as the `RewardsPage` (specifically with the empty referrals state) and the `NotificationsPage` (in its empty state), where dragging vertically could scroll the entire page view unexpectedly.

**"How We Fixed It"**

Two main approaches were used:

1.  **JavaScript Event Prevention:** For the `MobileStickyInput` and `MobileNavigation` components, `touchmove` event listeners were added via `useEffect` hooks. These listeners call `event.preventDefault()` to stop the default touch behavior (scrolling/dragging) when the touch originates on these specific elements. This prevents the gesture from propagating and causing the underlying page to scroll.
2.  **Localized Layout Height Enforcement:** For the `RewardsPage` and `NotificationsPage`, we introduced specific layout CSS classes (`.RewardsPageLayout`, `.NotificationsPageLayout`) applied to the `CWPageLayout` component on those pages. These classes set a `min-height` using `calc(100vh - 80px)` (approximating nav bar height) and use `overflow-y: auto` to manage scrolling within the layout container itself. The main content containers within these pages (`.RewardsPage`, `.KnockNotifications`) were then styled with `flex: 1` to ensure they expand to fill this calculated height, preventing the empty space that allowed the browser's default body scrolling/dragging.

## Test Plan
- Inspect for visual regressions on desktop / mobile on the Rewards, Notifications pages

### Before

![image](https://github.com/user-attachments/assets/c921cef9-1b6f-4f09-97ae-a9341fa1643d)

![IMG_3283](https://github.com/user-attachments/assets/a73f535f-c18c-4022-b6a1-12e12ad3249b)

## Other Considerations

**Other Considerations**

*   **Potential Global Fix:** We initially attempted a global fix within `CWPageLayout.scss` itself, applying the `min-height: calc(...)` and flexbox structure directly to `.PageLayout` and `.layout-container`. This would avoid needing custom layout classes per page. However, reverting this proved difficult during development, suggesting potential complexities or edge cases with existing page structures. If this pattern of short pages allowing unwanted scrolling appears frequently, revisiting this global approach in `CWPageLayout.scss` might be worthwhile for consistency. It would require careful testing across various pages and ensuring all main page content containers are correctly set to `flex: 1` (or similar) to fill the layout.
*   **Navigation Bar Height:** The `calc(100vh - 80px)` uses an estimated height for the mobile navigation bar (`80px`). If the actual height changes, this calculation should be updated in `RewardsPage.scss` and `notifications/index.scss`. A CSS variable could make this more maintainable.