### PR TITLE
Add SSO provider filter for XP quests

### DIFF
--- a/libs/model/src/aggregates/user/signIn/emitSignInEvents.ts
+++ b/libs/model/src/aggregates/user/signIn/emitSignInEvents.ts
@@ -75,6 +75,29 @@ export async function emitSignInEvents({
         },
       });
     }
+
+    // check if this is a new SSO provider
+    if (addressInstance.oauth_provider) {
+      const existingSso = await models.Address.findOne({
+        where: {
+          user_id: user.id,
+          oauth_provider: addressInstance.oauth_provider,
+          address: { [Op.ne]: address },
+        },
+      });
+      if (!existingSso) {
+        events.push({
+          event_name: 'SSOLinked',
+          event_payload: {
+            user_id: user.id!,
+            new_user: newUser,
+            oauth_provider: addressInstance.oauth_provider,
+            community_id,
+            created_at: created_at!,
+          },
+        });
+      }
+    }
   }
 
   if (newUser)

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/SpecialCaseDynamicFields/ContentIdInput.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/SpecialCaseDynamicFields/ContentIdInput.tsx
@@ -1,5 +1,6 @@
 import { PRODUCTION_DOMAIN } from '@hicommonwealth/shared';
 import React from 'react';
+import { WalletSsoSource } from '@hicommonwealth/shared';
 import { fetchCachedNodes } from 'state/api/nodes';
 import { CWSelectList } from 'views/components/component_kit/new_designs/CWSelectList';
 import { CWTextInput } from 'views/components/component_kit/new_designs/CWTextInput';
