### PR TITLE
fix: wrap long community descriptions

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.scss
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/TokenDetails/TokenDetails.scss
@@ -36,6 +36,12 @@
 
 .token-description {
   margin-top: 12px;
+
+  .Text:last-child {
+    display: inline-block;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
 }
 
 .token-stats {


### PR DESCRIPTION
## Summary
- prevent long community descriptions from breaking layout by forcing word wrapping

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz; Proxy response 403 when HTTP Tunneling)*
- `pnpm -F commonwealth test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz; Proxy response 403 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ea481ed4832fba6d4da14312c4a9