### PR TITLE
upvote modal

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/InsufficientBalanceModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/InsufficientBalanceModal.tsx
@@ -1,0 +1,122 @@
+import { ChainBase } from '@hicommonwealth/shared';
+import { notifyError } from 'controllers/app/notifications';
+import React from 'react';
+import useGetCommunityByIdQuery from 'state/api/communities/getCommuityById';
+import useManageCommunityStakeModalStore from 'state/ui/modals/manageCommunityStakeModal';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { CWModal } from 'views/components/component_kit/new_designs/CWModal';
+import { CWModalBody } from 'views/components/component_kit/new_designs/CWModal/CWModalBody';
+import { CWModalFooter } from 'views/components/component_kit/new_designs/CWModal/CWModalFooter';
+import { CWModalHeader } from 'views/components/component_kit/new_designs/CWModal/CWModalHeader';
+import { ManageCommunityStakeModalMode } from './ManageCommunityStakeModal/types';
+
+interface InsufficientBalanceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tokenSymbol?: string;
+  isCommunityStake: boolean;
+  communityId: string;
+}
+
+export const InsufficientBalanceModal: React.FC<
+  InsufficientBalanceModalProps
+> = ({ isOpen, onClose, tokenSymbol, isCommunityStake, communityId }) => {
+  const { setModeOfManageCommunityStakeModal, setSelectedCommunity } =
+    useManageCommunityStakeModalStore();
+
+  const { data: community, isLoading: isLoadingCommunity } =
+    useGetCommunityByIdQuery({
+      id: communityId,
+      includeNodeInfo: true,
+      enabled: isOpen,
+    });
+
+  const handleGetVotingPower = () => {
+    if (
+      community &&
+      community.name &&
+      community.base &&
+      community.icon_url &&
+      community.namespace &&
+      community.ChainNode &&
+      community.ChainNode.url &&
+      community.ChainNode.eth_chain_id !== null &&
+      community.ChainNode.eth_chain_id !== undefined
+    ) {
+      setSelectedCommunity({
+        id: community.id,
+        name: community.name,
+        base: community.base as ChainBase,
+        iconUrl: community.icon_url,
+        namespace: community.namespace,
+        ChainNode: {
+          url: community.ChainNode.url,
+          ethChainId: community.ChainNode.eth_chain_id,
+        },
+      });
+      setModeOfManageCommunityStakeModal(
+        'buy' as ManageCommunityStakeModalMode,
+      );
+      onClose();
+    } else {
+      console.error(
+        'Could not find complete community details for',
+        communityId,
+        'Community data:',
+        community,
+      );
+      notifyError('Could not load community staking details.');
+      onClose();
+    }
+  };
+
+  const title = 'Insufficient Balance to Upvote';
+  let message = '';
+
+  if (isCommunityStake) {
+    message =
+      'You need to stake in this community to get voting power for upvoting.';
+  } else if (tokenSymbol) {
+    message = `You need ${tokenSymbol} tokens to upvote in this topic.`;
+  } else {
+    message = 'You do not have the required balance to upvote.';
+  }
+
+  const isGetVotingPowerDisabled = isLoadingCommunity || !community;
+
+  const modalContent = (
+    <>
+      <CWModalHeader label={title} onModalClose={onClose} />
+      <CWModalBody>
+        <CWText style={{ display: 'block', textAlign: 'center' }}>
+          {message}
+        </CWText>
+      </CWModalBody>
+      <CWModalFooter>
+        <CWButton
+          buttonType="secondary"
+          buttonHeight="lg"
+          label="Dismiss"
+          onClick={onClose}
+        />
+        <CWButton
+          buttonType="primary"
+          buttonHeight="lg"
+          label="Get Voting Power"
+          onClick={handleGetVotingPower}
+          disabled={!!isGetVotingPowerDisabled}
+        />
+      </CWModalFooter>
+    </>
+  );
+
+  return (
+    <CWModal
+      open={isOpen}
+      onClose={onClose}
+      size="small"
+      content={modalContent}
+    />
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -201,7 +201,7 @@ export const ReactionButton = ({
       <InsufficientBalanceModal
         isOpen={isInsufficientBalanceModalOpen}
         onClose={() => setIsInsufficientBalanceModalOpen(false)}
-        tokenSymbol={thread.topic?.token_symbol}
+        tokenSymbol={thread.topic?.token_symbol ?? undefined}
         isCommunityStake={!thread.topic?.weighted_voting}
         communityId={communityId}
       />

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadOptions/ReactionButton/ReactionButton.tsx
@@ -20,6 +20,7 @@ import CWUpvoteSmall from 'views/components/component_kit/new_designs/CWUpvoteSm
 import { TooltipWrapper } from 'views/components/component_kit/new_designs/cw_thread_action';
 import { CWUpvote } from 'views/components/component_kit/new_designs/cw_upvote';
 import { AuthModal } from 'views/modals/AuthModal';
+import { InsufficientBalanceModal } from 'views/modals/InsufficientBalanceModal';
 import { ReactionButtonSkeleton } from './ReactionButtonSkeleton';
 
 type ReactionButtonProps = {
@@ -40,6 +41,8 @@ export const ReactionButton = ({
   undoUpvoteDisabled,
 }: ReactionButtonProps) => {
   const [isAuthModalOpen, setIsAuthModalOpen] = useState<boolean>(false);
+  const [isInsufficientBalanceModalOpen, setIsInsufficientBalanceModalOpen] =
+    useState<boolean>(false);
   const reactors = thread?.associatedReactions?.map((t) => t.address!);
 
   const { checkForSessionKeyRevalidationErrors } = useAuthModalStore();
@@ -125,9 +128,7 @@ export const ReactionButton = ({
           return;
         }
         if ((e.message as string)?.includes('Insufficient token balance')) {
-          notifyError(
-            'You must have the requisite tokens to upvote in this topic',
-          );
+          setIsInsufficientBalanceModalOpen(true);
         } else {
           notifyError('Failed to upvote');
         }
@@ -196,6 +197,13 @@ export const ReactionButton = ({
       <AuthModal
         onClose={() => setIsAuthModalOpen(false)}
         isOpen={isAuthModalOpen}
+      />
+      <InsufficientBalanceModal
+        isOpen={isInsufficientBalanceModalOpen}
+        onClose={() => setIsInsufficientBalanceModalOpen(false)}
+        tokenSymbol={thread.topic?.token_symbol}
+        isCommunityStake={!thread.topic?.weighted_voting}
+        communityId={communityId}
       />
     </>
   );


### PR DESCRIPTION
members of a community who do not meet the weighted upvote qualifications had no clear path to meet requirement

fix adds a modal that more clearly explains error and directs user to modal where they can obtain token

## Link to Issue
(https://github.com/hicommonwealth/commonwealth/issues/11915)

## Description of Changes
Before:
![image](https://github.com/user-attachments/assets/136f6df8-ba23-40db-82b5-de6ad6a79dc6)
After:
<img width="959" alt="Screenshot 2025-04-25 at 12 11 22 PM" src="https://github.com/user-attachments/assets/776d55d7-8d8f-4ebe-8145-745079416ee5" />


## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 