### PR TITLE
chore: rename karma label to aura

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.tsx
@@ -120,7 +120,7 @@ const ProfileHeader = ({ profile, isOwner }: ProfileHeaderProps) => {
               <CWText type="b1" className="stat-value">
                 {karma}
               </CWText>
-              <CWText type="caption">Karma earned across Common</CWText>
+              <CWText type="caption">Aura earned across Common</CWText>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace 'Karma earned across Common' label with 'Aura earned across Common' on user profile page

## Testing
- `pnpm lint packages/commonwealth/client/scripts/views/components/Profile/ProfileHeader/ProfileHeader.tsx` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a951c7cb9c832fa9c2e5fd5ecd9eb3