### PR TITLE
feat: draft referrer xp backfill

### DIFF
--- a/common_knowledge/Retroactive-Referrer-XP-Backfill.md
+++ b/common_knowledge/Retroactive-Referrer-XP-Backfill.md
@@ -1,0 +1,12 @@
+# Retroactive Referrer XP Backfill
+
+## Summary
+- Award referrer bonuses for historical XP logs by looking up each user's `referred_by_address` in the database.
+- Grant referrers an extra 10% of each action's reward without deducting from the original actor's XP.
+- Only credit the difference between the expected bonus and the referrer's existing `xp_referrer_points`.
+
+## Acceptance Criteria
+- Script `libs/model/scripts/backfill-referrer-xp.ts` computes historical referral totals and increments referrers accordingly.
+- Running the script is idempotent and never reduces any user's XP.
+- Ticket created to track implementation of the retroactive XP backfill.
+- Address lookups are case-insensitive and skip banned users so no XP is credited to invalid referrers.

--- a/libs/model/scripts/backfill-referrer-xp.ts
+++ b/libs/model/scripts/backfill-referrer-xp.ts
@@ -1,0 +1,82 @@
+import { logger } from '@hicommonwealth/core';
+import { UserTierMap } from '@hicommonwealth/shared';
+import { Op, Sequelize } from 'sequelize';
+import { models } from '../src/database';
+
+const log = logger(import.meta);
+
+async function backfillReferrerXp() {
+  const referredUsers = await models.User.findAll({
+    attributes: ['id', 'referred_by_address'],
+    where: { referred_by_address: { [Op.ne]: null } },
+  });
+
+  const totals = new Map<number, number>();
+
+  for (const user of referredUsers) {
+    const refAddr = user.referred_by_address;
+    if (!refAddr) continue;
+
+    const ref = await models.Address.findOne({
+      attributes: ['user_id'],
+      where: {
+        [Op.and]: [
+          Sequelize.where(
+            Sequelize.fn('LOWER', Sequelize.col('address')),
+            Sequelize.fn('LOWER', refAddr),
+          ),
+          { user_id: { [Op.not]: null }, is_banned: false },
+        ],
+      },
+      include: [
+        {
+          model: models.User,
+          attributes: ['id'],
+          required: true,
+          where: { tier: { [Op.ne]: UserTierMap.BannedUser } },
+        },
+      ],
+    });
+    const referrerId = ref?.user_id;
+    if (!referrerId) continue;
+
+    const logs = await models.XpLog.findAll({
+      attributes: ['xp_points', 'creator_xp_points'],
+      where: { user_id: user.id },
+    });
+
+    let expected = 0;
+    for (const logEntry of logs) {
+      const reward = logEntry.xp_points + (logEntry.creator_xp_points || 0);
+      expected += Math.round(reward * 0.1);
+    }
+    totals.set(referrerId, (totals.get(referrerId) || 0) + expected);
+  }
+
+  for (const [referrerId, total] of totals.entries()) {
+    const refUser = await models.User.findOne({
+      where: { id: referrerId, tier: { [Op.ne]: UserTierMap.BannedUser } },
+      attributes: ['xp_referrer_points'],
+    });
+    if (!refUser) continue;
+    const current = refUser.xp_referrer_points || 0;
+    const missing = total - current;
+    if (missing > 0) {
+      await models.User.increment(
+        { xp_points: missing, xp_referrer_points: missing },
+        { where: { id: referrerId } },
+      );
+      log.info(`Credited ${missing} XP to referrer ${referrerId}`);
+    }
+  }
+}
+
+backfillReferrerXp()
+  .then(() => {
+    log.info('Referrer XP backfill complete');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/libs/model/src/aggregates/user/Xp.projection.ts
+++ b/libs/model/src/aggregates/user/Xp.projection.ts
@@ -59,6 +59,14 @@ async function getUserByAddress(address: string) {
   return addr?.user_id ?? undefined;
 }
 
+async function getReferrerByUserId(user_id: number) {
+  const user = await models.User.findOne({
+    where: { id: user_id },
+    attributes: ['referred_by_address'],
+  });
+  return user?.referred_by_address ?? null;
+}
+
 /*
  * Finds all active quest action metas for a given event
  */
@@ -99,7 +107,6 @@ async function recordXpsForQuest({
   user_id,
   event_created_at,
   action_metas,
-  shared_with,
   scope,
 }: {
   event_id: number;
@@ -112,13 +119,18 @@ async function recordXpsForQuest({
   };
   scope?: z.infer<typeof schemas.QuestActionScope>;
 }) {
-  const shared_with_address =
-    shared_with?.creator_address || shared_with?.referrer_address;
+  const creator_user_id = shared_with?.creator_address
+    ? await getUserByAddress(shared_with.creator_address)
+    : null;
+  const referrer_address =
+    shared_with && 'referrer_address' in shared_with
+      ? shared_with.referrer_address
+      : await getReferrerByUserId(user_id);
+  const referrer_user_id = referrer_address
+    ? await getUserByAddress(referrer_address)
+    : null;
   await sequelize.transaction(async (transaction) => {
-    const shared_with_user_id = shared_with_address
-      ? await getUserByAddress(shared_with_address)
-      : null;
-
+    
     for (const action_meta of action_metas) {
       if (!action_meta?.id) continue;
       if (action_meta.content_id) {
@@ -177,10 +189,13 @@ async function recordXpsForQuest({
       const reward_amount = Math.round(
         (scope?.amount || action_meta.reward_amount) * x,
       );
-      const shared_xp_points = shared_with_user_id
+      const creator_xp_points = creator_user_id
         ? Math.round(reward_amount * action_meta.creator_reward_weight)
-        : null;
-      const xp_points = reward_amount - (shared_xp_points ?? 0);
+        : 0;
+      const referrer_xp_points = referrer_user_id
+        ? Math.round(reward_amount * 0.1)
+        : 0;
+      const xp_points = reward_amount - creator_xp_points;
 
       await models.sequelize.query(
         `
@@ -207,8 +222,8 @@ async function recordXpsForQuest({
             NULL,
 
             :xp_points,
-            :shared_with_user_id,
-            :shared_xp_points,
+            :creator_user_id,
+            :creator_xp_points,
             :event_id,
             :scope,
             NOW()
@@ -219,24 +234,29 @@ async function recordXpsForQuest({
         update_user AS (
           UPDATE "Users"
           SET xp_points = COALESCE(xp_points, 0) + :xp_points
-          WHERE id = :user_id 
+          WHERE id = :user_id
             AND EXISTS(SELECT 1 FROM inserted)
           RETURNING 1
         ),
         update_creator AS (
           UPDATE "Users"
-          SET 
-            xp_points = COALESCE(xp_points, 0) 
-              + CASE WHEN :is_referral THEN 0 ELSE :shared_xp_points END,
-            xp_referrer_points = COALESCE(xp_referrer_points, 0) 
-              + CASE WHEN :is_referral THEN :shared_xp_points ELSE 0 END
-          WHERE id = :shared_with_user_id 
-            AND :shared_xp_points IS NOT NULL
+          SET xp_points = COALESCE(xp_points, 0) + :creator_xp_points
+          WHERE id = :creator_user_id
+            AND :creator_xp_points > 0
+            AND EXISTS(SELECT 1 FROM inserted)
+          RETURNING 1
+        ),
+        update_referrer AS (
+          UPDATE "Users"
+          SET xp_points = COALESCE(xp_points, 0) + :referrer_xp_points,
+              xp_referrer_points = COALESCE(xp_referrer_points, 0) + :referrer_xp_points
+          WHERE id = :referrer_user_id
+            AND :referrer_xp_points > 0
             AND EXISTS(SELECT 1 FROM inserted)
           RETURNING 1
         )
         UPDATE "Quests"
-        SET 
+        SET
           xp_awarded = xp_awarded + :reward_amount,
           end_date = CASE 
               WHEN (xp_awarded + :reward_amount) >= max_xp_to_end
@@ -252,11 +272,12 @@ async function recordXpsForQuest({
             event_id,
             event_created_at,
             user_id,
-            shared_with_user_id,
+            creator_user_id,
+            creator_xp_points,
+            referrer_user_id,
+            referrer_xp_points,
             reward_amount,
             xp_points,
-            shared_xp_points,
-            is_referral: !!shared_with?.referrer_address,
             scope: scope ? JSON.stringify(scope) : null,
           },
           transaction,
@@ -271,12 +292,13 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
     inputs: schemas.QuestEvents,
     body: {
       SignUpFlowCompleted: async ({ id, payload }) => {
-        const referee_address = await models.User.findOne({
+        const user = await models.User.findOne({
           where: {
             id: payload.user_id,
             tier: { [Op.ne]: UserTierMap.BannedUser },
           },
         });
+        if (!user) return;
         const action_metas = await getQuestActionMetas(
           payload,
           'SignUpFlowCompleted',
@@ -286,9 +308,6 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           user_id: payload.user_id,
           event_created_at: payload.created_at!,
           action_metas,
-          shared_with: {
-            referrer_address: referee_address?.referred_by_address,
-          },
         });
       },
       CommunityCreated: async ({ id, payload }) => {
@@ -306,7 +325,6 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
             user_id: payload.user_id,
             event_created_at: payload.created_at!,
             action_metas,
-            shared_with: { referrer_address: payload.referrer_address },
             scope: {
               chain_id: community.chain_node_id || undefined,
               community_id: community.id,
@@ -325,13 +343,12 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
             tier: { [Op.ne]: UserTierMap.BannedUser },
           },
         });
-        if (action_metas.length > 0) {
+        if (action_metas.length > 0 && user) {
           await recordXpsForQuest({
             event_id: id,
             user_id: payload.user_id,
             event_created_at: payload.created_at!,
             action_metas,
-            shared_with: { referrer_address: user?.referred_by_address },
             scope: { community_id: payload.community_id },
           });
         }
@@ -343,11 +360,13 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           payload,
           'ThreadCreated',
         );
+        const referrer_address = await getReferrerByUserId(user_id);
         await recordXpsForQuest({
           event_id: id,
           user_id,
           event_created_at: payload.created_at!,
           action_metas,
+          shared_with: { referrer_address },
           scope: {
             community_id: payload.community_id,
             topic_id: payload.topic_id,
@@ -374,12 +393,16 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           payload,
           'ThreadUpvoted',
         );
+        const referrer_address = await getReferrerByUserId(user_id);
         await recordXpsForQuest({
           event_id: id,
           user_id,
           event_created_at: payload.created_at!,
           action_metas,
-          shared_with: { creator_address: thread!.Address!.address },
+          shared_with: {
+            creator_address: thread!.Address!.address,
+            referrer_address,
+          },
           scope: {
             community_id: thread.community_id,
             topic_id: thread.topic_id,
@@ -398,11 +421,13 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           payload,
           'CommentCreated',
         );
+        const referrer_address = await getReferrerByUserId(user_id);
         await recordXpsForQuest({
           event_id: id,
           user_id,
           event_created_at: payload.created_at!,
           action_metas,
+          shared_with: { referrer_address },
           scope: {
             community_id: thread.community_id,
             topic_id: thread.topic_id,
@@ -438,12 +463,16 @@ export function Xp(): Projection<typeof schemas.QuestEvents> {
           },
           'CommentUpvoted',
         );
+        const referrer_address = await getReferrerByUserId(user_id);
         await recordXpsForQuest({
           event_id: id,
           user_id,
           event_created_at: payload.created_at!,
           action_metas,
-          shared_with: { creator_address: comment!.Address!.address },
+          shared_with: {
+            creator_address: comment!.Address!.address,
+            referrer_address,
+          },
           scope: {
             community_id: comment.Thread!.community_id,
             topic_id: comment.Thread!.topic_id,


### PR DESCRIPTION
## Summary
- add ticket outlining retroactive referrer XP backfill
- draft script to credit 10% referral bonus for historical XpLogs
- ensure recordXpsForQuest only adds referrer bonuses without deducting base XP
- propagate referrer addresses through thread and comment events so valid referrers receive points
- make backfill script case-insensitive and skip banned addresses

## Testing
- ❌ `corepack pnpm test libs/model` (Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)
- ❌ `npm test` (Missing script: "test")
- ❌ `npm run lint` (Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a4a1d399e0832f99900a327c357cec