### PR TITLE
fix: reset profile image upload state on failure

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Avatar/AvatarUpload.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Avatar/AvatarUpload.tsx
@@ -34,9 +34,7 @@ export const AvatarUpload = ({
 }: AvatarUploadProps) => {
   const [files, setFiles] = useState([]);
 
-  const { mutateAsync: uploadImage } = useUploadFileMutation({
-    onSuccess: uploadCompleteCallback,
-  });
+  const { mutateAsync: uploadImage } = useUploadFileMutation();
 
   const { getRootProps, getInputProps } = useDropzone({
     maxFiles: 1,
@@ -61,10 +59,15 @@ export const AvatarUpload = ({
     onDropAccepted: (acceptedFiles: Array<File>) => {
       uploadImage({
         file: acceptedFiles[0],
-      }).catch((e) => {
-        console.error(e);
-        notifyError('Failed to get an S3 signed upload URL');
-      });
+      })
+        .then((url) => {
+          uploadCompleteCallback?.(url);
+        })
+        .catch((e) => {
+          console.error(e);
+          notifyError('Failed to get an S3 signed upload URL');
+          uploadCompleteCallback?.('');
+        });
     },
   });
 

--- a/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/EditProfile/EditProfile.tsx
@@ -311,7 +311,9 @@ const EditProfile = () => {
                     }
                     uploadCompleteCallback={(uploadUrl: string) => {
                       setIsUploadingProfileImage(false);
-                      setAvatarUrl(uploadUrl);
+                      if (uploadUrl) {
+                        setAvatarUrl(uploadUrl);
+                      }
                     }}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- ensure avatar upload always fires completion callback
- avoid retaining profile image upload state when upload fails

## Testing
- `pnpm lint-diff` *(fails: Request was cancelled)*
- `pnpm -F commonwealth test-unit` *(fails: Request was cancelled)*
- `pnpm -F commonwealth check-types` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f3cd408c832fb0f36cad25fa28fd