### PR TITLE
Fix addressSwapper prefix handling

### DIFF
--- a/libs/shared/src/utils.ts
+++ b/libs/shared/src/utils.ts
@@ -189,11 +189,12 @@ export async function getFileSizeBytes(url: string): Promise<number> {
 
 export const addressSwapper = (options: {
   address: string;
-  currentPrefix: number;
+  currentPrefix: number | undefined | null;
 }): string => {
   if (!options.address) throw new Error('No address provided to swap');
 
-  if (!options.currentPrefix) return options.address;
+  if (options.currentPrefix === undefined || options.currentPrefix === null)
+    return options.address;
 
   if (isU8a(options.address) || isHex(options.address)) {
     throw new Error('address not in SS58 format');

--- a/packages/commonwealth/shared/utils.ts
+++ b/packages/commonwealth/shared/utils.ts
@@ -82,11 +82,12 @@ export function formatAddressShort(
 
 export const addressSwapper = (options: {
   address: string;
-  currentPrefix: number;
+  currentPrefix: number | undefined | null;
 }): string => {
   if (!options.address) throw new Error('No address provided to swap');
 
-  if (!options.currentPrefix) return options.address;
+  if (options.currentPrefix === undefined || options.currentPrefix === null)
+    return options.address;
 
   if (isU8a(options.address) || isHex(options.address)) {
     throw new Error('address not in SS58 format');


### PR DESCRIPTION
## Summary
- fix check for SS58 prefix in `addressSwapper`

## Testing
- `npx tsc -p libs/shared/tsconfig.json` *(fails: cannot find module '@canvas-js/core' et al.)*