### PR TITLE
Launchpad Trades To Include User Data

### DIFF
--- a/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
+++ b/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
@@ -30,19 +30,29 @@ export function GetLaunchpadTrades(): Query<typeof schemas.GetLaunchpadTrades> {
 
       const trades = await models.sequelize.query(
         `
+          WITH addresses AS (
+            SELECT DISTINCT ON (address) *
+            FROM "Addresses"
+            ORDER BY address, id DESC
+          )
           SELECT 
             trades.*,
             tokens.name,
             tokens.symbol,
             c.id as community_id,
-            c.icon_url as community_icon_url
+            c.icon_url as community_icon_url,
+            u.id as user_id,
+            u.profile->>'name' as user_name
           FROM 
             "LaunchpadTrades" trades
           LEFT JOIN 
             "LaunchpadTokens" tokens ON trades.token_address = tokens.token_address
           LEFT JOIN 
             "Communities" c ON c.namespace = tokens.namespace
-          
+          LEFT JOIN
+            addresses a ON a.address = trades.trader_address
+          LEFT JOIN
+            "Users" u ON u.id = a.user_id
           ${whereClauseCondition}
         `,
         {

--- a/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
+++ b/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
@@ -42,7 +42,8 @@ export function GetLaunchpadTrades(): Query<typeof schemas.GetLaunchpadTrades> {
             c.id as community_id,
             c.icon_url as community_icon_url,
             u.id as user_id,
-            u.profile->>'name' as user_name
+            u.profile->>'name' as user_name,
+            u.profile->>'avatar_url' as user_avatar_url
           FROM 
             "LaunchpadTrades" trades
           LEFT JOIN 

--- a/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
+++ b/libs/model/src/aggregates/token/GetLaunchpadTrades.query.ts
@@ -46,7 +46,7 @@ export function GetLaunchpadTrades(): Query<typeof schemas.GetLaunchpadTrades> {
           LEFT JOIN 
             "Communities" c ON c.namespace = tokens.namespace
           LEFT JOIN LATERAL (
-            SELECT DISTINCT ON (address) address, user_id
+            SELECT DISTINCT ON (address) user_id
             FROM "Addresses"
             WHERE address = trades.trader_address
             ORDER BY address, id

--- a/libs/schemas/src/commands/token.schemas.ts
+++ b/libs/schemas/src/commands/token.schemas.ts
@@ -43,6 +43,8 @@ export const GetLaunchpadTrades = {
     symbol: z.string(),
     community_id: z.string(),
     community_icon_url: z.string(),
+    user_id: z.string(),
+    user_name: z.string(),
   }).array(),
 };
 

--- a/libs/schemas/src/commands/token.schemas.ts
+++ b/libs/schemas/src/commands/token.schemas.ts
@@ -43,8 +43,9 @@ export const GetLaunchpadTrades = {
     symbol: z.string(),
     community_id: z.string(),
     community_icon_url: z.string(),
-    user_id: z.string(),
-    user_name: z.string(),
+    user_id: z.number().nullish(),
+    user_name: z.string().nullish(),
+    user_avatar_url: z.string().nullish(),
   }).array(),
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12278


## Description of Changes
- It Extends the `GetLaunchpadTrades` query to include user data by joining the `LaunchpadTrades` table with `Users` through the `Addresses` table, extracting the `user_id` , `user_name` and `avatar_url` from their profile JSON, and making these user fields optional to handle cases where a trader's address isn't associated with any user.

## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 