### PR TITLE
fix: hide join banner on unscoped new thread

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/NewThreadFormModern/NewThreadForm.tsx
@@ -233,7 +233,10 @@ export const NewThreadForm = () => {
     // }
   };
 
-  const showBanner = !user.activeAccount && isBannerVisible;
+  // Only show join banner when a community is selected and the user has not
+  // connected an address for it. On unscoped pages there is no community, so we
+  // should not prompt the user to join.
+  const showBanner = !!communityId && !user.activeAccount && isBannerVisible;
 
   const permissions = Permissions.getCreateThreadPermission({
     actionGroups,


### PR DESCRIPTION
## Summary
- avoid join banner when creating new threads before selecting a community

## Testing
- `pnpm lint-branch` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.14.2.tgz; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting)*

------
https://chatgpt.com/codex/tasks/task_e_68b213bad2e8832f9ef0aea10603eaa3