### PR TITLE
Edit Topic Modal To Allow Tokenization

### DIFF
--- a/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/edit_topic_modal.tsx
@@ -45,6 +45,7 @@ export const EditTopicModal = ({
   noRedirect,
 }: EditTopicModalProps) => {
   const privateTopicsEnabled = useFlag('privateTopics');
+  const tokenizedThreadsEnabled = useFlag('tokenizedThreads');
 
   const {
     description: descriptionProp,
@@ -74,6 +75,9 @@ export const EditTopicModal = ({
   );
   const [featuredInNewPost, setFeaturedInNewPost] = useState<boolean>(
     topic?.featured_in_new_post || false,
+  );
+  const [allowTokenizedThreads, setAllowTokenizedThreads] = useState<boolean>(
+    topic?.allow_tokenized_threads || false,
   );
   const [name, setName] = useState<string>(nameProp);
   const [characterCount, setCharacterCount] = useState(0);
@@ -153,6 +157,7 @@ export const EditTopicModal = ({
         telegram: null,
         featured_in_sidebar: featuredInSidebar,
         featured_in_new_post: featuredInNewPost,
+        allow_tokenized_threads: allowTokenizedThreads,
         default_offchain_template:
           featuredInNewPost && newPostTemplate
             ? JSON.stringify(newPostTemplate)
@@ -317,6 +322,17 @@ export const EditTopicModal = ({
           value=""
           disabled={!!topic.archived_at}
         />
+        {tokenizedThreadsEnabled && (
+          <CWCheckbox
+            label="Allow Tokenized Threads"
+            checked={allowTokenizedThreads}
+            onChange={() => {
+              setAllowTokenizedThreads(!allowTokenizedThreads);
+            }}
+            value=""
+            disabled={!!topic.archived_at}
+          />
+        )}
         {privateTopicsEnabled && (
           <CWCheckbox
             label="Private topic"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: #13024

## Description of Changes
We should have the ability for tokenization from edit topic page like we have on the integration page

## Test Plan
- Use Flag `FLAG_TOKENIZED_THREADS`
- Navigate to community.
- Attach the Thread Primary Token.
- On the edit topic page there is a check box that allow_tokenization.

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 