### PR TITLE
Migrate Staging DBs to Neon

### DIFF
--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -186,6 +186,21 @@ jobs:
               console.log('No deployment URL found to comment on PR');
             }
 
+      - name: Comment on PR if Deployment Fails
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const message = `❌ Review app deployment failed!\n\nYou can view the failed workflow run for details: [View Run](${runUrl})`;
+            github.rest.issues.createComment({
+              issue_number: ${{ steps.set_pr_number.outputs.pr_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });
+
       # TODO: check if this posts a new comment for each commit to an open PR if this updates the comment
       # TODO: if this creates a new comment for each commit, we need to update if so it only posts a
       # new comment when a migration changes in one of the commits since last execution

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ redis-data
 *coverage
 **/*.dump.sql
 **/*.dump.sql.gz
+**/dump_for_neon.sql
 external-production-openapi.json
 external-openapi.json
 .eslintcache

--- a/packages/commonwealth/package.json
+++ b/packages/commonwealth/package.json
@@ -44,6 +44,7 @@
     "lint-diff-canary": "cp test/canary/eslint_canary.ts.disabled test/canary/eslint_canary.ts && (NODE_OPTIONS='--max-old-space-size=16384' eslint --cache -c ../../.eslintrc-diff.cjs test/canary/eslint_canary.ts | tail +2; true) > test/canary/eslint_canary.log ; diff -w -u test/canary/eslint_canary.log test/canary/eslint_canary.snap",
     "migrate-db": "npx sequelize db:migrate",
     "migrate-db-down": "npx sequelize db:migrate:undo",
+    "migrate-db-to-neon": "chmod u+x scripts/migrate-db-to-neon.sh && ./scripts/migrate-db-to-neon.sh",
     "preview": "concurrently -p '{name}' -c red,green 'PORT=3000 pnpm run start' 'vite preview -c ./client/vite.config.ts'",
     "psql": "chmod u+x scripts/start-psql.sh && ./scripts/start-psql.sh",
     "publish-rmq-msg": "tsx ./scripts/publishRmqMessageScript.ts",

--- a/packages/commonwealth/scripts/migrate-db-to-neon.sh
+++ b/packages/commonwealth/scripts/migrate-db-to-neon.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# this path is relative to the location from which the script is called i.e. /commonwealth root rather than the path
+# from which the script exists i.e. commonwealth/scripts/
+. ../../scripts/load-env-var.sh --source-only
+
+load-env-var '../../.env';
+
+if [[ -z "${BRANCH_NAME}" ]]; then
+  BRANCH_NAME="production"
+else
+  BRANCH_NAME="${BRANCH_NAME}"
+fi
+
+DATABASE_NAME="commonwealth"
+PROJECT_ID="${NEON_PROJECT_ID}"
+ORG_ID="${NEON_ORG_ID}"
+
+if [[ -z "${PROJECT_ID}" ]]; then
+    echo "Error: NEON_PROJECT_ID is not set"
+    exit 1
+fi
+
+if [[ -z "${ORG_ID}" ]]; then
+    echo "Error: NEON_ORG_ID is not set"
+    exit 1
+fi
+
+neon() {
+   if [ -n "$PROJECT_ID" ]; then
+       neonctl "$@" --org-id "$ORG_ID" --project-id "$PROJECT_ID"
+   else
+       neonctl "$@" --org-id "$ORG_ID"
+   fi
+}
+
+echo "Checking if database '$DATABASE_NAME' exists on branch '$BRANCH_NAME'..."
+
+if neon databases list --branch-name "$BRANCH_NAME" --output json | jq -r '.[].name' | grep -q "^${DATABASE_NAME}$"; then
+   echo "Database '$DATABASE_NAME' found. Dropping it..."
+
+   if neon databases delete "$DATABASE_NAME" --branch-name "$BRANCH_NAME"; then
+       echo "Database dropped successfully."
+   else
+       echo "Failed to drop database. Exiting."
+       exit 1
+   fi
+else
+   echo "Database '$DATABASE_NAME' does not exist."
+fi
+
+echo "Creating database '$DATABASE_NAME'..."
+if neon databases create --name "$DATABASE_NAME" --branch-name "$BRANCH_NAME"; then
+   echo "Database '$DATABASE_NAME' created successfully."
+else
+   echo "Failed to create database."
+   exit 1
+fi
+
+echo "Fetching database URI..."
+DB_URL=$(neon connection-string --branch-name "$BRANCH_NAME" --database-name "$DATABASE_NAME")
+
+# Check if dump file already exists
+if [[ -f "dump_for_neon.sql" ]]; then
+    echo "Found existing dump file: dump_for_neon.sql"
+    read -p "Do you want to use the existing dump file? (Y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "Creating new dump from Heroku DB..."
+        HEROKU_DB_URL=$(heroku config:get HEROKU_POSTGRESQL_MAROON_URL -a commonwealth-beta)
+        if [[ -z "$HEROKU_DB_URL" ]]; then
+            echo "Error: Failed to get Heroku database URL"
+            exit 1
+        fi
+
+        pg_dump "$HEROKU_DB_URL" \
+            --verbose \
+            --no-privileges \
+            --no-owner \
+            --no-acl \
+            -f dump_for_neon.sql
+    else
+        echo "Using existing dump file."
+    fi
+else
+    echo "Dumping Heroku DB..."
+    HEROKU_DB_URL=$(heroku config:get HEROKU_POSTGRESQL_MAROON_URL -a commonwealth-beta)
+    if [[ -z "$HEROKU_DB_URL" ]]; then
+        echo "Error: Failed to get Heroku database URL"
+        exit 1
+    fi
+
+    pg_dump "$HEROKU_DB_URL" \
+        --verbose \
+        --no-privileges \
+        --no-owner \
+        --no-acl \
+        -f dump_for_neon.sql
+fi
+
+echo "Uploading Heroku dump to Neon branch '$BRANCH_NAME' in database '$DATABASE_NAME'"
+
+psql "$DB_URL" \
+    --echo-queries \
+    --file=dump_for_neon.sql \
+    --single-transaction \
+    --set ON_ERROR_STOP=on
+
+echo "Upload complete!"
+
+read -p "Do you want to delete the dump file? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    rm -f dump_for_neon.sql
+    echo "Dump file deleted."
+fi
+

--- a/packages/commonwealth/scripts/reset-db.sh
+++ b/packages/commonwealth/scripts/reset-db.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit on any error
+set -e
+
 # this path is relative to the location from which the script is called i.e. /commonwealth root rather than the path
 # from which the script exists i.e. commonwealth/scripts/
 . ../../scripts/load-env-var.sh --source-only
@@ -12,12 +15,30 @@ else
   PGPASSWORD="${PGPASSWORD}"
 fi
 
+PROJECT_ID="${NEON_PROJECT_ID}"
+ORG_ID="${NEON_ORG_ID}"
+
 app=${1:-local}
 
 if [ "$app" == "local" ]; then
   psql -h localhost -d postgres -U commonwealth -c 'DROP DATABASE commonwealth WITH (FORCE);'; npx sequelize db:create
-elif [ "$app" == "frick" ] || [ "$app" == "frack" ] || [ "$app" == "beta" ]|| [ "$app" == "demo" ]; then
-  heroku pg:copy commonwealth-beta::HEROKU_POSTGRESQL_MAROON_URL DATABASE_URL --app commonwealth-"$app" --confirm commonwealth-"$app"
+elif [ "$app" == "frick" ] || [ "$app" == "frack" ] || [ "$app" == "beta" ] || [ "$app" == "demo" ]; then
+  if [[ -z "${PROJECT_ID}" ]]; then
+      echo "Error: NEON_PROJECT_ID is not set"
+      exit 1
+  fi
+
+  if [[ -z "${ORG_ID}" ]]; then
+      echo "Error: NEON_ORG_ID is not set"
+      exit 1
+  fi
+
+  echo "Resetting Neon branch '$app' from 'production' branch..."
+  neonctl branches reset "$app" \
+    --parent \
+    --project-id "$PROJECT_ID" \
+    --org-id "$ORG_ID"
+  echo "Branch '$app' has been reset successfully."
 else
-  echo "Invalid app argument. Please use 'local', 'frick', 'frack', 'beta' or 'demo'.."
+  echo "Invalid app argument. Please use 'local', 'frick', 'frack', 'beta' or 'demo'."
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #TODO

## Description of Changes
- Added `pnpm migrate-db-to-neon` script
  - This script will be deleted once we migrate the production database.
  - Currently, this script copies the follower database to the "production" branch on Neon
- Modified reset-db script to reset the specified branch using "production" as the parent
- Modified review app workflow so that if the deploy job fails, it comments with a link to the action

## Test Plan

## Deployment Plan
1. Delete Heroku Postgres add-ons on frack, beta, demo (frick already done)
2. Update `DATABASE_URL` to the corresponding branch URI

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 