### PR TITLE
feat: index newly launched tokens

### DIFF
--- a/libs/model/assets/minimal_schema.sql
+++ b/libs/model/assets/minimal_schema.sql
@@ -2536,6 +2536,13 @@ CREATE UNIQUE INDEX "Quests_community_id_name_key" ON public."Quests" USING btre
 
 
 --
+-- Name: LaunchpadTokens_liquidity_transferred_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "LaunchpadTokens_liquidity_transferred_created_at" ON public."LaunchpadTokens" USING btree (liquidity_transferred, created_at DESC);
+
+
+--
 -- Name: address_trgm_idx; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
+++ b/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
@@ -4,15 +4,22 @@
 export default {
   async up(queryInterface, Sequelize) {
     await queryInterface.sequelize.transaction(async (transaction) => {
-      await queryInterface.addIndex(
-        'LaunchpadTokens',
-        ['liquidity_transferred', 'created_at'],
-        {
-          name: 'LaunchpadTokens_liquidity_transferred_created_at',
-          transaction,
-          order: ['liquidity_transferred', 'created_at DESC'],
-        },
+      const indexes = await queryInterface.sequelize.query(
+        `SELECT indexname FROM pg_indexes WHERE indexname = 'LaunchpadTokens_liquidity_transferred_created_at'`,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
       );
+
+      if (indexes.length === 0) {
+        await queryInterface.addIndex(
+          'LaunchpadTokens',
+          ['liquidity_transferred', 'created_at'],
+          {
+            name: 'LaunchpadTokens_liquidity_transferred_created_at',
+            transaction,
+            order: ['liquidity_transferred', 'created_at DESC'],
+          },
+        );
+      }
     });
   },
 

--- a/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
+++ b/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
@@ -10,6 +10,7 @@ export default {
         {
           name: 'LaunchpadTokens_liquidity_transferred_created_at',
           transaction,
+          order: ['liquidity_transferred', 'created_at DESC'],
         },
       );
     });
@@ -25,4 +26,3 @@ export default {
     });
   },
 };
-

--- a/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
+++ b/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addIndex(
+        'LaunchpadTokens',
+        ['liquidity_transferred', 'created_at'],
+        {
+          name: 'LaunchpadTokens_liquidity_transferred_created_at',
+          transaction,
+        },
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex(
+        'LaunchpadTokens',
+        'LaunchpadTokens_liquidity_transferred_created_at',
+        { transaction },
+      );
+    });
+  },
+};
+


### PR DESCRIPTION
## Summary
- ensure token listings can be ordered and filtered to surface newly launched coins
- add composite index on liquidity_transferred and created_at for launchpad tokens

## Testing
- `pnpm -F model test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ee830a4832f81bff08974ceabae