### PR TITLE
Show contest prizes in discussion banners

### DIFF
--- a/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
+++ b/packages/commonwealth/client/scripts/views/pages/discussions/HeaderWithFilters/HeaderWithFilters.tsx
@@ -724,6 +724,7 @@ export const HeaderWithFilters = ({
               finishDate={end_time ? moment(end_time).toISOString() : ''}
               isCancelled={contest.cancelled}
               isRecurring={!contest.funding_token_address}
+              contestBalance={parseInt(contest.contest_balance || '0', 10)}
               isHorizontal
               showShareButton={false}
               payoutStructure={contest.payout_structure}


### PR DESCRIPTION
## Link to Issue
Closes: #8596

/claim #8596

## Description of Changes
- Passes the existing contest balance from discussion-page active contests into `ContestCard`.
- This lets the discussion contest banner compute and display prize amounts immediately from the API payload instead of falling back to `0` while the on-chain balance query is unavailable/pending.
- Keeps the existing on-chain balance override in `ContestCard` when it is available.

## Test Plan
- `git diff --check`
- Manual code inspection of discussion active contest rendering path.

## Deployment Plan
- Normal frontend deploy.

## Other Considerations
- Local dependency install was not present in this fresh checkout, so I kept validation to the changed TSX path and whitespace/diff checks.