### PR TITLE
fix: guard directory initial load

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/DirectoryPage/DirectoryPage.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import { useCommonNavigate } from 'navigation/helpers';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import app from 'state';
 import {
   useGetCommunityByIdQuery,
@@ -146,15 +146,21 @@ const DirectoryPage = () => {
     [],
   );
 
+  const initialDataLoaded = useRef(false);
+
   useEffect(() => {
-    if (isLoadingTagsAndCommunities) {
-      return;
-    }
+    if (initialDataLoaded.current) return;
+    if (isLoadingTagsAndCommunities) return;
+
     if (tagsAndCommunitiesError) {
       console.error(
         'Error loading tags and communities:',
         tagsAndCommunitiesError,
       );
+      return;
+    }
+
+    if (!filteredRelatedCommunitiesData || !tableData) {
       return;
     }
 
@@ -175,24 +181,21 @@ const DirectoryPage = () => {
     setSelectedTags(initialTags);
     setSelectedCommunities(initialCommunities);
 
-    if (filteredRelatedCommunitiesData) {
-      const initialFilteredCommunities = getFilteredCommunities(
-        filteredRelatedCommunitiesData,
-        initialTags,
-        initialCommunities,
-      );
-      setFilteredCommunities(initialFilteredCommunities);
+    const initialFilteredCommunities = getFilteredCommunities(
+      filteredRelatedCommunitiesData,
+      initialTags,
+      initialCommunities,
+    );
+    setFilteredCommunities(initialFilteredCommunities);
 
-      if (tableData) {
-        const newTableData = getFilteredCommunities(
-          tableData,
-          initialTags,
-          initialCommunities,
-        );
+    const newTableData = getFilteredCommunities(
+      tableData,
+      initialTags,
+      initialCommunities,
+    );
+    setFilteredTableData(newTableData);
 
-        setFilteredTableData(newTableData);
-      }
-    }
+    initialDataLoaded.current = true;
   }, [
     communityTagsAndCommunities,
     isLoadingTagsAndCommunities,


### PR DESCRIPTION
## Summary
- guard directory settings initial load to avoid race condition and unresponsive page

## Testing
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b2250f7bec832fa4aa243aedbbee3a