### PR TITLE
Limit group name length

### DIFF
--- a/libs/schemas/src/commands/community.schemas.ts
+++ b/libs/schemas/src/commands/community.schemas.ts
@@ -282,8 +282,8 @@ export const ToggleArchiveTopic = {
 };
 
 const GroupMetadata = z.object({
-  name: z.string(),
-  description: z.string(),
+  name: z.string().max(40),
+  description: z.string().max(250),
   groupImageUrl: z.string().nullish(),
   required_requirements: PG_INT.nullish(),
   membership_ttl: PG_INT.optional(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Link to Issue
Closes: Internal

## Description of Changes
- Limits group name length to 40 on the backend. It was previously limited on the frontend, but not backend.

## Test Plan

## Deployment Plan
N/A

## Other Considerations
N/A