### PR TITLE
Fix spacing between username and trust tag

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
@@ -70,7 +70,7 @@ const ProfileCard = () => {
               className="user-info"
             >
               <h3 className="profile-name">
-                {data?.profile.name}
+                {data?.profile.name}{' '}
                 <TrustLevelRole type="user" level={data?.tier} withTooltip />
               </h3>
             </Link>

--- a/packages/commonwealth/client/scripts/views/pages/Leaderboard/XPTable/XPTable.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/Leaderboard/XPTable/XPTable.tsx
@@ -165,7 +165,7 @@ const XPTable = ({
                           address={rank.user_profile.id}
                         />
                         <p>
-                          {rank.user_profile.name}
+                          {rank.user_profile.name}{' '}
                           <TrustLevelRole
                             type="user"
                             level={rank.user_profile.tier}


### PR DESCRIPTION
## Summary
- ensure space before TrustLevelRole in XPTable's username column
- add space between sidebar profile name and TrustLevelRole tag

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to registry.npmjs.org)*
- `pnpm test-api` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7fd98b8832f88c2e7fabdbfd3ef