### PR TITLE
Add links to the external market pages in the betting mar...

### DIFF
--- a/.ai/progress.txt
+++ b/.ai/progress.txt
@@ -183,3 +183,11 @@ Each AI run should append an entry with:
   * PR title defaults to issue title if available, otherwise derived from branch name
   * The script is interactive and requires user confirmation before creating PR
 - Commit: 979ff661dc
+
+---
+
+[2026-01-12] #13294 feat: add external links to betting market cards
+- Files: types.ts, MarketCard.tsx, MarketCard.scss, MarketsAppPage.tsx, MarketsAppPage.scss, getExternalMarketUrl.spec.ts
+- Changes: Added clickable external links to provider pills on both admin MarketCard and MarketsAppPage. Users can navigate to Polymarket/Kalshi pages.
+- Decisions: URL format: Polymarket `/event/{slug}`, Kalshi `/markets/{base_ticker}/{title_slug}/{full_ticker}` (extracts base ticker, slugifies title)
+- Issues: None

--- a/packages/commonwealth/client/scripts/views/components/MarketIntegrations/MarketCard.scss
+++ b/packages/commonwealth/client/scripts/views/components/MarketIntegrations/MarketCard.scss
@@ -60,6 +60,27 @@
     }
 
     .market-provider {
+      .provider-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        text-decoration: none;
+        transition: opacity 0.2s ease;
+
+        &:hover {
+          opacity: 0.85;
+
+          .Icon {
+            transform: translateX(1px) translateY(-1px);
+          }
+        }
+
+        .Icon {
+          color: #667eea;
+          transition: transform 0.2s ease;
+        }
+      }
+
       .provider-badge {
         display: inline-block;
         padding: 6px 12px;

--- a/packages/commonwealth/client/scripts/views/components/MarketIntegrations/MarketCard.tsx
+++ b/packages/commonwealth/client/scripts/views/components/MarketIntegrations/MarketCard.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { CWIcon } from 'views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'views/components/component_kit/cw_text';
 import { CWButton } from 'views/components/component_kit/new_designs/CWButton';
 import { CWTag } from 'views/components/component_kit/new_designs/CWTag';
 import './MarketCard.scss';
-import { Market } from './types';
+import { getExternalMarketUrl, Market } from './types';
 
 interface MarketCardProps {
   market: Market;
@@ -66,7 +67,20 @@ export const MarketCard = ({
             />
           </div>
           <div className="market-provider">
-            <span className="provider-badge">{market.provider}</span>
+            <a
+              href={getExternalMarketUrl(
+                market.provider,
+                market.slug,
+                market.question,
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="provider-link"
+              aria-label={`View on ${market.provider}`}
+            >
+              <span className="provider-badge">{market.provider}</span>
+              <CWIcon iconName="externalLink" iconSize="small" />
+            </a>
           </div>
         </div>
 

--- a/packages/commonwealth/client/scripts/views/components/MarketIntegrations/types.ts
+++ b/packages/commonwealth/client/scripts/views/components/MarketIntegrations/types.ts
@@ -18,3 +18,54 @@ export interface MarketFilters {
   provider: MarketProvider | 'all';
   category: string | 'all';
 }
+
+/**
+ * Converts a title/question to a URL-friendly slug.
+ * @param text - The text to slugify
+ * @returns A lowercase, hyphenated slug
+ */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Replace multiple hyphens with single
+    .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
+}
+
+/**
+ * Extracts the base event ticker from a Kalshi market ticker.
+ * Kalshi tickers have format like "KXERUPTSUPER-0" where "-0" is the market suffix.
+ * @param ticker - The full market ticker
+ * @returns The base event ticker (lowercase)
+ */
+function getKalshiBaseTicker(ticker: string): string {
+  // Remove the -N suffix (e.g., "-0", "-1", "-26feb07")
+  const baseTicker = ticker.replace(/-[a-z0-9]+$/i, '');
+  return baseTicker.toLowerCase();
+}
+
+/**
+ * Constructs the external URL for a market based on the provider.
+ * @param provider - The market provider ('polymarket' or 'kalshi')
+ * @param slug - The market slug/identifier (event_ticker for Kalshi)
+ * @param question - The market question/title (required for Kalshi URLs)
+ * @returns The full URL to the market page on the provider's website
+ */
+export function getExternalMarketUrl(
+  provider: MarketProvider,
+  slug: string,
+  question?: string,
+): string {
+  switch (provider) {
+    case 'polymarket':
+      return `https://polymarket.com/event/${slug}`;
+    case 'kalshi': {
+      // Kalshi URL format: /markets/{base_ticker}/{title_slug}/{full_ticker}
+      const baseTicker = getKalshiBaseTicker(slug);
+      const fullTicker = slug.toLowerCase();
+      const titleSlug = question ? slugify(question) : '';
+      return `https://kalshi.com/markets/${baseTicker}/${titleSlug}/${fullTicker}`;
+    }
+  }
+}

--- a/packages/commonwealth/client/scripts/views/pages/MarketsAppPage.scss
+++ b/packages/commonwealth/client/scripts/views/pages/MarketsAppPage.scss
@@ -127,6 +127,27 @@
       }
 
       .market-provider {
+        .provider-link {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          text-decoration: none;
+          transition: opacity 0.2s ease;
+
+          &:hover {
+            opacity: 0.85;
+
+            .Icon {
+              transform: translateX(1px) translateY(-1px);
+            }
+          }
+
+          .Icon {
+            color: #667eea;
+            transition: transform 0.2s ease;
+          }
+        }
+
         .provider-badge {
           display: inline-block;
           padding: 6px 12px;

--- a/packages/commonwealth/client/scripts/views/pages/MarketsAppPage.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/MarketsAppPage.tsx
@@ -4,11 +4,13 @@ import {
 } from 'client/scripts/controllers/app/notifications';
 import app from 'client/scripts/state';
 import { trpc } from 'client/scripts/utils/trpcClient';
+import { CWIcon } from 'client/scripts/views/components/component_kit/cw_icons/cw_icon';
 import { CWText } from 'client/scripts/views/components/component_kit/cw_text';
 import { CWButton } from 'client/scripts/views/components/component_kit/new_designs/CWButton';
 import CWCircleMultiplySpinner from 'client/scripts/views/components/component_kit/new_designs/CWCircleMultiplySpinner';
 import CWPageLayout from 'client/scripts/views/components/component_kit/new_designs/CWPageLayout';
 import { CWTag } from 'client/scripts/views/components/component_kit/new_designs/CWTag';
+import { getExternalMarketUrl } from 'client/scripts/views/components/MarketIntegrations/types';
 import React from 'react';
 
 import './MarketsAppPage.scss';
@@ -137,7 +139,22 @@ const MarketsAppPage = () => {
                       />
                     </div>
                     <div className="market-provider">
-                      <span className="provider-badge">{market.provider}</span>
+                      <a
+                        href={getExternalMarketUrl(
+                          market.provider,
+                          market.slug,
+                          market.question,
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="provider-link"
+                        aria-label={`View on ${market.provider}`}
+                      >
+                        <span className="provider-badge">
+                          {market.provider}
+                        </span>
+                        <CWIcon iconName="externalLink" iconSize="small" />
+                      </a>
                     </div>
                   </div>
 

--- a/packages/commonwealth/test/unit/market_integrations/getExternalMarketUrl.spec.ts
+++ b/packages/commonwealth/test/unit/market_integrations/getExternalMarketUrl.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import { getExternalMarketUrl } from '../../../client/scripts/views/components/MarketIntegrations/types';
+
+describe('getExternalMarketUrl', () => {
+  describe('Polymarket URLs', () => {
+    test('should construct correct URL for Polymarket events', () => {
+      const url = getExternalMarketUrl('polymarket', 'will-trump-win-2024');
+      expect(url).toBe('https://polymarket.com/event/will-trump-win-2024');
+    });
+
+    test('should handle slugs with special characters', () => {
+      const url = getExternalMarketUrl(
+        'polymarket',
+        'bitcoin-above-100k-by-end-of-2024',
+      );
+      expect(url).toBe(
+        'https://polymarket.com/event/bitcoin-above-100k-by-end-of-2024',
+      );
+    });
+
+    test('should ignore question parameter for Polymarket', () => {
+      const url = getExternalMarketUrl(
+        'polymarket',
+        'some-slug',
+        'Will something happen?',
+      );
+      expect(url).toBe('https://polymarket.com/event/some-slug');
+    });
+  });
+
+  describe('Kalshi URLs', () => {
+    test('should construct correct URL with base ticker, title slug, and full ticker', () => {
+      const url = getExternalMarketUrl(
+        'kalshi',
+        'KXERUPTSUPER-0',
+        'Will a supervolcano erupt before 2050?',
+      );
+      expect(url).toBe(
+        'https://kalshi.com/markets/kxeruptsuper/will-a-supervolcano-erupt-before-2050/kxeruptsuper-0',
+      );
+    });
+
+    test('should handle tickers with alphanumeric suffixes', () => {
+      const url = getExternalMarketUrl(
+        'kalshi',
+        'kxmamdanimention-26feb07',
+        'What will Zorhan Mamdani say?',
+      );
+      expect(url).toBe(
+        'https://kalshi.com/markets/kxmamdanimention/what-will-zorhan-mamdani-say/kxmamdanimention-26feb07',
+      );
+    });
+
+    test('should handle uppercase tickers and convert to lowercase', () => {
+      const url = getExternalMarketUrl(
+        'kalshi',
+        'KXBTCUSD-1',
+        'Will Bitcoin hit $100,000?',
+      );
+      expect(url).toBe(
+        'https://kalshi.com/markets/kxbtcusd/will-bitcoin-hit-100000/kxbtcusd-1',
+      );
+    });
+
+    test('should handle tickers without suffix', () => {
+      const url = getExternalMarketUrl(
+        'kalshi',
+        'KXPRES24',
+        'Presidential election 2024',
+      );
+      // When there's no -N suffix, the full ticker equals base ticker
+      expect(url).toBe(
+        'https://kalshi.com/markets/kxpres24/presidential-election-2024/kxpres24',
+      );
+    });
+
+    test('should handle empty question string', () => {
+      const url = getExternalMarketUrl('kalshi', 'KXTEST-0', '');
+      expect(url).toBe('https://kalshi.com/markets/kxtest//kxtest-0');
+    });
+
+    test('should handle missing question parameter', () => {
+      const url = getExternalMarketUrl('kalshi', 'KXTEST-0');
+      expect(url).toBe('https://kalshi.com/markets/kxtest//kxtest-0');
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('should handle empty slug for Polymarket', () => {
+      const url = getExternalMarketUrl('polymarket', '');
+      expect(url).toBe('https://polymarket.com/event/');
+    });
+
+    test('should handle question with only special characters for Kalshi', () => {
+      const url = getExternalMarketUrl('kalshi', 'KXTEST-0', '???!!!');
+      expect(url).toBe('https://kalshi.com/markets/kxtest//kxtest-0');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add external link icons next to provider pills on betting market cards that link to the original Polymarket or Kalshi market pages
- Implement URL construction helper with support for both providers' URL patterns (Polymarket uses slug, Kalshi uses ticker_name)
- Links open in new tabs with proper security attributes (`rel="noopener noreferrer"`)

## Test Plan
- [ ] Verify external link icons appear next to provider pills for both Polymarket and Kalshi markets
- [ ] Click links and confirm they navigate to the correct external market pages
- [ ] Verify links open in new tabs
- [ ] Check visual alignment and hover states match existing card styling
- [ ] Run unit tests: `pnpm -F commonwealth test-select packages/commonwealth/test/unit/client/getExternalMarketUrl.spec.ts`

Closes #13294


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*


https://github.com/user-attachments/assets/d75c0d0e-bc18-41ec-b4dc-d231b6be3197


