### PR TITLE
Added `OneOffContestManagerDeployed` quest

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -54,6 +54,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
       'DiscordServerJoined',
       'MembershipsRefreshed',
       'LaunchpadTokenCreated',
+      'OneOffContestManagerDeployed',
     ] as QuestAction[],
     channel: ['TweetEngagement'] as QuestAction[],
   };

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
@@ -16,6 +16,7 @@ export const actionCopies = {
     ['DiscordServerJoined']: 'Join Discord Community',
     ['MembershipsRefreshed']: 'Join a Group',
     ['LaunchpadTokenCreated']: 'Launch a Token on Common',
+    ['OneOffContestManagerDeployed']: 'Create a 1-time contest',
   },
   pre_reqs: {
     ['SignUpFlowCompleted']: '',
@@ -33,6 +34,7 @@ export const actionCopies = {
       `Requires Discord SSO sign-in/linked-to ${displayFor === 'admin' ? 'user' : 'your'} account.`,
     ['MembershipsRefreshed']: '',
     ['LaunchpadTokenCreated']: '',
+    ['OneOffContestManagerDeployed']: '',
   },
   explainer: {
     ['SignUpFlowCompleted']: '',
@@ -82,9 +84,10 @@ export const actionCopies = {
         </ul>
       </div>
     ),
-    ['DiscordServerJoined']: '',
-    ['MembershipsRefreshed']: '',
-    ['LaunchpadTokenCreated']: '',
+    ['DiscordServerJoined']: () => '',
+    ['MembershipsRefreshed']: () => '',
+    ['LaunchpadTokenCreated']: () => '',
+    ['OneOffContestManagerDeployed']: () => '',
   },
   shares: {
     ['SignUpFlowCompleted']: '',
@@ -101,5 +104,6 @@ export const actionCopies = {
     ['DiscordServerJoined']: '',
     ['MembershipsRefreshed']: '',
     ['LaunchpadTokenCreated']: '',
+    ['OneOffContestManagerDeployed']: '',
   },
 };

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -299,6 +299,10 @@ const QuestDetails = ({ id }: { id: number }) => {
         navigate(`/createTokenCommunity`, {}, null);
         break;
       }
+      case 'OneOffContestManagerDeployed': {
+        // TODO: navigation needed
+        break;
+      }
       default:
         return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/11882

## Description of Changes
Added `OneOffContestManagerDeployed` quest

## "How We Fixed It"
N/A

## Test Plan
1. Create `OneOffContestManagerDeployed` quest
2. Verify you can update this quest
3. Verify you can view correct data for this quest on the quest details page
4. Verify you can start this quest
5. Verify you earn aura for this quest

## Deployment Plan
N/A

## Other Considerations
N/A