@@ -29,6 +30,7 @@ const ContentIdInput = ({
       chainId: `Select community chain`,
       groupId: `https://${PRODUCTION_DOMAIN}/common/members?tab=groups&groupId=1234`,
       tokenThresholdAmount: '0.00001',
+      sso: 'Select SSO provider',
     },
     labels: {
       threadId: 'Thread Link (optional)',
@@ -39,6 +41,7 @@ const ContentIdInput = ({
       discordServerId: 'Discord Server Id',
       groupId: 'Group Link',
       tokenThresholdAmount: 'Min ETH Trade Amount (optional)',
+      sso: 'SSO Provider',
     },
     instructionalMessages: {
       threadId: '',
@@ -50,6 +53,7 @@ const ContentIdInput = ({
       groupId: '',
       tokenThresholdAmount:
         'Aura is awarded after this amount of token is traded',
+      sso: '',
     },
   };
 
@@ -115,6 +119,14 @@ const ContentIdInput = ({
       };
     }
 
+    if (config?.requires_sso_source) {
+      return {
+        label: inputConfig.labels.sso,
+        placeholder: inputConfig.placeholders.sso,
+        instructionalMessages: inputConfig.instructionalMessages.sso,
+      };
+    }
+
     if (config?.with_optional_token_trade_threshold) {
       return {
         label: inputConfig.labels.tokenThresholdAmount,
@@ -165,6 +177,33 @@ const ContentIdInput = ({
       })}
       customError={errors?.contentIdentifier}
     />;
+  }
+
+  if (config?.requires_sso_source) {
+    return (
+      <CWSelectList
+        isClearable={true}
+        key={`contentIdentifier-${defaultValues?.action}`}
+        name="contentIdentifier"
+        label={inputConfig.labels.sso}
+        placeholder={inputConfig.placeholders.sso}
+        containerClassname="span-3"
+        options={Object.values(WalletSsoSource).map((v) => ({
+          label: v,
+          value: v,
+        }))}
+        onChange={(v) =>
+          onChange?.({ contentIdentifier: `${v?.value || ''}` })
+        }
+        {...(defaultValues?.contentIdentifier && {
+          value: {
+            value: defaultValues?.contentIdentifier,
+            label: defaultValues?.contentIdentifier,
+          },
+        })}
+        customError={errors?.contentIdentifier}
+      />
+    );
   }
 
   return (

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/types.ts
@@ -15,6 +15,7 @@ export enum QuestActionContentIdScope {
   DiscordServer = 'discord_server',
   Chain = 'chain',
   Group = 'group',
+  Sso = 'sso',
   TokenTradeThreshold = 'threshold',
   Goal = 'goal',
 }
@@ -92,6 +93,7 @@ export type QuestActionSubFormConfig = {
   requires_start_link: boolean;
   requires_amount_multipler: boolean;
   with_optional_token_trade_threshold: boolean;
+  requires_sso_source?: boolean;
 };
 
 export type QuestActionSubFormInternalRefs = {

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useMultipleQuestActionForms.ts
@@ -190,6 +190,7 @@ const useQuestActionMultiFormsState = ({
         requires_amount_multipler:
           doesActionRequireAmountMultipler(chosenAction),
         with_optional_token_trade_threshold: allowsTokenTradeThreshold,
+        requires_sso_source: chosenAction === 'SSOLinked',
       };
 
       // set fixed action repitition per certain actions
@@ -238,6 +239,11 @@ const useQuestActionMultiFormsState = ({
             QuestActionContentIdScope.Group;
           break;
         }
+        case 'SSOLinked': {
+          updatedSubForms[index].values.contentIdScope =
+            QuestActionContentIdScope.Sso;
+          break;
+        }
         case 'LaunchpadTokenTraded': {
           updatedSubForms[index].values.contentIdScope =
             QuestActionContentIdScope.TokenTradeThreshold;
@@ -281,7 +287,10 @@ const useQuestActionMultiFormsState = ({
             !requiresGroupId) ||
           (updatedSubForms[index].values.contentIdScope ===
             QuestActionContentIdScope.TokenTradeThreshold &&
-            !allowsTokenTradeThreshold)
+            !allowsTokenTradeThreshold) ||
+          (updatedSubForms[index].values.contentIdScope ===
+            QuestActionContentIdScope.Sso &&
+            !updatedSubForms[index].config?.requires_sso_source)
         ) {
           updatedSubForms[index].values.contentIdScope =
             QuestActionContentIdScope.Thread;

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/validation.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/validation.ts
@@ -15,6 +15,7 @@ import {
 import { VALIDATION_MESSAGES } from 'helpers/formValidations/messages';
 import { parseAbiItem } from 'viem';
 import { z } from 'zod';
+import { WalletSsoSource } from '@hicommonwealth/shared';
 import { QuestActionSubFormConfig } from './types';
 
 const questSubFormValidationSchema = z.object({
@@ -39,7 +40,8 @@ export const buildQuestSubFormValidationSchema = (
     config?.with_optional_thread_id ||
     config?.with_optional_topic_id ||
     config?.with_optional_chain_id ||
-    config?.with_optional_token_trade_threshold;
+    config?.with_optional_token_trade_threshold ||
+    config?.requires_sso_source;
   const requiresTwitterEngagement = config?.requires_twitter_tweet_link;
   const requiresDiscordServerId = config?.requires_discord_server_id;
   const requiresGoalConfig = config?.requires_goal_config;
@@ -52,6 +54,7 @@ export const buildQuestSubFormValidationSchema = (
   const allowsChainIdAsContentId = config?.with_optional_chain_id;
   const allowsTokenThresholdAmountAsContentId =
     config?.with_optional_token_trade_threshold;
+  const requiresSsoSource = config?.requires_sso_source;
 
   const needsExtension =
     requiresCreatorPoints ||
@@ -63,7 +66,8 @@ export const buildQuestSubFormValidationSchema = (
     requiresStartLink ||
     allowsChainIdAsContentId ||
     allowsTokenThresholdAmountAsContentId ||
-    requiresChainEvent;
+    requiresChainEvent ||
+    requiresSsoSource;
 
   if (!needsExtension) return questSubFormValidationSchema;
 
@@ -77,6 +81,10 @@ export const buildQuestSubFormValidationSchema = (
     } else if (allowsTokenThresholdAmountAsContentId) {
       baseSchema = baseSchema.extend({
         contentIdentifier: numberDecimalValidationSchema.optional,
+      }) as unknown as typeof baseSchema;
+    } else if (requiresSsoSource) {
+      baseSchema = baseSchema.extend({
+        contentIdentifier: z.nativeEnum(WalletSsoSource).optional(),
       }) as unknown as typeof baseSchema;
     } else {
       baseSchema = baseSchema.extend({

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/helpers.ts
@@ -24,7 +24,8 @@ export type ContentIdType =
   | 'discord_server_id'
   | 'chain'
   | 'threshold'
-  | 'goal';
+  | 'goal'
+  | 'sso';
 
 export const inferContentIdTypeFromContentId = (
   action: QuestAction,
@@ -66,6 +67,8 @@ export const inferContentIdTypeFromContentId = (
       return QuestActionContentIdScope.Group;
     case 'threshold':
       return QuestActionContentIdScope.TokenTradeThreshold;
+    case 'sso':
+      return QuestActionContentIdScope.Sso;
     default:
       return QuestActionContentIdScope.Thread;
   }
@@ -85,6 +88,9 @@ export const buildContentIdFromIdentifier = (
     return `${idType}:${identifier}`;
   }
   if (idType === 'goal') {
+    return `${idType}:${identifier}`;
+  }
+  if (idType === 'sso') {
     return `${idType}:${identifier}`;
   }
 
@@ -161,6 +167,9 @@ export const buildRedirectURLFromContentId = (
   if (idType === 'goal') {
     return `${idOrURL}`;
   }
+  if (idType === 'sso') {
+    return '';
+  }
 
   return '';
 };
@@ -177,6 +186,7 @@ export const doesConfigAllowContentIdField = (
     // config?.requires_goal_config || // hidden, will be set programatically
     config?.with_optional_chain_id ||
     config?.requires_group_id ||
-    config?.with_optional_token_trade_threshold
+    config?.with_optional_token_trade_threshold ||
+    config?.requires_sso_source
   );
 };

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -279,6 +279,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
         if (scope === QuestActionContentIdScope.Chain) return 'chain';
         if (scope === QuestActionContentIdScope.Group) return 'group';
         if (scope === QuestActionContentIdScope.Goal) return 'goal';
+        if (scope === QuestActionContentIdScope.Sso) return 'sso';
         if (scope === QuestActionContentIdScope.TokenTradeThreshold) {
           return 'threshold';
         }


### PR DESCRIPTION
## Summary
- support `sso:` content id scope for quest actions
- allow selecting an SSO provider when creating quests
- handle sso provider in quest action forms and validation logic
- emit `SSOLinked` event when a new SSO provider is linked

## Testing
- `pnpm lint-diff` *(fails: fetch failed – no network)*

------
https://chatgpt.com/codex/tasks/task_e_684890200da8832f92a418a1aaec17db