### PR TITLE
Allow user to delete AI generated comments

### DIFF
--- a/libs/model/migrations/20251002000000-add-comment-id-to-ai-completion-tokens.js
+++ b/libs/model/migrations/20251002000000-add-comment-id-to-ai-completion-tokens.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Add comment_id column to AICompletionTokens table
+      await queryInterface.addColumn(
+        'AICompletionTokens',
+        'comment_id',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: {
+            model: 'Comments',
+            key: 'id',
+          },
+          onDelete: 'CASCADE',
+        },
+        { transaction },
+      );
+
+      // Create index on comment_id for efficient lookups
+      await queryInterface.addIndex('AICompletionTokens', ['comment_id'], {
+        transaction,
+      });
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Remove index first
+      await queryInterface.removeIndex('AICompletionTokens', ['comment_id'], {
+        transaction,
+      });
+
+      // Remove column
+      await queryInterface.removeColumn('AICompletionTokens', 'comment_id', {
+        transaction,
+      });
+    });
+  },
+};

--- a/libs/model/src/aggregates/comment/CreateAICompletionComment.command.ts
+++ b/libs/model/src/aggregates/comment/CreateAICompletionComment.command.ts
@@ -141,9 +141,9 @@ export function CreateAICompletionComment(): Command<
         context: mockContext,
       });
 
-      // Mark the token as used after successful comment creation
+      // Mark the token as used and store the comment_id after successful comment creation
       await models.AICompletionToken.update(
-        { used_at: new Date() },
+        { used_at: new Date(), comment_id: result.id },
         { where: { id: completionToken.id } },
       );
 

--- a/libs/model/src/models/ai_completion_token.ts
+++ b/libs/model/src/models/ai_completion_token.ts
@@ -79,6 +79,15 @@ export default (
         type: Sequelize.DATE,
         allowNull: true,
       },
+      comment_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: 'Comments',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
     },
     {
       timestamps: true,
@@ -92,6 +101,7 @@ export default (
         { fields: ['expires_at'] },
         { fields: ['used_at'] },
         { fields: ['thread_id'] },
+        { fields: ['comment_id'] },
       ],
     },
   );

--- a/libs/model/src/utils/botUser.ts
+++ b/libs/model/src/utils/botUser.ts
@@ -35,3 +35,17 @@ export const getBotUser = async (): Promise<BotUserWithAddress> => {
     address,
   };
 };
+
+/**
+ * Check if a given address_id belongs to the AI bot user
+ */
+export const isBotAddress = async (address_id: number): Promise<boolean> => {
+  try {
+    const { user: botUser } = await getBotUser();
+    const address = await models.Address.findByPk(address_id);
+    return address?.user_id === botUser.id;
+  } catch (error) {
+    // If bot user is not configured or not found, return false
+    return false;
+  }
+};

--- a/libs/schemas/src/entities/ai-completion-token.schemas.ts
+++ b/libs/schemas/src/entities/ai-completion-token.schemas.ts
@@ -11,6 +11,7 @@ export const AICompletionToken = z.object({
   content: z.string(),
   expires_at: z.coerce.date(),
   used_at: z.coerce.date().nullish(),
+  comment_id: PG_INT.nullish(),
   created_at: z.coerce.date().optional(),
   updated_at: z.coerce.date().optional(),
 });

--- a/libs/schemas/src/queries/thread.schemas.ts
+++ b/libs/schemas/src/queries/thread.schemas.ts
@@ -145,6 +145,7 @@ export const CommentView = Comment.omit({
   profile_name: z.string().optional(),
   avatar_url: z.string().optional(),
   user_id: PG_INT,
+  triggered_by_user_id: PG_INT.nullish(),
   CommentVersionHistories: z.array(CommentVersionHistoryView).nullish(),
 });
 

--- a/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/TreeHierarchy.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/CommentTree/TreeHierarchy.tsx
@@ -1,8 +1,8 @@
 import { TopicWeightedVoting } from '@hicommonwealth/schemas';
 import {
+  DEFAULT_AI_ASSISTANT_NAME,
   DEFAULT_COMPLETION_MODEL,
   DEFAULT_COMPLETION_MODEL_LABEL,
-  DEFAULT_AI_ASSISTANT_NAME,
   MAX_COMMENT_DEPTH,
 } from '@hicommonwealth/shared';
 import {
@@ -392,6 +392,8 @@ export const TreeHierarchy = ({
     index: number,
   ) => {
     const isCommentAuthor = comment.address === user.activeAccount?.address;
+    const isTriggeredByCurrentUser =
+      comment.triggered_by_user_id && comment.triggered_by_user_id === user.id;
 
     return (
       <div
@@ -420,7 +422,10 @@ export const TreeHierarchy = ({
             onEditConfirm={(newDelta) => onEditConfirm(comment, newDelta)}
             isSavingEdit={commentEdits?.[comment.id]?.isSavingEdit || false}
             isEditing={commentEdits?.[comment.id]?.isEditing || false}
-            canDelete={!isThreadLocked && (isCommentAuthor || isAdminOrMod)}
+            canDelete={
+              !isThreadLocked &&
+              (isCommentAuthor || isAdminOrMod || isTriggeredByCurrentUser)
+            }
             onReply={() => {
               onCommentReplyStart(comment.id, index);
             }}
@@ -430,7 +435,10 @@ export const TreeHierarchy = ({
             onDelete={() => onDelete(comment)}
             isSpam={!!comment.marked_as_spam_at}
             onSpamToggle={() => onSpamToggle(comment)}
-            canToggleSpam={!isThreadLocked && (isCommentAuthor || isAdminOrMod)}
+            canToggleSpam={
+              !isThreadLocked &&
+              (isCommentAuthor || isAdminOrMod || isTriggeredByCurrentUser)
+            }
             comment={comment}
             shareURL={`${window.location.origin}${window.location.pathname}?comment=${comment.id}`}
             weightType={thread.topic?.weighted_voting as TopicWeightedVoting}


### PR DESCRIPTION
Currently, AI-generated comments cannot be modified or deleted my the user who triggered it because it's the bot user is the author. This is a problem in a public context because AI responses may be derived from private data, so the user should have authority to delete derived content.

## Link to Issue
Closes: #TODO

## Description of Changes
- Enables a user to delete any comment that they indirectly created via AI generation

## Test Plan

## Deployment Plan
<!--- Omit if unneeded -->

## Other Considerations
<!--- Follow-up tickets, breaking changes, etc -->
- 