### PR TITLE
Capitalize Common in onboarding referral message

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/WelcomeOnboardModal/steps/InviteModal/InviteModal.tsx
@@ -82,7 +82,7 @@ const InviteModal = ({ onComplete }: InviteModalProps) => {
       />
 
       <CWText type="h3" className="title" isCentered>
-        Get a referral bonus for inviting friends to common!{' '}
+        Get a referral bonus for inviting friends to Common!{' '}
       </CWText>
 
       <div className="share-section">


### PR DESCRIPTION
## Summary
- Capitalize "Common" in the referral bonus message shown during onboarding

## Testing
- `pnpm lint-diff` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a6100effe4832f94f1bff0b3985164