### PR TITLE
feat: index newly launched tokens

### DIFF
--- a/libs/model/assets/minimal_schema.sql
+++ b/libs/model/assets/minimal_schema.sql
@@ -2536,6 +2536,17 @@ CREATE UNIQUE INDEX "Quests_community_id_name_key" ON public."Quests" USING btre
 
 
 --
+-- Name: LaunchpadTokens_liquidity_transferred; Type: INDEX; Schema: public; Owner: -
+
+CREATE INDEX "LaunchpadTokens_liquidity_transferred" ON public."LaunchpadTokens" USING btree (liquidity_transferred);
+
+--
+-- Name: LaunchpadTokens_created_at_desc; Type: INDEX; Schema: public; Owner: -
+
+CREATE INDEX "LaunchpadTokens_created_at_desc" ON public."LaunchpadTokens" USING btree (created_at DESC);
+
+
+--
 -- Name: address_trgm_idx; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
+++ b/libs/model/migrations/20250815120000-add-launchpad-tokens-liquidity-created-at-index.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Index for liquidity_transferred
+      const liquidityIndex = await queryInterface.sequelize.query(
+        `SELECT indexname FROM pg_indexes WHERE indexname = 'LaunchpadTokens_liquidity_transferred'`,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
+      );
+      if (liquidityIndex.length === 0) {
+        await queryInterface.addIndex(
+          'LaunchpadTokens',
+          ['liquidity_transferred'],
+          {
+            name: 'LaunchpadTokens_liquidity_transferred',
+            transaction,
+          },
+        );
+      }
+
+      // Index for created_at DESC (latest first)
+      const createdAtIndex = await queryInterface.sequelize.query(
+        `SELECT indexname FROM pg_indexes WHERE indexname = 'LaunchpadTokens_created_at_desc'`,
+        { type: Sequelize.QueryTypes.SELECT, transaction },
+      );
+      if (createdAtIndex.length === 0) {
+        await queryInterface.addIndex(
+          'LaunchpadTokens',
+          ['created_at'],
+          {
+            name: 'LaunchpadTokens_created_at_desc',
+            transaction,
+            order: [['created_at', 'DESC']],
+          },
+        );
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex(
+        'LaunchpadTokens',
+        'LaunchpadTokens_liquidity_transferred',
+        { transaction },
+      );
+      await queryInterface.removeIndex(
+        'LaunchpadTokens',
+        'LaunchpadTokens_created_at_desc',
+        { transaction },
+      );
+    });
+  },
+};
+


### PR DESCRIPTION
## Summary
- ensure token listings can be ordered and filtered to surface newly launched coins
- add separate indexes on liquidity_transferred and created_at for launchpad tokens

## Testing
- `pnpm -F model test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ee830a4832f81bff08974ceabae