### PR TITLE
Improve rate limit toast messages

### DIFF
--- a/packages/commonwealth/client/scripts/helpers/rateLimit.ts
+++ b/packages/commonwealth/client/scripts/helpers/rateLimit.ts
@@ -1,0 +1,21 @@
+export const RATE_LIMIT_MESSAGE =
+  'You are being rate limited. Please wait and try again.';
+
+interface RateLimitErrorType {
+  data?: { httpStatus?: number; message?: string };
+  status?: number;
+  response?: { status?: number; data?: { message?: string } };
+  message?: string;
+}
+
+export const isRateLimitError = (err: RateLimitErrorType) => {
+  const status = err?.data?.httpStatus || err?.status || err?.response?.status;
+  if (status === 429) return true;
+
+  const msg =
+    err?.data?.message || err?.message || err?.response?.data?.message || '';
+  const lowerMsg = String(msg).toLowerCase();
+  return (
+    lowerMsg.includes('rate limit') || lowerMsg.includes('too many requests')
+  );
+};

--- a/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CreateComment.tsx
@@ -2,6 +2,7 @@ import { ContentType } from '@hicommonwealth/shared';
 import { buildCreateCommentInput } from 'client/scripts/state/api/comments/createComment';
 import { useAuthModalStore } from 'client/scripts/state/ui/modals';
 import { notifyError } from 'controllers/app/notifications';
+import { isRateLimitError, RATE_LIMIT_MESSAGE } from 'helpers/rateLimit';
 import { SessionKeyError } from 'controllers/server/sessions';
 import { useDraft } from 'hooks/useDraft';
 import Account from 'models/Account';
@@ -143,7 +144,11 @@ export const CreateComment = ({
       const errMsg = err?.responseJSON?.error || err?.message;
       console.error('CreateComment - Error:', errMsg);
 
-      notifyError('Failed to create comment');
+      if (isRateLimitError(err)) {
+        notifyError(RATE_LIMIT_MESSAGE);
+      } else {
+        notifyError('Failed to create comment');
+      }
       setErrorMsg(errMsg);
       throw err;
     } finally {

--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormLegacy/NewThreadForm.tsx
@@ -18,6 +18,7 @@ import {
   getEthChainIdOrBech32Prefix,
   SessionKeyError,
 } from 'controllers/server/sessions';
+import { isRateLimitError, RATE_LIMIT_MESSAGE } from 'helpers/rateLimit';
 import { weightedVotingValueToLabel } from 'helpers';
 import { detectURL } from 'helpers/threads';
 import useAppStatus from 'hooks/useAppStatus';
@@ -494,7 +495,11 @@ export const NewThreadForm = forwardRef<
         }
 
         console.error('NewThreadForm: Unhandled error:', err?.message);
-        notifyError(err.message);
+        if (isRateLimitError(err)) {
+          notifyError(RATE_LIMIT_MESSAGE);
+        } else {
+          notifyError(err.message);
+        }
 
         // Reset turnstile if there's an error
         resetTurnstile();
@@ -933,7 +938,11 @@ export const NewThreadForm = forwardRef<
           navigate(`/discussion/${thread.id}`);
         } catch (error) {
           console.error('Error creating thread:', error);
-          notifyError('Failed to create thread');
+          if (isRateLimitError(error)) {
+            notifyError(RATE_LIMIT_MESSAGE);
+          } else {
+            notifyError('Failed to create thread');
+          }
         } finally {
           setIsSaving(false);
         }

--- a/packages/commonwealth/client/scripts/views/pages/CommunityHome/CommunityHomePage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityHome/CommunityHomePage.tsx
@@ -4,6 +4,7 @@ import { useGetCommunityByIdQuery } from 'client/scripts/state/api/communities';
 import { useFetchGlobalActivityQuery } from 'client/scripts/state/api/feeds/fetchUserActivity';
 import useUserStore from 'client/scripts/state/ui/user';
 import { notifyError, notifySuccess } from 'controllers/app/notifications';
+import { isRateLimitError, RATE_LIMIT_MESSAGE } from 'helpers/rateLimit';
 import { findDenominationString } from 'helpers/findDenomination';
 import { useFlag } from 'hooks/useFlag';
 import type { DeltaStatic } from 'quill';
@@ -113,7 +114,11 @@ const CommunityHome = () => {
       console.error('Error creating thread:', error);
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      notifyError(`Failed to create thread: ${errorMessage}`);
+      if (isRateLimitError(error)) {
+        notifyError(RATE_LIMIT_MESSAGE);
+      } else {
+        notifyError(`Failed to create thread: ${errorMessage}`);
+      }
       return -1;
     }
   };


### PR DESCRIPTION
## Summary
- add utility to detect rate-limit errors and provide default message
- show clearer toast when comment creation hits rate limits
- show clearer toast when thread creation hits rate limits

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*
- `pnpm lint-diff` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b220983474832f9981ab2dfd0f04f1