### PR TITLE
fix: link trust level tooltip to edit profile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/UserDropdown/UserDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/SublayoutHeader/DesktopHeader/UserDropdown/UserDropdown.tsx
@@ -45,6 +45,7 @@ const UserDropdown = ({ onAuthModalOpen }: UserDropdownProps) => {
             avatarSize={24}
             userAddress={user?.address}
             userCommunityId={user?.community?.id}
+            shouldShowTrustLevelTooltip
           />
           <CWIcon
             iconName={isOpen ? 'caretUp' : 'caretDown'}

--- a/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TrustLevelRole/TrustLevelRole.tsx
@@ -54,7 +54,7 @@ const TrustLevelRole = ({
   if (withTooltip && tooltipContent) {
     return (
       <CWTooltip
-        placement="top"
+        placement="bottom"
         content={tooltipContent}
         renderTrigger={(handleInteraction, isTooltipOpen) => (
           <span

--- a/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/sidebar/CommunitySection/ProfileCard.tsx
@@ -3,8 +3,7 @@ import useUserStore from 'client/scripts/state/ui/user';
 import clsx from 'clsx';
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { handleMouseEnter, handleMouseLeave } from 'views/menus/utils';
-import { CWTooltip } from '../../../components/component_kit/new_designs/CWTooltip';
+// removed tooltip hover for profile name
 import TrustLevelRole from '../../TrustLevelRole';
 
 import './ProfileCard.scss';
@@ -52,38 +51,20 @@ const ProfileCard = () => {
             alt="Profile"
           />
         </Link>
-        <CWTooltip
-          content={
-            data?.profile.name && data?.profile.name.length > 17
-              ? data?.profile.name
-              : null
-          }
-          placement="top"
-          renderTrigger={(handleInteraction, isTooltipOpen) => (
-            <div
-              onMouseEnter={(e) => {
-                handleMouseEnter({ e, isTooltipOpen, handleInteraction });
-              }}
-              onMouseLeave={(e) => {
-                handleMouseLeave({ e, isTooltipOpen, handleInteraction });
-              }}
-              className="user-info"
-            >
-              <Link to={`/profile/id/${userData.id}`}>
-                <h3 className="profile-name">{data?.profile.name}</h3>
-              </Link>
-              <span
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  navigate('/profile/edit');
-                }}
-              >
-                <TrustLevelRole type="user" level={data?.tier} withTooltip />
-              </span>
-            </div>
-          )}
-        />
+        <div className="user-info">
+          <Link to={`/profile/id/${userData.id}`}>
+            <h3 className="profile-name">{data?.profile.name}</h3>
+          </Link>
+          <span
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              navigate('/profile/edit');
+            }}
+          >
+            <TrustLevelRole type="user" level={data?.tier} withTooltip />
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/packages/commonwealth/client/scripts/views/components/user/user.tsx
+++ b/packages/commonwealth/client/scripts/views/components/user/user.tsx
@@ -27,6 +27,7 @@ export const User = ({
   shouldShowPopover,
   shouldShowRole,
   shouldShowAsDeleted = false,
+  shouldShowTrustLevelTooltip,
   userAddress,
   userCommunityId,
   shouldHideAvatar,
@@ -113,13 +114,21 @@ export const User = ({
       ) : !shouldShowAddressWithDisplayName ? (
         <>
           {profile?.name} &nbsp;
-          <TrustLevelRole type="user" level={profile?.tier} />
+          <TrustLevelRole
+            type="user"
+            level={profile?.tier}
+            withTooltip={!!shouldShowTrustLevelTooltip}
+          />
         </>
       ) : (
         <>
           <div>
             {profile?.name} &nbsp;
-            <TrustLevelRole type="user" level={profile?.tier} />
+            <TrustLevelRole
+              type="user"
+              level={profile?.tier}
+              withTooltip={!!shouldShowTrustLevelTooltip}
+            />
           </div>
           <div className="id-short">{fullAddress}</div>
         </>

--- a/packages/commonwealth/client/scripts/views/components/user/user.types.ts
+++ b/packages/commonwealth/client/scripts/views/components/user/user.types.ts
@@ -14,6 +14,8 @@ export type UserAttrs = {
   userCommunityId: string;
   shouldShowAsDeleted?: boolean;
   shouldShowRole?: boolean;
+  // when true, shows TrustLevelRole with tooltip on hover where applicable
+  shouldShowTrustLevelTooltip?: boolean;
   shouldHideAvatar?: boolean;
   shouldShowAvatarOnly?: boolean;
   shouldLinkProfile?: boolean;


### PR DESCRIPTION
## Summary
- ensure user trust level icon in sidebar links to edit profile page

## Testing
- `pnpm lint-diff` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fd60dd7c832f86a6d57ff1b662ec