### PR TITLE
Add Copy On Token Creation page

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/QuickTokenLaunchForm.tsx
@@ -509,6 +509,10 @@ export const QuickTokenLaunchForm = ({
                 body={`Launching your token on BASE requires a small amount of BASE ETH to cover gas fees.
                       ${ethFee ? `Estimated fee: ${ethFee} BASE ETH.` : ''}`}
               />
+              <CWBanner
+                type="info"
+                body="The wallet connected to Common needs to be accessed via a desktop plugin with approximately 3 USD in ETH."
+              />
               <div className="cta-elements">
                 {/* allows to switch b/w generated ideas */}
                 <PageCounter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12909

## Description of Changes
- Add copy in the token creation page stating that the wallet connected to Common needs to be accessed via a desktop plugin with approximately 3 USD in ETH

## Screenshot
<img width="795" height="589" alt="Screenshot 2025-08-29 at 9 34 15 PM" src="https://github.com/user-attachments/assets/a5307f09-c482-4d0d-83e5-11e2ac3371a2" />
<img width="1055" height="568" alt="Screenshot 2025-08-29 at 9 34 38 PM" src="https://github.com/user-attachments/assets/77908c06-02c8-4591-bd58-45170e6becd8" />


## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 