### PR TITLE
Ensure ETH balance fetched after Magic login

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/DesktopHeader.tsx
@@ -18,7 +18,10 @@ import UserDropdown from './UserDropdown';
 import { ChainBase } from '@hicommonwealth/shared';
 import { getUniqueUserAddresses } from 'client/scripts/helpers/user';
 import { useGetUserEthBalanceQuery } from 'client/scripts/state/api/communityStake';
-import { fetchCachedNodes } from 'client/scripts/state/api/nodes';
+import {
+  fetchCachedNodes,
+  useFetchNodesQuery,
+} from 'client/scripts/state/api/nodes';
 import { useFlag } from 'hooks/useFlag';
 import { useFetchCustomDomainQuery } from 'state/api/configuration';
 import useUserStore from 'state/ui/user';
@@ -56,6 +59,8 @@ const DesktopHeader = ({ onMobile, onAuthModalOpen }: DesktopHeaderProps) => {
     }, 200);
   };
 
+  // Ensure chain node data is loaded before attempting to read from cache
+  useFetchNodesQuery();
   const nodes = fetchCachedNodes();
   const baseNode = nodes?.find((node) => node.id === baseNodeId);
 


### PR DESCRIPTION
## Summary
- ensure chain node data is loaded in `DesktopHeader` so ETH balance displays after Magic login

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a639bbfce4832fa3d67760c04b6778