### PR TITLE
Add FLAG_MARKETS feature flag

### DIFF
--- a/common_knowledge/Environment-Variables.md
+++ b/common_knowledge/Environment-Variables.md
@@ -39,6 +39,7 @@ If you add a new environment variable, you must add documentation here. Please d
 - [ETH_ALCHEMY_API_KEY](#eth_alchemy_api_key)
 - [ETH_RPC](#eth_rpc)
 - [FALLBACK_NODE_DURATION_S](#fallback_node_duration_s)
+- [FLAG_MARKETS](#flag_markets)
 - [FLAG_NEW_CREATE_COMMUNITY](#flag_new_create_community)
 - [HEROKU_APP_NAME](#heroku_app_name)
 - [IS_CI](#is_ci)
@@ -211,6 +212,10 @@ Owner: Ian Rowan
 Optional. Defaults to 5 minutes (300 seconds).
 This is number, in seconds. It configures the length of time we will use a community-maintained public endpoint if a given ChainNode fails.
 After this time, the server will try the original DB endpoint again.
+
+## FLAG_MARKETS
+
+Boolean toggle enabling prediction markets functionality (UI + API). When `false`, prediction markets features are disabled.
 
 ## FLAG_NEW_CREATE_COMMUNITY
 

--- a/libs/model/src/aggregates/community/GetMarkets.query.ts
+++ b/libs/model/src/aggregates/community/GetMarkets.query.ts
@@ -1,7 +1,8 @@
-import { Query } from '@hicommonwealth/core';
+import { InvalidState, Query } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
 import { QueryTypes } from 'sequelize';
 import { z } from 'zod';
+import { config } from '../../config';
 import { models } from '../../database';
 
 export function GetMarkets(): Query<typeof schemas.GetMarkets> {
@@ -9,6 +10,10 @@ export function GetMarkets(): Query<typeof schemas.GetMarkets> {
     ...schemas.GetMarkets,
     auth: [],
     body: async ({ payload }) => {
+      if (!config.MARKETS?.ENABLED) {
+        throw new InvalidState('Markets not enabled');
+      }
+
       const { community_id } = payload;
 
       const markets = await models.sequelize.query<

--- a/libs/model/src/aggregates/community/SubscribeMarket.command.ts
+++ b/libs/model/src/aggregates/community/SubscribeMarket.command.ts
@@ -1,5 +1,6 @@
-import { Command } from '@hicommonwealth/core';
+import { Command, InvalidState } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
+import { config } from '../../config';
 import { models } from '../../database';
 import { authRoles } from '../../middleware';
 
@@ -8,6 +9,10 @@ export function SubscribeMarket(): Command<typeof schemas.SubscribeMarket> {
     ...schemas.SubscribeMarket,
     auth: [authRoles('admin')],
     body: async ({ payload }) => {
+      if (!config.MARKETS?.ENABLED) {
+        throw new InvalidState('Markets not enabled');
+      }
+
       const {
         community_id,
         provider,

--- a/libs/model/src/aggregates/community/UnsubscribeMarket.command.ts
+++ b/libs/model/src/aggregates/community/UnsubscribeMarket.command.ts
@@ -1,5 +1,6 @@
-import { Command } from '@hicommonwealth/core';
+import { Command, InvalidState } from '@hicommonwealth/core';
 import * as schemas from '@hicommonwealth/schemas';
+import { config } from '../../config';
 import { models } from '../../database';
 import { authRoles, mustExist } from '../../middleware';
 
@@ -8,6 +9,10 @@ export function UnsubscribeMarket(): Command<typeof schemas.UnsubscribeMarket> {
     ...schemas.UnsubscribeMarket,
     auth: [authRoles('admin')],
     body: async ({ payload }) => {
+      if (!config.MARKETS?.ENABLED) {
+        throw new InvalidState('Markets not enabled');
+      }
+
       const { community_id, slug } = payload;
 
       const market = await models.Market.findOne({ where: { slug } });

--- a/libs/model/src/config.ts
+++ b/libs/model/src/config.ts
@@ -110,6 +110,7 @@ const {
   SLACK_WEBHOOK_URL_ALL_ENG,
   SLACK_WEBHOOK_URL_MAGNA_NOTIFS,
   FLAG_CLAIMS,
+  FLAG_MARKETS,
 } = process.env;
 
 const NAME = target.NODE_ENV === 'test' ? 'common_test' : 'commonwealth';
@@ -370,6 +371,9 @@ export const config = configure(
     },
     CLAIMS: {
       ENABLED: FLAG_CLAIMS === 'true',
+    },
+    MARKETS: {
+      ENABLED: FLAG_MARKETS === 'true',
     },
   },
   z.object({
@@ -791,6 +795,9 @@ export const config = configure(
       }),
     }),
     CLAIMS: z.object({
+      ENABLED: z.boolean(),
+    }),
+    MARKETS: z.object({
       ENABLED: z.boolean(),
     }),
   }),

--- a/libs/model/src/vitest.setup.ts
+++ b/libs/model/src/vitest.setup.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import { beforeAll } from 'vitest';
 import { bootstrap_testing } from './tester';
 
+process.env.FLAG_MARKETS = process.env.FLAG_MARKETS ?? 'true';
+
 beforeAll(async ({ name }) => {
   const lcsuite = name.includes('-lifecycle');
   if (lcsuite) {

--- a/packages/commonwealth/client/scripts/helpers/feature-flags.ts
+++ b/packages/commonwealth/client/scripts/helpers/feature-flags.ts
@@ -25,6 +25,7 @@ const featureFlags = {
   contestDev: buildFlag(process.env.FLAG_CONTEST_DEV),
   newEditor: buildFlag(process.env.FLAG_NEW_EDITOR),
   launchpad: buildFlag(process.env.FLAG_LAUNCHPAD),
+  markets: buildFlag(process.env.FLAG_MARKETS),
   newContestPage: buildFlag(process.env.FLAG_NEW_CONTEST_PAGE),
   referrals: buildFlag(process.env.FLAG_REFERRALS),
   mobileDownload: buildFlag(process.env.FLAG_MOBILE_DOWNLOAD),

--- a/packages/commonwealth/client/vite.config.ts
+++ b/packages/commonwealth/client/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => {
     'process.env.FLAG_NEW_EDITOR': JSON.stringify(env.FLAG_NEW_EDITOR),
     'process.env.FLAG_CONTEST_DEV': JSON.stringify(env.FLAG_CONTEST_DEV),
     'process.env.FLAG_LAUNCHPAD': JSON.stringify(env.FLAG_LAUNCHPAD),
+    'process.env.FLAG_MARKETS': JSON.stringify(env.FLAG_MARKETS),
     'process.env.FLAG_NEW_CONTEST_PAGE': JSON.stringify(
       env.FLAG_NEW_CONTEST_PAGE,
     ),


### PR DESCRIPTION
## Summary\n- add FLAG_MARKETS env + frontend flag wiring\n- gate market subscribe/unsubscribe/get queries behind config\n- document FLAG_MARKETS and default-enable in model tests\n\n## Testing\n- not run (not requested)\n\nCloses #13265

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a prediction markets feature flag and gates related APIs behind it.
> 
> - Adds `FLAG_MARKETS` env var, documents it, and exposes `config.MARKETS.ENABLED` with schema validation
> - Guards `GetMarkets`, `SubscribeMarket`, and `UnsubscribeMarket` to throw `InvalidState` when markets are disabled
> - Wires frontend flag (`markets`) via `feature-flags.ts` and `vite.config.ts`
> - Defaults flag to `true` in `libs/model` tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061623bdcf61f3006518a6008c1a3c7234608aaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->