### PR TITLE
Burton/fix email sms auth

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
+++ b/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
@@ -26,6 +26,10 @@ export function usePrivySignOn() {
     async (props: UsePrivySignOnProps) => {
       const { wallet, ssoOAuthToken, ssoProvider, onSuccess } = props;
 
+      console.log(
+        'Authenticating with privy user: ' + JSON.stringify(privyUser, null, 2),
+      );
+
       if (ssoProvider === 'email' && !privyUser?.email) {
         // trying to login via email but the privyUser is wrong.
         console.log('Skipping attempt at email auth... ');
@@ -73,6 +77,6 @@ export function usePrivySignOn() {
 
       onSuccess(wallet.address, newlyCreated);
     },
-    [identityTokenRef, signIn, signMessage],
+    [identityTokenRef, privyUser, signIn, signMessage],
   );
 }

--- a/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
+++ b/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
@@ -28,11 +28,13 @@ export function usePrivySignOn() {
 
       if (ssoProvider === 'email' && !privyUser?.email) {
         // trying to login via email but the privyUser is wrong.
+        console.log('Skipping attempt at email auth... ');
         return;
       }
 
       if (ssoProvider === 'phone' && !privyUser?.phone) {
         // trying to login via phone but the privyUser is wrong.
+        console.log('Skipping attempt at phone auth... ');
         return;
       }
 

--- a/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
+++ b/packages/commonwealth/client/scripts/views/components/Privy/usePrivySignOn.ts
@@ -1,5 +1,5 @@
 import { ChainBase, WalletId } from '@hicommonwealth/shared';
-import { ConnectedWallet } from '@privy-io/react-auth';
+import { ConnectedWallet, usePrivy } from '@privy-io/react-auth';
 import { PrivyEthereumWebWalletController } from 'controllers/app/webWallets/privy_ethereum_web_wallet';
 import { getSessionFromWallet } from 'controllers/server/sessions';
 import { useCallback } from 'react';
@@ -20,10 +20,21 @@ export function usePrivySignOn() {
   const { signIn } = useSignIn();
   const signMessage = useSignMessageMemo();
   const identityTokenRef = useIdentityTokenRef();
+  const { user: privyUser } = usePrivy();
 
   return useCallback(
     async (props: UsePrivySignOnProps) => {
       const { wallet, ssoOAuthToken, ssoProvider, onSuccess } = props;
+
+      if (ssoProvider === 'email' && !privyUser?.email) {
+        // trying to login via email but the privyUser is wrong.
+        return;
+      }
+
+      if (ssoProvider === 'phone' && !privyUser?.phone) {
+        // trying to login via phone but the privyUser is wrong.
+        return;
+      }
 
       const ethereumProvider = async () => {
         return await wallet.getEthereumProvider();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12561

## Description of Changes

Privy was trying to login both via email and via phone.

This was a bug due to the unusual configuration I had to go with to get privy auth to work in the webapp.

I DID NOT test the new user path though.  

I can't test that since I don't have infinite phone numbers :)

## Test Plan

Try to authenticate with your phone via sms.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 