### PR TITLE
Update nav behavior for create token / community

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/MobileNavigation/CreateContentDrawer/CreateContentDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/components/MobileNavigation/CreateContentDrawer/CreateContentDrawer.tsx
@@ -54,16 +54,16 @@ const CreateContentDrawer = ({ onClose }: CreateContentDrawerProps) => {
         <CWText className="header" fontWeight="medium" type="caption">
           Universal create
         </CWText>
-        <div className="item" onClick={handleCreateCommunity}>
-          <CWIcon iconName="peopleNew" />
-          <CWText>Create community</CWText>
-        </div>
         {launchpadEnabled && (
           <div className="item" onClick={handleCreateTokenCommunity}>
             <CWIcon iconName="rocketLaunch" />
             <CWText>Launch Token</CWText>
           </div>
         )}
+        <div className="item" onClick={handleCreateCommunity}>
+          <CWIcon iconName="peopleNew" />
+          <CWText>Create community</CWText>
+        </div>
       </div>
       <CWIconButton iconName="close" onClick={onClose} />
     </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -25,7 +25,6 @@ import useManageCommunityStakeModalStore from '../../../../state/ui/modals/manag
 import Permissions from '../../../../utils/Permissions';
 import AccountConnectionIndicator from '../AccountConnectionIndicator';
 import { AdminSection } from '../AdminSection';
-import CreateCommunityButton from '../CreateCommunityButton';
 import DirectoryMenuItem from '../DirectoryMenuItem';
 import SidebarSignInButton from '../SidebarSignInButton/SidebarSignInButton';
 import { DiscussionSection } from '../discussion_section';
@@ -170,8 +169,6 @@ export const CommunitySection = ({
         )}
 
         {launchpadEnabled && <TokenTradeWidget />}
-
-        <CreateCommunityButton />
 
         <CWDivider />
         <DiscussionSection

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   align-items: center;
 
-  padding: 16px;
+  padding: 8px 16px;
 }

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.tsx
@@ -45,7 +45,7 @@ const CreateCommunityButton = ({
       <CWButton
         label="Create Community"
         buttonHeight={buttonHeight}
-        buttonWidth="full"
+        buttonWidth="auto"
         {...(withIcon && { iconLeft: 'peopleNew' })}
         onClick={handleCreateCommunity}
       />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CreateCommunityButton/CreateCommunityButton.tsx
@@ -45,7 +45,6 @@ const CreateCommunityButton = ({
       <CWButton
         label="Create Community"
         buttonHeight={buttonHeight}
-        buttonWidth="auto"
         {...(withIcon && { iconLeft: 'peopleNew' })}
         onClick={handleCreateCommunity}
       />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/SidebarProfileSection/SidebarProfileSection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/SidebarProfileSection/SidebarProfileSection.tsx
@@ -10,6 +10,7 @@ import { AddressList } from '../CommunitySection/AddressList';
 import { CommunitySectionSkeleton } from '../CommunitySection/CommunitySectionSkeleton';
 import ProfileCard from '../CommunitySection/ProfileCard';
 import CreateCommunityButton from '../CreateCommunityButton';
+import TokenLaunchButton from '../TokenLaunchButton';
 import './SidebarProfileSection.scss';
 
 interface SidebarProfileSectionProps {
@@ -98,6 +99,7 @@ export const SidebarProfileSection = ({
         )}
 
         <CWDivider />
+        <TokenLaunchButton buttonHeight="sm" />
         <CreateCommunityButton />
         <CWDivider />
       </div>

--- a/packages/commonwealth/client/scripts/views/components/sidebar/TokenLaunchButton/TokenLaunchButton.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/TokenLaunchButton/TokenLaunchButton.scss
@@ -4,8 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0;
-  max-width: fit-content;
+  padding: 16px;
 
   .btn-border {
     border: 0 !important;

--- a/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
@@ -103,11 +103,7 @@ const getCreateContentMenuItems = (
       type: 'element',
       element: (
         <div onClick={resetSidebarState} key="create-community-wrapper">
-          <CreateCommunityButton
-            withIcon
-            buttonHeight="sm"
-            buttonWidth="auto"
-          />
+          <CreateCommunityButton withIcon buttonHeight="sm" />
         </div>
       ),
     } as PopoverMenuItem,

--- a/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
+++ b/packages/commonwealth/client/scripts/views/menus/CreateContentMenu/CreateContentMenu.tsx
@@ -7,7 +7,6 @@ import { useFlag } from 'hooks/useFlag';
 import { uuidv4 } from 'lib/util';
 import { useCommonNavigate } from 'navigation/helpers';
 import React from 'react';
-import { isMobile } from 'react-device-detect';
 import type { NavigateOptions, To } from 'react-router-dom';
 import app from 'state';
 import { fetchCachedCustomDomain } from 'state/api/configuration';
@@ -26,19 +25,13 @@ import {
 import { CWIconButton } from '../../components/component_kit/cw_icon_button';
 import { CWSidebarMenu } from '../../components/component_kit/cw_sidebar_menu';
 import { getClasses } from '../../components/component_kit/helpers';
+import CreateCommunityButton from '../../components/sidebar/CreateCommunityButton';
 import TokenLaunchButton from '../../components/sidebar/TokenLaunchButton';
 import './CreateContentMenu.scss';
 
 const resetSidebarState = () => {
-  //Bouncer pattern -- I have found isMobile does not always detect screen
-  //size when responsively resizing so added a redundancy with window.innerWidth
-  if (!isMobile || window.innerWidth > 425) return;
-
-  if (sidebarStore.getState().userToggledVisibility !== 'open') {
-    sidebarStore.getState().setMenu({ name: 'default', isVisible: false });
-  } else {
-    sidebarStore.getState().setMenu({ name: 'default', isVisible: true });
-  }
+  // Always set the menu back to default, effectively closing the CreateContentMenu
+  sidebarStore.getState().setMenu({ name: 'default' });
 };
 
 const getCreateContentMenuItems = (
@@ -94,25 +87,30 @@ const getCreateContentMenuItems = (
       : [];
 
   const getUniversalCreateItems = (): PopoverMenuItem[] => [
-    {
-      label: 'Create community',
-      isButton: true,
-      iconLeft: 'peopleNew',
-      iconLeftWeight: 'bold',
-      onClick: (e) => {
-        e?.preventDefault();
-        resetSidebarState();
-        navigate('/createCommunity', {}, null);
-      },
-    },
     ...(launchpadEnabled
       ? [
           {
             type: 'element',
-            element: <TokenLaunchButton key={2} buttonHeight="sm" />,
+            element: (
+              <div onClick={resetSidebarState} key="token-launch-wrapper">
+                <TokenLaunchButton key={2} buttonHeight="sm" />
+              </div>
+            ),
           } as PopoverMenuItem,
         ]
       : []),
+    {
+      type: 'element',
+      element: (
+        <div onClick={resetSidebarState} key="create-community-wrapper">
+          <CreateCommunityButton
+            withIcon
+            buttonHeight="sm"
+            buttonWidth="auto"
+          />
+        </div>
+      ),
+    } as PopoverMenuItem,
   ];
 
   const getDiscordBotConnectionItems = (): PopoverMenuItem[] => {
@@ -125,6 +123,7 @@ const getCreateContentMenuItems = (
           label: 'Connect Discord',
           iconLeft: 'discord',
           onClick: () => {
+            resetSidebarState();
             const verificationToken = uuidv4();
             createDiscordBotConfig!({
               verification_token: verificationToken,

--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
@@ -1,4 +1,4 @@
-import { ChainBase } from '@hicommonwealth/shared';
+import { ChainBase, DefaultPage } from '@hicommonwealth/shared';
 import { useFlag } from 'client/scripts/hooks/useFlag';
 import clsx from 'clsx';
 import { notifyError } from 'controllers/app/notifications';
@@ -286,10 +286,11 @@ export const QuickTokenLaunchForm = ({
           ...(sanitizedTokenInfo.imageURL && {
             icon_url: sanitizedTokenInfo.imageURL,
           }),
+          default_page: DefaultPage.Homepage,
         }).catch(() => undefined); // failure of this call shouldn't break this handler
 
-        setCreatedCommunityId(communityId);
         onCommunityCreated(communityId);
+        setCreatedCommunityId(communityId);
       } catch (e) {
         console.error(`Error creating token: `, e, e.name);
 

--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
@@ -289,8 +289,8 @@ export const QuickTokenLaunchForm = ({
           default_page: DefaultPage.Homepage,
         }).catch(() => undefined); // failure of this call shouldn't break this handler
 
-        onCommunityCreated(communityId);
         setCreatedCommunityId(communityId);
+        onCommunityCreated(communityId);
       } catch (e) {
         console.error(`Error creating token: `, e, e.name);
 


### PR DESCRIPTION
- Misc fixes to emphasize token launch
- When navigating to create community / token, it will close the sidebar menu (had some weird behavior before)

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 