### PR TITLE
Fix event stream race condition

### DIFF
--- a/libs/model/src/policies/EventStream.policy.ts
+++ b/libs/model/src/policies/EventStream.policy.ts
@@ -266,9 +266,9 @@ export function EventStreamPolicy(): Policy<{
         );
       },
       LaunchpadTokenCreated: async ({ payload }) => {
-        await pushToEventStream(
-          await eventStreamMappers.LaunchpadTokenCreated(payload),
-        );
+        // await pushToEventStream(
+        //   await eventStreamMappers.LaunchpadTokenCreated(payload),
+        // );
       },
       LaunchpadTokenTraded: async ({ payload }) => {
         // await pushToEventStream(

--- a/libs/model/test/policies/eventStream.policy.spec.ts
+++ b/libs/model/test/policies/eventStream.policy.spec.ts
@@ -331,14 +331,14 @@ describe('EventStream Policy Integration Tests', () => {
           topic_id: 1,
         } satisfies z.infer<typeof events.ThreadCreated>,
       },
-      {
-        event_name: 'LaunchpadTokenCreated',
-        event_payload: serializeBigIntObj({
-          transaction_hash: '0x7777777777777777777777777777777777777777',
-          eth_chain_id: 1,
-          block_timestamp: 1n,
-        } satisfies z.infer<typeof events.LaunchpadTokenCreated>),
-      },
+      // {
+      //   event_name: 'LaunchpadTokenCreated',
+      //   event_payload: serializeBigIntObj({
+      //     transaction_hash: '0x7777777777777777777777777777777777777777',
+      //     eth_chain_id: 1,
+      //     block_timestamp: 1n,
+      //   } satisfies z.infer<typeof events.LaunchpadTokenCreated>),
+      // },
       // {
       //   event_name: 'LaunchpadTokenTraded',
       //   event_payload: serializeBigIntObj({
@@ -378,7 +378,7 @@ describe('EventStream Policy Integration Tests', () => {
       'ContestEnding',
       'CommunityCreated',
       'ThreadCreated',
-      'LaunchpadTokenCreated',
+      // 'LaunchpadTokenCreated',
       // 'LaunchpadTokenTraded',
       'LaunchpadTokenGraduated',
     ] satisfies Events[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12246

## Description of Changes
Disables `LaunchpadTokenCreated` event in EventStream policy because there's a race condition where the LaunchpadToken entity doesn't get projected in time. Since we don't use the data yet, there's no benefit to a spending more time on a full solution.

## Test Plan
- Logic is commented out, no need to test

## Deployment Plan
N/A

## Other Considerations
N/A