### PR TITLE
Add LaunchpadTokenGraduated XP event

### DIFF
--- a/libs/model/src/aggregates/user/Xp.projection.ts
+++ b/libs/model/src/aggregates/user/Xp.projection.ts
@@ -621,6 +621,32 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           },
         });
       },
+      LaunchpadTokenGraduated: async ({ id, payload }) => {
+        const user_id =
+          payload.token.creator_address &&
+          (await getUserByAddress(payload.token.creator_address));
+        config.LOG_XP_LAUNCHPAD &&
+          log.info('Xp->LaunchpadTokenGraduated', { id, payload, user_id });
+        if (!user_id) return;
+
+        const created_at = payload.token.updated_at
+          ? new Date(payload.token.updated_at)
+          : new Date();
+        const action_metas = await getQuestActionMetas(
+          { created_at },
+          'LaunchpadTokenGraduated',
+        );
+        await recordXpsForQuest({
+          event_id: id,
+          user_id,
+          event_created_at: created_at,
+          action_metas,
+          scope: {
+            namespace: payload.token.namespace,
+            launchpad_token_address: payload.token.token_address,
+          },
+        });
+      },
       WalletLinked: async ({ id, payload }) => {
         const action_metas = await getQuestActionMetas(payload, 'WalletLinked');
         // TODO: use action meta attributes to determine denomination and conversion to XP,

--- a/libs/schemas/src/entities/quest.schemas.ts
+++ b/libs/schemas/src/entities/quest.schemas.ts
@@ -35,6 +35,7 @@ export const QuestEvents = {
   ContestEnded: events.ContestEnded,
   LaunchpadTokenRecordCreated: events.LaunchpadTokenRecordCreated,
   LaunchpadTokenTraded: events.LaunchpadTokenTraded,
+  LaunchpadTokenGraduated: events.LaunchpadTokenGraduated,
   WalletLinked: events.WalletLinked,
   SSOLinked: events.SSOLinked,
   NamespaceLinked: events.NamespaceLinked,

--- a/packages/commonwealth/client/scripts/helpers/quest.ts
+++ b/packages/commonwealth/client/scripts/helpers/quest.ts
@@ -123,6 +123,7 @@ export const doesActionRequireBasicRewardAmount = (action: QuestActionType) => {
     'MembershipsRefreshed',
     'ContestEnded',
     'LaunchpadTokenRecordCreated',
+    'LaunchpadTokenGraduated',
     'CommunityGoalReached',
   ];
   const channelQuest: QuestActionType[] = [

--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/useQuestForm.ts
@@ -74,6 +74,7 @@ const useQuestForm = ({ mode, initialValues, questId }: QuestFormProps) => {
       'RecurringContestManagerDeployed',
       'LaunchpadTokenRecordCreated',
       'LaunchpadTokenTraded',
+      'LaunchpadTokenGraduated',
       'ContestEnded',
       'CommunityGoalReached',
     ] as QuestAction[],

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestActionCard/helpers.tsx
@@ -18,6 +18,7 @@ export const actionCopies = {
     ['XpChainEventCreated']: 'Engage on Blockchain',
     ['LaunchpadTokenRecordCreated']: 'Launch a Token on Common',
     ['LaunchpadTokenTraded']: 'Trade a Launchpad Token on Common',
+    ['LaunchpadTokenGraduated']: 'Graduate a Launchpad Token',
     ['ContestEnded']: 'Engage on a Contest till completion',
     ['CommunityGoalReached']: 'Complete the community goal',
     ['RecurringContestManagerDeployed']: 'Create a Recurring Contest',
@@ -40,6 +41,7 @@ export const actionCopies = {
     ['XpChainEventCreated']: () => '',
     ['LaunchpadTokenRecordCreated']: () => '',
     ['LaunchpadTokenTraded']: () => '',
+    ['LaunchpadTokenGraduated']: () => '',
     ['ContestEnded']: '',
     ['CommunityGoalReached']: () => '',
     ['RecurringContestManagerDeployed']: '',
@@ -126,6 +128,7 @@ export const actionCopies = {
       </div>
     ),
     ['LaunchpadTokenRecordCreated']: () => '',
+    ['LaunchpadTokenGraduated']: () => '',
     // eslint-disable-next-line react/no-multi-comp
     ['LaunchpadTokenTraded']: (
       amountMultipler: string | number,
@@ -201,6 +204,7 @@ export const actionCopies = {
     ['MembershipsRefreshed']: '',
     ['XpChainEventCreated']: '',
     ['LaunchpadTokenRecordCreated']: '',
+    ['LaunchpadTokenGraduated']: '',
     ['LaunchpadTokenTraded']: '',
     ['ContestEnded']: '',
     ['CommunityGoalReached']: '',

--- a/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/QuestDetails/QuestDetails.tsx
@@ -319,6 +319,10 @@ const QuestDetails = ({ id }: { id: number }) => {
         navigate(`/explore?tab=tokens`);
         break;
       }
+      case 'LaunchpadTokenGraduated': {
+        navigate(`/explore?tab=tokens`);
+        break;
+      }
       case 'CommunityGoalReached': {
         if (quest.community_id) {
           navigate(`/${quest.community_id}/discussions`, {}, null);


### PR DESCRIPTION
## Summary
- support `LaunchpadTokenGraduated` in XP projection
- expose new quest action in schema and quest creation tools
- add text for LaunchpadTokenGraduated quests

## Testing
- `pnpm lint-branch` *(fails: Request was cancelled - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686f2bd538e4832fafae5cc6bb71f78f