### PR TITLE
Fix buy stake eth chain ID

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/buyStake.ts
@@ -28,7 +28,7 @@ const buyStake = async ({
     commonProtocol.factoryContracts[ethChainId].communityStake,
     commonProtocol.factoryContracts[ethChainId].factory,
     chainRpc,
-    chainId,
+    `${ethChainId}`,
   );
 
   return await communityStakes.buyStake(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12221 

## Description of Changes
Fix buy stake modal to use correct chain

## Test Plan
- Create community on sepolia
- Enable stake
- Attempt to buy stake, should use sepolia ETH

## Deployment Plan
N/A

## Other Considerations
N/A