### PR TITLE
Fixed launchpad error message

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
@@ -303,6 +303,10 @@ export const QuickTokenLaunchForm = ({
             .includes('user denied transaction signature')
         ) {
           notifyError('Transaction rejected!');
+        } else if (
+          e?.data?.message?.toLowerCase().includes('insufficient funds')
+        ) {
+          notifyError('Insufficient funds to launch token!');
         } else {
           notifyError('Failed to create token!');
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: hotfix

## Description of Changes
- Fixes undescriptive error message when launching token with insufficient funds
<img width="673" alt="image" src="https://github.com/user-attachments/assets/3d13f310-0015-424d-a208-0331d4828147" />

## Test Plan
- Try to launch token with insufficient funds