### PR TITLE
Add index on user profile name to speed up updateUser

### DIFF
--- a/libs/model/assets/minimal_schema.sql
+++ b/libs/model/assets/minimal_schema.sql
@@ -2689,14 +2689,7 @@ CREATE INDEX groups_chain_id ON public."Groups" USING btree (community_id);
 CREATE INDEX idx_threads_is_not_spam ON public."Threads" USING btree (((marked_as_spam_at IS NULL)));
 
 
---
--- Name: idx_users_profile_name; Type: INDEX; Schema: public; Owner: -
---
 
-CREATE INDEX idx_users_profile_name ON public."Users" USING gin (((profile ->> 'name'::text)) public.gin_trgm_ops);
-
-
---
 -- Name: launchpad_trades_token_address_timestamp; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2879,10 +2872,11 @@ CREATE INDEX topics_community_id_idx ON public."Topics" USING btree (community_i
 
 
 --
+
 -- Name: unique_profile_name_not_anonymous; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX unique_profile_name_not_anonymous ON public."Users" USING btree (((profile ->> 'name'::text))) WHERE ((profile ->> 'name'::text) IS DISTINCT FROM 'Anonymous'::text);
+CREATE UNIQUE INDEX unique_profile_name_not_anonymous ON public."Users" USING btree (LOWER((profile ->> 'name'::text))) WHERE (LOWER((profile ->> 'name'::text)) IS DISTINCT FROM 'anonymous'::text);
 
 
 --

--- a/libs/model/assets/minimal_schema.sql
+++ b/libs/model/assets/minimal_schema.sql
@@ -2873,10 +2873,10 @@ CREATE INDEX topics_community_id_idx ON public."Topics" USING btree (community_i
 
 --
 
--- Name: unique_profile_name_not_anonymous; Type: INDEX; Schema: public; Owner: -
+-- Name: unique_profile_name_lower; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX unique_profile_name_not_anonymous ON public."Users" USING btree (LOWER((profile ->> 'name'::text))) WHERE (LOWER((profile ->> 'name'::text)) IS DISTINCT FROM 'anonymous'::text);
+CREATE UNIQUE INDEX unique_profile_name_lower ON public."Users" USING btree (LOWER((profile ->> 'name'::text)));
 
 
 --

--- a/libs/model/migrations/20250821120000-add-user-profile-name-index.js
+++ b/libs/model/migrations/20250821120000-add-user-profile-name-index.js
@@ -6,9 +6,8 @@ export default {
     await queryInterface.sequelize.transaction(async (transaction) => {
       await queryInterface.sequelize.query(
         `
-        CREATE UNIQUE INDEX IF NOT EXISTS unique_profile_name_not_anonymous
-          ON public."Users" (LOWER(profile ->> 'name'))
-          WHERE (LOWER(profile ->> 'name') IS DISTINCT FROM 'anonymous');
+        CREATE UNIQUE INDEX IF NOT EXISTS unique_profile_name_lower
+          ON public."Users" (LOWER(profile ->> 'name'));
       `,
         { transaction },
       );
@@ -19,7 +18,7 @@ export default {
     await queryInterface.sequelize.transaction(async (transaction) => {
       await queryInterface.sequelize.query(
         `
-        DROP INDEX IF EXISTS unique_profile_name_not_anonymous;
+        DROP INDEX IF EXISTS unique_profile_name_lower;
       `,
         { transaction },
       );

--- a/libs/model/migrations/20250821120000-add-user-profile-name-index.js
+++ b/libs/model/migrations/20250821120000-add-user-profile-name-index.js
@@ -6,16 +6,9 @@ export default {
     await queryInterface.sequelize.transaction(async (transaction) => {
       await queryInterface.sequelize.query(
         `
-        CREATE INDEX IF NOT EXISTS idx_users_profile_name
-          ON public."Users" USING gin ((profile ->> 'name') public.gin_trgm_ops);
-      `,
-        { transaction },
-      );
-      await queryInterface.sequelize.query(
-        `
         CREATE UNIQUE INDEX IF NOT EXISTS unique_profile_name_not_anonymous
-          ON public."Users" ((profile ->> 'name'))
-          WHERE ((profile ->> 'name') IS DISTINCT FROM 'Anonymous');
+          ON public."Users" (LOWER(profile ->> 'name'))
+          WHERE (LOWER(profile ->> 'name') IS DISTINCT FROM 'anonymous');
       `,
         { transaction },
       );
@@ -24,12 +17,6 @@ export default {
 
   async down(queryInterface) {
     await queryInterface.sequelize.transaction(async (transaction) => {
-      await queryInterface.sequelize.query(
-        `
-        DROP INDEX IF EXISTS idx_users_profile_name;
-      `,
-        { transaction },
-      );
       await queryInterface.sequelize.query(
         `
         DROP INDEX IF EXISTS unique_profile_name_not_anonymous;

--- a/libs/model/migrations/20250821120000-add-user-profile-name-index.js
+++ b/libs/model/migrations/20250821120000-add-user-profile-name-index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        CREATE INDEX IF NOT EXISTS idx_users_profile_name
+          ON public."Users" USING gin ((profile ->> 'name') public.gin_trgm_ops);
+      `,
+        { transaction },
+      );
+      await queryInterface.sequelize.query(
+        `
+        CREATE UNIQUE INDEX IF NOT EXISTS unique_profile_name_not_anonymous
+          ON public."Users" ((profile ->> 'name'))
+          WHERE ((profile ->> 'name') IS DISTINCT FROM 'Anonymous');
+      `,
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        DROP INDEX IF EXISTS idx_users_profile_name;
+      `,
+        { transaction },
+      );
+      await queryInterface.sequelize.query(
+        `
+        DROP INDEX IF EXISTS unique_profile_name_not_anonymous;
+      `,
+        { transaction },
+      );
+    });
+  },
+};
+

--- a/libs/model/src/aggregates/user/UpdateUser.command.ts
+++ b/libs/model/src/aggregates/user/UpdateUser.command.ts
@@ -111,9 +111,15 @@ export function UpdateUser(): Command<typeof schemas.UpdateUser> {
                 const existingUsername = await models.User.findOne({
                   where: {
                     id: { [Op.ne]: id },
-                    profile: {
-                      name: updates?.profile?.name,
-                    },
+                    [Op.and]: [
+                      models.sequelize.where(
+                        models.sequelize.fn(
+                          'LOWER',
+                          models.sequelize.col("profile->>'name'")
+                        ),
+                        updates.profile.name.toLowerCase(),
+                      ),
+                    ],
                   },
                 });
                 if (existingUsername) {


### PR DESCRIPTION
## Summary
- add unique indexes on `Users.profile->>'name'`

Before Loom: https://www.loom.com/share/2ae023592b124b41869d90a394271f0f

After Loom: https://www.loom.com/share/6629affe38bf46a38199610b18f923d0 (10x speed improvement)

## Testing
- `pnpm test-api` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0ea5070832f88fa02fa5ce3bbd1