### PR TITLE
Add Conductor workspace scripts

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "pnpm install; if [ -f \"$CONDUCTOR_ROOT_PATH/.env\" ]; then ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env; elif [ ! -f .env ]; then cp .env.example .env; fi; docker-compose up -d; for i in {1..30}; do docker exec cw_postgres pg_isready -U commonwealth >/dev/null 2>&1 && break; sleep 2; done; docker exec cw_postgres pg_isready -U commonwealth >/dev/null 2>&1 || (echo \"Postgres not ready\" && exit 1); pnpm migrate-db",
+    "setup": "pnpm install; if [ -f \"$CONDUCTOR_ROOT_PATH/.env\" ]; then ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env; elif [ ! -f .env ]; then cp .env.example .env; fi; if docker compose version >/dev/null 2>&1; then COMPOSE=\"docker compose\"; elif command -v docker-compose >/dev/null 2>&1; then COMPOSE=\"docker-compose\"; else echo \"docker compose not found\" >&2; exit 1; fi; $COMPOSE up -d --wait >/dev/null 2>&1 || $COMPOSE up -d; i=0; READY=\"\"; while [ $i -lt 30 ]; do if docker exec cw_postgres pg_isready -U commonwealth >/dev/null 2>&1; then READY=1; break; fi; i=$((i+1)); sleep 2; done; if [ \"$READY\" != \"1\" ]; then echo \"Postgres not ready\" >&2; exit 1; fi; pnpm migrate-db",
     "run": "pnpm start-all"
   },
   "runScriptMode": "nonconcurrent"


### PR DESCRIPTION
## Summary\n- add a Conductor setup script for deps, env, Docker services, and migrations\n- set run script to start all services in nonconcurrent mode\n\n## Testing\n- not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Conductor workspace automation.
> 
> - New `conductor.json` with `scripts.setup` to install dependencies, link/copy `.env`, detect and start `docker compose`/`docker-compose`, wait for `cw_postgres` readiness, then run `pnpm migrate-db`
> - Adds `scripts.run` as `pnpm start-all`
> - Sets `runScriptMode` to `nonconcurrent`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1489854f7594627d01a19aceba50dc39402c7b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->