### PR TITLE
fix: handle missing top holders data

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenPerformance/TopHolders/TopHolders.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenPerformance/TopHolders/TopHolders.tsx
@@ -42,7 +42,12 @@ const TopHolders = ({ supply }: { supply: number }) => {
     },
   ];
 
-  const rowData = topHolders?.results.map((holder) => {
+  // Map API results to the structure expected by CWTable. If no data is
+  // returned from the API (for example, due to a network error), default to an
+  // empty array so that CWTable doesn't receive `undefined` row data which
+  // would cause runtime errors when it attempts to access properties like
+  // `originalRows.length`.
+  const rowData = topHolders?.results?.map((holder) => {
     const name = holder.name || '';
     const percentage = (holder.tokens * 100) / supply;
     return {
@@ -89,7 +94,7 @@ const TopHolders = ({ supply }: { supply: number }) => {
         sortValue: percentage,
       },
     };
-  });
+    }) ?? [];
 
   return (
     <div className="TopHolders">
@@ -109,7 +114,7 @@ const TopHolders = ({ supply }: { supply: number }) => {
         {isLoading ? (
           <CWText>Loading...</CWText>
         ) : (
-          <CWTable columnInfo={columnInfo} rowData={rowData!} />
+        <CWTable columnInfo={columnInfo} rowData={rowData} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- prevent TopHolders from sending undefined data to CWTable
- default rowData to empty array when API returns nothing

## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68acbfedb764832fbed024b4123a8676