### PR TITLE
collapsed the card default and wrap the card in one view on mobile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPage/CWContentPage.scss
@@ -48,6 +48,16 @@
       }
     }
 
+    .mobile-action-card-container {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      .actions {
+        width: 100%;
+        max-width: 100%;
+      }
+    }
+
     .action-cards {
       display: flex;
       flex-direction: column;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPageCard/CWContentPageCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWContentPageCard/CWContentPageCard.tsx
@@ -13,7 +13,7 @@ type ContentPageCardProps = {
 
 export const CWContentPageCard = (props: ContentPageCardProps) => {
   const { content, header, showCollapsedIcon = false } = props;
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
   return (
     <CWCard className={clsx('ContentPageCard', { isCollapsed: isCollapsed })}>
       <div className="header-container">

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -114,6 +114,8 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const [votingModalOpen, setVotingModalOpen] = useState(false);
   const [proposalRedrawState, redrawProposals] = useState<boolean>(true);
 
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
   const { isBannerVisible, handleCloseBanner } = useJoinCommunityBanner();
   const { handleJoinCommunity, JoinCommunityModals } = useJoinCommunity();
   useInitChainIfNeeded(app);
@@ -1026,10 +1028,33 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
                 </>
               )}
               {isWindowSmallInclusive && (
-                <div className="action-cards">
-                  {sidebarComponent.map((view) => (
-                    <div key={view.label}>{view.item}</div>
-                  ))}
+                <div className="mobile-action-card-container ">
+                  <div className="actions">
+                    <div className="left-container">
+                      <CWIcon
+                        iconName="squaresFour"
+                        iconSize="medium"
+                        weight="bold"
+                      />
+                      <CWText type="h5" fontWeight="semiBold">
+                        Actions
+                      </CWText>
+                    </div>
+                    <CWIcon
+                      iconName={isCollapsed ? 'caretDown' : 'caretUp'}
+                      iconSize="small"
+                      className="caret-icon"
+                      weight="bold"
+                      onClick={() => setIsCollapsed(!isCollapsed)}
+                    />
+                  </div>
+
+                  <div className="action-cards">
+                    {!isCollapsed &&
+                      sidebarComponent.map((view) => (
+                        <div key={view.label}>{view.item}</div>
+                      ))}
+                  </div>
                 </div>
               )}
             </>

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/snapshot_creation_card.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/snapshot_creation_card.tsx
@@ -30,6 +30,7 @@ export const SnapshotCreationCard = ({
     <>
       <CWContentPageCard
         header="Create Snapshot"
+        showCollapsedIcon={true}
         content={
           <div className="SnapshotCreationCard">
             <CWText type="b2" className="no-threads-text">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12030 
## Description of Changes
- collapsed the card default and wrap the card in one view on mobile

## "How We Fixed It"
<!-- Brief description of solution, if bug, to be added once issue is resolved. -->
collapsed the card default and wrap the card in one view on mobile
## Test Plan
Goto any thread view  on mobile and make sure actions are collapsed default 