### PR TITLE
feat: add token search option

### DIFF
--- a/packages/commonwealth/client/scripts/models/SearchQuery.ts
+++ b/packages/commonwealth/client/scripts/models/SearchQuery.ts
@@ -5,6 +5,7 @@ export enum SearchScope {
   'Proposals' = 'Proposals',
   'Threads' = 'Threads',
   'Replies' = 'Replies',
+  'Tokens' = 'Tokens',
   'All' = 'All',
 }
 
@@ -12,6 +13,7 @@ export const VALID_SEARCH_SCOPES: SearchScope[] = [
   SearchScope.Threads,
   SearchScope.Replies,
   SearchScope.Communities,
+  SearchScope.Tokens,
   SearchScope.Members,
   SearchScope.Topics,
   SearchScope.Proposals,
@@ -120,6 +122,7 @@ export default class SearchQuery implements SearchParams {
       SearchScope.Threads,
       SearchScope.Replies,
       SearchScope.Communities,
+      SearchScope.Tokens,
       SearchScope.Members,
     ];
   }

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/CWSearchBar.tsx
@@ -73,6 +73,7 @@ export const CWSearchBar: FC<SearchBarProps> = ({
     // @ts-expect-error <StrictNullChecks/>
     communityId === 'all_communities' ? 'communities' : null,
     'members',
+    'tokens',
   ]);
 
   //on mobile, focus the input when the component (search modal) mounts

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarDropdown.tsx
@@ -7,12 +7,14 @@ import { SearchBarCommentPreviewRow } from './SearchBarCommentPreviewRow';
 import { SearchBarCommunityPreviewRow } from './SearchBarCommunityPreviewRow';
 import { SearchBarMemberPreviewRow } from './SearchBarMemberPreviewRow';
 import { SearchBarThreadPreviewRow } from './SearchBarThreadPreviewRow';
+import { SearchBarTokenPreviewRow } from './SearchBarTokenPreviewRow';
 
 import {
   CommentSearchView,
   SearchCommunityView,
   SearchUserProfilesView,
   ThreadView,
+  TokenView,
 } from '@hicommonwealth/schemas';
 import { z } from 'zod';
 import { SearchResults } from '../../../../../hooks/useSearchResults';
@@ -23,7 +25,8 @@ interface SearchBarPreviewSectionProps {
     | z.infer<typeof ThreadView>[]
     | z.infer<typeof CommentSearchView>[]
     | z.infer<typeof SearchCommunityView>[]
-    | z.infer<typeof SearchUserProfilesView>[];
+    | z.infer<typeof SearchUserProfilesView>[]
+    | z.infer<typeof TokenView>[];
   searchTerm: string;
   searchScope: SearchScope;
   onSearchItemClick?: () => void;
@@ -47,6 +50,7 @@ const SearchBarPreviewSection: FC<SearchBarPreviewSectionProps> = ({
     [SearchScope.Replies]: 'Comments',
     [SearchScope.Communities]: 'Communities',
     [SearchScope.Members]: 'Members',
+    [SearchScope.Tokens]: 'Tokens',
   };
 
   const PreviewRowComponentMap = {
@@ -54,6 +58,7 @@ const SearchBarPreviewSection: FC<SearchBarPreviewSectionProps> = ({
     [SearchScope.Replies]: SearchBarCommentPreviewRow,
     [SearchScope.Communities]: SearchBarCommunityPreviewRow,
     [SearchScope.Members]: SearchBarMemberPreviewRow,
+    [SearchScope.Tokens]: SearchBarTokenPreviewRow,
   };
 
   const PreviewRowComponent = PreviewRowComponentMap[searchScope];

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarTokenPreviewRow.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarTokenPreviewRow.scss
@@ -1,0 +1,6 @@
+@use '../../../../../styles/shared';
+@use 'CWSearchBar.scss';
+
+.SearchBarTokenPreviewRow {
+  @include CWSearchBar.everyRowStyles;
+}

--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarTokenPreviewRow.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWSearchBar/SearchBarTokenPreviewRow.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react';
+import { useCommonNavigate } from '../../../../../navigation/helpers';
+import { TokenResult } from '../../../../pages/search/helpers';
+import { CommunityLabel } from '../../../community_label';
+import './SearchBarTokenPreviewRow.scss';
+
+interface SearchBarTokenPreviewRowProps {
+  searchResult: TokenResult;
+  searchTerm?: string;
+  onSearchItemClick?: () => void;
+}
+
+export const SearchBarTokenPreviewRow: FC<SearchBarTokenPreviewRowProps> = ({
+  searchResult,
+  onSearchItemClick,
+}) => {
+  const navigate = useCommonNavigate();
+
+  const handleClick = () => {
+    navigate('/', {}, searchResult.community_id);
+    onSearchItemClick?.();
+  };
+
+  return (
+    <div className="SearchBarTokenPreviewRow" onClick={handleClick}>
+      <CommunityLabel
+        name={searchResult.name || ''}
+        iconUrl={searchResult.icon_url || ''}
+      />
+    </div>
+  );
+};

--- a/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/search/helpers.tsx
@@ -1,4 +1,8 @@
-import { SearchUserProfilesView, ThreadView } from '@hicommonwealth/schemas';
+import {
+  SearchUserProfilesView,
+  ThreadView,
+  TokenView,
+} from '@hicommonwealth/schemas';
 import { getDecodedString } from '@hicommonwealth/shared';
 import moment from 'moment';
 import React, { useMemo } from 'react';
@@ -190,6 +194,30 @@ const CommunityResultRow = ({
   );
 };
 
+export type TokenResult = z.infer<typeof TokenView> & { community_id: string };
+
+type TokenResultRowProps = {
+  token: TokenResult;
+  setRoute: any;
+};
+
+// eslint-disable-next-line react/no-multi-comp
+const TokenResultRow = ({ token, setRoute }: TokenResultRowProps) => {
+  const handleClick = () => {
+    setRoute('/', {}, token.community_id);
+  };
+
+  return (
+    <div
+      key={token.token_address}
+      className="token-result-row"
+      onClick={handleClick}
+    >
+      <CommunityLabel name={token.name || ''} iconUrl={token.icon_url || ''} />
+    </div>
+  );
+};
+
 export type MemberResult = z.infer<typeof SearchUserProfilesView>;
 
 type MemberResultRowProps = {
@@ -261,6 +289,8 @@ export const renderSearchResults = (
             setRoute={setRoute}
           />
         );
+      case SearchScope.Tokens:
+        return <TokenResultRow token={res} setRoute={setRoute} />;
       case SearchScope.Replies:
         return (
           <ReplyResultRow

--- a/packages/commonwealth/client/scripts/views/pages/search/index.scss
+++ b/packages/commonwealth/client/scripts/views/pages/search/index.scss
@@ -116,6 +116,10 @@
           }
         }
       }
+
+      .token-result-row {
+        @include searchRowStyles;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow tokens to be searched alongside threads, replies, communities, and members
- render token results and token previews in search UI

## Testing
- `pnpm test` (fails: Missing script: test)
- `pnpm lint-branch`

------
https://chatgpt.com/codex/tasks/task_e_68b21b86640483228dbfe9c60d424a9a