### PR TITLE
feat: add trust level growl

### DIFF
--- a/packages/commonwealth/client/scripts/views/Sublayout.tsx
+++ b/packages/commonwealth/client/scripts/views/Sublayout.tsx
@@ -220,13 +220,12 @@ const Sublayout = ({ children, isInsideCommunity }: SublayoutProps) => {
           </div>
           {growlEnabled && showGrowlOnMobile && (
             <CWGrowlTemplate
-              headerText=""
-              bodyText=""
-              buttonText=""
-              buttonLink=""
-              growlType=""
-              growlImage=""
-              extraText=""
+              headerText="What are Trust Levels?"
+              bodyText="Trust levels reflect your reputation in the community. Climb the ranks to unlock new abilities and earn recognition."
+              buttonText="Learn more"
+              buttonLink="https://docs.commonwealth.im/trust-levels"
+              growlType="trust_levels"
+              expiryDays={7}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- add expiration support to CWGrowlTemplate
- announce trust levels in Sublayout for one week

## Testing
- `pnpm lint-branch` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test-api` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7ca83d0832faa72e0c465505b15