### PR TITLE
Fix missing chain select in community creation

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/CommunityInformationForm/CommunityInformationForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/CommunityInformationForm/CommunityInformationForm.tsx
@@ -95,13 +95,13 @@ const CommunityInformationForm = ({
 
     if (withChainsConfig?.community?.type === CommunityType.Solana) {
       return sortedChains
-        .filter((chainType) => chainType.chainBase === CommunityType.Solana)
+        .filter((chainType) => chainType.chainBase === 'solana')
         .map(mappedChainValue);
     }
 
     if (withChainsConfig?.community?.type === CommunityType.Sui) {
       return sortedChains
-        .filter((chainType) => chainType.chainBase === CommunityType.Sui)
+        .filter((chainType) => chainType.chainBase === 'sui')
         .map(mappedChainValue);
     }
 
@@ -110,8 +110,8 @@ const CommunityInformationForm = ({
         (chainType) =>
           chainType.chainBase ===
           (withChainsConfig?.community?.type === CommunityType.Cosmos
-            ? CommunityType.Cosmos
-            : CommunityType.Ethereum),
+            ? 'cosmos'
+            : 'ethereum'),
       )
       .map(mappedChainValue);
   };
@@ -138,6 +138,7 @@ const CommunityInformationForm = ({
               return options?.find((o) => o.value === SONEIUM_ID);
             case CommunityType.Polygon:
             case CommunityType.Solana:
+            case CommunityType.Sui:
               return options?.[0];
           }
         })(),
@@ -194,7 +195,8 @@ const CommunityInformationForm = ({
           placeholder="Select chain"
           isDisabled={
             withChainsConfig.community.type === CommunityType.Polygon ||
-            withChainsConfig.community.type === CommunityType.Solana
+            withChainsConfig.community.type === CommunityType.Solana ||
+            withChainsConfig.community.type === CommunityType.Sui
           }
           options={getChainOptions()}
         />


### PR DESCRIPTION
## Link to Issue
Closes: #TODO

## Description of Changes
This PR fixes an issue in the Community Create Flow where the chain selection dropdown was empty when "Ethereum (EVM)" was selected, preventing community creation.

The core problem was incorrect filtering logic in `CommunityInformationForm.tsx`:
1.  **Incorrect Chain Filtering:** `chainType.chainBase` (a string like `'ethereum'`) was being compared against `CommunityType` enum values (e.g., `CommunityType.Ethereum`) instead of their corresponding string values. This caused the filter to return no results for EVM, Solana, Sui, and Cosmos communities.
2.  **Missing Sui Handling:** `CommunityType.Sui` was not included in the `isDisabled` condition for the chain selection dropdown, nor in the `getInitialValue()` switch statement.

**Changes Made:**
*   Updated `getChainOptions()` to correctly filter chains by comparing `chainType.chainBase` with the appropriate string values (`'solana'`, `'sui'`, `'cosmos'`, `'ethereum'`).
*   Added `CommunityType.Sui` to the `isDisabled` condition for the chain selection dropdown, as Sui communities have a pre-selected chain.
*   Included `CommunityType.Sui` in the `getInitialValue()` switch statement to ensure the correct initial chain is set.

This ensures that selecting "Ethereum (EVM)" correctly displays all EVM-compatible chains, and other community types (Solana, Sui, Cosmos) also filter and behave as expected.

## Test Plan
Manually verify the Community Create Flow:
*   Select "Ethereum (EVM)" and confirm EVM chains are listed.
*   Select "Solana" and confirm only Solana chains are listed and the dropdown is disabled.
*   Select "Sui" and confirm only Sui chains are listed and the dropdown is disabled.
*   Select "Cosmos" and confirm only Cosmos chains are listed.
*   Select other specific EVM chains (e.g., Polygon, Base) and confirm their respective chains are pre-selected and the dropdown is disabled.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-

---
[Slack Thread](https://commonxyz.slack.com/archives/C052DMYFKDL/p1755722056470839?thread_ts=1755722056.470839&cid=C052DMYFKDL)

<a href="https://cursor.com/background-agent?bcId=bc-fc8fb966-8311-4209-933d-b56a294180b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc8fb966-8311-4209-933d-b56a294180b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

