### PR TITLE
Add token sort and filter to explore

### DIFF
--- a/libs/model/src/aggregates/community/GetCommunities.query.ts
+++ b/libs/model/src/aggregates/community/GetCommunities.query.ts
@@ -35,6 +35,7 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
         search = '',
         has_launchpad_token,
         has_pinned_token,
+        has_any_token,
       } = payload;
 
       // pagination configuration
@@ -155,6 +156,24 @@ export function GetCommunities(): Query<typeof schemas.GetCommunities> {
                             SELECT 1
                             FROM   "PinnedTokens" AS "PinnedTokens"
                             WHERE  "PinnedTokens"."community_id" = "Community"."id"
+                          )
+                        `,
+              )}
+              ${iQ(
+                has_any_token,
+                `
+                          AND (
+                            EXISTS (
+                              SELECT 1
+                              FROM "LaunchpadTokens" AS "LaunchpadTokens"
+                              WHERE "LaunchpadTokens"."namespace" = "Community"."namespace"
+                            )
+                            OR
+                            EXISTS (
+                              SELECT 1
+                              FROM "PinnedTokens" AS "PinnedTokens"
+                              WHERE "PinnedTokens"."community_id" = "Community"."id"
+                            )
                           )
                         `,
               )}

--- a/libs/schemas/src/queries/community.schemas.ts
+++ b/libs/schemas/src/queries/community.schemas.ts
@@ -58,6 +58,7 @@ export const GetCommunities = {
     has_groups: z.boolean().optional(),
     has_launchpad_token: z.boolean().optional(),
     has_pinned_token: z.boolean().optional(),
+    has_any_token: z.boolean().optional(),
     include_last_30_day_thread_count: z.boolean().optional(),
     order_by: z
       .enum([

--- a/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
+++ b/packages/commonwealth/client/scripts/state/api/communities/fetchCommunities.ts
@@ -26,6 +26,7 @@ const useFetchCommunitiesQuery = ({
   search,
   has_launchpad_token,
   has_pinned_token,
+  has_any_token,
   enabled = true,
 }: UseFetchCommunitiesProps) => {
   return trpc.community.getCommunities.useInfiniteQuery(
@@ -46,6 +47,7 @@ const useFetchCommunitiesQuery = ({
       search,
       has_launchpad_token,
       has_pinned_token,
+      has_any_token,
       relevance_by,
       ...(tag_ids &&
         tag_ids?.length > 0 && {

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/CommunitiesList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/CommunitiesList.tsx
@@ -74,6 +74,7 @@ const CommunitiesList: React.FC<CommunitiesListProps> = ({
     withStakeEnabled: undefined,
     withLaunchpadToken: undefined,
     withPinnedToken: undefined,
+    withAnyToken: undefined,
     withTagsIds: undefined,
     withCommunitySortBy: CommunitySortOptions.MemberCount,
     withCommunitySortOrder: CommunitySortDirections.Descending,
@@ -129,6 +130,7 @@ const CommunitiesList: React.FC<CommunitiesListProps> = ({
     stake_enabled: filters.withStakeEnabled,
     has_launchpad_token: filters.withLaunchpadToken,
     has_pinned_token: filters.withPinnedToken,
+    has_any_token: filters.withAnyToken,
     cursor: 1,
     tag_ids: filters.withTagsIds,
     community_type: filters.withCommunityType
@@ -174,6 +176,13 @@ const CommunitiesList: React.FC<CommunitiesListProps> = ({
     setFilters({
       ...filters,
       withPinnedToken: false,
+    });
+  };
+
+  const removeAnyTokenFilter = () => {
+    setFilters({
+      ...filters,
+      withAnyToken: false,
     });
   };
 
@@ -307,6 +316,13 @@ const CommunitiesList: React.FC<CommunitiesListProps> = ({
             onCloseClick={removePinnedTokenFilter}
           />
         )}
+        {filters.withAnyToken && (
+          <CWTag
+            label="With: Token"
+            type="filter"
+            onCloseClick={removeAnyTokenFilter}
+          />
+        )}
         {filters.withTagsIds &&
           filters.withTagsIds.map((id) => (
             <CWTag
@@ -397,6 +413,9 @@ const CommunitiesList: React.FC<CommunitiesListProps> = ({
                   {filters.withCommunityEcosystem ||
                   filters.withNetwork ||
                   filters.withStakeEnabled ||
+                  filters.withLaunchpadToken ||
+                  filters.withPinnedToken ||
+                  filters.withAnyToken ||
                   filters.withTagsIds ||
                   filters.withCommunityType ||
                   filters.withEcosystemChainId

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/FiltersDrawer/FiltersDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/FiltersDrawer/FiltersDrawer.tsx
@@ -45,6 +45,8 @@ export const FiltersDrawer = ({
     onFiltersChange({
       ...filters,
       withLaunchpadToken: !filters.withLaunchpadToken,
+      // Clear "Has Token" filter when selecting specific token filter
+      withAnyToken: !filters.withLaunchpadToken ? false : filters.withAnyToken,
     });
   };
 
@@ -52,6 +54,20 @@ export const FiltersDrawer = ({
     onFiltersChange({
       ...filters,
       withPinnedToken: !filters.withPinnedToken,
+      // Clear "Has Token" filter when selecting specific token filter
+      withAnyToken: !filters.withPinnedToken ? false : filters.withAnyToken,
+    });
+  };
+
+  const onAnyTokenFilterChange = () => {
+    onFiltersChange({
+      ...filters,
+      withAnyToken: !filters.withAnyToken,
+      // Clear specific token filters when selecting "Has Token"
+      withLaunchpadToken: !filters.withAnyToken
+        ? false
+        : filters.withLaunchpadToken,
+      withPinnedToken: !filters.withAnyToken ? false : filters.withPinnedToken,
     });
   };
 
@@ -148,6 +164,17 @@ export const FiltersDrawer = ({
                 size="small"
                 checked={filters.withStakeEnabled}
                 onChange={() => onStakeFilterChange()}
+              />
+            </div>
+
+            <div className="stake-filter">
+              <CWText type="h5" fontWeight="semiBold">
+                Has Token
+              </CWText>
+              <CWToggle
+                size="small"
+                checked={filters.withAnyToken}
+                onChange={() => onAnyTokenFilterChange()}
               />
             </div>
 

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/FiltersDrawer/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/CommunitiesList/FiltersDrawer/types.ts
@@ -18,6 +18,7 @@ export type CommunityFilters = {
   withStakeEnabled?: boolean;
   withLaunchpadToken?: boolean;
   withPinnedToken?: boolean;
+  withAnyToken?: boolean;
   withTagsIds?: number[];
   withCommunityType?: CommunityType;
   withCommunitySortBy?: CommunitySortOptions;


### PR DESCRIPTION
## Link to Issue
Closes: #TODO

## Description of Changes
This PR introduces a new "Has Token" filter on the Explore page, allowing users to easily find communities that have *any* type of associated token (either launchpad or external).

Previously, users could only filter for "Has Launchpad Token" or "Has External Token" separately. This change addresses the user's request for a more general and prominent "token option" in the community search model, providing a more intuitive way to discover token-gated or token-associated communities.

**Key changes include:**
-   **Backend:** Added a new `has_any_token` parameter to the `GetCommunities` query, implementing SQL `OR` logic to match communities with either launchpad or pinned tokens.
-   **Frontend:**
    -   Introduced a new `withAnyToken` filter type and integrated it into the API calls.
    -   Added a prominent "Has Token" toggle filter in the `FiltersDrawer`.
    -   Implemented mutual exclusion logic: selecting "Has Token" automatically clears specific token filters, and vice versa, to ensure a clear user experience.
    -   Added a "With: Token" filter tag display and removal functionality.

## Test Plan
1.  Navigate to the Explore page (`/explore` or `/search?tab=Communities`).
2.  Open the filters drawer.
3.  Verify the new "Has Token" toggle is present.
4.  **Test "Has Token" filter:**
    *   Select "Has Token".
    *   Observe that "Has Launchpad Token" and "Has External Token" are deselected (if previously active).
    *   Verify that communities with either launchpad or external tokens are displayed.
    *   Verify the "With: Token" filter tag appears.
5.  **Test specific token filters with "Has Token":**
    *   Select "Has Launchpad Token".
    *   Observe that "Has Token" is deselected (if previously active).
    *   Select "Has External Token".
    *   Observe that "Has Token" is deselected (if previously active).
6.  **Test combinations:**
    *   Select "Has Token", then try selecting "Has Launchpad Token" – verify "Has Token" clears.
    *   Select "Has Launchpad Token", then try selecting "Has Token" – verify "Has Launchpad Token" clears.
7.  Verify filter removal by clicking the 'x' on the "With: Token" tag.
8.  Check that the empty state message correctly reflects when token filters are active.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
-   The new `has_any_token` backend parameter uses `OR` logic, which is distinct from the `AND` logic that would result from simultaneously setting `has_launchpad_token` and `has_pinned_token`.
-   Mutual exclusion logic is implemented in the frontend to prevent conflicting filter selections and provide a clear user experience.

---
[Slack Thread](https://commonxyz.slack.com/archives/C052DMYFKDL/p1756491012126829?thread_ts=1756491012.126829&cid=C052DMYFKDL)

<a href="https://cursor.com/background-agent?bcId=bc-12c0101a-f737-45a1-82bf-b94b24b7a2d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12c0101a-f737-45a1-82bf-b94b24b7a2d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

