### PR TITLE
Kaleem neslit.11109 generate poll

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/ai/prompts.ts
+++ b/packages/commonwealth/client/scripts/state/api/ai/prompts.ts
@@ -49,8 +49,33 @@ IMPORTANT: Return only the comment without any introduction, explanations, or me
   `;
 };
 
+const generatePollPrompt = (context: string) => {
+  return `
+You are an AI assistant skilled in analyzing discussion threads to create engaging polls.
+Based on the following thread content, generate one poll suggestion in JSON format that reflects the main debate, topic, or question raised.
+
+THREAD CONTENT:
+${context}
+
+Guidelines:
+- Identify a key theme, opinion, or question discussed in the thread.
+- Create only one concise, neutral, and relevant poll that encourages participation.
+- The poll must include:
+  - A clear question (max 100 characters).
+  - 2–3 short, specific answer options.
+- If the thread is vague or lacks a clear debate, suggest a broader, inclusive poll relevant to the content.
+- Requests only one poll suggestion.
+- Removes conflicting instructions about generating three polls or returning an array.
+- Outputs just one JSON object (not wrapped in an array), like:
+  { "question": "string", "options": ["string", "string", ...] }
+
+IMPORTANT: Return only the JSON object without any introduction, explanation, or meta-text.
+  `;
+};
+
 export {
   generateCommentPrompt,
+  generatePollPrompt,
   generateThreadPrompt,
   generateThreadTitlePrompt,
 };

--- a/packages/commonwealth/client/scripts/state/api/ai/prompts.ts
+++ b/packages/commonwealth/client/scripts/state/api/ai/prompts.ts
@@ -52,8 +52,8 @@ IMPORTANT: Return only the comment without any introduction, explanations, or me
 const generatePollPrompt = (context: string) => {
   return `
 You are an AI assistant skilled in analyzing discussion threads to create engaging polls.
-Based on the following thread content, generate one poll suggestion in JSON format that reflects the main debate, topic, or question raised.
-
+Based on the following thread content, generate one poll suggestion in JSON format that reflects the main debate, topic,
+ or question raised.
 THREAD CONTENT:
 ${context}
 

--- a/packages/commonwealth/client/scripts/state/api/threads/createThreadPoll.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/createThreadPoll.ts
@@ -6,7 +6,7 @@ import { updateThreadInAllCaches } from 'state/api/threads/helpers/cache';
 import { userStore } from 'state/ui/user';
 
 interface CreateThreadPollProps {
-  threadId: number;
+  threadId?: number;
   prompt: string;
   options: string[];
   customDuration?: string;
@@ -22,17 +22,22 @@ const createThreadPoll = async ({
   authorCommunity,
   address,
 }: CreateThreadPollProps) => {
-  const response = await axios.post(`${SERVER_URL}/threads/${threadId}/polls`, {
-    community_id: app.activeChainId(),
-    author_chain: authorCommunity,
-    address,
-    jwt: userStore.getState().jwt,
-    prompt,
-    options,
-    custom_duration: customDuration?.split(' ')[0],
-  });
+  if (threadId) {
+    const response = await axios.post(
+      `${SERVER_URL}/threads/${threadId}/polls`,
+      {
+        community_id: app.activeChainId(),
+        author_chain: authorCommunity,
+        address,
+        jwt: userStore.getState().jwt,
+        prompt,
+        options,
+        custom_duration: customDuration?.split(' ')[0],
+      },
+    );
 
-  return response.data.result;
+    return response.data.result;
+  }
 };
 
 const useCreateThreadPollMutation = () => {

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -58,8 +58,9 @@ import {
 } from 'client/scripts/helpers/snapshot_utils';
 import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import useForceRerender from 'client/scripts/hooks/useForceRerender';
-// eslint-disable-next-line max-len
+
 import Poll from 'client/scripts/models/Poll';
+// eslint-disable-next-line max-len
 import { convertAddressToDropdownOption } from '../../modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/helpers';
 import ProposalVotesDrawer from '../../pages/NewProposalViewPage/ProposalVotesDrawer/ProposalVotesDrawer';
 import { useCosmosProposal } from '../../pages/NewProposalViewPage/useCosmosProposal';
@@ -627,7 +628,6 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
   const onModalClose = () => {
     setVotingModalOpen(false);
   };
-  console.log('<<<<<<pollsData>>>>', { pollsData });
   const sidebarComponent = [
     {
       label: 'Links',
@@ -661,7 +661,8 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
                       poll={poll}
                       key={poll.id}
                       isTopicMembershipRestricted={isRestrictedMembership}
-                      showDeleteButton={isAdmin}
+                      showDeleteButton={false}
+                      isCreateThreadPage={true}
                     />
                   );
                 })}

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -661,8 +661,9 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
                       poll={poll}
                       key={poll.id}
                       isTopicMembershipRestricted={isRestrictedMembership}
