### PR TITLE
Add token trade button on explore communities

### DIFF
--- a/packages/commonwealth/client/scripts/hooks/useCommunityToken.tsx
+++ b/packages/commonwealth/client/scripts/hooks/useCommunityToken.tsx
@@ -1,0 +1,101 @@
+import { generateBlobImageFromAlphabet } from 'helpers/image';
+import { useFlag } from 'hooks/useFlag';
+import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
+import { useMemo, useState } from 'react';
+import { useGetPinnedTokenByCommunityId } from 'state/api/communities';
+import {
+  useGetTokenByCommunityId,
+  useTokenMetadataQuery,
+} from 'state/api/tokens';
+import { LaunchpadToken } from 'views/modals/TradeTokenModel/CommonTradeModal/types';
+import { ExternalToken } from 'views/modals/TradeTokenModel/UniswapTradeModal/types';
+
+export const useCommunityToken = (communityId: string) => {
+  const launchpadEnabled = useFlag('launchpad');
+  const [generatedFallbackImageForPinnedToken, setGeneratedFallbackImageForPinnedToken] =
+    useState('');
+
+  const { data: communityLaunchpadToken, isLoading: isLoadingLaunchpadToken } =
+    useGetTokenByCommunityId({
+      community_id: communityId,
+      with_stats: true,
+      enabled: !!communityId && launchpadEnabled,
+    });
+
+  const { data: communityPinnedTokens, isLoading: isLoadingPinnedToken } =
+    useGetPinnedTokenByCommunityId({
+      community_ids: [communityId],
+      with_chain_node: true,
+      with_price: true,
+      enabled: !!communityId,
+    });
+  const communityPinnedToken = communityPinnedTokens?.[0];
+  const { data: tokenMetadata, isLoading: isLoadingTokenMetadata } =
+    useTokenMetadataQuery({
+      tokenId: communityPinnedToken?.contract_address || '',
+      nodeEthChainId: communityPinnedToken?.ChainNode?.eth_chain_id || 0,
+      apiEnabled: !!(communityPinnedToken?.contract_address || ''),
+    });
+
+  const communityPinnedTokenWithMetadata = useMemo(() => {
+    return communityPinnedToken && tokenMetadata
+      ? { ...communityPinnedToken, ...tokenMetadata }
+      : null;
+  }, [communityPinnedToken, tokenMetadata]);
+
+  const isLoadingToken =
+    (launchpadEnabled && isLoadingLaunchpadToken) ||
+    (isLoadingPinnedToken && !communityLaunchpadToken) ||
+    (isLoadingTokenMetadata && communityPinnedToken);
+
+  const communityToken = useMemo(
+    (): LaunchpadToken | ExternalToken | undefined => {
+      if (communityLaunchpadToken) {
+        return {
+          ...communityLaunchpadToken,
+          community_id: communityId,
+        } as LaunchpadToken;
+      } else if (communityPinnedTokenWithMetadata) {
+        return {
+          ...communityPinnedTokenWithMetadata,
+          logo:
+            communityPinnedTokenWithMetadata.logo ||
+            generatedFallbackImageForPinnedToken ||
+            'https://assets.commonwealth.im/b531c73a-eb29-4348-96af-db1114346f90.jpeg',
+        } as ExternalToken;
+      } else {
+        return undefined;
+      }
+    },
+    [
+      communityLaunchpadToken,
+      communityPinnedTokenWithMetadata,
+      generatedFallbackImageForPinnedToken,
+      communityId,
+    ],
+  );
+
+  useRunOnceOnCondition({
+    callback: () => {
+      if (communityPinnedTokenWithMetadata?.name) {
+        generateBlobImageFromAlphabet({
+          letter: communityPinnedTokenWithMetadata.name.charAt(0),
+        })
+          .then(setGeneratedFallbackImageForPinnedToken)
+          .catch(console.error);
+      }
+    },
+    shouldRun:
+      !!communityPinnedTokenWithMetadata &&
+      !communityPinnedTokenWithMetadata.logo &&
+      !!communityPinnedTokenWithMetadata.name,
+  });
+
+  return {
+    isLoadingToken,
+    communityToken,
+    isPinnedToken: !communityLaunchpadToken && !!communityPinnedTokenWithMetadata,
+  };
+};
+
+export default useCommunityToken;

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWRelatedCommunityCard/CWRelatedCommunityCard.tsx
@@ -35,6 +35,9 @@ type CWRelatedCommunityCardProps = {
   threadCount: string | number;
   canBuyStake?: boolean;
   onStakeBtnClick?: () => void;
+  hasToken?: boolean;
+  canTradeToken?: boolean;
+  onTokenBtnClick?: () => void;
   ethUsdRate?: string;
   historicalPrice?: string;
   onlyShowIfStakeEnabled?: boolean;
@@ -46,6 +49,9 @@ export const CWRelatedCommunityCard = ({
   threadCount,
   canBuyStake,
   onStakeBtnClick,
+  hasToken,
+  canTradeToken,
+  onTokenBtnClick,
   ethUsdRate,
   historicalPrice,
   onlyShowIfStakeEnabled,
@@ -108,6 +114,10 @@ export const CWRelatedCommunityCard = ({
         },
       });
     }
+  };
+
+  const handleTradeTokenClick = () => {
+    onTokenBtnClick?.();
   };
 
   const disableStakeButton = !user.isLoggedIn || !canBuyStake;
@@ -219,26 +229,44 @@ export const CWRelatedCommunityCard = ({
             </CWText>
           </div>
         </div>
-        {stakeEnabled && (
+        {(stakeEnabled || hasToken) && (
           <div className="actions">
-            {disableStakeButton ? (
-              <CWTooltip
-                placement="right"
-                content={disabledStakeButtonTooltipText({
-                  isLoggedIn: user.isLoggedIn,
-                  connectBaseChainToBuy: community?.base,
-                })}
-                renderTrigger={(handleInteraction) => (
-                  <span
-                    onMouseEnter={handleInteraction}
-                    onMouseLeave={handleInteraction}
-                  >
-                    {stakeButton}
-                  </span>
+            {stakeEnabled && (
+              <>
+                {disableStakeButton ? (
+                  <CWTooltip
+                    placement="right"
+                    content={disabledStakeButtonTooltipText({
+                      isLoggedIn: user.isLoggedIn,
+                      connectBaseChainToBuy: community?.base,
+                    })}
+                    renderTrigger={(handleInteraction) => (
+                      <span
+                        onMouseEnter={handleInteraction}
+                        onMouseLeave={handleInteraction}
+                      >
+                        {stakeButton}
+                      </span>
+                    )}
+                  />
+                ) : (
+                  stakeButton
                 )}
+              </>
+            )}
+            {hasToken && (
+              <CWButton
+                label="Trade Token"
+                buttonType="secondary"
+                buttonAlt="green"
+                buttonHeight="sm"
+                buttonWidth="narrow"
+                disabled={!canTradeToken}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleTradeTokenClick();
+                }}
               />
-            ) : (
-              stakeButton
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- add `useCommunityToken` hook to fetch token data for arbitrary communities
- show token trade button on community cards
- load community token data on explore page and open TradeToken modal

## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68518ab1cce0832fabbe39d6b88dbd18