### PR TITLE
Handle rate limit toasts on token creation page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/useGenerateTokenIdea.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/useGenerateTokenIdea.tsx
@@ -4,6 +4,28 @@ import { useRef, useState } from 'react';
 import { ApiEndpoints, SERVER_URL } from 'state/api/config';
 import { userStore } from 'state/ui/user';
 
+const RATE_LIMIT_MESSAGE =
+  'You are being rate limited. Please wait and try again.';
+
+const isRateLimitError = (err: any) => {
+  const status =
+    err?.data?.httpStatus || err?.status || err?.response?.status;
+  if (status === 429) return true;
+
+  if (status === 401) {
+    const msg =
+      err?.data?.message || err?.message || err?.response?.data?.message || '';
+    const lowerMsg = String(msg).toLowerCase();
+    return (
+      lowerMsg.includes('image') &&
+      lowerMsg.includes('prompt') &&
+      lowerMsg.includes('overload')
+    );
+  }
+
+  return false;
+};
+
 type TokenIdea = {
   name: string;
   description: string;
@@ -129,7 +151,12 @@ export const useGenerateTokenIdea = ({
         };
         return temp;
       });
-      notifyError(error.message);
+
+      if (isRateLimitError(error)) {
+        notifyError(RATE_LIMIT_MESSAGE);
+      } else {
+        notifyError(error.message);
+      }
       console.error('Error fetching token idea:', error.message);
     } finally {
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- add `RATE_LIMIT_MESSAGE` and `isRateLimitError` helpers
- surface a toast for 429/401 errors in QuickTokenLaunchForm and token idea generation
- check for `image prompt` overload in 401 errors

## Testing
- `pnpm lint-diff` *(fails: fetch failed)*
- `pnpm -F commonwealth test-unit` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683a147f517c832fa9fef9775fc856dc