### PR TITLE
fix: avoid double community prefix on trending threads

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingThreadList/TrendingThreadList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingThreadList/TrendingThreadList.tsx
@@ -46,12 +46,14 @@ const FeedThread = ({ thread, onClick }: FeedThreadProps) => {
   const navigate = useCommonNavigate();
   const user = useUserStore();
   const { data: domain } = useFetchCustomDomainQuery();
-
+  const activeCommunityId = app.activeChainId();
+  const isSameCommunity = thread.communityId === activeCommunityId;
+  const omitChainId = isSameCommunity || domain?.isCustomDomain;
   const discussionLink = getProposalUrlPath(
     thread?.slug,
     `${thread?.identifier}-${slugify(thread.title)}`,
-    false,
-    thread?.communityId,
+    omitChainId,
+    omitChainId ? undefined : thread?.communityId,
   );
 
   const { data: community } = useGetCommunityByIdQuery({
@@ -88,14 +90,19 @@ const FeedThread = ({ thread, onClick }: FeedThreadProps) => {
       thread={thread}
       canUpdateThread={false} // we dont want user to update thread from here, even if they have permissions
       onStageTagClick={() => {
-        navigate(
-          `${
-            domain?.isCustomDomain ? '' : `/${thread.communityId}`
-          }/discussions?stage=${thread.stage}`,
-        );
+        const path = `${
+          isSameCommunity || domain?.isCustomDomain ? '' : `/${thread.communityId}`
+        }/discussions?stage=${thread.stage}`;
+        navigate(path, {}, domain?.isCustomDomain ? null : undefined);
       }}
       threadHref={discussionLink}
-      onCommentBtnClick={() => navigate(`${discussionLink}?focusComments=true`)}
+      onCommentBtnClick={() =>
+        navigate(
+          `${discussionLink}?focusComments=true`,
+          {},
+          domain?.isCustomDomain ? null : undefined,
+        )
+      }
       customStages={community.custom_stages}
       hideReactionButton
       hideUpvotesDrawer


### PR DESCRIPTION
## Summary
- ensure trending thread actions avoid double community prefix by omitting redundant community id and disabling scoped navigation on custom domains

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ae24431308832fbc8054478413f5e0