### PR TITLE
Admin Sidebar change

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/CommunitySection.tsx
@@ -174,17 +174,20 @@ export const CommunitySection = ({
         <CreateCommunityButton />
 
         <CWDivider />
-        <DiscussionSection
-          // @ts-expect-error <StrictNullChecks/>
-          topicIdsIncludedInContest={topicIdsIncludedInContest}
-        />
-        <CWDivider />
+
         {isAdmin && (
           <>
             <AdminSection />
             <CWDivider />
           </>
         )}
+
+        <DiscussionSection
+          // @ts-expect-error <StrictNullChecks/>
+          topicIdsIncludedInContest={topicIdsIncludedInContest}
+        />
+        <CWDivider />
+
         <GovernanceSection isContestAvailable={isContestAvailable} />
         <CWDivider />
         <DirectoryMenuItem />

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.scss
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.scss
@@ -22,6 +22,10 @@
     .Icon {
       margin-right: 4px;
     }
+
+    .sidebar-section-new-tag {
+      margin-left: 4px;
+    }
   }
 
   .sections-container {
@@ -141,4 +145,14 @@
   svg {
     fill: transparent;
   }
+}
+
+// Specific styles for the 'New' tag variant in the sidebar
+.cw-tag--sidebar-new {
+  padding-left: 4px; // Reduce horizontal padding
+  padding-right: 4px;
+  gap: 0; // Remove gap between icon and text
+  // Optionally, adjust height/font-size if needed
+  // height: 20px;
+  // font-size: 11px;
 }

--- a/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/sidebar_section.tsx
@@ -7,6 +7,7 @@ import { isNotUndefined } from 'helpers/typeGuards';
 import useSidebarStore from 'state/ui/sidebar';
 import { CWIcon } from '../component_kit/cw_icons/cw_icon';
 import { CWText } from '../component_kit/cw_text';
+import { CWTag } from '../component_kit/new_designs/CWTag';
 import type {
   SectionGroupAttrs,
   SidebarSectionAttrs,
@@ -14,8 +15,16 @@ import type {
 } from './types';
 
 const SubSection = (props: SubSectionAttrs) => {
-  const { isActive, isUpdated, isVisible, onClick, leftIcon, rowIcon, title } =
-    props;
+  const {
+    isActive,
+    isUpdated,
+    isVisible,
+    onClick,
+    leftIcon,
+    rowIcon,
+    title,
+    isNew,
+  } = props;
 
   if (!isVisible) {
     return;
@@ -35,12 +44,20 @@ const SubSection = (props: SubSectionAttrs) => {
 
   return (
     <div
-      className={`SubSection${isActive ? ' active' : ''}`}
+      className={clsx('SubSection', isActive && 'active')}
       onClick={(e) => clickHandler(e)}
     >
       {isNotUndefined(rowIcon) && <CWIcon iconName="hash" iconSize="small" />}
-      <div className={titleTextClass} title={title}>
-        {title}
+      <div className={clsx('title-container', titleTextClass)} title={title}>
+        <span className="title-text">{title}</span>
+        {isNew && (
+          <CWTag
+            label="New"
+            type="new"
+            iconName="newStar"
+            classNames={clsx('sidebar-section-new-tag', 'cw-tag--sidebar-new')}
+          />
+        )}
       </div>
       {isNotUndefined(leftIcon) && <div className="left-icon">{leftIcon}</div>}
     </div>
@@ -60,6 +77,7 @@ export const SubSectionGroup = (props: SectionGroupAttrs) => {
     leftIcon,
     title,
     className,
+    isNew,
   } = props;
 
   const { setMenu, menuName, menuVisible } = useSidebarStore();
@@ -136,9 +154,17 @@ export const SubSectionGroup = (props: SectionGroupAttrs) => {
           <div className="no-carat" />
         )}
         <div className="left-icon">{leftIcon}</div>
-        <CWText type="b2" className={`title-text ${titleTextClass}`}>
+        <CWText type="b2" className={clsx('title-text', titleTextClass)}>
           {title}
         </CWText>
+        {isNew && (
+          <CWTag
+            label="New"
+            type="new"
+            iconName="newStar"
+            classNames={clsx('sidebar-section-new-tag', 'cw-tag--sidebar-new')}
+          />
+        )}
       </div>
       {containsChildren && toggled && (
         <div className="subsections">
@@ -161,6 +187,7 @@ export const SidebarSectionGroup = (props: SidebarSectionAttrs) => {
     onClick,
     title,
     toggleDisabled,
+    isNew,
   } = props;
 
   const [toggled, setToggled] = React.useState<boolean>(
@@ -214,6 +241,14 @@ export const SidebarSectionGroup = (props: SidebarSectionAttrs) => {
       >
         {carat}
         <CWText>{title}</CWText>
+        {isNew && (
+          <CWTag
+            label="New"
+            type="new"
+            iconName="newStar"
+            classNames={clsx('sidebar-section-new-tag', 'cw-tag--sidebar-new')}
+          />
+        )}
       </div>
       {toggled && (
         <div className="sections-container">

--- a/packages/commonwealth/client/scripts/views/components/sidebar/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/types.ts
@@ -12,12 +12,17 @@ export type BaseSidebarAttrs = {
 
 export type SubSectionAttrs = {
   rowIcon?: boolean;
+  isVisible: boolean;
+  leftIcon?: React.ReactNode;
+  isNew?: boolean;
 } & BaseSidebarAttrs;
 
 export type SectionGroupAttrs = {
   containsChildren: boolean;
   displayData: SubSectionAttrs[] | null;
   hasDefaultToggle: boolean;
+  leftIcon?: React.ReactNode;
+  isNew?: boolean;
 } & BaseSidebarAttrs;
 
 export type SidebarSectionAttrs = {
@@ -25,6 +30,7 @@ export type SidebarSectionAttrs = {
   displayData?: SectionGroupAttrs[];
   extraComponents?: React.ReactNode;
   toggleDisabled?: boolean;
+  isNew?: boolean;
 } & BaseSidebarAttrs;
 
 export type ToggleTree = {


### PR DESCRIPTION
An admin will
-have a prioritized view of the sidebar, eg admin capabilties will show first before every other section
-admins of new and existing communities will see a "New!" tag by the sidebar within the first 24 hours of being granted admin status
-the new tag and its logic are client side/local

## Description of Changes
Before:
<img width="305" alt="Screenshot 2025-04-24 at 12 44 46 PM" src="https://github.com/user-attachments/assets/62aecd6e-3220-40ad-b771-bf06d035f0c6" />
After:
<img width="274" alt="Screenshot 2025-04-24 at 12 43 09 PM" src="https://github.com/user-attachments/assets/959d05d9-ddb1-435c-829b-d47251586497" />