### PR TITLE
Align card styling with token cards

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.scss
@@ -1,6 +1,7 @@
 @use '../../../styles/shared';
 @use '../../../styles/mixins/colors.module';
 @use '../../../styles/mixins/media_queries';
+@use '../../../styles/mixins/border_radius';
 
 .ContestCard {
   max-width: 600px;
@@ -9,7 +10,7 @@
   position: relative;
 
   @include media_queries.smallInclusive {
-    min-width: 350px;
+    min-width: 330px;
   }
 
   &.isHorizontal {
@@ -17,7 +18,8 @@
     max-width: unset;
 
     .contest-image {
-      border-radius: 5px 0 0 5px;
+      border-radius: border_radius.$border-radius-corners 0 0
+        border_radius.$border-radius-corners;
       max-height: 240px;
       max-width: 522px;
     }
@@ -38,7 +40,7 @@
     padding: 12px;
 
     .contest-image {
-      border-radius: 6px;
+      border-radius: border_radius.$border-radius-corners;
       width: 100%;
       max-height: 275px;
       object-fit: cover;

--- a/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/ContestCard/ContestCard.tsx
@@ -273,6 +273,8 @@ const ContestCard = ({
       className={clsx('ContestCard', {
         isHorizontal: isHorizontal && !isWindowMediumSmallInclusive,
       })}
+      elevation="elevation-1"
+      interactive
     >
       {imageUrl && (
         <div className="contest-image-container">

--- a/packages/commonwealth/client/scripts/views/components/EmptyThreadCard/EmptyThreadCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/EmptyThreadCard/EmptyThreadCard.scss
@@ -9,10 +9,11 @@
   text-align: center;
   padding: 40px 20px;
   min-height: 250px;
-  width: 325px;
+  width: 330px;
   height: 280px;
   box-sizing: border-box;
   margin: 10px 0;
+  cursor: default;
 
   .content-wrapper {
     display: flex;

--- a/packages/commonwealth/client/scripts/views/components/EmptyThreadCard/EmptyThreadCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EmptyThreadCard/EmptyThreadCard.tsx
@@ -28,7 +28,11 @@ export const EmptyThreadCard = () => {
 
   return (
     <>
-      <CWCard className="EmptyThreadCard">
+      <CWCard
+        className="EmptyThreadCard"
+        elevation="elevation-1"
+        interactive
+      >
         <div className="content-wrapper">
           <CWIcon iconName="chats" iconSize="large" className="icon" />
           <CWText type="h2" fontWeight="bold" className="title">

--- a/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.scss
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.scss
@@ -38,8 +38,8 @@
     overflow-x: auto;
 
     .ContestCard {
-      width: 335px;
-
+      width: 330px;
+      
       .contest-image {
         max-height: 160px;
       }

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/CommunityPreviewCard/CommunityPreviewCard.scss
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/CommunityPreviewCard/CommunityPreviewCard.scss
@@ -1,14 +1,15 @@
 @use '../../../../../styles/shared';
 @use '../../../../../styles/mixins/colors.module';
 @use '../../../../../styles/mixins/media_queries';
+@use '../../../../../styles/mixins/border_radius';
 
 .CommunityPreviewCard.Card {
   display: flex;
   flex-direction: row;
   gap: 12px;
   padding: 8px;
-  width: 392px;
-  border-radius: 12px;
+  width: 330px;
+  border-radius: border_radius.$border-radius-corners;
   min-height: 78px;
   position: relative;
   flex-wrap: wrap;

--- a/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.scss
+++ b/packages/commonwealth/client/scripts/views/pages/user_dashboard/TrendingCommunitiesPreview/TrendingCommunitiesPreview.scss
@@ -35,7 +35,7 @@
 
     .Card {
       align-items: center;
-      min-width: 350px;
+      min-width: 330px;
       .CommunityAvatar {
         margin-top: 0 !important;
       }


### PR DESCRIPTION
## Summary
- Standardize widths and border radii on trending community and contest cards
- Resize create thread placeholder to match token card dimensions
- Use shared border radius mixins for contest imagery
- Add hover drop shadow to contest and create-thread cards

## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b2223296c8832f9e624032dd29ecbc