### PR TITLE
feat: add trust level tooltip

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
@@ -50,6 +50,7 @@ const UserTrustLevel = () => {
     <div className="UserTrustLevel">
       {tiers.map((level) => {
         const isLocked = level.level > currentTier + 1;
+        const isCurrentLevel = level.level === currentTier;
 
         return (
           <LevelBox
@@ -59,7 +60,14 @@ const UserTrustLevel = () => {
             description={level.description}
             status={level.status}
             isLocked={isLocked}
-            icon={<TrustLevelRole type="user" level={level.level} size="xl" />}
+            icon={
+              <TrustLevelRole
+                type="user"
+                level={level.level}
+                size="xl"
+                withTooltip={isCurrentLevel}
+              />
+            }
             items={level.items}
             showArrow={level.redirect}
             onItemClick={handleItemClick}

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
 
+import { USER_TIERS } from '@hicommonwealth/shared';
 import { useFlag } from 'hooks/useFlag';
+import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
 import { CWIcon } from '../component_kit/cw_icons/cw_icon';
+import { CWText } from '../component_kit/cw_text';
+import { CWTooltip } from '../component_kit/new_designs/CWTooltip';
 import { getCommunityTrustLevel, getUserTrustLevel } from './utils';
 
 interface TrustLevelRoleProps {
   type: 'community' | 'user';
   level: number;
   size?: 'small' | 'medium' | 'large' | 'xl';
+  withTooltip?: boolean;
 }
 
 const TrustLevelRole = ({
   type,
   level,
   size = 'small',
+  withTooltip = false,
 }: TrustLevelRoleProps) => {
   const isTrustLevelEnabled = useFlag('trustLevel');
 
@@ -23,6 +29,46 @@ const TrustLevelRole = ({
     type === 'community'
       ? getCommunityTrustLevel(level)
       : getUserTrustLevel(level);
+
+  const tier = Object.values(USER_TIERS).find(
+    (t) => t.clientInfo?.trustLevel === level,
+  );
+
+  const tooltipContent = tier ? (
+    <div style={{ maxWidth: 240 }}>
+      <CWText type="b2">
+        {tier.name}: {tier.description}
+      </CWText>
+      <a
+        href="https://docs.common.xyz/commonwealth/account-overview/user-trust-levels#trust-levels-on-common"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        See more
+      </a>
+    </div>
+  ) : null;
+
+  if (withTooltip && tooltipContent) {
+    return (
+      <CWTooltip
+        placement="top"
+        content={tooltipContent}
+        renderTrigger={(handleInteraction, isTooltipOpen) => (
+          <span
+            onMouseEnter={(e) =>
+              handleMouseEnter({ e, isTooltipOpen, handleInteraction })
+            }
+            onMouseLeave={(e) =>
+              handleMouseLeave({ e, isTooltipOpen, handleInteraction })
+            }
+          >
+            <CWIcon iconName={icon} iconSize={size} />
+          </span>
+        )}
+      />
+    );
+  }
 
   return <CWIcon iconName={icon} iconSize={size} />;
 };

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
@@ -71,7 +71,11 @@ const ProfileCard = () => {
             >
               <h3 className="profile-name">
                 {data?.profile.name}
-                <TrustLevelRole type="user" level={data?.tier} />
+                <TrustLevelRole
+                  type="user"
+                  level={data?.tier}
+                  withTooltip
+                />
               </h3>
             </Link>
           )}


### PR DESCRIPTION
## Summary
- show trust level tooltip with description and docs link
- enable tooltip in sidebar profile card and edit profile page

## Testing
- `pnpm -F commonwealth test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db1adfa0832fa16f12dc7f4944bb