### PR TITLE
Add `connect a new address` to unscoped pages

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -249,17 +249,18 @@ const useUserMenuItems = ({
               label: 'Addresses',
             },
             ...addresses,
-            {
-              type: 'default',
-              label: 'Connect a new address',
-              onClick: () => {
-                onAuthModalOpen();
-                onAddressItemClick?.();
-              },
-            },
             { type: 'divider' },
           ] as PopoverMenuItem[])
         : []),
+      {
+        type: 'default',
+        label: 'Connect a new address',
+        onClick: () => {
+          onAuthModalOpen();
+          onAddressItemClick?.();
+        },
+      },
+      { type: 'divider' },
       {
         type: 'header',
         label: 'Settings',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/7900e945-308f-4489-8611-8136c8ec5353" />

<img width="424" alt="image" src="https://github.com/user-attachments/assets/9058a8b4-7292-45ec-ba26-3b4325ea3d89" />


## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 