### PR TITLE
docs: Prediction Markets (Futarchy) integration spec

### DIFF
--- a/common_knowledge/Prediction-Markets.md
+++ b/common_knowledge/Prediction-Markets.md
@@ -590,7 +590,7 @@ Foundation layer: all Zod schemas (single file per category, like quests) and Se
 - [ ] `PredictionMarketPositions` table with UNIQUE (prediction_market_id, user_address)
 - [ ] `Threads` table has new `has_prediction_market` BOOLEAN column
 - [ ] Associations: Community->PM (1:N), Thread->PM (1:N), PM->Trade (1:N), PM->Position (1:N)
-- [ ] Indexes on: thread_id, community_id, market_id, status, vault_address, trader_address
+- [ ] Indexes on: thread_id, community_id, market_id, status, vault_address, trader_address, PredictionMarket (status, end_time)
 - [ ] `PredictionMarketContext` added to context.ts
 - [ ] 8 domain event schemas in events.schemas.ts
 - [ ] Migration runs + rolls back cleanly


### PR DESCRIPTION
## Description of Changes

Added comprehensive engineering specification for integrating the Futarchy Protocol prediction markets into Commonwealth. This is a foundational spec document for the prediction markets feature.

**What's included:**
- Complete architecture overview with ASCII diagrams (system, flows, state machine, ERD, chain events pipeline)
- Contract source reference (common-protocol repo, branch, commit, file tree)
- 10 pre-cut engineering tickets (PM-1 through PM-10) with sizes, dependencies, acceptance criteria, and test requirements
- Dependency graph with parallelization notes
- Detailed test plan (unit, integration, E2E)
- Implementation phases and key patterns to reuse

## Test Plan

This is a documentation commit. No code changes were made.

## Other Considerations

- Tickets are pre-cut in the spec (PM-1 through PM-10) ready to be copied into GitHub Issues / Linear
- The spec references `common-protocol` branch `dillchen/prediction-market` commit `8504b0c` as the contract source
- Implementation can proceed in 4 parallel phases with clear dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition; no runtime, schema, or behavior changes, so risk is limited to potential misalignment if the spec becomes outdated.
> 
> **Overview**
> Adds a new `common_knowledge/Prediction-Markets.md` engineering spec describing how to integrate Futarchy-based binary prediction markets into Commonwealth.
> 
> The doc includes architecture/flow diagrams, proposed DB/command/event model, chain-events ingestion plan (ABIs/event signatures/mappers/policy), and a set of pre-cut implementation tickets with dependencies, acceptance criteria, and test plans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2db4a93fd9531771dfd459575820403808b0b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->