### PR TITLE
feat: add aura tab to profile

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/Profile.tsx
@@ -169,7 +169,11 @@ const Profile = ({ userId }: ProfileProps) => {
           >
             {/* @ts-expect-error StrictNullChecks*/}
             <ProfileHeader profile={profile} isOwner={isOwner} />
-            <ProfileActivity threads={threads} comments={comments} />
+            <ProfileActivity
+              threads={threads}
+              comments={comments}
+              userId={userId}
+            />
           </div>
         </CWPageLayout>
       </div>
@@ -181,7 +185,11 @@ const Profile = ({ userId }: ProfileProps) => {
           <div className="ProfilePageContainer">
             {/* @ts-expect-error StrictNullChecks*/}
             <ProfileHeader profile={profile} isOwner={isOwner} />
-            <ProfileActivity threads={threads} comments={comments} />
+            <ProfileActivity
+              threads={threads}
+              comments={comments}
+              userId={userId}
+            />
           </div>
         </div>
       </CWPageLayout>

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/ProfileActivity.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/ProfileActivity.tsx
@@ -20,10 +20,16 @@ export type CommentWithAssociatedThread = Comment<IUniqueId> & {
 type ProfileActivityProps = {
   comments: CommentWithAssociatedThread[];
   threads: Thread[];
+  userId: number;
 };
 
-const ProfileActivity = ({ comments, threads }: ProfileActivityProps) => {
+const ProfileActivity = ({
+  comments,
+  threads,
+  userId,
+}: ProfileActivityProps) => {
   const newProfilePageEnabled = useFlag('newProfilePage');
+  const xpEnabled = useFlag('xp');
 
   const [selectedActivity, setSelectedActivity] = useState(
     ProfileActivityType.Comments,
@@ -60,6 +66,15 @@ const ProfileActivity = ({ comments, threads }: ProfileActivityProps) => {
             }}
             isSelected={selectedActivity === ProfileActivityType.MyTokens}
           />
+          {xpEnabled && (
+            <CWTab
+              label="Aura"
+              onClick={() => {
+                setSelectedActivity(ProfileActivityType.Aura);
+              }}
+              isSelected={selectedActivity === ProfileActivityType.Aura}
+            />
+          )}
           {newProfilePageEnabled && (
             <CWTab
               label={
@@ -92,6 +107,7 @@ const ProfileActivity = ({ comments, threads }: ProfileActivityProps) => {
           option={selectedActivity}
           threads={threads}
           comments={comments}
+          userId={userId}
         />
       </div>
     </div>

--- a/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/ProfileActivityContent.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Profile/ProfileActivity/ProfileActivityContent.tsx
@@ -1,5 +1,6 @@
 import Thread from 'models/Thread';
 import React from 'react';
+import { XPEarningsTable } from '../../../pages/WalletPage/tables';
 import { CWText } from '../../component_kit/cw_text';
 import './../Profile.scss';
 import CommunityTab from './CommunityTab';
@@ -14,18 +15,21 @@ export enum ProfileActivityType {
   Communities,
   Threads,
   MyTokens,
+  Aura,
 }
 
 type ProfileActivityContentProps = {
   option: ProfileActivityType;
   threads: Thread[];
   comments: CommentWithAssociatedThread[];
+  userId: number;
 };
 
 const ProfileActivityContent = ({
   option,
   comments,
   threads,
+  userId,
 }: ProfileActivityContentProps) => {
   if (option === ProfileActivityType.Threads) {
     if (threads.length === 0) {
@@ -53,6 +57,10 @@ const ProfileActivityContent = ({
 
   if (option === ProfileActivityType.MyTokens) {
     return <TransactionsTab transactionsType="tokens" />;
+  }
+
+  if (option === ProfileActivityType.Aura) {
+    return <XPEarningsTable userId={userId} />;
   }
 
   if (option === ProfileActivityType.Communities) {

--- a/packages/commonwealth/client/scripts/views/pages/WalletPage/WalletPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/WalletPage/WalletPage.tsx
@@ -169,7 +169,9 @@ const WalletPage = () => {
         {tableTab === TableType.Referrals && (
           <ReferralTable referrals={referrals} isLoading={isReferralsLoading} />
         )}
-        {xpEnabled && tableTab === TableType.XPEarnings && <XPEarningsTable />}
+        {xpEnabled && tableTab === TableType.XPEarnings && (
+          <XPEarningsTable userId={user.id} />
+        )}
       </section>
 
       <AuthModal

--- a/packages/commonwealth/client/scripts/views/pages/WalletPage/tables/XPEarningsTable/XPEarningsTable.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/WalletPage/tables/XPEarningsTable/XPEarningsTable.tsx
@@ -4,7 +4,6 @@ import { APIOrderDirection } from 'helpers/constants';
 import moment from 'moment';
 import React from 'react';
 import { useGetXPs } from 'state/api/user';
-import useUserStore from 'state/ui/user';
 import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import {
   CWTable,
@@ -125,17 +124,15 @@ function buildActionLink(log: z.infer<typeof XpLogView>) {
   return title;
 }
 
-export const XPEarningsTable = () => {
+export const XPEarningsTable = ({ userId }: { userId: number }) => {
   const tableState = useCWTableState({
     columns,
     initialSortColumn: 'earnTime',
     initialSortDirection: APIOrderDirection.Desc,
   });
 
-  const user = useUserStore();
-
   const { data: xpLogs = [] } = useGetXPs({
-    user_or_creator_id: user.id,
+    user_or_creator_id: userId,
   });
 
   const tableData = xpLogs.map((log) => ({
@@ -165,7 +162,7 @@ export const XPEarningsTable = () => {
     },
     completedBy: {
       customElement:
-        log.is_creator && log.user_id !== user.id ? (
+        log.is_creator && log.user_id !== userId ? (
           <FullUser
             profile={{
               address: '',
@@ -183,8 +180,8 @@ export const XPEarningsTable = () => {
         ),
     },
     auraAmount:
-      (user.id === log.user_id ? log.xp_points : 0) +
-      (user.id === log.creator_user_id ? log.creator_xp_points || 0 : 0),
+      (userId === log.user_id ? log.xp_points : 0) +
+      (userId === log.creator_user_id ? log.creator_xp_points || 0 : 0),
     questLink: {
       customElement: (
         <a


### PR DESCRIPTION
## Summary
- expose users' Aura publicly on profiles
- reuse XP earnings table with user-specific data

## Testing
- `pnpm test` *(fails: Missing script)*
- `pnpm lint` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b0da5e88322befa55a210394331