### PR TITLE
Address github issue 13028

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
+++ b/packages/commonwealth/client/scripts/views/components/component_kit/cw_breadcrumbs.tsx
@@ -20,9 +20,11 @@ type BreadcrumbsProps = {
   tooltipStr?: string;
 };
 
-const handleNavigation = (label, navigate, isParent) => {
+const handleNavigation = (label, navigate, isParent, path) => {
   if (label === 'Discussions' && isParent) {
     navigate(`/discussions`);
+  } else if (path) {
+    navigate(path);
   }
 };
 const handleMouseInteraction = (
@@ -45,7 +47,7 @@ export const CWBreadcrumbs = ({
         const isCurrent = index === breadcrumbs.length - 1;
         return (
           <React.Fragment key={index}>
-            {isParent && breadcrumbs.length !== 1 ? (
+            {isParent && breadcrumbs.length !== 1 && tooltipStr ? (
               <CWTooltip
                 content={tooltipStr}
                 placement="bottom"
@@ -63,7 +65,7 @@ export const CWBreadcrumbs = ({
                       'current-text': isCurrent,
                       'parent-text': !isCurrent,
                     })}
-                    onClick={() => handleNavigation(label, navigate, isParent)}
+                    onClick={() => handleNavigation(label, navigate, isParent, path)}
                   >
                     {truncateText(label)}
                   </CWText>


### PR DESCRIPTION
## Link to Issue
Closes: #13028

## Description of Changes
This PR addresses an issue where breadcrumbs within a community displayed incorrect tooltips and parent breadcrumbs did not navigate to the community's root page.

The changes include:
-   **Enhanced Navigation**: Updated the `handleNavigation` function in `cw_breadcrumbs.tsx` to accept and utilize a `path` parameter, ensuring parent breadcrumbs in a community context correctly navigate to the community's root.
-   **Refined Tooltip Logic**: Modified the tooltip rendering condition in `cw_breadcrumbs.tsx` to explicitly check for the existence of `tooltipStr`, preventing "not selectable" tooltips from appearing when inside a community.

## Test Plan
-   Verified no compilation errors.
-   Confirmed logic flow for both community and non-community contexts.
-   Ensured tooltip conditions prevent display in community context.
-   Validated navigation paths are correctly set and handled for parent breadcrumbs in communities.

## Other Considerations
-

---
[Slack Thread](https://commonxyz.slack.com/archives/C051XFN57FT/p1758701029722329?thread_ts=1758701029.722329&cid=C051XFN57FT)

<a href="https://cursor.com/background-agent?bcId=bc-995c7845-dfe6-4414-9c04-f6479202a94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-995c7845-dfe6-4414-9c04-f6479202a94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

