### PR TITLE
chore: raise daily quest repetition cap

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useQuestActionSubForm.ts
+++ b/packages/commonwealth/client/scripts/views/pages/CreateQuest/QuestForm/QuestActionSubForm/useQuestActionSubForm.ts
@@ -13,9 +13,9 @@ import { QuestAction, QuestActionSubFormProps } from './types';
 
 // these restrictions are only on client side, update per future requirements
 const MAX_REPETITION_COUNTS = {
-  PER_DAY: 4,
-  PER_WEEK: 28,
-  PER_MONTH: 120,
+  PER_DAY: 100,
+  PER_WEEK: 700,
+  PER_MONTH: 3000,
 };
 
 const useQuestActionSubForm = ({


### PR DESCRIPTION
## Summary
- increase daily quest action repetition limit to 100
- scale weekly and monthly repetition limits accordingly

## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm -F commonwealth test-unit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c5746278832f987c0b9936ec6afc