### PR TITLE
Fix base chain node retrieval

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/useCreateTokenCommunity.ts
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/useCreateTokenCommunity.ts
@@ -1,17 +1,24 @@
 import AddressInfo from 'models/AddressInfo';
 import NodeInfo from 'models/NodeInfo';
-import { useState } from 'react';
-import { fetchCachedNodes } from 'state/api/nodes';
+import { useEffect, useState } from 'react';
+import { fetchNodes } from 'state/api/nodes';
 
 const useCreateTokenCommunity = () => {
-  // get base chain node info
-  const nodes = fetchCachedNodes();
-  const baseNode = nodes?.find(
-    (n) => n.ethChainId === parseInt(process.env.LAUNCHPAD_CHAIN_ID || '8453'),
-  ) as NodeInfo; // this is expected to exist
+  const LAUNCHPAD_CHAIN_ID = parseInt(process.env.LAUNCHPAD_CHAIN_ID || '8453');
 
+  const [baseNode, setBaseNode] = useState<NodeInfo | undefined>();
   const [selectedAddress, setSelectedAddress] = useState<AddressInfo>();
   const [createdCommunityId, setCreatedCommunityId] = useState<string>();
+
+  // fetch nodes from cache or API and select the base node
+  useEffect(() => {
+    fetchNodes()
+      .then((nodes) => {
+        const found = nodes.find((n) => n.ethChainId === LAUNCHPAD_CHAIN_ID);
+        setBaseNode(found as NodeInfo | undefined);
+      })
+      .catch(console.error);
+  }, [LAUNCHPAD_CHAIN_ID]);
 
   return {
     baseNode,


### PR DESCRIPTION
## Summary
- simplify token launch node logic

## Testing
- `pnpm lint-branch` *(fails: unable to download pnpm)*