### PR TITLE
Gracefully handle disabled Privy flag and refactor auth flow

### DIFF
--- a/packages/commonwealth/client/scripts/App.tsx
+++ b/packages/commonwealth/client/scripts/App.tsx
@@ -8,10 +8,8 @@ import { HelmetProvider } from 'react-helmet-async';
 import { RouterProvider } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import { queryClient } from 'state/api/config';
-import { DefaultPrivyProvider } from 'views/components/DefaultPrivyProvider/DefaultPrivyProvider';
 import { DisableMavaOnMobile } from 'views/components/DisableMavaOnMobile';
 import ForceMobileAuth from 'views/components/ForceMobileAuth';
-import { PrivyMobileAuthenticator } from 'views/components/PrivyMobile/PrivyMobileAuthenticator';
 import { ReactNativeBridgeUser } from 'views/components/ReactNativeBridge';
 import { ReactNativeLogForwarder } from 'views/components/ReactNativeBridge/ReactNativeLogForwarder';
 import { ReactNativeScrollToTopListener } from 'views/components/ReactNativeBridge/ReactNativeScrollToTopListener';
@@ -36,17 +34,18 @@ const App = () => {
                 {isLoading ? (
                   <Splash />
                 ) : (
-                  <PrivyMobileAuthenticator>
-                    <DefaultPrivyProvider>
-                      <ForceMobileAuth>
-                        <OnBoardingWrapperForMobile>
-                          <ReactNativeBridgeUser />
-                          <ReactNativeScrollToTopListener />
-                          <RouterProvider router={router()} />
-                        </OnBoardingWrapperForMobile>
-                      </ForceMobileAuth>
-                    </DefaultPrivyProvider>
-                  </PrivyMobileAuthenticator>
+                  // Add Those components back in when we are ready to use Privy
+                  // <PrivyMobileAuthenticator>
+                  // <DefaultPrivyProvider>
+                  <ForceMobileAuth>
+                    <OnBoardingWrapperForMobile>
+                      <ReactNativeBridgeUser />
+                      <ReactNativeScrollToTopListener />
+                      <RouterProvider router={router()} />
+                    </OnBoardingWrapperForMobile>
+                  </ForceMobileAuth>
+                  // </DefaultPrivyProvider>
+                  // </PrivyMobileAuthenticator>
                 )}
                 <ToastContainer />
                 {import.meta.env.DEV && (

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/PrivyAuth.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/PrivyAuth.tsx
@@ -1,0 +1,135 @@
+import {
+  useLoginWithOAuth,
+  useOAuthTokens,
+  usePrivy,
+} from '@privy-io/react-auth';
+import { useUserStore } from 'client/scripts/state/ui/user/user';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  isOauthProvider,
+  toSignInProvider,
+  waitForOAuthToken,
+  waitForWallet,
+} from 'views/components/Privy/helpers';
+import { PrivyCallbacks } from 'views/components/Privy/PrivyCallbacks';
+import { OAuthProvider } from 'views/components/Privy/types';
+import { useConnectedWallet } from 'views/components/Privy/useConnectedWallet';
+import { usePrivySignOn } from 'views/components/Privy/usePrivySignOn';
+
+/**
+ * Use privy auth with OAuth providers. Like google.
+ */
+export function PrivyAuth(props: PrivyCallbacks) {
+  const { onError } = props;
+
+  const privy = usePrivy();
+  const wallet = useConnectedWallet();
+  const userStore = useUserStore();
+  const privySignOn = usePrivySignOn();
+
+  const [oAuthTokens, setOAuthTokens] = useState<Record<string, string>>({});
+
+  // Refs and effects for privy, wallet and oAuthTokens used to avoid stale closures
+  const privyRef = useRef(privy);
+  const walletRef = useRef(wallet);
+  const oAuthTokensRef = useRef(oAuthTokens);
+
+  useEffect(() => {
+    privyRef.current = privy;
+  }, [privy]);
+
+  useEffect(() => {
+    walletRef.current = wallet;
+  }, [wallet]);
+
+  useEffect(() => {
+    oAuthTokensRef.current = oAuthTokens;
+  }, [oAuthTokens]);
+
+  useOAuthTokens({
+    onOAuthTokenGrant: ({ oAuthTokens: tokens }) => {
+      setOAuthTokens((prev) => ({
+        ...prev,
+        [tokens.provider]: tokens.accessToken,
+      }));
+    },
+  });
+
+  const handleOAuthComplete = useCallback(
+    async (params) => {
+      if (userStore.isLoggedIn) return;
+
+      const ssoProvider = toSignInProvider(params.loginMethod as OAuthProvider);
+
+      const oAuthToken = await waitForOAuthToken(
+        params.loginMethod,
+        oAuthTokensRef,
+      );
+
+      if (!oAuthToken) {
+        props.onError(new Error('OAuth token not available'));
+        return;
+      }
+
+      const walletAvailable = await waitForWallet(walletRef);
+      if (!walletAvailable) {
+        props.onError(new Error('Wallet not available'));
+        return;
+      }
+
+      const currentWallet = walletRef.current;
+      if (!currentWallet) {
+        console.warn('No wallet available');
+        return;
+      }
+
+      await privySignOn({
+        wallet: currentWallet,
+        onSuccess: props.onSuccess,
+        onError: props.onError,
+        ssoOAuthToken: oAuthToken,
+        ssoProvider,
+      });
+    },
+    [userStore.isLoggedIn, privySignOn, props, walletRef, oAuthTokensRef],
+  );
+
+  const { loading, initOAuth } = useLoginWithOAuth({
+    onComplete: (params) => {
+      void handleOAuthComplete(params).catch(onError);
+    },
+  });
+
+  const providerRef = useRef<OAuthProvider | undefined>(undefined);
+
+  const onInitOAuth = useCallback(
+    (provider: OAuthProvider) => {
+      async function doAsync() {
+        if (isOauthProvider(provider)) {
+          providerRef.current = provider;
+
+          window.history.pushState(null, '', '/sign-in');
+
+          await initOAuth({ provider });
+        } else {
+          throw new Error('Not supported: ' + provider);
+        }
+      }
+
+      doAsync().catch((err) => {
+        console.error(err);
+        onError(err);
+      });
+    },
+    [initOAuth, onError],
+  );
+
+  return useMemo(() => {
+    return {
+      onInitOAuth,
+      authenticated: privy.authenticated,
+      logout: privy.logout,
+      loading,
+    };
+  }, [privy.authenticated, privy.logout, onInitOAuth, loading]);
+}

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -52,9 +52,10 @@ import usePrivyEmailDialogStore, {
 } from 'views/components/Privy/stores/usePrivyEmailDialogStore';
 import { smsDialogStore } from 'views/components/Privy/stores/usePrivySMSDialogStore';
 import type { PrivySignInSSOProvider } from 'views/components/Privy/types';
+import { OAuthProvider } from 'views/components/Privy/types';
 import { useConnectedWallet } from 'views/components/Privy/useConnectedWallet';
-import { usePrivyAuthWithOAuth } from 'views/components/Privy/usePrivyAuthWithOAuth';
 import { usePrivySignOn } from 'views/components/Privy/usePrivySignOn';
+import { PrivyAuth } from 'views/modals/AuthModal/PrivyAuth';
 import {
   BaseMixpanelPayload,
   MixpanelCommunityInteractionEvent,
@@ -156,7 +157,7 @@ const useAuthentication = (props: UseAuthenticationProps) => {
     };
   }, [handlePrivyError, handlePrivySuccess]);
 
-  const privyAuthWithOAuth = usePrivyAuthWithOAuth(privyCallbacks);
+  const privyAuthWithOAuth = privyEnabled && PrivyAuth(privyCallbacks);
 
   // Handle SMS login completion (similar to OAuth pattern)
   const handleSMSLoginComplete = useCallback(async () => {
@@ -464,7 +465,9 @@ const useAuthentication = (props: UseAuthenticationProps) => {
   const onSocialLoginPrivy = async (provider: WalletSsoSource) => {
     setIsMagicLoading(true);
     console.log('onSocialLoginPrivy: ' + provider);
-    privyAuthWithOAuth.onInitOAuth(provider);
+    if (privyAuthWithOAuth) {
+      privyAuthWithOAuth.onInitOAuth(provider as OAuthProvider);
+    }
   };
 
   const onSocialLogin = privyEnabled ? onSocialLoginPrivy : onSocialLoginMagic;

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -152,6 +152,7 @@ export default defineConfig(({ mode }) => {
           secure: false,
         },
       },
+      allowedHosts: ['common.ngrok.app'],
     },
     resolve: {
       alias: [


### PR DESCRIPTION
You are absolutely right, thank you for the correction. My apologies for misinterpreting the intent.

Here is a more accurate description of the changes based on your explanation:

The primary goal of these changes is to allow the mobile application to function correctly with the Privy feature flag turned off, ensuring the application defaults to Magic for authentication without crashing.

To achieve this, the `PrivyMobileAuthenticator` and `DefaultPrivyProvider` components, which were causing issues in the mobile app when Privy was disabled, have been commented out in `App.tsx`.

The authentication hook `useAuthentication` has been refactored to conditionally initialize Privy features. Specifically, the OAuth logic was extracted into a new `PrivyAuth` module and is only activated if the `privy` feature flag is enabled. This prevents Privy-related code from executing when it's not needed.

Finally, to facilitate mobile development, the Vite configuration was updated to allow connections from `ngrok`, which is detailed in the related mobile repository [PR #10](https://github.com/hicommonwealth/commonwealth-mobile2/pull/10).