### PR TITLE
Fix comment submission turnstile handling

### DIFF
--- a/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
+++ b/packages/commonwealth/client/scripts/views/components/Comments/CommentEditor/CommentEditor.tsx
@@ -10,7 +10,6 @@ import { useAiCompletion } from 'state/api/ai';
 import { generateCommentPrompt } from 'state/api/ai/prompts';
 import useGetCommunityByIdQuery from 'state/api/communities/getCommuityById';
 import { useAIFeatureEnabled, useUserAiSettingsStore } from 'state/ui/user';
-import { useTurnstile } from 'views/components/useTurnstile';
 import { User } from 'views/components/user/user';
 import { jumpHighlightComment } from 'views/pages/discussions/CommentTree/helpers';
 import { ImageActionModal } from '../../ImageActionModal/ImageActionModal';
@@ -53,6 +52,10 @@ export type CommentEditorProps = {
   webSearchEnabled?: boolean;
   setWebSearchEnabled?: (enabled: boolean) => void;
   communityId?: string;
+  isTurnstileEnabled?: boolean;
+  turnstileToken?: string | null;
+  resetTurnstile?: () => void;
+  TurnstileWidget?: React.FC;
 };
 
 // eslint-disable-next-line react/display-name
@@ -81,6 +84,10 @@ const CommentEditor = forwardRef<unknown, CommentEditorProps>(
       webSearchEnabled,
       setWebSearchEnabled,
       communityId,
+      isTurnstileEnabled = false,
+      turnstileToken,
+      resetTurnstile,
+      TurnstileWidget,
     },
     _ref,
   ) => {
@@ -101,15 +108,6 @@ const CommentEditor = forwardRef<unknown, CommentEditorProps>(
       setWebSearchEnabled || setLocalWebSearchEnabled;
 
     const { generateCompletion } = useAiCompletion();
-
-    const {
-      resetTurnstile,
-      turnstileToken,
-      isTurnstileEnabled,
-      TurnstileWidget,
-    } = useTurnstile({
-      action: 'create-comment',
-    });
 
     // Fetch community details
     const { data: community } = useGetCommunityByIdQuery({
@@ -162,6 +160,7 @@ ${parentCommentText ? `Parent Comment: ${parentCommentText}` : ''}`;
       });
     };
 
+    const TurnstileWidgetComponent = TurnstileWidget ?? (() => <></>);
     const handleEnhancedSubmit = async () => {
       // Immediately close the editor before any operations
       onCancel?.(
@@ -182,7 +181,7 @@ ${parentCommentText ? `Parent Comment: ${parentCommentText}` : ''}`;
         } catch (error) {
           console.error('Failed to submit comment:', error);
           if (isTurnstileEnabled) {
-            resetTurnstile();
+            resetTurnstile?.();
           }
           return;
         }
@@ -236,7 +235,7 @@ ${parentCommentText ? `Parent Comment: ${parentCommentText}` : ''}`;
       } catch (error) {
         console.error('Error during submission:', error);
         if (isTurnstileEnabled) {
-          resetTurnstile();
+          resetTurnstile?.();
         }
       }
     };
@@ -316,7 +315,7 @@ ${parentCommentText ? `Parent Comment: ${parentCommentText}` : ''}`;
           placeholder={placeholder}
         />
 
-        {isTurnstileEnabled && <TurnstileWidget />}
+        {isTurnstileEnabled && <TurnstileWidgetComponent />}
 
         <div className="form-bottom">
           <div className="form-buttons">

--- a/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
+++ b/packages/commonwealth/client/scripts/views/components/StickEditorContainer/StickyInput/StickyInput.tsx
@@ -575,6 +575,10 @@ const StickyInput = (props: StickyInputProps) => {
                 webSearchEnabled={webSearchEnabled}
                 setWebSearchEnabled={setWebSearchEnabled}
                 communityId={props.communityId}
+                isTurnstileEnabled={isTurnstileEnabled}
+                turnstileToken={turnstileToken}
+                resetTurnstile={resetTurnstile}
+                TurnstileWidget={TurnstileWidget}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- prevent CommentEditor from instantiating its own Turnstile widget and accept tokens from parent instead
- forward StickyInput turnstile state into CommentEditor so the submit button no longer stays disabled when verification is complete

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e01e24f54832f99d2b129147e71df)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decouples Turnstile from `CommentEditor` and centralizes verification in `StickyInput` for reliable submit gating.
> 
> - Removes internal Turnstile hook from `CommentEditor`; adds props: `isTurnstileEnabled`, `turnstileToken`, `resetTurnstile`, `TurnstileWidget`
> - Uses `TurnstileWidgetComponent` fallback and renders widget when enabled; guards `resetTurnstile` calls with optional chaining
> - Submission flow in `CommentEditor` now validates `turnstileToken`, passes it to `handleSubmitComment`, and re-enables reset on errors
> - Disables "Post" until verified when Turnstile is enabled
> - `StickyInput` retains Turnstile via `useTurnstile(...)` and forwards `turnstileToken/resetTurnstile/TurnstileWidget/isTurnstileEnabled` to `CommentEditor`; also gates quick-submit/send button on token
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0afc55ee8e70eb25879b88998861602e8ac662c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->