### PR TITLE
Add secure flag to GetTokenStats query (#12763)

### DIFF
--- a/libs/model/src/aggregates/token/GetTokenStats.query.ts
+++ b/libs/model/src/aggregates/token/GetTokenStats.query.ts
@@ -7,6 +7,7 @@ export function GetTokenStats(): Query<typeof schemas.GetTokenStats> {
   return {
     ...schemas.GetTokenStats,
     auth: [],
+    secure: false,
     async body({ payload }) {
       const { token_address } = payload;
       const sql = `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12477

## Description of Changes
- Added secure flag in GetTokenStats query
- secure is set to false

## Test Plan
1. Start app locally
2. Go to Explore page
3. Obeserve console
4. Unsigned users should see token stats on explore page

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 