### PR TITLE
Update Prediction Markets plan: projection architecture, ABI-driven EVM event slices

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -58,3 +58,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: handleCommunityStakeTrades.ts→projectCommunityStakeTrades.ts, handleReferralFeeDistributed.ts→projectReferralFeeDistributed.ts (moved from policies/handlers/ to aggregates/community/projections/), policies/utils/utils.ts, utils/utils.ts, LaunchpadTrade.projection.ts, ChainEventCreated.projection.ts, chainEventCreatedPolicy.spec.ts
 - Changes: Moved projection handler files to live alongside their projection consumers under projections/ subfolder with project* naming convention. Moved chainNodeMustExist utility from policies/utils/utils.ts to the shared utils/utils.ts module. Updated all import paths and function names.
 - Decisions: Only moved handlers exclusively consumed by projections. Notification handlers (notify*.ts) and policy-specific handlers (handleNamespaceDeployed, handleTokenStaking) remain in policies/handlers/.
+
+[2026-02-13] #13385 docs: update prediction markets plan for projection architecture and ABI events
+- Files: common_knowledge/Prediction-Markets.md
+- Changes: Replaced all PredictionMarketPolicy references with PredictionMarketProjection. Removed ProjectPredictionMarketTrade/Resolution command indirection pattern. Updated PM-4 to import ABIs from @commonxyz/common-protocol-abis instead of creating local files. Marked PM-1 and PM-2 (Slices 1+2) as completed. Added complete EVM event-to-mapper-to-projection mapping table with all 8 ABI event signatures. Updated all diagrams to show projection-based flow (no policy or system command boxes).
+- Decisions: Kept ProjectPredictionMarketTrade/Resolution schemas in prediction-market.schemas.ts as they define the shape of event payloads used by the projection.


### PR DESCRIPTION
## Summary
- Refactored the Prediction Markets plan to replace all `PredictionMarketPolicy` references with `PredictionMarketProjection`, removing the anti-pattern "Project..." command indirection (`ProjectPredictionMarketTrade`, `ProjectPredictionMarketResolution`) in favor of direct DB mutations in the projection
- Defined all 8 EVM event slices from actual on-chain ABI signatures (BinaryVault, FutarchyGovernor, FutarchyRouter) with complete event→mapper→projection mappings, and updated PM-4 to import ABIs from `@commonxyz/common-protocol-abis` instead of creating ABI files
- Marked Slice 2 (deploy flow + proposal/market linkage) as completed and updated all diagrams and dependency graphs to reflect the projection-based architecture

## Test Plan
- [ ] Verify no references to `PredictionMarketPolicy`, `ProjectPredictionMarketTrade.command.ts`, or `ProjectPredictionMarketResolution.command.ts` remain in the plan
- [ ] Verify all 8 EVM events from BinaryVaultAbi, FutarchyGovernorAbi, and FutarchyRouterAbi are documented with exact parameter signatures
- [ ] Verify Slice 2 is marked as completed and PM-4 references `@commonxyz/common-protocol-abis` imports
- [ ] Verify all diagrams show projection-based flow without policy or system command boxes

Closes #13385


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*