### PR TITLE
Add export key link

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/useUserMenuItems.tsx
@@ -301,6 +301,11 @@ const useUserMenuItems = ({
               ),
               onClick: () => openMagicWallet(),
             },
+            {
+              type: 'default',
+              label: 'Export private key',
+              onClick: () => navigate('/export-magic', {}, null),
+            },
           ]
         : []),
       ...(referralsEnabled


### PR DESCRIPTION
## Summary
- add a link to export Magic private keys in the user menu

## Testing
- `pnpm test-unit` *(fails: fetch to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0ffbae4832fa385506a0fdf14f0