### PR TITLE
Fix bigint serialization error

### DIFF
--- a/libs/model/src/aggregates/token/utils.ts
+++ b/libs/model/src/aggregates/token/utils.ts
@@ -95,6 +95,9 @@ export async function handleCapReached(
         privateKey: config.WEB3.LAUNCHPAD_PRIVATE_KEY!,
       });
 
+      token.liquidity_transferred = true;
+      log.debug(`Liquidity transferred to ${token_address}`);
+
       if (notifyUsers.length > 0) {
         await provider.triggerWorkflow({
           key: WorkflowKeys.LaunchpadCapReached,
@@ -105,13 +108,11 @@ export async function handleCapReached(
           },
         });
       }
-
-      token.liquidity_transferred = true;
-      log.debug(`Liquidity transferred to ${token_address}`);
     }
 
     await models.sequelize.transaction(async (transaction) => {
       if (token.liquidity_transferred) {
+        console.log({ onChainTokenData });
         await emitEvent(
           models.Outbox,
           [
@@ -119,7 +120,6 @@ export async function handleCapReached(
               event_name: 'LaunchpadTokenGraduated',
               event_payload: {
                 token: token.toJSON(),
-                ...onChainTokenData,
               },
             },
           ],

--- a/libs/model/src/aggregates/token/utils.ts
+++ b/libs/model/src/aggregates/token/utils.ts
@@ -112,7 +112,6 @@ export async function handleCapReached(
 
     await models.sequelize.transaction(async (transaction) => {
       if (token.liquidity_transferred) {
-        console.log({ onChainTokenData });
         await emitEvent(
           models.Outbox,
           [

--- a/libs/model/src/policies/EventStream.policy.ts
+++ b/libs/model/src/policies/EventStream.policy.ts
@@ -183,6 +183,10 @@ const eventStreamMappers: EventStreamMappers = {
     };
   },
   LaunchpadTokenTraded: async (payload) => {
+    // TODO: the LaunchpadToken usually hasn't been projected by this point,
+    // so only the transaction data is available. Refactor to use tokenData
+    // and make sure bigint is serialized correctly, then re-enable in policy.
+
     const launchpadToken = await models.LaunchpadToken.findOne({
       where: { token_address: payload.token_address },
     });
@@ -266,9 +270,9 @@ export function EventStreamPolicy(): Policy<{
         );
       },
       LaunchpadTokenTraded: async ({ payload }) => {
-        await pushToEventStream(
-          await eventStreamMappers.LaunchpadTokenTraded(payload),
-        );
+        // await pushToEventStream(
+        //   await eventStreamMappers.LaunchpadTokenTraded(payload),
+        // );
       },
       LaunchpadTokenGraduated: async ({ payload }) => {
         await pushToEventStream(

--- a/libs/model/test/policies/eventStream.policy.spec.ts
+++ b/libs/model/test/policies/eventStream.policy.spec.ts
@@ -366,13 +366,6 @@ describe('EventStream Policy Integration Tests', () => {
             launchpad_liquidity: 1n,
             eth_market_cap_target: 1000,
           },
-          launchpadLiquidity: 1n,
-          poolLiquidity: 1n,
-          curveId: 1n,
-          scalar: 1n,
-          reserveRation: 1n,
-          LPhook: '0x123',
-          funded: true,
         } satisfies z.infer<typeof events.LaunchpadTokenGraduated>),
       },
     ];

--- a/libs/model/test/policies/eventStream.policy.spec.ts
+++ b/libs/model/test/policies/eventStream.policy.spec.ts
@@ -339,20 +339,20 @@ describe('EventStream Policy Integration Tests', () => {
           block_timestamp: 1n,
         } satisfies z.infer<typeof events.LaunchpadTokenCreated>),
       },
-      {
-        event_name: 'LaunchpadTokenTraded',
-        event_payload: serializeBigIntObj({
-          block_timestamp: 1n,
-          transaction_hash: '0x1111111111111111111111111111111111111111',
-          trader_address: '0x1111111111111111111111111111111111111111',
-          token_address: '0x7777777777777777777777777777777777777777',
-          is_buy: true,
-          eth_chain_id: 1,
-          eth_amount: 1n,
-          community_token_amount: 1n,
-          floating_supply: 1n,
-        } satisfies z.infer<typeof events.LaunchpadTokenTraded>),
-      },
+      // {
+      //   event_name: 'LaunchpadTokenTraded',
+      //   event_payload: serializeBigIntObj({
+      //     block_timestamp: 1n,
+      //     transaction_hash: '0x1111111111111111111111111111111111111111',
+      //     trader_address: '0x1111111111111111111111111111111111111111',
+      //     token_address: '0x7777777777777777777777777777777777777777',
+      //     is_buy: true,
+      //     eth_chain_id: 1,
+      //     eth_amount: 1n,
+      //     community_token_amount: 1n,
+      //     floating_supply: 1n,
+      //   } satisfies z.infer<typeof events.LaunchpadTokenTraded>),
+      // },
       {
         event_name: 'LaunchpadTokenGraduated',
         event_payload: serializeBigIntObj({
@@ -379,7 +379,7 @@ describe('EventStream Policy Integration Tests', () => {
       'CommunityCreated',
       'ThreadCreated',
       'LaunchpadTokenCreated',
-      'LaunchpadTokenTraded',
+      // 'LaunchpadTokenTraded',
       'LaunchpadTokenGraduated',
     ] satisfies Events[];
 

--- a/libs/schemas/src/events/events.schemas.ts
+++ b/libs/schemas/src/events/events.schemas.ts
@@ -400,14 +400,7 @@ export const events = {
   }),
 
   LaunchpadTokenGraduated: z.object({
-    token: LaunchpadToken.extend({}),
-    launchpadLiquidity: z.coerce.bigint(),
-    poolLiquidity: z.coerce.bigint(),
-    curveId: z.coerce.bigint(),
-    scalar: z.coerce.bigint(),
-    reserveRation: z.coerce.bigint(),
-    LPhook: z.string(),
-    funded: z.boolean(),
+    token: LaunchpadToken,
   }),
 
   LaunchpadTokenTraded: z.object({

--- a/libs/schemas/src/utils.ts
+++ b/libs/schemas/src/utils.ts
@@ -33,7 +33,7 @@ export const DiscordMetaSchema = z.object({
 
 export const PG_INT = z.number().int().min(MIN_SCHEMA_INT).max(MAX_SCHEMA_INT);
 
-export const PG_ETH = z.bigint().min(MIN_SCHEMA_ETH).max(MAX_SCHEMA_ETH);
+export const PG_ETH = z.coerce.bigint().min(MIN_SCHEMA_ETH).max(MAX_SCHEMA_ETH);
 
 export const zBoolean = z.preprocess((v) => v && v !== 'false', z.boolean());
 

--- a/libs/schemas/src/utils.ts
+++ b/libs/schemas/src/utils.ts
@@ -33,7 +33,7 @@ export const DiscordMetaSchema = z.object({
 
 export const PG_INT = z.number().int().min(MIN_SCHEMA_INT).max(MAX_SCHEMA_INT);
 
-export const PG_ETH = z.coerce.bigint().min(MIN_SCHEMA_ETH).max(MAX_SCHEMA_ETH);
+export const PG_ETH = z.bigint().min(MIN_SCHEMA_ETH).max(MAX_SCHEMA_ETH);
 
 export const zBoolean = z.preprocess((v) => v && v !== 'false', z.boolean());
 


### PR DESCRIPTION
There was some additional metadata added to the `LaunchpadTokenGraduated` event which failed to serialize the bigint values. The data isn't strictly necessary, so it was removed. Also, a failing EventStream handler was so it doesn't spam the logs.

Test Plan:
- Launch a token
- Buy it to marketcap threshold to trigger graduation
- There should be no errors