### PR TITLE
Remove Community Trust Level Display for only 🚫 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWSidebarHeader/CWSidebarHeader.tsx
@@ -82,6 +82,7 @@ const SidebarHeader = ({
                 </CWText>
                 {trustLevelEnabled &&
                   community?.tier &&
+                  community.tier !== CommunityTierMap.Unverified &&
                   (() => {
                     const tier = community.tier as CommunityTierMap;
                     return (

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
@@ -151,6 +151,7 @@ export const CWRelatedCommunityCard = ({
                 </CWText>
                 {trustLevelEnabled &&
                   community?.tier &&
+                  community.tier !== CommunityTierMap.Unverified &&
                   (() => {
                     const tier = community.tier as CommunityTierMap;
                     return (

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/CommunityPreviewCard/CommunityPreviewCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/CommunityPreviewCard/CommunityPreviewCard.tsx
@@ -108,6 +108,7 @@ const CommunityPreviewCard = ({
                 )}
                 {trustLevelEnabled &&
                   community?.tier &&
+                  community.tier !== CommunityTierMap.Unverified &&
                   (() => {
                     const tier = community.tier as CommunityTierMap;
                     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12088

## Description of Changes
- Not Showing Unverified Badge for trust level 1 communities.

## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 