### PR TITLE
Fix top holders not refreshing

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/communities/getTopHolders.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/getTopHolders.ts
@@ -4,15 +4,23 @@ export type GetTopHoldersProps = {
   community_id: string;
   limit?: number;
   apiEnabled?: boolean;
+  shouldPolling?: boolean;
 };
+
+const TOP_HOLDERS_STALE_TIME = 10 * 1_000; // 10 s
 
 export const useGetTopHoldersQuery = ({
   community_id,
   limit = 30,
   apiEnabled = true,
+  shouldPolling = false,
 }: GetTopHoldersProps) => {
   return trpc.community.getTopHolders.useQuery(
     { community_id, limit },
-    { enabled: apiEnabled },
+    {
+      enabled: apiEnabled,
+      staleTime: TOP_HOLDERS_STALE_TIME,
+      refetchInterval: shouldPolling ? TOP_HOLDERS_STALE_TIME : false,
+    },
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenPerformance/TopHolders/TopHolders.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenPerformance/TopHolders/TopHolders.tsx
@@ -17,6 +17,7 @@ const TopHolders = ({ supply }: { supply: number }) => {
   const { data: topHolders, isLoading } = useGetTopHoldersQuery({
     community_id: communityId,
     limit: 10,
+    shouldPolling: true,
   });
 
   const columnInfo: CWTableColumnInfo[] = [


### PR DESCRIPTION
## Summary
- enable polling for top holders API
- poll from community homepage top holders table

## Testing
- `pnpm lint-branch` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683a2326aa00832fac830d9ef6136d70