### PR TITLE
feat: position tooltips at cursor

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTooltip/CWTooltip.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTooltip/CWTooltip.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode } from 'react';
 
 import './CWTooltip.scss';
 
+import type { VirtualElement } from '@popperjs/core';
 import { Placement } from '@popperjs/core/lib';
 import CWPopover, {
   PopoverTriggerProps,
@@ -24,9 +25,31 @@ export const CWTooltip: FC<TooltipProps> = ({
 }) => {
   const popoverProps = usePopover();
 
+  const handleInteraction = (e: React.MouseEvent<HTMLElement>) => {
+    if (popoverProps.open) {
+      popoverProps.setAnchorEl(null);
+      return;
+    }
+
+    const virtualElement: VirtualElement = {
+      getBoundingClientRect: () => ({
+        width: 0,
+        height: 0,
+        top: e.clientY,
+        bottom: e.clientY,
+        left: e.clientX,
+        right: e.clientX,
+      }),
+      // @ts-expect-error <StrictNullChecks/>
+      contextElement: e.currentTarget,
+    };
+
+    popoverProps.setAnchorEl(virtualElement);
+  };
+
   return (
     <>
-      {renderTrigger(popoverProps.handleInteraction, popoverProps.open)}
+      {renderTrigger(handleInteraction, popoverProps.open)}
       {content && (
         <CWPopover
           disablePortal={disablePortal}


### PR DESCRIPTION
## Summary
- anchor tooltips to the user's cursor instead of element center for better hover location accuracy

## Testing
- `pnpm -F commonwealth test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm -F commonwealth check-types` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b214bdbf40832fab921cdadb3b4c8d