### PR TITLE
feat: enforce unique token suggestions

### DIFF
--- a/libs/model/src/services/openai/generateTokenIdea.ts
+++ b/libs/model/src/services/openai/generateTokenIdea.ts
@@ -7,14 +7,16 @@ import {
 } from 'openai/resources/index.mjs';
 import { config } from '../../config';
 import { models } from '../../database';
-import { LaunchpadTokenInstance } from '../../models/token';
 import {
   generateImage,
   ImageGenerationErrors,
 } from '../../utils/generateImage';
 
+type RecentSuggestion = { name: string; symbol: string };
+
 type GenerateTokenIdeaProps = {
   ideaPrompt?: string;
+  recentSuggestions?: RecentSuggestion[];
 };
 
 type TokenStyle = 'BRAINROT' | 'POLITICAL' | 'STARTUP';
@@ -207,6 +209,7 @@ const chatWithOpenAI = async (prompt = '', openai: OpenAI) => {
 
 const generateTokenIdea = async function* ({
   ideaPrompt,
+  recentSuggestions = [],
 }: GenerateTokenIdeaProps): AsyncGenerator {
   if (!config.OPENAI.API_KEY) {
     log.error(TokenErrors.OpenAINotConfigured);
@@ -226,28 +229,57 @@ const generateTokenIdea = async function* ({
   let tokenName = '';
   try {
     // generate a unique token name
-    let foundToken: LaunchpadTokenInstance | boolean | null = true;
-    while (foundToken) {
+    let nameUnique = false;
+    let attempts = 0;
+    while (!nameUnique) {
+      if (attempts++ > 5) {
+        throw new Error('failed to generate unique token name');
+      }
+
       tokenName = await chatWithOpenAI(
         TOKEN_AI_PROMPTS_CONFIG.name(ideaPrompt),
         openai,
       );
 
-      foundToken = await models.LaunchpadToken.findOne({
-        where: {
-          name: tokenName,
-        },
+      const nameConflict = await models.LaunchpadToken.findOne({
+        where: { name: tokenName },
       });
+
+      const recentConflict = recentSuggestions.some(
+        (s) => s.name.toLowerCase() === tokenName.toLowerCase(),
+      );
+
+      nameUnique = !nameConflict && !recentConflict;
     }
 
     log.info(`Generated name: "${tokenName}" (Style: ${selectedTokenStyle})`);
     yield 'event: name\n';
     yield `data: ${tokenName}\n\n`;
 
-    const tokenSymbol = await chatWithOpenAI(
-      TOKEN_AI_PROMPTS_CONFIG.symbol(),
-      openai,
-    );
+    // generate a unique token symbol
+    let tokenSymbol = '';
+    let symbolUnique = false;
+    attempts = 0;
+    while (!symbolUnique) {
+      if (attempts++ > 5) {
+        throw new Error('failed to generate unique token symbol');
+      }
+
+      tokenSymbol = await chatWithOpenAI(
+        TOKEN_AI_PROMPTS_CONFIG.symbol(),
+        openai,
+      );
+
+      const symbolConflict = await models.LaunchpadToken.findOne({
+        where: { symbol: tokenSymbol },
+      });
+
+      const recentSymbolConflict = recentSuggestions.some(
+        (s) => s.symbol.toUpperCase() === tokenSymbol.toUpperCase(),
+      );
+
+      symbolUnique = !symbolConflict && !recentSymbolConflict;
+    }
 
     log.info(
       `Generated symbol: "${tokenSymbol}" (Style: ${selectedTokenStyle})`,

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -123,7 +123,17 @@ function setupRouter(app: Express, cacheDecorator: CacheDecorator) {
           ? req.body?.ideaPrompt
           : undefined;
 
-      const ideaGenerator = generateTokenIdea({ ideaPrompt });
+      const recentSuggestions = Array.isArray(req.body?.recentSuggestions)
+        ? req.body.recentSuggestions.filter(
+            (s: any) =>
+              s && typeof s.name === 'string' && typeof s.symbol === 'string',
+          )
+        : [];
+
+      const ideaGenerator = generateTokenIdea({
+        ideaPrompt,
+        recentSuggestions,
+      });
 
       for await (const chunk of ideaGenerator) {
         if ((chunk as { error?: string }).error) {


### PR DESCRIPTION
## Summary
- accept recent token suggestions from the client when generating a token idea
- re-roll token names and symbols until they are unique against the DB and recent suggestions

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c64db96c832f8618f9facf0620bf