-                      showDeleteButton={false}
+                      showDeleteButton={true}
                       isCreateThreadPage={true}
+                      setLocalPoll={setPollData}
                     />
                   );
                 })}

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -26,6 +26,7 @@ import useFetchProfileByIdQuery from 'state/api/profiles/fetchProfileById';
 import {
   useAddThreadLinksMutation,
   useCreateThreadMutation,
+  useCreateThreadPollMutation,
 } from 'state/api/threads';
 import { buildCreateThreadInput } from 'state/api/threads/createThread';
 import useFetchThreadsQuery from 'state/api/threads/fetchThreads';
@@ -58,11 +59,14 @@ import {
 import useBrowserWindow from 'client/scripts/hooks/useBrowserWindow';
 import useForceRerender from 'client/scripts/hooks/useForceRerender';
 // eslint-disable-next-line max-len
+import Poll from 'client/scripts/models/Poll';
 import { convertAddressToDropdownOption } from '../../modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/helpers';
 import ProposalVotesDrawer from '../../pages/NewProposalViewPage/ProposalVotesDrawer/ProposalVotesDrawer';
 import { useCosmosProposal } from '../../pages/NewProposalViewPage/useCosmosProposal';
 import { useSnapshotProposal } from '../../pages/NewProposalViewPage/useSnapshotProposal';
 import { SnapshotPollCardContainer } from '../../pages/Snapshots/ViewSnapshotProposal/SnapshotPollCard';
+import { ThreadPollCard } from '../../pages/view_thread/ThreadPollCard';
+import { ThreadPollEditorCard } from '../../pages/view_thread/ThreadPollEditorCard';
 import { LinkedProposalsCard } from '../../pages/view_thread/linked_proposals_card';
 import { ProposalState } from '../NewThreadFormModern/NewThreadForm';
 import { CWGatedTopicBanner } from '../component_kit/CWGatedTopicBanner';
@@ -92,7 +96,9 @@ const MIN_ETH_FOR_CONTEST_THREAD = 0.0005;
 interface NewThreadFormProps {
   onCancel?: (e: React.MouseEvent | undefined) => void;
 }
-
+export interface ExtendedPoll extends Poll {
+  customDuration?: string;
+}
 export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
   const navigate = useCommonNavigate();
   const location = useLocation();
@@ -102,6 +108,9 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
   const [proposalRedrawState, redrawProposals] = useState<boolean>(true);
   const [linkedProposals, setLinkedProposals] =
     useState<ProposalState | null>();
+  const [pollsData, setPollData] = useState<ExtendedPoll[]>();
+
+  const { mutateAsync: createPoll } = useCreateThreadPollMutation();
 
   const user = useUserStore();
   const { data: userProfile } = useFetchProfileByIdQuery({
@@ -368,6 +377,17 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
         }).catch(console.error);
       }
 
+      if (thread && pollsData && pollsData?.length) {
+        await createPoll({
+          threadId: thread.id,
+          prompt: pollsData[0]?.prompt,
+          options: pollsData[0]?.options,
+          customDuration: pollsData[0]?.customDuration || undefined,
+          authorCommunity: user.activeAccount?.community?.id || '',
+          address: user.activeAccount?.address || '',
+        });
+      }
+
       setThreadContentDelta(createDeltaFromText(''));
       clearDraft();
 
