### PR TITLE
Fix sticky editor issues

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.scss
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.scss
@@ -115,7 +115,7 @@
       .CWEditor {
         .ql-container {
           min-height: unset !important;
-          max-height: 76px !important;
+          max-height: 152px !important;
         }
       }
     }
@@ -126,6 +126,14 @@
       border-radius: 0;
       display: flex;
       flex-direction: column;
+    }
+
+    &.not-expanded.thread-mode {
+      .CWEditor {
+        .ql-container {
+          max-height: unset !important;
+        }
+      }
     }
 
     .MobileStickyInputFocused {

--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
@@ -32,9 +32,7 @@ import {
 import {
   createDeltaFromText,
   ReactQuillEditor,
-  getTextFromDelta,
 } from 'views/components/react_quill_editor';
-import { countLinesQuill } from 'views/components/react_quill_editor/utils';
 import { useTurnstile } from 'views/components/useTurnstile';
 import { listenForComment } from 'views/pages/discussions/CommentTree/helpers';
 import { StickCommentContext } from '../context/StickCommentProvider';
@@ -277,16 +275,6 @@ const StickyInput = (props: StickyInputProps) => {
     }
   }, [isExpanded, openModalOnExpand, mode]);
 
-  useEffect(() => {
-    if (isExpanded) return;
-
-    const lines = countLinesQuill(contentDelta);
-
-    if (lines >= 5) {
-      setIsExpanded(true);
-    }
-  }, [contentDelta, isExpanded, setIsExpanded]);
-
   // Add toggle handler for the AI auto reply feature
   const handleToggleAiAutoReply = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -381,7 +369,7 @@ const StickyInput = (props: StickyInputProps) => {
 
     const inputContent = (
       <div
-        className={`StickyInput ${isExpanded ? 'expanded' : 'not-expanded'} ${isMobile ? 'mobile' : 'desktop'}`}
+        className={`StickyInput ${isExpanded ? 'expanded' : 'not-expanded'} ${isMobile ? 'mobile' : 'desktop'} ${mode === 'thread' ? 'thread-mode' : ''}`}
         ref={containerRef}
         style={isMobile && menuVisible ? { zIndex: -1 } : undefined}
       >


### PR DESCRIPTION
## Summary
- prevent sticky editor from submitting on Shift+Enter
- ~~auto-expand to modal when content exceeds five lines (problematic behavior around clearing content, removed)~~
- disable sticky editor controls when commenting is not allowed
- add spacing above sticky editor to avoid overlap

https://www.loom.com/share/25833c31c951423ba8b77b3937471bab

## Testing
- `npx eslint packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx` *(fails: ESLint couldn't find configuration)*