### PR TITLE
fix: prevent file picker reopen

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/CWImageInput/UploadControl.tsx
@@ -40,6 +40,7 @@ export const UploadControl = ({
     formFieldErrorMessage,
     imageToRender,
     openFilePicker,
+    ignoreNextClickRef,
     registeredFormContext,
     dropzoneRef,
     imageInputRef,
@@ -95,7 +96,18 @@ export const UploadControl = ({
         { hasImageURL: !!imageToRender },
         uploadControlClassName,
       )}
-      onClick={() => openFilePicker()}
+      onClick={(e) => {
+        // Ignore the synthetic click triggered after the native file picker closes
+        if (ignoreNextClickRef.current) {
+          ignoreNextClickRef.current = false;
+          return;
+        }
+
+        // Prevent reopening when the click originates from the hidden input itself
+        if (e.target !== imageInputRef.current) {
+          openFilePicker();
+        }
+      }}
       onKeyUp={(e) =>
         e.target === e.currentTarget &&
         (e.key === 'Enter' || e.key === ' ') &&


### PR DESCRIPTION
## Summary
- ignore synthetic click after native file picker closes to stop reopening

## Testing
- ❌ `pnpm lint packages/commonwealth` (Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)
- ❌ `pnpm -F commonwealth test` (Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)


------
https://chatgpt.com/codex/tasks/task_e_68acda460508832fa06ad2cc5dfb277f