### PR TITLE
refactor: simplify potential contest rendering

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/ActiveContestList/ActiveContestList.tsx
@@ -60,15 +60,12 @@ const ActiveContestList = ({
   const isGraduated = launchpadToken?.liquidity_transferred;
   const hasActiveContests = activeContests.length > 0;
 
-  const showPotentialCardCase1 =
-    isLaunchpadToken && !isGraduated && !hasActiveContests;
-  const showPotentialCardCase2 =
-    isLaunchpadToken && !isGraduated && hasActiveContests;
+  const shouldRenderPotentialCard = isLaunchpadToken && !isGraduated;
 
-  const shouldRenderPotentialCard =
-    showPotentialCardCase1 || showPotentialCardCase2;
-
-  const activeContestsLimited = activeContests.slice(0, 3);
+  const activeContestsLimited = activeContests.slice(
+    0,
+    shouldRenderPotentialCard ? 2 : 3,
+  );
 
   const communityIds = [
     ...new Set(activeContestsLimited.map((contest) => contest.community_id)),
@@ -106,7 +103,6 @@ const ActiveContestList = ({
         </Link>
       </div>
       <>
-        {shouldRenderPotentialCard && <PotentialContestCard />}
         {!isLoading &&
           !shouldRenderPotentialCard &&
           !isCommunityHomePage &&
@@ -119,16 +115,15 @@ const ActiveContestList = ({
           !shouldRenderPotentialCard &&
           isCommunityHomePage &&
           !hasActiveContests && <NoContestsCard />}
-        {isLoading ? (
-          <div className="content">
+        <div className="content">
+          {shouldRenderPotentialCard && <PotentialContestCard />}
+          {isLoading ? (
             <>
               <Skeleton height="300px" />
               <Skeleton height="300px" />
             </>
-          </div>
-        ) : (
-          <div className="content">
-            {activeContestsLimited.map((contest) => {
+          ) : (
+            activeContestsLimited.map((contest) => {
               const sortedContests = (contest?.contests || []).toSorted(
                 (a, b) => (moment(a.end_time).isBefore(b.end_time) ? -1 : 1),
               );
@@ -156,9 +151,9 @@ const ActiveContestList = ({
                   community={community[contest.community_id as string]}
                 />
               );
-            })}
-          </div>
-        )}
+            })
+          )}
+        </div>
       </>
     </div>
   );


### PR DESCRIPTION
## Summary
- collapse potential contest card logic to a single condition
- render contests and skeletons within one shared content container

Before
<img width="930" height="909" alt="image" src="https://github.com/user-attachments/assets/9a6e6513-d0d7-4aac-a4f0-b9a34ac56026" />

After
<img width="733" height="635" alt="image" src="https://github.com/user-attachments/assets/e820bbcb-bf09-46e8-a9f4-37a9685aa4f1" />



## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm -F commonwealth test-unit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b228e7f750832f8a7b295a3345e207