### PR TITLE
Swap axios with trpc routes

### DIFF
--- a/libs/schemas/src/queries/user.schemas.ts
+++ b/libs/schemas/src/queries/user.schemas.ts
@@ -83,9 +83,9 @@ export const UserStatusCommunityView = z.object({
   name: z.string(),
   icon_url: z.string().nullish(),
   redirect: z.string().nullish(),
-  created_at: z.date().or(z.string()).nullish(),
-  updated_at: z.date().or(z.string()).nullish(),
-  starred_at: z.date().or(z.string()).nullish(),
+  created_at: z.coerce.date().nullish(),
+  updated_at: z.coerce.date().nullish(),
+  starred_at: z.coerce.date().nullish(),
 });
 
 export const GetStatus = {

--- a/libs/schemas/src/queries/user.schemas.ts
+++ b/libs/schemas/src/queries/user.schemas.ts
@@ -83,9 +83,9 @@ export const UserStatusCommunityView = z.object({
   name: z.string(),
   icon_url: z.string().nullish(),
   redirect: z.string().nullish(),
-  created_at: z.coerce.date().nullish(),
-  updated_at: z.coerce.date().nullish(),
-  starred_at: z.coerce.date().nullish(),
+  created_at: z.date().or(z.string()).nullish(),
+  updated_at: z.date().or(z.string()).nullish(),
+  starred_at: z.date().or(z.string()).nullish(),
 });
 
 export const GetStatus = {

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -29,7 +29,7 @@ import { isSameAccount } from 'helpers';
 import { Magic } from 'magic-sdk';
 import moment from 'moment';
 import app, { initAppState } from 'state';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from 'state/api/communities/getCommuityById';
+import { getCommunityByIdQuery } from 'state/api/communities/getCommuityById';
 import { SERVER_URL } from 'state/api/config';
 import { welcomeOnboardModal } from 'state/ui/modals/welcomeOnboardModal';
 import { userStore } from 'state/ui/user';
@@ -416,10 +416,7 @@ export async function handleSocialLoginCallback({
   // a page without a chain, in which case we default to an eth login
   let desiredChain = app.chain?.meta;
   if (!desiredChain && chain) {
-    const communityInfo = await EXCEPTION_CASE_VANILLA_getCommunityById(
-      chain || '',
-      true,
-    );
+    const communityInfo = await getCommunityByIdQuery(chain || '', true);
     desiredChain = communityInfo as z.infer<typeof ExtendedCommunity>;
   }
   const isCosmos = desiredChain?.base === ChainBase.CosmosSDK;
@@ -553,10 +550,7 @@ export async function handleSocialLoginCallback({
       let chainInfo = userStore.getState().activeCommunity;
 
       if (!chainInfo && chain) {
-        const communityInfo = await EXCEPTION_CASE_VANILLA_getCommunityById(
-          chain || '',
-          true,
-        );
+        const communityInfo = await getCommunityByIdQuery(chain || '', true);
         chainInfo = communityInfo as z.infer<typeof ExtendedCommunity>;
       }
 

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -417,7 +417,9 @@ export async function handleSocialLoginCallback({
   let desiredChain = app.chain?.meta;
   if (!desiredChain && chain) {
     const communityInfo = await getCommunityByIdQuery(chain || '', true);
-    desiredChain = communityInfo as z.infer<typeof ExtendedCommunity>;
+    desiredChain = communityInfo as unknown as z.infer<
+      typeof ExtendedCommunity
+    >;
   }
   const isCosmos = desiredChain?.base === ChainBase.CosmosSDK;
   const magic = await constructMagic(isCosmos, desiredChain?.id);
@@ -551,7 +553,9 @@ export async function handleSocialLoginCallback({
 
       if (!chainInfo && chain) {
         const communityInfo = await getCommunityByIdQuery(chain || '', true);
-        chainInfo = communityInfo as z.infer<typeof ExtendedCommunity>;
+        chainInfo = communityInfo as unknown as z.infer<
+          typeof ExtendedCommunity
+        >;
       }
 
       chainInfo && (await updateActiveAddresses(chainInfo.id || ''));

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -5,7 +5,7 @@ import type Web3 from 'web3';
 
 import { SIWESigner } from '@canvas-js/chain-ethereum';
 import { ExtendedCommunity } from '@hicommonwealth/schemas';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from 'state/api/communities/getCommuityById';
+import { getCommunityByIdQuery } from 'state/api/communities/getCommuityById';
 import { userStore } from 'state/ui/user';
 import { hexToNumber } from 'web3-utils';
 import { z } from 'zod';
@@ -102,7 +102,7 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
     this._chainInfo = app?.chain?.meta;
 
     if (!this._chainInfo && app.activeChainId()) {
-      const communityInfo = await EXCEPTION_CASE_VANILLA_getCommunityById(
+      const communityInfo = await getCommunityByIdQuery(
         app.activeChainId() || '',
         true,
       );

--- a/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/webWallets/walletconnect_web_wallet.ts
@@ -107,7 +107,9 @@ class WalletConnectWebWalletController implements IWebWallet<string> {
         true,
       );
 
-      this._chainInfo = communityInfo as z.infer<typeof ExtendedCommunity>;
+      this._chainInfo = communityInfo as unknown as z.infer<
+        typeof ExtendedCommunity
+      >;
     }
 
     const chainId = this._chainInfo?.ChainNode?.eth_chain_id || 1;

--- a/packages/commonwealth/client/scripts/helpers/chain.ts
+++ b/packages/commonwealth/client/scripts/helpers/chain.ts
@@ -4,7 +4,7 @@ import { updateActiveAddresses } from 'controllers/app/login';
 import { DEFAULT_CHAIN } from 'helpers/constants';
 import app, { ApiStatus } from 'state';
 import { z } from 'zod';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from '../state/api/communities/getCommuityById';
+import { getCommunityByIdQuery } from '../state/api/communities/getCommuityById';
 import { userStore } from '../state/ui/user';
 
 export const deinitChainOrCommunity = async () => {
@@ -41,11 +41,8 @@ export const loadCommunityChainInfo = async (
     if (activeCommunity) {
       tempChain = activeCommunity;
     } else {
-      const communityInfo = await EXCEPTION_CASE_VANILLA_getCommunityById(
-        DEFAULT_CHAIN,
-        true,
-      );
-      tempChain = communityInfo;
+      const communityInfo = await getCommunityByIdQuery(DEFAULT_CHAIN, true);
+      tempChain = communityInfo as z.infer<typeof ExtendedCommunity>;
     }
 
     if (!tempChain) {

--- a/packages/commonwealth/client/scripts/state/api/communities/getCommuityById.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/getCommuityById.ts
@@ -1,7 +1,6 @@
 import { ExtendedCommunity } from '@hicommonwealth/schemas';
 import { getQueryKey } from '@trpc/react-query';
-import axios from 'axios';
-import { BASE_API_PATH, trpc } from 'utils/trpcClient';
+import { trpc, trpcQueryUtils } from 'utils/trpcClient';
 import { z } from 'zod';
 import { queryClient } from '../config';
 
@@ -85,39 +84,19 @@ export const invalidateAllQueriesForCommunity = async (communityId: string) => {
   }
 };
 
-export const EXCEPTION_CASE_VANILLA_getCommunityById = async (
+export const getCommunityByIdQuery = async (
   communityId: string,
   includeNodeInfo = false,
-): Promise<z.infer<typeof ExtendedCommunity> | undefined> => {
-  // make trpc query key for this request
-  const queryKey = getQueryKey(trpc.community.getCommunity, {
-    id: communityId,
-    include_node_info: includeNodeInfo,
-  });
-
-  // if community already exists in cache, return that
-  const cachedCommunity = queryClient.getQueryData<
-    z.infer<typeof ExtendedCommunity> | undefined
-  >(queryKey);
-  if (cachedCommunity) {
-    return cachedCommunity;
-  }
-
-  // HACK: with @trpc/react-query v10.x, we can't directly call an endpoint outside of 'react-context'
-  // with this way the api can be used in non-react files. This should be cleaned up when we migrate
-  // to @trpc/react-query v11.x
-  const response = await axios.get(
-    // eslint-disable-next-line max-len
-    `${BASE_API_PATH}/community.getCommunity?batch=1&input=%7B%220%22%3A%7B%22id%22%3A%22${communityId}%22%2C%22include_node_info%22%3A${includeNodeInfo}%7D%7D`,
+) => {
+  return await trpcQueryUtils.community.getCommunity.fetch(
+    {
+      id: communityId,
+      include_node_info: includeNodeInfo,
+    },
+    {
+      staleTime: COMMUNITIY_STALE_TIME,
+    },
   );
-  const fetchedCommunity = response?.data[0]?.result?.data as z.infer<
-    typeof ExtendedCommunity
-  >;
-
-  // add response in cache
-  queryClient.setQueryData(queryKey, fetchedCommunity);
-
-  return fetchedCommunity;
 };
 
 const useGetCommunityByIdQuery = ({

--- a/packages/commonwealth/client/scripts/state/api/configuration/fetchPublicEnvVar.ts
+++ b/packages/commonwealth/client/scripts/state/api/configuration/fetchPublicEnvVar.ts
@@ -1,41 +1,18 @@
 import { GetPublicEnvVar } from '@hicommonwealth/schemas';
-import { getQueryKey } from '@trpc/react-query';
-import axios from 'axios';
-import { BASE_API_PATH, trpc } from 'utils/trpcClient';
+import { trpc, trpcQueryUtils } from 'utils/trpcClient';
 import { z } from 'zod';
-import { queryClient } from '../config';
 
 export const fetchCachedPublicEnvVar = () => {
-  const queryKey = getQueryKey(trpc.configuration.getPublicEnvVar);
-  return queryClient.getQueryData<z.infer<(typeof GetPublicEnvVar)['output']>>(
-    queryKey,
-  );
+  return trpcQueryUtils.configuration.getPublicEnvVar.getData();
 };
 
-export const fetchPublicEnvVar = async (): Promise<
+export const fetchPublicEnvVarQuery = async (): Promise<
   z.infer<(typeof GetPublicEnvVar)['output']>
 > => {
-  const queryKey = getQueryKey(trpc.configuration.getPublicEnvVar);
-  const cache =
-    queryClient.getQueryData<z.infer<(typeof GetPublicEnvVar)['output']>>(
-      queryKey,
-    );
-  if (cache) return cache;
-
-  // HACK: with @trpc/react-query v10.x, we can't directly call an endpoint outside of 'react-context'
-  // with this way the api can be used in non-react files. This should be cleaned up when we migrate
-  // to @trpc/react-query v11.x
-  const { data } = await axios.get(
-    `${BASE_API_PATH}/configuration.getPublicEnvVar`,
-  );
-
-  if (!data.result.data) {
-    // TODO: this should never happen but how should we handle it if it does?
-    throw new Error('No public env var returned from the API');
-  }
-
-  queryClient.setQueryData(queryKey, data.result.data);
-  return data.result.data as z.infer<(typeof GetPublicEnvVar)['output']>;
+  return await trpcQueryUtils.configuration.getPublicEnvVar.fetch(undefined, {
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
 };
 
 const useFetchPublicEnvVarQuery = () => {

--- a/packages/commonwealth/client/scripts/state/api/configuration/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/configuration/index.ts
@@ -4,14 +4,14 @@ import useFetchCustomDomainQuery, {
 } from './fetchCustomDomain';
 import useFetchPublicEnvVarQuery, {
   fetchCachedPublicEnvVar,
-  fetchPublicEnvVar,
+  fetchPublicEnvVarQuery,
 } from './fetchPublicEnvVar';
 
 export {
   fetchCachedCustomDomain,
   fetchCachedPublicEnvVar,
   fetchCustomDomainQuery,
-  fetchPublicEnvVar,
+  fetchPublicEnvVarQuery,
   useFetchCustomDomainQuery,
   useFetchPublicEnvVarQuery,
 };

--- a/packages/commonwealth/client/scripts/state/api/profiles/fetchProfilesByAddress.ts
+++ b/packages/commonwealth/client/scripts/state/api/profiles/fetchProfilesByAddress.ts
@@ -1,13 +1,7 @@
-import * as schemas from '@hicommonwealth/schemas';
 import { UserTierMap } from '@hicommonwealth/shared';
-import { getQueryKey } from '@trpc/react-query';
-import axios from 'axios';
 import MinimumProfile from 'models/MinimumProfile';
-import { queryClient } from 'state/api/config';
-import { BASE_API_PATH, trpc } from 'utils/trpcClient';
-import { z } from 'zod';
-import { userStore } from '../../ui/user';
-const PROFILES_STALE_TIME = 30 * 1_000; // 3 minutes
+import { trpc, trpcQueryUtils } from 'utils/trpcClient';
+const PROFILES_STALE_TIME = 60 * 3_000; // 3 mins
 
 interface FetchProfilesByAddressProps {
   currentChainId: string;
@@ -19,6 +13,8 @@ interface FetchProfilesByAddressProps {
 interface UseFetchProfilesByAddressesQuery extends FetchProfilesByAddressProps {
   apiCallEnabled?: boolean;
 }
+
+// use this for react components and hooks
 const useFetchProfilesByAddressesQuery = ({
   currentChainId,
   profileChainIds,
@@ -51,80 +47,33 @@ const useFetchProfilesByAddressesQuery = ({
   );
 };
 
-// Some of the core logic in the app is non-reactive like the Account.ts file. These non-reactive
-// touch points call the api directly. After the RQ migration we needed to move them to react but
-// moving the core logic all at once isn't a very good option. As a gradual migration process to use
-// proper state and react'ive code, we created this method. It provides a link to get the benefits of
-// react query like cache/stale timer and more in non-react files. As the name suggests its discouraged
-// to use and should be avoided at all costs. If this is used anywhere, then it should follow the underlying
-// reason of its creation.
-// TODO: After account controller is de-side-effected (all api calls removed). Then we would be in a better
-// position to remove this discouraged method
-export const DISCOURAGED_NONREACTIVE_fetchProfilesByAddress = async (
+// use this for non-react components
+export const fetchProfilesByAddress = async (
   communities: string[],
   addresses: string[],
 ) => {
-  const queryKey = getQueryKey(trpc.user.getUserAddresses, {
+  const profilesData = await trpcQueryUtils.user.getUserAddresses.fetch({
     communities: communities.join(','),
     addresses: addresses.join(','),
   });
 
-  // if profile already exists in cache, return that
-  const cachedProfile = queryClient.getQueryData<
-    z.infer<typeof schemas.GetUserAddresses.output> | undefined
-  >(queryKey);
-
-  if (cachedProfile) {
-    return cachedProfile;
+  if (!profilesData) {
+    return [];
   }
 
-  // HACK: with @trpc/react-query v10.x, we can't directly call an endpoint outside of 'react-context'
-  // with this way the api can be used in non-react files. This should be cleaned up when we migrate
-  // to @trpc/react-query v11.x
-
-  // eslint-disable-next-line max-len
-  const getUserAddressesTrpcUrl = `user.getUserAddresses?batch=1&input=${encodeURIComponent(`{"0":{"communities":"${communities.join(',')}","addresses":"${addresses.join(',')}"}}`)}`;
-
-  const user = userStore.getState();
-
-  if (
-    !user.addressSelectorSelectedAddress &&
-    !user.activeAccount &&
-    user.addresses.length === 0
-  ) {
-    return;
-  }
-
-  const response = await axios.get(
-    `${BASE_API_PATH}/${getUserAddressesTrpcUrl}`,
-    {
-      headers: {
-        authorization: user.jwt || '',
-        address:
-          user.addressSelectorSelectedAddress ??
-          user.activeAccount?.address ??
-          user.addresses?.at(0)?.address,
-      },
-    },
-  );
-
-  const mappedProfiles = (response?.data?.[0]?.result?.data || []).map((t) => {
+  return profilesData.map((t) => {
     const profile = new MinimumProfile(t.address, communities[0]);
     profile.initialize(
       t.userId,
       t.name,
       t.address,
-      t.avatarUrl,
+      t.avatarUrl ?? '',
       communities[0],
-      t.lastActive,
+      new Date(t.lastActive),
       t.tier ?? UserTierMap.IncompleteUser,
     );
     return profile;
   });
-
-  queryClient.setQueryData(queryKey, mappedProfiles);
-
-  return mappedProfiles;
 };
 
 export default useFetchProfilesByAddressesQuery;

--- a/packages/commonwealth/client/scripts/state/index.ts
+++ b/packages/commonwealth/client/scripts/state/index.ts
@@ -1,4 +1,4 @@
-import { GetPublicEnvVar } from '@hicommonwealth/schemas';
+import { ExtendedCommunity, GetPublicEnvVar } from '@hicommonwealth/schemas';
 import { updateActiveUser } from 'controllers/app/login';
 import CosmosAccount from 'controllers/chain/cosmos/account';
 import EthereumAccount from 'controllers/chain/ethereum/account';
@@ -14,7 +14,7 @@ import {
 import { errorStore } from 'state/ui/error';
 import { z } from 'zod';
 import SuiAccount from '../controllers/chain/sui/account';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from './api/communities/getCommuityById';
+import { getCommunityByIdQuery } from './api/communities/getCommuityById';
 import { fetchNodes } from './api/nodes';
 import { fetchStatus } from './api/user/fetchStatus';
 import { userStore } from './ui/user';
@@ -85,10 +85,10 @@ export async function initAppState(
       if (updateSelectedCommunity && status?.selected_community_id) {
         userStore.getState().setData({
           // TODO: api should be updated to get relevant data
-          activeCommunity: await EXCEPTION_CASE_VANILLA_getCommunityById(
+          activeCommunity: (await getCommunityByIdQuery(
             status.selected_community_id,
             true,
-          ),
+          )) as z.infer<typeof ExtendedCommunity>,
         });
       }
     }

--- a/packages/commonwealth/client/scripts/state/index.ts
+++ b/packages/commonwealth/client/scripts/state/index.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'events';
 import type IChainAdapter from 'models/IChainAdapter';
 import {
   fetchCustomDomainQuery,
-  fetchPublicEnvVar,
+  fetchPublicEnvVarQuery,
 } from 'state/api/configuration';
 import { errorStore } from 'state/ui/error';
 import { z } from 'zod';
@@ -73,7 +73,7 @@ export async function initAppState(
   try {
     const [status, publicEnvVars] = await Promise.all([
       fetchStatus(),
-      fetchPublicEnvVar(),
+      fetchPublicEnvVarQuery(),
       fetchNodes(),
       fetchCustomDomainQuery(),
     ]);

--- a/packages/commonwealth/client/scripts/state/index.ts
+++ b/packages/commonwealth/client/scripts/state/index.ts
@@ -88,7 +88,7 @@ export async function initAppState(
           activeCommunity: (await getCommunityByIdQuery(
             status.selected_community_id,
             true,
-          )) as z.infer<typeof ExtendedCommunity>,
+          )) as unknown as z.infer<typeof ExtendedCommunity>,
         });
       }
     }

--- a/packages/commonwealth/client/scripts/utils/trpcClient.ts
+++ b/packages/commonwealth/client/scripts/utils/trpcClient.ts
@@ -1,12 +1,15 @@
 import { httpLink } from '@trpc/client';
-import { createTRPCReact } from '@trpc/react-query';
+import { createTRPCQueryUtils, createTRPCReact } from '@trpc/react-query';
 import type { API } from '../../../server/api/internal-router';
+import { queryClient } from '../state/api/config';
 import { userStore } from '../state/ui/user';
 
+// React hooks for tRPC queries and mutations - use these in React components
 export const trpc = createTRPCReact<API>();
 
 export const BASE_API_PATH = '/api/internal/trpc';
 
+// tRPC client instance - used internally by React hooks and utils
 export const trpcClient = trpc.createClient({
   links: [
     httpLink({
@@ -25,4 +28,11 @@ export const trpcClient = trpc.createClient({
     }),
   ],
   transformer: undefined,
+});
+
+// tRPC query utilities for non-React contexts (e.g., utility functions, event handlers)
+// Use this instead of axios for calling tRPC procedures outside of React components
+export const trpcQueryUtils = createTRPCQueryUtils({
+  queryClient,
+  client: trpcClient,
 });

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useCheckAuthenticatedAddresses.ts
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useCheckAuthenticatedAddresses.ts
@@ -8,7 +8,7 @@ import {
   getSessionSigners,
 } from '@hicommonwealth/shared';
 import app from 'state';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from 'state/api/communities/getCommuityById';
+import { getCommunityByIdQuery } from 'state/api/communities/getCommuityById';
 import useUserStore from 'state/ui/user';
 
 interface UseCheckAuthenticatedAddressesProps {
@@ -39,10 +39,7 @@ const useCheckAuthenticatedAddresses = ({
       // making a fresh query to get chain and community info for this address
       // as all the necessary fields don't exist on user.address, these should come
       // from api in the user address response, and the extra api call here removed
-      const community = await EXCEPTION_CASE_VANILLA_getCommunityById(
-        account.community.id,
-        true,
-      );
+      const community = await getCommunityByIdQuery(account.community.id, true);
       if (!community) continue;
 
       const communityCaip2Prefix = chainBaseToCaip2(community.base);

--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -20,7 +20,7 @@ import { useFlag } from 'hooks/useFlag';
 import { useCommonNavigate } from 'navigation/helpers';
 import React, { useCallback, useEffect, useState } from 'react';
 import app, { initAppState } from 'state';
-import { EXCEPTION_CASE_VANILLA_getCommunityById } from 'state/api/communities/getCommuityById';
+import { getCommunityByIdQuery } from 'state/api/communities/getCommuityById';
 import { SERVER_URL } from 'state/api/config';
 import useAdminOnboardingSliderMutationStore from 'state/ui/adminOnboardingCards';
 import { darkModeStore, useDarkMode } from 'state/ui/darkMode/darkMode';
@@ -158,7 +158,7 @@ const useUserMenuItems = ({
         // making a fresh query to get chain and community info for this address
         // as all the necessary fields don't exist on user.address, these should come
         // from api in the user address response, and the extra api call here removed
-        const community = await EXCEPTION_CASE_VANILLA_getCommunityById(
+        const community = await getCommunityByIdQuery(
           account.community.id,
           true,
         );

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -9,7 +9,7 @@ import {
 } from '@hicommonwealth/shared';
 import axios from 'axios';
 import { useFlag } from 'client/scripts/hooks/useFlag';
-import { BASE_API_PATH, trpc } from 'client/scripts/utils/trpcClient';
+import { BASE_API_PATH } from 'client/scripts/utils/trpcClient';
 import {
   completeClientLogin,
   setActiveAccount,
@@ -93,7 +93,6 @@ const useAuthentication = (props: UseAuthenticationProps) => {
   const [isMobileWalletVerificationStep, setIsMobileWalletVerificationStep] =
     useState(false);
   const privyEnabled = useFlag('privy');
-  const utils = trpc.useUtils();
 
   const { isAddedToHomeScreen } = useAppStatus();
   const { setState: setSMSDialogState } = usePrivySMSDialogStore();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12392 

## Description of Changes

This branch refactors data fetching by replacing manual `axios` calls to tRPC endpoints with the recommended `trpcQueryUtils`. This provides a cleaner and more type-safe way to fetch data from outside React components.

The main change was introducing `trpcQueryUtils` in `utils/trpcClient.ts` and using it to update data-fetching functions in the following files:

*   `state/api/communities/getCommuityById.ts`
*   `state/api/configuration/fetchPublicEnvVar.ts`
*   `state/api/nodes/fetchNodes.ts`
*   `state/api/profiles/fetchProfilesByAddress.ts`

This improves the data-fetching architecture by removing hacky workarounds and aligning with tRPC best practices.

## Test Plan
- click around the app, login, logout, everything should work the same way

## Deployment Plan
<!--- Omit if unneeded -->
n/a

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
n/a