### PR TITLE
Improve Twitter/Discord quest UX with connect prompt if not linked

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/AuthModal.tsx
@@ -21,6 +21,7 @@ const AuthModal = ({
   onClose,
   onSuccess,
   showWalletsFor,
+  showAuthOptionFor,
   showAuthOptionTypesFor,
   isUserFromWebView,
 }: AuthModalProps) => {
@@ -58,6 +59,7 @@ const AuthModal = ({
       onClose,
       onSuccess: handleSuccess,
       showWalletsFor,
+      showAuthOptionFor,
       showAuthOptionTypesFor: (showAuthOptionTypesFor
         ? showAuthOptionTypesFor
         : mobileApp
@@ -81,6 +83,7 @@ const AuthModal = ({
             {...commonVariantProps}
             // TODO: session keys should support all wallet types, atm they only work with sso
             // this is broken in master branch, create a ticket for fix
+            // This is also intentionally meant to override the custom `showAuthOptionFor` value if provided
             {...(sessionKeyValidationError?.ssoSource &&
               sessionKeyValidationError?.ssoSource !==
                 WalletSsoSource.Unknown && {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/types.ts
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/types.ts
@@ -14,6 +14,8 @@ export type ModalBaseTabs = {
 
 export type AuthOptionTypes = 'wallets' | 'sso';
 
+export type AuthOptions = AuthWallets | AuthSSOs;
+
 export type ModalVariantProps = {
   onClose: () => any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,7 +26,7 @@ export type ModalVariantProps = {
     | ChainBase.Solana
     | ChainBase.Substrate;
 
-  showAuthOptionFor?: AuthWallets | AuthSSOs;
+  showAuthOptionFor?: AuthOptions;
   showAuthOptionTypesFor?: AuthOptionTypes[];
   onSignInClick?: () => void;
   triggerOpenEVMWalletsSubModal?: boolean;
@@ -49,6 +51,7 @@ export type AuthModalProps = Pick<
   | 'onClose'
   | 'onSuccess'
   | 'showWalletsFor'
+  | 'showAuthOptionFor'
   | 'showAuthOptionTypesFor'
   | 'triggerOpenEVMWalletsSubModal'
   | 'isUserFromWebView'

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -49,7 +49,6 @@ const QuestActionCard = ({
   questStartDate,
   questEndDate,
 }: QuestActionCardProps) => {
-  console.log('questAction => ', questAction);
   const creatorXP = {
     percentage: roundDecimalsOrReturnWhole(
       questAction.creator_reward_weight * 100,
@@ -62,6 +61,27 @@ const QuestActionCard = ({
   const isUserReferred = !!user.referredByAddress;
   const hideShareSplit =
     doesActionRewardShareForReferrer(questAction.event_name) && !isUserReferred;
+
+  // Function to determine the button label based on quest action type
+  const getButtonLabel = () => {
+    const hasDiscordLinked = user.addresses?.some(
+      (address) => address.walletSsoSource === 'discord',
+    );
+
+    const hasTwitterLinked = user.addresses?.some(
+      (address) => address.walletSsoSource === 'twitter',
+    );
+
+    if (questAction.event_name === 'DiscordServerJoined' && !hasDiscordLinked) {
+      return 'Connect Discord';
+    }
+
+    if (questAction.event_name === 'TweetEngagement' && !hasTwitterLinked) {
+      return 'Connect Twitter';
+    }
+
+    return 'Start';
+  };
 
   const isRepeatableQuest =
     questAction?.participation_limit === QuestParticipationLimit.OncePerPeriod;
@@ -202,7 +222,7 @@ const QuestActionCard = ({
                 <CWButton
                   buttonType="secondary"
                   buttonAlt="green"
-                  label="Start"
+                  label={getButtonLabel()}
                   buttonHeight="sm"
                   buttonWidth="narrow"
                   iconRight="arrowRightPhosphor"

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/QuestActionCard.tsx
@@ -73,11 +73,11 @@ const QuestActionCard = ({
     );
 
     if (questAction.event_name === 'DiscordServerJoined' && !hasDiscordLinked) {
-      return 'Connect Discord';
+      return 'Connect Discord & Start';
     }
 
     if (questAction.event_name === 'TweetEngagement' && !hasTwitterLinked) {
-      return 'Connect Twitter';
+      return 'Connect Twitter & Start';
     }
 
     return 'Start';

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -266,6 +266,7 @@ const QuestDetails = ({ id }: { id: number }) => {
         if (!action.start_link) {
           // requires a start link
           notifyError(`Start link is invalid for this action`);
+          return;
         }
 
         if (hasDiscordLinked && action.start_link) {

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -231,16 +231,44 @@ const QuestDetails = ({ id }: { id: number }) => {
         break;
       }
       case 'TweetEngagement': {
-        if (actionContentId) {
-          window.open(buildRedirectURLFromContentId(actionContentId), '_blank');
+        // Check if user has Twitter linked
+        const hasTwitterLinked = user.addresses?.some(
+          (address) => address.walletSsoSource === 'twitter',
+        );
+
+        if (hasTwitterLinked) {
+          if (actionContentId) {
+            window.open(
+              buildRedirectURLFromContentId(actionContentId),
+              '_blank',
+            );
+          } else {
+            notifyError(`Linked twitter tweet url is invalid`);
+          }
         } else {
-          notifyError(`Linked twitter tweet url is invalid`);
+          // Open Twitter SSO modal if Twitter isn't linked
+          setAuthModalConfig({
+            type: AuthModalType.SignIn,
+            options: ['sso'],
+          });
         }
         break;
       }
       case 'DiscordServerJoined': {
-        // requires a start link
-        notifyError(`Start link is invalid for this action`);
+        // Check if user has Discord linked and if there's a start link
+        const hasDiscordLinked = user.addresses?.some(
+          (address) => address.walletSsoSource === 'discord',
+        );
+
+        if (hasDiscordLinked && action.start_link) {
+          window.open(action.start_link, '_blank');
+        } else {
+          // Open Discord SSO modal if Discord isn't linked
+          setAuthModalConfig({
+            type: AuthModalType.SignIn,
+            options: ['sso'],
+          });
+        }
         break;
       }
       case 'MembershipsRefreshed': {

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -263,6 +263,11 @@ const QuestDetails = ({ id }: { id: number }) => {
           (address) => address.walletSsoSource === 'discord',
         );
 
+        if (!action.start_link) {
+          // requires a start link
+          notifyError(`Start link is invalid for this action`);
+        }
+
         if (hasDiscordLinked && action.start_link) {
           window.open(action.start_link, '_blank');
         } else {

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -35,7 +35,7 @@ import CWPopover, {
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
 import { withTooltip } from 'views/components/component_kit/new_designs/CWTooltip';
 import { AuthModal, AuthModalType } from 'views/modals/AuthModal';
-import { AuthOptionTypes } from 'views/modals/AuthModal/types';
+import { AuthOptions, AuthOptionTypes } from 'views/modals/AuthModal/types';
 import { openConfirmation } from 'views/modals/confirmation_modal';
 import { z } from 'zod';
 import { PageNotFound } from '../404';
@@ -64,9 +64,11 @@ const QuestDetails = ({ id }: { id: number }) => {
   const [authModalConfig, setAuthModalConfig] = useState<{
     type: AuthModalType | undefined;
     options: AuthOptionTypes[] | undefined;
+    specificAuthOption?: AuthOptions;
   }>({
     type: undefined,
     options: undefined,
+    specificAuthOption: undefined,
   });
 
   const { mutateAsync: deleteQuest, isLoading: isDeletingQuest } =
@@ -250,6 +252,7 @@ const QuestDetails = ({ id }: { id: number }) => {
           setAuthModalConfig({
             type: AuthModalType.SignIn,
             options: ['sso'],
+            specificAuthOption: 'x', // only show twitter option
           });
         }
         break;
@@ -267,6 +270,7 @@ const QuestDetails = ({ id }: { id: number }) => {
           setAuthModalConfig({
             type: AuthModalType.SignIn,
             options: ['sso'],
+            specificAuthOption: 'discord', // only show discord option
           });
         }
         break;
@@ -584,6 +588,9 @@ const QuestDetails = ({ id }: { id: number }) => {
         showWalletsFor={
           (app?.chain?.base as Exclude<ChainBase, ChainBase.NEAR>) || undefined
         }
+        {...(authModalConfig.specificAuthOption && {
+          showAuthOptionFor: authModalConfig.specificAuthOption,
+        })}
         showAuthOptionTypesFor={authModalConfig.options}
         isOpen={!!(authModalConfig.type && authModalConfig.options)}
       />


### PR DESCRIPTION
- Shows 'Connect Discord' or 'Connect Twitter' when service not linked
- Shows 'Start' when service is already linked
- Opens SSO auth modal when service not linked
- Navigates to start link when service is linked
- Removes console.log in QuestActionCard

🤖 Above is generated with [Claude Code](https://claude.ai/code)

[Context in Slack](https://commonxyz.slack.com/archives/C07TT3HH4B0/p1745000710223239?thread_ts=1744926181.029759&cid=C07TT3HH4B0)

## Link to Issue
Closes: #TODO

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 