### PR TITLE
Got rid of rerenders 

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
@@ -6,7 +6,7 @@ import { useFlag } from 'hooks/useFlag';
 import AddressInfo from 'models/AddressInfo';
 import NewProfile from 'models/NewProfile';
 import { useCommonNavigate } from 'navigation/helpers';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useFetchProfileByIdQuery } from 'state/api/profiles';
 import useUserStore, { useLocalAISettingsStore } from 'state/ui/user';
 import useUserOnboardingSliderMutationStore from 'state/ui/userTrainingCards';
@@ -91,6 +91,13 @@ const EditProfile = () => {
   } = useFetchProfileByIdQuery({
     apiCallEnabled: user.isLoggedIn,
   });
+
+  const handleImageProcessingChange = useCallback(
+    ({ isGenerating, isUploading }: ImageProcessingProps) => {
+      setIsUploadingCoverImage(isGenerating || isUploading);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (isLoadingProfile) return;
@@ -375,9 +382,7 @@ const EditProfile = () => {
                 hookToForm
                 withAIImageGeneration
                 imageBehavior={imageBehavior}
-                onImageProcessingChange={({ isGenerating, isUploading }) =>
-                  setIsUploadingCoverImage(isGenerating || isUploading)
-                }
+                onImageProcessingChange={handleImageProcessingChange}
                 onImageUploaded={console.log}
                 onImageBehaviorChange={setImageBehavior}
                 allowedImageBehaviours={['Fill', 'Tiled']}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -3,7 +3,7 @@ import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import Group from 'models/Group';
 import { useCommonNavigate } from 'navigation/helpers';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import app from 'state';
 import { useEditGroupMutation, useFetchGroupsQuery } from 'state/api/groups';
 import useUserStore from 'state/ui/user';
@@ -55,12 +55,6 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
   );
 
   const { isAddedToHomeScreen } = useAppStatus();
-
-  useEffect(() => {
-    if (initialAllowlist) {
-      setAllowedAddresses(initialAllowlist);
-    }
-  }, [initialAllowlist]);
 
   useBrowserAnalyticsTrack({
     payload: {

--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/GroupForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/common/GroupForm/GroupForm.tsx
@@ -7,7 +7,7 @@ import {
 import { weightedVotingValueToLabel } from 'helpers';
 import { isValidEthAddress } from 'helpers/validateTypes';
 import { useCommonNavigate } from 'navigation/helpers';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import app from 'state';
 import { useFetchGroupsQuery } from 'state/api/groups';
 import { useFetchTopicsQuery } from 'state/api/topics';
@@ -181,6 +181,13 @@ const GroupForm = ({
   ] = useState<TopicPermissionToggleGroupSubFormsState[]>([]);
   const [isProcessingProfileImage, setIsProcessingProfileImage] =
     useState(false);
+
+  const handleImageProcessingChange = useCallback(
+    ({ isGenerating, isUploading }) => {
+      setIsProcessingProfileImage(isGenerating || isUploading);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (initialValues.requirements) {
@@ -501,9 +508,7 @@ const GroupForm = ({
 
               <CWImageInput
                 label="Group Image (Accepts JPG and PNG files)"
-                onImageProcessingChange={({ isGenerating, isUploading }) => {
-                  setIsProcessingProfileImage(isGenerating || isUploading);
-                }}
+                onImageProcessingChange={handleImageProcessingChange}
                 name="groupImageUrl"
                 hookToForm
                 imageBehavior={ImageBehavior.Circle}

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/CommunityProfile/CommunityProfileForm/CommunityProfileForm.tsx
@@ -129,6 +129,13 @@ const CommunityProfileForm = () => {
     community?.id?.toLowerCase() || '',
   );
 
+  const handleImageProcessingChange = useCallback(
+    ({ isGenerating, isUploading }) => {
+      setIsProcessingProfileImage(isGenerating || isUploading);
+    },
+    [],
+  );
+
   const onSubmit = async (values: FormSubmitValues) => {
     if (
       !community?.id ||
@@ -295,9 +302,7 @@ const CommunityProfileForm = () => {
               name="communityProfileImageURL"
               canSelectImageBehavior={false}
               imageBehavior={ImageBehavior.Circle}
-              onImageProcessingChange={({ isGenerating, isUploading }) =>
-                setIsProcessingProfileImage(isGenerating || isUploading)
-              }
+              onImageProcessingChange={handleImageProcessingChange}
               label="Community Profile Image (Accepts JPG and PNG files)"
             />
           </section>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12173
Closes: #12194

## Description of Changes

**1. Refactored image processing state handling:**  
- Replaced inline functions with `useCallback` handlers for `onImageProcessingChange` in `EditProfile.tsx`, `GroupForm.tsx`, and `CommunityProfileForm.tsx`.  
- This improves code clarity and may reduce unnecessary re-renders.

**2. Removed redundant useEffect:**  
- Deleted an unnecessary `useEffect` in `UpdateCommunityGroupPage.tsx` that set state from `initialAllowlist`.





## Test Plan
- goto group edit page
- go to edit profile page
- make sure pages work well and there are no rerenders

## Deployment Plan
<!--- Omit if unneeded -->
n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- n/a