### PR TITLE
Refactor LinkedAddresses component to include claim address logic

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/linked_addresses.tsx
+++ b/packages/commonwealth/client/scripts/views/components/linked_addresses.tsx
@@ -147,10 +147,6 @@ export const LinkedAddresses = (props: LinkedAddressesProps) => {
   const { data: claimAddress } = useGetClaimAddressQuery({
     enabled: user.isLoggedIn,
   });
-  const normalizedClaimAddress = useMemo(
-    () => claimAddress?.address?.toLowerCase() ?? null,
-    [claimAddress?.address],
-  );
 
   const groupedAddresses = useMemo(() => {
     return addresses.reduce((acc: Record<string, AddressInfo[]>, addr) => {
@@ -169,8 +165,9 @@ export const LinkedAddresses = (props: LinkedAddressesProps) => {
     ) => {
       if (
         val &&
-        normalizedClaimAddress &&
-        selectedAddress?.address?.toLowerCase() === normalizedClaimAddress
+        claimAddress?.address &&
+        selectedAddress?.address?.toLowerCase() ===
+          claimAddress.address.toLowerCase()
       ) {
         notifyError(
           'You cannot disconnect the address saved for claiming rewards.',
@@ -183,7 +180,7 @@ export const LinkedAddresses = (props: LinkedAddressesProps) => {
       setIsBulkDeleteState(val ? isBulkDelete : false);
       setSelectedCommunity(val ? community : null);
     },
-    [normalizedClaimAddress],
+    [claimAddress],
   );
 
   const rowData = useMemo(


### PR DESCRIPTION
- Added useGetClaimAddressQuery to fetch the user's claim address.
- Implemented logic to prevent disconnection of the claim address in handleToggleRemoveModal.
- Updated rowData to utilize the new toggleRemoveModal function.
- Improved memoization for performance optimization.

<img width="1399" height="1377" alt="image" src="https://github.com/user-attachments/assets/a699a76f-dd97-48bf-88aa-9e3fd548d9c5" />
