### PR TITLE
Display poll end timestamp in thread poll card

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Polls/PollCard/PollCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/Polls/PollCard/PollCard.scss
@@ -30,6 +30,17 @@
     .poll-title-text.Text {
       width: 100%;
     }
+
+    .poll-end-timestamp.Text {
+      color: colors.$neutral-500;
+    }
+
+    .poll-title-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      width: 100%;
+    }
   }
 
   .poll-voting-section {

--- a/packages/commonwealth/client/scripts/views/components/Polls/PollCard/PollCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Polls/PollCard/PollCard.tsx
@@ -45,6 +45,7 @@ export type PollCardProps = PollOptionProps &
     tokenDecimals?: number;
     topicWeight?: TopicWeightedVoting | null;
     isLoadingVotes?: boolean;
+    endTimestamp?: string;
   };
 
 export const PollCard = ({
@@ -57,6 +58,7 @@ export const PollCard = ({
   pollEnded,
   proposalTitle = 'Poll',
   timeRemaining,
+  endTimestamp,
   tokenSymbol,
   tooltipErrorMessage,
   votedFor,
@@ -138,9 +140,16 @@ export const PollCard = ({
   return (
     <CWCard className="PollCard">
       <div className="poll-title-section">
-        <CWText type="b2" className="poll-title-text">
-          {proposalTitle}
-        </CWText>
+        <div className="poll-title-wrapper">
+          <CWText type="b2" className="poll-title-text">
+            {proposalTitle}
+          </CWText>
+          {endTimestamp && (
+            <CWText type="caption" className="poll-end-timestamp">
+              {`Ends ${endTimestamp}`}
+            </CWText>
+          )}
+        </div>
         <CWModal
           size="small"
           content={

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/ThreadPollCard.tsx
@@ -11,7 +11,7 @@ import { openConfirmation } from 'views/modals/confirmation_modal';
 import { z } from 'zod';
 import Permissions from '../../../utils/Permissions';
 import { PollCard } from '../../components/Polls';
-import { getPollTimestamp } from './helpers';
+import { getPollTimestamp, getPollEndDateString } from './helpers';
 import './poll_cards.scss';
 
 type ThreadPollCardProps = {
@@ -172,6 +172,7 @@ export const ThreadPollCard = ({
           poll,
           !!poll.ends_at && moment(poll.ends_at).isBefore(moment().utc()),
         )}
+        endTimestamp={getPollEndDateString(poll)}
         totalVoteCount={pollVotes.length}
         totalVoteWeight={totalVoteWeight}
         voteInformation={voteInformation}

--- a/packages/commonwealth/client/scripts/views/pages/view_thread/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/view_thread/helpers.tsx
@@ -17,3 +17,16 @@ export const getPollTimestamp = (
     ? `Ended ${moment(end).format('lll')}`
     : `${moment().from(end).replace(' ago', '')} left`;
 };
+
+export const getPollEndDateString = (
+  poll: z.infer<typeof PollView> & { custom_duration?: string },
+) => {
+  if (
+    (!poll.ends_at || !moment(poll.ends_at).isValid()) &&
+    (poll.custom_duration === 'Infinite' || !poll.custom_duration)
+  ) {
+    return '';
+  }
+  const end = poll.ends_at ?? poll.custom_duration;
+  return moment(end).format('lll');
+};


### PR DESCRIPTION
## Summary
- add poll end timestamp string helper
- pass endTimestamp to `PollCard` from `ThreadPollCard`
- show end timestamp in the poll card header
- style poll card header for timestamp

## Testing
- Create a Poll
- See Timestamp is reflective of exact end date of the poll
**Take screenshot and loom of the whole process** 

------
https://chatgpt.com/codex/tasks/task_e_68597387da10832f8aea9161af79126a