### PR TITLE
Add Outbox table existence check before starting message relayer loop

### DIFF
--- a/packages/commonwealth/server/bindings/relayForever.ts
+++ b/packages/commonwealth/server/bindings/relayForever.ts
@@ -1,12 +1,41 @@
 import { broker, logger } from '@hicommonwealth/core';
 import { models } from '@hicommonwealth/model/db';
+import { QueryTypes } from 'sequelize';
 import { config } from '../config';
 import { relay } from './relay';
 import { isShutdownInProgress } from './workerLifecycle';
 
 const INITIAL_ERROR_TIMEOUT = 2_000;
+const OUTBOX_CHECK_INITIAL_DELAY = 1_000;
+const OUTBOX_CHECK_MAX_DELAY = 30_000;
 
 const log = logger(import.meta);
+
+/**
+ * Waits for the Outbox table to be accessible before proceeding.
+ * Retries with exponential backoff, respecting shutdown signals.
+ */
+export async function waitForOutboxTable(): Promise<void> {
+  let delay = OUTBOX_CHECK_INITIAL_DELAY;
+
+  log.info('Checking Outbox table accessibility...');
+
+  while (!isShutdownInProgress()) {
+    try {
+      await models.sequelize.query('SELECT 1 FROM "Outbox" LIMIT 0', {
+        type: QueryTypes.SELECT,
+      });
+      log.info('Outbox table is accessible');
+      return;
+    } catch {
+      log.warn(`Outbox table not yet accessible, retrying in ${delay}ms...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      delay = Math.min(delay * 2, OUTBOX_CHECK_MAX_DELAY);
+    }
+  }
+
+  log.info('Shutdown in progress, aborting Outbox readiness check');
+}
 
 export async function relayForever(maxIterations?: number) {
   const brokerInstance = broker();

--- a/packages/commonwealth/test/unit/waitForOutboxTable.spec.ts
+++ b/packages/commonwealth/test/unit/waitForOutboxTable.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock only the database module - partial mock to avoid breaking transitive imports
+vi.mock('@hicommonwealth/model/db', () => ({
+  models: {
+    sequelize: {
+      query: vi.fn(),
+    },
+  },
+}));
+
+// Must import after mocks are set up
+import { models } from '@hicommonwealth/model/db';
+import { waitForOutboxTable } from '../../server/bindings/relayForever';
+import {
+  resetForTests,
+  stopAllWorkers,
+} from '../../server/bindings/workerLifecycle';
+
+const mockQuery = vi.mocked(models.sequelize.query);
+
+describe('waitForOutboxTable', () => {
+  beforeEach(() => {
+    resetForTests();
+    vi.useFakeTimers();
+    mockQuery.mockReset();
+  });
+
+  afterEach(() => {
+    resetForTests();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('should resolve immediately when table is accessible', async () => {
+    mockQuery.mockResolvedValueOnce([] as never);
+
+    await waitForOutboxTable();
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT 1 FROM "Outbox" LIMIT 0',
+      expect.objectContaining({ type: 'SELECT' }),
+    );
+  });
+
+  test('should retry on failure then succeed', async () => {
+    mockQuery
+      .mockRejectedValueOnce(new Error('table not found'))
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce([] as never);
+
+    const promise = waitForOutboxTable();
+
+    // First retry: 1000ms delay
+    await vi.advanceTimersByTimeAsync(1_000);
+    // Second retry: 2000ms delay (exponential backoff)
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await promise;
+
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+  });
+
+  test('should use exponential backoff capped at 30s', async () => {
+    mockQuery.mockRejectedValue(new Error('table not found'));
+
+    const promise = waitForOutboxTable();
+
+    // Advance through multiple retries: 1s, 2s, 4s, 8s, 16s, 30s (capped), 30s
+    const expectedDelays = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+    for (const delay of expectedDelays) {
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+
+    // After 7 failures + initial call = 8 calls total
+    expect(mockQuery).toHaveBeenCalledTimes(8);
+
+    // Stop the loop by resolving
+    mockQuery.mockResolvedValueOnce([] as never);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await promise;
+  });
+
+  test('should abort when shutdown is triggered', async () => {
+    mockQuery.mockRejectedValue(new Error('table not found'));
+
+    const promise = waitForOutboxTable();
+
+    // Let the first check fail and start waiting
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // Trigger shutdown
+    await stopAllWorkers();
+
+    // Advance past the retry delay so the loop can check shutdown
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await promise;
+
+    // Should have stopped retrying after shutdown
+    const callCount = mockQuery.mock.calls.length;
+    // Advance more time and verify no new calls
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockQuery.mock.calls.length).toBe(callCount);
+  });
+});

--- a/progress.txt
+++ b/progress.txt
@@ -2,3 +2,8 @@
 - Files: server.ts, bootstrap.ts, relayForever.ts, graphileWorker.ts, workerLifecycle.ts, workerLifecycle.spec.ts, archiveOutbox.ts
 - Changes: Added workerLifecycle module for coordinating worker shutdown. Workers register cleanup functions called on SIGTERM/SIGINT. Workers start in background to avoid blocking server. Fixed blocking execSync in archiveOutbox by converting to async exec.
 - Decisions: Used Promise.all for parallel worker startup; 30s timeout for graceful shutdown; workers check isShutdownInProgress() flag.
+
+[2026-02-06] #13354 fix: add Outbox table existence check before starting message relayer loop
+- Files: relayForever.ts, bootstrap.ts, waitForOutboxTable.spec.ts
+- Changes: Added waitForOutboxTable() with exponential backoff (1s-30s) that polls for Outbox table accessibility before relay loop starts. Called from bootstrapRelayer() so isServiceHealthy gates on DB readiness.
+- Decisions: Placed readiness check in bootstrapRelayer (awaited) rather than inside fire-and-forget relayForever, so health check naturally gates on it.


### PR DESCRIPTION
## Summary
- Add a `waitForOutboxTable` readiness gate in `relayForever.ts` that polls for the `Outbox` table with exponential backoff (1s to 30s cap), ensuring the message relayer does not attempt relay calls until the database is confirmed accessible
- Call `waitForOutboxTable` in `bootstrapRelayer` before starting the relay loop, gating the `isServiceHealthy` health check on actual database readiness — particularly important for Neon serverless pooler cold starts
- Add unit tests covering immediate success, retry with backoff, backoff cap at 30s, and clean abort on shutdown signals

## Test Plan
- [x] Unit tests for `waitForOutboxTable`: immediate resolution, retry on failure, exponential backoff capped at 30s, and shutdown signal respect
- [ ] Verify `pnpm -F commonwealth test-select test/unit/waitForOutboxTable.spec.ts` passes
- [ ] Deploy to Neon-backed environment and confirm clean startup logs without transient Outbox query errors
- [ ] Verify health check (`isServiceHealthy`) is not marked true until the Outbox table is confirmed accessible

Closes #13354


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*