### PR TITLE
Added filter to show only the active quests by default

### DIFF
--- a/libs/model/src/aggregates/quest/GetQuests.query.ts
+++ b/libs/model/src/aggregates/quest/GetQuests.query.ts
@@ -22,11 +22,13 @@ export function GetQuests(): Query<typeof schemas.GetQuests> {
         start_before,
         start_after,
         include_system_quests,
+        include_active_only,
       } = payload;
 
       const direction = order_direction || 'DESC';
       const order = order_by || 'created_at';
       const offset = limit! * (cursor! - 1);
+      const now = new Date();
       const replacements = {
         search: search ? `%${search.toLowerCase()}%` : '',
         direction,
@@ -38,6 +40,7 @@ export function GetQuests(): Query<typeof schemas.GetQuests> {
         start_after: start_after ? new Date(start_after) : null,
         start_before: start_before ? new Date(start_before) : null,
         end_after: end_after ? new Date(end_after) : null,
+        now: include_active_only ? now : undefined,
       };
       const filterConditions = [
         include_system_quests ? '' : 'Q.id > 0',
@@ -47,6 +50,9 @@ export function GetQuests(): Query<typeof schemas.GetQuests> {
         end_after ? `Q.end_date > :end_after` : '',
         end_before ? `Q.end_date <= :end_before` : '',
         search ? 'LOWER(Q.name) LIKE :search' : '',
+        include_active_only
+          ? 'Q.start_date <= :now AND Q.end_date >= :now'
+          : '',
       ].filter(Boolean);
 
       const sql = `

--- a/libs/schemas/src/queries/quest.schemas.ts
+++ b/libs/schemas/src/queries/quest.schemas.ts
@@ -49,6 +49,7 @@ export const GetQuests = {
     end_after: z.coerce.date().optional(),
     end_before: z.coerce.date().optional(),
     include_system_quests: z.boolean().default(false).optional(),
+    include_active_only: z.boolean().default(false).optional(),
   }),
   output: PaginatedResultSchema.extend({
     results: z.array(QuestView),

--- a/packages/commonwealth/client/scripts/state/api/quest/fetchQuests.ts
+++ b/packages/commonwealth/client/scripts/state/api/quest/fetchQuests.ts
@@ -18,6 +18,7 @@ const useFetchQuestsQuery = ({
   order_by,
   order_direction,
   include_system_quests,
+  include_active_only,
   search,
   enabled = true,
 }: UseFetchQuestsProps) => {
@@ -32,6 +33,7 @@ const useFetchQuestsQuery = ({
       order_by,
       order_direction,
       include_system_quests,
+      include_active_only,
       search,
     },
     {

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/FiltersDrawer.scss
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/FiltersDrawer.scss
@@ -11,6 +11,13 @@
       }
     }
 
+    .active-filter {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    }
+
     .content-container {
       padding: 20px 32px;
 

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/FiltersDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/FiltersDrawer.tsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import React from 'react';
 import { CWText } from 'views/components/component_kit/cw_text';
 import CWDateTimeInput from 'views/components/component_kit/CWDateTimeInput';
+import { CWToggle } from 'views/components/component_kit/new_designs/cw_toggle';
 import CWDrawer, {
   CWDrawerTopBar,
 } from 'views/components/component_kit/new_designs/CWDrawer';
@@ -27,6 +28,22 @@ export const FiltersDrawer = ({
         <div className="content-container">
           <CWText type="h3">Quest Filters</CWText>
           <div className="filter-content">
+            <div className="active-filter">
+              <CWText type="h5" fontWeight="semiBold">
+                Show Active Only
+              </CWText>
+              <CWToggle
+                size="small"
+                checked={filters.activeOnly}
+                onChange={() =>
+                  onFiltersChange({
+                    ...filters,
+                    activeOnly: !filters.activeOnly,
+                  })
+                }
+              />
+            </div>
+
             <CWDateTimeInput
               label="Ending After"
               selected={moment(filters.endingAfter).utc().local().toDate()}

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/FiltersDrawer/types.ts
@@ -1,6 +1,7 @@
 export type QuestFilters = {
   endingAfter: Date;
   startingBefore?: Date;
+  activeOnly?: boolean;
 };
 
 export type FiltersDrawerProps = {

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/QuestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/QuestList/QuestList.tsx
@@ -46,6 +46,7 @@ const QuestList = ({
   const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
   const [filters, setFilters] = useState<QuestFilters>({
+    activeOnly: true,
     endingAfter: moment().startOf('week').toDate(),
     startingBefore: moment().endOf('year').toDate(),
   });
@@ -67,6 +68,7 @@ const QuestList = ({
     start_before: filters.startingBefore,
     // dont show system quests in quest lists for communities
     include_system_quests: questsForCommunityId ? false : true,
+    include_active_only: filters.activeOnly || false,
     enabled: xpEnabled,
   });
   const quests = (questsList?.pages || []).flatMap((page) => page.results);
@@ -115,6 +117,15 @@ const QuestList = ({
               label={`Search: ${searchText?.trim()}`}
               type="filter"
               onCloseClick={onClearSearch}
+            />
+          )}
+          {filters.activeOnly && (
+            <CWTag
+              label="Active Quests"
+              type="filter"
+              onCloseClick={() =>
+                setFilters((f) => ({ ...f, activeOnly: false }))
+              }
             />
           )}
           <CWTag


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12687

## Description of Changes
Added filter to show only the active quests by default

## Test Plan
1. Visit quests explore `/explore?tab=quests`
2. Verify the new `Active` filter shows only the active quests with in the selected date range filters.

## Deployment Plan
N/A

## Other Considerations
N/A