### PR TITLE
Fix homepage contest display

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/ExploreContestsCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/ExploreContestsCard.scss
@@ -1,0 +1,20 @@
+@use '../../../../styles/mixins/colors.module';
+
+.ExploreContestsCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  border: 1px solid colors.$neutral-200;
+  border-radius: 6px;
+  padding: 40px 16px;
+
+  .title {
+    color: colors.$neutral-600;
+  }
+
+  .subtitle {
+    color: colors.$neutral-500;
+  }
+}

--- a/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/ExploreContestsCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/ExploreContestsCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { CWCard } from 'views/components/component_kit/cw_card';
+import { CWText } from 'views/components/component_kit/cw_text';
+import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
+import { useCommonNavigate } from 'navigation/helpers';
+import './ExploreContestsCard.scss';
+
+const ExploreContestsCard = () => {
+  const navigate = useCommonNavigate();
+  return (
+    <CWCard className="ExploreContestsCard" fullWidth>
+      <CWText type="h4" className="title">
+        No contests in this community
+      </CWText>
+      <CWText type="b1" className="subtitle">
+        Explore contests running in other communities
+      </CWText>
+      <CWButton
+        label="Explore contests"
+        buttonWidth="full"
+        onClick={() => navigate('/explore?tab=contests', {}, null)}
+      />
+    </CWCard>
+  );
+};
+
+export default ExploreContestsCard;

--- a/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/index.ts
+++ b/packages/commonwealth/client/scripts/views/components/ExploreContestsCard/index.ts
@@ -1,0 +1,2 @@
+import ExploreContestsCard from './ExploreContestsCard';
+export default ExploreContestsCard;

--- a/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.tsx
@@ -7,6 +7,7 @@ import { trpc } from 'utils/trpcClient';
 import { CWText } from 'views/components/component_kit/cw_text';
 import ContestCard from 'views/components/ContestCard';
 import { PotentialContestCard } from 'views/components/PotentialContestCard/PotentialContestCard';
+import ExploreContestsCard from 'views/components/ExploreContestsCard';
 import { useTokenTradeWidget } from 'views/components/sidebar/CommunitySection/TokenTradeWidget/useTokenTradeWidget';
 import { Skeleton } from 'views/components/Skeleton';
 import { LaunchpadToken } from 'views/modals/TradeTokenModel/CommonTradeModal/types';
@@ -42,12 +43,10 @@ const ActiveContestList = ({
   isCommunityHomePage = false,
 }: ActiveContestListProps) => {
   const {
-    contestsData: { active: activeContests, suggested: suggestedContest },
+    contestsData: { active: activeContests },
     isContestDataLoading,
-    isSuggestedMode,
   } = useCommunityContests({
     fetchAll: true,
-    isCommunityHomePage,
   });
 
   const { communityToken, isLoadingToken, isPinnedToken, isLoadingPricing } =
@@ -68,11 +67,7 @@ const ActiveContestList = ({
   const shouldRenderPotentialCard =
     showPotentialCardCase1 || showPotentialCardCase2;
 
-  const activeContestsLimited = isCommunityHomePage
-    ? activeContests.length > 0
-      ? activeContests.slice(0, 3)
-      : suggestedContest.slice(0, 3) || []
-    : activeContests.slice(0, 3);
+  const activeContestsLimited = activeContests.slice(0, 3);
 
   const communityIds = [
     ...new Set(activeContestsLimited.map((contest) => contest.community_id)),
@@ -109,9 +104,6 @@ const ActiveContestList = ({
           </div>
         </Link>
       </div>
-      {isSuggestedMode && !shouldRenderPotentialCard && (
-        <CWText type="h5">Suggested</CWText>
-      )}
       <>
         {shouldRenderPotentialCard && <PotentialContestCard />}
         {!isLoading &&
@@ -122,6 +114,10 @@ const ActiveContestList = ({
               No active contests found
             </CWText>
           )}
+        {!isLoading &&
+          !shouldRenderPotentialCard &&
+          isCommunityHomePage &&
+          !hasActiveContests && <ExploreContestsCard />}
         {isLoading ? (
           <div className="content">
             <>


### PR DESCRIPTION
## Summary
- hide contests from other communities on Community Home page
- show Explore Contests card when no contests available

## Testing
- `pnpm lint-diff` *(fails: npm registry blocked)*
- `pnpm format` *(fails: npm registry blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68596e45234c832fb07dcb12ce1b114e