### PR TITLE
Epic 2.5: migrate trpcClient to shared/api with legacy stub

### DIFF
--- a/common_knowledge/Commonwealth-Frontend-Refactor-Plan.md
+++ b/common_knowledge/Commonwealth-Frontend-Refactor-Plan.md
@@ -28,7 +28,7 @@ Legend: [ ] Not started, [~] In progress, [x] Done. Add a completion date in par
 - [~] 2.2 Create shared/ directory scaffolding + tsconfig/vite aliases — scoped `shared/hooks/*`, `shared/utils/*`, `shared/api/*`, and `features/*` mappings + `client/scripts/shared/*` scaffolding are in progress via issue #13412 while preserving existing `packages/commonwealth/shared/*` imports
 - [~] 2.3 Migrate shared reusable hooks to shared/hooks/ — audited 17-hook move to `client/scripts/shared/hooks/*` + legacy `client/scripts/hooks/*` re-export stubs in progress via issue #13413
 - [~] 2.4 Migrate shared utility helpers to shared/utils/ — shared helper/util module set migrated to `client/scripts/shared/utils/*` with legacy compatibility stubs in progress via issue #13414
-- [ ] 2.5 Migrate trpcClient to shared/api/
+- [~] 2.5 Migrate trpcClient to shared/api/ — source moved to `client/scripts/shared/api/trpcClient.ts` with legacy `utils/trpcClient.ts` compatibility re-export in progress via issue #13415
 - [ ] 2.6 Update consumer imports for shared hooks
 - [ ] 2.7 Update consumer imports for shared utils (batch 1)
 - [ ] 2.8 Update consumer imports for shared utils (batch 2)

--- a/packages/commonwealth/client/scripts/shared/api/trpcClient.ts
+++ b/packages/commonwealth/client/scripts/shared/api/trpcClient.ts
@@ -1,0 +1,38 @@
+import { httpLink } from '@trpc/client';
+import { createTRPCQueryUtils, createTRPCReact } from '@trpc/react-query';
+import type { API } from '../../../../server/api/internal-router';
+import { queryClient } from '../../state/api/config';
+import { userStore } from '../../state/ui/user';
+
+// React hooks for tRPC queries and mutations - use these in React components
+export const trpc = createTRPCReact<API>();
+
+export const BASE_API_PATH = '/api/internal/trpc';
+
+// tRPC client instance - used internally by React hooks and utils
+export const trpcClient = trpc.createClient({
+  links: [
+    httpLink({
+      url: BASE_API_PATH,
+      headers: () => {
+        const user = userStore.getState();
+        return {
+          authorization: user.jwt || '',
+          isPWA: user.isOnPWA?.toString(),
+          address:
+            user.addressSelectorSelectedAddress ||
+            user.activeAccount?.address ||
+            user.addresses?.at(0)?.address,
+        };
+      },
+    }),
+  ],
+  transformer: undefined,
+});
+
+// tRPC query utilities for non-React contexts (e.g., utility functions, event handlers)
+// Use this instead of axios for calling tRPC procedures outside of React components
+export const trpcQueryUtils = createTRPCQueryUtils({
+  queryClient,
+  client: trpcClient,
+});

--- a/packages/commonwealth/client/scripts/utils/trpcClient.ts
+++ b/packages/commonwealth/client/scripts/utils/trpcClient.ts
@@ -1,38 +1,6 @@
-import { httpLink } from '@trpc/client';
-import { createTRPCQueryUtils, createTRPCReact } from '@trpc/react-query';
-import type { API } from '../../../server/api/internal-router';
-import { queryClient } from '../state/api/config';
-import { userStore } from '../state/ui/user';
+import * as sharedTrpcClient from 'shared/api/trpcClient';
 
-// React hooks for tRPC queries and mutations - use these in React components
-export const trpc = createTRPCReact<API>();
-
-export const BASE_API_PATH = '/api/internal/trpc';
-
-// tRPC client instance - used internally by React hooks and utils
-export const trpcClient = trpc.createClient({
-  links: [
-    httpLink({
-      url: BASE_API_PATH,
-      headers: () => {
-        const user = userStore.getState();
-        return {
-          authorization: user.jwt || '',
-          isPWA: user.isOnPWA?.toString(),
-          address:
-            user.addressSelectorSelectedAddress ||
-            user.activeAccount?.address ||
-            user.addresses?.at(0)?.address,
-        };
-      },
-    }),
-  ],
-  transformer: undefined,
-});
-
-// tRPC query utilities for non-React contexts (e.g., utility functions, event handlers)
-// Use this instead of axios for calling tRPC procedures outside of React components
-export const trpcQueryUtils = createTRPCQueryUtils({
-  queryClient,
-  client: trpcClient,
-});
+export const BASE_API_PATH = sharedTrpcClient.BASE_API_PATH;
+export const trpc = sharedTrpcClient.trpc;
+export const trpcClient = sharedTrpcClient.trpcClient;
+export const trpcQueryUtils = sharedTrpcClient.trpcQueryUtils;


### PR DESCRIPTION
## Link to Issue
Closes: #13415

## Description of Changes
- moves `trpcClient` implementation to `client/scripts/shared/api/trpcClient.ts`
- keeps `client/scripts/utils/trpcClient.ts` as a compatibility stub that forwards the stable exports (`trpc`, `trpcClient`, `trpcQueryUtils`, `BASE_API_PATH`)
- updates EPIC-2.5 status in `common_knowledge/Commonwealth-Frontend-Refactor-Plan.md`
- adjusts the legacy stub implementation style to avoid Rollup re-export cycle warnings introduced by direct export forwarding

## Test Plan
1. `pnpm -F commonwealth bundle`
2. `pnpm -F commonwealth test-component -- --allowOnly=false`
3. `cd packages/commonwealth && APP_ENV=local NODE_ENV=test FEATURE_FLAG_GROUP_CHECK_ENABLED=true pnpm exec vitest --config ../../vite.config.ts run test/unit/epic2/trpcClient.contract.spec.ts` (currently blocked by missing required env values `ALCHEMY.APP_KEYS.PRIVATE` and `ALCHEMY.APP_KEYS.PUBLIC` in this local environment)
4. `pnpm -r check-types` (fails in current workspace baseline with TS6305 project-reference artifact mismatch at `libs/core` -> `libs/schemas/build/index.d.ts`)

## Deployment Plan
- N/A (refactor with compatibility path retained)

## Other Considerations
- stacked PR: base is `codex/feature-d-epic2-4-utils-move`
- legacy path is intentionally retained to avoid churn while consumer rewires proceed in follow-up tickets