### PR TITLE
Added "not-found" fallback in pages without error handling cases

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Update/UpdateCommunityGroupPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Groups/Update/UpdateCommunityGroupPage.tsx
@@ -65,7 +65,8 @@ const UpdateCommunityGroupPage = ({ groupId }: { groupId: string }) => {
 
   if (
     !user.isLoggedIn ||
-    !(Permissions.isCommunityAdmin() || Permissions.isSiteAdmin())
+    !(Permissions.isCommunityAdmin() || Permissions.isSiteAdmin()) ||
+    (!foundGroup && !isLoading)
   ) {
     return <PageNotFound />;
   }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityManagement/Integrations/Snapshots/validation.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-const snapshotNameSchema = z
+export const snapshotNameSchema = z
   .string()
   .regex(/^[a-zA-Z0-9-.]+\.((xyz)|(eth)|(io))$/, {
     message: 'Snapshot must be valid, and end in *.eth, *.xyz, or *.io',
@@ -20,4 +20,13 @@ const snapshotValidationSchema = z.union([
   snapshotLinkSchema,
 ]);
 
-export { snapshotValidationSchema };
+const isValidSnapshotName = (snapshotName: string) => {
+  try {
+    snapshotNameSchema.parse(snapshotName.trim());
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export { isValidSnapshotName, snapshotValidationSchema };

--- a/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/NewProposalViewPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/NewProposalViewPage.tsx
@@ -65,7 +65,7 @@ const NewProposalViewPage = ({ identifier, scope }: ViewProposalPageProps) => {
     isLoading,
     error: cosmosError,
     threads: cosmosThreads,
-  } = useCosmosProposal({ proposalId });
+  } = useCosmosProposal({ proposalId, enabled: queryType === 'cosmos' });
 
   const {
     proposal: snapshotProposal,
@@ -80,10 +80,11 @@ const NewProposalViewPage = ({ identifier, scope }: ViewProposalPageProps) => {
     loadVotes,
     power,
     threads,
+    error: snapshotProposalError,
   } = useSnapshotProposal({
     identifier: proposalId,
     snapshotId: querySnapshotId!,
-    enabled: queryType === 'cosmos' ? false : true,
+    enabled: queryType !== 'cosmos',
   });
   const snapShotVotingResult = React.useMemo(() => {
     if (!snapshotProposal || !votes) return [];
@@ -139,7 +140,11 @@ const NewProposalViewPage = ({ identifier, scope }: ViewProposalPageProps) => {
     return <LoadingIndicator message="Loading..." />;
   }
 
-  if (cosmosError) {
+  if (
+    (queryType === 'cosmos' && (cosmosError || !(proposal && isLoading))) ||
+    (queryType !== 'cosmos' &&
+      (snapshotProposalError || !(snapshotProposal && isSnapshotLoading)))
+  ) {
     return (
       <PageNotFound
         message={"We couldn't find what you searched for. Try searching again."}

--- a/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/useSnapshotProposal.ts
+++ b/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/useSnapshotProposal.ts
@@ -37,17 +37,23 @@ export const useSnapshotProposal = ({
   const [isLoading, setIsLoading] = useState(true);
 
   const user = useUserStore();
-  const { data: spaceData, isLoading: isSpaceLoading } =
-    useGetSnapshotSpaceQuery({
-      space: snapshotId,
-      enabled: enabled,
-    });
+  const {
+    data: spaceData,
+    isLoading: isSpaceLoading,
+    error: spaceDataError,
+  } = useGetSnapshotSpaceQuery({
+    space: snapshotId,
+    enabled: enabled,
+  });
 
-  const { data: proposalsData, isLoading: isProposalsLoading } =
-    useGetSnapshotProposalsQuery({
-      space: snapshotId,
-      enabled: enabled,
-    });
+  const {
+    data: proposalsData,
+    isLoading: isProposalsLoading,
+    error: proposalLoadingError,
+  } = useGetSnapshotProposalsQuery({
+    space: snapshotId,
+    enabled: enabled,
+  });
 
   const {
     data: threadsData,
@@ -165,6 +171,11 @@ export const useSnapshotProposal = ({
     totals,
     proposalAuthor,
     activeUserAddress,
+    error:
+      proposalLoadingError ||
+      spaceDataError ||
+      proposalLoadingError ||
+      threadsError,
     loadVotes: () => loadVotes(identifier),
   };
 };

--- a/packages/commonwealth/client/scripts/views/pages/Snapshots/NewSnapshotProposal/NewSnapshotProposal.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Snapshots/NewSnapshotProposal/NewSnapshotProposal.tsx
@@ -6,6 +6,8 @@ import CWPageLayout from 'views/components/component_kit/new_designs/CWPageLayou
 import NewSnapshotProposalForm from './NewSnapshotProposalForm';
 import SnapshotSpaceSelectorModal from './SnapshotSpaceSelectorModal';
 
+import { PageNotFound } from '../../404';
+import { isValidSnapshotName } from '../../CommunityManagement/Integrations/Snapshots/validation';
 import './NewSnapshotProposal.scss';
 
 type NewSnapshotProposalProps = {
@@ -15,6 +17,8 @@ type NewSnapshotProposalProps = {
 export const NewSnapshotProposal = ({
   snapshotId,
 }: NewSnapshotProposalProps) => {
+  const isValidSnapshot = isValidSnapshotName(snapshotId);
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [snapshotSpace, setSnapshotSpace] = useState('');
 
@@ -33,6 +37,10 @@ export const NewSnapshotProposal = ({
     setSnapshotSpace(space);
     setIsModalOpen(false);
   };
+
+  if (!isValidSnapshot) {
+    return <PageNotFound />;
+  }
 
   return (
     <CWPageLayout>

--- a/packages/commonwealth/client/scripts/views/pages/Snapshots/SnapshotProposals/SnapshotProposals.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Snapshots/SnapshotProposals/SnapshotProposals.tsx
@@ -14,6 +14,8 @@ import { SnapshotProposalCard } from './SnapshotProposalCard';
 
 import { SnapshotProposal } from 'helpers/snapshot_utils';
 import { useGetSnapshotProposalsQuery } from 'state/api/snapshots';
+import { PageNotFound } from '../../404';
+import { isValidSnapshotName } from '../../CommunityManagement/Integrations/Snapshots/validation';
 import './SnapshotProposals.scss';
 
 type SnapshotProposalsProps = {
@@ -22,6 +24,7 @@ type SnapshotProposalsProps = {
 };
 
 const SnapshotProposals = ({ snapshotId }: SnapshotProposalsProps) => {
+  const isValidSnapshot = isValidSnapshotName(snapshotId);
   const [activeTab, setActiveTab] = useState<number>(1);
 
   const { data: snapshotProposals, isLoading: isSnapshotProposalsLoading } =
@@ -45,6 +48,10 @@ const SnapshotProposals = ({ snapshotId }: SnapshotProposalsProps) => {
     activeTab === 1 ? getActiveProposals() : getEndedProposals();
 
   useManageDocumentTitle('Snapshots');
+
+  if (!isValidSnapshot) {
+    return <PageNotFound />;
+  }
 
   return (
     <CWPageLayout>

--- a/packages/commonwealth/client/scripts/views/pages/UnSubscribePage/UnSubscribePage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/UnSubscribePage/UnSubscribePage.tsx
@@ -4,8 +4,14 @@ import { useUnSubscribeEmailMutation } from 'state/api/trpc/subscription/useUnSu
 import { CWModal } from '../../components/component_kit/new_designs/CWModal';
 import CWPageLayout from '../../components/component_kit/new_designs/CWPageLayout';
 import UnSubscribeModal from '../../modals/UnSubscribeModal/UnSubscribeModal';
+import { PageNotFound } from '../404';
 
-const UnSubscribePage = () => {
+type UnSubscribePageProps = {
+  userId: string;
+};
+
+const UnSubscribePage = ({ userId }: UnSubscribePageProps) => {
+  const _userId = parseInt(`${userId || 0}`);
   const { mutateAsync: unSubscribeEmail } = useUnSubscribeEmailMutation();
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -14,12 +20,11 @@ const UnSubscribePage = () => {
     setModalOpen(false);
     navigate('/dashboard');
   };
-  const userId = window.location.pathname.split('/').at(-1);
 
   const handleUnsubscribe = async () => {
-    if (userId) {
+    if (_userId) {
       await unSubscribeEmail({
-        user_uuid: userId,
+        user_uuid: String(_userId),
         email_notifications_enabled: false,
       }).catch(console.error);
       navigate('/dashboard');
@@ -33,10 +38,14 @@ const UnSubscribePage = () => {
   };
 
   useEffect(() => {
-    if (userId) {
+    if (_userId) {
       setModalOpen(true);
     }
-  }, [userId]);
+  }, [_userId]);
+
+  if (!_userId) {
+    return <PageNotFound />;
+  }
 
   return (
     <CWPageLayout>

--- a/packages/commonwealth/client/scripts/views/pages/new_profile.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/new_profile.tsx
@@ -3,8 +3,15 @@ import React from 'react';
 import './new_profile.scss';
 
 import Profile from '../components/Profile';
+import { PageNotFound } from './404';
 
 const NewProfile = ({ userId }: { userId: number }) => {
+  const _userId = parseInt(`${userId || 0}`);
+
+  if (!_userId) {
+    return <PageNotFound />;
+  }
+
   return <Profile userId={+userId} />;
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/snapshot_proposal_link_redirect.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/snapshot_proposal_link_redirect.tsx
@@ -1,8 +1,9 @@
 import useNecessaryEffect from 'hooks/useNecessaryEffect';
 import { useCommonNavigate } from 'navigation/helpers';
-import React from 'react';
+import React, { useState } from 'react';
 import { getSnapshotProposalQuery } from 'state/api/snapshots';
 import { LoadingIndicator } from '../components/LoadingIndicator/LoadingIndicator';
+import { PageNotFound } from './404';
 
 type SnapshotProposalLinkRedirectProps = {
   identifier: string;
@@ -13,6 +14,7 @@ const SnapshotProposalLinkRedirect = ({
   identifier,
 }: SnapshotProposalLinkRedirectProps) => {
   const navigate = useCommonNavigate();
+  const [notFound, setNotFound] = useState(false);
 
   useNecessaryEffect(() => {
     const fetchSnapshotData = async () => {
@@ -33,13 +35,16 @@ const SnapshotProposalLinkRedirect = ({
         // 3. redirect
         navigate(`/proposal/${newLink.identifier}`, { replace: true });
       } catch (e) {
-        // TODO: show error page
-        throw new Error('could not find entity');
+        setNotFound(true);
       }
     };
 
     fetchSnapshotData();
   }, [navigate]);
+
+  if (notFound) {
+    return <PageNotFound />;
+  }
 
   return <LoadingIndicator />;
 };

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ViewThreadPage.tsx
@@ -106,7 +106,7 @@ type VoterProfileData = {
 };
 
 const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
-  const threadId = identifier.split('-')[0];
+  const threadId = parseInt(`${identifier.split('-')?.[0] || 0}`);
   const [searchParams] = useSearchParams();
   const isEdit = searchParams.get('isEdit') ?? undefined;
   const navigate = useCommonNavigate();
@@ -142,7 +142,7 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
   const { isAddedToHomeScreen } = useAppStatus();
 
   const communityId = app.activeChainId() || '';
-  const { data: groups = [] } = useFetchGroupsQuery({
+  useFetchGroupsQuery({
     communityId,
     includeTopics: true,
     enabled: !!communityId,
@@ -309,13 +309,12 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
 
   const { mutateAsync: addThreadLinks } = useAddThreadLinksMutation();
 
-  const { actionGroups, bypassGating, memberships, isTopicGated } =
-    useTopicGating({
-      communityId,
-      apiEnabled: !!user?.activeAccount?.address && !!communityId,
-      userAddress: user?.activeAccount?.address || '',
-      topicId: thread?.topic?.id || 0,
-    });
+  const { actionGroups, bypassGating, isTopicGated } = useTopicGating({
+    communityId,
+    apiEnabled: !!user?.activeAccount?.address && !!communityId,
+    userAddress: user?.activeAccount?.address || '',
+    topicId: thread?.topic?.id || 0,
+  });
 
   const { isWindowLarge } = useBrowserWindow({
     onResize: () =>
@@ -414,7 +413,11 @@ const ViewThreadPage = ({ identifier }: ViewThreadPageProps) => {
     }
   }, [fetchedProfiles]);
 
-  if (typeof identifier !== 'string') {
+  if (
+    typeof identifier !== 'string' ||
+    !(threadId && isLoading) ||
+    fetchThreadError
+  ) {
     return <PageNotFound />;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12196

## Description of Changes
Added "not-found" fallback in pages without error handling cases

## Test Plan
Visit all these links with an invalid dynamic param and verify you see a not-found page

1.`/unSubscribe/:userId`
2. `/:scope/members/groups/:groupId/update`
3. `/:scope/proposal-details/:identifier`
4. `/:scope/discussion/:identifier`
5. `/:scope/new/snapshot/:snapshotId`
6. `/:scope/snapshot/:snapshotId`
7. `/:scope/link/snapshot-proposal/:identifier`
8. `/profile/id/:userId`

## Deployment Plan
N/A

## Other Considerations
N/A