### PR TITLE
Enable all contest routes in external API

### DIFF
--- a/packages/commonwealth/server/api/external-router.ts
+++ b/packages/commonwealth/server/api/external-router.ts
@@ -61,8 +61,16 @@ const {
   toggleCommentSpam,
 } = comment.trpcRouter;
 const { getNewContent } = user.trpcRouter;
-const { createContestMetadata, updateContestMetadata, cancelContestMetadata } =
-  contest.trpcRouter;
+const {
+  createContestMetadata,
+  updateContestMetadata,
+  cancelContestMetadata,
+  deleteContestMetadata,
+  getContestLog,
+  getFarcasterCasts,
+  farcasterWebhook,
+  getJudgeStatus,
+} = contest.trpcRouter;
 const { createToken, createTrade, getLaunchpadTrades, getTokenInfoAlchemy } =
   launchpad.trpcRouter;
 const { launchTokenBot } = bot.trpcRouter;
@@ -109,6 +117,11 @@ const api = {
   createContestMetadata,
   updateContestMetadata,
   cancelContestMetadata,
+  deleteContestMetadata,
+  getContestLog,
+  getFarcasterCasts,
+  farcasterWebhook,
+  getJudgeStatus,
   createCommunity,
   updateCommunity,
   createTopic,


### PR DESCRIPTION
## Summary
- expose every contest route in the external API router

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/...)*