### PR TITLE
does not prompt use for magic

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/ContractBase.ts
@@ -26,12 +26,17 @@ abstract class ContractBase {
   async initialize(
     withWallet: boolean = false,
     chainId?: string,
+    providerInstance?: any,
   ): Promise<void> {
-    if (!this.initialized || withWallet) {
+    if (!this.initialized || withWallet || providerInstance) {
       try {
         this.chainId = chainId || '1';
         let provider = this.rpc;
-        if (withWallet) {
+
+        if (providerInstance) {
+          provider = providerInstance;
+          this.walletEnabled = true;
+        } else if (withWallet) {
           this.wallet = WebWalletController.Instance.availableWallets(
             ChainBase.Ethereum,
           )[0];
@@ -39,7 +44,6 @@ abstract class ContractBase {
           if (!this.wallet.api) {
             await this.wallet.enable(chainId);
           }
-          // @ts-expect-error StrictNullChecks
           await this.wallet.switchNetwork(chainId);
           provider = this.wallet.api.givenProvider;
           this.walletEnabled = true;

--- a/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
+++ b/packages/commonwealth/client/scripts/helpers/ContractHelpers/Launchpad.ts
@@ -29,8 +29,9 @@ class LaunchpadBondingCurve extends ContractBase {
   async initialize(
     withWallet?: boolean,
     chainId?: string | undefined,
+    providerInstance?: any,
   ): Promise<void> {
-    await super.initialize(withWallet, chainId);
+    await super.initialize(withWallet, chainId, providerInstance);
     this.launchpadFactory = new this.web3.eth.Contract(
       LaunchpadAbi,
       this.launchpadFactoryAddress,
@@ -65,9 +66,7 @@ class LaunchpadBondingCurve extends ContractBase {
   }
 
   async buyToken(amountEth: number, walletAddress: string, chainId: string) {
-    if (!this.initialized || !this.walletEnabled) {
-      await this.initialize(true, chainId);
-    }
+    this.isInitialized();
 
     const txReceipt = await cp.buyToken(
       this.contract,
@@ -79,9 +78,8 @@ class LaunchpadBondingCurve extends ContractBase {
   }
 
   async sellToken(amountSell: number, walletAddress: string, chainId: string) {
-    if (!this.initialized || !this.walletEnabled) {
-      await this.initialize(true, chainId);
-    }
+    this.isInitialized();
+
     const tokenContract = new this.web3.eth.Contract(
       erc20Abi as unknown as AbiItem[],
       this.tokenAddress,
@@ -110,8 +108,8 @@ class LaunchpadBondingCurve extends ContractBase {
   }
 
   async getAmountOut(amountIn: number, buy: boolean, chainId: string) {
-    if (!this.initialized || !this.walletEnabled) {
-      await this.initialize(true, chainId);
+    if (!this.initialized) {
+      await this.initialize(false, chainId);
     }
 
     const amountOut = await cp.getPrice(

--- a/packages/commonwealth/client/scripts/state/api/launchPad/buyToken.ts
+++ b/packages/commonwealth/client/scripts/state/api/launchPad/buyToken.ts
@@ -1,6 +1,8 @@
 import { commonProtocol } from '@hicommonwealth/evm-protocols';
 import { useMutation } from '@tanstack/react-query';
 import LaunchpadBondingCurve from 'helpers/ContractHelpers/Launchpad';
+import { userStore } from 'state/ui/user';
+import { getMagicForChain } from 'utils/magicNetworkUtils';
 import { resetBalancesCache } from './helpers/resetBalancesCache';
 
 export interface BuyTokenProps {
@@ -18,12 +20,38 @@ const buyToken = async ({
   amountEth,
   walletAddress,
 }: BuyTokenProps) => {
+  // Check if the selected address belongs to a Magic user
+  const userAddresses = userStore.getState().addresses;
+  const isMagicAddress = userAddresses.some(
+    (addr) =>
+      addr.address.toLowerCase() === walletAddress.toLowerCase() &&
+      addr.walletId?.toLowerCase().includes('magic'),
+  );
+
+  let magicProvider: any = null;
+  if (isMagicAddress) {
+    const magic = getMagicForChain(ethChainId);
+    if (magic) {
+      magicProvider = magic.rpcProvider;
+    } else {
+      // Handle error appropriately - maybe throw or notify
+      throw new Error('Could not initialize Magic for transaction.');
+    }
+  }
+
   const launchPad = new LaunchpadBondingCurve(
     commonProtocol.factoryContracts[ethChainId].lpBondingCurve,
     commonProtocol.factoryContracts[ethChainId].launchpad,
     tokenAddress,
     commonProtocol.factoryContracts[ethChainId].tokenCommunityManager,
     chainRpc,
+  );
+
+  // Always initialize before use. Pass magicProvider if it exists.
+  await launchPad.initialize(
+    true, // Always initialize with wallet context for transactions
+    `${ethChainId}`,
+    magicProvider, // Pass provider if available, otherwise ContractBase uses default
   );
 
   return await launchPad.buyToken(amountEth, walletAddress, `${ethChainId}`);

--- a/packages/commonwealth/client/scripts/state/api/launchPad/sellToken.ts
+++ b/packages/commonwealth/client/scripts/state/api/launchPad/sellToken.ts
@@ -1,6 +1,8 @@
 import { commonProtocol } from '@hicommonwealth/evm-protocols';
 import { useMutation } from '@tanstack/react-query';
 import LaunchpadBondingCurve from 'helpers/ContractHelpers/Launchpad';
+import { userStore } from 'state/ui/user';
+import { getMagicForChain } from 'utils/magicNetworkUtils';
 import { resetBalancesCache } from './helpers/resetBalancesCache';
 
 interface SellTokenProps {
@@ -18,12 +20,38 @@ const sellToken = async ({
   amountToken,
   walletAddress,
 }: SellTokenProps) => {
+  // Check if the selected address belongs to a Magic user
+  const userAddresses = userStore.getState().addresses;
+  const isMagicAddress = userAddresses.some(
+    (addr) =>
+      addr.address.toLowerCase() === walletAddress.toLowerCase() &&
+      addr.walletId?.toLowerCase().includes('magic'),
+  );
+
+  let magicProvider: any = null;
+  if (isMagicAddress) {
+    const magic = getMagicForChain(ethChainId);
+    if (magic) {
+      magicProvider = magic.rpcProvider;
+    } else {
+      // Handle error appropriately - maybe throw or notify
+      throw new Error('Could not initialize Magic for transaction.');
+    }
+  }
+
   const launchPad = new LaunchpadBondingCurve(
     commonProtocol.factoryContracts[ethChainId].lpBondingCurve,
     commonProtocol.factoryContracts[ethChainId].launchpad,
     tokenAddress,
     commonProtocol.factoryContracts[ethChainId].tokenCommunityManager,
     chainRpc,
+  );
+
+  // Always initialize before use. Pass magicProvider if it exists.
+  await launchPad.initialize(
+    true, // Always initialize with wallet context for transactions
+    `${ethChainId}`,
+    magicProvider, // Pass provider if available, otherwise ContractBase uses default
   );
 
   return await launchPad.sellToken(amountToken, walletAddress, `${ethChainId}`);

--- a/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/useCommonTradeTokenForm.ts
+++ b/packages/commonwealth/client/scripts/views/modals/TradeTokenModel/CommonTradeModal/CommonTradeTokenForm/useCommonTradeTokenForm.ts
@@ -1,4 +1,5 @@
 import { ExtendedCommunity } from '@hicommonwealth/schemas';
+import { useNetworkSwitching } from 'hooks/useNetworkSwitching';
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
 import NodeInfo from 'models/NodeInfo';
 import { useMemo, useState } from 'react';
@@ -44,6 +45,21 @@ const useCommonTradeTokenForm = ({
       enabled: !!tradeConfig.token.community_id,
       includeNodeInfo: true,
     });
+
+  const ethChainId = tokenCommunity?.ChainNode?.eth_chain_id;
+  const rpcUrl = tokenCommunity?.ChainNode?.url;
+
+  const { isWrongNetwork, promptNetworkSwitch } = useNetworkSwitching({
+    ethChainId,
+    rpcUrl,
+    // Provider is needed for network switching in non-Magic wallets,
+    // but CommonTrade doesn't directly handle wallet connection UI like Uniswap modal.
+    // We might need a different approach here if we want to *force*
+    // connection before switching, or assume a provider exists.
+    // For now, leaving provider as undefined, which might limit switching
+    // capabilities for non-Magic users if they aren't already connected.
+    provider: undefined, // TODO: Revisit provider handling for network switching
+  });
 
   useRunOnceOnCondition({
     callback: () => setSelectedAddress(userAddresses[0]),
@@ -94,6 +110,11 @@ const useCommonTradeTokenForm = ({
 
   const onCTAClick = () => {
     if (isActionPending) return;
+
+    if (isWrongNetwork) {
+      void promptNetworkSwitch();
+      return; // Prevent trade execution
+    }
 
     switch (tradingMode) {
       case TradingMode.Buy:


### PR DESCRIPTION
Should automatically switch networks when using Magic to prevent Wallet Connect from popping up on the Community Homepage or other pages

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 