### PR TITLE
Fixed view counts

### DIFF
--- a/packages/commonwealth/server/workers/graphileWorker/tasks/countAggregator.ts
+++ b/packages/commonwealth/server/workers/graphileWorker/tasks/countAggregator.ts
@@ -172,6 +172,9 @@ async function processViewCounts() {
   for (const [threadId, count] of <[string, string][]>(
     Object.entries(threadIdHash)
   )) {
+    if (!Number(threadId) || !Number(count)) {
+      continue;
+    }
     const threadRankIncrease = Math.round(
       config.HEURISTIC_WEIGHTS.VIEW_COUNT_WEIGHT * parseInt(count),
     );


### PR DESCRIPTION
Not sure where this comes from, but for some reason we can get nullish view counts in redis. When this happens the sql statement we generate throws an error, and as a result the view count never gets updated

## Link to Issue
Closes: #12685