@@ -443,6 +463,8 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
     resetTurnstile,
     addThreadLinks,
     linkedProposals,
+    createPoll,
+    pollsData,
   ]);
 
   const handleCancel = (e: React.MouseEvent | undefined) => {
@@ -605,7 +627,7 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
   const onModalClose = () => {
     setVotingModalOpen(false);
   };
-
+  console.log('<<<<<<pollsData>>>>', { pollsData });
   const sidebarComponent = [
     {
       label: 'Links',
@@ -621,6 +643,42 @@ export const NewThreadForm = ({ onCancel }: NewThreadFormProps) => {
         </div>
       ),
     },
+    ...((pollsData && pollsData?.length > 0) ||
+    !app.chain?.meta?.admin_only_polling ||
+    isAdmin
+      ? [
+          {
+            label: 'Polls',
+            item: (
+              <div className="cards-column">
+                {[
+                  ...new Map(
+                    pollsData?.map((poll) => [poll?.id, poll]),
+                  ).values(),
+                ].map((poll: Poll) => {
+                  return (
+                    <ThreadPollCard
+                      poll={poll}
+                      key={poll.id}
+                      isTopicMembershipRestricted={isRestrictedMembership}
+                      showDeleteButton={isAdmin}
+                    />
+                  );
+                })}
+                {(!app.chain?.meta?.admin_only_polling || isAdmin) && (
+                  <ThreadPollEditorCard
+                    threadAlreadyHasPolling={!pollsData?.length}
+                    setLocalPoll={setPollData}
+                    isCreateThreadPage={true}
+                    threadTitle={threadTitle}
+                    threadContentDelta={threadContentDelta}
+                  />
+                )}
+              </div>
+            ),
+          },
+        ]
+      : []),
   ];
 
   const proposalDetailSidebar = [

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPageCard/CWContentPageCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPageCard/CWContentPageCard.scss
@@ -10,7 +10,7 @@
   }
   &.isCollapsed {
     min-height: 40px;
-    height: 40px;
+    height: fit-content;
     overflow: hidden;
   }
 

--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -50,9 +50,9 @@ const customDurationOptions = [
 type PollEditorModalProps = {
   onModalClose: () => void;
   thread?: Thread;
-  pollData?: any;
+  pollData?: string;
   isAIresponseCompleted: boolean;
-  setLocalPoll?: any;
+  setLocalPoll?: (params) => void;
 };
 
 export const PollEditorModal = ({
@@ -68,10 +68,8 @@ export const PollEditorModal = ({
   const [prompt, setPrompt] = useState('');
   const modalContainerRef = useRef(null);
   const user = useUserStore();
-  console.log('pollData', { pollData });
   useEffect(() => {
     if (pollData && pollData !== undefined && isAIresponseCompleted) {
-      console.log('pollData', { pollData });
       const newPollData = JSON.parse(pollData);
       setPrompt(newPollData?.question);
       setOptions(newPollData?.options);
@@ -128,7 +126,7 @@ export const PollEditorModal = ({
           customDuration: customDurationEnabled ? customDuration : undefined,
           authorCommunity: user.activeAccount?.community?.id || '',
           address: user.activeAccount?.address || '',
-        });
+        }).catch(console.error);
 
         notifySuccess('Poll creation succeeded');
       } else if (setLocalPoll) {
@@ -233,7 +231,7 @@ export const PollEditorModal = ({
               label="Save changes"
               buttonType="primary"
               buttonHeight="sm"
-              onClick={handleSavePoll}
+              onClick={() => void handleSavePoll()}
             />
           </CWModalFooter>
         </>

--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import _ from 'underscore';
 
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
@@ -20,6 +20,7 @@ import {
   CWModalHeader,
 } from '../components/component_kit/new_designs/CWModal';
 
+import CWCircleMultiplySpinner from '../components/component_kit/new_designs/CWCircleMultiplySpinner';
 import './poll_editor_modal.scss';
 
 const getPollDurationCopy = (
@@ -49,11 +50,15 @@ const customDurationOptions = [
 type PollEditorModalProps = {
   onModalClose: () => void;
   thread: Thread;
+  pollData?: any;
+  isAIresponseCompleted: boolean;
 };
 
 export const PollEditorModal = ({
   onModalClose,
   thread,
+  pollData,
+  isAIresponseCompleted,
 }: PollEditorModalProps) => {
   const [customDuration, setCustomDuration] = useState(INFINITE_OPTION);
   const [customDurationEnabled, setCustomDurationEnabled] = useState(false);
@@ -61,6 +66,14 @@ export const PollEditorModal = ({
   const [prompt, setPrompt] = useState('');
   const modalContainerRef = useRef(null);
   const user = useUserStore();
+
+  useEffect(() => {
+    if (pollData && pollData !== undefined && isAIresponseCompleted) {
+      const newPollData = JSON.parse(pollData);
+      setPrompt(newPollData?.question);
+      setOptions(newPollData?.options);
+    }
+  }, [pollData, isAIresponseCompleted]);
 
   const { mutateAsync: createPoll } = useCreateThreadPollMutation();
 
@@ -125,82 +138,88 @@ export const PollEditorModal = ({
   return (
     <div className="PollEditorModal" ref={modalContainerRef}>
       <CWModalHeader label="Create Poll" onModalClose={onModalClose} />
-      <CWModalBody>
-        <CWTextInput
-          label="Question"
-          placeholder="Do you support this proposal?"
-          value={prompt}
-          onInput={(e) => {
-            setPrompt(e.target.value);
-          }}
-        />
-        <div className="options-and-label-container">
-          <CWLabel label="Options" />
-          <div className="options-container">
-            {options.map((choice, index) => (
-              <CWTextInput
-                key={index}
-                placeholder={`${index + 1}.`}
-                value={choice}
-                onInput={(e) => handleInputChange(e.target.value, index)}
-              />
-            ))}
-          </div>
-          <div className="buttons-row">
+      {!isAIresponseCompleted ? (
+        <CWCircleMultiplySpinner />
+      ) : (
+        <>
+          <CWModalBody>
+            <CWTextInput
+              label="Question"
+              placeholder="Do you support this proposal?"
+              value={prompt}
+              onInput={(e) => {
+                setPrompt(e.target.value);
+              }}
+            />
+            <div className="options-and-label-container">
+              <CWLabel label="Options" />
+              <div className="options-container">
+                {options?.map((choice, index) => (
+                  <CWTextInput
+                    key={index}
+                    placeholder={`${index + 1}.`}
+                    value={choice}
+                    onInput={(e) => handleInputChange(e.target.value, index)}
+                  />
+                ))}
+              </div>
+              <div className="buttons-row">
+                <CWButton
+                  label="Remove choice"
+                  buttonType="destructive"
+                  buttonHeight="sm"
+                  disabled={options?.length <= 2}
+                  onClick={handleRemoveLastChoice}
+                />
+                <CWButton
+                  label="Add choice"
+                  buttonType="primary"
+                  buttonHeight="sm"
+                  disabled={options?.length >= 6}
+                  onClick={handleAddChoice}
+                />
+              </div>
+            </div>
+            <div className="duration-row">
+              <CWText type="caption" className="poll-duration-text">
+                {getPollDurationCopy(customDuration, customDurationEnabled)}
+              </CWText>
+              <div className="duration-row-actions">
+                <CWCheckbox
+                  label="Custom duration"
+                  checked={customDurationEnabled}
+                  onChange={handleCustomDurationChange}
+                  value=""
+                />
+                {customDurationEnabled && (
+                  <SelectList
+                    menuPortalTarget={modalContainerRef?.current}
+                    isSearchable={false}
+                    options={customDurationOptions}
+                    defaultValue={customDurationOptions[0]}
+                    // @ts-expect-error <StrictNullChecks/>
+                    onChange={({ value }) => setCustomDuration(value)}
+                  />
+                )}
+              </div>
+            </div>
+          </CWModalBody>
+          <CWModalFooter>
             <CWButton
-              label="Remove choice"
-              buttonType="destructive"
+              label="Cancel"
+              buttonType="secondary"
               buttonHeight="sm"
-              disabled={options.length <= 2}
-              onClick={handleRemoveLastChoice}
+              onClick={onModalClose}
             />
             <CWButton
-              label="Add choice"
+              label="Save changes"
               buttonType="primary"
               buttonHeight="sm"
-              disabled={options.length >= 6}
-              onClick={handleAddChoice}
+              onClick={handleSavePoll}
             />
-          </div>
-        </div>
-        <div className="duration-row">
-          <CWText type="caption" className="poll-duration-text">
-            {getPollDurationCopy(customDuration, customDurationEnabled)}
-          </CWText>
-          <div className="duration-row-actions">
-            <CWCheckbox
-              label="Custom duration"
-              checked={customDurationEnabled}
-              onChange={handleCustomDurationChange}
-              value=""
-            />
-            {customDurationEnabled && (
-              <SelectList
-                menuPortalTarget={modalContainerRef?.current}
-                isSearchable={false}
-                options={customDurationOptions}
-                defaultValue={customDurationOptions[0]}
-                // @ts-expect-error <StrictNullChecks/>
-                onChange={({ value }) => setCustomDuration(value)}
-              />
-            )}
-          </div>
-        </div>
-      </CWModalBody>
-      <CWModalFooter>
-        <CWButton
-          label="Cancel"
-          buttonType="secondary"
-          buttonHeight="sm"
-          onClick={onModalClose}
-        />
-        <CWButton
-          label="Save changes"
-          buttonType="primary"
-          buttonHeight="sm"
-          onClick={handleSavePoll}
-        />
-      </CWModalFooter>
+          </CWModalFooter>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/poll_editor_modal.tsx
@@ -49,9 +49,10 @@ const customDurationOptions = [
 
 type PollEditorModalProps = {
   onModalClose: () => void;
-  thread: Thread;
+  thread?: Thread;
   pollData?: any;
   isAIresponseCompleted: boolean;
+  setLocalPoll?: any;
 };
 
 export const PollEditorModal = ({
@@ -59,6 +60,7 @@ export const PollEditorModal = ({
   thread,
   pollData,
   isAIresponseCompleted,
+  setLocalPoll,
 }: PollEditorModalProps) => {
   const [customDuration, setCustomDuration] = useState(INFINITE_OPTION);
   const [customDurationEnabled, setCustomDurationEnabled] = useState(false);
@@ -66,9 +68,10 @@ export const PollEditorModal = ({
   const [prompt, setPrompt] = useState('');
   const modalContainerRef = useRef(null);
   const user = useUserStore();
-
+  console.log('pollData', { pollData });
   useEffect(() => {
     if (pollData && pollData !== undefined && isAIresponseCompleted) {
+      console.log('pollData', { pollData });
       const newPollData = JSON.parse(pollData);
       setPrompt(newPollData?.question);
       setOptions(newPollData?.options);
@@ -117,16 +120,31 @@ export const PollEditorModal = ({
     }
 
     try {
-      await createPoll({
-        threadId: thread.id,
-        prompt,
-        options,
-        customDuration: customDurationEnabled ? customDuration : undefined,
-        authorCommunity: user.activeAccount?.community?.id || '',
-        address: user.activeAccount?.address || '',
-      });
+      if (thread) {
+        await createPoll({
+          threadId: thread?.id,
+          prompt,
+          options,
+          customDuration: customDurationEnabled ? customDuration : undefined,
+          authorCommunity: user.activeAccount?.community?.id || '',
+          address: user.activeAccount?.address || '',
+        });
 
-      notifySuccess('Poll creation succeeded');
+        notifySuccess('Poll creation succeeded');
+      } else if (setLocalPoll) {
+        setLocalPoll([
+          {
+            options: options,
+            prompt: prompt,
+            communityId: user.activeAccount?.community?.id,
+            customDuration: customDurationEnabled ? customDuration : undefined,
+            address: user.activeAccount?.address || '',
+            createdAt: moment(),
+            endsAt: moment('2025-04-20T19:04:53.661Z'),
+            votes: [],
+          },
+        ]);
+      }
     } catch (err) {
       notifyError('Poll creation failed');
       console.error(err);

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
@@ -104,7 +104,7 @@ export const ThreadPollCard = ({
     });
   };
 
-  const userVote = poll.getUserVote(
+  const userVote = poll?.getUserVote?.(
     user.activeAccount?.community?.id || '',
     user.activeAccount?.address || '',
   );
@@ -119,7 +119,7 @@ export const ThreadPollCard = ({
         proposalTitle={poll.prompt}
         timeRemaining={getPollTimestamp(
           poll,
-          poll.endsAt && poll.endsAt?.isBefore(moment().utc()),
+          poll?.endsAt && poll?.endsAt?.isBefore(moment().utc()),
         )}
         totalVoteCount={poll.votes?.length}
         voteInformation={poll.options.map((option) => {

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
@@ -16,6 +16,7 @@ type ThreadPollCardProps = {
   showDeleteButton?: boolean;
   isTopicMembershipRestricted?: boolean;
   isCreateThreadPage?: boolean;
+  setLocalPoll?: (params) => void;
 };
 
 export const ThreadPollCard = ({
@@ -23,6 +24,7 @@ export const ThreadPollCard = ({
   showDeleteButton,
   isTopicMembershipRestricted = false,
   isCreateThreadPage = false,
+  setLocalPoll,
 }: ThreadPollCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -150,8 +152,12 @@ export const ThreadPollCard = ({
         }}
         showDeleteButton={showDeleteButton}
         onDeleteClick={() => {
-          //@typescript-eslint/no-misused-promises
-          handleDeletePoll().catch(console.error);
+          if (isCreateThreadPage && setLocalPoll) {
+            setLocalPoll([]);
+          } else {
+            //@typescript-eslint/no-misused-promises
+            handleDeletePoll().catch(console.error);
+          }
         }}
       />
       <CWModal

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
@@ -15,12 +15,14 @@ type ThreadPollCardProps = {
   poll: Poll;
   showDeleteButton?: boolean;
   isTopicMembershipRestricted?: boolean;
+  isCreateThreadPage?: boolean;
 };
 
 export const ThreadPollCard = ({
   poll,
   showDeleteButton,
   isTopicMembershipRestricted = false,
+  isCreateThreadPage = false,
 }: ThreadPollCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -114,7 +116,11 @@ export const ThreadPollCard = ({
       <PollCard
         pollEnded={poll.endsAt && poll.endsAt?.isBefore(moment().utc())}
         hasVoted={!!userVote}
-        disableVoteButton={!user.activeAccount || isTopicMembershipRestricted}
+        disableVoteButton={
+          !user.activeAccount ||
+          isTopicMembershipRestricted ||
+          isCreateThreadPage
+        }
         votedFor={userVote?.option || ''}
         proposalTitle={poll.prompt}
         timeRemaining={getPollTimestamp(

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
@@ -14,7 +14,7 @@ import './poll_cards.scss';
 type ThreadPollEditorCardProps = {
   thread?: Thread;
   threadAlreadyHasPolling: boolean;
-  setLocalPoll?: any;
+  setLocalPoll?: (params) => void;
   isCreateThreadPage?: boolean;
   aiInteractionsToggleEnabled?: boolean;
   threadContentDelta?: string;
@@ -31,7 +31,7 @@ export const ThreadPollEditorCard = ({
   threadContentDelta,
 }: ThreadPollEditorCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [pollData, setPollData] = useState<any>();
+  const [pollData, setPollData] = useState<string>();
 
   const [isAIresponseCompleted, setIsAIresponseCompleted] = useState(false);
 
@@ -116,7 +116,11 @@ export const ThreadPollEditorCard = ({
         content={
           <PollEditorModal
             thread={thread}
-            onModalClose={() => setIsModalOpen(false)}
+            onModalClose={() => {
+              setIsModalOpen(false);
+              setIsAIresponseCompleted(false);
+              setPollData('');
+            }}
             pollData={pollData}
             isAIresponseCompleted={isAIresponseCompleted}
             setLocalPoll={setLocalPoll}

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
@@ -67,8 +67,8 @@ export const ThreadPollEditorCard = ({
       model: 'gpt-4o-mini',
       stream: true,
       onError: (error) => {
-        console.error('Error generating AI comment:', error);
-        notifyError('Failed to generate AI comment');
+        console.error('Error generating Poll:', error);
+        notifyError('Failed to generate  Poll');
       },
       onChunk: (chunk) => {
         text += chunk;
@@ -79,7 +79,7 @@ export const ThreadPollEditorCard = ({
         setIsAIresponseCompleted(true);
       },
     }).catch((error) => {
-      console.error('Failed to generate comment:', error);
+      console.error('Failed to generate poll:', error);
     });
   };
 

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollEditorCard.tsx
@@ -38,14 +38,10 @@ export const ThreadPollEditorCard = ({
   const { generateCompletion } = useAiCompletion();
   const DEFAULT_THREAD_TITLE = 'Untitled Discussion';
   const DEFAULT_THREAD_BODY = 'No content provided.';
-  console.log('>threadContentDelta>>>', { threadContentDelta });
   const handleGeneratePoll = () => {
     let effectiveTitle;
     let effectiveBody;
 
-    if (isCreateThreadPage && !threadContentDelta) {
-      alert('no content');
-    }
     if (isCreateThreadPage && threadContentDelta && threadTitle) {
       effectiveTitle = aiInteractionsToggleEnabled
         ? threadTitle?.trim() || DEFAULT_THREAD_TITLE
@@ -66,8 +62,6 @@ export const ThreadPollEditorCard = ({
 
     setPollData(text);
     const prompt = generatePollPrompt(context);
-
-    console.log(prompt);
 
     generateCompletion(prompt, {
       model: 'gpt-4o-mini',
@@ -96,6 +90,7 @@ export const ThreadPollEditorCard = ({
           threadAlreadyHasPolling ? 'an' : 'another'
         } offchain poll to this
         thread?`}
+        showCollapsedIcon={true}
         content={
           <div className="PollEditorCard">
             <CWButton

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -717,6 +717,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const onModalClose = () => {
     setVotingModalOpen(false);
   };
+
+  console.log('<<<<<<<PPPP>>>>', pollsData);
   return (
     <StickCommentProvider>
       <MetaTags

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -718,7 +718,6 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     setVotingModalOpen(false);
   };
 
-  console.log('<<<<<<<PPPP>>>>', pollsData);
   return (
     <StickCommentProvider>
       <MetaTags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #11109 

## Description of Changes

When a user clicks "Create Poll" on the Thread View page or Create Thread page, we utilize ChatGPT to generate an AI-powered poll. Users retain the ability to edit the poll's question and options as needed.
On the Create Thread page, we use local state to temporarily display the poll. After the user clicks the "Create Thread" button and the API call succeeds, we link the poll to the thread.

Made the card collapsable .

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

When a user clicks "Create Poll" on the Thread View page or Create Thread page, we utilize ChatGPT to generate an AI-powered poll. Users retain the ability to edit the poll's question and options as needed.
On the Create Thread page, we use local state to temporarily display the poll. After the user clicks the "Create Thread" button and the API call succeeds, we link the poll to the thread.

Made the card collapsable .

## Test Plan

- Navigate to any thread where you are both the community admin and the thread author. You will see a card to link a poll. Click it to view the AI-generated poll.
- Go to the Create Thread page in a community where you are an admin. You will see a card to link a poll.