### PR TITLE
Fix view and thread count rendering

### DIFF
--- a/libs/model/src/aggregates/thread/GetActiveThreads.query.ts
+++ b/libs/model/src/aggregates/thread/GetActiveThreads.query.ts
@@ -36,6 +36,7 @@ TH AS (
 		T.has_poll,
 		T.last_commented_on,
 		T.comment_count,
+		T.view_count,
 		T.marked_as_spam_at,
 		T.archived_at,
 		T.topic_id,

--- a/libs/model/src/aggregates/thread/GetThreads.query.ts
+++ b/libs/model/src/aggregates/thread/GetThreads.query.ts
@@ -102,6 +102,7 @@ export function GetThreads(): Query<typeof schemas.GetThreads> {
                 T.has_poll,
                 T.last_commented_on,
                 T.comment_count,
+                T.view_count,
                 T.marked_as_spam_at,
                 T.archived_at,
                 T.topic_id,

--- a/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/ThreadCard/ThreadCard.tsx
@@ -231,6 +231,7 @@ export const ThreadCard = ({
               hideTrendingTag={hideTrendingTag}
               communityHomeLayout={communityHomeLayout}
               shouldShowRole
+              viewsCount={thread.viewCount}
             />
             <div className="content-header-icons">
               {thread.pinned && <CWIcon iconName="pin" />}


### PR DESCRIPTION
## Fix: Display View and Thread Counts

## Link to Issue
Closes: #TODO

## Description of Changes
This PR addresses an issue where view counts were not rendering on thread cards.

The problem was twofold:
1.  The `view_count` field was missing from the `SELECT` clause in the `GetThreads` and `GetActiveThreads` backend queries, preventing the data from being fetched.
2.  The `ThreadCard` component was not passing the `viewsCount` prop to the `AuthorAndPublishInfo` component, which is responsible for displaying the count.

This PR fixes both issues by:
*   Adding `T.view_count` to the `SELECT` clauses in `GetThreads.query.ts` and `GetActiveThreads.query.ts`.
*   Passing `viewsCount={thread.viewCount}` to the `AuthorAndPublishInfo` component within `ThreadCard.tsx`.

Note: Thread (comment) counts were found to be working correctly and did not require changes.

## Test Plan
*   Verified that the application builds successfully after changes.
*   Expected: View counts should now display correctly on thread cards in the discussion list.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-

---
[Slack Thread](https://commonxyz.slack.com/archives/C051XFN57FT/p1756244280952319?thread_ts=1756244280.952319&cid=C051XFN57FT)

<a href="https://cursor.com/background-agent?bcId=bc-c0ca0e20-19b9-4eb0-a23e-461706836b62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0ca0e20-19b9-4eb0-a23e-461706836b62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

