### PR TITLE
Add MCP server selection

### DIFF
--- a/libs/shared/src/types/ai.ts
+++ b/libs/shared/src/types/ai.ts
@@ -62,6 +62,8 @@ export interface CompletionOptions {
   stream?: boolean;
   useOpenRouter?: boolean;
   useWebSearch?: boolean;
+  /** Optional MCP server URL to direct the completion request */
+  mcpServerUrl?: string;
 }
 
 export interface CompletionResponse {

--- a/packages/commonwealth/client/scripts/state/api/ai/useAiCompletion.ts
+++ b/packages/commonwealth/client/scripts/state/api/ai/useAiCompletion.ts
@@ -11,6 +11,7 @@ interface AiCompletionOptions extends Partial<CompletionOptions> {
   onError?: (error: Error) => void;
   includeContextualMentions?: boolean;
   communityId?: string;
+  mcpServerUrl?: string;
 }
 
 interface CompletionError {
@@ -125,6 +126,9 @@ ${contextualData}
           jwt: userStore.getState().jwt,
           ...(typeof options?.useWebSearch === 'boolean'
             ? { useWebSearch: options.useWebSearch }
+            : {}),
+          ...(options?.mcpServerUrl
+            ? { mcpServerUrl: options.mcpServerUrl }
             : {}),
         };
 

--- a/packages/commonwealth/client/scripts/state/api/mcp/fetchMcpServers.ts
+++ b/packages/commonwealth/client/scripts/state/api/mcp/fetchMcpServers.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from '@hicommonwealth/schemas';
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+export type McpServer = z.infer<typeof MCPServer>;
+
+const FETCH_MCP_SERVERS_STALE_TIME = 60 * 1000; // 1 minute
+
+const fetchServers = async (): Promise<McpServer[]> => {
+  const response = await fetch('/api/mcp-servers');
+  if (!response.ok) {
+    throw new Error('Failed to fetch MCP servers');
+  }
+  return response.json();
+};
+
+const useFetchMcpServersQuery = (enabled = true) =>
+  useQuery({
+    queryKey: ['mcp-servers'],
+    queryFn: fetchServers,
+    staleTime: FETCH_MCP_SERVERS_STALE_TIME,
+    enabled,
+  });
+
+export default useFetchMcpServersQuery;

--- a/packages/commonwealth/client/scripts/state/api/mcp/index.ts
+++ b/packages/commonwealth/client/scripts/state/api/mcp/index.ts
@@ -1,0 +1,3 @@
+import useFetchMcpServersQuery from './fetchMcpServers';
+export { useFetchMcpServersQuery };
+export type { McpServer } from './fetchMcpServers';

--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
@@ -53,6 +53,7 @@ import {
   getCompletionModelValue,
   MAX_MODELS_SELECTABLE,
 } from './utils';
+import { useFetchMcpServersQuery, McpServer } from 'state/api/mcp';
 
 import './StickyInput.scss';
 
@@ -93,6 +94,11 @@ const StickyInput = (props: StickyInputProps) => {
   const { generateCompletion } = useAiCompletion();
 
   const aiModelPopover = usePopover();
+
+  const { data: mcpServers } = useFetchMcpServersQuery();
+  const [selectedMcpServer, setSelectedMcpServer] = useState<McpServer | null>(
+    null,
+  );
 
   const [streamingReplyIds, setStreamingReplyIds] = useState<number[]>([]);
   const [openModalOnExpand, setOpenModalOnExpand] = useState(false);
@@ -172,6 +178,7 @@ const StickyInput = (props: StickyInputProps) => {
           stream: true,
           systemPrompt,
           useWebSearch: webSearchEnabled,
+          ...(selectedMcpServer && { mcpServerUrl: selectedMcpServer.server_url }),
           includeContextualMentions: true,
           communityId: props.communityId,
           onError: (error) => {
@@ -203,6 +210,7 @@ const StickyInput = (props: StickyInputProps) => {
           stream: true,
           systemPrompt,
           useWebSearch: webSearchEnabled,
+          ...(selectedMcpServer && { mcpServerUrl: selectedMcpServer.server_url }),
           includeContextualMentions: true,
           communityId: props.communityId,
           onError: (error) => {
@@ -228,6 +236,7 @@ const StickyInput = (props: StickyInputProps) => {
     setContentDelta,
     webSearchEnabled,
     selectedModels,
+    selectedMcpServer,
     props.communityId,
   ]);
 
@@ -591,6 +600,8 @@ const StickyInput = (props: StickyInputProps) => {
                   isDisabled={!canComment}
                   onKeyDown={handleKeyDown}
                   justClosed={setJustClosedMentionDropdown}
+                  mcpServers={mcpServers || []}
+                  onMcpServerSelect={setSelectedMcpServer}
                   placeholder={placeholderText}
                 />
               </div>

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/mention-config.ts
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/mention-config.ts
@@ -16,6 +16,7 @@ export enum MentionEntityType {
   THREAD = 'thread',
   COMMUNITY = 'community',
   PROPOSAL = 'proposal',
+  MCP_SERVER = 'mcp_server',
 }
 
 export const MENTION_DENOTATION_CHARS = {
@@ -23,6 +24,7 @@ export const MENTION_DENOTATION_CHARS = {
   '#': MentionEntityType.TOPIC,
   '!': MentionEntityType.THREAD,
   '~': MentionEntityType.COMMUNITY,
+  '/': 'mcp',
 } as const;
 
 export const ENTITY_TYPE_INDICATORS = {
@@ -84,6 +86,12 @@ export const DENOTATION_SEARCH_CONFIG = {
     communityScoped: false,
     description: 'Search all communities',
   },
+  '/': {
+    scopes: [],
+    communityScoped: false,
+    description: 'Search MCP servers',
+    isMcpServer: true,
+  },
 } as const;
 
 // Type alias for search results from SearchEntities query
@@ -110,6 +118,8 @@ export const formatEntityDisplayName = (
       return result.name || 'Unknown Community';
     case MentionEntityType.PROPOSAL:
       return result.name || 'Unknown Proposal';
+    case MentionEntityType.MCP_SERVER:
+      return result.name || 'Unknown Server';
     default:
       return 'Unknown Entity';
   }

--- a/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/react_quill_editor/react_quill_editor.tsx
@@ -18,6 +18,8 @@ import { useImageUploader } from './use_image_uploader';
 import { useMarkdownShortcuts } from './use_markdown_shortcuts';
 import { useMention } from './use_mention';
 import { RTFtoMD, SerializableDeltaStatic, getTextFromDelta } from './utils';
+import { MCPServer } from '@hicommonwealth/schemas';
+import { z } from 'zod';
 
 import { useQuillPasteText } from './useQuillPasteText';
 
@@ -57,6 +59,8 @@ type ReactQuillEditorProps = {
   fromManageTopic?: boolean;
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   justClosed?: (isOpen: boolean) => void;
+  mcpServers?: Array<z.infer<typeof MCPServer>>;
+  onMcpServerSelect?: (server: z.infer<typeof MCPServer>) => void;
 } & ReactQuillEditorFormValidationProps;
 
 const TABS = [
@@ -81,6 +85,8 @@ const ReactQuillEditor = ({
   fromManageTopic = false,
   onKeyDown,
   justClosed,
+  mcpServers = [],
+  onMcpServerSelect,
 }: ReactQuillEditorProps) => {
   const toolbarId = useMemo(() => {
     return `cw-toolbar-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
@@ -130,6 +136,8 @@ const ReactQuillEditor = ({
     editorRef,
     lastSelectionRef,
     justClosed,
+    mcpServers,
+    onMcpServerSelect,
   });
 
   // handle image upload for drag and drop


### PR DESCRIPTION
## Summary
- support MCP server url on AI completion requests
- fetch MCP servers on the client
- allow selecting MCP server via mention search

## Testing
- `pnpm test-api` *(fails: Request was cancelled)*
- `pnpm lint-branch` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685c42500f40832f95cef4144ed7d884