### PR TITLE
feat: restrict SMS login to US and Canada

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPhoneInput/CWPhoneInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWPhoneInput/CWPhoneInput.tsx
@@ -7,6 +7,7 @@ type CWPhoneInputProps = {
   name: string;
   label?: string;
   country?: string;
+  onlyCountries?: string[];
   disabled?: boolean;
   hookToForm?: boolean;
 };
@@ -14,6 +15,7 @@ type CWPhoneInputProps = {
 const CWPhoneInput = ({
   name,
   country = 'us',
+  onlyCountries,
   disabled,
   hookToForm,
 }: CWPhoneInputProps) => {
@@ -26,6 +28,7 @@ const CWPhoneInput = ({
       <PhoneInput
         {...formFieldContext}
         country={country}
+        onlyCountries={onlyCountries}
         disabled={disabled}
         onChange={(value) => formContext.setValue(name, value)}
         inputClass="input-container"

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -58,6 +58,8 @@ const MODAL_COPY = {
 
 const mobileApp = isMobileApp();
 
+const SMS_ALLOWED_COUNTRIES = ['US', 'CA', 'AS', 'GU', 'MP', 'PR', 'VI'];
+
 const SSO_OPTIONS_DEFAULT: AuthSSOs[] = [
   'google',
   'discord',
@@ -117,7 +119,7 @@ const ModalBase = ({
       .then((res) => res.json())
       .then((data) => {
         const country = data.country?.toUpperCase();
-        setIsSMSAllowed(['US', 'CA'].includes(country));
+        setIsSMSAllowed(SMS_ALLOWED_COUNTRIES.includes(country));
       })
       .catch(() => {
         setIsSMSAllowed(false);

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/ModalBase.tsx
@@ -113,10 +113,10 @@ const ModalBase = ({
   const [isSMSAllowed, setIsSMSAllowed] = useState(false);
 
   useEffect(() => {
-    fetch('https://ipapi.co/json/')
+    fetch('/api/ipCountry')
       .then((res) => res.json())
       .then((data) => {
-        const country = data.country_code?.toUpperCase();
+        const country = data.country?.toUpperCase();
         setIsSMSAllowed(['US', 'CA'].includes(country));
       })
       .catch(() => {

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/SMSForm/SMSForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/SMSForm/SMSForm.tsx
@@ -41,6 +41,7 @@ const SMSForm = ({ onSubmit, onCancel, isLoading }: SMSFormProps) => {
               name="SMS"
               label="Phone Number"
               country="us"
+              onlyCountries={['us', 'ca']}
               disabled={isLoading}
             />
             <div className="action-btns">

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/SMSForm/SMSForm.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/common/ModalBase/SMSForm/SMSForm.tsx
@@ -41,7 +41,7 @@ const SMSForm = ({ onSubmit, onCancel, isLoading }: SMSFormProps) => {
               name="SMS"
               label="Phone Number"
               country="us"
-              onlyCountries={['us', 'ca']}
+              onlyCountries={['us', 'ca', 'as', 'gu', 'mp', 'pr', 'vi']}
               disabled={isLoading}
             />
             <div className="action-btns">

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -69,7 +69,7 @@ function setupRouter(app: Express, cacheDecorator: CacheDecorator) {
     // otherwise, return false
     return res.json({ customDomain: null });
   });
-  registerRoute(router, 'get', '/ipCountry', async (req, res) => {
+  registerRoute(router, 'get', '/ipCountry', (req, res) => {
     const country = (req.headers['CF-IPCountry'] as string)?.toUpperCase();
     return res.json({ country });
   });

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -70,11 +70,7 @@ function setupRouter(app: Express, cacheDecorator: CacheDecorator) {
     return res.json({ customDomain: null });
   });
   registerRoute(router, 'get', '/ipCountry', async (req, res) => {
-    const country = (
-      (req.headers['cf-ipcountry'] as string | undefined) ||
-      (req.headers['x-vercel-ip-country'] as string | undefined) ||
-      (req.headers['x-country'] as string | undefined)
-    )?.toUpperCase();
+    const country = (req.headers['CF-IPCountry'] as string)?.toUpperCase();
     return res.json({ country });
   });
   registerRoute(router, 'get', '/finishUpdateEmail', async (req, res) => {

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -69,6 +69,14 @@ function setupRouter(app: Express, cacheDecorator: CacheDecorator) {
     // otherwise, return false
     return res.json({ customDomain: null });
   });
+  registerRoute(router, 'get', '/ipCountry', async (req, res) => {
+    const country = (
+      (req.headers['cf-ipcountry'] as string | undefined) ||
+      (req.headers['x-vercel-ip-country'] as string | undefined) ||
+      (req.headers['x-country'] as string | undefined)
+    )?.toUpperCase();
+    return res.json({ country });
+  });
   registerRoute(router, 'get', '/finishUpdateEmail', async (req, res) => {
     const { token, email } = req.query;
     try {

--- a/tickets/sms-login-us-ca.md
+++ b/tickets/sms-login-us-ca.md
@@ -1,9 +1,0 @@
-# Restrict SMS Login to US and Canada
-
-## Context
-SMS login should be available only for users with United States or Canadian phone numbers and IP addresses.
-
-## Requirements
-- Hide SMS login option for users outside the US and Canada.
-- Restrict phone input to US and Canadian numbers.
-

--- a/tickets/sms-login-us-ca.md
+++ b/tickets/sms-login-us-ca.md
@@ -1,0 +1,9 @@
+# Restrict SMS Login to US and Canada
+
+## Context
+SMS login should be available only for users with United States or Canadian phone numbers and IP addresses.
+
+## Requirements
+- Hide SMS login option for users outside the US and Canada.
+- Restrict phone input to US and Canadian numbers.
+


### PR DESCRIPTION
## Summary
- add ticket for limiting SMS login to US and CA
- restrict phone input to US/CA numbers
- show SMS login only for US/CA IPs

## Testing
- `pnpm lint-branch-warnings` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -r check-types` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e8bbbf2c832f8309ab4eff801341