### PR TITLE
Reset token carousel scroll on revisit

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingTokenList/TrendingTokenList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingTokenList/TrendingTokenList.tsx
@@ -6,7 +6,7 @@ import { APIOrderDirection } from 'helpers/constants';
 import useDeferredConditionTriggerCallback from 'hooks/useDeferredConditionTriggerCallback';
 import { useFlag } from 'hooks/useFlag';
 import { navigateToCommunity, useCommonNavigate } from 'navigation/helpers';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useFetchTokensQuery } from 'state/api/tokens';
 import useUserStore from 'state/ui/user';
@@ -71,6 +71,12 @@ const TrendingTokensList = ({
     .flatMap((page) => page.results)
     .slice(0, limit);
 
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({ left: 0 });
+  }, []);
+
   const openAuthModalOrTriggerCallback = () => {
     if (user.isLoggedIn) {
       trigger();
@@ -118,7 +124,7 @@ const TrendingTokensList = ({
           </CWText>
         </div>
       ) : (
-        <div className="list">
+        <div className="list" ref={listRef}>
           {(tokens || []).map((token) => {
             return (
               <TrendingToken


### PR DESCRIPTION
## Summary
- ensure trending and recent token lists reset their scroll position when returning to the page

## Testing
- `npx eslint packages/commonwealth/client/scripts/views/pages/HomePage/TrendingTokenList/TrendingTokenList.tsx` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npx eslint@8 -c .eslintrc.cjs packages/commonwealth/client/scripts/views/pages/HomePage/TrendingTokenList/TrendingTokenList.tsx` *(fails: 403 Forbidden fetching ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e9e9d598832fa89ac9a9fcf0480e