### PR TITLE
Add Sui NFT balance provider

### DIFF
--- a/libs/model/src/services/tokenBalanceCache/providers/cacheBalances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/cacheBalances.ts
@@ -88,6 +88,8 @@ function buildCacheKey(options: GetBalancesOptions, address: string): string {
         : `sui_${options.sourceOptions.suiNetwork}_${address}`;
     case BalanceSourceType.SuiToken:
       return `sui_${options.sourceOptions.suiNetwork}_${address}_${options.sourceOptions.coinType}`;
+    case BalanceSourceType.SuiNFT:
+      return `sui_${options.sourceOptions.suiNetwork}_${address}_${options.sourceOptions.collectionId}`;
   }
 }
 

--- a/libs/model/src/services/tokenBalanceCache/providers/getSuiBalances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/getSuiBalances.ts
@@ -6,13 +6,18 @@ import {
   Balances,
   GetSuiNativeBalanceOptions,
   GetSuiTokenBalanceOptions,
+  GetSuiNftBalanceOptions,
 } from '../types';
 import { cacheBalances, getCachedBalances } from './cacheBalances';
+import { __get_suinft_balances } from './get_suinft_balances';
 
 const log = logger(import.meta);
 
 export async function getSuiBalances(
-  options: GetSuiNativeBalanceOptions | GetSuiTokenBalanceOptions,
+  options:
+    | GetSuiNativeBalanceOptions
+    | GetSuiTokenBalanceOptions
+    | GetSuiNftBalanceOptions,
   ttl?: number,
 ): Promise<Balances> {
   const cachedBalances = await getCachedBalances(options, options.addresses);
@@ -34,10 +39,16 @@ export async function getSuiBalances(
     return cachedBalances;
   }
 
-  const freshBalances: Balances = await __get_sui_balances(
-    chainNode.private_url || chainNode.url,
-    options,
-  );
+  const freshBalances: Balances =
+    options.balanceSourceType === BalanceSourceType.SuiNFT
+      ? await __get_suinft_balances(
+          chainNode.private_url || chainNode.url,
+          options as GetSuiNftBalanceOptions,
+        )
+      : await __get_sui_balances(
+          chainNode.private_url || chainNode.url,
+          options as GetSuiNativeBalanceOptions | GetSuiTokenBalanceOptions,
+        );
 
   await cacheBalances(options, freshBalances, ttl);
 

--- a/libs/model/src/services/tokenBalanceCache/providers/get_suinft_balances.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/get_suinft_balances.ts
@@ -1,0 +1,40 @@
+import { logger } from '@hicommonwealth/core';
+import { SuiClient } from '@mysten/sui/client';
+import type { Balances, GetSuiNftBalanceOptions } from '../types';
+
+const log = logger(import.meta);
+
+export async function __get_suinft_balances(
+  rpcEndpoint: string,
+  options: GetSuiNftBalanceOptions,
+): Promise<Balances> {
+  const client = new SuiClient({ url: rpcEndpoint });
+  const balances: Balances = {};
+  const batchSize = options.batchSize || 100;
+
+  for (let i = 0; i < options.addresses.length; i += batchSize) {
+    const batchAddresses = options.addresses.slice(i, i + batchSize);
+    for (const address of batchAddresses) {
+      try {
+        let cursor: string | null | undefined = null;
+        let count = 0;
+        do {
+          const res = await client.getOwnedObjects({
+            owner: address,
+            cursor,
+            filter: { StructType: options.sourceOptions.collectionId },
+            options: { showType: true },
+          });
+          count += res.data.length;
+          cursor = res.hasNextPage ? res.nextCursor : null;
+        } while (cursor);
+        balances[address] = count.toString();
+      } catch (e) {
+        log.error(`Failed to fetch Sui NFT balance for ${address}`, e as Error);
+        balances[address] = '0';
+      }
+    }
+  }
+
+  return balances;
+}

--- a/libs/model/src/services/tokenBalanceCache/providers/index.ts
+++ b/libs/model/src/services/tokenBalanceCache/providers/index.ts
@@ -1,3 +1,4 @@
 export * from './getCosmosBalances';
 export * from './getEvmBalances';
 export * from './getSuiBalances';
+export * from './get_suinft_balances';

--- a/libs/model/src/services/tokenBalanceCache/tokenBalanceCache.ts
+++ b/libs/model/src/services/tokenBalanceCache/tokenBalanceCache.ts
@@ -12,6 +12,7 @@ import {
   GetSPLBalancesOptions,
   GetSuiNativeBalanceOptions,
   GetSuiTokenBalanceOptions,
+  GetSuiNftBalanceOptions,
 } from './types';
 
 const log = logger(import.meta);
@@ -42,10 +43,14 @@ export async function getBalances(
       balances = await getSolanaBalances(options, ttl);
     } else if (
       options.balanceSourceType === BalanceSourceType.SuiNative ||
-      options.balanceSourceType === BalanceSourceType.SuiToken
+      options.balanceSourceType === BalanceSourceType.SuiToken ||
+      options.balanceSourceType === BalanceSourceType.SuiNFT
     ) {
       balances = await getSuiBalances(
-        options as GetSuiNativeBalanceOptions | GetSuiTokenBalanceOptions,
+        options as
+          | GetSuiNativeBalanceOptions
+          | GetSuiTokenBalanceOptions
+          | GetSuiNftBalanceOptions,
         ttl,
       );
     } else {
@@ -56,8 +61,14 @@ export async function getBalances(
       options.balanceSourceType === BalanceSourceType.SPL
         ? 'solana'
         : options.balanceSourceType === BalanceSourceType.SuiNative ||
-            options.balanceSourceType === BalanceSourceType.SuiToken
-          ? (options as GetSuiNativeBalanceOptions | GetSuiTokenBalanceOptions)
+            options.balanceSourceType === BalanceSourceType.SuiToken ||
+            options.balanceSourceType === BalanceSourceType.SuiNFT
+          ? (
+              options as
+                | GetSuiNativeBalanceOptions
+                | GetSuiTokenBalanceOptions
+                | GetSuiNftBalanceOptions
+            ).sourceOptions.suiNetwork
               .sourceOptions.suiNetwork
           : (options as GetEvmBalancesOptions).sourceOptions.evmChainId ||
             (options as GetCosmosBalancesOptions).sourceOptions.cosmosChainId;
@@ -68,6 +79,8 @@ export async function getBalances(
       (options as GetSuiNativeBalanceOptions).sourceOptions.objectId ||
       (options.balanceSourceType === BalanceSourceType.SuiToken
         ? (options as GetSuiTokenBalanceOptions).sourceOptions.coinType
+        : options.balanceSourceType === BalanceSourceType.SuiNFT
+        ? (options as GetSuiNftBalanceOptions).sourceOptions.collectionId
         : undefined);
 
     const msg =
@@ -85,12 +98,19 @@ export async function getBalances(
       cosmosChainId: (options as GetCosmosBalancesOptions).sourceOptions
         ?.cosmosChainId,
       suiNetwork: (
-        options as GetSuiNativeBalanceOptions | GetSuiTokenBalanceOptions
+        options as
+          | GetSuiNativeBalanceOptions
+          | GetSuiTokenBalanceOptions
+          | GetSuiNftBalanceOptions
       ).sourceOptions?.suiNetwork,
       objectId: (options as GetSuiNativeBalanceOptions).sourceOptions?.objectId,
       coinType:
         options.balanceSourceType === BalanceSourceType.SuiToken
           ? (options as GetSuiTokenBalanceOptions).sourceOptions.coinType
+          : undefined,
+      collectionId:
+        options.balanceSourceType === BalanceSourceType.SuiNFT
+          ? (options as GetSuiNftBalanceOptions).sourceOptions.collectionId
           : undefined,
     });
   }

--- a/libs/model/src/services/tokenBalanceCache/types.ts
+++ b/libs/model/src/services/tokenBalanceCache/types.ts
@@ -100,6 +100,13 @@ export type GetSuiTokenBalanceOptions = GetSuiBalancesBase & {
   };
 };
 
+export type GetSuiNftBalanceOptions = GetSuiBalancesBase & {
+  balanceSourceType: BalanceSourceType.SuiNFT;
+  sourceOptions: {
+    collectionId: string;
+  };
+};
+
 export type GetErcBalanceOptions =
   | GetErc20BalanceOptions
   | GetErc721BalanceOptions
@@ -120,7 +127,8 @@ export type GetCwBalancesOptions =
 
 export type GetSuiBalancesOptions =
   | GetSuiNativeBalanceOptions
-  | GetSuiTokenBalanceOptions;
+  | GetSuiTokenBalanceOptions
+  | GetSuiNftBalanceOptions;
 
 export type GetBalancesOptions =
   | GetEvmBalancesOptions

--- a/libs/model/src/utils/makeGetBalancesOptions.ts
+++ b/libs/model/src/utils/makeGetBalancesOptions.ts
@@ -7,6 +7,7 @@ import {
   type SolanaSource,
   type SuiSource,
   type SuiTokenSource,
+  type SuiNFTSource,
 } from '@hicommonwealth/shared';
 import type { GroupAttributes } from '../models/group';
 import type {
@@ -19,6 +20,7 @@ import type {
   GetSPLBalancesOptions,
   GetSuiNativeBalanceOptions,
   GetSuiTokenBalanceOptions,
+  GetSuiNftBalanceOptions,
 } from '../services/tokenBalanceCache/types';
 
 export function makeGetBalancesOptions(
@@ -220,6 +222,30 @@ export function makeGetBalancesOptions(
                 sourceOptions: {
                   suiNetwork: castedSource.sui_network,
                   coinType: castedSource.coin_type,
+                },
+                addresses,
+              });
+            }
+            break;
+          }
+          case BalanceSourceType.SuiNFT: {
+            const castedSource = requirement.data.source as SuiNFTSource;
+            const existingOptions = allOptions.find((opt) => {
+              const castedOpt = opt as GetSuiNftBalanceOptions;
+              return (
+                castedOpt.balanceSourceType === BalanceSourceType.SuiNFT &&
+                castedOpt.sourceOptions.suiNetwork ===
+                  castedSource.sui_network &&
+                castedOpt.sourceOptions.collectionId ===
+                  castedSource.collection_id
+              );
+            });
+            if (!existingOptions) {
+              allOptions.push({
+                balanceSourceType: BalanceSourceType.SuiNFT,
+                sourceOptions: {
+                  suiNetwork: castedSource.sui_network,
+                  collectionId: castedSource.collection_id,
                 },
                 addresses,
               });

--- a/libs/model/src/utils/validateGroupMembership.ts
+++ b/libs/model/src/utils/validateGroupMembership.ts
@@ -162,6 +162,12 @@ function _thresholdCheck(
         contractAddress = thresholdData.source.coin_type;
         break;
       }
+      case 'sui_nft': {
+        balanceSourceType = BalanceSourceType.SuiNFT;
+        chainId = thresholdData.source.sui_network.toString();
+        contractAddress = thresholdData.source.collection_id;
+        break;
+      }
       case 'erc20': {
         balanceSourceType = BalanceSourceType.ERC20;
         contractAddress = thresholdData.source.contract_address;
@@ -250,6 +256,11 @@ function _thresholdCheck(
             return (
               b.options.sourceOptions.suiNetwork === chainId &&
               b.options.sourceOptions.coinType === contractAddress
+            );
+          case BalanceSourceType.SuiNFT:
+            return (
+              b.options.sourceOptions.suiNetwork === chainId &&
+              b.options.sourceOptions.collectionId === contractAddress
             );
           default:
             return null;

--- a/libs/schemas/src/entities/group.schemas.ts
+++ b/libs/schemas/src/entities/group.schemas.ts
@@ -40,6 +40,13 @@ const SuiTokenSource = z.object({
   coin_type: z.string(),
 });
 
+const SuiNFTSource = z.object({
+  source_type: z.enum([BalanceSourceType.SuiNFT]),
+  sui_network: z.string(),
+  collection_id: z.string(),
+  token_standard: z.string().optional(),
+});
+
 const NativeSource = z.object({
   source_type: z.enum([BalanceSourceType.ETHNative]),
   evm_chain_id: PG_INT,
@@ -67,6 +74,7 @@ export const ThresholdData = z.object({
     SolanaSource,
     SuiSource,
     SuiTokenSource,
+    SuiNFTSource,
   ]),
 });
 

--- a/libs/shared/src/types/protocol.ts
+++ b/libs/shared/src/types/protocol.ts
@@ -10,6 +10,7 @@ export enum BalanceSourceType {
   SOLNFT = 'metaplex',
   SuiNative = 'sui_native',
   SuiToken = 'sui_token',
+  SuiNFT = 'sui_nft',
 }
 
 export enum BalanceType {
@@ -50,6 +51,12 @@ export type SuiTokenSource = {
   coin_type: string;
 };
 
+export type SuiNFTSource = {
+  source_type: BalanceSourceType.SuiNFT;
+  sui_network: string;
+  collection_id: string;
+};
+
 export type NativeSource = {
   source_type: BalanceSourceType.ETHNative;
   evm_chain_id: number;
@@ -76,7 +83,8 @@ export type ThresholdData = {
     | CosmosContractSource
     | SolanaSource
     | SuiSource
-    | SuiTokenSource;
+    | SuiTokenSource
+    | SuiNFTSource;
 };
 
 export type AbiType = Record<string, unknown>[];


### PR DESCRIPTION
## Summary
- support `sui_nft` balance source
- add schema & types for SuiNFT
- implement Sui NFT balance fetcher
- hook SuiNFT into group gating and token balance cache logic

## Testing
- `pnpm lint-branch` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687684aca5ac832fb6829512846e0936