### PR TITLE
Fixed topic redirects for topics with `?` in name

### DIFF
--- a/libs/schemas/src/entities/topic.schemas.ts
+++ b/libs/schemas/src/entities/topic.schemas.ts
@@ -1,3 +1,4 @@
+import { DISALLOWED_TOPIC_NAMES_REGEX } from '@hicommonwealth/shared';
 import { z } from 'zod';
 import { PG_INT } from '../utils';
 
@@ -15,7 +16,7 @@ export const Topic = z.object({
     .max(255)
     .default('General')
     .refine(
-      (v) => !v.match(/["<>%{}|\\/^`]/g),
+      (v) => !v.match(DISALLOWED_TOPIC_NAMES_REGEX),
       'Name must not contain special characters',
     ),
   community_id: z.string().max(255),

--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -77,11 +77,16 @@ export const generateTopicIdentifiersFromUrl = (url: string) => {
   return generateTopicIdentifiersFromUrlPart(splitURLPath?.[2] || '');
 };
 
+export const sanitizeTopicName = (name: string) => {
+  return name.replaceAll(`?`, '');
+};
+
 export const generateUrlPartForTopicIdentifiers = (
   topicId: string | number | undefined,
   topicName: string,
 ) => {
-  return topicId ? `${topicId}-${topicName}` : `${topicName}`;
+  const _topicName = sanitizeTopicName(topicName);
+  return topicId ? `${topicId}-${_topicName}` : `${_topicName}`;
 };
 
 // WARN: Using process.env to avoid webpack failures

--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -77,6 +77,8 @@ export const generateTopicIdentifiersFromUrl = (url: string) => {
   return generateTopicIdentifiersFromUrlPart(splitURLPath?.[2] || '');
 };
 
+export const DISALLOWED_TOPIC_NAMES_REGEX = /["<>%{}|\\/^`?]/g;
+
 export const sanitizeTopicName = (name: string) => {
   return name.replaceAll(`?`, '');
 };

--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -18,6 +18,7 @@ import {
 } from '../components/component_kit/new_designs/CWModal';
 import { openConfirmation } from './confirmation_modal';
 
+import { DISALLOWED_TOPIC_NAMES_REGEX } from '@hicommonwealth/shared';
 import clsx from 'clsx';
 import { notifySuccess } from 'controllers/app/notifications';
 import { DeltaStatic } from 'quill';
@@ -199,7 +200,9 @@ export const EditTopicModal = ({
           inputValidationFn={(text: string) => {
             let newErrorMsg;
 
-            const disallowedCharMatches = text.match(/["<>%{}|\\/^`]/g);
+            const disallowedCharMatches = text.match(
+              DISALLOWED_TOPIC_NAMES_REGEX,
+            );
             if (disallowedCharMatches) {
               newErrorMsg = `The ${pluralizeWithoutNumberPrefix(
                 disallowedCharMatches.length,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/validation.ts
@@ -7,13 +7,13 @@ export const topicCreationValidationSchema = z.object({
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .min(1, { message: VALIDATION_MESSAGES.NO_INPUT })
     .superRefine((value, ctx) => {
-      const disallowedCharMatches = value.match(/["<>%{}|\\/^`]/g);
+      const disallowedCharMatches = value.match(/["<>%{}|\\/^`?]/g);
 
       if (disallowedCharMatches) {
-        const errMsg = `The ${pluralizeWithoutNumberPrefix(
+        const errMsg = `These ${pluralizeWithoutNumberPrefix(
           disallowedCharMatches.length,
           'char',
-        )} ${disallowedCharMatches.join(', ')} are not permitted`;
+        )} are not permitted: ${disallowedCharMatches.join(', ')}`;
 
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Topics/TopicDetails/CreateTopicsSection/validation.ts
@@ -1,3 +1,4 @@
+import { DISALLOWED_TOPIC_NAMES_REGEX } from '@hicommonwealth/shared';
 import { pluralizeWithoutNumberPrefix } from 'helpers';
 import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
 import z from 'zod';
@@ -7,7 +8,7 @@ export const topicCreationValidationSchema = z.object({
     .string({ invalid_type_error: VALIDATION_MESSAGES.NO_INPUT })
     .min(1, { message: VALIDATION_MESSAGES.NO_INPUT })
     .superRefine((value, ctx) => {
-      const disallowedCharMatches = value.match(/["<>%{}|\\/^`?]/g);
+      const disallowedCharMatches = value.match(DISALLOWED_TOPIC_NAMES_REGEX);
 
       if (disallowedCharMatches) {
         const errMsg = `These ${pluralizeWithoutNumberPrefix(

--- a/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/DiscussionsPage.tsx
@@ -27,6 +27,7 @@ import {
   formatDecimalToWei,
   generateTopicIdentifiersFromUrl,
   generateUrlPartForTopicIdentifiers,
+  sanitizeTopicName,
 } from '@hicommonwealth/shared';
 import { useGetUserEthBalanceQuery } from 'client/scripts/state/api/communityStake';
 import useUserStore from 'client/scripts/state/ui/user';
@@ -127,7 +128,8 @@ const DiscussionsPage = () => {
     window.location.href,
   );
   const topicObj = topics?.find(
-    ({ name }) => name === topicIdentifiersFromURL?.topicName,
+    ({ name }) =>
+      sanitizeTopicName(name) === topicIdentifiersFromURL?.topicName,
   );
   const topicId = topicObj?.id;
 
@@ -227,7 +229,8 @@ const DiscussionsPage = () => {
       }
 
       const validTopic = topics?.find(
-        (topic) => topic?.name === topicIdentifiersFromURL.topicName,
+        (topic) =>
+          sanitizeTopicName(topic?.name) === topicIdentifiersFromURL.topicName,
       );
       if (!validTopic) {
         navigate('/discussions');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12047

## Description of Changes
1. Fixed topic redirects for topics with `?` in name
2. Updated all instances of topic name validations to disallow `?` char

## Test Plan
1. Ensure you can no longer add `?` in topic name by create/update flows
2. Verify that clicking on an existing topic with `?` in name redirects to discussion page for that topic correctly.

## Deployment Plan
N/A

## Other Considerations
N/A