### PR TITLE
Fixed member count for community

### DIFF
--- a/libs/model/src/aggregates/community/CreateCommunity.command.ts
+++ b/libs/model/src/aggregates/community/CreateCommunity.command.ts
@@ -156,6 +156,7 @@ export function CreateCommunity(): Command<typeof schemas.CreateCommunity> {
             thread_purchase_token,
             namespace_verified: false,
             environment: config.APP_ENV,
+            profile_count: 1,
           },
           { transaction },
         );

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -289,7 +289,10 @@ const CommunityMembersPage = () => {
     return clonedFilteredGroups;
   }, [groups, searchFilters, memberships]);
 
-  const totalResults = members?.pages?.[0]?.totalResults || 0;
+  let totalResults = members?.pages?.[0]?.totalResults || 0;
+  if (totalResults < 20) {
+    totalResults = members?.pages?.[0]?.results?.length || 1;
+  }
 
   const updateActiveTab = (activeTab: TabValues) => {
     const params = new URLSearchParams(window.location.search);

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -290,7 +290,7 @@ const CommunityMembersPage = () => {
   }, [groups, searchFilters, memberships]);
 
   let totalResults = members?.pages?.[0]?.totalResults || 0;
-  if (totalResults < 20) {
+  if (totalResults < 30) {
     totalResults = members?.pages?.[0]?.results?.length || 1;
   }
 

--- a/packages/commonwealth/server/migrations/20250506161839-fix-profile-counts.js
+++ b/packages/commonwealth/server/migrations/20250506161839-fix-profile-counts.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+        UPDATE "Communities" C
+        SET profile_count = 1 WHERE profile_count = 0;
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #10907

## Description of Changes
- Made it so when the members count is small (< 20) we just count the members coming back from the frontend instead of getting the total count. This is because the total count is computed async in batches to avoid load on the DB.

## Test Plan
- Create a community, ensure member count is correct on members page