### PR TITLE
Fixed broken pagination for threads on discussion page

### DIFF
--- a/libs/model/src/aggregates/thread/GetThreads.query.ts
+++ b/libs/model/src/aggregates/thread/GetThreads.query.ts
@@ -287,7 +287,11 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
       return schemas.buildPaginatedResponse(
         threads,
         threads.at(0)?.total_num_thread_results || 0,
-        { limit: replacements.limit, cursor: replacements.page },
+        {
+          limit: replacements.limit,
+          cursor: replacements.page,
+          offset: replacements.offset,
+        },
       );
     },
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12678

## Description of Changes
Fixed broken pagination for threads on discussion page

## Test Plan
1. Visit any community's discussion page
2. Scroll to stimulate paginated response
3. Ensure no duplicate threads are present after new one's are loaded.

## Deployment Plan
N/A

## Other Considerations
N/A