### PR TITLE
fix trust level mapping for chain verification

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
@@ -1,4 +1,6 @@
 import {
+  USER_TIERS,
+  UserTierMap,
   UserVerificationItem,
   UserVerificationItemType,
 } from '@hicommonwealth/shared';
@@ -25,7 +27,10 @@ const UserTrustLevel = () => {
     apiCallEnabled: userData.isLoggedIn,
   });
 
-  const currentTier = data?.tier || 0;
+  const currentTier: UserTierMap =
+    (data?.tier as UserTierMap) ?? (userData.tier as UserTierMap);
+  const currentTrustLevel =
+    USER_TIERS[currentTier]?.clientInfo?.trustLevel || 0;
 
   const handleItemClick = (item: UserVerificationItem) => {
     if (item.type === 'VERIFY_SOCIAL') {
@@ -49,8 +54,8 @@ const UserTrustLevel = () => {
   return (
     <div className="UserTrustLevel">
       {tiers.map((level) => {
-        const isLocked = level.level > currentTier + 1;
-        const isCurrentLevel = level.level === currentTier;
+        const isLocked = level.level > currentTrustLevel + 1;
+        const isCurrentLevel = level.level === currentTrustLevel;
 
         return (
           <LevelBox

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/UserTrustLevel.tsx
@@ -29,8 +29,10 @@ const UserTrustLevel = () => {
 
   const currentTier: UserTierMap =
     (data?.tier as UserTierMap) ?? (userData.tier as UserTierMap);
+  const tierInfo = USER_TIERS[currentTier];
   const currentTrustLevel =
-    USER_TIERS[currentTier]?.clientInfo?.trustLevel || 0;
+    (tierInfo && 'clientInfo' in tierInfo && tierInfo.clientInfo?.trustLevel) ||
+    0;
 
   const handleItemClick = (item: UserVerificationItem) => {
     if (item.type === 'VERIFY_SOCIAL') {

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/helpers/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/helpers/helpers.ts
@@ -20,17 +20,13 @@ export const getLevelRedirect = (tier: UserTierMap): boolean => {
   return [UserTierMap.SocialVerified, UserTierMap.ChainVerified].includes(tier);
 };
 
-export const getLevelStatus = (level: number, currentTier: number): Status => {
-  const tierEntry = Object.entries(USER_TIERS).find(([key]) => {
-    const tier = USER_TIERS[parseInt(key) as UserTierMap] as Tier & {
-      clientInfo?: { trustLevel: number };
-    };
-    return tier.clientInfo?.trustLevel === level;
-  });
-
-  if (!tierEntry) return 'Not Started';
-  const tierNum = parseInt(tierEntry[0]) as UserTierMap;
-  return tierNum <= currentTier ? 'Done' : 'Not Started';
+export const getLevelStatus = (
+  level: number,
+  currentTier: UserTierMap,
+): Status => {
+  const currentTrustLevel =
+    USER_TIERS[currentTier]?.clientInfo?.trustLevel || 0;
+  return currentTrustLevel >= level ? 'Done' : 'Not Started';
 };
 
 export const getCommunityNavigation = (
@@ -61,7 +57,7 @@ export const getCommunityNavigation = (
   }
 };
 
-export const mapTiers = (currentTier: number): TierInfo[] => {
+export const mapTiers = (currentTier: UserTierMap): TierInfo[] => {
   return Object.entries(USER_TIERS)
     .filter(([key]) => {
       const tier = parseInt(key) as UserTierMap;

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/helpers/helpers.ts
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/UserTrustLevel/helpers/helpers.ts
@@ -24,8 +24,10 @@ export const getLevelStatus = (
   level: number,
   currentTier: UserTierMap,
 ): Status => {
+  const tierInfo = USER_TIERS[currentTier];
   const currentTrustLevel =
-    USER_TIERS[currentTier]?.clientInfo?.trustLevel || 0;
+    (tierInfo && 'clientInfo' in tierInfo && tierInfo.clientInfo?.trustLevel) ||
+    0;
   return currentTrustLevel >= level ? 'Done' : 'Not Started';
 };
 


### PR DESCRIPTION
## Summary
- ensure current trust tier uses `UserTierMap` and derived trust level
- compare trust levels consistently in `getLevelStatus`
- base UI state on trust level to show completed chain-verification items

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm -F commonwealth test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fc0ca104832f9f139aad4eb56aa0