### PR TITLE
Fix Sui login session handling in auth flow

### DIFF
--- a/packages/commonwealth/client/scripts/controllers/server/sessions.ts
+++ b/packages/commonwealth/client/scripts/controllers/server/sessions.ts
@@ -117,7 +117,13 @@ export async function getSessionFromWallet(
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const session = (wallet as any).getSession();
-      return session;
+      if (session) {
+        return session;
+      }
+
+      // Revalidation paths may request a Sui session before a local cached
+      // session exists. In that case, mint one on-demand.
+      return getSessionFromWallet(wallet, { newSession: true });
     }
   }
 

--- a/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
+++ b/packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx
@@ -76,6 +76,9 @@ type UseAuthenticationProps = {
 type Wallet = IWebWallet<any>;
 
 const useAuthentication = (props: UseAuthenticationProps) => {
+  const isSuiSession = (session?: Session) =>
+    !!session?.did?.startsWith('did:pkh:sui:');
+
   const [username, setUsername] = useState<string>(DEFAULT_NAME);
   const [email, setEmail] = useState<string>();
   const [SMS, setSMS] = useState<string>();
@@ -407,8 +410,9 @@ const useAuthentication = (props: UseAuthenticationProps) => {
           block_info: account.validationBlockInfo,
           referrer_address: refcode,
         });
-      // @ts-expect-error StrictNullChecks
-      await verifySession(session);
+      if (session && !isSuiSession(session)) {
+        await verifySession(session);
+      }
       // @ts-expect-error <StrictNullChecks>
       await onLogInWithAccount(account, false, true);
       // Important: when we first create an account and verify it, the user id
@@ -657,7 +661,9 @@ const useAuthentication = (props: UseAuthenticationProps) => {
         ? JSON.stringify(validationBlockInfo)
         : null,
     });
-    await verifySession(session);
+    if (!isSuiSession(session)) {
+      await verifySession(session);
+    }
     console.log('Started new session for', wallet.chain, chainIdentifier);
 
     // ensure false for newlyCreated / linking vars on revalidate


### PR DESCRIPTION
### Motivation
- Prevent Sui wallet login paths from failing due to missing cached sessions or Canvas verification that is incompatible with Sui session payloads.
- Sui sessions use a custom `did:pkh:sui:*` format which `verifySession` intentionally does not support, and some revalidation paths could request a session before one existed.

### Description
- Ensure on-demand Sui session creation in `getSessionFromWallet` by returning a newly minted session when `(wallet as any).getSession()` yields `undefined` for Sui wallets; change in `packages/commonwealth/client/scripts/controllers/server/sessions.ts`.
- Add an `isSuiSession` helper and skip calling `verifySession` for Sui sessions in account-creation and session-key revalidation flows; changes in `packages/commonwealth/client/scripts/views/modals/AuthModal/useAuthentication.tsx`.
- These changes avoid attempting Canvas verification on Sui sessions and prevent revalidation from failing when no cached Sui session is present.

### Testing
- Attempted to run `pnpm -C packages/commonwealth exec eslint client/scripts/controllers/server/sessions.ts client/scripts/views/modals/AuthModal/useAuthentication.tsx`, but the package manager bootstrap failed due to a blocked network fetch (corepack/pnpm download returned HTTP 403), so linting could not complete.
- No other automated tests were executed in this environment due to the same network/tooling limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc71c1af8832fa61741be4cef1f52)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/session creation and verification paths; mistakes could break Sui authentication or inadvertently weaken session validation if the Sui-detection check is wrong.
> 
> **Overview**
> Fixes Sui wallet auth edge cases by **minting a new Sui session on-demand** when `getSessionFromWallet()` finds no locally cached session (instead of returning `undefined`).
> 
> Updates the Auth modal flow to **detect `did:pkh:sui:` sessions and skip `verifySession`** during account creation and session-key revalidation, avoiding verification failures for Sui session payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb9e074ee7c43d9d6d142df9a7af272f42928f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->