### PR TITLE
Integrated postcoin display with launchpad tokens display in explore page

### DIFF
--- a/libs/model/src/aggregates/token/GetTokenStats.query.ts
+++ b/libs/model/src/aggregates/token/GetTokenStats.query.ts
@@ -10,7 +10,37 @@ export function GetTokenStats(): Query<typeof schemas.GetTokenStats> {
     secure: false,
     async body({ payload }) {
       const { token_address } = payload;
-      const sql = `
+
+      const tokenTypeQuery = `
+        SELECT 
+          CASE 
+            WHEN EXISTS(SELECT 1 FROM "LaunchpadTokens" WHERE token_address = :token_address) 
+            THEN 'launchpad'
+            WHEN EXISTS(SELECT 1 FROM "ThreadTokens" WHERE token_address = :token_address)
+            THEN 'postcoin'
+            ELSE 'unknown'
+          END as token_type
+      `;
+
+      const [tokenTypeRow] = await models.sequelize.query<{
+        token_type: string;
+      }>(tokenTypeQuery, {
+        replacements: { token_address },
+        type: QueryTypes.SELECT,
+      });
+
+      const tokenType = tokenTypeRow?.token_type;
+
+      if (tokenType === 'unknown') {
+        return {
+          holder_count: 0,
+          volume_24h: 0,
+        };
+      }
+
+      const sql =
+        tokenType === 'launchpad'
+          ? `
         SELECT
           COUNT(DISTINCT trader_address) AS holder_count,
           COALESCE(
@@ -25,7 +55,24 @@ export function GetTokenStats(): Query<typeof schemas.GetTokenStats> {
           ) AS volume_24h
         FROM "LaunchpadTrades" 
         WHERE token_address = :token_address
+      `
+          : `
+        SELECT
+          COUNT(DISTINCT trader_address) AS holder_count,
+          COALESCE(
+            SUM(
+              CASE 
+                WHEN timestamp >= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '24 hours')
+                THEN price * community_token_amount 
+                ELSE 0 
+              END
+            ),
+            0
+          ) AS volume_24h
+        FROM "ThreadTokenTrades" 
+        WHERE token_address = :token_address
       `;
+
       const [row] = await models.sequelize.query<{
         holder_count: number;
         volume_24h: string;
@@ -33,6 +80,7 @@ export function GetTokenStats(): Query<typeof schemas.GetTokenStats> {
         replacements: { token_address },
         type: QueryTypes.SELECT,
       });
+
       return {
         holder_count: parseInt(row?.holder_count as unknown as string) || 0,
         volume_24h: parseFloat(row?.volume_24h || '0'),

--- a/libs/model/src/aggregates/token/GetTokens.query.ts
+++ b/libs/model/src/aggregates/token/GetTokens.query.ts
@@ -18,6 +18,7 @@ export function GetLaunchpadTokens(): Query<typeof schemas.GetTokens> {
         order_direction,
         with_stats,
         is_graduated,
+        token_type,
       } = payload;
 
       // pagination configuration
@@ -25,20 +26,19 @@ export function GetLaunchpadTokens(): Query<typeof schemas.GetTokens> {
       let order_col: string;
       switch (order_by) {
         case '24_hr_pct_change':
-          order_col =
-            '(trades.latest_price - trades.old_price) / trades.old_price';
+          order_col = '(CT.latest_price - CT.old_price) / CT.old_price';
           break;
         case 'market_cap':
         case 'price':
-          order_col = 'trades.latest_price';
+          order_col = 'CT.latest_price';
           break;
         case 'created_at':
         case 'name':
         default:
-          order_col = `T.${order_by || 'name'}`;
+          order_col = `CT.${order_by || 'name'}`;
           break;
       }
-      const includeStats = with_stats || order_col === 'trades.latest_price';
+      const includeStats = with_stats || order_col === 'CT.latest_price';
 
       const offset = limit! * (cursor! - 1);
       const replacements: {
@@ -57,69 +57,149 @@ export function GetLaunchpadTokens(): Query<typeof schemas.GetTokens> {
 
       const conditions: string[] = [];
       if (search) {
-        conditions.push('LOWER(T.name) LIKE :search');
+        conditions.push('LOWER(CT.name) LIKE :search');
       }
       if (is_graduated) {
         conditions.push(
-          `T.liquidity_transferred IS ${is_graduated ? 'TRUE' : 'FALSE'}`,
+          `CT.liquidity_transferred IS ${is_graduated ? 'TRUE' : 'FALSE'}`,
         );
       }
       if (order_by === '24_hr_pct_change' && includeStats) {
-        conditions.push(`trades.old_price > 0`);
+        conditions.push(`CT.old_price > 0`);
       }
       const where_clause = conditions.length
         ? `WHERE ${conditions.join(' AND ')}`
         : '';
 
-      const sql = includeStats
+      const statsSubQuery = includeStats
         ? `
-      WITH latest_trades AS (
+            WITH 
+            ${
+              !token_type || token_type === 'launchpad'
+                ? `latest_launchpad_trades AS (
                 SELECT DISTINCT ON (token_address) *
                 FROM "LaunchpadTrades"
                 ORDER BY token_address, timestamp DESC
             ),
-            older_trades AS (
+            older_launchpad_trades AS (
                 SELECT DISTINCT ON (token_address) *
                 FROM "LaunchpadTrades"
                 WHERE timestamp <= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '24 hours')
                 ORDER BY token_address, timestamp ASC
+            ),`
+                : ''
+            }
+            ${
+              !token_type || token_type === 'postcoin'
+                ? `latest_thread_trades AS (
+                SELECT DISTINCT ON (token_address) *
+                FROM "ThreadTokenTrades"
+                ORDER BY token_address, timestamp DESC
             ),
+            older_thread_trades AS (
+                SELECT DISTINCT ON (token_address) *
+                FROM "ThreadTokenTrades"
+                WHERE timestamp <= EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - INTERVAL '24 hours')
+                ORDER BY token_address, timestamp ASC
+            ),`
+                : ''
+            }
             trades AS (
-                SELECT lt.token_address,
+                ${
+                  !token_type || token_type === 'launchpad'
+                    ? `SELECT lt.token_address,
                         lt.price AS latest_price,
                         ot.price AS old_price
-                FROM latest_trades lt
-                LEFT JOIN older_trades ot ON lt.token_address = ot.token_address
+                FROM latest_launchpad_trades lt
+                LEFT JOIN older_launchpad_trades ot ON lt.token_address = ot.token_address`
+                    : ''
+                }
+                ${!token_type ? 'UNION ALL' : ''}
+                ${
+                  !token_type || token_type === 'postcoin'
+                    ? `SELECT ltt.token_address,
+                        ltt.price AS latest_price,
+                        ott.price AS old_price
+                FROM latest_thread_trades ltt
+                LEFT JOIN older_thread_trades ott ON ltt.token_address = ott.token_address`
+                    : ''
+                }
             )
-      SELECT
-            T.*,
-            C.id AS community_id,
-            trades.latest_price, trades.old_price,
-            count(*) OVER () AS total
-      FROM "LaunchpadTokens" AS T
-      JOIN "Communities" AS C ON T.namespace = C.namespace
-      LEFT JOIN trades ON trades.token_address = T.token_address
-      ${where_clause}
-      ORDER BY ${order_col} ${direction} ${order_col === 'trades.latest_price' ? 'NULLS LAST' : ''}
-      LIMIT :limit OFFSET :offset
-    `
-        : `
-      SELECT T.*,
-            C.id AS community_id,
-            count(*) OVER () AS total
-      FROM "LaunchpadTokens" AS T
-      JOIN "Communities" AS C ON T.namespace = C.namespace
-      ${where_clause}
-      ORDER BY ${order_col} ${direction}
-      LIMIT :limit OFFSET :offset
+          `
+        : ``;
+
+      const sql = `
+      ${statsSubQuery ? `${statsSubQuery},` : `WITH `}
+      combined_tokens AS (
+          ${
+            !token_type || token_type === 'launchpad'
+              ? `SELECT 
+            LT.token_address as token_address,
+            LT.name as name,
+            LT.symbol as symbol,
+            LT.initial_supply as initial_supply,
+            LT.liquidity_transferred as liquidity_transferred,
+            LT.launchpad_liquidity as launchpad_liquidity,
+            LT.eth_market_cap_target as eth_market_cap_target,
+            LT.icon_url as icon_url,
+            LT.description as description,
+            LT.created_at as created_at,
+            LT.updated_at as updated_at,
+            LT.namespace as namespace,
+            LT.creator_address as creator_address,
+            LTC.id AS community_id,
+            NULL AS thread_id,
+            'launchpad' AS token_type,
+            ${statsSubQuery ? `trades.latest_price` : `NULL`} as latest_price,
+            ${statsSubQuery ? `trades.old_price` : `NULL`} as old_price
+          FROM "LaunchpadTokens" AS LT
+          JOIN "Communities" AS LTC ON LT.namespace = LTC.namespace
+          ${statsSubQuery ? `LEFT JOIN trades ON trades.token_address = LT.token_address` : ``}`
+              : ``
+          }
+
+          ${!token_type ? 'UNION ALL' : ''}
+
+          ${
+            !token_type || token_type === 'postcoin'
+              ? `SELECT 
+            PT.token_address as token_address,
+            PT.name as name,
+            PT.symbol as symbol,
+            PT.initial_supply as initial_supply,
+            PT.liquidity_transferred as liquidity_transferred,
+            PT.launchpad_liquidity as launchpad_liquidity,
+            PT.eth_market_cap_target as eth_market_cap_target,
+            NULL as icon_url,
+            NULL as description,
+            PT.created_at as created_at,
+            PT.updated_at as updated_at,
+            NULL as namespace,
+            PT.creator_address as creator_address,
+            PTC.id AS community_id,
+            PT.thread_id AS thread_id,
+            'postcoin' AS token_type,
+            ${statsSubQuery ? `trades.latest_price` : `NULL`} as latest_price,
+            ${statsSubQuery ? `trades.old_price` : `NULL`} as old_price
+          FROM "ThreadTokens" AS PT
+          JOIN "Threads" AS PTT ON PTT.id = PT.thread_id
+          JOIN "Communities" AS PTC ON PTT.community_id = PTC.id
+          ${statsSubQuery ? `LEFT JOIN trades ON trades.token_address = PT.token_address` : ``}`
+              : ``
+          }
+        )
+        SELECT 
+          CT.*, 
+          count(CT.*) OVER () AS total 
+        FROM combined_tokens AS CT
+        ${where_clause}
+        ORDER BY ${order_col} ${direction} ${order_col === 'CT.latest_price' ? 'NULLS LAST' : ''}
+        LIMIT :limit OFFSET :offset;
     `;
 
       const tokens = await models.sequelize.query<
         z.infer<typeof schemas.TokenView> & {
           total?: number;
-          community_id: string;
-          latest_price?: number;
-          old_price?: number;
         }
       >(sql, {
         replacements,

--- a/libs/schemas/src/queries/token.schemas.ts
+++ b/libs/schemas/src/queries/token.schemas.ts
@@ -2,7 +2,25 @@ import { z } from 'zod';
 import { LaunchpadToken, LaunchpadTrade, ThreadToken } from '../entities';
 import { PaginatedResultSchema, PaginationParamsSchema } from './pagination';
 
-export const TokenView = LaunchpadToken.extend({
+const TokenTypeEnum = z.enum(['launchpad', 'postcoin']);
+
+export const LaunchpadTokenView = LaunchpadToken.extend({
+  community_id: z.string(),
+  thread_id: z.number().nullish(),
+  token_type: TokenTypeEnum.default('launchpad'),
+  launchpad_liquidity: z.string(),
+  latest_price: z.number().nullish(),
+  old_price: z.number().nullish(),
+});
+
+export const TokenView = LaunchpadTokenView;
+
+export const ThreadTokenView = ThreadToken.extend({
+  community_id: z.string(),
+  namespace: z.string().nullish(),
+  description: z.string().nullish(),
+  icon_url: z.string().nullish(),
+  token_type: TokenTypeEnum.default('postcoin'),
   launchpad_liquidity: z.string(),
   latest_price: z.number().nullish(),
   old_price: z.number().nullish(),
@@ -16,9 +34,10 @@ export const GetTokens = {
       .optional(),
     with_stats: z.boolean().optional(),
     is_graduated: z.boolean().optional(),
+    token_type: TokenTypeEnum.optional(),
   }),
   output: PaginatedResultSchema.extend({
-    results: TokenView.extend({ community_id: z.string() }).array(),
+    results: z.union([LaunchpadTokenView, ThreadTokenView]).array(),
   }),
 };
 

--- a/packages/commonwealth/client/scripts/hooks/useTokenPricing.ts
+++ b/packages/commonwealth/client/scripts/hooks/useTokenPricing.ts
@@ -35,16 +35,16 @@ export const usePostcoinTokenPricing = ({
   );
 
   // Calculate pricing from token data
-  const currentPrice = token.latest_price || 0;
-  const oldPrice = token.old_price || 0;
+  const currentPrice = token?.latest_price || 0;
+  const oldPrice = token?.old_price || 0;
 
   // Calculate 24h price change percentage
   const pricePercentage24HourChange =
     oldPrice > 0 ? ((currentPrice - oldPrice) / oldPrice) * 100 : 0;
 
   // Calculate market cap (current price * initial supply)
-  const marketCapCurrent = currentPrice * (token.initial_supply || 0);
-  const marketCapGoal = token.eth_market_cap_target || 0;
+  const marketCapCurrent = currentPrice * (token?.initial_supply || 0);
+  const marketCapGoal = token?.eth_market_cap_target || 0;
   const isMarketCapGoalReached = marketCapCurrent >= marketCapGoal;
 
   const pricing: PostcoinTokenPricing = {
@@ -164,5 +164,5 @@ export const useTokenPricing = ({ token }: { token: Token }) => {
   });
 
   // Return the appropriate pricing based on token type
-  return token.token_type === 'postcoin' ? postcoinPricing : launchpadPricing;
+  return token?.token_type === 'postcoin' ? postcoinPricing : launchpadPricing;
 };

--- a/packages/commonwealth/client/scripts/state/api/tokens/fetchTokens.ts
+++ b/packages/commonwealth/client/scripts/state/api/tokens/fetchTokens.ts
@@ -16,6 +16,7 @@ const useFetchTokensQuery = ({
   with_stats = false,
   enabled = true,
   is_graduated,
+  token_type,
 }: UseFetchTokensProps) => {
   return trpc.launchpadToken.getTokens.useInfiniteQuery(
     {
@@ -25,6 +26,7 @@ const useFetchTokensQuery = ({
       search,
       with_stats,
       is_graduated,
+      token_type,
     },
     {
       gcTime: FETCH_TOKENS_STALE_TIME,

--- a/packages/commonwealth/client/scripts/views/components/PotentialContestCard/PotentialContestCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/PotentialContestCard/PotentialContestCard.tsx
@@ -60,7 +60,7 @@ export const PotentialContestCard = ({
     isGoalReached
   ) {
     if (isLoading) {
-    return (
+      return (
         <CWCard
           className="PotentialContestCard PotentialContestCard--Skeleton"
           elevation="elevation-1"
@@ -96,7 +96,11 @@ export const PotentialContestCard = ({
   };
 
   return (
-    <CWCard className="PotentialContestCard" elevation="elevation-1" interactive>
+    <CWCard
+      className="PotentialContestCard"
+      elevation="elevation-1"
+      interactive
+    >
       <div className="contest-body">
         <div className="header-row">
           <CWText type="h4">Projected Weekly Prizes</CWText>

--- a/packages/commonwealth/client/scripts/views/components/TokenCard/TokenCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/TokenCard/TokenCard.scss
@@ -67,10 +67,4 @@
     margin: 0 !important;
     margin-top: auto;
   }
-
-  .token-stats {
-    display: flex;
-    justify-content: space-between;
-    padding: 0 4px;
-  }
 }

--- a/packages/commonwealth/client/scripts/views/components/TokenCard/TokenHolderStats.scss
+++ b/packages/commonwealth/client/scripts/views/components/TokenCard/TokenHolderStats.scss
@@ -1,0 +1,7 @@
+@use '../../../styles/shared';
+
+.TokenHolderStats {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 4px;
+}

--- a/packages/commonwealth/client/scripts/views/components/TokenCard/TokenHolderStats.tsx
+++ b/packages/commonwealth/client/scripts/views/components/TokenCard/TokenHolderStats.tsx
@@ -1,0 +1,55 @@
+import {
+  currencyNameToSymbolMap,
+  SupportedFiatCurrencies,
+} from 'helpers/currency';
+import React from 'react';
+import { useGetTokenStatsQuery } from 'state/api/tokens';
+import { CWText } from 'views/components/component_kit/cw_text';
+import FormattedDisplayNumber from '../FormattedDisplayNumber/FormattedDisplayNumber';
+import './TokenHolderStats.scss';
+
+interface TokenStats {
+  holder_count: number;
+  volume_24h: number;
+}
+
+export interface TokenHolderStatsProps {
+  tokenAddress: string;
+  currency?: SupportedFiatCurrencies;
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+const TokenHolderStats = ({
+  tokenAddress,
+  currency = SupportedFiatCurrencies.USD,
+  className,
+  onClick,
+}: TokenHolderStatsProps) => {
+  const { data: stats } = useGetTokenStatsQuery({
+    token_address: tokenAddress,
+  }) as { data: TokenStats | undefined };
+
+  const currencySymbol = currencyNameToSymbolMap[currency];
+
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <div className={className} onClick={onClick}>
+      <CWText type="caption" className="text-light">
+        Holders {stats.holder_count}
+      </CWText>
+      <CWText type="caption" className="ml-auto text-light">
+        Vol 24h {currencySymbol}
+        <FormattedDisplayNumber
+          value={stats.volume_24h}
+          options={{ decimals: 1, useShortSuffixes: true }}
+        />
+      </CWText>
+    </div>
+  );
+};
+
+export default TokenHolderStats;

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/TokensList/FiltersDrawer/FiltersDrawer.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/TokensList/FiltersDrawer/FiltersDrawer.tsx
@@ -16,6 +16,7 @@ import {
   FiltersDrawerProps,
   TokenSortDirections,
   TokenSortOptions,
+  TokenTypes,
 } from './types';
 
 export const FiltersDrawer = ({
@@ -25,6 +26,14 @@ export const FiltersDrawer = ({
   onFiltersChange,
 }: FiltersDrawerProps) => {
   const launchpadEnabled = useFlag('launchpad');
+  const tokenizedThreadsEnabled = useFlag('tokenizedThreads');
+
+  const onTokenTypeChange = (tokenType: TokenTypes) => {
+    onFiltersChange({
+      ...filters,
+      withTokenType: tokenType,
+    });
+  };
 
   const onTokenSortOptionChange = (sortOption: TokenSortOptions) => {
     onFiltersChange({
@@ -85,6 +94,28 @@ export const FiltersDrawer = ({
                 onChange={() => onIsGraduatedChange(!filters.isGraduated)}
               />
             </div>
+
+            {launchpadEnabled && tokenizedThreadsEnabled && (
+              <CWAccordion
+                header="Token type"
+                content={
+                  <div className="options-list">
+                    {Object.entries(TokenTypes).map(([tokenType]) => (
+                      <CWRadioButton
+                        key={tokenType}
+                        groupName="token-type"
+                        value={tokenType}
+                        label={tokenType}
+                        checked={filters.withTokenType === tokenType}
+                        onChange={() =>
+                          onTokenTypeChange(tokenType as TokenTypes)
+                        }
+                      />
+                    ))}
+                  </div>
+                }
+              />
+            )}
 
             {launchpadEnabled && (
               <>

--- a/packages/commonwealth/client/scripts/views/pages/ExplorePage/TokensList/FiltersDrawer/types.ts
+++ b/packages/commonwealth/client/scripts/views/pages/ExplorePage/TokensList/FiltersDrawer/types.ts
@@ -16,9 +16,15 @@ export const TokenSortDirectionsToEnumMap = {
   [TokenSortDirections.Descending]: APIOrderDirection.Desc,
 };
 
+export enum TokenTypes {
+  Launchpad = 'launchpad',
+  Postcoin = 'postcoin',
+}
+
 export type TokenFilters = {
   withTokenSortBy?: TokenSortOptions;
   withTokenSortOrder?: TokenSortDirections;
+  withTokenType?: TokenTypes;
   isGraduated?: boolean;
 };
 

--- a/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingToken/TrendingToken.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/HomePage/TrendingToken/TrendingToken.tsx
@@ -1,3 +1,4 @@
+import { getDefaultContestImage } from '@hicommonwealth/shared';
 import {
   navigateToCommunity,
   useCommonNavigate,
@@ -53,7 +54,11 @@ const TrendingToken = ({
     >
       <div className="header">
         <div className="token-data">
-          <img src={icon_url || ''} className="image" alt={name} />
+          <img
+            src={icon_url || getDefaultContestImage()}
+            className="image"
+            alt={name}
+          />
           <div className="info">
             <CWText fontWeight="semiBold">{smartTrim(name, 12)}</CWText>
             <div className="detail">

--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/steps/TokenInformationFormStep/TokenInformationFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/steps/TokenInformationFormStep/TokenInformationFormStep.tsx
@@ -72,6 +72,7 @@ const TokenInformationFormStep = ({
     cursor: 1,
     limit: 50,
     search: debouncedSearchTerm,
+    token_type: 'launchpad',
     enabled: !!debouncedSearchTerm,
   });
 


### PR DESCRIPTION
## Link to Issue
Closes: https://github.com/hicommonwealth/commonwealth/issues/12815

## Description of Changes
Integrated postcoin display with launchpad tokens display in explore page

https://github.com/user-attachments/assets/60fc324e-cdae-471d-9279-5e542e47dd9d

## Test Plan
1. Verify you are able to view/filter and interact with postcoin tokens in the explore tokens tab, the same way you'd be able to interact with launchpad tokens
2. Verify correctness of pricing, stats and other data points for postcoins
3. Verify no regressions occurred with launchpad tokens display
4. Verify there is a clear distinction b/w postcoin and launchpad tokens

## Deployment Plan
N/A

## Other Considerations
N/A