### PR TITLE
fixed bug

### DIFF
--- a/libs/model/src/aggregates/user/GetUserProfile.query.ts
+++ b/libs/model/src/aggregates/user/GetUserProfile.query.ts
@@ -42,7 +42,7 @@ open_gates AS (
     BOOL_AND(
       COALESCE(G.is_private, FALSE) = FALSE
       OR M.address_id IS NOT NULL
-      OR ${actor.user.isAdmin ? 'TRUE' : 'FALSE'}
+      OR ${actor?.user?.isAdmin ? 'TRUE' : 'FALSE'}
     )
 ),
 comments AS (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

If the user is not logged in, we cannot get their isAdmin value, and this returns undefined

## Link to Issue
Closes: hotfix