### PR TITLE
Fix : Individual Cosmos Proposals not Loading 

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/NewProposalViewPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/NewProposalViewPage/NewProposalViewPage.tsx
@@ -147,10 +147,22 @@ const NewProposalViewPage = ({ identifier, scope }: ViewProposalPageProps) => {
 
   if (
     isCosmosChain &&
-    ((queryType === 'cosmos' &&
-      (cosmosError || !(proposal && isCosmosLoading))) ||
-      (queryType !== 'cosmos' &&
-        (snapshotProposalError || !(snapshotProposal && isSnapshotLoading))))
+    queryType === 'cosmos' &&
+    !isCosmosLoading &&
+    (cosmosError || !proposal)
+  ) {
+    return (
+      <PageNotFound
+        message={"We couldn't find what you searched for. Try searching again."}
+      />
+    );
+  }
+
+  if (
+    isCosmosChain &&
+    queryType !== 'cosmos' &&
+    !isSnapshotLoading &&
+    (snapshotProposalError || !snapshotProposal)
   ) {
     return (
       <PageNotFound


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12516

## Description of Changes
- Updated logic in NewProposalViewPage to display the "not found" error only after loading finishes and the proposal is missing or errored.
- Prevents premature error display while data is still loading.

## Test Plan
- Navigate to any cosmos community e.g (kyve).
- Navigate to proposals section from the left sidebar.
- Click on any proposla verify you are redirected to proposal details page and is shown.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 