### PR TITLE
Adjust search input icon spacing

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTextInput/CWTextInput.scss
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/new_designs/CWTextInput/CWTextInput.scss
@@ -52,7 +52,11 @@
         border-radius: 6px;
       }
 
-      &.hasLeftIcon {
+      &.large.hasLeftIcon {
+        padding-left: 48px !important;
+      }
+
+      &.small.hasLeftIcon {
         padding-left: 40px !important;
       }
 


### PR DESCRIPTION
## Summary
- increase the left padding applied to large CWTextInput fields when a left icon is present so the search text is separated from the icon
- keep compact inputs aligned by retaining their existing padding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbac1b9370832fa7af3715d18bd470