### PR TITLE
Update to show system quest in weekly progress bar

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/TaskList/TaskList.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/TaskList/TaskList.tsx
@@ -19,7 +19,7 @@ const TaskList = ({ className }: TaskListProps) => {
     isLoadingQuestsList,
     isLoadingXPProgression,
     pendingWeeklyQuests,
-  } = useXPProgress({ includeSystemQuests: false }); // dont show system quests in xp progression bar
+  } = useXPProgress({ includeSystemQuests: true }); // dont show system quests in xp progression bar
 
   if (isLoadingXPProgression) return;
 

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/XPProgressIndicator.tsx
@@ -17,7 +17,7 @@ const XPProgressIndicator = ({
   mode = XPProgressIndicatorMode.Detailed,
   className,
 }: XPProgressIndicatorProps) => {
-  const { weeklyGoal } = useXPProgress({ includeSystemQuests: false }); // dont show system quests in xp progression bar
+  const { weeklyGoal } = useXPProgress({ includeSystemQuests: true }); // dont show system quests in xp progression bar
 
   const user = useUserStore();
 

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/useXPProgress.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/XPProgressIndicator/useXPProgress.tsx
@@ -15,12 +15,14 @@ type UseXPProgress = {
 const useXPProgress = ({ includeSystemQuests }: UseXPProgress) => {
   const xpEnabled = useFlag('xp');
   const user = useUserStore();
+  const currentWeekStart = moment().startOf('week');
+  const currentWeekEnd = moment().endOf('week');
 
   const { data: xpProgressions = [], isLoading: isLoadingXPProgression } =
     useGetXPs({
       user_id: user.id,
-      from: moment().startOf('week').toDate(),
-      to: moment().endOf('week').toDate(),
+      from: currentWeekStart.toDate(),
+      to: currentWeekEnd.toDate(),
       enabled: user.isLoggedIn && xpEnabled,
     });
 
@@ -28,8 +30,8 @@ const useXPProgress = ({ includeSystemQuests }: UseXPProgress) => {
     useFetchQuestsQuery({
       cursor: 1,
       limit: 40,
-      end_after: moment().startOf('week').toDate(),
-      start_before: moment().endOf('week').toDate(),
+      end_after: currentWeekStart.toDate(),
+      start_before: currentWeekEnd.toDate(),
       include_system_quests: includeSystemQuests,
       enabled: user.isLoggedIn && xpEnabled,
     });
@@ -37,9 +39,24 @@ const useXPProgress = ({ includeSystemQuests }: UseXPProgress) => {
   const allWeeklyQuests = (questsList?.pages || [])
     .flatMap((page) => page.results)
     .map((quest) => {
+      // Filter XP logs for this quest
+      const questXpLogs = xpProgressions.filter((p) => p.quest_id === quest.id);
+
+      // For system quests (negative IDs), only include XP earned in current week
+      const isSystemQuest = quest.id < 0;
+      const validXpLogs = isSystemQuest
+        ? questXpLogs.filter((xpLog) => {
+            // Check if the XP was earned in the current week
+            const xpEarnedDate = moment(xpLog.created_at);
+            return (
+              xpEarnedDate.isSameOrAfter(currentWeekStart) &&
+              xpEarnedDate.isSameOrBefore(currentWeekEnd)
+            );
+          })
+        : questXpLogs;
+
       const gainedXP =
-        xpProgressions
-          .filter((p) => p.quest_id === quest.id)
+        validXpLogs
           .map((p) => p.xp_points)
           .reduce(
             (accumulator, currentValue) => accumulator + currentValue,


### PR DESCRIPTION
Flag was previously false in `weeklyprogressindicator`

One line fix

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 