### PR TITLE
Adjust banner padding for collapsed sidebar

### DIFF
--- a/packages/commonwealth/client/scripts/views/Sublayout.scss
+++ b/packages/commonwealth/client/scripts/views/Sublayout.scss
@@ -65,18 +65,10 @@
           margin-left: 0;
         }
 
-        .Banner {
-          padding-left: calc(#{shared.$sidebar-width} + 20px);
-          margin-left: calc(
-            -#{shared.$sidebar-width} + 1px
-          ); // give it a negative margin equal to the parent's margin
-        }
-
+        .Banner,
         .MessageBanner {
-          padding-left: calc(#{shared.$sidebar-width} + 20px);
-          margin-left: calc(
-            -#{shared.$sidebar-width} + 1px
-          ); // give it a negative margin equal to the parent's margin
+          padding-left: calc(#{shared.$quick-switcher-width} + 32px);
+          margin-left: 0;
         }
       }
 


### PR DESCRIPTION
## Summary
- pad community banners by quick-switcher width when sidebar collapsed to prevent caret overlap

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ae256f0b10832fb1cd24a381857e16