### PR TITLE
Error Description

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWForm.tsx
@@ -70,6 +70,13 @@ const CWForm = forwardRef<UseFormReturn, FormProps>(
         })
         .catch((e) => {
           console.error(`CWForm submit error => `, e);
+          if (onErrors && e.name === 'ZodError') {
+            const formErrors = {};
+            e.issues?.forEach((issue) => {
+              formErrors[issue.path.join('.')] = { message: issue.message };
+            });
+            onErrors(formErrors);
+          }
         });
     };
 

--- a/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/steps/TokenInformationFormStep/TokenInformationFormStep.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/LaunchToken/QuickTokenLaunchForm/steps/TokenInformationFormStep/TokenInformationFormStep.tsx
@@ -1,5 +1,6 @@
 import { ChainBase } from '@hicommonwealth/shared';
 import clsx from 'clsx';
+import { notifyError } from 'controllers/app/notifications';
 import useAppStatus from 'hooks/useAppStatus';
 import { useBrowserAnalyticsTrack } from 'hooks/useBrowserAnalyticsTrack';
 import useRunOnceOnCondition from 'hooks/useRunOnceOnCondition';
@@ -122,6 +123,15 @@ const TokenInformationFormStep = ({
     [isTokenNameTaken, openAddressSelectionModal, selectedAddress, onSubmit],
   );
 
+  const handleFormErrors = useCallback(
+    (errors: Record<string, { message: string }>) => {
+      if (errors.description) {
+        notifyError('Description must be 180 characters or less.');
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     if (shouldSubmitOnAddressSelection.current) {
       formMethodsRef.current &&
@@ -179,6 +189,7 @@ const TokenInformationFormStep = ({
       // @ts-expect-error <StrictNullChecks/>
       ref={formMethodsRef}
       onSubmit={handleSubmit}
+      onErrors={handleFormErrors}
       onWatch={onFormUpdate}
       validationSchema={tokenInformationFormValidationSchema}
       className={clsx('TokenInformationFormStep', containerClassName)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #12995

## Description of Changes
When launching a community on the "Launch Token" page, if the description field exceeds the maximum character limit, the launch fails without providing a meaningful user-facing error message. Instead, the error only appears in the browser console.

<img width="415" height="153" alt="Screenshot 2025-09-16 at 7 35 26 PM" src="https://github.com/user-attachments/assets/350cb142-1063-4ae5-b18a-afc0555429d4" />


## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 