### PR TITLE
Apply group filter to all member pages

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/CommunityGroupsAndMembers/Members/CommunityMembersPage.tsx
@@ -419,7 +419,7 @@ const CommunityMembersPage = () => {
                 }))
               }
             />
-            {user.activeAccount && (
+            {(groups && groups.length > 0) && (
               <div className="select-dropdown-container">
                 <CWText type="b2" fontWeight="bold" className="filter-text">
                   Filter


### PR DESCRIPTION
## Link to Issue
Closes: #TODO

## Description of Changes
Previously, the group filter dropdown on the members page was only visible if a user was logged in (`user.activeAccount` existed). This prevented the filter from appearing in communities with only automatically created groups (e.g., from token launches) or for unauthenticated users, as reported in the Slack thread.

This change updates the display condition for the filter dropdown to `(groups && groups.length > 0)`. This ensures the filter is shown whenever groups exist in a community, regardless of the user's login status or whether the groups were manually or automatically created. The `groups` data is fetched for both logged-in and unauthenticated users, and the filtering logic correctly handles both scenarios.

## Test Plan
Manually verified by running the application and confirming the filter dropdown appears on the "All members" and "Groups" tabs when groups are present, even for unauthenticated users.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
-

---
[Slack Thread](https://commonxyz.slack.com/archives/C052DMYFKDL/p1756840447863849?thread_ts=1756840447.863849&cid=C052DMYFKDL)

<a href="https://cursor.com/background-agent?bcId=bc-f5aec6dd-0660-4dad-80e7-8fce114efb7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5aec6dd-0660-4dad-80e7-8fce114efb7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

