### PR TITLE
Fixed custom domains

### DIFF
--- a/packages/commonwealth/cfworker/README.md
+++ b/packages/commonwealth/cfworker/README.md
@@ -1,0 +1,7 @@
+This Cloudflare Worker rewrites all incoming requests from custom domains 
+so that they connect to your Railway app origin (common.xyz),
+fixing the issue where Railway routes requests by Host header.
+
+# Setup & Deployment
+1. Authenticate with Cloudflare `pnpm wrangler login`
+2. Deploy the Worker `pnpm wrangler deploy`

--- a/packages/commonwealth/cfworker/src/commonProxy.ts
+++ b/packages/commonwealth/cfworker/src/commonProxy.ts
@@ -1,17 +1,16 @@
 export default {
-  async fetch(req: Request, env: Env): Promise<Response> {
+  async fetch(req: Request): Promise<Response> {
     const inUrl = new URL(req.url);
 
     // Replace hostname so the Host header will be common.xyz
     const outUrl = new URL(req.url);
-    const originUrl = new URL('common.xyz');
+    const originUrl = new URL('https://common.xyz');
     outUrl.hostname = originUrl.hostname;
     outUrl.protocol = originUrl.protocol;
 
-    // Copy headers and optionally forward client info
     const headers = new Headers(req.headers);
     headers.set('Origin', originUrl.origin);
-    headers.set('X-Forwarded-Host', inUrl.hostname);
+    headers.set('cf-original-host', inUrl.hostname);
 
     const outbound = new Request(outUrl.toString(), {
       method: req.method,

--- a/packages/commonwealth/cfworker/src/commonProxy.ts
+++ b/packages/commonwealth/cfworker/src/commonProxy.ts
@@ -1,0 +1,33 @@
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const inUrl = new URL(req.url);
+
+    // Replace hostname so the Host header will be common.xyz
+    const outUrl = new URL(req.url);
+    const originUrl = new URL('common.xyz');
+    outUrl.hostname = originUrl.hostname;
+    outUrl.protocol = originUrl.protocol;
+
+    // Copy headers and optionally forward client info
+    const headers = new Headers(req.headers);
+    headers.set('Origin', originUrl.origin);
+    headers.set('X-Forwarded-Host', inUrl.hostname);
+
+    const outbound = new Request(outUrl.toString(), {
+      method: req.method,
+      headers,
+      body: canHaveBody(req.method) ? await req.arrayBuffer() : undefined,
+      redirect: 'manual',
+    });
+
+    return fetch(outbound, {
+      cf: {
+        resolveOverride: originUrl.hostname,
+      },
+    });
+  },
+};
+
+function canHaveBody(m: string) {
+  return !['GET', 'HEAD'].includes(m.toUpperCase());
+}

--- a/packages/commonwealth/server/routing/router.ts
+++ b/packages/commonwealth/server/routing/router.ts
@@ -54,7 +54,7 @@ function setupRouter(app: Express, cacheDecorator: CacheDecorator) {
     expressAdapter.query(Community.GetNamespaceMetadata()),
   );
   registerRoute(router, 'get', '/domain', async (req, res) => {
-    const hostname = req.headers['x-forwarded-host'] || req.hostname;
+    const hostname = req.headers['cf-original-host'] || req.hostname;
     // return the community id matching the hostname's custom domain
     try {
       const result = await query(Community.GetByDomain(), {

--- a/packages/commonwealth/wrangler.jsonc
+++ b/packages/commonwealth/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "name": "common-proxy",
+  "main": "src/commonProxy.ts",
+  "compatibility_date": "2025-10-06",
+
+  // Routes determine which requests invoke this Worker
+  "routes": [
+    {
+      // Catch-all route for SaaS Custom Hostnames attached to this zone
+      "pattern": "*",
+      "custom_domain": true,
+    },
+  ],
+}

--- a/packages/commonwealth/wrangler.jsonc
+++ b/packages/commonwealth/wrangler.jsonc
@@ -1,14 +1,5 @@
 {
   "name": "common-proxy",
-  "main": "src/commonProxy.ts",
+  "main": "cfworker/src/commonProxy.ts",
   "compatibility_date": "2025-10-06",
-
-  // Routes determine which requests invoke this Worker
-  "routes": [
-    {
-      // Catch-all route for SaaS Custom Hostnames attached to this zone
-      "pattern": "*",
-      "custom_domain": true,
-    },
-  ],
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: hotfix

## Description of Changes
Adds cloudflare worker deployment to proxy requests and forward as common.xyz.

Modifies the domain route to work with new header to notify which custom domain the request comes from.