### PR TITLE
Added migration to deduplicate names

### DIFF
--- a/libs/model/src/aggregates/user/GetStatus.query.ts
+++ b/libs/model/src/aggregates/user/GetStatus.query.ts
@@ -88,6 +88,7 @@ export function GetStatus(): Query<typeof schemas.GetStatus> {
         referred_by_address: user.referred_by_address,
         xp_points: user.xp_points,
         xp_referrer_points: user.xp_referrer_points,
+        notify_user_name_change: user.notify_user_name_change,
         addresses: (addresses || []).map((a) => a.toJSON()) as Array<
           z.infer<typeof schemas.UserStatusAddressView>
         >,

--- a/libs/model/src/aggregates/user/GetStatus.query.ts
+++ b/libs/model/src/aggregates/user/GetStatus.query.ts
@@ -88,7 +88,7 @@ export function GetStatus(): Query<typeof schemas.GetStatus> {
         referred_by_address: user.referred_by_address,
         xp_points: user.xp_points,
         xp_referrer_points: user.xp_referrer_points,
-        notify_user_name_change: user.notify_user_name_change,
+        notify_user_name_change: user.notify_user_name_change ?? false,
         addresses: (addresses || []).map((a) => a.toJSON()) as Array<
           z.infer<typeof schemas.UserStatusAddressView>
         >,

--- a/libs/model/src/aggregates/user/UpdateUser.command.ts
+++ b/libs/model/src/aggregates/user/UpdateUser.command.ts
@@ -1,6 +1,7 @@
 import { InvalidInput, InvalidState, type Command } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { DEFAULT_NAME } from '@hicommonwealth/shared';
+import { Op } from 'sequelize';
 import { models } from '../../database';
 import { authVerified } from '../../middleware/auth';
 import { mustExist } from '../../middleware/guards';
@@ -104,6 +105,7 @@ export function UpdateUser(): Command<typeof schemas.UpdateUser> {
               }
               const existingUsername = await models.User.findOne({
                 where: {
+                  id: { [Op.ne]: id },
                   profile: {
                     name: updates?.profile?.name,
                   },

--- a/libs/model/src/aggregates/user/UpdateUser.command.ts
+++ b/libs/model/src/aggregates/user/UpdateUser.command.ts
@@ -47,9 +47,15 @@ export function UpdateUser(): Command<typeof schemas.UpdateUser> {
         user.promotional_emails_enabled ??
         false;
 
+      const notify_user_name_change =
+        payload.notify_user_name_change ??
+        user.notify_user_name_change ??
+        false;
+
       const user_delta = getDelta(user, {
         is_welcome_onboard_flow_complete,
         promotional_emails_enabled,
+        notify_user_name_change,
         profile: {
           email,
           slug,

--- a/libs/model/src/aggregates/user/UpdateUser.command.ts
+++ b/libs/model/src/aggregates/user/UpdateUser.command.ts
@@ -1,4 +1,4 @@
-import { InvalidInput, type Command } from '@hicommonwealth/core';
+import { InvalidInput, InvalidState, type Command } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { DEFAULT_NAME } from '@hicommonwealth/shared';
 import { models } from '../../database';
@@ -101,6 +101,16 @@ export function UpdateUser(): Command<typeof schemas.UpdateUser> {
               };
               if (updates.profile.bio === '') {
                 updates.profile.bio = null;
+              }
+              const existingUsername = await models.User.findOne({
+                where: {
+                  profile: {
+                    name: updates?.profile?.name,
+                  },
+                },
+              });
+              if (existingUsername) {
+                throw new InvalidState('Username already exists');
               }
               const [, rows] = await models.User.update(updates, {
                 where: { id: user.id },

--- a/libs/model/src/models/user.ts
+++ b/libs/model/src/models/user.ts
@@ -102,7 +102,7 @@ export default (sequelize: Sequelize.Sequelize): UserModelStatic =>
       notify_user_name_change: {
         type: Sequelize.BOOLEAN,
         defaultValue: false,
-        allowNull: false,
+        allowNull: true,
       },
     },
     {

--- a/libs/model/src/models/user.ts
+++ b/libs/model/src/models/user.ts
@@ -99,6 +99,11 @@ export default (sequelize: Sequelize.Sequelize): UserModelStatic =>
         type: Sequelize.STRING,
         allowNull: true,
       },
+      notify_user_name_change: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
     },
     {
       timestamps: true,

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -66,6 +66,7 @@ export const User = z.object({
   xp_points: PG_INT.default(0).nullish(),
   xp_referrer_points: PG_INT.default(0).nullish(),
   privy_id: z.string().max(255).nullish(),
+  notify_user_name_change: z.boolean().default(false).optional(),
 
   ProfileTags: z.array(ProfileTags).optional(),
   ApiKey: ApiKey.optional(),

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -66,7 +66,7 @@ export const User = z.object({
   xp_points: PG_INT.default(0).nullish(),
   xp_referrer_points: PG_INT.default(0).nullish(),
   privy_id: z.string().max(255).nullish(),
-  notify_user_name_change: z.boolean().default(false).optional(),
+  notify_user_name_change: z.boolean().default(false).nullish(),
 
   ProfileTags: z.array(ProfileTags).optional(),
   ApiKey: ApiKey.optional(),

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -66,7 +66,7 @@ export const User = z.object({
   xp_points: PG_INT.default(0).nullish(),
   xp_referrer_points: PG_INT.default(0).nullish(),
   privy_id: z.string().max(255).nullish(),
-  notify_user_name_change: z.boolean().default(false).optional(),
+  notify_user_name_change: z.boolean().default(false),
 
   ProfileTags: z.array(ProfileTags).optional(),
   ApiKey: ApiKey.optional(),

--- a/libs/schemas/src/entities/user.schemas.ts
+++ b/libs/schemas/src/entities/user.schemas.ts
@@ -66,7 +66,7 @@ export const User = z.object({
   xp_points: PG_INT.default(0).nullish(),
   xp_referrer_points: PG_INT.default(0).nullish(),
   privy_id: z.string().max(255).nullish(),
-  notify_user_name_change: z.boolean().default(false),
+  notify_user_name_change: z.boolean().default(false).optional(),
 
   ProfileTags: z.array(ProfileTags).optional(),
   ApiKey: ApiKey.optional(),

--- a/libs/schemas/src/queries/user.schemas.ts
+++ b/libs/schemas/src/queries/user.schemas.ts
@@ -96,6 +96,7 @@ export const GetStatus = {
       communities: z.array(UserStatusCommunityView),
       jwt: z.string(),
       knockJwtToken: z.string().optional(),
+      notify_user_name_change: z.boolean().default(false),
     })
     .optional(),
 };

--- a/packages/commonwealth/client/scripts/controllers/app/login.ts
+++ b/packages/commonwealth/client/scripts/controllers/app/login.ts
@@ -189,6 +189,7 @@ export function updateActiveUser(data?: z.infer<(typeof GetStatus)['output']>) {
       referredByAddress: undefined,
       xpPoints: 0,
       xpReferrerPoints: 0,
+      notifyUserNameChange: false,
     });
   } else {
     const addresses = data.addresses.map((a) => {
@@ -236,6 +237,7 @@ export function updateActiveUser(data?: z.infer<(typeof GetStatus)['output']>) {
       referredByAddress: data.referred_by_address || undefined,
       xpReferrerPoints: data.xp_referrer_points || undefined,
       tier: data.tier || undefined,
+      notifyUserNameChange: data.notify_user_name_change || false,
     });
   }
 }

--- a/packages/commonwealth/client/scripts/state/ui/user/user.ts
+++ b/packages/commonwealth/client/scripts/state/ui/user/user.ts
@@ -40,6 +40,7 @@ type CommonProps = {
   xpReferrerPoints: number;
   referredByAddress?: string;
   tier: number;
+  notifyUserNameChange: boolean;
 };
 
 export type UserStoreProps = CommonProps & {
@@ -71,6 +72,7 @@ export const userStore = createStore<UserStoreProps>()(
     xpReferrerPoints: 0,
     referredByAddress: undefined,
     tier: 0,
+    notifyUserNameChange: false,
     // when logged-in, set the auth-user values
     setData: (data) => {
       if (Object.keys(data).length > 0) {

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -5,10 +5,12 @@ import React, { ReactNode, Suspense, useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useParams } from 'react-router-dom';
 import app from 'state';
+import { useSelectCommunityMutation } from 'state/api/communities/selectCommunity';
 import {
   useFetchCustomDomainQuery,
   useFetchPublicEnvVarQuery,
 } from 'state/api/configuration';
+import { useFetchProfileByIdQuery } from 'state/api/profiles';
 import useErrorStore from 'state/ui/error';
 import useUserStore from 'state/ui/user';
 import { MobileScrollBuffer } from 'views/components/MobileNavigation/MobileScrollBuffer';
@@ -19,13 +21,14 @@ import { z } from 'zod';
 import useAppStatus from '../hooks/useAppStatus';
 import useNecessaryEffect from '../hooks/useNecessaryEffect';
 import { useGetCommunityByIdQuery } from '../state/api/communities';
-import { useSelectCommunityMutation } from '../state/api/communities/selectCommunity';
+import { useUpdateUserMutation } from '../state/api/user';
 import './Layout.scss';
 import SubLayout from './Sublayout';
 import MetaTags from './components/MetaTags';
 import { CWEmptyState } from './components/component_kit/cw_empty_state';
 import { CWText } from './components/component_kit/cw_text';
 import CWCircleMultiplySpinner from './components/component_kit/new_designs/CWCircleMultiplySpinner';
+import { openConfirmation } from './modals/confirmation_modal';
 
 type LayoutAttrs = {
   Component: ReactNode | any;
@@ -54,6 +57,11 @@ const LayoutComponent = ({
   const user = useUserStore();
   const appError = useErrorStore();
 
+  const { data } = useFetchProfileByIdQuery({
+    apiCallEnabled: user.notifyUserNameChange,
+  });
+
+  const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
   const [communityToLoad, setCommunityToLoad] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>();
 
@@ -68,6 +76,38 @@ const LayoutComponent = ({
       user.setData({ isOnPWA: isAddedToHomeScreen });
     }
   }, [isAddedToHomeScreen, user.isOnPWA, user]);
+
+  const { mutateAsync: updateUser } = useUpdateUserMutation();
+
+  useEffect(() => {
+    if (user.notifyUserNameChange && data && !confirmationModalOpen) {
+      setConfirmationModalOpen(true);
+      const handleAcknowledge = async () => {
+        await updateUser({
+          id: user.id,
+          profile: data.profile,
+          notify_user_name_change: false,
+        });
+        user.setData({ notifyUserNameChange: false });
+      };
+
+      openConfirmation({
+        title: 'Notice',
+        onClose: handleAcknowledge,
+        description:
+          'User name has been set to Anonymous due to duplicate ' +
+          'name. Please change your name in the edit profile section.',
+        buttons: [
+          {
+            label: 'Confirm',
+            buttonHeight: 'sm',
+            onClick: handleAcknowledge,
+          },
+        ],
+        hideWarning: true,
+      });
+    }
+  }, [user.notifyUserNameChange, updateUser, user, data]);
 
   // If community id was updated ex: `${PRODUCTION_DOMAIN}/{community-id}/**/*`
   // redirect to new community id ex: `${PRODUCTION_DOMAIN}/{new-community-id}/**/*`

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -2,6 +2,9 @@ import { ExtendedCommunity } from '@hicommonwealth/schemas';
 import { deinitChainOrCommunity, loadCommunityChainInfo } from 'helpers/chain';
 import withRouter, { useCommonNavigate } from 'navigation/helpers';
 import React, { ReactNode, Suspense, useEffect, useState } from 'react';
+import {
+  notifyError,
+} from 'controllers/app/notifications';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useParams } from 'react-router-dom';
 import app from 'state';
@@ -82,12 +85,20 @@ const LayoutComponent = ({
   useEffect(() => {
     if (user.notifyUserNameChange && data && !confirmationModalOpen) {
       setConfirmationModalOpen(true);
-      const handleAcknowledge = async () => {
-        await updateUser({
-          id: user.id,
-          profile: data.profile,
-          notify_user_name_change: false,
-        });
+      const handleAcknowledge = () => {
+        (async () => {
+          try {
+            await updateUser({
+              id: user.id,
+              profile: data.profile,
+              notify_user_name_change: false,
+            });
+            user.setData({ notifyUserNameChange: false });
+          } catch (err) {
+            notifyError('Failed to update profile');
+          }
+        })();
+      };
         user.setData({ notifyUserNameChange: false });
       };
 

--- a/packages/commonwealth/client/scripts/views/Layout.tsx
+++ b/packages/commonwealth/client/scripts/views/Layout.tsx
@@ -107,7 +107,13 @@ const LayoutComponent = ({
         hideWarning: true,
       });
     }
-  }, [user.notifyUserNameChange, updateUser, user, data]);
+  }, [
+    user.notifyUserNameChange,
+    updateUser,
+    user,
+    data,
+    confirmationModalOpen,
+  ]);
 
   // If community id was updated ex: `${PRODUCTION_DOMAIN}/{community-id}/**/*`
   // redirect to new community id ex: `${PRODUCTION_DOMAIN}/{new-community-id}/**/*`

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
@@ -231,7 +231,11 @@ const EditProfile = () => {
           }
         })
         .catch((err) => {
-          notifyError(err?.response?.data?.error || 'Something went wrong.');
+          notifyError(
+            err?.response?.data?.error ||
+              err.message ||
+              'Something went wrong.',
+          );
         });
     };
 

--- a/packages/commonwealth/server/migrations/20250709170354-unique-profile-name.js
+++ b/packages/commonwealth/server/migrations/20250709170354-unique-profile-name.js
@@ -52,12 +52,5 @@ module.exports = {
     });
   },
 
-  async down(queryInterface, Sequelize) {
-    /**
-     * Add reverting commands here.
-     *
-     * Example:
-     * await queryInterface.dropTable('users');
-     */
-  },
+  async down(queryInterface, Sequelize) {},
 };

--- a/packages/commonwealth/server/migrations/20250709170354-unique-profile-name.js
+++ b/packages/commonwealth/server/migrations/20250709170354-unique-profile-name.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'Users',
+        'notify_user_name_change',
+        {
+          type: Sequelize.BOOLEAN,
+          defaultValue: false,
+        },
+        { transaction },
+      );
+
+      // If two users have the same name, only keep the earliest users name.
+      // Set the other users names to Anonymous, and set the
+      // notify_user_name_change to true
+      await queryInterface.sequelize.query(
+        `
+            WITH ranked_users AS (
+                SELECT id, profile, created_at,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY profile->>'name'
+                      ORDER BY created_at ASC, id ASC
+                ) AS rn
+                FROM "Users"
+                WHERE profile->>'name' <> 'Anonymous'
+            ),
+            to_update AS (
+                SELECT id
+                FROM ranked_users
+                WHERE rn > 1
+            )
+            UPDATE "Users" u
+            SET profile = jsonb_set(profile, '{name}', '"Anonymous"'),
+                notify_user_name_change = true
+            WHERE u.id IN (SELECT id FROM to_update);
+        `,
+        { transaction },
+      );
+
+      await queryInterface.sequelize.query(
+        `
+          CREATE UNIQUE INDEX unique_profile_name_not_anonymous
+          ON "Users" ((profile ->> 'name'))
+          WHERE (profile->>'name') IS DISTINCT FROM 'Anonymous';
+             `,
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12608

## Description of Changes
### Backend
- Adds partial unique index on Users.profile.names. Updates user.updateUser

### Frontend
- Adds notice screen to notify users whose names were duplicated and set to 'Anonymous' as a result:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/565c6622-f36a-434d-a98c-e87b6f326bfd" />

- Adds error message when trying to update name with existing username:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/e7457582-5371-49fb-8b9f-feb55ac4119a" />

