### PR TITLE
Encapsulates bindings

### DIFF
--- a/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
+++ b/libs/adapters/src/rabbitmq/RabbitMQAdapter.ts
@@ -201,11 +201,12 @@ export class RabbitMQAdapter implements Broker {
     const topic = consumer.name;
 
     if (!this.initialized) {
+      this._log.fatal('Adapter not initialized', undefined, { topic });
       return false;
     }
 
     if (!this.subscribers.includes(topic)) {
-      this._log.error(
+      this._log.fatal(
         `${topic} not supported by this adapter instance`,
         undefined,
         {

--- a/packages/commonwealth/server/bindings/bootstrap.ts
+++ b/packages/commonwealth/server/bindings/bootstrap.ts
@@ -19,28 +19,23 @@ import {
   DiscordBotPolicy,
   FarcasterWorker,
   LaunchpadPolicy,
+  NotificationsPolicy,
   TwitterEngagementPolicy,
   User,
   models,
 } from '@hicommonwealth/model';
 import { Client } from 'pg';
 import { config } from 'server/config';
+import { NotificationsSettingsPolicy } from 'server/workers/knock/NotificationsSettings.policy';
 import { setupListener } from './pgListener';
 import { rascalConsumerMap } from './rascalConsumerMap';
 import { incrementNumUnrelayedEvents, relayForever } from './relayForever';
 
 const log = logger(import.meta);
 
-function checkSubscriptionResponse(subRes: boolean, topic: string) {
-  if (!subRes) {
-    log.fatal(`Failed to subscribe to ${topic}. Requires restart!`, undefined, {
-      topic,
-    });
-  }
-}
-
 export async function bootstrapBindings(
   skipRmqAdapter?: boolean,
+  knockWorker?: boolean,
 ): Promise<void> {
   let brokerInstance: Broker;
   try {
@@ -64,10 +59,28 @@ export async function bootstrapBindings(
     throw e;
   }
 
-  const chainEventSubRes = await brokerInstance.subscribe(ChainEventPolicy);
-  checkSubscriptionResponse(chainEventSubRes, ChainEventPolicy.name);
+  if (knockWorker) {
+    await brokerInstance.subscribe(
+      NotificationsPolicy,
+      // This disables retry strategies on any handler error/failure
+      // This is because we cannot guarantee whether a Knock workflow trigger
+      // call was successful or not. It is better to 'miss' notifications then
+      // to double send a notification
+      buildRetryStrategy((err, topic, content, ackOrNackFn, log_) => {
+        log_.error(err.message, err, {
+          topic,
+          message: content,
+        });
+        ackOrNackFn({ strategy: 'ack' });
+        return true;
+      }),
+    );
+    await brokerInstance.subscribe(NotificationsSettingsPolicy);
+    return;
+  }
 
-  const contestWorkerSubRes = await brokerInstance.subscribe(
+  await brokerInstance.subscribe(ChainEventPolicy);
+  await brokerInstance.subscribe(
     ContestWorker,
     buildRetryStrategy(undefined, 20_000),
     {
@@ -81,45 +94,17 @@ export async function bootstrapBindings(
       },
     },
   );
-  checkSubscriptionResponse(contestWorkerSubRes, ContestWorker.name);
-
-  const contestProjectionsSubRes = await brokerInstance.subscribe(
-    Contest.Contests,
-  );
-  checkSubscriptionResponse(contestProjectionsSubRes, Contest.Contests.name);
-
-  const xpProjectionSubRes = await brokerInstance.subscribe(User.Xp);
-  checkSubscriptionResponse(xpProjectionSubRes, User.Xp.name);
-
-  const farcasterWorkerSubRes = await brokerInstance.subscribe(
+  await brokerInstance.subscribe(Contest.Contests);
+  await brokerInstance.subscribe(User.Xp);
+  await brokerInstance.subscribe(
     FarcasterWorker,
     buildRetryStrategy(undefined, 20_000),
   );
-  checkSubscriptionResponse(farcasterWorkerSubRes, FarcasterWorker.name);
-
-  const discordBotSubRes = await brokerInstance.subscribe(DiscordBotPolicy);
-  checkSubscriptionResponse(discordBotSubRes, DiscordBotPolicy.name);
-
-  const launchpadSubRes = await brokerInstance.subscribe(LaunchpadPolicy);
-  checkSubscriptionResponse(launchpadSubRes, LaunchpadPolicy.name);
-
-  const createUnverifiedUserSubRes =
-    await brokerInstance.subscribe(CreateUnverifiedUser);
-  checkSubscriptionResponse(
-    createUnverifiedUserSubRes,
-    CreateUnverifiedUser.name,
-  );
-
-  const twitterEngSubRes = await brokerInstance.subscribe(
-    TwitterEngagementPolicy,
-  );
-  checkSubscriptionResponse(twitterEngSubRes, TwitterEngagementPolicy.name);
-  const createCommunityGoalsSubRes =
-    await brokerInstance.subscribe(CommunityGoalsPolicy);
-  checkSubscriptionResponse(
-    createCommunityGoalsSubRes,
-    CommunityGoalsPolicy.name,
-  );
+  await brokerInstance.subscribe(DiscordBotPolicy);
+  await brokerInstance.subscribe(LaunchpadPolicy);
+  await brokerInstance.subscribe(CreateUnverifiedUser);
+  await brokerInstance.subscribe(TwitterEngagementPolicy);
+  await brokerInstance.subscribe(CommunityGoalsPolicy);
 }
 
 export async function bootstrapRelayer(

--- a/packages/commonwealth/server/workers/knock/knockWorker.ts
+++ b/packages/commonwealth/server/workers/knock/knockWorker.ts
@@ -1,31 +1,22 @@
 import {
   HotShotsStats,
   KnockProvider,
-  RabbitMQAdapter,
   ServiceKey,
-  buildRetryStrategy,
-  createRmqConfig,
   startHealthCheckLoop,
 } from '@hicommonwealth/adapters';
 import {
-  Broker,
-  broker,
   dispose,
   logger,
   notificationsProvider,
   stats,
 } from '@hicommonwealth/core';
-import { NotificationsPolicy } from '@hicommonwealth/model';
+import { bootstrapBindings } from 'server/bindings/bootstrap';
 import { fileURLToPath } from 'url';
-import { rascalConsumerMap } from '../../bindings/rascalConsumerMap';
 import { config } from '../../config';
-import { NotificationsSettingsPolicy } from './NotificationsSettings.policy';
 
 const log = logger(import.meta);
 
-stats({
-  adapter: HotShotsStats(),
-});
+stats({ adapter: HotShotsStats() });
 
 let isServiceHealthy = false;
 
@@ -42,25 +33,6 @@ startHealthCheckLoop({
 
 async function startKnockWorker() {
   log.info('Starting Knock Worker');
-  let brokerInstance: Broker;
-  try {
-    const rmqAdapter = new RabbitMQAdapter(
-      createRmqConfig({
-        rabbitMqUri: config.BROKER.RABBITMQ_URI,
-        map: rascalConsumerMap,
-      }),
-    );
-    await rmqAdapter.init();
-    broker({
-      adapter: rmqAdapter,
-    });
-    brokerInstance = rmqAdapter;
-  } catch (e) {
-    log.error(
-      'Rascal consumer setup failed. Please check the Rascal configuration',
-    );
-    throw e;
-  }
 
   // init Knock as notifications provider - this is necessary since the policies do not define the provider
   if (config.NOTIFICATIONS.FLAG_KNOCK_INTEGRATION_ENABLED)
@@ -69,47 +41,7 @@ async function startKnockWorker() {
     });
   else notificationsProvider();
 
-  const sub = await brokerInstance.subscribe(
-    NotificationsPolicy,
-    // This disables retry strategies on any handler error/failure
-    // This is because we cannot guarantee whether a Knock workflow trigger
-    // call was successful or not. It is better to 'miss' notifications then
-    // to double send a notification
-    buildRetryStrategy((err, topic, content, ackOrNackFn, log_) => {
-      log_.error(err.message, err, {
-        topic,
-        message: content,
-      });
-      ackOrNackFn({ strategy: 'ack' });
-      return true;
-    }),
-  );
-
-  if (!sub) {
-    log.fatal(
-      'Failed to subscribe to notifications. Requires restart!',
-      undefined,
-      {
-        topic: NotificationsPolicy.name,
-      },
-    );
-    await dispose()('ERROR', true);
-  }
-
-  const settingsSub = await brokerInstance.subscribe(
-    NotificationsSettingsPolicy,
-  );
-
-  if (!settingsSub) {
-    log.fatal(
-      'Failed to subscribe to notifications. Requires restart!',
-      undefined,
-      {
-        topic: NotificationsSettingsPolicy.name,
-      },
-    );
-    await dispose()('ERROR', true);
-  }
+  await bootstrapBindings(false, true);
 
   isServiceHealthy = true;
   log.info('Knock Worker started');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Encapsulates RMQ policy/projection bindings in a single function, removing unnecessary check for false results since`subscribe()` is already taking care of aborting.

## Link to Issue
Closes: #12008

## Description of Changes
- Adds FIXME widget to TODO page.
- 

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->

## Test Plan
- Unit tested the `FIXME()` call.
- CA (click around) tested on local and frack:
  - TODO page
  - 

## Deployment Plan
<!--- Omit if unneeded -->
1. 

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 