### PR TITLE
Don't emit events for spam

### DIFF
--- a/libs/model/src/aggregates/comment/CreateComment.command.ts
+++ b/libs/model/src/aggregates/comment/CreateComment.command.ts
@@ -139,20 +139,22 @@ export function CreateComment(): Command<typeof schemas.CreateComment> {
             { transaction },
           );
 
-          await emitEvent(
-            models.Outbox,
-            [
-              {
-                event_name: 'CommentCreated',
-                event_payload: {
-                  ...comment.toJSON(),
-                  community_id: thread.community_id,
-                  users_mentioned: mentions.map((u) => parseInt(u.userId)),
+          if (!marked_as_spam_at) {
+            await emitEvent(
+              models.Outbox,
+              [
+                {
+                  event_name: 'CommentCreated',
+                  event_payload: {
+                    ...comment.toJSON(),
+                    community_id: thread.community_id,
+                    users_mentioned: mentions.map((u) => parseInt(u.userId)),
+                  },
                 },
-              },
-            ],
-            transaction,
-          );
+              ],
+              transaction,
+            );
+          }
 
           mentions.length &&
             (await emitMentions(transaction, {

--- a/libs/model/src/models/thread.ts
+++ b/libs/model/src/models/thread.ts
@@ -155,20 +155,22 @@ export default (
             thread.address_id,
           )) as AddressAttributes | null;
 
-          await emitEvent(
-            Outbox,
-            [
-              {
-                event_name: 'ThreadCreated',
-                event_payload: {
-                  ...thread.get({ plain: true }),
-                  address: address!.address,
-                  contestManagers,
+          if (!thread.marked_as_spam_at) {
+            await emitEvent(
+              Outbox,
+              [
+                {
+                  event_name: 'ThreadCreated',
+                  event_payload: {
+                    ...thread.get({ plain: true }),
+                    address: address!.address,
+                    contestManagers,
+                  },
                 },
-              },
-            ],
-            options.transaction,
-          );
+              ],
+              options.transaction,
+            );
+          }
         },
         afterDestroy: async (thread: ThreadInstance) => {
           await cache().setKey(


### PR DESCRIPTION
## Link to Issue
Closes: #11715

## Description of Changes
- Don't emit event when thread or comment is automatically marked as spam

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 