### PR TITLE
Enable all contest routes in external API

### DIFF
--- a/packages/commonwealth/server/api/contest.ts
+++ b/packages/commonwealth/server/api/contest.ts
@@ -24,9 +24,5 @@ export const trpcRouter = trpc.router({
     Contest.GetFarcasterContestCasts,
     trpc.Tag.Community,
   ),
-  farcasterWebhook: trpc.command(
-    Contest.FarcasterCastWebhook,
-    trpc.Tag.Integration,
-  ),
   getJudgeStatus: trpc.query(Contest.GetJudgeStatus, trpc.Tag.Community),
 });

--- a/packages/commonwealth/server/api/external-router.ts
+++ b/packages/commonwealth/server/api/external-router.ts
@@ -66,7 +66,6 @@ const {
   updateContestMetadata,
   cancelContestMetadata,
   deleteContestMetadata,
-  farcasterWebhook,
 } = contest.trpcRouter;
 const { createToken, createTrade, getLaunchpadTrades, getTokenInfoAlchemy } =
   launchpad.trpcRouter;
@@ -118,12 +117,6 @@ const api = {
   getContestLog: trpc.query(Contest.GetContestLog, trpc.Tag.Contest, {
     forceSecure: true,
   }),
-  getFarcasterCasts: trpc.query(
-    Contest.GetFarcasterContestCasts,
-    trpc.Tag.Contest,
-    { forceSecure: true },
-  ),
-  farcasterWebhook,
   getJudgeStatus: trpc.query(Contest.GetJudgeStatus, trpc.Tag.Contest, {
     forceSecure: true,
   }),

--- a/packages/commonwealth/server/api/external-router.ts
+++ b/packages/commonwealth/server/api/external-router.ts
@@ -61,8 +61,13 @@ const {
   toggleCommentSpam,
 } = comment.trpcRouter;
 const { getNewContent } = user.trpcRouter;
-const { createContestMetadata, updateContestMetadata, cancelContestMetadata } =
-  contest.trpcRouter;
+const {
+  createContestMetadata,
+  updateContestMetadata,
+  cancelContestMetadata,
+  deleteContestMetadata,
+  farcasterWebhook,
+} = contest.trpcRouter;
 const { createToken, createTrade, getLaunchpadTrades, getTokenInfoAlchemy } =
   launchpad.trpcRouter;
 const { launchTokenBot } = bot.trpcRouter;
@@ -109,6 +114,19 @@ const api = {
   createContestMetadata,
   updateContestMetadata,
   cancelContestMetadata,
+  deleteContestMetadata,
+  getContestLog: trpc.query(Contest.GetContestLog, trpc.Tag.Contest, {
+    forceSecure: true,
+  }),
+  getFarcasterCasts: trpc.query(
+    Contest.GetFarcasterContestCasts,
+    trpc.Tag.Contest,
+    { forceSecure: true },
+  ),
+  farcasterWebhook,
+  getJudgeStatus: trpc.query(Contest.GetJudgeStatus, trpc.Tag.Contest, {
+    forceSecure: true,
+  }),
   createCommunity,
   updateCommunity,
   createTopic,

--- a/packages/commonwealth/server/api/external-router.ts
+++ b/packages/commonwealth/server/api/external-router.ts
@@ -114,12 +114,6 @@ const api = {
   updateContestMetadata,
   cancelContestMetadata,
   deleteContestMetadata,
-  getContestLog: trpc.query(Contest.GetContestLog, trpc.Tag.Contest, {
-    forceSecure: true,
-  }),
-  getJudgeStatus: trpc.query(Contest.GetJudgeStatus, trpc.Tag.Contest, {
-    forceSecure: true,
-  }),
   createCommunity,
   updateCommunity,
   createTopic,


### PR DESCRIPTION
## Summary
- expose every contest route in the external API router
- mark contest queries as secured

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*