### PR TITLE
Fixes retry loop and encapsulates gating logic a bit more

### DIFF
--- a/libs/core/src/framework/types.ts
+++ b/libs/core/src/framework/types.ts
@@ -59,6 +59,9 @@ export type User = {
 export type Actor = {
   readonly user: Readonly<User>;
   readonly address?: string;
+  readonly address_id?: number;
+  readonly community_id?: string;
+  readonly role?: string;
   readonly is_system_actor?: boolean;
 };
 

--- a/libs/model/src/aggregates/thread/GetThreadById.query.ts
+++ b/libs/model/src/aggregates/thread/GetThreadById.query.ts
@@ -13,33 +13,25 @@ export function GetThreadById(): Query<typeof schemas.GetThreadById> {
     secure: true,
     body: async ({ actor, payload, context }) => {
       const { thread_id } = payload;
-      const address_id = context?.address?.id;
-
-      const gating = {
-        address_id,
-        admin_or_moderator:
-          actor.user.isAdmin ||
-          ['admin', 'moderator'].includes(context?.address?.role || ''),
-      };
 
       // find open gates in thread's community
       const [open_thread] = await sequelize.query<{
         id: number;
       }>(
         `
-        ${withGates(gating)}
+        ${withGates(actor)}
         SELECT T.id
         FROM
           "Threads" T
-          ${joinGates(gating)}
+          ${joinGates(actor)}
         WHERE
           T.id = :thread_id
-          ${filterGates(gating)}
+          ${filterGates(actor)}
         `,
         {
           type: QueryTypes.SELECT,
           replacements: {
-            address_id,
+            address_id: actor.address_id,
             community_id: context?.community_id,
             thread_id,
           },

--- a/libs/model/src/aggregates/thread/SearchThreads.query.ts
+++ b/libs/model/src/aggregates/thread/SearchThreads.query.ts
@@ -23,10 +23,9 @@ export function SearchThreads(): Query<typeof schemas.SearchThreads> {
         order_direction,
         include_count,
       } = payload;
-      const address_id = context?.address?.id;
 
       const replacements = {
-        address_id,
+        address_id: actor.address_id,
         community_id:
           community_id && community_id !== ALL_COMMUNITIES
             ? community_id
@@ -36,15 +35,8 @@ export function SearchThreads(): Query<typeof schemas.SearchThreads> {
         offset: limit * (cursor - 1),
       };
 
-      const gating = {
-        address_id,
-        admin_or_moderator:
-          actor.user.isAdmin ||
-          ['admin', 'moderator'].includes(context?.address?.role || ''),
-      };
-
       const sql = `
-${withGates(gating)}
+${withGates(actor)}
 SELECT 
   'thread' as type,
   T.community_id,
@@ -70,13 +62,13 @@ FROM
     "Threads" T
     JOIN "Addresses" A ON T.address_id = A.id
     JOIN "Users" U ON A.user_id = U.id
-    ${joinGates(gating)}
+    ${joinGates(actor)}
     , websearch_to_tsquery('english', :search_term) as tsquery
 WHERE
   T.deleted_at IS NULL
   AND T.marked_as_spam_at IS NULL
   ${replacements.community_id ? 'AND T.community_id = :community_id' : ''} 
-  ${filterGates(gating)}
+  ${filterGates(actor)}
   AND (T.title ILIKE '%' || :search_term || '%' ${!thread_title_only ? 'OR tsquery @@ T.search' : ''})
 ORDER BY
   ${order_by === 'created_at' ? `T.${order_by} ${order_direction || 'DESC'}` : `rank, T.created_at DESC`}

--- a/libs/model/src/aggregates/user/GetUserProfile.query.ts
+++ b/libs/model/src/aggregates/user/GetUserProfile.query.ts
@@ -57,10 +57,11 @@ comments AS (
     JOIN user_addresses ua ON ua.id = c.address_id
     JOIN "Addresses" a ON c.address_id = a.id
     JOIN "Threads" t ON c.thread_id = t.id
-    JOIN open_gates og ON t.topic_id = og.topic_id
+    LEFT JOIN open_gates og ON t.topic_id = og.topic_id
   WHERE
-    t.deleted_at IS NULL AND 
-    c.deleted_at IS NULL
+    t.deleted_at IS NULL
+    AND c.deleted_at IS NULL
+    AND (og.topic_id IS NOT NULL OR a.user_id = :actor_id)
   ORDER BY
     c.created_at DESC
 ) 
@@ -160,13 +161,14 @@ SELECT
   	ORDER BY t.created_at DESC), '[]'::json)
     FROM
       "Threads" t
-      JOIN open_gates og ON t.topic_id = og.topic_id
       JOIN user_addresses ua ON ua.id = t.address_id
       JOIN "Addresses" a ON ua.id = a.id
       JOIN "Users" u ON a.user_id = u.id
       JOIN "Topics" g ON t.topic_id = g.id
+      LEFT JOIN open_gates og ON t.topic_id = og.topic_id
     WHERE
       t.deleted_at IS NULL 
+      AND (og.topic_id IS NOT NULL OR a.user_id = :actor_id)
   ) AS threads
 , (
   SELECT COALESCE(json_agg(
@@ -233,7 +235,6 @@ SELECT
 	FROM
 	  comments c
 	  JOIN "Threads" t ON c.thread_id = t.id
-    JOIN open_gates og ON t.topic_id = og.topic_id
 	  JOIN "Addresses" a ON c.address_id = a.id
 	  JOIN "Users" u ON a.user_id = u.id
 	  JOIN "Topics" g ON t.topic_id = g.id

--- a/libs/model/src/middleware/auth.ts
+++ b/libs/model/src/middleware/auth.ts
@@ -159,6 +159,9 @@ async function findVerifiedAddress(
   });
 
   if (address) {
+    (actor as { address_id: number }).address_id = address.id!;
+    (actor as { community_id: string }).community_id = address.community_id;
+    (actor as { role: string }).role = address.role;
     // fire and forget address activity tracking
     address.last_active = new Date();
     void address.save();
@@ -217,6 +220,9 @@ async function findAddress(
   });
 
   if (address) {
+    (actor as { address_id: number }).address_id = address.id!;
+    (actor as { community_id: string }).community_id = address.community_id;
+    (actor as { role: string }).role = address.role;
     // fire and forget address activity tracking
     address.last_active = new Date();
     void address.save();

--- a/packages/commonwealth/client/scripts/state/api/threads/getThreadById.ts
+++ b/packages/commonwealth/client/scripts/state/api/threads/getThreadById.ts
@@ -10,6 +10,12 @@ const useGetThreadByIdQuery = (thread_id: number, enabled = true) => {
       staleTime: THREAD_STALE_TIME,
       select: (data) => new Thread(data),
       enabled,
+      retry: (failureCount, error) => {
+        // Avoid retrying if unauthorized
+        if (error?.data?.code === 'UNAUTHORIZED') return false;
+        // Optional: limit retries to 2 times for other errors
+        return failureCount < 2;
+      },
     },
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12545

## Description of Changes

- Stops getThreadById retry when first error is UNAUTHORIZED
- Enhances actor context in all auth middleware, to include address_id, community_id, and role
- Encapsulates gating sql logic to use actor's context 
  - bypass gating when super admin or community admin/moderator
  - gate community when in community/address context
  - filter private topics when no community context is found     

## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 