### PR TITLE
Fixed community stake

### DIFF
--- a/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getBuyPrice.ts
@@ -19,6 +19,7 @@ const getBuyPrice = async ({
     getFactoryContract(ethChainId).CommunityStake,
     getFactoryContract(ethChainId).NamespaceFactory,
     chainRpc,
+    `${ethChainId}`,
   );
 
   return await communityStakes.getBuyPrice(namespace, stakeId, amount);

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getSellPrice.ts
@@ -19,6 +19,7 @@ const getSellPrice = async ({
     getFactoryContract(ethChainId).CommunityStake,
     getFactoryContract(ethChainId).NamespaceFactory,
     chainRpc,
+    `${ethChainId}`,
   );
 
   return await communityStakes.getSellPrice(namespace, stakeId, amount);

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserEthBalance.ts
@@ -20,6 +20,7 @@ const getUserEthBalance = async ({
     getFactoryContract(ethChainId).CommunityStake,
     getFactoryContract(ethChainId).NamespaceFactory,
     chainRpc,
+    `${ethChainId}`,
   );
 
   return await communityStakes.getUserEthBalance(walletAddress);

--- a/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/getUserStakeBalance.ts
@@ -22,6 +22,7 @@ const getUserStakeBalance = async ({
     getFactoryContract(ethChainId).CommunityStake,
     getFactoryContract(ethChainId).NamespaceFactory,
     chainRpc,
+    `${ethChainId}`,
   );
 
   return await communityStakes.getUserStakeBalance(

--- a/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
+++ b/packages/commonwealth/client/scripts/state/api/communityStake/sellStake.ts
@@ -26,6 +26,7 @@ const sellStake = async ({
     getFactoryContract(ethChainId).CommunityStake,
     getFactoryContract(ethChainId).NamespaceFactory,
     chainRpc,
+    `${ethChainId}`,
   );
 
   return await communityStakes.sellStake(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12806 

## Description of Changes
Buying stake always worked because we pass in the ethChainId when we instantiate the communityStakes in the call. But for other methods we do not pass in the ethChainId so it defaults to 1 "ethereum". This breaks subsequent logic.

Fix was to pass in the ethChainId through to the constructor in all scenarios.

## Test Plan
Sell stake, get success modal

<img width="460" height="568" alt="image" src="https://github.com/user-attachments/assets/a94a4b70-76e8-403f-9182-d3c2468d2236" />